### PR TITLE
fix(IEC): move resource[iec_network_acl,iec_network_acl_rule] into services/iec and fix codecheck error

### DIFF
--- a/docs/resources/iec_network_acl.md
+++ b/docs/resources/iec_network_acl.md
@@ -65,6 +65,6 @@ This resource provides the following timeouts configuration options:
 
 Network ACL can be imported using the `id`, e.g.
 
-```
-$ terraform import huaweicloud_iec_network_acl.acl_test 40b1159c-4e6e-11eb-a00e-fa165c365e51
+```bash
+$ terraform import huaweicloud_iec_network_acl.acl_test <id>
 ```

--- a/docs/resources/iec_network_acl_rule.md
+++ b/docs/resources/iec_network_acl_rule.md
@@ -31,23 +31,23 @@ The following arguments are supported:
 
 * `network_acl_id` - (Required, String) Specifies a unique id for the iec network ACL.
 
-* `direction` - (Required, String, ForceNew) Specifies the direction of the rule, valid values are *ingress* or *egress*
-  . Changing this parameter creates a new iec network ACL rule resource.
+* `direction` - (Required, String, ForceNew) Specifies the direction of the rule, valid values are **ingress** or **egress**.
+  Changing this parameter creates a new iec network ACL rule resource.
 
 * `description` - (Optional, String) Specifies the description for the iec network ACL rule.
 
-* `protocol` - (Optional, String) Specifies the protocol supported by the iec network ACL rule. Valid values are: *tcp*
-  , *udp*, *icmp* and *any*.
+* `protocol` - (Optional, String) Specifies the protocol supported by the iec network ACL rule.Valid values are: **tcp**,
+  **udp**, **icmp** and **any**.
 
-* `action` - (Optional, String) Specifies the action in the iec network ACL rule. Currently, the value can be *allow*
-  or *deny*.
+* `action` - (Optional, String) Specifies the action in the iec network ACL rule. Currently, the value can be **allow**
+  or **deny**.
 
 * `source_ip_address` - (Optional, String) Specifies the source IP address that the traffic is allowed from. The default
-  value is *0.0.0.0/0*. For example:
+  value is **0.0.0.0/0**. For example:
   xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
 
 * `destination_ip_address` - (Optional, String) Specifies the destination IP address to which the traffic is allowed.
-  The default value is *0.0.0.0/0*. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
+  The default value is **0.0.0.0/0**. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
 
 * `source_port` - (Optional, String) Specifies the source port number or port number range. The value ranges from 1 to
   65535. For a port number range, enter two port numbers connected by a hyphen (-). For example, 1-100.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -966,15 +966,14 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_iec_eip":                 iec.ResourceIecNetworkEip(),
 			"huaweicloud_iec_keypair":             iec.ResourceKeypair(),
-			"huaweicloud_iec_network_acl":         resourceIecNetworkACL(),
-			"huaweicloud_iec_network_acl_rule":    resourceIecNetworkACLRule(),
+			"huaweicloud_iec_network_acl":         iec.ResourceNetworkACL(),
+			"huaweicloud_iec_network_acl_rule":    iec.ResourceNetworkACLRule(),
 			"huaweicloud_iec_security_group_rule": iec.ResourceIecSecurityGroupRule(),
 			"huaweicloud_iec_security_group":      iec.ResourceIecSecurityGroup(),
-
-			"huaweicloud_iec_server":     iec.ResourceIecServer(),
-			"huaweicloud_iec_vip":        iec.ResourceIecVip(),
-			"huaweicloud_iec_vpc":        iec.ResourceIecVpc(),
-			"huaweicloud_iec_vpc_subnet": iec.ResourceIecSubnet(),
+			"huaweicloud_iec_server":              iec.ResourceIecServer(),
+			"huaweicloud_iec_vip":                 iec.ResourceIecVip(),
+			"huaweicloud_iec_vpc":                 iec.ResourceIecVpc(),
+			"huaweicloud_iec_vpc_subnet":          iec.ResourceIecSubnet(),
 
 			"huaweicloud_images_image":                ims.ResourceImsImage(),
 			"huaweicloud_images_image_copy":           ims.ResourceImsImageCopy(),

--- a/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_network_acl_rule_test.go
+++ b/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_network_acl_rule_test.go
@@ -1,0 +1,109 @@
+package iec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/iec/v1/firewalls"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getNetworkACLRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	iecV1Client, err := conf.IECV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IEC v1 client: %s", err)
+	}
+
+	fwGroup, err := firewalls.Get(iecV1Client, state.Primary.ID).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(fwGroup.IngressFWPolicy.FirewallRules) < 1 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return fwGroup, nil
+}
+
+func TestAccNetworkACLRuleResource_basic(t *testing.T) {
+	var fwGroup firewalls.RespFirewallRulesEntity
+
+	aclResourceName := "huaweicloud_iec_network_acl.acl_test"
+	aclRuleResourceName := "huaweicloud_iec_network_acl_rule.rule_test"
+
+	rc := acceptance.InitResourceCheck(
+		aclResourceName,
+		&fwGroup,
+		getNetworkACLRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkACLRule_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(aclRuleResourceName, "protocol", "tcp"),
+					resource.TestCheckResourceAttr(aclRuleResourceName, "action", "allow"),
+					resource.TestCheckResourceAttr(aclRuleResourceName, "destination_port", "445"),
+				),
+			},
+			{
+				Config: testAccNetworkACLRule_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(aclRuleResourceName, "protocol", "udp"),
+					resource.TestCheckResourceAttr(aclRuleResourceName, "action", "deny"),
+					resource.TestCheckResourceAttr(aclRuleResourceName, "destination_port", "23-30"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkACLRule_basic() string {
+	return `
+resource "huaweicloud_iec_network_acl" "acl_test" {
+  name = "iec-acl-basic"
+}
+
+resource "huaweicloud_iec_network_acl_rule" "rule_test" {
+  network_acl_id         = huaweicloud_iec_network_acl.acl_test.id
+  direction              = "ingress"
+  protocol               = "tcp"
+  action                 = "allow"
+  source_ip_address      = "0.0.0.0/0"
+  destination_ip_address = "0.0.0.0/0"
+  destination_port       = "445"
+  enabled                = true
+}
+`
+}
+
+func testAccNetworkACLRule_basic_update() string {
+	return `
+resource "huaweicloud_iec_network_acl" "acl_test" {
+  name = "iec-acl-update"
+}
+
+resource "huaweicloud_iec_network_acl_rule" "rule_test" {
+  network_acl_id         = huaweicloud_iec_network_acl.acl_test.id
+  direction              = "ingress"
+  protocol               = "udp"
+  action                 = "deny"
+  source_ip_address      = "0.0.0.0/0"
+  destination_ip_address = "0.0.0.0/0"
+  destination_port       = "23-30"
+  enabled                = true
+}
+`
+}

--- a/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_network_acl_test.go
+++ b/huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_network_acl_test.go
@@ -1,0 +1,169 @@
+package iec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/iec/v1/firewalls"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getNetworkACLResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	iecV1Client, err := conf.IECV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IEC v1 client: %s", err)
+	}
+
+	fwGroup, err := firewalls.Get(iecV1Client, state.Primary.ID).Extract()
+	if err != nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return fwGroup, err
+}
+
+func TestAccNetworkACLResource_basic(t *testing.T) {
+	var fwGroup firewalls.Firewall
+
+	name := fmt.Sprintf("iec-acl-%s", acctest.RandString(5))
+	rName := "huaweicloud_iec_network_acl.acl_demo"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&fwGroup,
+		getNetworkACLResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIecNetworkACL_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform test acc"),
+					testAccCheckNetworkACLNetBlockExists(&fwGroup),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccIecNetworkACL_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
+					resource.TestCheckResourceAttr(rName, "description", "Updated by terraform test acc"),
+					testAccCheckNetworkACLNetBlockExists(&fwGroup),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkACLResource_no_subnets(t *testing.T) {
+	var fwGroup firewalls.Firewall
+
+	name := fmt.Sprintf("acc-fw-%s", acctest.RandString(5))
+	rName := "huaweicloud_iec_network_acl.acl_demo"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&fwGroup,
+		getNetworkACLResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIecNetworkACL_no_subnets(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"-noSubnet"),
+					resource.TestCheckResourceAttr(rName, "description", "Iec network acl without subents"),
+					resource.TestCheckResourceAttr(rName, "status", "INACTIVE"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkACLNetBlockExists(r *firewalls.Firewall) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(r.Subnets) == 0 {
+			return fmt.Errorf("the Subnet of IEC network ACL is not set")
+		}
+		return nil
+	}
+}
+
+var testAccIecNetworkACLRules = `
+data "huaweicloud_iec_sites" "sites_test" {}
+
+resource "huaweicloud_iec_vpc" "vpc_test" {
+  name = "vpc_demo"
+  cidr = "192.168.0.0/16"
+  mode = "CUSTOMER"
+}
+
+resource "huaweicloud_iec_vpc_subnet" "subnet_test" {
+  name        = "subnet_demo"
+  cidr        = "192.168.128.0/18"
+  vpc_id      = huaweicloud_iec_vpc.vpc_test.id
+  site_id     = data.huaweicloud_iec_sites.sites_test.sites[0].id
+  gateway_ip  = "192.168.128.3"
+}
+`
+
+func testAccIecNetworkACL_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_iec_network_acl" "acl_demo" {
+  name        = "%s"
+  description = "Created by terraform test acc"
+  networks {
+    vpc_id    = huaweicloud_iec_vpc.vpc_test.id
+    subnet_id = huaweicloud_iec_vpc_subnet.subnet_test.id
+  }
+}
+`, testAccIecNetworkACLRules, rName)
+}
+
+func testAccIecNetworkACL_basic_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_iec_network_acl" "acl_demo" {
+  name        = "%s-update"
+  description = "Updated by terraform test acc"
+  networks {
+    vpc_id    = huaweicloud_iec_vpc.vpc_test.id
+    subnet_id = huaweicloud_iec_vpc_subnet.subnet_test.id
+  }
+}
+`, testAccIecNetworkACLRules, rName)
+}
+
+func testAccIecNetworkACL_no_subnets(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_iec_network_acl" "acl_demo" {
+  name        = "%s-noSubnet"
+  description = "Iec network acl without subents"
+}
+`, rName)
+}

