### PR TITLE
fix(WAF): WAF dedicated domain resource support three new fields

### DIFF
--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_domain_test.go
@@ -64,6 +64,14 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "custom_page.0.block_page_type", "application/json"),
 					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key1", "$time_local"),
 					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key2", "$tenant_id"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.status", "false"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "50"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "200"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "200"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.0", "ip_tag"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.1", "$remote_addr"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.session_tag", "session_tag"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.user_tag", "user_tag"),
 					resource.TestCheckResourceAttrSet(resourceName, "custom_page.0.page_content"),
 					resource.TestCheckResourceAttrSet(resourceName, "server.0.vpc_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "certificate_id"),
@@ -76,10 +84,16 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "alarm_page.template_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "compliance_certification.pci_3ds"),
 					resource.TestCheckResourceAttrSet(resourceName, "compliance_certification.pci_dss"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_protection.0.error_threshold"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_protection.0.error_percentage"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_protection.0.initial_downtime"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_protection.0.multiplier_for_consecutive_breakdowns"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_protection.0.pending_url_request_threshold"),
+					resource.TestCheckResourceAttrSet(resourceName, "connection_protection.0.duration"),
 				),
 			},
 			{
-				Config: testAccWafDedicatedDomainV1_update(randName),
+				Config: testAccWafDedicatedDomainV1_update1(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
@@ -99,6 +113,56 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "server.1.address", "119.8.0.15"),
 					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key2", "$request_length"),
 					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key3", "$remote_addr"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.error_threshold", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.error_percentage", "87.5"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.initial_downtime", "200"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.multiplier_for_consecutive_breakdowns", "5"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.pending_url_request_threshold", "7000"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.duration", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.status", "true"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "100"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.0", "ip_tag_update"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.1", "ip_tag_another"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.session_tag", "session_tag_update"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.user_tag", "user_tag_update"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedDomainV1_update2(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.error_threshold", "2147483647"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.error_percentage", "99"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.initial_downtime", "2147483647"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.multiplier_for_consecutive_breakdowns", "2147483647"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.pending_url_request_threshold", "2147483647"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.duration", "2147483647"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.status", "false"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "180"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.0", "ip_tag_update"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.1", "ip_tag_another"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.session_tag", "session_tag_update"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.user_tag", "user_tag_update"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedDomainV1_update3(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.error_threshold", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.error_percentage", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.initial_downtime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.multiplier_for_consecutive_breakdowns", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.pending_url_request_threshold", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.duration", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connection_protection.0.status", "true"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "0"),
 				),
 			},
 			{
@@ -272,6 +336,18 @@ EOF
     "key2" = "$tenant_id"
   }
 
+  timeout_settings {
+    connection_timeout = 50
+    read_timeout       = 200
+    write_timeout      = 200
+  }
+
+  traffic_mark {
+    ip_tags     = ["ip_tag", "$remote_addr"]
+    session_tag = "session_tag"
+    user_tag    = "user_tag"
+  }
+
   depends_on = [
     huaweicloud_waf_certificate.certificate_1
   ]
@@ -279,7 +355,7 @@ EOF
 `, testAccWafCertificateV1_conf(name), name)
 }
 
-func testAccWafDedicatedDomainV1_update(name string) string {
+func testAccWafDedicatedDomainV1_update1(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -318,6 +394,156 @@ resource "huaweicloud_waf_dedicated_domain" "domain_1" {
   forward_header_map = {
     "key2" = "$request_length"
     "key3" = "$remote_addr"
+  }
+
+  connection_protection {
+    error_threshold                       = 1000
+    error_percentage                      = 87.5
+    initial_downtime                      = 200
+    multiplier_for_consecutive_breakdowns = 5
+    pending_url_request_threshold         = 7000
+    duration                              = 10000
+    status                                = true
+  }
+
+  timeout_settings {
+    connection_timeout = 100
+    read_timeout       = 1000
+    write_timeout      = 1000
+  }
+
+  traffic_mark {
+    ip_tags     = ["ip_tag_update", "ip_tag_another"]
+    session_tag = "session_tag_update"
+    user_tag    = "user_tag_update"
+  }
+
+  depends_on = [
+    huaweicloud_waf_certificate.certificate_1
+  ]
+}
+`, testAccWafCertificateV1_conf(name), name)
+}
+
+func testAccWafDedicatedDomainV1_update2(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_dedicated_domain" "domain_1" {
+  domain         = "www.%s.com"
+  certificate_id = huaweicloud_waf_certificate.certificate_1.id
+  keep_policy    = false
+  proxy          = true
+  tls            = "TLS v1.2"
+  cipher         = "cipher_2"
+  pci_3ds        = true
+  pci_dss        = true
+  protect_status = 0
+  website_name   = "websiteName_update"
+  description    = "test description update"
+  redirect_url   = "$${http_host}/error.html"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.15"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+
+  forward_header_map = {
+    "key2" = "$request_length"
+    "key3" = "$remote_addr"
+  }
+
+  connection_protection {
+    error_threshold                       = 2147483647
+    error_percentage                      = 99
+    initial_downtime                      = 2147483647
+    multiplier_for_consecutive_breakdowns = 2147483647
+    pending_url_request_threshold         = 2147483647
+    duration                              = 2147483647
+    status                                = false
+  }
+
+  timeout_settings {
+    connection_timeout = 180
+    read_timeout       = 3600
+    write_timeout      = 3600
+  }
+
+  depends_on = [
+    huaweicloud_waf_certificate.certificate_1
+  ]
+}
+`, testAccWafCertificateV1_conf(name), name)
+}
+
+func testAccWafDedicatedDomainV1_update3(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_dedicated_domain" "domain_1" {
+  domain         = "www.%s.com"
+  certificate_id = huaweicloud_waf_certificate.certificate_1.id
+  keep_policy    = false
+  proxy          = true
+  tls            = "TLS v1.2"
+  cipher         = "cipher_2"
+  pci_3ds        = true
+  pci_dss        = true
+  protect_status = 0
+  website_name   = "websiteName_update"
+  description    = "test description update"
+  redirect_url   = "$${http_host}/error.html"
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.15"
+    port            = 8443
+    type            = "ipv4"
+    vpc_id          = huaweicloud_vpc.test.id
+  }
+
+  forward_header_map = {
+    "key2" = "$request_length"
+    "key3" = "$remote_addr"
+  }
+
+  connection_protection {
+    error_threshold                       = 0
+    error_percentage                      = 0
+    initial_downtime                      = 0
+    multiplier_for_consecutive_breakdowns = 0
+    pending_url_request_threshold         = 0
+    duration                              = 0
+    status                                = true
+  }
+
+  timeout_settings {
+    connection_timeout = 0
+    read_timeout       = 0
+    write_timeout      = 0
   }
 
   depends_on = [


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

WAF dedicated domain resource support three new fields

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Add three new fields: `connection_protection`, `timeout_setting`, `traffic_mark`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicateDomainV1_'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicateDomainV1_ -timeout 360m -parallel 4
=== RUN   TestAccWafDedicateDomainV1_basic
=== PAUSE TestAccWafDedicateDomainV1_basic
=== RUN   TestAccWafDedicateDomainV1_withEpsID
=== PAUSE TestAccWafDedicateDomainV1_withEpsID
=== CONT  TestAccWafDedicateDomainV1_basic
=== CONT  TestAccWafDedicateDomainV1_withEpsID
--- PASS: TestAccWafDedicateDomainV1_withEpsID (494.57s)
--- PASS: TestAccWafDedicateDomainV1_basic (549.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       549.912s
```
