### PR TITLE
fix(IEC): fix iec move iecvip to service/iec

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -965,7 +965,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iec_security_group":      resourceIecSecurityGroup(),
 			"huaweicloud_iec_security_group_rule": resourceIecSecurityGroupRule(),
 			"huaweicloud_iec_server":              iec.ResourceIecServer(),
-			"huaweicloud_iec_vip":                 resourceIecVipV1(),
+			"huaweicloud_iec_vip":                 iec.ResourceIecVip(),
 			"huaweicloud_iec_vpc":                 iec.ResourceIecVpc(),
 			"huaweicloud_iec_vpc_subnet":          iec.ResourceIecSubnet(),
 

--- a/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vip_test.go
+++ b/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vip_test.go
@@ -1,29 +1,29 @@
-package huaweicloud
+package iec
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	iec_common "github.com/chnsz/golangsdk/openstack/iec/v1/common"
+	ieccommon "github.com/chnsz/golangsdk/openstack/iec/v1/common"
 	"github.com/chnsz/golangsdk/openstack/iec/v1/ports"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccIecVipResource_basic(t *testing.T) {
-	var iecPort iec_common.Port
+	var iecPort ieccommon.Port
 	rName := fmt.Sprintf("iec-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_iec_vip.vip_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIecVipDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIecVipDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIecVip_basic(rName),
@@ -43,14 +43,14 @@ func TestAccIecVipResource_basic(t *testing.T) {
 }
 
 func TestAccIecVipResource_associate(t *testing.T) {
-	var iecPort iec_common.Port
+	var iecPort ieccommon.Port
 	rName := fmt.Sprintf("iec-%s", acctest.RandString(5))
 	resourceName := "huaweicloud_iec_vip.vip_test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIecVipDestroy,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIecVipDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIecVip_associate(rName),
@@ -72,10 +72,10 @@ func TestAccIecVipResource_associate(t *testing.T) {
 }
 
 func testAccCheckIecVipDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*config.Config)
-	iecV1Client, err := config.IECV1Client(HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	iecV1Client, err := conf.IECV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud IEC client: %s", err)
+		return fmt.Errorf("Error creating IEC client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -85,28 +85,28 @@ func testAccCheckIecVipDestroy(s *terraform.State) error {
 
 		_, err := ports.Get(iecV1Client, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("IEC Vip still exists")
+			return fmt.Errorf("IEC Vip still exists")
 		}
 	}
 
 	return nil
 }
 
-func testAccCheckIecVipExists(n string, resource *iec_common.Port) resource.TestCheckFunc {
+func testAccCheckIecVipExists(n string, vipResource *ieccommon.Port) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID is set")
+			return fmt.Errorf("No ID is set")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		iecV1Client, err := config.IECV1Client(HW_REGION_NAME)
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		iecV1Client, err := config.IECV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating Huaweicloud IEC client: %s", err)
+			return fmt.Errorf("Error creating IEC client: %s", err)
 		}
 
 		found, err := ports.Get(iecV1Client, rs.Primary.ID).Extract()
@@ -115,10 +115,10 @@ func testAccCheckIecVipExists(n string, resource *iec_common.Port) resource.Test
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("IEC Vip not found")
+			return fmt.Errorf("IEC Vip not found")
 		}
 
-		*resource = *found
+		*vipResource = *found
 
 		return nil
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fix(IEC): fix iec move iecvip to service/iec

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

./scripts/codecheck.sh ./huaweicloud/services/iec

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        5      1622      199        27     1396        204            77.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~rvices/iec/resource_huaweicloud_iec_vip.go       313       42         9      262         55            20.99
~rvices/iec/resource_huaweicloud_iec_eip.go       313       38         3      272         53            19.49
~ces/iec/resource_huaweicloud_iec_server.go       593       61        11      521         50             9.60
~iec/resource_huaweicloud_iec_vpc_subnet.go       256       34         3      219         28            12.79
~rvices/iec/resource_huaweicloud_iec_vpc.go       147       24         1      122         18            14.75
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     5      1622      199        27     1396        204            77.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 43809 bytes, 0.044 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
9 iec updateIecVipAssociate huaweicloud/services/iec/resource_huaweicloud_iec_vip.go:258:1
8 iec resourceIecVIPCreate huaweicloud/services/iec/resource_huaweicloud_iec_vip.go:78:1
7 iec resourceIecServerCreate huaweicloud/services/iec/resource_huaweicloud_iec_server.go:333:1
7 iec waitForIecEipStatus huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:286:1
7 iec resourceIecEipCreate huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:105:1
6 iec resourceIecServerRead huaweicloud/services/iec/resource_huaweicloud_iec_server.go:412:1
6 iec resourceIecEipDelete huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:231:1
6 iec resourceIecEipUpdate huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:203:1
6 iec resourceIecEipRead huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:159:1
5 iec resourceIecSubnetUpdate huaweicloud/services/iec/resource_huaweicloud_iec_vpc_subnet.go:182:1
Average: 3.85

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go:138: // lintignore:R018

==> Checking for TF features in iec...

==> Checking for misspell in iec...

==> Checking for code complexity in ./huaweicloud/services/acceptance/iec...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        5       780      101         0      679         80            61.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~esource_huaweicloud_iec_vpc_subnet_test.go       147       20         0      127         16            12.60
~e/iec/resource_huaweicloud_iec_eip_test.go       109       18         0       91         16            17.58
~e/iec/resource_huaweicloud_iec_vpc_test.go       182       25         0      157         16            10.19
~ec/resource_huaweicloud_iec_server_test.go       168       15         0      153         16            10.46
~e/iec/resource_huaweicloud_iec_vip_test.go       174       23         0      151         16            10.60
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     5       780      101         0      679         80            61.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 22603 bytes, 0.023 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 iec testAccCheckIecVpcV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_test.go:114:1
6 iec testAccCheckIecVpcSubnetV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_subnet_test.go:77:1
6 iec testAccCheckIecVipExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vip_test.go:95:1
6 iec testAccCheckIecServerExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_server_test.go:56:1
6 iec testAccCheckIecEIPExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_eip_test.go:71:1
Average: 2.61

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/iec...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/iec...

==> Cleanup patch...

Check Completed!



## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/iec TESTARGS='-run TestAccIecVipResource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iec -v -run TestAccIecVipResource -timeout 360m -parallel 4
=== RUN   TestAccIecVipResource_basic
=== PAUSE TestAccIecVipResource_basic
=== RUN   TestAccIecVipResource_associate
=== PAUSE TestAccIecVipResource_associate
=== CONT  TestAccIecVipResource_basic
=== CONT  TestAccIecVipResource_associate
--- PASS: TestAccIecVipResource_basic (67.03s)
--- PASS: TestAccIecVipResource_associate (211.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iec       211.216s

