### PR TITLE
fix(CodeArts): fix codearts instance resource lint error

### DIFF
--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_host_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_host_test.go
@@ -242,7 +242,7 @@ resource "huaweicloud_compute_instance" "test" {
 
   name                        = "%[2]s"
   image_id                    = data.huaweicloud_images_image.test.id
-  flavor_id                   = "sn3.large.2"
+  flavor_id                   = data.huaweicloud_compute_flavors.test.ids[0]
   availability_zone           = data.huaweicloud_availability_zones.test.names[0]
   admin_pass                  = "Test@123"
   delete_disks_on_termination = true

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_project_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_project_test.go
@@ -5,29 +5,30 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getProjectResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getProjectResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getProject: Query the Project
 	var (
 		getProjectHttpUrl = "v4/projects/{id}"
 		getProjectProduct = "projectman"
 	)
-	getProjectClient, err := config.NewServiceClient(getProjectProduct, region)
+	getProjectClient, err := cfg.NewServiceClient(getProjectProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Project Client: %s", err)
 	}
 
 	getProjectPath := getProjectClient.Endpoint + getProjectHttpUrl
-	getProjectPath = strings.Replace(getProjectPath, "{id}", state.Primary.ID, -1)
+	getProjectPath = strings.ReplaceAll(getProjectPath, "{id}", state.Primary.ID)
 
 	getProjectOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_repository_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_repository_test.go
@@ -5,29 +5,30 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getRepositoryResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getRepositoryResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getRepository: Query the resource detail of the CodeHub repository
 	var (
 		getRepositoryHttpUrl = "v2/repositories/{repository_uuid}"
 		getRepositoryProduct = "codehub"
 	)
-	getRepositoryClient, err := config.NewServiceClient(getRepositoryProduct, region)
+	getRepositoryClient, err := cfg.NewServiceClient(getRepositoryProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating repository client: %s", err)
 	}
 
 	getRepositoryPath := getRepositoryClient.Endpoint + getRepositoryHttpUrl
-	getRepositoryPath = strings.Replace(getRepositoryPath, "{repository_uuid}", state.Primary.ID, -1)
+	getRepositoryPath = strings.ReplaceAll(getRepositoryPath, "{repository_uuid}", state.Primary.ID)
 
 	getRepositoryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_project.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_project.go
@@ -9,16 +9,17 @@ import (
 	"context"
 	"strings"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/jmespath/go-jmespath"
 )
 
 func ResourceProject() *schema.Resource {
@@ -100,15 +101,15 @@ func ResourceProject() *schema.Resource {
 }
 
 func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createProject: create a Project
 	var (
 		createProjectHttpUrl = "v4/project"
 		createProjectProduct = "projectman"
 	)
-	createProjectClient, err := config.NewServiceClient(createProjectProduct, region)
+	createProjectClient, err := cfg.NewServiceClient(createProjectProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Project Client: %s", err)
 	}
@@ -121,7 +122,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 			200,
 		},
 	}
-	createProjectOpt.JSONBody = utils.RemoveNil(buildCreateProjectBodyParams(d, config))
+	createProjectOpt.JSONBody = utils.RemoveNil(buildCreateProjectBodyParams(d, cfg))
 	createProjectResp, err := createProjectClient.Request("POST", createProjectPath, &createProjectOpt)
 	if err != nil {
 		return diag.Errorf("error creating Project: %s", err)
@@ -141,11 +142,11 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return resourceProjectRead(ctx, d, meta)
 }
 
-func buildCreateProjectBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateProjectBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"project_name":  utils.ValueIngoreEmpty(d.Get("name")),
 		"description":   utils.ValueIngoreEmpty(d.Get("description")),
-		"enterprise_id": utils.ValueIngoreEmpty(common.GetEnterpriseProjectID(d, config)),
+		"enterprise_id": utils.ValueIngoreEmpty(common.GetEnterpriseProjectID(d, cfg)),
 		"project_type":  utils.ValueIngoreEmpty(d.Get("type")),
 		"source":        utils.ValueIngoreEmpty(d.Get("source")),
 		"template_id":   utils.ValueIngoreEmpty(d.Get("template_id")),
@@ -153,9 +154,9 @@ func buildCreateProjectBodyParams(d *schema.ResourceData, config *config.Config)
 	return bodyParams
 }
 
-func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceProjectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -164,13 +165,13 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 		getProjectHttpUrl = "v4/projects/{id}"
 		getProjectProduct = "projectman"
 	)