--- a/huaweicloud/services/iec/resource_huaweicloud_iec_network_acl.go
+++ b/huaweicloud/services/iec/resource_huaweicloud_iec_network_acl.go
@@ -1,0 +1,222 @@
+package iec
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/iec/v1/firewalls"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceNetworkACL() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNetworkACLCreate,
+		ReadContext:   resourceNetworkACLRead,
+		UpdateContext: resourceNetworkACLUpdate,
+		DeleteContext: resourceNetworkACLDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"networks": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"inbound_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"outbound_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNetworkACLNetworks(d *schema.ResourceData) []firewalls.ReqSubnet {
+	rawNetworks := d.Get("networks").(*schema.Set).List()
+	networkOpts := make([]firewalls.ReqSubnet, len(rawNetworks))
+
+	for i, val := range rawNetworks {
+		raw := val.(map[string]interface{})
+		networkOpts[i] = firewalls.ReqSubnet{
+			ID:    raw["subnet_id"].(string),
+			VpcID: raw["vpc_id"].(string),
+		}
+	}
+	return networkOpts
+}
+
+func resourceNetworkACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IEC v1 client: %s", err)
+	}
+
+	createOpts := firewalls.CreateOpts{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+	log.Printf("[DEBUG] create IEC network ACL: %#v", createOpts)
+	group, err := firewalls.Create(iecClient, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error creating IEC network ACL: %s", err)
+	}
+	d.SetId(group.ID)
+
+	// Associate subnets
+	subnetsOpts := resourceNetworkACLNetworks(d)
+	if len(subnetsOpts) > 0 {
+		updateOpts := firewalls.UpdateOpts{
+			Name:    d.Get("name").(string),
+			Subnets: &subnetsOpts,
+		}
+		log.Printf("[DEBUG] attempt to associate IEC network ACL with subnets: %#v", updateOpts)
+		_, err := firewalls.Update(iecClient, group.ID, updateOpts).Extract()
+		if err != nil {
+			return diag.Errorf("error associating subnets with IEC network ACL: %s", err)
+		}
+	}
+
+	return resourceNetworkACLRead(ctx, d, meta)
+}
+
+func resourceNetworkACLRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	var mErr *multierror.Error
+	if err != nil {
+		return diag.Errorf("error creating IEC v1 client: %s", err)
+	}
+
+	fwGroup, err := firewalls.Get(iecClient, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IEC network ACL")
+	}
+
+	log.Printf("[DEBUG] read IEC network ACL %s: %#v", d.Id(), fwGroup)
+	mErr = multierror.Append(
+		mErr,
+		d.Set("name", fwGroup.Name),
+		d.Set("status", fwGroup.Status),
+		d.Set("description", fwGroup.Description),
+		d.Set("inbound_rules", getFirewallRuleIDs(fwGroup.IngressFWPolicy)),
+		d.Set("outbound_rules", getFirewallRuleIDs(fwGroup.EgressFWPolicy)),
+	)
+	var networkSet []map[string]interface{}
+	for _, val := range fwGroup.Subnets {
+		subnet := make(map[string]interface{})
+		subnet["vpc_id"] = val.VpcID
+		subnet["subnet_id"] = val.ID
+		networkSet = append(networkSet, subnet)
+	}
+	if err = d.Set("networks", networkSet); err != nil {
+		return diag.Errorf("saving IEC networks failed: %s", err)
+	}
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceNetworkACLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IEC v1 client: %s", err)
+	}
+
+	if d.HasChanges("name", "description", "networks") {
+		opts := firewalls.UpdateOpts{
+			Name: d.Get("name").(string),
+		}
+
+		if d.HasChange("description") {
+			desc := d.Get("description").(string)
+			opts.Description = &desc
+		}
+
+		if d.HasChange("networks") {
+			subnetsOpts := resourceNetworkACLNetworks(d)
+			opts.Subnets = &subnetsOpts
+		}
+
+		log.Printf("[DEBUG] updating IEC network ACL with id %s: %#v", d.Id(), opts)
+		_, err := firewalls.Update(iecClient, d.Id(), opts).Extract()
+		if err != nil {
+			return diag.Errorf("error updating IEC network ACL: %s", err)
+		}
+	}
+
+	return resourceNetworkACLRead(ctx, d, meta)
+}
+
+func resourceNetworkACLDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating IEC v1 client: %s", err)
+	}
+
+	// Unbind subents before deleting the network acl.
+	rawNetworks := d.Get("networks").(*schema.Set).List()
+	if len(rawNetworks) > 0 {
+		unbindSubnets := make([]firewalls.ReqSubnet, 0)
+		opts := firewalls.UpdateOpts{
+			Name:    d.Get("name").(string),
+			Subnets: &unbindSubnets,
+		}
+		err = firewalls.Update(iecClient, d.Id(), opts).Err
+		if err != nil {
+			return diag.Errorf("error disassociating all subents with IEC network ACL: %s", err)
+		}
+	}
+
+	err = firewalls.Delete(iecClient, d.Id()).ExtractErr()
+	if err != nil {
+		return diag.Errorf("error deleting IEC firewall: %s", err)
+	}
+
+	return nil
+}

