### PR TITLE
fix(Cts): fix cts instance resource lint error

### DIFF
--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
@@ -14,6 +14,7 @@ import (
 
 	client "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3"
 	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -112,7 +113,6 @@ func ResourceCTSDataTracker() *schema.Resource {
 			},
 		},
 	}
-
 }
 
 func buildCreateRequestBody(d *schema.ResourceData) *cts.CreateTrackerRequestBody {
@@ -253,7 +253,6 @@ func resourceCTSDataTrackerUpdate(ctx context.Context, d *schema.ResourceData, m
 func resourceCTSDataTrackerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	var mErr *multierror.Error
 	ctsClient, err := cfg.HcCtsV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating CTS client: %s", err)
@@ -285,8 +284,8 @@ func resourceCTSDataTrackerRead(_ context.Context, d *schema.ResourceData, meta 
 	allTrackers := *response.Trackers
 	ctsTracker := allTrackers[0]
 
-	mErr = multierror.Append(
-		mErr,
+	mErr := multierror.Append(
+		nil,
 		d.Set("region", region),
 		d.Set("name", ctsTracker.TrackerName),
 		d.Set("lts_enabled", ctsTracker.Lts.IsLtsEnabled),
@@ -319,7 +318,6 @@ func resourceCTSDataTrackerRead(_ context.Context, d *schema.ResourceData, meta 
 				d.Set("transfer_enabled", true),
 				d.Set("obs_retention_period", ctsTracker.ObsInfo.BucketLifecycle),
 			)
-
 		} else {
 			mErr = multierror.Append(mErr, d.Set("transfer_enabled", false))
 		}
@@ -337,7 +335,7 @@ func resourceCTSDataTrackerRead(_ context.Context, d *schema.ResourceData, meta 
 		)
 	}
 
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func resourceCTSDataTrackerDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
@@ -6,13 +6,15 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/chnsz/golangsdk"
+
 	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -118,7 +120,6 @@ func ResourceCTSNotification() *schema.Resource {
 			},
 		},
 	}
-
 }
 
 func buildNotificationCreateRequestBody(d *schema.ResourceData) *cts.CreateNotificationRequestBody {
@@ -348,7 +349,6 @@ func formatCreateNotificationType(operationType string) cts.CreateNotificationRe
 		return allTypes.COMPLETE
 	}
 	return allTypes.CUSTOMIZED
-
 }
 
 func formatUpdateNotificationType(operationType string) cts.UpdateNotificationRequestBodyOperationType {

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go
@@ -205,7 +205,6 @@ func resourceCTSTrackerUpdate(ctx context.Context, d *schema.ResourceData, meta 
 func resourceCTSTrackerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	var mErr *multierror.Error
 	ctsClient, err := cfg.HcCtsV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating CTS client: %s", err)
@@ -222,9 +221,8 @@ func resourceCTSTrackerRead(_ context.Context, d *schema.ResourceData, meta inte
 		d.SetId("system")
 	}
 
-
-	mErr = multierror.Append(
-		mErr,
+	mErr := multierror.Append(
+		nil,
 		d.Set("region", region),
 		d.Set("name", ctsTracker.TrackerName),
 		d.Set("lts_enabled", ctsTracker.Lts.IsLtsEnabled),
@@ -260,7 +258,7 @@ func resourceCTSTrackerRead(_ context.Context, d *schema.ResourceData, meta inte
 		)
 	}
 
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func resourceCTSTrackerDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix cts instance resource lint error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 ./scripts/codecheck.sh ./huaweicloud/services/cts 
==> Checking for running environment... 

==> Applying patch... 
error: patch failed: huaweicloud/utils/fmtp/errors.go:7
error: huaweicloud/utils/fmtp/errors.go: patch does not apply
error: patch failed: huaweicloud/utils/logp/log.go:6
error: huaweicloud/utils/logp/log.go: patch does not apply
warning: cannot apply patch


==> Checking for code complexity...
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3      1153      160        10      983        171            52.27
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~es/cts/resource_huaweicloud_cts_tracker.go       377       56         4      317         60            18.93
~s/resource_huaweicloud_cts_data_tracker.go       382       49         4      329         56            17.02
~s/resource_huaweicloud_cts_notification.go       394       55         2      337         55            16.32
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3      1153      160        10      983        171            52.27
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 33027 bytes, 0.033 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
 
the TOP10 most complex functions:
12 cts resourceCTSDataTrackerRead huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go:253:1 
11 cts resourceCTSNotificationRead huaweicloud/services/cts/resource_huaweicloud_cts_notification.go:220:1
10 cts resourceCTSTrackerUpdate huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go:143:1
9 cts resourceCTSTrackerCreate huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go:104:1
8 cts resourceCTSTrackerRead huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go:199:1
8 cts resourceCTSDataTrackerUpdate huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go:203:1
6 cts buildDataBucketOpts huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go:133:1
5 cts resourceCTSNotificationUpdate huaweicloud/services/cts/resource_huaweicloud_cts_notification.go:286:1
5 cts buildNotifyUserOpts huaweicloud/services/cts/resource_huaweicloud_cts_notification.go:165:1
5 cts buildKeyOperationOpts huaweicloud/services/cts/resource_huaweicloud_cts_notification.go:138:1
Average: 4

==> Checking for golangci-lint...

==> Checking for Nolint directives... 

==> Checking for TF features in cts... 

==> Checking for misspell in cts... 

==> Checking for code complexity in ./huaweicloud/services/acceptance/cts... 
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3       463       55         0      408         45            31.85
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~s/resource_huaweicloud_cts_tracker_test.go       173       24         0      149         29            19.46
~ource_huaweicloud_cts_data_tracker_test.go       138       15         0      123          8             6.50
~ource_huaweicloud_cts_notification_test.go       152       16         0      136          8             5.88
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3       463       55         0      408         45            31.85
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 13899 bytes, 0.014 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
9 cts testAccCheckCTSTrackerDestroy huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go:106:1 
7 cts testAccCheckCTSTrackerExists huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go:71:1
5 cts getCTSNotificationResourceObj huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go:16:1
5 cts getCTSDataTrackerResourceObj huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go:16:1
3 cts testAccCTSTrackerImportState huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go:56:1
Average: 2.6

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/cts...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/cts... 

Check Completed!
```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cts/' TESTARGS='-run TestAccCTSDataTracker_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts/ -v -run TestAccCTSDataTracker_basic -timeout 360m -parallel 4 
=== RUN   TestAccCTSDataTracker_basic 
=== PAUSE TestAccCTSDataTracker_basic
=== CONT  TestAccCTSDataTracker_basic
--- PASS: TestAccCTSDataTracker_basic (78.27s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       78.308s

```
make testacc TEST='./huaweicloud/services/acceptance/cts/' TESTARGS='-run TestAccCTSNotification_basic'

```
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts/ -v -run TestAccCTSNotification_basic -timeout 360m -parallel 4 
=== RUN   TestAccCTSNotification_basic 
=== PAUSE TestAccCTSNotification_basic
=== CONT  TestAccCTSNotification_basic
--- PASS: TestAccCTSNotification_basic (69.07s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       69.114s

```
make testacc TEST='./huaweicloud/services/acceptance/cts/' TESTARGS='-run TestAccCTSTracker_basic'

```
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts/ -v -run TestAccCTSTracker_basic -timeout 360m -parallel 4 
=== RUN   TestAccCTSTracker_basic 
=== PAUSE TestAccCTSTracker_basic
=== CONT  TestAccCTSTracker_basic
--- PASS: TestAccCTSTracker_basic (38.55s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       38.589s

```
