### PR TITLE
fix(iec): move resource iec_security_group into services and fix codecheck errors

### DIFF
--- a/huaweicloud/data_source_huaweicloud_iec_security_group_test.go
+++ b/huaweicloud/data_source_huaweicloud_iec_security_group_test.go
@@ -14,9 +14,8 @@ func TestAccIECSecurityGroupDataSource_basic(t *testing.T) {
 	resourceName := "data.huaweicloud_iec_security_group.by_name"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIecSecurityGroupV1Destory,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceIECSecurityGroup_basic(rName, description),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -968,12 +968,13 @@ func Provider() *schema.Provider {
 			"huaweicloud_iec_keypair":             iec.ResourceKeypair(),
 			"huaweicloud_iec_network_acl":         resourceIecNetworkACL(),
 			"huaweicloud_iec_network_acl_rule":    resourceIecNetworkACLRule(),
-			"huaweicloud_iec_security_group":      resourceIecSecurityGroup(),
 			"huaweicloud_iec_security_group_rule": iec.ResourceIecSecurityGroupRule(),
-			"huaweicloud_iec_server":              iec.ResourceIecServer(),
-			"huaweicloud_iec_vip":                 iec.ResourceIecVip(),
-			"huaweicloud_iec_vpc":                 iec.ResourceIecVpc(),
-			"huaweicloud_iec_vpc_subnet":          iec.ResourceIecSubnet(),
+			"huaweicloud_iec_security_group":      iec.ResourceIecSecurityGroup(),
+
+			"huaweicloud_iec_server":     iec.ResourceIecServer(),
+			"huaweicloud_iec_vip":        iec.ResourceIecVip(),
+			"huaweicloud_iec_vpc":        iec.ResourceIecVpc(),
+			"huaweicloud_iec_vpc_subnet": iec.ResourceIecSubnet(),
 
 			"huaweicloud_images_image":                ims.ResourceImsImage(),
 			"huaweicloud_images_image_copy":           ims.ResourceImsImageCopy(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:fix(iec): move resource iec_group into services and fix codecheck errors

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

root@ecs-wangyuancheng:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud#  ./scripts/codecheck.sh ./huaweicloud/services/iec

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        9      2141      260        27     1854        257           120.48
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~rvices/iec/resource_huaweicloud_iec_vip.go       313       42         9      262         55            20.99
~rvices/iec/resource_huaweicloud_iec_eip.go       313       38         3      272         53            19.49
~ces/iec/resource_huaweicloud_iec_server.go       593       61        11      521         50             9.60
~iec/resource_huaweicloud_iec_vpc_subnet.go       256       34         3      219         28            12.79
~resource_huaweicloud_iec_security_group.go       219       28         0      191         28            14.66
~rvices/iec/resource_huaweicloud_iec_vpc.go       147       24         1      122         18            14.75
~iec/data_source_huaweicloud_iec_flavors.go       126       12         0      114         10             8.77
~/iec/data_source_huaweicloud_iec_images.go       112       12         0      100         10            10.00
~iec/data_source_huaweicloud_iec_keypair.go        62        9         0       53          5             9.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     9      2141      260        27     1854        257           120.48
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 57182 bytes, 0.057 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
9 iec updateIecVipAssociate huaweicloud/services/iec/resource_huaweicloud_iec_vip.go:258:1
8 iec resourceIecVIPCreate huaweicloud/services/iec/resource_huaweicloud_iec_vip.go:78:1
7 iec resourceIecServerCreate huaweicloud/services/iec/resource_huaweicloud_iec_server.go:333:1
7 iec waitForSecurityGroupDelete huaweicloud/services/iec/resource_huaweicloud_iec_security_group.go:190:1
7 iec resourceIecSecurityGroupV1Read huaweicloud/services/iec/resource_huaweicloud_iec_security_group.go:99:1
7 iec waitForIecEipStatus huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:286:1
7 iec resourceIecEipCreate huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:105:1
7 iec dataSourceIecImagesRead huaweicloud/services/iec/data_source_huaweicloud_iec_images.go:65:1
7 iec dataSourceIecFlavorsRead huaweicloud/services/iec/data_source_huaweicloud_iec_flavors.go:78:1
6 iec resourceIecServerRead huaweicloud/services/iec/resource_huaweicloud_iec_server.go:412:1
Average: 3.85

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go:138: // lintignore:R018

==> Checking for TF features in iec...

==> Checking for misspell in iec...

==> Checking for code complexity in ./huaweicloud/services/acceptance/iec...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        9      1063      141         0      922        102            90.35
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~rce_huaweicloud_iec_security_group_test.go       104       16         0       88         16            18.18
~e/iec/resource_huaweicloud_iec_vip_test.go       177       23         0      154         16            10.39
~ec/resource_huaweicloud_iec_server_test.go       168       15         0      153         16            10.46
~esource_huaweicloud_iec_vpc_subnet_test.go       147       20         0      127         16            12.60
~e/iec/resource_huaweicloud_iec_vpc_test.go       182       25         0      157         16            10.19
~e/iec/resource_huaweicloud_iec_eip_test.go       109       18         0       91         16            17.58
~data_source_huaweicloud_iec_images_test.go        53        8         0       45          3             6.67
~ata_source_huaweicloud_iec_flavors_test.go        81       11         0       70          3             4.29
~ata_source_huaweicloud_iec_keypair_test.go        42        5         0       37          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     9      1063      141         0      922        102            90.35
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 30559 bytes, 0.031 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 iec testAccCheckIecVpcV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_test.go:114:1
6 iec testAccCheckIecVpcSubnetV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_subnet_test.go:77:1
6 iec testAccCheckIecVipExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vip_test.go:95:1
6 iec testAccCheckIecServerExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_server_test.go:56:1
6 iec testAccCheckIecSecurityGroupV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_security_group_test.go:47:1
Average: 2.38

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/iec...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/iec...

==> Cleanup patch...

Check Completed!

## Acceptance Steps Performed

```
root@ecs-wangyuancheng:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/iec" TESTARGS="-run TestAccIecSecurityGroupResource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iec -v -run TestAccIecSecurityGroupResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecSecurityGroupResource_basic
--- PASS: TestAccIecSecurityGroupResource_basic (31.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iec       31.480s
```
