### PR TITLE
feat(iam): add data source to query identity agencies

### DIFF
--- a/docs/data-sources/identity_agencies.md
+++ b/docs/data-sources/identity_agencies.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# huaweicloud_identity_agencies
+
+Use this data source to query the IAM agency list within HuaweiCloud.
+
+-> **NOTE:** You *must* have IAM read privileges to use this data source.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_identity_agencies" "all" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, String) Specifies the name of agency. The name is a string of 1 to 64 characters.
+
+* `trust_domain_id` - (Optional, String) Specifies the ID of delegated user domain.
+
+## Attribute Reference
+
+* `id` - The data source ID.
+
+* `agencies` - The details of the queried IAM agencies. The structure is documented below.
+
+The `agencies` block contains:
+
+* `id` - The agency ID.
+
+* `name` - The agency name.
+
+* `description` - The supplementary information about the agency.
+
+* `expired_at` - The expiration time of agency.
+
+* `created_at` -  The time when the agency was created.
+
+* `trust_domain_id` - The ID of delegated user domain.
+
+* `trust_domain_name` - The name of delegated user domain.
+
+* `duration` - The validity period of an agency.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4
+	github.com/chnsz/golangsdk v0.0.0-20231101044551-8d90fc75a1f6
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4 h1:Hwcokg8qsuPlybCcI2Q/ZRtcrA0oNNveB5Gt/XVYCdA=
-github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231101044551-8d90fc75a1f6 h1:o1k3ypD+Lw7C6RFRrMEAAUAzCPUj6y9b/Nuho2S8Fl0=
+github.com/chnsz/golangsdk v0.0.0-20231101044551-8d90fc75a1f6/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -492,6 +492,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_group":       iam.DataSourceIdentityGroup(),
 			"huaweicloud_identity_projects":    iam.DataSourceIdentityProjects(),
 			"huaweicloud_identity_users":       iam.DataSourceIdentityUsers(),
+			"huaweicloud_identity_agencies":    iam.DataSourceIdentityAgencies(),
 
 			"huaweicloud_identitycenter_instance": identitycenter.DataSourceIdentityCenter(),
 			"huaweicloud_identitycenter_groups":   identitycenter.DataSourceIdentityCenterGroups(),

--- a/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_agencies_test.go
+++ b/huaweicloud/services/acceptance/iam/data_source_huaweicloud_identity_agencies_test.go
@@ -1,0 +1,137 @@
+package iam
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccIdentityAgenciesDataSource_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_identity_agencies.all"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityAgenciesDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.0.name"),
+				),
+			},
+		},
+	})
+}
+
+const testAccIdentityAgenciesDataSourceBasic string = `
+data "huaweicloud_identity_agencies" "all" {
+}
+`
+
+func TestAccIdentityAgenciesDataSource_byName(t *testing.T) {
+	dataSourceName := "data.huaweicloud_identity_agencies.query_by_name"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityAgenciesDataSource_byName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIdentityAgenciesDataSource_byName(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_agency" "test" {
+  name                  = "%s"
+  description           = "This is a test agency"
+  delegated_domain_name = "%s"
+  duration              = "ONEDAY"
+
+  project_role {
+    project = "%s"
+    roles   = ["CCE Administrator"]
+  }
+}
+
+data "huaweicloud_identity_agencies" "query_by_name" {
+  depends_on = [
+    huaweicloud_identity_agency.test
+  ]
+  name = huaweicloud_identity_agency.test.name
+}
+`, rName, acceptance.HW_DOMAIN_NAME, acceptance.HW_REGION_NAME)
+}
+
+func TestAccIdentityAgenciesDataSource_byTrustDomainId(t *testing.T) {
+	dataSourceName := "data.huaweicloud_identity_agencies.query_by_trust_domain_id"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	randUUID, _ := uuid.GenerateUUID()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPrecheckDomainId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityAgenciesDataSource_byTrustDomainId(randUUID),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "agencies.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIdentityAgenciesDataSource_byTrustDomainId(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_agency" "test" {
+  name                  = "%s"
+  description           = "This is a test agency"
+  delegated_domain_name = "%s"
+  duration              = "ONEDAY"
+
+  project_role {
+    project = "%s"
+    roles   = ["CCE Administrator"]
+  }
+}
+
+data "huaweicloud_identity_agencies" "query_by_trust_domain_id" {
+  depends_on = [
+    huaweicloud_identity_agency.test
+  ]
+  trust_domain_id = "%s"
+}
+`, rName, acceptance.HW_DOMAIN_NAME, acceptance.HW_REGION_NAME, acceptance.HW_DOMAIN_ID)
+}

