### PR TITLE
ci: use bflad/tfproviderlint-github-action v0.29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,6 @@ jobs:
           only-new-issues: true
 
   # This workflow contains a job called "tfproviderlint"
-  # Ignoring bflad/tfproviderlint until https://github.com/bflad/tfproviderlint/issues/255 is fixed...
-  # using ShiChangkuo/tfproviderlint instead
   # Ignore rules:
   # + R019: d.HasChanges() has many arguments, consider d.HasChangesExcept()
   # + S018: schema should use TypeList with MaxItems 1
@@ -66,27 +64,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ">=1.18"
+      - uses: actions/checkout@v3
 
-      - name: Checkout provider
-        uses: actions/checkout@v3
+      - uses: bflad/tfproviderlint-github-action@master
         with:
-          path: terraform-provider-huaweicloud
-
-      - name: Checkout tfproviderlint
-        uses: actions/checkout@v3
-        with:
-          repository: ShiChangkuo/tfproviderlint
-          path: tfproviderlint
-
-      - name: Install tfproviderlint and Check
-        run: |
-          cd ${{ github.workspace }}/tfproviderlint/cmd/tfproviderlint
-          go install
-          cd ${{ github.workspace }}/terraform-provider-huaweicloud
-          tfproviderlint -R019=false -S018=false -V011=false -V012=false -V013=false -V014=false ./...
+          args: -R019=false -S018=false -V011=false -V012=false -V013=false -V014=false ./...
 
   schema-markdown-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron-ci.yml
+++ b/.github/workflows/cron-ci.yml
@@ -29,33 +29,16 @@ jobs:
       run: make vet
 
   # This workflow contains a job called "tfproviderlint"
-  # Ignoring bflad/tfproviderlint until https://github.com/bflad/tfproviderlint/issues/255 is fixed...
-  # using ShiChangkuo/tfproviderlint instead
   tfproviderlint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ">=1.18"
+      - uses: actions/checkout@v3
 
-      - name: Checkout provider
-        uses: actions/checkout@v3
+      - uses: bflad/tfproviderlint-github-action@master
         with:
-          path: terraform-provider-huaweicloud
+          args: -R019=false -S018=false -V011=false -V012=false -V013=false -V014=false ./...
 
-      - name: Checkout tfproviderlint
-        uses: actions/checkout@v3
-        with:
-          repository: ShiChangkuo/tfproviderlint
-          path: tfproviderlint
-
-      - name: Install tfproviderlint and Check
-        run: |
-          cd ${{ github.workspace }}/tfproviderlint/cmd/tfproviderlint
-          go install
-          cd ${{ github.workspace }}/terraform-provider-huaweicloud
-          tfproviderlint -V011=false -V012=false -V013=false -V014=false -R019=false ./...
 
   # This workflow contains a job called "acc-test"
   acc-test:


### PR DESCRIPTION
the previous issue has been fixed in v0.29,
so we can use it directly.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
