### PR TITLE
fix(eps): fix eps resource lint error

### DIFF
--- a/docs/resources/enterprise_project.md
+++ b/docs/resources/enterprise_project.md
@@ -21,7 +21,7 @@ resource "huaweicloud_enterprise_project" "test" {
 ## Argument Reference
 
 * `name` - (Required, String) Specifies the name of the enterprise project.
-  This parameter can contain `1` to `64` characters. Only letters, digits, underscores (_), and hyphens (-) are allowed.
+  This parameter can contain **1** to **64** characters. Only letters, digits, underscores (_), and hyphens (-) are allowed.
   The name must be unique in the domain and cannot include any form of the word "default" ("deFaulT", for instance).
 
 * `description` - (Optional, String) Specifies the description of the enterprise project.
@@ -44,17 +44,9 @@ In addition to all arguments above, the following attributes are exported:
   + **1**: Indicates enabled.
   + **2**: Indicates disabled.
 
-* `created_at` - Indicates the time (UTC) when the enterprise project was created. Example: `2018-05-18T06:49:06Z`.
+* `created_at` - Indicates the time (UTC) when the enterprise project was created. Example: **2018-05-18T06:49:06Z**.
 
-* `updated_at` - Indicates the time (UTC) when the enterprise project was modified. Example: `2018-05-28T02:21:36Z`.
-
-## Import
-
-Enterprise projects can be imported using their `id`, e.g.
-
-```bash
-$ terraform import huaweicloud_enterprise_project.test 88f889c7-270e-4e77-8230-bf7db08d9b0e
-```
+* `updated_at` - Indicates the time (UTC) when the enterprise project was modified. Example: **2018-05-28T02:21:36Z**.
 
 ## Timeouts
 
@@ -63,3 +55,11 @@ This resource provides the following timeouts configuration options:
 * `create` - Default is 5 minutes.
 * `update` - Default is 5 minutes.
 * `delete` - Default is 5 minutes.
+
+## Import
+
+Enterprise projects can be imported using their `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_enterprise_project.test <id>
+```

--- a/huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go
+++ b/huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go
@@ -11,17 +11,15 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
-func getResourceEnterpriseProject(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	epsClient, err := config.EnterpriseProjectClient(acceptance.HW_REGION_NAME)
+func getResourceEnterpriseProject(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	epsClient, err := conf.EnterpriseProjectClient(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("Unable to create HuaweiCloud EPS client : %s", err)
+		return nil, fmt.Errorf("unable to create EPS client: %s", err)
 	}
 
 	return enterpriseprojects.Get(epsClient, state.Primary.ID).Extract()
-
 }
 
 func TestAccEnterpriseProject_basic(t *testing.T) {
@@ -71,10 +69,10 @@ func TestAccEnterpriseProject_basic(t *testing.T) {
 }
 
 func testAccCheckEnterpriseProjectDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	epsClient, err := config.EnterpriseProjectClient(acceptance.HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	epsClient, err := conf.EnterpriseProjectClient(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Unable to create HuaweiCloud EPS client : %s", err)
+		return fmt.Errorf("unable to create EPS client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -85,7 +83,7 @@ func testAccCheckEnterpriseProjectDestroy(s *terraform.State) error {
 		project, err := enterpriseprojects.Get(epsClient, rs.Primary.ID).Extract()
 		if err == nil {
 			if project.Status != 2 {
-				return fmtp.Errorf("Project still active")
+				return fmt.Errorf("project still active")
 			}
 		}
 	}

--- a/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project.go
+++ b/huaweicloud/services/eps/data_source_huaweicloud_enterprise_project.go
@@ -53,7 +53,7 @@ func dataSourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, 
 	region := cfg.GetRegion(d)
 	epsClient, err := cfg.EnterpriseProjectClient(region)
 	if err != nil {
-		return diag.Errorf("Error creating EPS client %s", err)
+		return diag.Errorf("error creating EPS client: %s", err)
 	}
 
 	listOpts := enterpriseprojects.ListOpts{
@@ -64,7 +64,7 @@ func dataSourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, 
 	projects, err := enterpriseprojects.List(epsClient, listOpts).Extract()
 
 	if err != nil {
-		return diag.Errorf("Error retrieving enterprise projects %s", err)
+		return diag.Errorf("error retrieving enterprise projects: %s", err)
 	}
 
 	project, err := flattenEnterpriseProject(d, projects)
@@ -81,7 +81,7 @@ func dataSourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, 
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("Error setting enterprise project fields: %s", err)
+		return diag.Errorf("error setting enterprise project fields: %s", err)
 	}
 
 	return nil
@@ -96,7 +96,7 @@ func flattenEnterpriseProject(d *schema.ResourceData, projects []enterpriseproje
 
 	if len(projects) > 1 {
 		name := d.Get("name").(string)
-		// there is no condition to find the target enterprise project
+		// There is no condition to find the target enterprise project.
 		if name == "" {
 			return nil, fmt.Errorf("your query returned more than one result." +
 				" Please specify your enterprise project name or enterprise project id")
@@ -104,7 +104,7 @@ func flattenEnterpriseProject(d *schema.ResourceData, projects []enterpriseproje
 
 		for _, v := range projects {
 			if v.Name == name {
-				// use name to find the target enterprise project
+				// Use name to find the target enterprise project.
 				return &v, nil
 			}
 		}

--- a/huaweicloud/services/eps/resource_huaweicloud_enterprise_project.go
+++ b/huaweicloud/services/eps/resource_huaweicloud_enterprise_project.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func ResourceEnterpriseProject() *schema.Resource {
@@ -34,7 +33,7 @@ func ResourceEnterpriseProject() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
-		//request and response parameters
+		// Request and response parameters.
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -83,11 +82,11 @@ func ResourceEnterpriseProject() *schema.Resource {
 }
 
 func resourceEnterpriseProjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	epsClient, err := config.EnterpriseProjectClient(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	epsClient, err := conf.EnterpriseProjectClient(conf.GetRegion(d))
 
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud EPS client : %s", err)
+		return diag.Errorf("unable to create EPS client: %s", err)
 	}
 
 	createOpts := enterpriseprojects.CreateOpts{
@@ -99,7 +98,7 @@ func resourceEnterpriseProjectCreate(ctx context.Context, d *schema.ResourceData
 	project, err := enterpriseprojects.Create(epsClient, createOpts).Extract()
 
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud Enterprise Project: %s", err)
+		return diag.Errorf("error creating Enterprise Project: %s", err)
 	}
 
 	d.SetId(project.ID)
@@ -108,11 +107,11 @@ func resourceEnterpriseProjectCreate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	epsClient, err := config.EnterpriseProjectClient(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	epsClient, err := conf.EnterpriseProjectClient(conf.GetRegion(d))
 
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud EPS client : %s", err)
+		return diag.Errorf("unable to create EPS client: %s", err)
 	}
 
 	project, err := enterpriseprojects.Get(epsClient, d.Id()).Extract()
@@ -136,18 +135,18 @@ func resourceEnterpriseProjectRead(_ context.Context, d *schema.ResourceData, me
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("error setting HuaweiCloud enterprise project fields: %w", err)
+		return diag.Errorf("error setting enterprise project fields: %s", err)
 	}
 
 	return nil
 }
 
 func resourceEnterpriseProjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	epsClient, err := config.EnterpriseProjectClient(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	epsClient, err := conf.EnterpriseProjectClient(conf.GetRegion(d))
 
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud EPS client : %s", err)
+		return diag.Errorf("unable to create EPS client: %s", err)
 	}
 
 	if d.HasChange("enable") {
@@ -160,9 +159,8 @@ func resourceEnterpriseProjectUpdate(ctx context.Context, d *schema.ResourceData
 
 		_, err = enterpriseprojects.Action(epsClient, actionOpts, d.Id()).Extract()
 		if err != nil {
-			return fmtp.DiagErrorf("Error enabling/disabling HuaweiCloud Enterprise Project: %s", err)
+			return diag.Errorf("error enabling/disabling Enterprise Project: %s", err)
 		}
-
 	}
 
 	if d.HasChanges("name", "description", "type") {
@@ -175,7 +173,7 @@ func resourceEnterpriseProjectUpdate(ctx context.Context, d *schema.ResourceData
 		_, err = enterpriseprojects.Update(epsClient, updateOpts, d.Id()).Extract()
 
 		if err != nil {
-			return fmtp.DiagErrorf("Error updating HuaweiCloud Enterprise Project: %s", err)
+			return diag.Errorf("error updating Enterprise Project: %s", err)
 		}
 	}
 
@@ -183,15 +181,15 @@ func resourceEnterpriseProjectUpdate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceEnterpriseProjectDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	epsClient, err := config.EnterpriseProjectClient(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	epsClient, err := conf.EnterpriseProjectClient(conf.GetRegion(d))
 
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud EPS client : %s", err)
+		return diag.Errorf("unable to create EPS client: %s", err)
 	}
 
 	if d.Get("skip_disable_on_destroy").(bool) {
-		log.Printf("[DEBUG] Skip disable on destroy for %s", d.Id())
+		log.Printf("[DEBUG] skip disable on destroy for %s", d.Id())
 		return nil
 	}
 
@@ -201,7 +199,7 @@ func resourceEnterpriseProjectDelete(_ context.Context, d *schema.ResourceData, 
 
 	_, err = enterpriseprojects.Action(epsClient, actionOpts, d.Id()).Extract()
 	if err != nil {
-		return fmtp.DiagErrorf("Error disabling HuaweiCloud Enterprise Project: %s", err)
+		return diag.Errorf("error disabling Enterprise Project: %s", err)
 	}
 
 	d.SetId("")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix eps resource lint error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
./scripts/codecheck.sh ./huaweicloud/services/eps

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2       330       50         3      277         42            30.32
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~resource_huaweicloud_enterprise_project.go       215       36         1      178         27            15.17
~a_source_huaweicloud_enterprise_project.go       115       14         2       99         15            15.15
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2       330       50         3      277         42            30.32
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 9057 bytes, 0.009 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
7 eps resourceEnterpriseProjectUpdate huaweicloud/services/eps/resource_huaweicloud_enterprise_project.go:144:1
6 eps flattenEnterpriseProject huaweicloud/services/eps/data_source_huaweicloud_enterprise_project.go:90:1
5 eps resourceEnterpriseProjectRead huaweicloud/services/eps/resource_huaweicloud_enterprise_project.go:109:1
5 eps dataSourceEnterpriseProjectRead huaweicloud/services/eps/data_source_huaweicloud_enterprise_project.go:51:1
4 eps resourceEnterpriseProjectDelete huaweicloud/services/eps/resource_huaweicloud_enterprise_project.go:183:1
3 eps resourceEnterpriseProjectCreate huaweicloud/services/eps/resource_huaweicloud_enterprise_project.go:84:1
1 eps ResourceEnterpriseProject huaweicloud/services/eps/resource_huaweicloud_enterprise_project.go:20:1
1 eps DataSourceEnterpriseProject huaweicloud/services/eps/data_source_huaweicloud_enterprise_project.go:16:1
Average: 4

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in eps...

==> Checking for misspell in eps...

==> Checking for code complexity in ./huaweicloud/services/acceptance/eps...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        2       143       21         0      122         11            11.83
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~rce_huaweicloud_enterprise_project_test.go       108       15         0       93         11            11.83
~rce_huaweicloud_enterprise_project_test.go        35        6         0       29          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     2       143       21         0      122         11            11.83
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 4159 bytes, 0.004 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 eps testAccCheckEnterpriseProjectDestroy huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go:71:1
2 eps getResourceEnterpriseProject huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go:16:1
1 eps testAccEnterpriseProject_update huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go:102:1
1 eps testAccEnterpriseProject_basic huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go:94:1
1 eps TestAccEnterpriseProject_basic huaweicloud/services/acceptance/eps/resource_huaweicloud_enterprise_project_test.go:25:1
Average: 2

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/eps...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/eps...

==> Cleanup patch...

Check Completed!

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eps" TESTARGS="-run TestAccEnterpriseProject_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eps -v -run TestAccEnterpriseProject_ -timeout 360m -parallel 4
=== RUN   TestAccEnterpriseProject_basic
=== PAUSE TestAccEnterpriseProject_basic
=== CONT  TestAccEnterpriseProject_basic
--- PASS: TestAccEnterpriseProject_basic (25.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eps       (cached)

```
