### PR TITLE
refactor(dli): adjust resources and acceptance tests

### DIFF
--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_test.go
@@ -17,10 +17,10 @@ import (
 func getDatabaseResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	c, err := conf.DliV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HuaweiCloud DLI v1 client: %s", err)
+		return nil, fmt.Errorf("error creating DLI v1 client: %s", err)
 	}
 
-	return dli.GetDliSqlDatabaseByName(c, state.Primary.Attributes["name"])
+	return dli.GetDliSQLDatabaseByName(c, state.Primary.Attributes["name"])
 }
 
 func TestAccDliDatabase_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_permission_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_permission_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 )
 
-func getDliAuthResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DliV1Client(acceptance.HW_REGION_NAME)
+func getDliAuthResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.DliV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Dli v1 client, err=%s", err)
 	}
@@ -328,7 +328,7 @@ func TestAccResourceDliAuth_queue(t *testing.T) {
 }
 
 func testAccDliAuthResource_queue(name string, projectId string, privileges string) string {
-	queue := testAccDliQueue_basic(name, dli.CU_16)
+	queue := testAccDliQueue_basic(name, dli.CU16)
 	userConfig := testAccDliAuthUserConfig(name, projectId)
 
 	return fmt.Sprintf(`

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 )
 
-func getDliQueueResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DliV1Client(acceptance.HW_REGION_NAME)
+func getDliQueueResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.DliV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Dli v1 client, err=%s", err)
 	}
@@ -42,12 +42,12 @@ func TestAccDliQueue_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliQueue_basic(rName, dli.CU_16),
+				Config: testAccDliQueue_basic(rName, dli.CU16),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QUEUE_TYPE_SQL),
-					resource.TestCheckResourceAttr(resourceName, "cu_count", fmt.Sprintf("%d", dli.CU_16)),
+					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QueueTypeSQL),
+					resource.TestCheckResourceAttr(resourceName, "cu_count", fmt.Sprintf("%d", dli.CU16)),
 					resource.TestCheckResourceAttrSet(resourceName, "resource_mode"),
 					resource.TestCheckResourceAttrSet(resourceName, "create_time"),
 				),
@@ -96,12 +96,12 @@ func TestAccDliQueue_withGeneral(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliQueue_withGeneral(rName, dli.CU_16),
+				Config: testAccDliQueue_withGeneral(rName, dli.CU16),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QUEUE_TYPE_GENERAL),
-					resource.TestCheckResourceAttr(resourceName, "cu_count", fmt.Sprintf("%d", dli.CU_16)),
+					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QueueTypeGeneral),
+					resource.TestCheckResourceAttr(resourceName, "cu_count", fmt.Sprintf("%d", dli.CU16)),
 					resource.TestCheckResourceAttrSet(resourceName, "resource_mode"),
 					resource.TestCheckResourceAttrSet(resourceName, "create_time"),
 				),
@@ -158,7 +158,7 @@ func TestAccDliQueue_cidr(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QUEUE_TYPE_SQL),
+					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QueueTypeSQL),
 					resource.TestCheckResourceAttr(resourceName, "cu_count", "16"),
 					resource.TestCheckResourceAttr(resourceName, "resource_mode", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_cidr", "172.16.0.0/21"),
@@ -171,7 +171,7 @@ func TestAccDliQueue_cidr(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QUEUE_TYPE_SQL),
+					resource.TestCheckResourceAttr(resourceName, "queue_type", dli.QueueTypeSQL),
 					resource.TestCheckResourceAttr(resourceName, "cu_count", "16"),
 					resource.TestCheckResourceAttr(resourceName, "resource_mode", "1"),
 					resource.TestCheckResourceAttr(resourceName, "vpc_cidr", "172.16.0.0/18"),

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_spark_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_spark_job_test.go
@@ -55,8 +55,8 @@ func TestAccDliSparkJobV2_basic(t *testing.T) {
 }
 
 func testAccCheckDliSparkJobDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	client, err := config.DliV2Client(acceptance.HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := cfg.DliV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating Dli v2 client: %s", err)
 	}
@@ -69,7 +69,7 @@ func testAccCheckDliSparkJobDestroy(s *terraform.State) error {
 		resp, err := batches.GetState(client, rs.Primary.ID)
 		// If the status of the spark job is "dead" or "success", it means that the life cycle of the job has ended.
 		if err == nil && resp != nil && (resp.State != batches.StateDead && resp.State != batches.StateSuccess) {
-			return fmt.Errorf("spark job (%s) still exists.", rs.Primary.ID)
+			return fmt.Errorf("spark job (%s) still exists", rs.Primary.ID)
 		}
 	}
 

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getDliSqlJobResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DliV1Client(acceptance.HW_REGION_NAME)
+func getDliSQLJobResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.DliV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Dli v1 client, err=%s", err)
 	}
@@ -30,13 +30,13 @@ func TestAccResourceDliSqlJob_basic(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&sqlJobObj,
-		getDliSqlJobResourceFunc,
+		getDliSQLJobResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckDliSqlJobDestroy,
+		CheckDestroy:      testAccCheckDliSQLJobDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSqlJobBaseResource_basic(name),
@@ -65,16 +65,16 @@ func TestAccResourceDliSqlJob_query(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&sqlJobObj,
-		getDliSqlJobResourceFunc,
+		getDliSQLJobResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckDliSqlJobDestroy,
+		CheckDestroy:      testAccCheckDliSQLJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlJobBaseResource_query(name),
+				Config: testAccSQLJobBaseResource_query(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "sql", fmt.Sprint("SELECT * FROM ", name)),
@@ -101,16 +101,16 @@ func TestAccResourceDliSqlJob_async(t *testing.T) {
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&sqlJobObj,
-		getDliSqlJobResourceFunc,
+		getDliSQLJobResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckDliSqlJobDestroy,
+		CheckDestroy:      testAccCheckDliSQLJobDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlJobResource_aync(name),
+				Config: testAccSQLJobResource_aync(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "sql", fmt.Sprint("SELECT * FROM ", name)),
@@ -137,10 +137,10 @@ resource "huaweicloud_dli_sql_job" "test" {
   sql           = "DESC ${huaweicloud_dli_table.test.name}"
   database_name = huaweicloud_dli_database.test.name
 }
-`, testAccSqlJobBaseResource(name))
+`, testAccSQLJobBaseResource(name))
 }
 
-func testAccSqlJobBaseResource(name string) string {
+func testAccSQLJobBaseResource(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dli_database" "test" {
   name        = "%s"
@@ -168,7 +168,7 @@ resource "huaweicloud_dli_table" "test" {
 `, name, name)
 }
 
