### PR TITLE
feat(RDS): add rds sqlserver account resource

### DIFF
--- a/docs/resources/rds_sqlserver_account.md
+++ b/docs/resources/rds_sqlserver_account.md
@@ -1,0 +1,84 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_sqlserver_account
+
+Manages RDS SQLServer account resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_rds_sqlserver_account" "test" {
+  instance_id = var.instance_id
+  name        = "test_account_name"
+  password    = "Test@12345678"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the RDS SQLServer instance.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the username of the DB account. The username consists of 1 to 128
+  characters and must be different from system usernames. System users include **rdsadmin**, **rdsuser**, **rdsbackup**,
+  and **rdsmirror**.
+
+  Changing this parameter will create a new resource.
+
+* `password` - (Required, String) Specifies the password of the DB account. It consists of 8 to 128 characters and
+  contains at least three types of the following characters: uppercase letters, lowercase letters, digits, and special
+  characters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID of account which is formatted `<instance_id>/<name>`.
+
+* `state` - Indicates the DB user status. Its value can be any of the following:
+  + **unavailable**: The database user is unavailable.
+  + **available**: The database user is available.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+The RDS sqlserver account can be imported using the `instance_id` and `name` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_rds_sqlserver_account.test <instance_id>/<name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `password`. It is generally recommended
+running `terraform plan` after importing a RDS SQLServer account. You can then decide if changes should be applied to
+the RDS SQLServer account, or the resource definition should be updated to align with the RDS SQLServer account. Also
+you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_rds_sqlserver_account" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      password,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1078,6 +1078,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_mysql_database":               rds.ResourceMysqlDatabase(),
 			"huaweicloud_rds_mysql_database_privilege":     rds.ResourceMysqlDatabasePrivilege(),
 			"huaweicloud_rds_pg_account":                   rds.ResourcePgAccount(),
