### PR TITLE
fix(IEC): fix move iec to services/iec

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -67,6 +67,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/hss"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/identitycenter"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iec"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iotda"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/koogallery"
@@ -960,8 +961,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_iec_security_group_rule": resourceIecSecurityGroupRule(),
 			"huaweicloud_iec_server":              resourceIecServer(),
 			"huaweicloud_iec_vip":                 resourceIecVipV1(),
-			"huaweicloud_iec_vpc":                 ResourceIecVpc(),
-			"huaweicloud_iec_vpc_subnet":          resourceIecSubnet(),
+			"huaweicloud_iec_vpc":                 iec.ResourceIecVpc(),
+			"huaweicloud_iec_vpc_subnet":          iec.ResourceIecSubnet(),
 
 			"huaweicloud_images_image":                ims.ResourceImsImage(),
 			"huaweicloud_images_image_copy":           ims.ResourceImsImageCopy(),

--- a/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_subnet_test.go
+++ b/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_subnet_test.go
@@ -1,0 +1,147 @@
+package iec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	ieccommon "github.com/chnsz/golangsdk/openstack/iec/v1/common"
+	"github.com/chnsz/golangsdk/openstack/iec/v1/subnets"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccIecVPCSubnetV1_basic(t *testing.T) {
+	var iecSubnet ieccommon.Subnet
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_iec_vpc_subnet.subnet_test"
+	rNameUpdate := rName + "-updated"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIecVpcSubnetV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIecVpcSubnetV1_customer(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIecVpcSubnetV1Exists(resourceName, &iecSubnet),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-subnet", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.128.0/18"),
+					resource.TestCheckResourceAttr(resourceName, "gateway_ip", "192.168.128.1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_list.#", "2"),
+				),
+			},
+			{
+				Config: testAccIecVpcSubnetV1_customer_update(rName, rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIecVpcSubnetV1Exists(resourceName, &iecSubnet),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-subnet", rNameUpdate)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIecVpcSubnetV1Destroy(s *terraform.State) error {
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	iecV1Client, err := conf.IECV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating IEC client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_iec_vpc_subnet" {
+			continue
+		}
+
+		_, err := subnets.Get(iecV1Client, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("IEC VPC still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIecVpcSubnetV1Exists(n string, subnetResource *ieccommon.Subnet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		iecV1Client, err := config.IECV1Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating Huaweicloud IEC client: %s", err)
+		}
+
+		found, err := subnets.Get(iecV1Client, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("IEC VPC not found")
+		}
+
+		*subnetResource = *found
+
+		return nil
+	}
+}
+
+func testAccIecVpcSubnetV1_customer(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_iec_sites" "sites_test" {}
+
+resource "huaweicloud_iec_vpc" "vpc_test" {
+  name = "%s-vpc"
+  cidr = "192.168.0.0/16"
+  mode = "CUSTOMER"
+}
+
+resource "huaweicloud_iec_vpc_subnet" "subnet_test" {
+  name       = "%s-subnet"
+  cidr       = "192.168.128.0/18"
+  vpc_id     = huaweicloud_iec_vpc.vpc_test.id
+  site_id    = data.huaweicloud_iec_sites.sites_test.sites[0].id
+  gateway_ip = "192.168.128.1"
+}
+`, rName, rName)
+}
+
+func testAccIecVpcSubnetV1_customer_update(rName, rNameUpdate string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_iec_sites" "sites_test" {}
+
+resource "huaweicloud_iec_vpc" "vpc_test" {
+  name = "%s-vpc"
+  cidr = "192.168.0.0/16"
+  mode = "CUSTOMER"
+}
+
+resource "huaweicloud_iec_vpc_subnet" "subnet_test" {
+  name       = "%s-subnet"
+  cidr       = "192.168.128.0/18"
+  vpc_id     = huaweicloud_iec_vpc.vpc_test.id
+  site_id    = data.huaweicloud_iec_sites.sites_test.sites[0].id
+  gateway_ip = "192.168.128.1"
+}
+`, rName, rNameUpdate)
+}