-func testAccSqlJobBaseResource_query(name string) string {
+func testAccSQLJobBaseResource_query(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -177,10 +177,10 @@ resource "huaweicloud_dli_sql_job" "test" {
   database_name = huaweicloud_dli_database.test.name
 
 }
-`, testAccSqlJobBaseResource(name))
+`, testAccSQLJobBaseResource(name))
 }
 
-func testAccSqlJobResource_aync(name string) string {
+func testAccSQLJobResource_aync(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -192,12 +192,12 @@ resource "huaweicloud_dli_sql_job" "test" {
     dli_sql_sqlasync_enabled = true
   }
 }
-`, testAccSqlJobBaseResource(name))
+`, testAccSQLJobBaseResource(name))
 }
 
-func testAccCheckDliSqlJobDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	client, err := config.DliV1Client(acceptance.HW_REGION_NAME)
+func testAccCheckDliSQLJobDestroy(s *terraform.State) error {
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := cfg.DliV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating Dli client, err=%s", err)
 	}

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_table_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_table_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 )
 
-func getDliTableResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.DliV1Client(acceptance.HW_REGION_NAME)
+func getDliTableResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.DliV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Dli v1 client, err=%s", err)
 	}
@@ -25,13 +25,13 @@ func getDliTableResourceFunc(config *config.Config, state *terraform.ResourceSta
 
 // check the dli table
 func TestAccResourceDliTable_basic(t *testing.T) {
-	var TableObj tables.CreateTableOpts
+	var tableObj tables.CreateTableOpts
 	resourceName := "huaweicloud_dli_table.test"
 	name := acceptance.RandomAccResourceName()
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
-		&TableObj,
+		&tableObj,
 		getDliTableResourceFunc,
 	)
 
@@ -61,7 +61,6 @@ func TestAccResourceDliTable_basic(t *testing.T) {
 }
 
 func testAccDliTableResource_basic(name string) string {
-
 	return fmt.Sprintf(`
 resource "huaweicloud_dli_database" "test" {
   name        = "%s"
@@ -90,14 +89,14 @@ resource "huaweicloud_dli_table" "test" {
 }
 
 func TestAccResourceDliTable_OBS(t *testing.T) {
-	var TableObj tables.CreateTableOpts
+	var tableObj tables.CreateTableOpts
 	resourceName := "huaweicloud_dli_table.test"
 	name := acceptance.RandomAccResourceName()
 	obsBucketName := acceptance.RandomAccResourceNameWithDash()
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
-		&TableObj,
+		&tableObj,
 		getDliTableResourceFunc,
 	)
 
@@ -129,7 +128,6 @@ func TestAccResourceDliTable_OBS(t *testing.T) {
 }
 
 func testAccDliTableResource_OBS(name string, obsBucketName string) string {
-
 	return fmt.Sprintf(`
 resource "huaweicloud_obs_bucket" "test" {
   bucket = "%s"

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_spark_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_spark_job.go
@@ -22,9 +22,12 @@ import (
 
 func ResourceDliSparkJobV2() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: ResourceDliSparkJobV2Create,
-		ReadContext:   ResourceDliSparkJobV2Read,
-		DeleteContext: ResourceDliSparkJobV2Delete,
+		CreateContext: resourceDliSparkJobCreate,
+		ReadContext:   resourceDliSparkJobRead,
+		DeleteContext: resourceDliSparkJobDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Delete: schema.DefaultTimeout(5 * time.Minute),
@@ -241,9 +244,10 @@ func buildDliSaprkJobCreateOpts(d *schema.ResourceData) batches.CreateOpts {
 	return result
 }
 
-func ResourceDliSparkJobV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	c, err := config.DliV2Client(config.GetRegion(d))
+func resourceDliSparkJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	c, err := cfg.DliV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DLI v2 client: %s", err)
 	}
@@ -255,12 +259,13 @@ func ResourceDliSparkJobV2Create(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(resp.ID)
 
-	return ResourceDliSparkJobV2Read(ctx, d, meta)
+	return resourceDliSparkJobRead(ctx, d, meta)
 }
 
-func ResourceDliSparkJobV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	c, err := config.DliV2Client(config.GetRegion(d))
+func resourceDliSparkJobRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	c, err := cfg.DliV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DLI v2 client: %s", err)
 	}
@@ -279,9 +284,10 @@ func ResourceDliSparkJobV2Read(_ context.Context, d *schema.ResourceData, meta i
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func ResourceDliSparkJobV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	c, err := config.DliV2Client(config.GetRegion(d))
+func resourceDliSparkJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	c, err := cfg.DliV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DLI v2 client: %s", err)
 	}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_sql_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_sql_job.go
@@ -21,9 +21,9 @@ import (
 
 func ResourceSqlJob() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSqlJobCreate,
-		ReadContext:   resourceSqlJobRead,
-		DeleteContext: resourceSqlJobDelete,
+		CreateContext: resourceSQLJobCreate,
+		ReadContext:   resourceSQLJobRead,
+		DeleteContext: resourceSQLJobDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -149,10 +149,10 @@ func ResourceSqlJob() *schema.Resource {
 	}
 }
 
-func resourceSqlJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.DliV1Client(region)
+func resourceSQLJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.DliV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DLI v1 client, err=%s", err)
 	}
@@ -187,13 +187,13 @@ func resourceSqlJobCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	return resourceSqlJobRead(ctx, d, meta)
+	return resourceSQLJobRead(ctx, d, meta)
 }
 
-func resourceSqlJobRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.DliV1Client(region)
+func resourceSQLJobRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.DliV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DLI v1 client, err=%s", err)
 	}
