### PR TITLE
fix(DIS): fix DIS instance resource lint error

### DIFF
--- a/docs/resources/dis_stream.md
+++ b/docs/resources/dis_stream.md
@@ -46,10 +46,10 @@ The following arguments are supported:
   provider-level region will be used. Changing this creates a new DIS Stream resource.
 
 * `retention_period` - (Optional, Int, ForceNew) The number of hours for which data from the stream will be retained in DIS.
-  Value range: `24` to `72`. Unit: `hour`. Default:`24`. Changing this parameter will create a new resource.
+  Value range: **24** to **72**. Unit: **hour**. Default:**24**. Changing this parameter will create a new resource.
 
-* `data_type` - (Optional, String, ForceNew) Data type of the data putting into the stream. The value is one of `BLOB`,
-  `JSON` and `CSV`. Changing this parameter will create a new resource.
+* `data_type` - (Optional, String, ForceNew) Data type of the data putting into the stream. The value is one of **BLOB**,
+  **JSON** and **CSV**. Changing this parameter will create a new resource.
 
 * `auto_scale_max_partition_count` - (Optional, Int, ForceNew) Maximum number of partition for automatic scaling.
   Changing this parameter will create a new resource.
@@ -83,7 +83,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `writable_partition_count` - Total number of writable partitions (including partitions in ACTIVE and DELETED states).
 
-* `status` - Status of stream: `CREATING`,`RUNNING`,`TERMINATING`,`TERMINATED`,`FROZEN`.
+* `status` - Status of stream: **CREATING**,**RUNNING**,**TERMINATING**,**TERMINATED**,**FROZEN**.
 
 * `stream_id` - Indicates a stream ID in UUID format.
 

--- a/huaweicloud/services/acceptance/dis/resource_huaweicloud_dis_streams_test.go
+++ b/huaweicloud/services/acceptance/dis/resource_huaweicloud_dis_streams_test.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
-	"github.com/chnsz/golangsdk/openstack/dis/v2/streams"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/dis/v2/streams"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getDisStreamsResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DisV2Client(acceptance.HW_REGION_NAME)
+func getDisStreamsResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.DisV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("error creating DIS V2 client, err=%s", err)
+		return nil, fmt.Errorf("error creating DIS V2 client, err: %s", err)
 	}
 
 	return streams.Get(client, state.Primary.ID, streams.GetOpts{})


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
fix DIS instance resource lint error

**Special notes for your reviewer**:
testcase error has not been resolved
**Release note**:
```
./scripts/codecheck.sh ./huaweicloud/services/dis

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1       567       64         8      495         67            13.54
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~dbss/resource_huaweicloud_dbss_instance.go       567       64         8      495         67            13.54
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1       567       64         8      495         67            13.54
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 17738 bytes, 0.018 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
11 dbss resourceInstanceCreate huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:187:1
7 dbss createInstaceWaitingForStateCompleted huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:349:1
6 dbss waitForInstanceDelete huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:520:1
6 dbss resourceInstanceRead huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:416:1
4 dbss FilterInstances huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:483:1
4 dbss buildCreateInstanceBodyParams huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:281:1
3 dbss resourceInstanceDelete huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:496:1
1 dbss buildCreateInstanceRequestBodyCreateInstanceRequestBodyProductInfos huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:337:1
1 dbss buildCreateInstanceRequestBodyCreateInstanceRequestBodySecurityGroups huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:329:1
1 dbss buildCreateInstanceRequestBodyCreateInstanceRequestBodyNics huaweicloud/services/dbss/resource_huaweicloud_dbss_instance.go:320:1
Average: 3.83

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in dbss...

==> Checking for misspell in dbss...

==> Checking for code complexity in ./huaweicloud/services/acceptance/dbss...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1       141       16         1      124          8             6.45
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~resource_huaweicloud_dbss_instance_test.go       141       16         1      124          8             6.45
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1       141       16         1      124          8             6.45
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 4223 bytes, 0.004 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
5 dbss getInstanceResourceFunc huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_instance_test.go:20:1
1 dbss testInstance_basic huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_instance_test.go:122:1
1 dbss testInstance_base huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_instance_test.go:101:1
1 dbss TestAccInstance_basic huaweicloud/services/acceptance/dbss/resource_huaweicloud_dbss_instance_test.go:59:1
Average: 2

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/dbss...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/dbss...

==> Cleanup patch...

Check Completed!

```


## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dis" TESTARGS="-run TestAccResourceDisStream_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dis -v -run TestAccResourceDisStream_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDisStream_basic
=== PAUSE TestAccResourceDisStream_basic
=== CONT  TestAccResourceDisStream_basic
--- PASS: TestAccResourceDisStream_basic (40.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dis       40.258s
```