+			"huaweicloud_rds_sqlserver_account":            rds.ResourceSQLServerAccount(),
 			"huaweicloud_rds_sqlserver_database":           rds.ResourceSQLServerDatabase(),
 			"huaweicloud_rds_instance":                     rds.ResourceRdsInstance(),
 			"huaweicloud_rds_parametergroup":               rds.ResourceRdsConfiguration(),

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sqlserver_account_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sqlserver_account_test.go
@@ -1,0 +1,128 @@
+package rds
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSQLServerAccountResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getSQLServerAccount: query RDS SQLServer account
+	var (
+		getSQLServerAccountHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user/detail?page=1&limit=100"
+		getSQLServerAccountProduct = "rds"
+	)
+	getSQLServerAccountClient, err := cfg.NewServiceClient(getSQLServerAccountProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	// Split instance_id and user from resource id
+	parts := strings.Split(state.Primary.ID, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid ID format, must be <instance_id>/<name>")
+	}
+	instanceId := parts[0]
+	accountName := parts[1]
+
+	getSQLServerAccountPath := getSQLServerAccountClient.Endpoint + getSQLServerAccountHttpUrl
+	getSQLServerAccountPath = strings.ReplaceAll(getSQLServerAccountPath, "{project_id}",
+		getSQLServerAccountClient.ProjectID)
+	getSQLServerAccountPath = strings.ReplaceAll(getSQLServerAccountPath, "{instance_id}", instanceId)
+
+	getSQLServerAccountResp, err := pagination.ListAllItems(
+		getSQLServerAccountClient,
+		"page",
+		getSQLServerAccountPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQLServer account: %s", err)
+	}
+
+	getSQLServerAccountRespJson, err := json.Marshal(getSQLServerAccountResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQLServer account: %s", err)
+	}
+	var getSQLServerAccountRespBody interface{}
+	err = json.Unmarshal(getSQLServerAccountRespJson, &getSQLServerAccountRespBody)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQLServer account: %s", err)
+	}
+
+	account := utils.PathSearch(fmt.Sprintf("users[?name=='%s']|[0]", accountName), getSQLServerAccountRespBody, nil)
+
+	if account != nil {
+		return account, nil
+	}
+
+	return nil, fmt.Errorf("error get RDS SQLServer account by instanceID %s and account %s", instanceId, accountName)
+}
+
+func TestAccSQLServerAccount_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_rds_sqlserver_account.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getSQLServerAccountResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSQLServerAccount_basic(name, "Test@12345678"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrSet(rName, "state"),
+				),
+			},
+			{
+				Config: testSQLServerAccount_basic(name, "Test@1234567890"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testSQLServerAccount_basic(name, password string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_sqlserver_account" "test" {
+  instance_id = huaweicloud_rds_instance.test.id
+  name        = "%[2]s"
+  password    = "%[3]s"
+}
+`, testAccRdsInstance_sqlserver(name, password), name, password)
+}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_sqlserver_account.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_sqlserver_account.go
@@ -1,0 +1,308 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product RDS
+// ---------------------------------------------------------------
+
+package rds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceSQLServerAccount() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSQLServerAccountCreate,
+		UpdateContext: resourceSQLServerAccountUpdate,
+		ReadContext:   resourceSQLServerAccountRead,
+		DeleteContext: resourceSQLServerAccountDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the RDS SQLServer instance.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the username of the DB account.`,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: `Specifies the password of the DB account.`,
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the DB user status.`,
+			},
+		},
+	}
+}
+
+func resourceSQLServerAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createSQLServerAccount: create RDS SQLServer account.
+	var (
+		createSQLServerAccountHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user"
+		createSQLServerAccountProduct = "rds"
+	)
+	createSQLServerAccountClient, err := cfg.NewServiceClient(createSQLServerAccountProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	createSQLServerAccountPath := createSQLServerAccountClient.Endpoint + createSQLServerAccountHttpUrl
+	createSQLServerAccountPath = strings.ReplaceAll(createSQLServerAccountPath, "{project_id}",
+		createSQLServerAccountClient.ProjectID)
+	createSQLServerAccountPath = strings.ReplaceAll(createSQLServerAccountPath, "{instance_id}", instanceId)
+
+	createSQLServerAccountOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	createSQLServerAccountOpt.JSONBody = utils.RemoveNil(buildCreateSQLServerAccountBodyParams(d))
+	retryFunc := func() (interface{}, bool, error) {
+		_, err = createSQLServerAccountClient.Request("POST", createSQLServerAccountPath, &createSQLServerAccountOpt)
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
+	}
+	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(createSQLServerAccountClient, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error creating RDS SQLServer account: %s", err)
+	}
+
+	accountName := d.Get("name").(string)
+	d.SetId(instanceId + "/" + accountName)
+
+	return resourceSQLServerAccountRead(ctx, d, meta)
+}
+
+func buildCreateSQLServerAccountBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":     d.Get("name"),
+		"password": d.Get("password"),
+	}
+	return bodyParams
+}
+
+func resourceSQLServerAccountRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getSQLServerAccount: query RDS SQLServer account
+	var (
+		getSQLServerAccountHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user/detail?page=1&limit=100"
+		getSQLServerAccountProduct = "rds"
+	)
+	getSQLServerAccountClient, err := cfg.NewServiceClient(getSQLServerAccountProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	// Split instance_id and account name from resource id
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return diag.Errorf("invalid ID format, must be <instance_id>/<name>")
+	}
+	instanceId := parts[0]
+	accountName := parts[1]
+
+	getSQLServerAccountPath := getSQLServerAccountClient.Endpoint + getSQLServerAccountHttpUrl
+	getSQLServerAccountPath = strings.ReplaceAll(getSQLServerAccountPath, "{project_id}",
+		getSQLServerAccountClient.ProjectID)
+	getSQLServerAccountPath = strings.ReplaceAll(getSQLServerAccountPath, "{instance_id}", instanceId)
+
+	getSQLServerAccountResp, err := pagination.ListAllItems(
+		getSQLServerAccountClient,
+		"page",
+		getSQLServerAccountPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving RDS SQLServer account")
+	}
+
+	getSQLServerAccountRespJson, err := json.Marshal(getSQLServerAccountResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var getSQLServerAccountRespBody interface{}
+	err = json.Unmarshal(getSQLServerAccountRespJson, &getSQLServerAccountRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	account := utils.PathSearch(fmt.Sprintf("users[?name=='%s']|[0]", accountName), getSQLServerAccountRespBody, nil)
+
+	if account == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", instanceId),
+		d.Set("name", utils.PathSearch("name", account, nil)),
+		d.Set("state", utils.PathSearch("state", account, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceSQLServerAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateSQLServerAccountChanges := []string{
+		"password",
+	}
+
+	if d.HasChanges(updateSQLServerAccountChanges...) {
+		// updateSQLServerAccount: update RDS SQLServer account password
+		var (
+			updateSQLServerAccountHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user/resetpwd"
+			updateSQLServerAccountProduct = "rds"
+		)
+		updateSQLServerAccountClient, err := cfg.NewServiceClient(updateSQLServerAccountProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating RDS client: %s", err)
+		}
+
+		instanceId := d.Get("instance_id").(string)
+		updateSQLServerAccountPath := updateSQLServerAccountClient.Endpoint + updateSQLServerAccountHttpUrl
+		updateSQLServerAccountPath = strings.ReplaceAll(updateSQLServerAccountPath, "{project_id}",
+			updateSQLServerAccountClient.ProjectID)
+		updateSQLServerAccountPath = strings.ReplaceAll(updateSQLServerAccountPath, "{instance_id}", instanceId)
+
+		updateSQLServerAccountOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		updateSQLServerAccountOpt.JSONBody = utils.RemoveNil(buildUpdateSQLServerAccountBodyParams(d))
+		retryFunc := func() (interface{}, bool, error) {
+			_, err = updateSQLServerAccountClient.Request("POST", updateSQLServerAccountPath, &updateSQLServerAccountOpt)
+			retry, err := handleMultiOperationsError(err)
+			return nil, retry, err
+		}
+		_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     rdsInstanceStateRefreshFunc(updateSQLServerAccountClient, instanceId),
+			WaitTarget:   []string{"ACTIVE"},
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			DelayTimeout: 1 * time.Second,
+			PollInterval: 10 * time.Second,
+		})
+		_, err = updateSQLServerAccountClient.Request("POST", updateSQLServerAccountPath, &updateSQLServerAccountOpt)
+		if err != nil {
+			return diag.Errorf("error updating RDS SQLServer account: %s", err)
+		}
+	}
+	return resourceSQLServerAccountRead(ctx, d, meta)
+}
+
+func buildUpdateSQLServerAccountBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":     utils.ValueIngoreEmpty(d.Get("name")),
+		"password": utils.ValueIngoreEmpty(d.Get("password")),
+	}
+	return bodyParams
+}
+
+func resourceSQLServerAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteSQLServerAccount: delete RDS SQLServer account
+	var (
+		deleteSQLServerAccountHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user/{user_name}"
+		deleteSQLServerAccountProduct = "rds"
+	)
+	deleteSQLServerAccountClient, err := cfg.NewServiceClient(deleteSQLServerAccountProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	deleteSQLServerAccountPath := deleteSQLServerAccountClient.Endpoint + deleteSQLServerAccountHttpUrl
+	deleteSQLServerAccountPath = strings.ReplaceAll(deleteSQLServerAccountPath, "{project_id}",
+		deleteSQLServerAccountClient.ProjectID)
+	deleteSQLServerAccountPath = strings.ReplaceAll(deleteSQLServerAccountPath, "{instance_id}", instanceId)
+	deleteSQLServerAccountPath = strings.ReplaceAll(deleteSQLServerAccountPath, "{user_name}",
+		d.Get("name").(string))
+
+	deleteSQLServerAccountOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		_, err = deleteSQLServerAccountClient.Request("DELETE", deleteSQLServerAccountPath, &deleteSQLServerAccountOpt)
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
+	}
+	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(deleteSQLServerAccountClient, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error deleting RDS SQLServer account: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
  add rds sqlserver account resource
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add rds sqlserver account resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccSQLServerAccount_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccSQLServerAccount_basic -timeout 360m -parallel 4
=== RUN   TestAccSQLServerAccount_basic
=== PAUSE TestAccSQLServerAccount_basic
=== CONT  TestAccSQLServerAccount_basic
--- PASS: TestAccSQLServerAccount_basic (853.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       853.143s
```
