### PR TITLE
feat(eg): event source support detail parameter

### DIFF
--- a/docs/resources/eg_custom_event_source.md
+++ b/docs/resources/eg_custom_event_source.md
@@ -8,15 +8,69 @@ Using this resource to manage an EG custom event source within Huaweicloud.
 
 ## Example Usage
 
+### Create a custom event source for the application type
+
 ```hcl
 variable "channel_id" {}
 variable "source_name" {}
 
 resource "huaweicloud_eg_custom_event_source" "test" {
   channel_id  = var.channel_id
-  type        = "RABBITMQ"
+  type        = "APPLICATION"
   name        = var.source_name
   description = "Created by script"
+}
+```
+
+### Create a custom event source for the RabbitMQ type
+
+```hcl
+variable "channel_id" {}
+variable "source_name" {}
+variable "rabbitmq_instance_id" {}
+variable "rabbitmq_user_name" {}
+variable "rabbitmq_user_password" {}
+variable "rabbitmq_vhost_name" {}
+variable "rabbitmq_queue_name" {}
+
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id = var.channel_id
+  type       = "RABBITMQ"
+  name       = var.source_name
+  detail     = jsonencode({
+    instance_id = var.rabbitmq_instance_id
+    user_name   = var.rabbitmq_user_name
+    password    = var.rabbitmq_user_password
+    vhost_name  = var.rabbitmq_vhost_name
+    queue_name  = var.rabbitmq_queue_name
+  })
+}
+```
+
+### Create a custom event source for the RocketMQ type
+
+```hcl
+variable "channel_id" {}
+variable "source_name" {}
+variable "rocketmq_instance_id" {}
+variable "rocketmq_instance_name" {}
+variable "rocketmq_instance_namesrv_address" {}
+variable "rocketmq_consumer_group_id" {}
+variable "rocketmq_topic_id" {}
+
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id = var.channel_id
+  type       = "ROCKETMQ"
+  name       = var.source_name
+  detail     = jsonencode({
+    instance_id     = var.rocketmq_instance_id
+    name            = var.rocketmq_instance_name
+    namesrv_address = var.rocketmq_instance_namesrv_address
+    group           = var.rocketmq_consumer_group_id
+    topic           = var.rocketmq_topic_id
+    enable_acl      = false
+    ssl_enable      = false
+  })
 }
 ```
 
@@ -46,7 +100,12 @@ The following arguments are supported:
   Defaults to **APPLICATION**.  
   Changing this will create a new resource.
 
+  -> Before creating a **RocketMQ** event source, you need to open ingress rule for TCP `8,100` and `10,100`-`10,103`
+     ports for the security group.
+
 * `description` - (Optional, String) Specifies the description of the custom event source.
