### PR TITLE
fix(ga): fix ga resource lint error

### DIFF
--- a/docs/resources/ga_accelerator.md
+++ b/docs/resources/ga_accelerator.md
@@ -128,6 +128,6 @@ This resource provides the following timeouts configuration options:
 
 The accelerator can be imported using the `id`, e.g.
 
-```
-$ terraform import huaweicloud_ga_accelerator.test ac1bf54f-6a23-4074-af77-800648d25bc8
+```bash
+$ terraform import huaweicloud_ga_accelerator.test <id>
 ```

--- a/docs/resources/ga_endpoint_group.md
+++ b/docs/resources/ga_endpoint_group.md
@@ -79,6 +79,6 @@ This resource provides the following timeouts configuration options:
 
 The endpointgroup can be imported using the `id`, e.g.
 
-```
-$ terraform import huaweicloud_ga_endpoint_group.test d150272b-ef55-42e9-b4ed-5204b97424b9
+```bash
+$ terraform import huaweicloud_ga_endpoint_group.test <id>
 ```

--- a/docs/resources/ga_health_check.md
+++ b/docs/resources/ga_health_check.md
@@ -76,6 +76,6 @@ This resource provides the following timeouts configuration options:
 
 The healthcheck can be imported using the `id`, e.g.
 
-```
-$ terraform import huaweicloud_ga_health_check.test 30a04052-b553-4292-af4e-a483106653ce
+```bash
+$ terraform import huaweicloud_ga_health_check.test <id>
 ```

--- a/docs/resources/ga_listener.md
+++ b/docs/resources/ga_listener.md
@@ -93,6 +93,6 @@ This resource provides the following timeouts configuration options:
 
 The listener can be imported using the `id`, e.g.
 
-```
-$ terraform import huaweicloud_ga_listener.test ac1bf54f-6a23-4074-af77-800648d25bc8
+```bash
+$ terraform import huaweicloud_ga_listener.test <id>
 ```

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_accelerator_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_accelerator_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getAcceleratorResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getAcceleratorResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getAccelerator: Query the GA accelerator detail
 	var (
 		getAcceleratorHttpUrl = "v1/accelerators/{id}"
 		getAcceleratorProduct = "ga"
 	)
