### PR TITLE
refactor(eip): adjust resources and acceptance tests

### DIFF
--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eip_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccVpcEipDataSource_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eips_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_eips_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccVpcEipsDataSource_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_associate_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_eip_associate_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix eip instance resource lint error
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
modify the name of some non-standard functions and variables
modify the order of import package
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccBandWidthDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccBandWidthDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccBandWidthDataSource_basic
=== PAUSE TestAccBandWidthDataSource_basic
=== CONT  TestAccBandWidthDataSource_basic
--- PASS: TestAccBandWidthDataSource_basic (44.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       44.650s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcEipDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcEipDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEipDataSource_basic
=== PAUSE TestAccVpcEipDataSource_basic
=== CONT  TestAccVpcEipDataSource_basic
--- PASS: TestAccVpcEipDataSource_basic (30.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       30.376s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcEipsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcEipsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEipsDataSource_basic
=== PAUSE TestAccVpcEipsDataSource_basic
=== CONT  TestAccVpcEipsDataSource_basic
--- PASS: TestAccVpcEipsDataSource_basic (31.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       31.105s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccEIPAssociate_port"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccEIPAssociate_port -timeout 360m -parallel 4
=== RUN   TestAccEIPAssociate_port
=== PAUSE TestAccEIPAssociate_port
=== CONT  TestAccEIPAssociate_port
--- PASS: TestAccEIPAssociate_port (93.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       93.755s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccBandWidthAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccBandWidthAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccBandWidthAssociate_basic
=== PAUSE TestAccBandWidthAssociate_basic
=== CONT  TestAccBandWidthAssociate_basic
--- PASS: TestAccBandWidthAssociate_basic (52.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       52.510s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcBandWidth_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcBandWidth_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcBandWidth_basic
=== PAUSE TestAccVpcBandWidth_basic
=== CONT  TestAccVpcBandWidth_basic
--- PASS: TestAccVpcBandWidth_basic (30.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       30.373s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcEip_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcEip_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEip_basic
=== PAUSE TestAccVpcEip_basic
=== CONT  TestAccVpcEip_basic
--- PASS: TestAccVpcEip_basic (40.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       41.005s
```