+
+* `detail` - (Optional, String) Specifies the configuration detail of the event source, in JSON format.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4
+	github.com/chnsz/golangsdk v0.0.0-20231101091647-f5fcd245e4e1
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4 h1:Hwcokg8qsuPlybCcI2Q/ZRtcrA0oNNveB5Gt/XVYCdA=
-github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231101091647-f5fcd245e4e1 h1:RgV1ThSi5aHyQz/evkNCb4jdsf4tbdIeDEDBmavqzSY=
+github.com/chnsz/golangsdk v0.0.0-20231101091647-f5fcd245e4e1/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -330,6 +330,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_custom_event_source_test.go
+++ b/huaweicloud/services/acceptance/eg/resource_huaweicloud_eg_custom_event_source_test.go
@@ -92,3 +92,166 @@ resource "huaweicloud_eg_custom_event_source" "test" {
 }
 `, acceptance.HW_EG_CHANNEL_ID, name)
 }
+
+func TestAccCustomEventSource_rocketMQ(t *testing.T) {
+	var (
+		obj custom.Source
+
+		rName = "huaweicloud_eg_custom_event_source.test"
+		name  = acceptance.RandomAccResourceName()
+		rc    = acceptance.InitResourceCheck(rName, &obj, getCustomEventSourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCustomEventSource_rocketMQ_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "channel_id", "huaweicloud_eg_custom_event_channel.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "ROCKETMQ"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccCustomEventSource_rocketMQ_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "channel_id", "huaweicloud_eg_custom_event_channel.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "ROCKETMQ"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCustomEventSource_rocketMQ_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+# The corresponding elastic network card cannot be deleted within one hour after the EG resources are deleted.
+data "huaweicloud_vpc_subnets" "test" {
+  name = "subnet-default"
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = "%[1]s"
+  delete_default_rules = true
+}
+  
+resource "huaweicloud_networking_secgroup_rule" "test" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  ports             = "8100,10100-10103"
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%[1]s"
+  engine_version    = "4.8.0"
+  storage_space     = 300
+  vpc_id            = try(data.huaweicloud_vpc_subnets.test.subnets[0].vpc_id, "")
+  subnet_id         = try(data.huaweicloud_vpc_subnets.test.subnets[0].id, "")
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 2)
+
+  flavor_id         = "c6.4u8g.cluster"
+  storage_spec_code = "dms.physical.storage.high.v2"
+  broker_num        = 1
+}
+
+resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
+  count = 2
+
+  instance_id     = huaweicloud_dms_rocketmq_instance.test.id
+  name            = format("%[1]s-%%d", count.index)
+  enabled         = true
+  broadcast       = true
+  brokers         = ["broker-0"]
+  retry_max_times = 3
+}
+
+resource "huaweicloud_dms_rocketmq_topic" "test" {
+  count = 2
+
+  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  name        = format("%[1]s-%%d", count.index)
+  queue_num   = 3
+  permission  = "all"
+
+  brokers {
+    name = "broker-0"
+  }
+}
+
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_eg_endpoint" "test" {
+  name      = "%[1]s"
+  vpc_id    = try(data.huaweicloud_vpc_subnets.test.subnets[0].vpc_id, "")
+  subnet_id = try(data.huaweicloud_vpc_subnets.test.subnets[0].id, "")
+}
+`, name)
+}
+
+func testAccCustomEventSource_rocketMQ_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+  name       = "%[2]s"
+  type       = "ROCKETMQ"
+  detail     = jsonencode({
+    instance_id     = huaweicloud_dms_rocketmq_instance.test.id
+    group           = try(split("/", huaweicloud_dms_rocketmq_consumer_group.test[0].id)[0], "")
+    topic           = try(split("/", huaweicloud_dms_rocketmq_topic.test[0].id)[0], "")
+    enable_acl      = false
+    name            = "%[2]s"
+    namesrv_address = huaweicloud_dms_rocketmq_instance.test.namesrv_address
+    ssl_enable      = false
+  })
+}
+`, testAccCustomEventSource_rocketMQ_base(name), name)
+}
+
+func testAccCustomEventSource_rocketMQ_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_eg_custom_event_source" "test" {
+  channel_id = huaweicloud_eg_custom_event_channel.test.id
+  name       = "%[2]s"
+  type       = "ROCKETMQ"
+  detail     = jsonencode({
+    instance_id     = huaweicloud_dms_rocketmq_instance.test.id
+    group           = try(split("/", huaweicloud_dms_rocketmq_consumer_group.test[1].id)[0], "")
+    topic           = try(split("/", huaweicloud_dms_rocketmq_topic.test[1].id)[0], "")
+    enable_acl      = false
+    name            = "%[2]s"
+    namesrv_address = huaweicloud_dms_rocketmq_instance.test.namesrv_address
+    ssl_enable      = false
+  })
+}
+`, testAccCustomEventSource_rocketMQ_base(name), name)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/requests.go
@@ -19,6 +19,8 @@ type CreateOpts struct {
 	Type string `json:"type,omitempty"`
 	// The description of the custom event source.
 	Description string `json:"description,omitempty"`
+	// The configuration detail of the event source, in JSON format.
+	Detail interface{} `json:"detail,omitempty"`
 }
 
 var requestOpts = golangsdk.RequestOpts{
@@ -101,6 +103,8 @@ type UpdateOpts struct {
 	SourceId string `json:"-" required:"true"`
 	// The description of the event source.
 	Description *string `json:"description,omitempty"`
+	// The configuration detail of the event source, in JSON format.
+	Detail interface{} `json:"detail,omitempty"`
 }
 
 // Update is a method used to modify an existing custom event source using given parameters.

--- a/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/eg/v1/source/custom/results.go
@@ -31,6 +31,8 @@ type Source struct {
 	// + RABBITMQ
 	// + ROCKETMQ
 	Type string `json:"type"`
+	// The configuration detail of the event source, in JSON format.
+	Detail interface{} `json:"detail"`
 	// The status of the event source
 	Status string `json:"status"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231027080141-c5721e2542e4
+# github.com/chnsz/golangsdk v0.0.0-20231101091647-f5fcd245e4e1
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -308,6 +308,7 @@ github.com/chnsz/golangsdk/openstack/servicestage/v2/jobs
 github.com/chnsz/golangsdk/openstack/servicestage/v2/metadata
 github.com/chnsz/golangsdk/openstack/sfs/v2/shares
 github.com/chnsz/golangsdk/openstack/sfs_turbo/v1/shares
+github.com/chnsz/golangsdk/openstack/smn/v2/logtank
 github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions
 github.com/chnsz/golangsdk/openstack/smn/v2/topics
 github.com/chnsz/golangsdk/openstack/sms/v3/sources


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The `detail` parameter is required if the event source of the type **ROCKETMQ** or type **RABBITMQ** is created.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. event source support detail parameter.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/eg' TESTARGS='-run=TestAccCustomEventSource_rocketMQ'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eg -v -run=TestAccCustomEventSource_rocketMQ -timeout 360m -parallel 4
=== RUN   TestAccCustomEventSource_rocketMQ
=== PAUSE TestAccCustomEventSource_rocketMQ
=== CONT  TestAccCustomEventSource_rocketMQ
--- PASS: TestAccCustomEventSource_rocketMQ (771.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        771.937s
```