--- a/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_test.go
+++ b/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_test.go
@@ -1,0 +1,182 @@
+package iec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	ieccommon "github.com/chnsz/golangsdk/openstack/iec/v1/common"
+	"github.com/chnsz/golangsdk/openstack/iec/v1/vpcs"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccIecVpcV1_basic(t *testing.T) {
+	var iecVPC ieccommon.VPC
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_iec_vpc.test"
+	rNameUpdate := rName + "-updated"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIecVpcV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIecVpcV1_system(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIecVpcV1Exists(resourceName, &iecVPC),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "SYSTEM"),
+				),
+			},
+			{
+				Config: testAccIecVpcV1_system_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIecVpcV1Exists(resourceName, &iecVPC),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIecVpcV1_customer(t *testing.T) {
+	var iecVPC ieccommon.VPC
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "huaweicloud_iec_vpc.customer"
+	rNameUpdate := rName + "-updated"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIecVpcV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIecVpcV1_customer(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIecVpcV1Exists(resourceName, &iecVPC),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "CUSTOMER"),
+				),
+			},
+			{
+				Config: testAccIecVpcV1_customer_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIecVpcV1Exists(resourceName, &iecVPC),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "172.30.0.0/16"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIecVpcV1Destroy(s *terraform.State) error {
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	iecV1Client, err := conf.IECV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating IEC client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "huaweicloud_iec_vpc" {
+			continue
+		}
+
+		_, err := vpcs.Get(iecV1Client, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("IEC VPC still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIecVpcV1Exists(n string, vpcResource *ieccommon.VPC) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
+		iecV1Client, err := conf.IECV1Client(acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating IEC client: %s", err)
+		}
+
+		found, err := vpcs.Get(iecV1Client, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("IEC VPC not found")
+		}
+
+		*vpcResource = *found
+
+		return nil
+	}
+}
+
+func testAccIecVpcV1_system(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_iec_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+`, rName)
+}
+
+func testAccIecVpcV1_system_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_iec_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+`, rName)
+}
+
+func testAccIecVpcV1_customer(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_iec_vpc" "customer" {
+  name = "%s"
+  cidr = "172.16.0.0/16"
+  mode = "CUSTOMER"
+}
+`, rName)
+}
+
+func testAccIecVpcV1_customer_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_iec_vpc" "customer" {
+  name = "%s"
+  cidr = "172.30.0.0/16"
+  mode = "CUSTOMER"
+}
+`, rName)
+}

--- a/huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go
+++ b/huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go
@@ -1,0 +1,147 @@
+package iec
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/iec/v1/vpcs"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceIecVpc() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIecVpcCreate,
+		ReadContext:   resourceIecVpcRead,
+		UpdateContext: resourceIecVpcUpdate,
+		DeleteContext: resourceIecVpcDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cidr": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "SYSTEM",
+			},
+			"subnet_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceIecVpcCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+
+	if err != nil {
+		return diag.Errorf("error creating IEC client: %s", err)
+	}
+
+	createOpts := vpcs.CreateOpts{
+		Name: d.Get("name").(string),
+		Cidr: d.Get("cidr").(string),
+		Mode: d.Get("mode").(string),
+	}
+
+	n, err := vpcs.Create(iecClient, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error creating IEC VPC: %s", err)
+	}
+
+	log.Printf("[INFO] IEC VPC ID: %s", n.ID)
+	d.SetId(n.ID)
+
+	return resourceIecVpcRead(ctx, d, meta)
+}
+
+func resourceIecVpcRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IEC client: %s", err)
+	}
+
+	n, err := vpcs.Get(iecClient, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IEC VPC")
+	}
+	mErr := multierror.Append(
+		nil,
+		d.Set("name", n.Name),
+		d.Set("cidr", n.Cidr),
+		d.Set("mode", n.Mode),
+		d.Set("subnet_num", n.SubnetNum),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceIecVpcUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IEC client: %s", err)
+	}
+
+	var updateOpts vpcs.UpdateOpts
+
+	if d.HasChange("name") {
+		updateOpts.Name = d.Get("name").(string)
+	}
+	if d.HasChange("cidr") {
+		updateOpts.Cidr = d.Get("cidr").(string)
+	}
+
+	_, err = vpcs.Update(iecClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error updating IEC VPC: %s", err)
+	}
+
+	return resourceIecVpcRead(ctx, d, meta)
+}
+
+func resourceIecVpcDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IEC client: %s", err)
+	}
+
+	// lintignore:R018
+	time.Sleep(3 * time.Second) // Prevent delete failure
+
+	err = vpcs.Delete(iecClient, d.Id()).ExtractErr()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IEC VPC")
+	}
+
+	return nil
+}

