### PR TITLE
fix(Dataarts): fix dataarts instance resource lint error

### DIFF
--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_instance_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_instance_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/dayu/v1/instances"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func getInstanceResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DataArtsV1Client(acceptance.HW_REGION_NAME)
+func getInstanceResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.DataArtsV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DataArts Studio v1 client, err=%s", err)
 	}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/dayu/v1/instances"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix dataarts instance resource lint error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
./scripts/codecheck.sh ./huaweicloud/services/dataarts/
==> Checking for running environment... 

==> Applying patch...
error: patch failed: huaweicloud/utils/fmtp/errors.go:7 
error: huaweicloud/utils/fmtp/errors.go: patch does not apply
error: patch failed: huaweicloud/utils/logp/log.go:6
error: huaweicloud/utils/logp/log.go: patch does not apply
warning: cannot apply patch


==> Checking for code complexity...
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1       281       33         1      247         37            14.98
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ce_huaweicloud_dataarts_studio_instance.go       281       33         1      247         37            14.98
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1       281       33         1      247         37            14.98
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 7731 bytes, 0.008 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
8 dataarts resourceStudioInstanceCreate huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go:140:1
4 dataarts findStudioInstanceByID huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go:269:1
4 dataarts resourceStudioInstanceDelete huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go:226:1
4 dataarts resourceStudioInstanceRead huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go:190:1
3 dataarts refreshInstanceStatusFunc huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go:256:1
2 dataarts formatAutoRenew huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go:132:1
2 dataarts formatPeriodType huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go:125:1
1 dataarts ResourceStudioInstance huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go:23:1
Average: 3.5

==> Checking for golangci-lint...

==> Checking for Nolint directives... 
./docs/resources/dataarts_studio_instance.md:36:<!--markdownlint-disable MD033--> 

==> Checking for TF features in dataarts...

==> Checking for misspell in dataarts... 
 
==> Checking for code complexity in ./huaweicloud/services/acceptance/dataarts... 
───────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        1       103       12         0       91          7             7.69
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~aweicloud_dataarts_studio_instance_test.go       103       12         0       91          7             7.69
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     1       103       12         0       91          7             7.69
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 3197 bytes, 0.003 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
5 dataarts getInstanceResourceFunc huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_instance_test.go:18:1 
1 dataarts testAccInstance_basic huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_instance_test.go:78:1
1 dataarts TestAccResourceInstance_basic huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_instance_test.go:37:1
Average: 2.33

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/dataarts...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/dataarts... 

Check Completed!
```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
make testacc TEST='./huaweicloud/services/acceptance/dataarts/' TESTARGS='-run TestAccResourceInstance_basic'
```
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts/ -v -run TestAccResourceInstance_basic -timeout 360m -parallel 4 
=== RUN   TestAccResourceInstance_basic 
=== PAUSE TestAccResourceInstance_basic 
=== CONT  TestAccResourceInstance_basic
--- PASS: TestAccResourceInstance_basic (926.45s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  926.492s
...
