### PR TITLE
feat(er): add data source er availability zones

### DIFF
--- a/docs/data-sources/er_availability_zones.md
+++ b/docs/data-sources/er_availability_zones.md
@@ -1,0 +1,28 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_availability_zones
+
+Use this data source to query availability zones where ER instances can be created within Huaweicloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_er_availability_zones" "all" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are supported:
+
+* `id` - The data source ID.
+
+* `names` - The names of availability zone.

--- a/docs/resources/er_instance.md
+++ b/docs/resources/er_instance.md
@@ -35,6 +35,8 @@ The following arguments are supported:
   allowed.
 
 * `availability_zones` - (Required, List) The availability zone list where the ER instance is located.
+  The maximum number of availability zone is two. Select two AZs to configure active-active deployment for high
+  availability which will ensure reliability and disaster recovery.
 
 * `asn` - (Required, Int, ForceNew) The BGP AS number of the ER instance.  
   The valid value is range from `64,512` to `65534` or range from `4,200,000,000` to `4,294,967,294`.
@@ -46,7 +48,6 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project ID to which the ER instance
 belongs.
-
   Changing this parameter will create a new resource.
 
 * `enable_default_propagation` - (Optional, Bool) Whether to enable the propagation of the default route table.  

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -465,9 +465,10 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_enterprise_project": eps.DataSourceEnterpriseProject(),
 
-			"huaweicloud_er_attachments":  er.DataSourceAttachments(),
-			"huaweicloud_er_instances":    er.DataSourceInstances(),
-			"huaweicloud_er_route_tables": er.DataSourceRouteTables(),
+			"huaweicloud_er_attachments":        er.DataSourceAttachments(),
+			"huaweicloud_er_instances":          er.DataSourceInstances(),
+			"huaweicloud_er_route_tables":       er.DataSourceRouteTables(),
+			"huaweicloud_er_availability_zones": er.DataSourceAvailabilityZones(),
 
 			"huaweicloud_evs_volumes":      evs.DataSourceEvsVolumesV2(),
 			"huaweicloud_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_availability_zones_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_availability_zones_test.go
@@ -1,0 +1,30 @@
+package er
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAZs_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_er_availability_zones.all"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAZs_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "names.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAZs_basic string = `data "huaweicloud_er_availability_zones" "all" {}`

--- a/huaweicloud/services/er/data_source_huaweicloud_er_availability_zones.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_availability_zones.go
@@ -1,0 +1,96 @@
+package er
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceAvailabilityZones() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAvailabilityZonesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// Attributes
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAvailabilityZonesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		listAvailabilityZoneHttpUrl = "v3/{project_id}/enterprise-router/availability-zones"
+		listAvailabilityZoneProduct = "er"
+	)
+	listAvailabilityZoneClient, err := cfg.NewServiceClient(listAvailabilityZoneProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating ER client: %s", err)
+	}
+
+	listAvailabilityZonePath := listAvailabilityZoneClient.Endpoint + listAvailabilityZoneHttpUrl
+	listAvailabilityZonePath = strings.ReplaceAll(listAvailabilityZonePath, "{project_id}",
+		listAvailabilityZoneClient.ProjectID)
+
+	listAvailabilityZoneOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	listAvailabilityZoneResp, err := listAvailabilityZoneClient.Request("GET", listAvailabilityZonePath,
+		&listAvailabilityZoneOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	listAvailabilityZoneRespBody, err := utils.FlattenResponse(listAvailabilityZoneResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("names", flattenListAvailabilityZone(listAvailabilityZoneRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListAvailabilityZone(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("availability_zones[?state == 'available'].code | sort(@)", resp, make([]string, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, v.(string))
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source er availability zones

## PR Checklist

* [√] Tests added/passed.
* [√] Documentation updated.
* [√] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/er" TESTARGS="-run TestAccDataSourceAZs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccDataSourceAZs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAZs_basic
=== PAUSE TestAccDataSourceAZs_basic
=== CONT  TestAccDataSourceAZs_basic
--- PASS: TestAccDataSourceAZs_basic (9.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        9.423s
```
