### PR TITLE
fix(er): fix er instance resource lint error 

### DIFF
--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er"
 )
 
-func getAssociationResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ErV3Client(acceptance.HW_REGION_NAME)
+func getAssociationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ErV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -92,7 +92,7 @@ func testAccAssociationImportStateFunc() resource.ImportStateIdFunc {
 
 func testAccAssociation_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 
 resource "huaweicloud_vpc" "test" {
   name = "%[1]s"
@@ -108,7 +108,7 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
 
   name = "%[1]s"
   asn  = %[2]d

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_instance_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_instance_test.go
@@ -16,21 +16,21 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getInstanceResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getInstanceResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getInstance: Query the Enterprise router instance detail
 	var (
 		getInstanceHttpUrl = "v3/{project_id}/enterprise-router/instances/{id}"
 		getInstanceProduct = "er"
 	)
-	getInstanceClient, err := config.NewServiceClient(getInstanceProduct, region)
+	getInstanceClient, err := cfg.NewServiceClient(getInstanceProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Instance Client: %s", err)
 	}
 
 	getInstancePath := getInstanceClient.Endpoint + getInstanceHttpUrl
-	getInstancePath = strings.Replace(getInstancePath, "{project_id}", getInstanceClient.ProjectID, -1)
-	getInstancePath = strings.Replace(getInstancePath, "{id}", state.Primary.ID, -1)
+	getInstancePath = strings.ReplaceAll(getInstancePath, "{project_id}", getInstanceClient.ProjectID)
+	getInstancePath = strings.ReplaceAll(getInstancePath, "{id}", state.Primary.ID)
 
 	getInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -71,7 +71,7 @@ func TestAccInstance_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttrPair(rName, "availability_zones.0",
-						"data.huaweicloud_availability_zones.test", "names.0"),
+						"data.huaweicloud_er_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttr(rName, "asn", fmt.Sprintf("%v", bgpAsNum)),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
@@ -101,10 +101,10 @@ func TestAccInstance_basic(t *testing.T) {
 
 func testInstance_basic_step1(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
 
   name = "%[1]s"
   asn  = %[2]d
@@ -119,10 +119,10 @@ resource "huaweicloud_er_instance" "test" {
 
 func testInstance_basic_step2(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
 
   name = "%[1]s"
   asn  = %[2]d

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er"
 )
 
-func getPropagationResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ErV3Client(acceptance.HW_REGION_NAME)
+func getPropagationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ErV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -92,7 +92,7 @@ func testAccPropagationImportStateFunc() resource.ImportStateIdFunc {
 
 func testAccPropagation_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 
 resource "huaweicloud_vpc" "test" {
   name = "%[1]s"
@@ -108,7 +108,7 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
 
   name = "%[1]s"
   asn  = %[2]d

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getRouteTableResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ErV3Client(acceptance.HW_REGION_NAME)
+func getRouteTableResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ErV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -96,10 +96,10 @@ func testAccRouteTableImportStateFunc() resource.ImportStateIdFunc {
 
 func testRouteTable_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
   name               = "%[1]s"
   asn                = %[2]d
 }

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_static_route_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_static_route_test.go
@@ -129,7 +129,7 @@ func testAccStaticRouteImportStateFunc(rsName string) resource.ImportStateIdFunc
 
 func testAccStaticRoute_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 
 variable "base_vpc_cidr" {
   type    = string
@@ -163,7 +163,7 @@ resource "huaweicloud_vpc_subnet" "destination" {
 }
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
   name               = "%[1]s"
   asn                = %[2]d
 }

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func getVpcAttachmentResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := config.ErV3Client(acceptance.HW_REGION_NAME)
+func getVpcAttachmentResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ErV3Client(acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -96,7 +96,7 @@ func testAccVpcAttachmentImportStateFunc() resource.ImportStateIdFunc {
 
 func testVpcAttachment_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 	
 resource "huaweicloud_vpc" "test" {
   name = "%[1]s"
@@ -112,7 +112,7 @@ resource "huaweicloud_vpc_subnet" "test" {
 }
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
 
   name = "%[1]s"
   asn  = %[2]d

--- a/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go
@@ -335,9 +335,9 @@ func flattenRouteTables(client *golangsdk.ServiceClient, instanceId string,
 }
 
 func dataSourceRouteTablesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ErV3Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}

--- a/huaweicloud/services/er/resource_huaweicloud_er_association.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_association.go
@@ -86,8 +86,8 @@ func ResourceAssociation() *schema.Resource {
 }
 
 func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ErV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ErV3Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -180,9 +180,9 @@ func associationStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, r
 }
 
 func resourceAssociationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ErV3Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -215,9 +215,9 @@ func resourceAssociationRead(_ context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ErV3Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}

--- a/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
@@ -86,8 +86,8 @@ func ResourcePropagation() *schema.Resource {
 }
 
 func resourcePropagationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ErV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ErV3Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -180,9 +180,9 @@ func propagationStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, r
 }
 
 func resourcePropagationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ErV3Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -215,9 +215,9 @@ func resourcePropagationRead(_ context.Context, d *schema.ResourceData, meta int
 }
 
 func resourcePropagationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ErV3Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}

--- a/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
@@ -115,8 +115,8 @@ func buildRouteTableCreateOpts(d *schema.ResourceData) routetables.CreateOpts {
 }
 
 func resourceRouteTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ErV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ErV3Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -169,9 +169,9 @@ func routeTableStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId, ro
 }
 
 func resourceRouteTableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ErV3Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -230,9 +230,9 @@ func updateRouteTableBasicInfo(ctx context.Context, client *golangsdk.ServiceCli
 }
 
 func resourceRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ErV3Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -283,9 +283,9 @@ func releaseRouteTablePropagations(client *golangsdk.ServiceClient, instanceId, 
 }
 
 func resourceRouteTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.ErV3Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}

--- a/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
@@ -114,8 +114,8 @@ func ResourceVpcAttachment() *schema.Resource {
 }
 
 func resourceVpcAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ErV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ErV3Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -152,13 +152,13 @@ func resourceVpcAttachmentCreate(ctx context.Context, d *schema.ResourceData, me
 
 func resourceVpcAttachmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		config       = meta.(*config.Config)
-		region       = config.GetRegion(d)
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
 		instanceId   = d.Get("instance_id").(string)
 		attachmentId = d.Id()
 	)
 
-	client, err := config.ErV3Client(region)
+	client, err := cfg.ErV3Client(region)
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -239,8 +239,8 @@ func vpcAttachmentStatusRefreshFunc(client *golangsdk.ServiceClient, instanceId,
 }
 
 func resourceVpcAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ErV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ErV3Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}
@@ -255,8 +255,8 @@ func resourceVpcAttachmentUpdate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceVpcAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.ErV3Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.ErV3Client(cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating ER v3 client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

Special notes for your reviewer**:

**Release note**:
==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                       10      2989      317        28     2644        330           125.23
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ces/er/resource_huaweicloud_er_instance.go       666       77        12      577         77            13.34
~/er/resource_huaweicloud_er_route_table.go       335       39         2      294         47            15.99
~/resource_huaweicloud_er_vpc_attachment.go       296       33         1      262         33            12.60
~/er/resource_huaweicloud_er_association.go       269       34         1      234         32            13.68
~/er/resource_huaweicloud_er_propagation.go       269       34         1      234         32            13.68
~data_source_huaweicloud_er_route_tables.go       369       25         1      343         30             8.75
~er/resource_huaweicloud_er_static_route.go       212       25         3      184         26            14.13
~/data_source_huaweicloud_er_attachments.go       225       18         3      204         23            11.27
~er/data_source_huaweicloud_er_instances.go       252       18         3      231         19             8.23
~ource_huaweicloud_er_availability_zones.go        96       14         1       81         11            13.58
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                    10      2989      317        28     2644        330           125.23
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 96271 bytes, 0.096 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
12 er resourceInstanceCreate huaweicloud/services/er/resource_huaweicloud_er_instance.go:176:1
10 er resourceInstanceUpdate huaweicloud/services/er/resource_huaweicloud_er_instance.go:468:1
7 er deleteInstanceWaitingForStateCompleted huaweicloud/services/er/resource_huaweicloud_er_instance.go:609:1
7 er instanceWaitingForStateCompleted huaweicloud/services/er/resource_huaweicloud_er_instance.go:301:1
7 er dataSourceAttachmentsRead huaweicloud/services/er/data_source_huaweicloud_er_attachments.go:190:1
6 er vpcAttachmentStatusRefreshFunc huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go:218:1
6 er resourceStaticRouteRead huaweicloud/services/er/resource_huaweicloud_er_static_route.go:113:1
6 er resourceRouteTableDelete huaweicloud/services/er/resource_huaweicloud_er_route_table.go:285:1
6 er routeTableStatusRefreshFunc huaweicloud/services/er/resource_huaweicloud_er_route_table.go:148:1
6 er propagationStatusRefreshFunc huaweicloud/services/er/resource_huaweicloud_er_propagation.go:159:1
Average: 3.45

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in er...

==> Checking for misspell in er...

==> Checking for code complexity in ./huaweicloud/services/acceptance/er...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                       10      1863      157         1     1705         51            35.97
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~esource_huaweicloud_er_association_test.go       144       13         0      131         11             8.40
~esource_huaweicloud_er_propagation_test.go       144       13         0      131         11             8.40
~urce_huaweicloud_er_vpc_attachment_test.go       173       13         0      160          9             5.62
~esource_huaweicloud_er_route_table_test.go       138       14         0      124          9             7.26
~source_huaweicloud_er_static_route_test.go       246       14         0      232          7             3.02
~r/resource_huaweicloud_er_instance_test.go       136       13         1      122          4             3.28
~_huaweicloud_er_availability_zones_test.go        30        6         0       24          0             0.00
~ta_source_huaweicloud_er_instances_test.go       252       24         0      228          0             0.00
~_source_huaweicloud_er_attachments_test.go       375       27         0      348          0             0.00
~_source_huaweicloud_er_route_table_test.go       225       20         0      205          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                    10      1863      157         1     1705         51            35.97
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 54997 bytes, 0.055 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 er testAccPropagationImportStateFunc huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go:74:1
6 er testAccAssociationImportStateFunc huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go:74:1
5 er testAccVpcAttachmentImportStateFunc huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go:80:1
5 er testAccRouteTableImportStateFunc huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go:80:1
4 er testAccStaticRouteImportStateFunc huaweicloud/services/acceptance/er/resource_huaweicloud_er_static_route_test.go:114:1
Average: 1.44

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/er...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/er...

==> Cleanup patch...

Check Completed!

** PR Checklist**

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

**Acceptance Steps Performed**


make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'

~/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev)$ make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run TestAccInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (145.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        145.352s
~/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev)$ make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run TestAccRouteTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccRouteTable_basic -timeout 360m -parallel 4
=== RUN   TestAccRouteTable_basic
=== PAUSE TestAccRouteTable_basic
=== CONT  TestAccRouteTable_basic
    acceptance.go:717: Skip all ER acceptance tests.
--- SKIP: TestAccRouteTable_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        0.055s
~/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev)$ make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run TestAccAssociation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccAssociation_basic -timeout 360m -parallel 4
=== RUN   TestAccAssociation_basic
=== PAUSE TestAccAssociation_basic
=== CONT  TestAccAssociation_basic
--- PASS: TestAccAssociation_basic (144.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        144.720s
~/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev)$ make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run TestAccPropagation_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccPropagation_basic -timeout 360m -parallel 4
=== RUN   TestAccPropagation_basic
=== PAUSE TestAccPropagation_basic
=== CONT  TestAccPropagation_basic
--- PASS: TestAccPropagation_basic (141.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        141.233s
~/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev)$ make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run TestAccStaticRoute_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccStaticRoute_basic -timeout 360m -parallel 4
=== RUN   TestAccStaticRoute_basic
=== PAUSE TestAccStaticRoute_basic
=== CONT  TestAccStaticRoute_basic
    acceptance.go:717: Skip all ER acceptance tests.
--- SKIP: TestAccStaticRoute_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        0.039s
~/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev)$ make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run TestAccVpcAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccVpcAttachment_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcAttachment_basic
=== PAUSE TestAccVpcAttachment_basic
=== CONT  TestAccVpcAttachment_basic
--- PASS: TestAccVpcAttachment_basic (166.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        166.294s