--- a/huaweicloud/services/iec/resource_huaweicloud_iec_vpc_subnet.go
+++ b/huaweicloud/services/iec/resource_huaweicloud_iec_vpc_subnet.go
@@ -1,0 +1,256 @@
+package iec
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/iec/v1/subnets"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func buildIecSubnetDNSList(d *schema.ResourceData) []string {
+	rawDNSN := d.Get("dns_list").([]interface{})
+
+	// set the default DNS if it was not specified
+	if len(rawDNSN) == 0 {
+		return []string{"114.114.114.114", "8.8.8.8"}
+	}
+
+	dnsn := make([]string, len(rawDNSN))
+	for i, raw := range rawDNSN {
+		dnsn[i] = raw.(string)
+	}
+	return dnsn
+}
+
+func ResourceIecSubnet() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIecSubnetCreate,
+		ReadContext:   resourceIecSubnetRead,
+		UpdateContext: resourceIecSubnetUpdate,
+		DeleteContext: resourceIecSubnetDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cidr": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"site_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"gateway_ip": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: utils.ValidateIP,
+			},
+			"dhcp_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"dns_list": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
+			"site_info": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceIecSubnetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	subnetClient, err := conf.IECV1Client(conf.GetRegion(d))
+
+	if err != nil {
+		return diag.Errorf("error creating IEC client: %s", err)
+	}
+
+	dhcp := d.Get("dhcp_enable").(bool)
+	createOpts := subnets.CreateOpts{
+		Name:       d.Get("name").(string),
+		Cidr:       d.Get("cidr").(string),
+		VpcID:      d.Get("vpc_id").(string),
+		SiteID:     d.Get("site_id").(string),
+		GatewayIP:  d.Get("gateway_ip").(string),
+		DhcpEnable: &dhcp,
+		DNSList:    buildIecSubnetDNSList(d),
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	n, err := subnets.Create(subnetClient, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error creating IEC subnets: %s", err)
+	}
+
+	d.SetId(n.ID)
+	log.Printf("[DEBUG] Waiting for IEC subnets (%s) to become active", n.ID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"UNKNOWN"},
+		Target:     []string{"ACTIVE"},
+		Refresh:    waitForIecSubnetStatus(subnetClient, n.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, stateErr := stateConf.WaitForStateContext(ctx)
+	if stateErr != nil {
+		return diag.Errorf(
+			"error waiting for IEC subnets (%s) to become ACTIVE: %s",
+			n.ID, stateErr)
+	}
+
+	return resourceIecSubnetRead(ctx, d, conf)
+}
+
+func resourceIecSubnetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	subnetClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IEC client: %s", err)
+	}
+
+	n, err := subnets.Get(subnetClient, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IEC subnets")
+	}
+
+	log.Printf("[DEBUG] IEC subnets %s: %+v", d.Id(), n)
+	mErr := multierror.Append(
+		nil,
+		d.Set("name", n.Name),
+		d.Set("cidr", n.Cidr),
+		d.Set("vpc_id", n.VpcID),
+		d.Set("site_id", n.SiteID),
+		d.Set("gateway_ip", n.GatewayIP),
+		d.Set("dhcp_enable", n.DhcpEnable),
+		d.Set("dns_list", n.DNSList),
+		d.Set("site_info", n.SiteInfo),
+		d.Set("status", n.Status),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceIecSubnetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	subnetClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IEC client: %s", err)
+	}
+
+	var updateOpts subnets.UpdateOpts
+
+	// name is mandatory while updating subnets
+	updateOpts.Name = d.Get("name").(string)
+
+	if d.HasChange("dhcp_enable") {
+		dhcp := d.Get("dhcp_enable").(bool)
+		updateOpts.DhcpEnable = &dhcp
+	}
+	if d.HasChange("dns_list") {
+		dnsList := utils.ExpandToStringList(d.Get("dns_list").([]interface{}))
+		updateOpts.DNSList = &dnsList
+	}
+
+	_, err = subnets.Update(subnetClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error updating IEC subnets: %s", err)
+	}
+
+	return resourceIecSubnetRead(ctx, d, meta)
+}
+
+func resourceIecSubnetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	subnetClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IEC client: %s", err)
+	}
+
+	err = subnets.Delete(subnetClient, d.Id()).ExtractErr()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting IEC subnets")
+	}
+
+	// waiting for subnets to become deleted
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"ACTIVE", "UNKNOWN"},
+		Target:     []string{"DELETED"},
+		Refresh:    waitForIecSubnetStatus(subnetClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, stateErr := stateConf.WaitForStateContext(ctx)
+	if stateErr != nil {
+		return diag.Errorf(
+			"error waiting for IEC subnets (%s) to become deleted: %s",
+			d.Id(), stateErr)
+	}
+
+	return nil
+}
+
+func waitForIecSubnetStatus(subnetClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		n, err := subnets.Get(subnetClient, id).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				log.Printf("[INFO] Successfully deleted IEC subnets %s", id)
+				return n, "DELETED", nil
+			}
+			return n, "ERROR", err
+		}
+
+		return n, n.Status, nil
+	}
+}


