### PR TITLE
feat(RDS): add rds sqlserver database privilege

### DIFF
--- a/docs/resources/rds_sqlserver_database_privilege.md
+++ b/docs/resources/rds_sqlserver_database_privilege.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_sqlserver_database_privilege
+
+Manages RDS SQL Server database privilege resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "db_name" {}
+variable "user_name_1" {}
+variable "user_name_2" {}
+
+resource "huaweicloud_rds_sqlserver_database_privilege" "test" {
+  instance_id = var.instance_id
+  db_name     = var.db_name
+
+  users {
+    name     = var.user_name_1
+    readonly = true
+  }
+
+  users {
+    name     = var.user_name_2
+    readonly = false
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the RDS SQL Server instance.
+
+  Changing this parameter will create a new resource.
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name.
+
+  Changing this parameter will create a new resource.
+
+* `users` - (Required, List) Specifies the account that associated with the database
+
+  --> **NOTE:** The account of **rdsuser** is system account, it can not be managed, and it will not be obtained.
+
+The [users](#SQLServerDatabasePrivilege_CreateUser) structure is documented below.
+
+<a name="SQLServerDatabasePrivilege_CreateUser"></a>
+The `users` block supports:
+
+* `name` - (Required, String) Specifies the username of the database account.
+
+* `readonly` - (Optional, Bool) Specifies the read-only permission. Value options:
+  + **true**: indicates the read-only permission.
+  + **false**: indicates the read and write permission.
+
+  Defaults to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID of database privilege which is formatted `<instance_id>/<db_name>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+The RDS SQL Server database privilege can be imported using the `instance_id` and `db_name` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_rds_sqlserver_database_privilege.test <instance_id>/<db_name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1084,6 +1084,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_pg_database":                  rds.ResourcePgDatabase(),
 			"huaweicloud_rds_sqlserver_account":            rds.ResourceSQLServerAccount(),
 			"huaweicloud_rds_sqlserver_database":           rds.ResourceSQLServerDatabase(),
+			"huaweicloud_rds_sqlserver_database_privilege": rds.ResourceSQLServerDatabasePrivilege(),
 			"huaweicloud_rds_instance":                     rds.ResourceRdsInstance(),
 			"huaweicloud_rds_parametergroup":               rds.ResourceRdsConfiguration(),
 			"huaweicloud_rds_read_replica_instance":        rds.ResourceRdsReadReplicaInstance(),

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sqlserver_database_privilege_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sqlserver_database_privilege_test.go
@@ -1,0 +1,179 @@
+package rds
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSQLServerDatabasePrivilegeResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getSQLServerDatabasePrivilege: query RDS SQLServer database privilege
+	var (
+		getSQLServerDatabasePrivilegeHttpUrl = "v3/{project_id}/instances/{instance_id}/database/db_user"
+		getSQLServerDatabasePrivilegeProduct = "rds"
+	)
+	getSQLServerDatabasePrivilegeClient, err := cfg.NewServiceClient(getSQLServerDatabasePrivilegeProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	// Split instance_id and database from resource id
+	parts := strings.Split(state.Primary.ID, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid ID format, must be <instance_id>/<db_name>")
+	}
+	instanceId := parts[0]
+	dbName := parts[1]
+
+	getSQLServerDatabasePrivilegePath := getSQLServerDatabasePrivilegeClient.Endpoint + getSQLServerDatabasePrivilegeHttpUrl
+	getSQLServerDatabasePrivilegePath = strings.ReplaceAll(getSQLServerDatabasePrivilegePath, "{project_id}",
+		getSQLServerDatabasePrivilegeClient.ProjectID)
+	getSQLServerDatabasePrivilegePath = strings.ReplaceAll(getSQLServerDatabasePrivilegePath, "{instance_id}", instanceId)
+
+	getSQLServerDatabasePrivilegeQueryParams := buildGetSQLServerDatabasePrivilegeQueryParams(dbName)
+	getSQLServerDatabasePrivilegePath += getSQLServerDatabasePrivilegeQueryParams
+
+	getSQLServerDatabasePrivilegeResp, err := pagination.ListAllItems(
+		getSQLServerDatabasePrivilegeClient,
+		"page",
+		getSQLServerDatabasePrivilegePath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQL Server database privilege: %s", err)
+	}
+
+	getSQLServerDatabasePrivilegeRespJson, err := json.Marshal(getSQLServerDatabasePrivilegeResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQL Server database privilege: %s", err)
+	}
+	var getSQLServerDatabasePrivilegeRespBody interface{}
+	err = json.Unmarshal(getSQLServerDatabasePrivilegeRespJson, &getSQLServerDatabasePrivilegeRespBody)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQL Server database privilege: %s", err)
+	}
+
+	curJson := utils.PathSearch("users[?name != 'rdsuser']", getSQLServerDatabasePrivilegeRespBody,
+		make([]interface{}, 0))
+	if len(curJson.([]interface{})) == 0 {
+		return nil, fmt.Errorf("error get RDS SQL Server database privilege")
+	}
+
+	return getSQLServerDatabasePrivilegeRespBody, nil
+}
+
+func buildGetSQLServerDatabasePrivilegeQueryParams(dbName string) string {
+	return fmt.Sprintf("?db-name=%s&page=1&limit=100", dbName)
+}
+
+func TestAccSQLServerDatabasePrivilege_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_rds_sqlserver_database_privilege.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getSQLServerDatabasePrivilegeResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSQLServerDatabasePrivilege_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "db_name",
+						"huaweicloud_rds_sqlserver_database.test", "name"),
+					resource.TestCheckResourceAttr(rName, "users.#", "1"),
+					resource.TestCheckResourceAttrPair(rName, "users.0.name",
+						"huaweicloud_rds_sqlserver_account.account_1", "name"),
+				),
+			},
+			{
+				Config: testSQLServerDatabasePrivilege_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "db_name",
+						"huaweicloud_rds_sqlserver_database.test", "name"),
+					resource.TestCheckResourceAttr(rName, "users.#", "1"),
+					resource.TestCheckResourceAttrPair(rName, "users.0.name",
+						"huaweicloud_rds_sqlserver_account.account_2", "name"),
+					resource.TestCheckResourceAttr(rName, "users.0.readonly", "true"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testSQLServerDatabasePrivilege_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_sqlserver_account" "account_1" {
+  instance_id = huaweicloud_rds_instance.test.id
+  name        = "%[2]s_1"
+  password    = "Test@12345678"
+}
+
+resource "huaweicloud_rds_sqlserver_database_privilege" "test" {
+  instance_id = huaweicloud_rds_instance.test.id
+  db_name     = huaweicloud_rds_sqlserver_database.test.name
+
+  users {
+    name = huaweicloud_rds_sqlserver_account.account_1.name
+  }
+}
+`, testSQLServerDatabase_basic(name), name)
+}
+
+func testSQLServerDatabasePrivilege_basic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_sqlserver_account" "account_1" {
+  instance_id = huaweicloud_rds_instance.test.id
+  name        = "%[2]s_1"
+  password    = "Test@12345678"
+}
+
+resource "huaweicloud_rds_sqlserver_account" "account_2" {
+  instance_id = huaweicloud_rds_instance.test.id
+  name        = "%[2]s_2"
+  password    = "Test@12345678"
+}
+
+resource "huaweicloud_rds_sqlserver_database_privilege" "test" {
+  instance_id = huaweicloud_rds_instance.test.id
+  db_name     = huaweicloud_rds_sqlserver_database.test.name
+
+  users {
+    name     = huaweicloud_rds_sqlserver_account.account_2.name
+    readonly = true
+  }
+}
+`, testSQLServerDatabase_basic(name), name)
+}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_sqlserver_database_privilege.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_sqlserver_database_privilege.go
@@ -1,0 +1,403 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product RDS
+// ---------------------------------------------------------------
+
+package rds
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const maxElementsPerRequest = 50
+
+func ResourceSQLServerDatabasePrivilege() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSQLServerDatabasePrivilegeCreate,
+		UpdateContext: resourceSQLServerDatabasePrivilegeUpdate,
+		ReadContext:   resourceSQLServerDatabasePrivilegeRead,
+		DeleteContext: resourceSQLServerDatabasePrivilegeDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the RDS SQL Server instance.`,
+			},
+			"db_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the database name.`,
+			},
+			"users": {
+				Type:        schema.TypeSet,
+				Elem:        sQLServerDatabasePrivilegeCreateUserSchema(),
+				Required:    true,
+				Set:         resourceRdsSQLServerDbPrivilegeHash,
+				Description: `Specifies the account that associated with the database`,
+			},
+		},
+	}
+}
+
+func sQLServerDatabasePrivilegeCreateUserSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the username of the database account.`,
+			},
+			"readonly": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the read-only permission.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceSQLServerDatabasePrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createSQLServerDatabasePrivilege: create RDS SQL Server database privilege.
+	var (
+		createSQLServerDatabasePrivilegeProduct = "rds"
+	)
+	createSQLServerDatabasePrivilegeClient, err := cfg.NewServiceClient(createSQLServerDatabasePrivilegeProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	if err = createSQLServerDatabasePrivilege(ctx, d, schema.TimeoutCreate, createSQLServerDatabasePrivilegeClient,
+		d.Get("users").(*schema.Set).List()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	dbName := d.Get("db_name").(string)
+	d.SetId(instanceId + "/" + dbName)
+
+	return resourceSQLServerDatabasePrivilegeRead(ctx, d, meta)
+}
+
+func resourceSQLServerDatabasePrivilegeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getSQLServerDatabasePrivilege: query RDS SQL Server database privilege
+	var (
+		getSQLServerDatabasePrivilegeHttpUrl = "v3/{project_id}/instances/{instance_id}/database/db_user"
+		getSQLServerDatabasePrivilegeProduct = "rds"
+	)
+	getSQLServerDatabasePrivilegeClient, err := cfg.NewServiceClient(getSQLServerDatabasePrivilegeProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	// Split instance_id and database from resource id
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return diag.Errorf("invalid ID format, must be <instance_id>/<db_name>")
+	}
+	instanceId := parts[0]
+	dbName := parts[1]
+
+	getSQLServerDatabasePrivilegePath := getSQLServerDatabasePrivilegeClient.Endpoint + getSQLServerDatabasePrivilegeHttpUrl
+	getSQLServerDatabasePrivilegePath = strings.ReplaceAll(getSQLServerDatabasePrivilegePath, "{project_id}",
+		getSQLServerDatabasePrivilegeClient.ProjectID)
+	getSQLServerDatabasePrivilegePath = strings.ReplaceAll(getSQLServerDatabasePrivilegePath, "{instance_id}", instanceId)
+
+	getSQLServerDatabasePrivilegeQueryParams := buildGetSQLServerDatabasePrivilegeQueryParams(dbName)
+	getSQLServerDatabasePrivilegePath += getSQLServerDatabasePrivilegeQueryParams
+
+	getSQLServerDatabasePrivilegeResp, err := pagination.ListAllItems(
+		getSQLServerDatabasePrivilegeClient,
+		"page",
+		getSQLServerDatabasePrivilegePath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving RDS SQL Server database privilege")
+	}
+
+	getSQLServerDatabasePrivilegeRespJson, err := json.Marshal(getSQLServerDatabasePrivilegeResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var getSQLServerDatabasePrivilegeRespBody interface{}
+	err = json.Unmarshal(getSQLServerDatabasePrivilegeRespJson, &getSQLServerDatabasePrivilegeRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// 'rdsuser' is system account, it can not be managed
+	users := utils.PathSearch("users[?name != 'rdsuser']", getSQLServerDatabasePrivilegeRespBody,
+		make([]interface{}, 0)).([]interface{})
+	if len(users) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", instanceId),
+		d.Set("db_name", dbName),
+		d.Set("users", users),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetSQLServerDatabasePrivilegeQueryParams(dbName string) string {
+	return fmt.Sprintf("?db-name=%s&page=1&limit=100", dbName)
+}
+
+func resourceSQLServerDatabasePrivilegeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// updateSQLServerDatabasePrivilege: update RDS SQL Server database privilege.
+	var (
+		updateSQLServerDatabasePrivilegeProduct = "rds"
+	)
+	updateSQLServerDatabasePrivilegeClient, err := cfg.NewServiceClient(updateSQLServerDatabasePrivilegeProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	oldRaws, newRaws := d.GetChange("users")
+	createUsers := newRaws.(*schema.Set).List()
+	deleteUsers := oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set)).List()
+
+	if len(deleteUsers) > 0 {
+		if err = deleteSQLServerDatabasePrivilege(ctx, d, schema.TimeoutUpdate, updateSQLServerDatabasePrivilegeClient,
+			deleteUsers); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if len(createUsers) > 0 {
+		if err = createSQLServerDatabasePrivilege(ctx, d, schema.TimeoutUpdate, updateSQLServerDatabasePrivilegeClient,
+			createUsers); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceSQLServerDatabasePrivilegeRead(ctx, d, meta)
+}
+
+func resourceSQLServerDatabasePrivilegeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteSQLServerDatabasePrivilege: delete RDS SQL Server database privilege
+	var (
+		deleteSQLServerDatabasePrivilegeProduct = "rds"
+	)
+	deleteSQLServerDatabasePrivilegeClient, err := cfg.NewServiceClient(deleteSQLServerDatabasePrivilegeProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	if err = deleteSQLServerDatabasePrivilege(ctx, d, schema.TimeoutDelete, deleteSQLServerDatabasePrivilegeClient,
+		d.Get("users").(*schema.Set).List()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func createSQLServerDatabasePrivilege(ctx context.Context, d *schema.ResourceData, timeout string,
+	client *golangsdk.ServiceClient, rawUsers interface{}) error {
+	// createSQLServerDatabasePrivilege: create RDS SQL Server database privilege.
+	createSQLServerDatabasePrivilegeHttpUrl := "v3/{project_id}/instances/{instance_id}/db_privilege"
+
+	instanceId := d.Get("instance_id").(string)
+	dbName := d.Get("db_name").(string)
+
+	createSQLServerDatabasePrivilegePath := client.Endpoint + createSQLServerDatabasePrivilegeHttpUrl
+	createSQLServerDatabasePrivilegePath = strings.ReplaceAll(createSQLServerDatabasePrivilegePath, "{project_id}",
+		client.ProjectID)
+	createSQLServerDatabasePrivilegePath = strings.ReplaceAll(createSQLServerDatabasePrivilegePath, "{instance_id}",
+		d.Get("instance_id").(string))
+
+	createSQLServerDatabasePrivilegeOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	users := buildCreateSQLServerDatabasePrivilegeRequestBodyCreateUser(rawUsers)
+	start := 0
+	end := int(math.Min(maxElementsPerRequest, float64(len(users))))
+	for start < end {
+		// A single request supports a maximum of 50 elements.
+		subUsers := users[start:end]
+		createSQLServerDatabasePrivilegeOpt.JSONBody = utils.RemoveNil(buildSQLServerDatabasePrivilegeBodyParams(dbName, subUsers))
+
+		retryFunc := func() (interface{}, bool, error) {
+			_, err := client.Request("POST", createSQLServerDatabasePrivilegePath, &createSQLServerDatabasePrivilegeOpt)
+			retry, err := handleMultiOperationsError(err)
+			return nil, retry, err
+		}
+		_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     rdsInstanceStateRefreshFunc(client, instanceId),
+			WaitTarget:   []string{"ACTIVE"},
+			Timeout:      d.Timeout(timeout),
+			DelayTimeout: 1 * time.Second,
+			PollInterval: 10 * time.Second,
+		})
+		if err != nil {
+			return fmt.Errorf("error creating RDS SQL Server database privilege: %s", err)
+		}
+		start += maxElementsPerRequest
+		end = int(math.Min(float64(end+maxElementsPerRequest), float64(len(users))))
+	}
+	return nil
+}
+
+func deleteSQLServerDatabasePrivilege(ctx context.Context, d *schema.ResourceData, timeout string,
+	client *golangsdk.ServiceClient, rawUsers interface{}) error {
+	// deleteSQLServerDatabasePrivilege: delete RDS SQL Server database privilege
+	deleteSQLServerDatabasePrivilegeHttpUrl := "v3/{project_id}/instances/{instance_id}/db_privilege"
+
+	instanceId := d.Get("instance_id").(string)
+	dbName := d.Get("db_name").(string)
+
+	deleteSQLServerDatabasePrivilegePath := client.Endpoint + deleteSQLServerDatabasePrivilegeHttpUrl
+	deleteSQLServerDatabasePrivilegePath = strings.ReplaceAll(deleteSQLServerDatabasePrivilegePath, "{project_id}",
+		client.ProjectID)
+	deleteSQLServerDatabasePrivilegePath = strings.ReplaceAll(deleteSQLServerDatabasePrivilegePath, "{instance_id}",
+		instanceId)
+
+	deleteSQLServerDatabasePrivilegeOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	users := buildDeleteSQLServerDatabasePrivilegeRequestBodyDeleteUser(rawUsers)
+	start := 0
+	end := int(math.Min(maxElementsPerRequest, float64(len(users))))
+	for start < end {
+		// A single request supports a maximum of 50 elements.
+		subUsers := users[start:end]
+		deleteSQLServerDatabasePrivilegeOpt.JSONBody = utils.RemoveNil(buildSQLServerDatabasePrivilegeBodyParams(dbName, subUsers))
+
+		retryFunc := func() (interface{}, bool, error) {
+			_, err := client.Request("DELETE", deleteSQLServerDatabasePrivilegePath, &deleteSQLServerDatabasePrivilegeOpt)
+			retry, err := handleMultiOperationsError(err)
+			return nil, retry, err
+		}
+		_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+			Ctx:          ctx,
+			RetryFunc:    retryFunc,
+			WaitFunc:     rdsInstanceStateRefreshFunc(client, instanceId),
+			WaitTarget:   []string{"ACTIVE"},
+			Timeout:      d.Timeout(timeout),
+			DelayTimeout: 1 * time.Second,
+			PollInterval: 10 * time.Second,
+		})
+		if err != nil {
+			return fmt.Errorf("error deleting RDS SQL Server database privilege: %s", err)
+		}
+		start += maxElementsPerRequest
+		end = int(math.Min(float64(end+maxElementsPerRequest), float64(len(users))))
+	}
+	return nil
+}
+
+func buildSQLServerDatabasePrivilegeBodyParams(dbName string, users interface{}) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"db_name": dbName,
+		"users":   users,
+	}
+	return bodyParams
+}
+
+func buildCreateSQLServerDatabasePrivilegeRequestBodyCreateUser(rawParams interface{}) []map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			raw := v.(map[string]interface{})
+			rst[i] = map[string]interface{}{
+				"name":     raw["name"],
+				"readonly": utils.ValueIngoreEmpty(raw["readonly"]),
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func buildDeleteSQLServerDatabasePrivilegeRequestBodyDeleteUser(rawParams interface{}) []map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			raw := v.(map[string]interface{})
+			rst[i] = map[string]interface{}{
+				"name": raw["name"],
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func resourceRdsSQLServerDbPrivilegeHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	if m["name"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+	}
+
+	return hashcode.String(buf.String())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
   add rds sqlserver database privilege
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   add rds sqlserver database privilege
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccSQLServerDatabasePrivilege_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccSQLServerDatabasePrivilege_basic -timeout 360m -parallel 4
=== RUN   TestAccSQLServerDatabasePrivilege_basic
=== PAUSE TestAccSQLServerDatabasePrivilege_basic
=== CONT  TestAccSQLServerDatabasePrivilege_basic
--- PASS: TestAccSQLServerDatabasePrivilege_basic (1161.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1161.122s
```