-	getProjectClient, err := config.NewServiceClient(getProjectProduct, region)
+	getProjectClient, err := cfg.NewServiceClient(getProjectProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Project Client: %s", err)
 	}
 
 	getProjectPath := getProjectClient.Endpoint + getProjectHttpUrl
-	getProjectPath = strings.Replace(getProjectPath, "{id}", d.Id(), -1)
+	getProjectPath = strings.ReplaceAll(getProjectPath, "{id}", d.Id())
 
 	getProjectOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -204,8 +205,8 @@ func resourceProjectRead(ctx context.Context, d *schema.ResourceData, meta inter
 }
 
 func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	updateProjecthasChanges := []string{
 		"name",
@@ -218,13 +219,13 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			updateProjectHttpUrl = "v4/projects/{id}"
 			updateProjectProduct = "projectman"
 		)
-		updateProjectClient, err := config.NewServiceClient(updateProjectProduct, region)
+		updateProjectClient, err := cfg.NewServiceClient(updateProjectProduct, region)
 		if err != nil {
 			return diag.Errorf("error creating Project Client: %s", err)
 		}
 
 		updateProjectPath := updateProjectClient.Endpoint + updateProjectHttpUrl
-		updateProjectPath = strings.Replace(updateProjectPath, "{id}", d.Id(), -1)
+		updateProjectPath = strings.ReplaceAll(updateProjectPath, "{id}", d.Id())
 
 		updateProjectOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
@@ -232,7 +233,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				204,
 			},
 		}
-		updateProjectOpt.JSONBody = utils.RemoveNil(buildUpdateProjectBodyParams(d, config))
+		updateProjectOpt.JSONBody = utils.RemoveNil(buildUpdateProjectBodyParams(d, cfg))
 		_, err = updateProjectClient.Request("PUT", updateProjectPath, &updateProjectOpt)
 		if err != nil {
 			return diag.Errorf("error updating Project: %s", err)
@@ -241,7 +242,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return resourceProjectRead(ctx, d, meta)
 }
 
-func buildUpdateProjectBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildUpdateProjectBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"project_name": utils.ValueIngoreEmpty(d.Get("name")),
 		"description":  utils.ValueIngoreEmpty(d.Get("description")),
@@ -249,22 +250,22 @@ func buildUpdateProjectBodyParams(d *schema.ResourceData, config *config.Config)
 	return bodyParams
 }
 
-func resourceProjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceProjectDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteProject: missing operation notes
 	var (
 		deleteProjectHttpUrl = "v4/projects/{id}"
 		deleteProjectProduct = "projectman"
 	)
-	deleteProjectClient, err := config.NewServiceClient(deleteProjectProduct, region)
+	deleteProjectClient, err := cfg.NewServiceClient(deleteProjectProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Project Client: %s", err)
 	}
 
 	deleteProjectPath := deleteProjectClient.Endpoint + deleteProjectHttpUrl
-	deleteProjectPath = strings.Replace(deleteProjectPath, "{id}", d.Id(), -1)
+	deleteProjectPath = strings.ReplaceAll(deleteProjectPath, "{id}", d.Id())
 
 	deleteProjectOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_project.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_project.go
@@ -233,7 +233,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				204,
 			},
 		}
-		updateProjectOpt.JSONBody = utils.RemoveNil(buildUpdateProjectBodyParams(d, cfg))
+		updateProjectOpt.JSONBody = utils.RemoveNil(buildUpdateProjectBodyParams(d))
 		_, err = updateProjectClient.Request("PUT", updateProjectPath, &updateProjectOpt)
 		if err != nil {
 			return diag.Errorf("error updating Project: %s", err)
@@ -242,7 +242,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return resourceProjectRead(ctx, d, meta)
 }
 
-func buildUpdateProjectBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
+func buildUpdateProjectBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"project_name": utils.ValueIngoreEmpty(d.Get("name")),
 		"description":  utils.ValueIngoreEmpty(d.Get("description")),

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go
@@ -11,16 +11,18 @@ import (
 	"strings"
 	"time"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/jmespath/go-jmespath"
 )
 
 func ResourceRepository() *schema.Resource {
@@ -166,7 +168,7 @@ func waitForRepositoryActive(ctx context.Context, cfg *config.Config, d *schema.
 	}
 
 	getRepositoryPath := getRepositoryClient.Endpoint + getRepositoryHttpUrl
-	getRepositoryPath = strings.Replace(getRepositoryPath, "{repository_uuid}", d.Id(), -1)
+	getRepositoryPath = strings.ReplaceAll(getRepositoryPath, "{repository_uuid}", d.Id())
 
 	createRepositoryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -248,7 +250,7 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return resourceRepositoryRead(ctx, d, meta)
 }
 