@@ -232,10 +232,10 @@ func resourceSqlJobRead(_ context.Context, d *schema.ResourceData, meta interfac
 }
 
 // This API is used to cancel a submitted job. If execution of a job completes or fails, this job cannot be canceled.
-func resourceSqlJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.DliV1Client(region)
+func resourceSQLJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.DliV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DLI v1 client, err=%s", err)
 	}
@@ -252,7 +252,6 @@ func resourceSqlJobDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	if detail.Status != sqljob.JobStatusFinished &&
 		detail.Status != sqljob.JobStatusFailed &&
 		detail.Status != sqljob.JobStatusCancelled {
-
 		cancelRst, err := sqljob.Cancel(client, jobId)
 		if err != nil {
 			return diag.Errorf("cancel DLI sql job failed. %q:%s", jobId, err)
@@ -260,10 +259,9 @@ func resourceSqlJobDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		if cancelRst == nil || !cancelRst.IsSuccess {
 			return diag.Errorf("cancel DLI sql job failed. %q", jobId)
 		}
-
 	}
 
-	err = checkSqlJobCancelledResult(ctx, client, jobId, d.Timeout(schema.TimeoutDelete))
+	err = checkSQLJobCancelledResult(ctx, client, jobId, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.Errorf("failed to check the result of deletion %s", err)
 	}
@@ -302,7 +300,7 @@ func buildConfParam(d *schema.ResourceData) []string {
 	return rt
 }
 
-func checkSqlJobCancelledResult(ctx context.Context, client *golangsdk.ServiceClient, id string,
+func checkSQLJobCancelledResult(ctx context.Context, client *golangsdk.ServiceClient, id string,
 	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Pending"},

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_table.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_table.go
@@ -143,9 +143,9 @@ func ResourceDliTable() *schema.Resource {
 }
 
 func resourceDliTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.DliV1Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.DliV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DLI v1 client, err=%s", err)
 	}
@@ -185,9 +185,9 @@ func resourceDliTableCreate(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourceDliTableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.DliV1Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.DliV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DLI v1 client, err=%s", err)
 	}
@@ -278,10 +278,10 @@ func setStoragePropertiesToState(d *schema.ResourceData, storageProperties []map
 	return mErr.ErrorOrNil()
 }
 
-func resourceDliTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.DliV1Client(region)
+func resourceDliTableDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.DliV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating DLI v1 client, err=%s", err)
 	}
@@ -305,16 +305,15 @@ func buildColumnParam(d *schema.ResourceData) []tables.ColumnOpts {
 	columns := d.Get("columns").([]interface{})
 	if len(columns) > 0 {
 		for _, raw := range columns {
-			config := raw.(map[string]interface{})
+			columnRaw := raw.(map[string]interface{})
 			column := tables.ColumnOpts{
-				ColumnName:        config["name"].(string),
-				Type:              config["type"].(string),
-				Description:       config["description"].(string),
-				IsPartitionColumn: utils.Bool(config["is_partition"].(bool)),
+				ColumnName:        columnRaw["name"].(string),
+				Type:              columnRaw["type"].(string),
+				Description:       columnRaw["description"].(string),
+				IsPartitionColumn: utils.Bool(columnRaw["is_partition"].(bool)),
 			}
 			rt = append(rt, column)
 		}
-
 	}
 
 	return rt
@@ -335,5 +334,4 @@ func filterByTableName(tablesResp []tables.Table4List, tableName string) (*table
 		}
 	}
 	return &tables.Table4List{}, golangsdk.ErrDefault404{}
-
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix dli instance resource lint error
the first test case do not have permission
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
modify the name of some non-standard functions and variables
modify the order of import package
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccDliAgency_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDliAgency_basic -timeout 360m -parallel 4
=== RUN   TestAccDliAgency_basic
=== PAUSE TestAccDliAgency_basic
=== CONT  TestAccDliAgency_basic
    acceptance.go:594: HW_DLI_AGENCY_FLAG must be set for DLI datasource DLI agency acceptance tests.
--- SKIP: TestAccDliAgency_basic (0.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       0.046s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccDliDatabase_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDliDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccDliDatabase_basic
=== PAUSE TestAccDliDatabase_basic
=== CONT  TestAccDliDatabase_basic
--- PASS: TestAccDliDatabase_basic (15.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       15.325s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccDatasourceAuth_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDatasourceAuth_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAuth_basic
=== PAUSE TestAccDatasourceAuth_basic
=== CONT  TestAccDatasourceAuth_basic
--- PASS: TestAccDatasourceAuth_basic (24.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       24.090s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccDatasourceConnection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDatasourceConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceConnection_basic
=== PAUSE TestAccDatasourceConnection_basic
=== CONT  TestAccDatasourceConnection_basic
--- PASS: TestAccDatasourceConnection_basic (323.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       323.184s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccGlobalVariable_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccGlobalVariable_basic -timeout 360m -parallel 4
=== RUN   TestAccGlobalVariable_basic
=== PAUSE TestAccGlobalVariable_basic
=== CONT  TestAccGlobalVariable_basic
--- PASS: TestAccGlobalVariable_basic (62.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       62.625s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccDliQueue_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDliQueue_basic -timeout 360m -parallel 4
=== RUN   TestAccDliQueue_basic
=== PAUSE TestAccDliQueue_basic
=== CONT  TestAccDliQueue_basic
--- PASS: TestAccDliQueue_basic (255.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       255.110s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccDliSparkJobV2_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDliSparkJobV2_basic -timeout 360m -parallel 4
=== RUN   TestAccDliSparkJobV2_basic
=== PAUSE TestAccDliSparkJobV2_basic
=== CONT  TestAccDliSparkJobV2_basic
--- PASS: TestAccDliSparkJobV2_basic (301.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       301.153s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccResourceDliSqlJob_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccResourceDliSqlJob_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDliSqlJob_basic
=== PAUSE TestAccResourceDliSqlJob_basic
=== CONT  TestAccResourceDliSqlJob_basic
--- PASS: TestAccResourceDliSqlJob_basic (70.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       70.688s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccResourceDliTable_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccResourceDliTable_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDliTable_basic
=== PAUSE TestAccResourceDliTable_basic
=== CONT  TestAccResourceDliTable_basic
--- PASS: TestAccResourceDliTable_basic (22.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       22.652s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccFlinkTemplate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccFlinkTemplate_basic -timeout 360m -parallel 4
=== RUN   TestAccFlinkTemplate_basic
=== PAUSE TestAccFlinkTemplate_basic
=== CONT  TestAccFlinkTemplate_basic
--- PASS: TestAccFlinkTemplate_basic (22.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       22.170s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccSparkTemplate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccSparkTemplate_basic -timeout 360m -parallel 4
=== RUN   TestAccSparkTemplate_basic
=== PAUSE TestAccSparkTemplate_basic
=== CONT  TestAccSparkTemplate_basic
--- PASS: TestAccSparkTemplate_basic (21.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       21.994s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccSQLTemplate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccSQLTemplate_basic -timeout 360m -parallel 4
=== RUN   TestAccSQLTemplate_basic
=== PAUSE TestAccSQLTemplate_basic
=== CONT  TestAccSQLTemplate_basic
--- PASS: TestAccSQLTemplate_basic (23.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       23.923s
```
```