-	getAcceleratorClient, err := config.NewServiceClient(getAcceleratorProduct, region)
+	getAcceleratorClient, err := conf.NewServiceClient(getAcceleratorProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Accelerator Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_group_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_group_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getEndpointGroupResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getEndpointGroupResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getEndpointGroup: Query the GA Endpoint Group detail
 	var (
 		getEndpointGroupHttpUrl = "v1/endpoint-groups/{id}"
 		getEndpointGroupProduct = "ga"
 	)
-	getEndpointGroupClient, err := config.NewServiceClient(getEndpointGroupProduct, region)
+	getEndpointGroupClient, err := conf.NewServiceClient(getEndpointGroupProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating EndpointGroup Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getEndpointResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getEndpointResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getEndpoint: Query the GA Endpoint detail
 	var (
 		getEndpointHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{id}"
 		getEndpointProduct = "ga"
 	)
-	getEndpointClient, err := config.NewServiceClient(getEndpointProduct, region)
+	getEndpointClient, err := conf.NewServiceClient(getEndpointProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Endpoint Client: %s", err)
 	}
@@ -145,13 +145,13 @@ func testEndpointImportState(name string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
-			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
 		}
 		if rs.Primary.Attributes["endpoint_group_id"] == "" {
-			return "", fmt.Errorf("Attribute (endpoint_group_id) of Resource (%s) not found: %s", name, rs)
+			return "", fmt.Errorf("attribute (endpoint_group_id) of Resource (%s) not found: %s", name, rs)
 		}
 		if rs.Primary.ID == "" {
-			return "", fmt.Errorf("Attribute (ID) of Resource (%s) not found: %s", name, rs)
+			return "", fmt.Errorf("attribute (ID) of Resource (%s) not found: %s", name, rs)
 		}
 
 		return rs.Primary.Attributes["endpoint_group_id"] + "/" +

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_health_check_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_health_check_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getHealthCheckResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getHealthCheckResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getHealthCheck: Query the GA Health Check detail
 	var (
 		getHealthCheckHttpUrl = "v1/health-checks/{id}"
 		getHealthCheckProduct = "ga"
 	)
-	getHealthCheckClient, err := config.NewServiceClient(getHealthCheckProduct, region)
+	getHealthCheckClient, err := conf.NewServiceClient(getHealthCheckProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating HealthCheck Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_listener_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_listener_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getListenerResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getListenerResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getListener: Query the GA Listener detail
 	var (
 		getListenerHttpUrl = "v1/listeners/{id}"
 		getListenerProduct = "ga"
 	)
-	getListenerClient, err := config.NewServiceClient(getListenerProduct, region)
+	getListenerClient, err := conf.NewServiceClient(getListenerProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Listener Client: %s", err)
 	}

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint_group.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint_group.go
@@ -127,15 +127,15 @@ func EndpointGroupIdSchema() *schema.Resource {
 }
 
 func resourceEndpointGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	// createEndpointGroup: Create a GA endpoint group.
 	var (
 		createEndpointGroupHttpUrl = "v1/endpoint-groups"
 		createEndpointGroupProduct = "ga"
 	)
-	createEndpointGroupClient, err := config.NewServiceClient(createEndpointGroupProduct, region)
+	createEndpointGroupClient, err := conf.NewServiceClient(createEndpointGroupProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating EndpointGroup Client: %s", err)
 	}
@@ -148,7 +148,7 @@ func resourceEndpointGroupCreate(ctx context.Context, d *schema.ResourceData, me
 			201,
 		},
 	}
-	createEndpointGroupOpt.JSONBody = utils.RemoveNil(buildCreateEndpointGroupBodyParams(d, config))
+	createEndpointGroupOpt.JSONBody = utils.RemoveNil(buildCreateEndpointGroupBodyParams(d))
 	createEndpointGroupResp, err := createEndpointGroupClient.Request("POST", createEndpointGroupPath, &createEndpointGroupOpt)
 	if err != nil {
 		return diag.Errorf("error creating EndpointGroup: %s", err)
@@ -172,7 +172,7 @@ func resourceEndpointGroupCreate(ctx context.Context, d *schema.ResourceData, me
 	return resourceEndpointGroupRead(ctx, d, meta)
 }
 
-func buildCreateEndpointGroupBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateEndpointGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"endpoint_group": map[string]interface{}{
 			"description":             utils.ValueIngoreEmpty(d.Get("description")),
@@ -229,7 +229,8 @@ func createEndpointGroupWaitingForStateCompleted(ctx context.Context, d *schema.
 					200,
 				},
 			}
-			createEndpointGroupWaitingResp, err := createEndpointGroupWaitingClient.Request("GET", createEndpointGroupWaitingPath, &createEndpointGroupWaitingOpt)
+			createEndpointGroupWaitingResp, err := createEndpointGroupWaitingClient.Request("GET",
+				createEndpointGroupWaitingPath, &createEndpointGroupWaitingOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
@@ -260,7 +261,6 @@ func createEndpointGroupWaitingForStateCompleted(ctx context.Context, d *schema.
 			}
 
 			return createEndpointGroupWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
@@ -270,9 +270,9 @@ func createEndpointGroupWaitingForStateCompleted(ctx context.Context, d *schema.
 	return err
 }
 
-func resourceEndpointGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceEndpointGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -281,7 +281,7 @@ func resourceEndpointGroupRead(ctx context.Context, d *schema.ResourceData, meta
 		getEndpointGroupHttpUrl = "v1/endpoint-groups/{id}"
 		getEndpointGroupProduct = "ga"
 	)
-	getEndpointGroupClient, err := config.NewServiceClient(getEndpointGroupProduct, region)
+	getEndpointGroupClient, err := conf.NewServiceClient(getEndpointGroupProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating EndpointGroup Client: %s", err)
 	}
@@ -337,8 +337,8 @@ func flattenGetEndpointGroupResponseBodyId(resp interface{}) []interface{} {
 }
 
 func resourceEndpointGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	updateEndpointGrouphasChanges := []string{
 		"description",
@@ -352,7 +352,7 @@ func resourceEndpointGroupUpdate(ctx context.Context, d *schema.ResourceData, me
 			updateEndpointGroupHttpUrl = "v1/endpoint-groups/{id}"
 			updateEndpointGroupProduct = "ga"
 		)
-		updateEndpointGroupClient, err := config.NewServiceClient(updateEndpointGroupProduct, region)
+		updateEndpointGroupClient, err := conf.NewServiceClient(updateEndpointGroupProduct, region)
 		if err != nil {
 			return diag.Errorf("error creating EndpointGroup Client: %s", err)
 		}
@@ -366,7 +366,7 @@ func resourceEndpointGroupUpdate(ctx context.Context, d *schema.ResourceData, me
 				200,
 			},
 		}
-		updateEndpointGroupOpt.JSONBody = utils.RemoveNil(buildUpdateEndpointGroupBodyParams(d, config))
+		updateEndpointGroupOpt.JSONBody = utils.RemoveNil(buildUpdateEndpointGroupBodyParams(d))
 		_, err = updateEndpointGroupClient.Request("PUT", updateEndpointGroupPath, &updateEndpointGroupOpt)
 		if err != nil {
 			return diag.Errorf("error updating EndpointGroup: %s", err)
@@ -379,7 +379,7 @@ func resourceEndpointGroupUpdate(ctx context.Context, d *schema.ResourceData, me
 	return resourceEndpointGroupRead(ctx, d, meta)
 }
 
-func buildUpdateEndpointGroupBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildUpdateEndpointGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"endpoint_group": map[string]interface{}{
 			"description":             d.Get("description"),
@@ -416,7 +416,8 @@ func updateEndpointGroupWaitingForStateCompleted(ctx context.Context, d *schema.
 					200,
 				},
 			}
-			updateEndpointGroupWaitingResp, err := updateEndpointGroupWaitingClient.Request("GET", updateEndpointGroupWaitingPath, &updateEndpointGroupWaitingOpt)
+			updateEndpointGroupWaitingResp, err := updateEndpointGroupWaitingClient.Request("GET",
+				updateEndpointGroupWaitingPath, &updateEndpointGroupWaitingOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
@@ -447,7 +448,6 @@ func updateEndpointGroupWaitingForStateCompleted(ctx context.Context, d *schema.
 			}
 
 			return updateEndpointGroupWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
@@ -458,15 +458,15 @@ func updateEndpointGroupWaitingForStateCompleted(ctx context.Context, d *schema.
 }
 
 func resourceEndpointGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	// deleteEndpointGroup: Delete an existing GA Endpoint Group
 	var (
 		deleteEndpointGroupHttpUrl = "v1/endpoint-groups/{id}"
 		deleteEndpointGroupProduct = "ga"
 	)
-	deleteEndpointGroupClient, err := config.NewServiceClient(deleteEndpointGroupProduct, region)
+	deleteEndpointGroupClient, err := conf.NewServiceClient(deleteEndpointGroupProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating EndpointGroup Client: %s", err)
 	}
@@ -518,7 +518,8 @@ func deleteEndpointGroupWaitingForStateCompleted(ctx context.Context, d *schema.
 					200,
 				},
 			}
-			deleteEndpointGroupWaitingResp, err := deleteEndpointGroupWaitingClient.Request("GET", deleteEndpointGroupWaitingPath, &deleteEndpointGroupWaitingOpt)
+			deleteEndpointGroupWaitingResp, err := deleteEndpointGroupWaitingClient.Request("GET",
+				deleteEndpointGroupWaitingPath, &deleteEndpointGroupWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
 					return deleteEndpointGroupWaitingResp, "COMPLETED", nil
@@ -546,7 +547,6 @@ func deleteEndpointGroupWaitingForStateCompleted(ctx context.Context, d *schema.
 			}
 
 			return deleteEndpointGroupWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go
@@ -117,15 +117,15 @@ func ResourceHealthCheck() *schema.Resource {
 }
 
 func resourceHealthCheckCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	// createHealthCheck: Create a GA Health Check.
 	var (
 		createHealthCheckHttpUrl = "v1/health-checks"
 		createHealthCheckProduct = "ga"
 	)
-	createHealthCheckClient, err := config.NewServiceClient(createHealthCheckProduct, region)
+	createHealthCheckClient, err := conf.NewServiceClient(createHealthCheckProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating HealthCheck Client: %s", err)
 	}
@@ -138,7 +138,7 @@ func resourceHealthCheckCreate(ctx context.Context, d *schema.ResourceData, meta
 			201,
 		},
 	}
-	createHealthCheckOpt.JSONBody = utils.RemoveNil(buildCreateHealthCheckBodyParams(d, config))
+	createHealthCheckOpt.JSONBody = utils.RemoveNil(buildCreateHealthCheckBodyParams(d))
 	createHealthCheckResp, err := createHealthCheckClient.Request("POST", createHealthCheckPath, &createHealthCheckOpt)
 	if err != nil {
 		return diag.Errorf("error creating HealthCheck: %s", err)
@@ -162,7 +162,7 @@ func resourceHealthCheckCreate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceHealthCheckRead(ctx, d, meta)
 }
 
-func buildCreateHealthCheckBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateHealthCheckBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"health_check": map[string]interface{}{
 			"enabled":           utils.ValueIngoreEmpty(d.Get("enabled")),
@@ -203,7 +203,8 @@ func createHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.Re
 					200,
 				},
 			}
-			createHealthCheckWaitingResp, err := createHealthCheckWaitingClient.Request("GET", createHealthCheckWaitingPath, &createHealthCheckWaitingOpt)
+			createHealthCheckWaitingResp, err := createHealthCheckWaitingClient.Request("GET",
+				createHealthCheckWaitingPath, &createHealthCheckWaitingOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
@@ -234,7 +235,6 @@ func createHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.Re
 			}
 
 			return createHealthCheckWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
@@ -244,9 +244,9 @@ func createHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.Re
 	return err
 }
 
-func resourceHealthCheckRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceHealthCheckRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -255,7 +255,7 @@ func resourceHealthCheckRead(ctx context.Context, d *schema.ResourceData, meta i
 		getHealthCheckHttpUrl = "v1/health-checks/{id}"
 		getHealthCheckProduct = "ga"
 	)
-	getHealthCheckClient, err := config.NewServiceClient(getHealthCheckProduct, region)
+	getHealthCheckClient, err := conf.NewServiceClient(getHealthCheckProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating HealthCheck Client: %s", err)
 	}
@@ -299,8 +299,8 @@ func resourceHealthCheckRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func resourceHealthCheckUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	updateHealthCheckhasChanges := []string{
 		"enabled",
@@ -317,7 +317,7 @@ func resourceHealthCheckUpdate(ctx context.Context, d *schema.ResourceData, meta
 			updateHealthCheckHttpUrl = "v1/health-checks/{id}"
 			updateHealthCheckProduct = "ga"
 		)
-		updateHealthCheckClient, err := config.NewServiceClient(updateHealthCheckProduct, region)
+		updateHealthCheckClient, err := conf.NewServiceClient(updateHealthCheckProduct, region)
 		if err != nil {
 			return diag.Errorf("error creating HealthCheck Client: %s", err)
 		}
@@ -331,7 +331,7 @@ func resourceHealthCheckUpdate(ctx context.Context, d *schema.ResourceData, meta
 				200,
 			},
 		}
-		updateHealthCheckOpt.JSONBody = utils.RemoveNil(buildUpdateHealthCheckBodyParams(d, config))
+		updateHealthCheckOpt.JSONBody = utils.RemoveNil(buildUpdateHealthCheckBodyParams(d))
 		_, err = updateHealthCheckClient.Request("PUT", updateHealthCheckPath, &updateHealthCheckOpt)
 		if err != nil {
 			return diag.Errorf("error updating HealthCheck: %s", err)
@@ -344,7 +344,7 @@ func resourceHealthCheckUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceHealthCheckRead(ctx, d, meta)
 }
 
-func buildUpdateHealthCheckBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildUpdateHealthCheckBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"health_check": map[string]interface{}{
 			"enabled":     d.Get("enabled"),
@@ -384,7 +384,8 @@ func updateHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.Re
 					200,
 				},
 			}
-			updateHealthCheckWaitingResp, err := updateHealthCheckWaitingClient.Request("GET", updateHealthCheckWaitingPath, &updateHealthCheckWaitingOpt)
+			updateHealthCheckWaitingResp, err := updateHealthCheckWaitingClient.Request("GET",
+				updateHealthCheckWaitingPath, &updateHealthCheckWaitingOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
@@ -415,7 +416,6 @@ func updateHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.Re
 			}
 
 			return updateHealthCheckWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
@@ -426,15 +426,15 @@ func updateHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.Re
 }
 
 func resourceHealthCheckDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	// deleteHealthCheck: Delete an existing GA Health Check
 	var (
 		deleteHealthCheckHttpUrl = "v1/health-checks/{id}"
 		deleteHealthCheckProduct = "ga"
 	)
-	deleteHealthCheckClient, err := config.NewServiceClient(deleteHealthCheckProduct, region)
+	deleteHealthCheckClient, err := conf.NewServiceClient(deleteHealthCheckProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating HealthCheck Client: %s", err)
 	}
@@ -486,7 +486,8 @@ func deleteHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.Re
 					200,
 				},
 			}