--- a/huaweicloud/services/iec/resource_huaweicloud_iec_network_acl_rule.go
+++ b/huaweicloud/services/iec/resource_huaweicloud_iec_network_acl_rule.go
@@ -1,0 +1,323 @@
+package iec
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/iec/v1/firewalls"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceNetworkACLRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNetworkACLRuleCreate,
+		ReadContext:   resourceNetworkACLRuleRead,
+		UpdateContext: resourceNetworkACLRuleUpdate,
+		DeleteContext: resourceNetworkACLRuleDelete,
+
+		Schema: map[string]*schema.Schema{
+			"network_acl_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"direction": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ingress", "egress",
+				}, true),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "any",
+				ValidateFunc: validation.StringInSlice([]string{
+					"tcp", "udp", "icmp", "any",
+				}, true),
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "allow",
+				ValidateFunc: validation.StringInSlice([]string{
+					"allow", "deny",
+				}, true),
+			},
+			"ip_version": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     4,
+				Description: "schema: Computed",
+			},
+			"source_ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "0.0.0.0/0",
+			},
+			"destination_ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "0.0.0.0/0",
+			},
+			"source_port": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"destination_port": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildNetworkACLRule(d *schema.ResourceData, operateType, ruleID string) firewalls.ReqFirewallRulesOpts {
+	enabled := d.Get("enabled").(bool)
+	ruleOpts := firewalls.ReqFirewallRulesOpts{
+		Description: d.Get("description").(string),
+		Action:      d.Get("action").(string),
+		IPVersion:   d.Get("ip_version").(int),
+		Protocol:    d.Get("protocol").(string),
+		SrcIPAddr:   d.Get("source_ip_address").(string),
+		DstIPAddr:   d.Get("destination_ip_address").(string),
+		SrcPort:     d.Get("source_port").(string),
+		DstPort:     d.Get("destination_port").(string),
+		Enabled:     &enabled,
+		OperateType: operateType,
+	}
+	if operateType != "add" {
+		ruleOpts.ID = ruleID
+	}
+	return ruleOpts
+}
+
+func resourceNetworkACLRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating fw client: %s", err)
+	}
+
+	aclID := d.Get("network_acl_id").(string)
+	fwGroup, err := firewalls.Get(iecClient, aclID).Extract()
+	if err != nil {
+		return diag.Errorf("error retrieving IEC network ACL %s: %s", aclID, err)
+	}
+
+	var oldRules, newRules []string
+	var opts firewalls.UpdateRuleOpts
+	var ruleOpts firewalls.ReqPolicyOpts
+	ruleOpts.FirewallRules = &[]firewalls.ReqFirewallRulesOpts{
+		buildNetworkACLRule(d, "add", ""),
+	}
+	if d.Get("direction").(string) == "ingress" {
+		oldRules = getFirewallRuleIDs(fwGroup.IngressFWPolicy)
+		ruleOpts.PolicyID = fwGroup.IngressFWPolicy.ID
+		opts.ReqFirewallInPolicy = &ruleOpts
+	} else {
+		oldRules = getFirewallRuleIDs(fwGroup.EgressFWPolicy)
+		ruleOpts.PolicyID = fwGroup.EgressFWPolicy.ID
+		opts.ReqFirewallOutPolicy = &ruleOpts
+	}
+
+	log.Printf("[DEBUG] create IEC network ACL rule: %#v", opts)
+	fwGroup, err = firewalls.UpdateRule(iecClient, aclID, opts).Extract()
+	if err != nil {
+		return diag.Errorf("error creating IEC network ACL rule: %s", err)
+	}
+
+	if d.Get("direction").(string) == "ingress" {
+		newRules = getFirewallRuleIDs(fwGroup.IngressFWPolicy)
+	} else {
+		newRules = getFirewallRuleIDs(fwGroup.EgressFWPolicy)
+	}
+
+	ruleID := getNewFirewallRuleID(oldRules, newRules)
+	if ruleID == "" {
+		return diag.Errorf("error creating IEC network ACL rule: not found")
+	}
+
+	log.Printf("[DEBUG] create IEC network ACL rule with id %s", ruleID)
+	d.SetId(ruleID)
+
+	return resourceNetworkACLRuleRead(ctx, d, meta)
+}
+
+func resourceNetworkACLRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	var mErr *multierror.Error
+	if err != nil {
+		return diag.Errorf("error creating IEC client: %s", err)
+	}
+
+	aclID := d.Get("network_acl_id").(string)
+	fwGroup, err := firewalls.Get(iecClient, aclID).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IEC network ACL")
+	}
+
+	var fwPolicy firewalls.RespPolicyEntity
+	if d.Get("direction").(string) == "ingress" {
+		fwPolicy = fwGroup.IngressFWPolicy
+	} else {
+		fwPolicy = fwGroup.EgressFWPolicy
+	}
+
+	ruleID := d.Id()
+	ruleEntity := getFirewallRuleEntity(fwPolicy, ruleID)
+	if ruleEntity.ID == "" {
+		d.SetId("")
+		log.Printf("[WARN] the IEC network ACL rule: %s can not be found", ruleID)
+		return nil
+	}
+
+	log.Printf("[DEBUG] retrieve IEC network ACL rule %s: %#v", ruleID, ruleEntity)
+	mErr = multierror.Append(
+		mErr,
+		d.Set("policy_id", fwPolicy.ID),
+		d.Set("description", ruleEntity.Description),
+		d.Set("enabled", ruleEntity.Enabled),
+		d.Set("action", ruleEntity.Action),
+		d.Set("ip_version", ruleEntity.IPVersion),
+		d.Set("source_ip_address", ruleEntity.SrcIPAddr),
+		d.Set("destination_ip_address", ruleEntity.DstIPAddr),
+		d.Set("source_port", ruleEntity.SrcPort),
+		d.Set("destination_port", ruleEntity.DstPort),
+	)
+
+	if ruleEntity.Protocol == "" {
+		d.Set("protocol", "any")
+	} else {
+		d.Set("protocol", ruleEntity.Protocol)
+	}
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceNetworkACLRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating fw client: %s", err)
+	}
+
+	aclID := d.Get("network_acl_id").(string)
+	fwGroup, err := firewalls.Get(iecClient, aclID).Extract()
+	if err != nil {
+		return diag.Errorf("error retrieving IEC network ACL %s: %s", aclID, err)
+	}
+
+	var opts firewalls.UpdateRuleOpts
+	var ruleOpts firewalls.ReqPolicyOpts
+	ruleOpts.FirewallRules = &[]firewalls.ReqFirewallRulesOpts{
+		buildNetworkACLRule(d, "modify", d.Id()),
+	}
+
+	if d.Get("direction").(string) == "ingress" {
+		ruleOpts.PolicyID = fwGroup.IngressFWPolicy.ID
+		opts.ReqFirewallInPolicy = &ruleOpts
+	} else {
+		ruleOpts.PolicyID = fwGroup.EgressFWPolicy.ID
+		opts.ReqFirewallOutPolicy = &ruleOpts
+	}
+
+	log.Printf("[DEBUG] updating IEC network ACL rule %s: %#v", d.Id(), opts)
+	_, err = firewalls.UpdateRule(iecClient, aclID, opts).Extract()
+
+	if err != nil {
+		return diag.Errorf("error updating IEC network ACL rule: %s", err)
+	}
+
+	return resourceNetworkACLRuleRead(ctx, d, meta)
+}
+
+func resourceNetworkACLRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	iecClient, err := conf.IECV1Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating fw client: %s", err)
+	}
+
+	aclID := d.Get("network_acl_id").(string)
+	fwGroup, err := firewalls.Get(iecClient, aclID).Extract()
+	if err != nil {
+		return diag.Errorf("error retrieving IEC network ACL %s: %s", aclID, err)
+	}
+
+	var opts firewalls.UpdateRuleOpts
+	var ruleOpts firewalls.ReqPolicyOpts
+	ruleOpts.FirewallRules = &[]firewalls.ReqFirewallRulesOpts{
+		buildNetworkACLRule(d, "delete", d.Id()),
+	}
+	if d.Get("direction").(string) == "ingress" {
+		ruleOpts.PolicyID = fwGroup.IngressFWPolicy.ID
+		opts.ReqFirewallInPolicy = &ruleOpts
+	} else {
+		ruleOpts.PolicyID = fwGroup.EgressFWPolicy.ID
+		opts.ReqFirewallOutPolicy = &ruleOpts
+	}
+
+	log.Printf("[DEBUG] destroy IEC network ACL rule: %s", d.Id())
+	_, err = firewalls.UpdateRule(iecClient, aclID, opts).Extract()
+	if err != nil {
+		return diag.Errorf("error deleting IEC network ACL rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func getFirewallRuleIDs(fwPolicy firewalls.RespPolicyEntity) []string {
+	rawRules := fwPolicy.FirewallRules
+	ruleIDs := make([]string, len(rawRules))
+	for i, val := range rawRules {
+		ruleIDs[i] = val.ID
+	}
+	return ruleIDs
+}
+
+func getFirewallRuleEntity(fwPolicy firewalls.RespPolicyEntity, ruleID string) firewalls.RespFirewallRulesEntity {
+	for _, val := range fwPolicy.FirewallRules {
+		if val.ID == ruleID {
+			return val
+		}
+	}
+	return firewalls.RespFirewallRulesEntity{}
+}
+
+func getNewFirewallRuleID(old []string, new []string) string {
+	ruleMap := make(map[string]int)
+	for _, v := range old {
+		ruleMap[v] = 1
+	}
+
+	for _, v := range new {
+		if ruleMap[v] == 0 {
+			return v
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
move resource[iec_network_acl,iec_network_acl_rule] into services/iec and fix codecheck error

**Special notes for your reviewer**:

**Release note**:

```./scripts/codecheck.sh ./huaweicloud/services/iec

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                       10      2465      297        29     2139        312           139.94
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~rvices/iec/resource_huaweicloud_iec_vip.go       313       42         9      262         55            20.99
~source_huaweicloud_iec_network_acl_rule.go       322       38         0      284         54            19.01
~rvices/iec/resource_huaweicloud_iec_eip.go       313       38         3      272         53            19.49
~ces/iec/resource_huaweicloud_iec_server.go       593       61        11      521         50             9.60
~ec/resource_huaweicloud_iec_network_acl.go       221       27         2      192         29            15.10
~iec/resource_huaweicloud_iec_vpc_subnet.go       256       34         3      219         28            12.79
~rvices/iec/resource_huaweicloud_iec_vpc.go       147       24         1      122         18            14.75
~iec/data_source_huaweicloud_iec_flavors.go       126       12         0      114         10             8.77
~/iec/data_source_huaweicloud_iec_images.go       112       12         0      100         10            10.00
~iec/data_source_huaweicloud_iec_keypair.go        62        9         0       53          5             9.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                    10      2465      297        29     2139        312           139.94
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 66707 bytes, 0.067 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
9 iec updateIecVipAssociate huaweicloud/services/iec/resource_huaweicloud_iec_vip.go:258:1
8 iec resourceIecVIPCreate huaweicloud/services/iec/resource_huaweicloud_iec_vip.go:78:1
7 iec resourceIecServerCreate huaweicloud/services/iec/resource_huaweicloud_iec_server.go:333:1
7 iec resourceNetworkACLRuleCreate huaweicloud/services/iec/resource_huaweicloud_iec_network_acl_rule.go:115:1
7 iec waitForIecEipStatus huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:286:1
7 iec resourceIecEipCreate huaweicloud/services/iec/resource_huaweicloud_iec_eip.go:105:1
7 iec dataSourceIecImagesRead huaweicloud/services/iec/data_source_huaweicloud_iec_images.go:65:1
7 iec dataSourceIecFlavorsRead huaweicloud/services/iec/data_source_huaweicloud_iec_flavors.go:78:1
6 iec resourceIecServerRead huaweicloud/services/iec/resource_huaweicloud_iec_server.go:412:1
6 iec resourceNetworkACLRuleRead huaweicloud/services/iec/resource_huaweicloud_iec_network_acl_rule.go:167:1
Average: 3.84

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./huaweicloud/services/iec/resource_huaweicloud_iec_vpc.go:138: // lintignore:R018

==> Checking for TF features in iec...
  -> the resource in resource_huaweicloud_iec_network_acl_rule.go should can be imported


==> Checking for misspell in iec...

==> Checking for code complexity in ./huaweicloud/services/acceptance/iec...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                       10      1291      167         0     1124        119            95.22
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~source_huaweicloud_iec_network_acl_test.go       193       24         0      169         18            10.65
~e/iec/resource_huaweicloud_iec_vpc_test.go       182       25         0      157         16            10.19
~e/iec/resource_huaweicloud_iec_eip_test.go       109       18         0       91         16            17.58
~ec/resource_huaweicloud_iec_server_test.go       168       15         0      153         16            10.46
~e/iec/resource_huaweicloud_iec_vip_test.go       177       23         0      154         16            10.39
~esource_huaweicloud_iec_vpc_subnet_test.go       147       20         0      127         16            12.60
~e_huaweicloud_iec_network_acl_rule_test.go       139       18         0      121         15            12.40
~ata_source_huaweicloud_iec_flavors_test.go        81       11         0       70          3             4.29
~data_source_huaweicloud_iec_images_test.go        53        8         0       45          3             6.67
~ata_source_huaweicloud_iec_keypair_test.go        42        5         0       37          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                    10      1291      167         0     1124        119            95.22
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 37335 bytes, 0.037 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
7 iec testAccCheckIecNetworkACLRuleExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_network_acl_rule_test.go:68:1
6 iec testAccCheckIecVpcV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_test.go:114:1
6 iec testAccCheckIecVpcSubnetV1Exists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vpc_subnet_test.go:77:1
6 iec testAccCheckIecVipExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_vip_test.go:95:1
6 iec testAccCheckIecServerExists huaweicloud/services/acceptance/iec/resource_huaweicloud_iec_server_test.go:56:1
Average: 2.35

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/iec...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/iec...

==> Cleanup patch...

Check Completed!

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST="./huaweicloud/services/acceptance/iec" TESTARGS="-run TestAccNetworkACLResource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iec -v -run TestAccIecNetworkACLResource_basic -timeout 360m -parallel 4
=== RUN   TestAccIecNetworkACLResource_basic
=== PAUSE TestAccIecNetworkACLResource_basic
=== CONT  TestAccIecNetworkACLResource_basic
--- PASS: TestAccIecNetworkACLResource_basic (143.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iec       143.427s
```
```
make testacc TEST="./huaweicloud/services/acceptance/iec" TESTARGS="-run TestAccNetworkACLResource_no_subnets"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iec -v -run TestAccIecNetworkACLResource_no_subnets -timeout 360m -parallel 4
=== RUN   TestAccIecNetworkACLResource_no_subnets
=== PAUSE TestAccIecNetworkACLResource_no_subnets
=== CONT  TestAccIecNetworkACLResource_no_subnets
--- PASS: TestAccIecNetworkACLResource_no_subnets (42.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iec       42.198s
```
```
make testacc TEST="./huaweicloud/services/acceptance/iec" TESTARGS="-run TestAccNetworkACLRuleResource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iec -v -run TestAccNetworkACLRuleResource_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkACLRuleResource_basic
=== PAUSE TestAccNetworkACLRuleResource_basic
=== CONT  TestAccNetworkACLRuleResource_basic
--- PASS: TestAccNetworkACLRuleResource_basic (76.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iec       76.608s
```