--- a/huaweicloud/services/iam/data_source_huaweicloud_identity_agencies.go
+++ b/huaweicloud/services/iam/data_source_huaweicloud_identity_agencies.go
@@ -1,0 +1,134 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/identity/v3/agency"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func DataSourceIdentityAgencies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIdentityAgenciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"trust_domain_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"agencies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"expired_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"duration": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"trust_domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"trust_domain_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIdentityAgenciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	iamClient, err := cfg.IAMV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	domainID := cfg.DomainID
+	if domainID == "" {
+		return diag.Errorf("the domain_id must be specified in the provider configuration")
+	}
+	opts := agency.ListOpts{
+		DomainID:      domainID,
+		Name:          d.Get("name").(string),
+		TrustDomainId: d.Get("trust_domain_id").(string),
+	}
+	pages, err := agency.List(iamClient, opts).AllPages()
+	if err != nil {
+		return diag.Errorf("error querying IAM agencies: %s", err)
+	}
+	resp, err := agency.ExtractList(pages)
+	if err != nil {
+		return diag.Errorf("error querying IAM agencies: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+	mErr := multierror.Append(nil,
+		d.Set("agencies", flattenAgencies(resp)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting IAM agencies fields: %s", err)
+	}
+
+	return nil
+}
+
+func flattenAgencies(agencies []agency.Agency) []map[string]interface{} {
+	if len(agencies) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(agencies))
+	for i, val := range agencies {
+		result[i] = map[string]interface{}{
+			"id":                val.ID,
+			"name":              val.Name,
+			"trust_domain_id":   val.DelegatedDomainID,
+			"trust_domain_name": val.DelegatedDomainName,
+			"created_at":        val.CreateTime,
+			"expired_at":        val.ExpireTime,
+			"description":       val.Description,
+			"duration":          val.Duration,
+		}
+	}
+	return result
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/vaults/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/vaults/requests.go
@@ -36,6 +36,7 @@ type BillingCreate struct {
 	PeriodType      string                  `json:"period_type,omitempty"`
 	IsAutoRenew     bool                    `json:"is_auto_renew,omitempty"`
 	IsAutoPay       bool                    `json:"is_auto_pay,omitempty"`
+	IsMultiAz       bool                    `json:"is_multi_az,omitempty"`
 }
 
 type BillingCreateExtraInfo struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/vaults/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/vaults/results.go
@@ -63,6 +63,7 @@ type Billing struct {
 	StorageUnit     string `json:"storage_unit"`
 	Used            int    `json:"used"`
 	FrozenScene     string `json:"frozen_scene"`
+	IsMultiAz       bool   `json:"is_multi_az"`
 }
 
 type ResourceResp struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3/agency/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3/agency/results.go
@@ -3,6 +3,7 @@ package agency
 import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/roles"
+	"github.com/chnsz/golangsdk/pagination"
 )
 
 type Agency struct {
@@ -78,4 +79,16 @@ func (r ListInheritedRolesResult) ExtractRoles() ([]InheritedRole, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Roles, err
+}
+
+type AgencyPage struct {
+	pagination.SinglePageBase
+}
+
+func ExtractList(r pagination.Page) ([]Agency, error) {
+	var s struct {
+		Agencies []Agency `json:"agencies"`
+	}
+	err := (r.(AgencyPage)).ExtractInto(&s)
+	return s.Agencies, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4
+# github.com/chnsz/golangsdk v0.0.0-20231101044551-8d90fc75a1f6
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -308,6 +308,7 @@ github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs
 github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata
 github.com/chnsz/golangsdk/openstack/sfs/v2/shares
 github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares
+github.com/chnsz/golangsdk/openstack/smn/v2/logtank
 github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions
 github.com/chnsz/golangsdk/openstack/smn/v2/topics
 github.com/chnsz/golangsdk/openstack/sms/v3/sources


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add data source to query identity agencies.


## PR Checklist

* [√] Tests added/passed.
* [√] Documentation updated.
* [√] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityAgenciesDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityAgenciesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityAgenciesDataSource_basic
=== PAUSE TestAccIdentityAgenciesDataSource_basic
=== CONT  TestAccIdentityAgenciesDataSource_basic
--- PASS: TestAccIdentityAgenciesDataSource_basic (11.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       11.965s
```