-			deleteHealthCheckWaitingResp, err := deleteHealthCheckWaitingClient.Request("GET", deleteHealthCheckWaitingPath, &deleteHealthCheckWaitingOpt)
+			deleteHealthCheckWaitingResp, err := deleteHealthCheckWaitingClient.Request("GET",
+				deleteHealthCheckWaitingPath, &deleteHealthCheckWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
 					return deleteHealthCheckWaitingResp, "COMPLETED", nil
@@ -514,7 +515,6 @@ func deleteHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.Re
 			}
 
 			return deleteHealthCheckWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_listener.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_listener.go
@@ -153,15 +153,15 @@ func ListenerPortRangeSchema() *schema.Resource {
 }
 
 func resourceListenerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	// createListener: Create a GA Listener.
 	var (
 		createListenerHttpUrl = "v1/listeners"
 		createListenerProduct = "ga"
 	)
-	createListenerClient, err := config.NewServiceClient(createListenerProduct, region)
+	createListenerClient, err := conf.NewServiceClient(createListenerProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Listener Client: %s", err)
 	}
@@ -174,7 +174,7 @@ func resourceListenerCreate(ctx context.Context, d *schema.ResourceData, meta in
 			201,
 		},
 	}
-	createListenerOpt.JSONBody = utils.RemoveNil(buildCreateListenerBodyParams(d, config))
+	createListenerOpt.JSONBody = utils.RemoveNil(buildCreateListenerBodyParams(d))
 	createListenerResp, err := createListenerClient.Request("POST", createListenerPath, &createListenerOpt)
 	if err != nil {
 		return diag.Errorf("error creating Listener: %s", err)
@@ -198,7 +198,7 @@ func resourceListenerCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return resourceListenerRead(ctx, d, meta)
 }
 