-func buildCreateRepositoryBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateRepositoryBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"name":             utils.ValueIngoreEmpty(d.Get("name")),
 		"project_uuid":     utils.ValueIngoreEmpty(d.Get("project_id")),
@@ -263,7 +265,7 @@ func buildCreateRepositoryBodyParams(d *schema.ResourceData, config *config.Conf
 	return bodyParams
 }
 
-func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRepositoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// getRepository: Query the resource detail of the CodeHub repository
 	var (
 		getRepositoryHttpUrl = "v2/repositories/{repository_uuid}"
@@ -279,7 +281,7 @@ func resourceRepositoryRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	getRepositoryPath := getRepositoryClient.Endpoint + getRepositoryHttpUrl
-	getRepositoryPath = strings.Replace(getRepositoryPath, "{repository_uuid}", d.Id(), -1)
+	getRepositoryPath = strings.ReplaceAll(getRepositoryPath, "{repository_uuid}", d.Id())
 
 	getRepositoryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -326,7 +328,7 @@ func parseRepositoryRequestError(respErr error) error {
 	return respErr
 }
 
-func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRepositoryDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// deleteRepository: Remove an existing CodeHub repository
 	var (
 		deleteRepositoryHttpUrl = "v1/repositories/{repository_uuid}"
@@ -341,7 +343,7 @@ func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	deleteRepositoryPath := deleteRepositoryClient.Endpoint + deleteRepositoryHttpUrl
-	deleteRepositoryPath = strings.Replace(deleteRepositoryPath, "{repository_uuid}", d.Id(), -1)
+	deleteRepositoryPath = strings.ReplaceAll(deleteRepositoryPath, "{repository_uuid}", d.Id())
 
 	deleteRepositoryOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go
@@ -228,7 +228,7 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta 
 			200,
 		},
 	}
-	createRepositoryOpt.JSONBody = buildCreateRepositoryBodyParams(d, cfg)
+	createRepositoryOpt.JSONBody = buildCreateRepositoryBodyParams(d)
 	createRepositoryResp, err := createRepositoryClient.Request("POST", createRepositoryPath, &createRepositoryOpt)
 	if err != nil {
 		return diag.Errorf("error creating CodeHub repository: %s", err)
@@ -250,7 +250,7 @@ func resourceRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return resourceRepositoryRead(ctx, d, meta)
 }
 
-func buildCreateRepositoryBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
+func buildCreateRepositoryBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"name":             utils.ValueIngoreEmpty(d.Get("name")),
 		"project_uuid":     utils.ValueIngoreEmpty(d.Get("project_id")),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
fix codearts instance resource lint error

**Special notes for your reviewer**:

**Release note**:
 ./scripts/codecheck.sh ./huaweicloud/services/codearts

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        5      1986      202        35     1749        203            57.22
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~source_huaweicloud_codearts_deploy_host.go       459       48         6      405         52            12.84
~ource_huaweicloud_codearts_deploy_group.go       418       47         7      364         50            13.74
~huaweicloud_codearts_deploy_application.go       467       37         6      424         45            10.61
~esource_huaweicloud_codearts_repository.go       360       35         8      317         33            10.41
~s/resource_huaweicloud_codearts_project.go       282       35         8      239         23             9.62
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     5      1986      202        35     1749        203            57.22
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 61387 bytes, 0.061 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
9 codearts resourceDeployHostCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_host.go:179:1
8 codearts resourceDeployApplicationCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_application.go:245:1
7 codearts resourceDeployGroupCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_group.go:156:1
6 codearts resourceRepositoryCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go:209:1
6 codearts repositoryRefreshFunc huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go:190:1
6 codearts resourceDeployHostRead huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_host.go:265:1
6 codearts resourceDeployGroupRead huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_group.go:212:1
6 codearts resourceDeployApplicationRead huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_application.go:349:1
5 codearts resourceProjectCreate huaweicloud/services/codearts/resource_huaweicloud_codearts_project.go:103:1
5 codearts resourceDeployHostDelete huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_host.go:404:1
Average: 3.12

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in codearts...

==> Checking for misspell in codearts...