### PR DESCRIPTION
==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2       406       58         4      344         46            27.30
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~iec/resource_huaweicloud_iec_vpc_subnet.go       258       34         3      221         28            12.67
~rvices/iec/resource_huaweicloud_iec_vpc.go       148       24         1      123         18            14.63
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2       406       58         4      344         46            27.30
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 10529 bytes, 0.011 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
5 iec resourceIecSubnetUpdate huaweicloud/services/iec/resource_huaweicloud_iec_vpc_subnet.go:183:1 5 iec resourceIecVpcUpdate huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go:107:1 4 iec resourceIecSubnetDelete huaweicloud/services/iec/resource_huaweicloud_iec_vpc_subnet.go:212:1 4 iec resourceIecSubnetCreate huaweicloud/services/iec/resource_huaweicloud_iec_vpc_subnet.go:107:1 3 iec waitForIecSubnetStatus huaweicloud/services/iec/resource_huaweicloud_iec_vpc_subnet.go:245:1 3 iec resourceIecSubnetRead huaweicloud/services/iec/resource_huaweicloud_iec_vpc_subnet.go:154:1 3 iec resourceIecSubnetDNSList huaweicloud/services/iec/resource_huaweicloud_iec_vpc_subnet.go:21:1 3 iec resourceIecVpcDelete huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go:131:1 3 iec resourceIecVpcRead huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go:85:1 3 iec resourceIecVpcCreate huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go:60:1 Average: 3.17

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go:138: // lintignore:R018

==> Checking for TF features in iec...

==> Checking for misspell in iec...

==> Checking for code complexity in ./huaweicloud/services/acceptance/iec... ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2       329       45         0      284         32            22.79
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~esource_huaweicloud_iec_vpc_subnet_test.go       147       20         0      127         16            12.60
~e/iec/resource_huaweicloud_iec_vpc_test.go       182       25         0      157         16            10.19
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2       329       45         0      284         32            22.79
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 9257 bytes, 0.009 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 iec testAccCheckIecVpcV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_test.go:114:1 6 iec testAccCheckIecVpcSubnetV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_subnet_test.go:77:1 5 iec testAccCheckIecVpcV1Destroy huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_test.go:93:1 5 iec testAccCheckIecVpcSubnetV1Destroy huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_subnet_test.go:56:1 1 iec testAccIecVpcV1_customer_update huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_test.go:174:1 Average: 2.38

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/iec...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/iec...

==> Cleanup patch...

Check Completed!

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/iec TESTARGS='-run TestAccIecVPCSubnetV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iec -v -run TestAccIecVPCSubnetV1_basic -timeout 360m -parallel 4
=== RUN   TestAccIecVPCSubnetV1_basic
=== PAUSE TestAccIecVPCSubnetV1_basic
=== CONT  TestAccIecVPCSubnetV1_basic
--- PASS: TestAccIecVPCSubnetV1_basic (79.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iec       79.668s

make testacc TEST=./huaweicloud/services/acceptance/iec TESTARGS='-run TestAccIecVpcV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iec -v -run TestAccIecVpcV1_basic -timeout 360m -parallel 4
=== RUN   TestAccIecVpcV1_basic
=== PAUSE TestAccIecVpcV1_basic
=== CONT  TestAccIecVpcV1_basic
--- PASS: TestAccIecVpcV1_basic (36.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iec       37.031s