-func buildCreateListenerBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildCreateListenerBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"listener": map[string]interface{}{
 			"accelerator_id":  utils.ValueIngoreEmpty(d.Get("accelerator_id")),
@@ -289,7 +289,6 @@ func createListenerWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 			}
 
 			return createListenerWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
@@ -299,9 +298,9 @@ func createListenerWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 	return err
 }
 
-func resourceListenerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+func resourceListenerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -310,7 +309,7 @@ func resourceListenerRead(ctx context.Context, d *schema.ResourceData, meta inte
 		getListenerHttpUrl = "v1/listeners/{id}"
 		getListenerProduct = "ga"
 	)
-	getListenerClient, err := config.NewServiceClient(getListenerProduct, region)
+	getListenerClient, err := conf.NewServiceClient(getListenerProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Listener Client: %s", err)
 	}
@@ -377,8 +376,8 @@ func flattenGetListenerResponseBodyResourceTag(resp interface{}) map[string]inte
 }
 
 func resourceListenerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	updateListenerhasChanges := []string{
 		"client_affinity",
@@ -393,7 +392,7 @@ func resourceListenerUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			updateListenerHttpUrl = "v1/listeners/{id}"
 			updateListenerProduct = "ga"
 		)
-		updateListenerClient, err := config.NewServiceClient(updateListenerProduct, region)
+		updateListenerClient, err := conf.NewServiceClient(updateListenerProduct, region)
 		if err != nil {
 			return diag.Errorf("error creating Listener Client: %s", err)
 		}
