### PR TITLE
fix(codearts): wait one more time for ACTIVE state when creating

### DIFF
--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_repository.go
@@ -182,6 +182,8 @@ func waitForRepositoryActive(ctx context.Context, cfg *config.Config, d *schema.
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        5 * time.Second,
 		PollInterval: 5 * time.Second,
+		// We can't query the repository after it becomes ACTIVE immediately
+		ContinuousTargetOccurence: 2,
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

the acceptance test runs failed
```
run acceptance basic test: TestAccRepository_basic
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccRepository_basic -timeout 360m -parallel 4
=== RUN   TestAccRepository_basic
=== PAUSE TestAccRepository_basic
=== CONT  TestAccRepository_basic
    resource_huaweicloud_codearts_repository_test.go:58: Step 1/2 error: Error running apply: exit status 1
        
        Error: Provider produced inconsistent result after apply
        
        When applying changes to huaweicloud_codearts_repository.test, provider
        "provider[\"registry.terraform.io/hashicorp/huaweicloud\"]" produced an
        unexpected new value: Root object was present, but now absent.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccRepository_basic (21.81s)
FAIL
FAIL	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts	21.844s
FAIL
make: *** [GNUmakefile:21: testacc] Error 1
```

the API return 401 when we query the repository when it becomes **ACTIVE**
```
API Request URL: GET https://codehub-ext.cn-north-4.myhuaweicloud.com/v2/repositories/a4f8dda3869542f38de1feb2dffxxxx
2023/10/31 23:17:34 [DEBUG] API Response Body: {
  "error": {
    "code": "CH.080401",
    "message": "未授权"
  },
  "status": "failed"
}
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/codearts" TESTARGS="-run TestAccRepository_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccRepository_basic -timeout 360m -parallel 4
=== RUN   TestAccRepository_basic
=== PAUSE TestAccRepository_basic
=== CONT  TestAccRepository_basic
--- PASS: TestAccRepository_basic (28.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  28.251s
```
