### PR TITLE
fix(iec): move resource iec_security_group_rule into services and fix codecheck errors

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -966,7 +966,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iec_network_acl":         resourceIecNetworkACL(),
 			"huaweicloud_iec_network_acl_rule":    resourceIecNetworkACLRule(),
 			"huaweicloud_iec_security_group":      resourceIecSecurityGroup(),
-			"huaweicloud_iec_security_group_rule": resourceIecSecurityGroupRule(),
+			"huaweicloud_iec_security_group_rule": iec.ResourceIecSecurityGroupRule(),
 			"huaweicloud_iec_server":              iec.ResourceIecServer(),
 			"huaweicloud_iec_vip":                 iec.ResourceIecVip(),
 			"huaweicloud_iec_vpc":                 iec.ResourceIecVpc(),

--- a/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_security_group_rule_test.go
+++ b/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_security_group_rule_test.go
@@ -1,4 +1,4 @@
-package huaweicloud
+package iec
 
 import (
 	"fmt"
@@ -12,11 +12,10 @@ import (
 	"github.com/chnsz/golangsdk/openstack/iec/v1/security/rules"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccIecSecurityGroupRuleResource_Basic(t *testing.T) {
-
 	groupName := "huaweicloud_iec_security_group.my_group"
 	ruleName1 := "huaweicloud_iec_security_group_rule.rule_1"
 	ruleName2 := "huaweicloud_iec_security_group_rule.rule_2"
@@ -26,9 +25,9 @@ func TestAccIecSecurityGroupRuleResource_Basic(t *testing.T) {
 	var rule1, rule2 rules.RespSecurityGroupRule
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckIecSecurityGroupRuleV1Destory,
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIecSecurityGroupRuleV1Destory,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIecSecurityGroupRuleV1_Basic(rName),
@@ -51,21 +50,20 @@ func TestAccIecSecurityGroupRuleResource_Basic(t *testing.T) {
 }
 
 func testAccCheckIecSecGroupV1Exists(n string, group *groups.RespSecurityGroupEntity) resource.TestCheckFunc {
-
 	return func(state *terraform.State) error {
 		rs, ok := state.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not found: %s", n)
+			return fmt.Errorf("not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID has been seted")
+			return fmt.Errorf("no ID has been seted")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		iecClient, err := config.IECV1Client(HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		iecClient, err := cfg.IECV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating Huaweicloud IEC client: %s", err)
+			return fmt.Errorf("error creating IEC client: %s", err)
 		}
 
 		found, err := groups.Get(iecClient, rs.Primary.ID).Extract()
@@ -74,7 +72,7 @@ func testAccCheckIecSecGroupV1Exists(n string, group *groups.RespSecurityGroupEn
 		}
 
 		if found.ID != rs.Primary.ID {
-			return fmtp.Errorf("IEC Security group not found")
+			return fmt.Errorf("IEC Security group not found")
 		}
 		*group = *found
 		return nil
@@ -82,21 +80,20 @@ func testAccCheckIecSecGroupV1Exists(n string, group *groups.RespSecurityGroupEn
 }
 
 func testAccCheckIecSecurityGroupRuleV1Exists(n string, rule *rules.RespSecurityGroupRule) resource.TestCheckFunc {
-
 	return func(state *terraform.State) error {
 		rs, ok := state.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Not fount: %s", n)
+			return fmt.Errorf("not fount: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("No ID has been seted")
+			return fmt.Errorf("no ID has been seted")
 		}
 
-		config := testAccProvider.Meta().(*config.Config)
-		iecClient, err := config.IECV1Client(HW_REGION_NAME)
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		iecClient, err := cfg.IECV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating Huaweicloud IEC client: %s", err)
+			return fmt.Errorf("error creating IEC client: %s", err)
 		}
 
 		found, err := rules.Get(iecClient, rs.Primary.ID).Extract()
@@ -104,7 +101,7 @@ func testAccCheckIecSecurityGroupRuleV1Exists(n string, rule *rules.RespSecurity
 			return err
 		}
 		if found.SecurityGroupRule.ID != rs.Primary.ID {
-			return fmtp.Errorf("IEC Security group rule not found")
+			return fmt.Errorf("IEC security group rule not found")
 		}
 		*rule = *found
 		return nil
@@ -112,11 +109,10 @@ func testAccCheckIecSecurityGroupRuleV1Exists(n string, rule *rules.RespSecurity
 }
 
 func testAccCheckIecSecurityGroupRuleV1Destory(state *terraform.State) error {
-
-	config := testAccProvider.Meta().(*config.Config)
-	iecClient, err := config.IECV1Client(HW_REGION_NAME)
+	cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+	iecClient, err := cfg.IECV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating Huaweicloud IEC client: %s", err)
+		return fmt.Errorf("error creating IEC client: %s", err)
 	}
 
 	for _, rs := range state.RootModule().Resources {
@@ -126,7 +122,7 @@ func testAccCheckIecSecurityGroupRuleV1Destory(state *terraform.State) error {
 
 		_, err := rules.Get(iecClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmtp.Errorf("IEC Security group rule still exists")
+			return fmt.Errorf("IEC security group rule still exists")
 		}
 	}
 

--- a/huaweicloud/services/iec/resource_huaweicloud_iec_security_group_rule.go
+++ b/huaweicloud/services/iec/resource_huaweicloud_iec_security_group_rule.go
@@ -1,28 +1,33 @@
-package huaweicloud
+package iec
 
 import (
+	"context"
+	"log"
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/iec/v1/common"
+	ieccommon "github.com/chnsz/golangsdk/openstack/iec/v1/common"
 	"github.com/chnsz/golangsdk/openstack/iec/v1/security/rules"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
-func resourceIecSecurityGroupRule() *schema.Resource {
-
+func ResourceIecSecurityGroupRule() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceIecSecurityGroupRuleV1Create,
-		Read:   resourceIecSecurityGroupRuleV1Read,
-		Delete: resourceIecSecurityGroupRuleV1Delete,
+		CreateContext: resourceIecSecurityGroupRuleV1Create,
+		ReadContext:   resourceIecSecurityGroupRuleV1Read,
+		DeleteContext: resourceIecSecurityGroupRuleV1Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -91,19 +96,18 @@ func resourceIecSecurityGroupRule() *schema.Resource {
 	}
 }
 
-func resourceIecSecurityGroupRuleV1Create(d *schema.ResourceData, meta interface{}) error {
-
-	config := meta.(*config.Config)
-	iecClient, err := config.IECV1Client(GetRegion(d, config))
+func resourceIecSecurityGroupRuleV1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	iecClient, err := cfg.IECV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud IEC client: %s", err)
+		return diag.Errorf("error creating IEC client: %s", err)
 	}
 
 	if d.Get("protocol").(string) != "icmp" && d.Get("port_range_min").(int) > d.Get("port_range_max").(int) {
-		return fmtp.Errorf("The value of `port_range_min` can not be greater than the value of `port_range_max`")
+		return diag.Errorf("the value of `port_range_min` can not be greater than the value of `port_range_max`")
 	}
 
-	sgRule := common.ReqSecurityGroupRuleEntity{
+	sgRule := ieccommon.ReqSecurityGroupRuleEntity{
 		Direction:       d.Get("direction").(string),
 		SecurityGroupID: d.Get("security_group_id").(string),
 		Description:     d.Get("description").(string),
@@ -124,33 +128,37 @@ func resourceIecSecurityGroupRuleV1Create(d *schema.ResourceData, meta interface
 
 	rule, err := rules.Create(iecClient, createOpts).Extract()
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud IEC Security Group Rule: %s", err)
+		return diag.Errorf("error creating IEC security group rule: %s", err)
 	}
 
 	d.SetId(rule.SecurityGroupRule.ID)
-	return resourceIecSecurityGroupRuleV1Read(d, meta)
+	return resourceIecSecurityGroupRuleV1Read(ctx, d, meta)
 }
 
-func resourceIecSecurityGroupRuleV1Read(d *schema.ResourceData, meta interface{}) error {
-
-	config := meta.(*config.Config)
-	iecClient, err := config.IECV1Client(GetRegion(d, config))
+func resourceIecSecurityGroupRuleV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	iecClient, err := cfg.IECV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud IEC client: %s", err)
+		return diag.Errorf("error creating IEC client: %s", err)
 	}
 
 	rule, err := rules.Get(iecClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "HuaweiCloud IEC Security Group Rule")
+		return common.CheckDeletedDiag(d, err, "IEC security group rule")
 	}
 
-	d.Set("description", rule.SecurityGroupRule.Description)
-	d.Set("direction", rule.SecurityGroupRule.Direction)
-	d.Set("ethertype", rule.SecurityGroupRule.EtherType)
-	d.Set("protocol", rule.SecurityGroupRule.Protocol)
-	d.Set("security_group_id", rule.SecurityGroupRule.SecurityGroupID)
-	d.Set("remote_ip_prefix", rule.SecurityGroupRule.RemoteIPPrefix)
-	d.Set("remote_group_id", rule.SecurityGroupRule.RemoteGroupID)
+	mErr := multierror.Append(
+		d.Set("description", rule.SecurityGroupRule.Description),
+		d.Set("direction", rule.SecurityGroupRule.Direction),
+		d.Set("ethertype", rule.SecurityGroupRule.EtherType),
+		d.Set("protocol", rule.SecurityGroupRule.Protocol),
+		d.Set("security_group_id", rule.SecurityGroupRule.SecurityGroupID),
+		d.Set("remote_ip_prefix", rule.SecurityGroupRule.RemoteIPPrefix),
+		d.Set("remote_group_id", rule.SecurityGroupRule.RemoteGroupID),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting fields: %s", err)
+	}
 
 	if ret, err := strconv.Atoi(rule.SecurityGroupRule.PortRangeMin.(string)); err == nil {
 		d.Set("port_range_min", ret)
@@ -162,12 +170,11 @@ func resourceIecSecurityGroupRuleV1Read(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func resourceIecSecurityGroupRuleV1Delete(d *schema.ResourceData, meta interface{}) error {
-
-	config := meta.(*config.Config)
-	iecClient, err := config.IECV1Client(GetRegion(d, config))
+func resourceIecSecurityGroupRuleV1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	iecClient, err := cfg.IECV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud IEC client: %s", err)
+		return diag.Errorf("error creating IEC client: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -179,9 +186,9 @@ func resourceIecSecurityGroupRuleV1Delete(d *schema.ResourceData, meta interface
 		MinTimeout: 3 * time.Second,
 	}
 
-	_, err = stateConf.WaitForState()
+	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmtp.Errorf("Error deleting HuaweiCloud IEC Security Group Rule: %s", err)
+		return diag.Errorf("error deleting IEC security group rule: %s", err)
 	}
 
 	d.SetId("")
@@ -189,12 +196,11 @@ func resourceIecSecurityGroupRuleV1Delete(d *schema.ResourceData, meta interface
 }
 
 func waitForSecurityGroupRuleDelete(client *golangsdk.ServiceClient, ruleID string) resource.StateRefreshFunc {
-
 	return func() (interface{}, string, error) {
 		rule, err := rules.Get(client, ruleID).Extract()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				logp.Printf("[DEBUG] Successfully deleted HuaweiCloud IEC Security Group Rule %s", ruleID)
+				log.Printf("[DEBUG] successfully deleted IEC security group rule %s", ruleID)
 				return rule, "DELETED", nil
 			}
 			return err, "ACTIVE", err
@@ -203,12 +209,12 @@ func waitForSecurityGroupRuleDelete(client *golangsdk.ServiceClient, ruleID stri
 		err = rules.Delete(client, ruleID).ExtractErr()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				logp.Printf("[DEBUG] Successfully deleted HuaweiCloud IEC Security Group Rule %s", ruleID)
+				log.Printf("[DEBUG] successfully deleted IEC security group rule %s", ruleID)
 				return rule, "DELETED", nil
 			}
 			return rule, "ACTIVE", err
 		}
-		logp.Printf("[DEBUG] HuaweiCloud IEC Security Group Rule %s still active.\n", ruleID)
+		log.Printf("[DEBUG] IEC security group rule %s still active.\n", ruleID)
 		return rule, "ACTIVE", nil
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:fix(iec): move resource iec_group_rule into services and fix codecheck errors
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

root@ecs-wangyuancheng:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# ./scripts/codecheck.sh ./huaweicloud/services/iec

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        9      2142      257        27     1858        258           120.69
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~rvices/iec/resource_huaweicloud_iec_vip.go       313       42         9      262         55            20.99
~rvices/iec/resource_huaweicloud_iec_eip.go       313       38         3      272         53            19.49
~ces/iec/resource_huaweicloud_iec_server.go       593       61        11      521         50             9.60
~rce_huaweicloud_iec_security_group_rule.go       220       25         0      195         29            14.87
~iec/resource_huaweicloud_iec_vpc_subnet.go       256       34         3      219         28            12.79
~rvices/iec/resource_huaweicloud_iec_vpc.go       147       24         1      122         18            14.75
~iec/data_source_huaweicloud_iec_flavors.go       126       12         0      114         10             8.77
~/iec/data_source_huaweicloud_iec_images.go       112       12         0      100         10            10.00
~iec/data_source_huaweicloud_iec_keypair.go        62        9         0       53          5             9.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     9      2142      257        27     1858        258           120.69
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 57942 bytes, 0.058 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
9 iec updateIecVipAssociate huaweicloud/services/iec/resource_huaweicloud_iec_vip.go:258:1
8 iec resourceIecVIPCreate huaweicloud/services/iec/resource_huaweicloud_iec_vip.go:78:1
7 iec resourceIecServerCreate huaweicloud/services/iec/resource_huaweicloud_iec_server.go:333:1
7 iec waitForIecEipStatus huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:286:1
7 iec resourceIecEipCreate huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:105:1
7 iec dataSourceIecImagesRead huaweicloud/services/iec/data_source_huaweicloud_iec_images.go:65:1
7 iec dataSourceIecFlavorsRead huaweicloud/services/iec/data_source_huaweicloud_iec_flavors.go:78:1
6 iec resourceIecServerRead huaweicloud/services/iec/resource_huaweicloud_iec_server.go:412:1
6 iec resourceIecSecurityGroupRuleV1Read huaweicloud/services/iec/resource_huaweicloud_iec_security_group_rule.go:138:1
6 iec resourceIecSecurityGroupRuleV1Create huaweicloud/services/iec/resource_huaweicloud_iec_security_group_rule.go:99:1
Average: 3.85

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go:138: // lintignore:R018

==> Checking for TF features in iec...

==> Checking for misspell in iec...

==> Checking for code complexity in ./huaweicloud/services/acceptance/iec...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        9      1115      146         0      969        111            90.69
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~uaweicloud_iec_security_group_rule_test.go       156       21         0      135         25            18.52
~ec/resource_huaweicloud_iec_server_test.go       168       15         0      153         16            10.46
~e/iec/resource_huaweicloud_iec_vip_test.go       177       23         0      154         16            10.39
~esource_huaweicloud_iec_vpc_subnet_test.go       147       20         0      127         16            12.60
~e/iec/resource_huaweicloud_iec_eip_test.go       109       18         0       91         16            17.58
~e/iec/resource_huaweicloud_iec_vpc_test.go       182       25         0      157         16            10.19
~data_source_huaweicloud_iec_images_test.go        53        8         0       45          3             6.67
~ata_source_huaweicloud_iec_flavors_test.go        81       11         0       70          3             4.29
~ata_source_huaweicloud_iec_keypair_test.go        42        5         0       37          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     9      1115      146         0      969        111            90.69
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 32335 bytes, 0.032 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 iec testAccCheckIecVpcV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_test.go:114:1
6 iec testAccCheckIecVpcSubnetV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_subnet_test.go:77:1
6 iec testAccCheckIecVipExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vip_test.go:95:1
6 iec testAccCheckIecServerExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_server_test.go:56:1
6 iec testAccCheckIecSecurityGroupRuleV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_security_group_rule_test.go:82:1
Average: 2.47

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/iec...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/iec...

==> Cleanup patch...

Check Completed!

## Acceptance Steps Performed

```
root@ecs-wangyuancheng:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/iec" TESTARGS="-run TestAccIecSecurityGroupRuleResource_Basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iec -v -run TestAccIecSecurityGroupRuleResource_Basic -timeout 360m -parallel 4
=== RUN   TestAccIecSecurityGroupRuleResource_Basic
--- PASS: TestAccIecSecurityGroupRuleResource_Basic (51.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iec       51.411s
```