@@ -407,7 +406,7 @@ func resourceListenerUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				200,
 			},
 		}
-		updateListenerOpt.JSONBody = utils.RemoveNil(buildUpdateListenerBodyParams(d, config))
+		updateListenerOpt.JSONBody = utils.RemoveNil(buildUpdateListenerBodyParams(d))
 		_, err = updateListenerClient.Request("PUT", updateListenerPath, &updateListenerOpt)
 		if err != nil {
 			return diag.Errorf("error updating Listener: %s", err)
@@ -420,7 +419,7 @@ func resourceListenerUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return resourceListenerRead(ctx, d, meta)
 }
 
-func buildUpdateListenerBodyParams(d *schema.ResourceData, config *config.Config) map[string]interface{} {
+func buildUpdateListenerBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"listener": map[string]interface{}{
 			"client_affinity": utils.ValueIngoreEmpty(d.Get("client_affinity")),
@@ -508,7 +507,6 @@ func updateListenerWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 			}
 
 			return updateListenerWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
@@ -519,15 +517,15 @@ func updateListenerWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 }
 
 func resourceListenerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 
 	// deleteListener: Delete an existing GA Listener
 	var (
 		deleteListenerHttpUrl = "v1/listeners/{id}"
 		deleteListenerProduct = "ga"
 	)