==> Checking for code complexity in ./huaweicloud/services/acceptance/codearts...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        5      1362      123         7     1232         44            18.28
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~_huaweicloud_codearts_deploy_group_test.go       277       29         2      246         13             5.28
~e_huaweicloud_codearts_deploy_host_test.go       432       34         2      396         13             3.28
~icloud_codearts_deploy_application_test.go       368       30         1      337         10             2.97
~ce_huaweicloud_codearts_repository_test.go       176       17         1      158          4             2.53
~ource_huaweicloud_codearts_project_test.go       109       13         1       95          4             4.21
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     5      1362      123         7     1232         44            18.28
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 41084 bytes, 0.041 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 codearts getDeployHostResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_host_test.go:20:1
6 codearts getDeployGroupResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_group_test.go:19:1
6 codearts getDeployApplicationResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_deploy_application_test.go:19:1
3 codearts getRepositoryResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_repository_test.go:18:1
3 codearts getProjectResourceFunc huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_project_test.go:18:1
Average: 1.56

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/codearts...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/codearts...

==> Cleanup patch...

Check Completed!



```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployApplication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccDeployApplication -timeout 360m -parallel 4
=== RUN   TestAccDeployApplication_basic
=== PAUSE TestAccDeployApplication_basic
=== RUN   TestAccDeployApplication_resourcePoolId
=== PAUSE TestAccDeployApplication_resourcePoolId
=== RUN   TestAccDeployApplication_errorCheckInvalidArgument
=== PAUSE TestAccDeployApplication_errorCheckInvalidArgument
=== RUN   TestAccDeployApplication_errorCheckErrorCode
=== PAUSE TestAccDeployApplication_errorCheckErrorCode
=== CONT  TestAccDeployApplication_basic
=== CONT  TestAccDeployApplication_errorCheckInvalidArgument
=== CONT  TestAccDeployApplication_errorCheckErrorCode
=== CONT  TestAccDeployApplication_resourcePoolId
    acceptance.go:840: HW_CODEARTS_RESOURCE_POOL_ID must be set for this acceptance test
--- SKIP: TestAccDeployApplication_resourcePoolId (0.01s)
--- PASS: TestAccDeployApplication_errorCheckInvalidArgument (13.56s)
--- PASS: TestAccDeployApplication_errorCheckErrorCode (13.94s)
--- PASS: TestAccDeployApplication_basic (21.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  21.886s
make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccDeployGroup -timeout 360m -parallel 4
=== RUN   TestAccDeployGroup_basic
=== PAUSE TestAccDeployGroup_basic
=== RUN   TestAccDeployGroup_resourcePoolId
=== PAUSE TestAccDeployGroup_resourcePoolId
=== RUN   TestAccDeployGroup_errorCheck
=== PAUSE TestAccDeployGroup_errorCheck
=== CONT  TestAccDeployGroup_basic
=== CONT  TestAccDeployGroup_errorCheck
=== CONT  TestAccDeployGroup_resourcePoolId
    acceptance.go:840: HW_CODEARTS_RESOURCE_POOL_ID must be set for this acceptance test
--- SKIP: TestAccDeployGroup_resourcePoolId (0.01s)
--- PASS: TestAccDeployGroup_errorCheck (11.42s)
--- PASS: TestAccDeployGroup_basic (30.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  30.449s
make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccDeployHost'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccDeployHost -timeout 360m -parallel 4
=== RUN   TestAccDeployHost_withProxyMode
=== PAUSE TestAccDeployHost_withProxyMode
=== RUN   TestAccDeployHost_withoutProxyMode
=== PAUSE TestAccDeployHost_withoutProxyMode
=== RUN   TestAccDeployHost_errorCheck
=== PAUSE TestAccDeployHost_errorCheck
=== CONT  TestAccDeployHost_withProxyMode
=== CONT  TestAccDeployHost_errorCheck
=== CONT  TestAccDeployHost_withoutProxyMode
    acceptance.go:847: Skip the CodeArts acceptance tests.
--- SKIP: TestAccDeployHost_withoutProxyMode (0.00s)
=== CONT  TestAccDeployHost_withProxyMode
    acceptance.go:847: Skip the CodeArts acceptance tests.
--- SKIP: TestAccDeployHost_withProxyMode (0.00s)
--- PASS: TestAccDeployHost_errorCheck (207.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  207.704s
make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccRepository'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccRepository -timeout 360m -parallel 4
=== RUN   TestAccRepository_basic
=== PAUSE TestAccRepository_basic
=== RUN   TestAccRepository_default
=== PAUSE TestAccRepository_default
=== CONT  TestAccRepository_basic
=== CONT  TestAccRepository_default
--- PASS: TestAccRepository_default (26.78s)
--- PASS: TestAccRepository_basic (26.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  26.954s
make testacc TEST='/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccProject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test /home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts -v -run TestAccProject -timeout 360m -parallel 4
=== RUN   TestAccProject_basic
=== PAUSE TestAccProject_basic
=== CONT  TestAccProject_basic
--- PASS: TestAccProject_basic (22.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  22.705s

```