-	deleteListenerClient, err := config.NewServiceClient(deleteListenerProduct, region)
+	deleteListenerClient, err := conf.NewServiceClient(deleteListenerProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Listener Client: %s", err)
 	}
@@ -607,7 +605,6 @@ func deleteListenerWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 			}
 
 			return deleteListenerWaitingRespBody, "PENDING", nil
-
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix ga resource lint error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
./scripts/codecheck.sh ./huaweicloud/services/ga

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        5      2888      323        56     2509        325            65.06
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ces/ga/resource_huaweicloud_ga_listener.go       615       67        11      537         72            13.41
~/ga/resource_huaweicloud_ga_accelerator.go       666       72        11      583         67            11.49
~/resource_huaweicloud_ga_endpoint_group.go       557       63        11      483         66            13.66
~ces/ga/resource_huaweicloud_ga_endpoint.go       525       62        12      451         61            13.53
~ga/resource_huaweicloud_ga_health_check.go       525       59        11      455         59            12.97
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     5      2888      323        56     2509        325            65.06
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 98659 bytes, 0.099 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
7 ga deleteListenerWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_listener.go:554:1
7 ga updateListenerWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_listener.go:453:1
7 ga createListenerWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_listener.go:235:1
7 ga deleteHealthCheckWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go:463:1
7 ga updateHealthCheckWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go:361:1
7 ga createHealthCheckWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go:180:1
7 ga deleteEndpointGroupWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_endpoint_group.go:495:1
7 ga updateEndpointGroupWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_endpoint_group.go:393:1
7 ga createEndpointGroupWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_endpoint_group.go:206:1
7 ga deleteEndpointWaitingForStateCompleted huaweicloud/services/ga/resource_huaweicloud_ga_endpoint.go:450:1
Average: 3.75

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in ga...

==> Checking for misspell in ga...

==> Checking for code complexity in ./huaweicloud/services/acceptance/ga...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        5       676       67         5      604         25            20.23
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~a/resource_huaweicloud_ga_endpoint_test.go       160       15         1      144          9             6.25
~urce_huaweicloud_ga_endpoint_group_test.go       121       13         1      107          4             3.74
~source_huaweicloud_ga_health_check_test.go       126       13         1      112          4             3.57
~esource_huaweicloud_ga_accelerator_test.go       126       13         1      112          4             3.57
~a/resource_huaweicloud_ga_listener_test.go       143       13         1      129          4             3.10
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     5       676       67         5      604         25            20.23
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 19604 bytes, 0.020 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
4 ga testEndpointImportState huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_test.go:144:1
3 ga getListenerResourceFunc huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_listener_test.go:18:1
3 ga getHealthCheckResourceFunc huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_health_check_test.go:18:1
3 ga getEndpointResourceFunc huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_test.go:18:1
3 ga getEndpointGroupResourceFunc huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_group_test.go:18:1
Average: 1.62

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/ga...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/ga...

==> Cleanup patch...

Check Completed!

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/ga"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v  -timeout 360m -parallel 4
=== RUN   TestAccAccelerator_basic
=== PAUSE TestAccAccelerator_basic
=== RUN   TestAccEndpointGroup_basic
=== PAUSE TestAccEndpointGroup_basic
=== RUN   TestAccEndpoint_basic
=== PAUSE TestAccEndpoint_basic
=== RUN   TestAccHealthCheck_basic
=== PAUSE TestAccHealthCheck_basic
=== RUN   TestAccListener_basic
=== PAUSE TestAccListener_basic
=== CONT  TestAccAccelerator_basic
=== CONT  TestAccHealthCheck_basic
=== CONT  TestAccEndpoint_basic
=== CONT  TestAccEndpointGroup_basic
--- PASS: TestAccAccelerator_basic (62.66s)
=== CONT  TestAccListener_basic
--- PASS: TestAccEndpointGroup_basic (134.66s)
--- PASS: TestAccListener_basic (96.83s)
--- PASS: TestAccHealthCheck_basic (160.87s)
--- PASS: TestAccEndpoint_basic (186.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        186.083s

```
