### PR TITLE
feat(DEW): DEW support a new resource to manage CSMS event

### DIFF
--- a/docs/resources/csms_event.md
+++ b/docs/resources/csms_event.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+---
+
+# huaweicloud_csms_event
+
+Manages a CSMS (Cloud Secret Management Service) event resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "notification_target_type" {}
+variable "notification_target_id" {}
+variable "notification_target_name" {}
+
+resource "huaweicloud_csms_event" "test" {
+  name                     = "test_name"
+  event_types              = ["SECRET_VERSION_CREATED", "SECRET_ROTATED"]
+  status                   = "ENABLED"
+  notification_target_type = var.notification_target_type
+  notification_target_id   = var.notification_target_id
+  notification_target_name = var.notification_target_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the event name. The valid length is limited from `1` to `64`.
+  Only letters, digits, underscores (_) and hyphens (-) are allowed.
+
+  Changing this parameter will create a new resource.
+
+* `event_types` - (Required, List) Specifies the event type list. Valid values are:
+  + **SECRET_VERSION_CREATED**: Triggered when a version of a secret is created.
+  + **SECRET_VERSION_EXPIRED**: Triggered when a secret version expires, and only once per expiration.
+  + **SECRET_ROTATED**: Triggered when a secret is rotated. Currently, only RDS secrets can be automatically rotated.
+  + **SECRET_DELETED**: Triggered when a secret is deleted.
+
+* `status` - (Required, String) Specifies the event status. Valid values are **ENABLED** and **DISABLED**.
+  Only the event in **ENABLED** status can be triggered.
+
+* `notification_target_type` - (Required, String) Specifies the notification target type.
+  Currently, only **SMN** is supported.
+
+* `notification_target_id` - (Required, String) Specifies the notification target ID.
+  Currently, only SMN topic URN is supported.
+
+* `notification_target_name` - (Required, String) Specifies the notification target name.
+  Currently, only SMN topic name is supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals the `name`.
+
+* `event_id` - The event ID.
+
+## Import
+
+The CSMS event can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_csms_event.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -805,6 +805,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cse_microservice_engine":   cse.ResourceMicroserviceEngine(),
 			"huaweicloud_cse_microservice_instance": cse.ResourceMicroserviceInstance(),
 
+			"huaweicloud_csms_event":  dew.ResourceCsmsEvent(),
 			"huaweicloud_csms_secret": dew.ResourceCsmsSecret(),
 
 			"huaweicloud_css_cluster":       css.ResourceCssCluster(),

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_event_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_event_test.go
@@ -1,0 +1,142 @@
+package dew
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getCsmsEventResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/{project_id}/csms/events/{event_name}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{event_name}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CSMS event: %s", err)
+	}
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccCsmsEvent_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_csms_event.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getCsmsEventResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCsmsEvent_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "event_types.0", "SECRET_VERSION_CREATED"),
+					resource.TestCheckResourceAttr(rName, "event_types.1", "SECRET_ROTATED"),
+					resource.TestCheckResourceAttr(rName, "status", "ENABLED"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_id",
+						"huaweicloud_smn_topic.testA", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name",
+						"huaweicloud_smn_topic.testA", "name"),
+					resource.TestCheckResourceAttrSet(rName, "event_id"),
+				),
+			},
+			{
+				Config: testCsmsEvent_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "event_types.0", "SECRET_VERSION_EXPIRED"),
+					resource.TestCheckResourceAttr(rName, "status", "DISABLED"),
+					resource.TestCheckResourceAttr(rName, "notification_target_type", "SMN"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_id",
+						"huaweicloud_smn_topic.testB", "id"),
+					resource.TestCheckResourceAttrPair(rName, "notification_target_name",
+						"huaweicloud_smn_topic.testB", "name"),
+					resource.TestCheckResourceAttrSet(rName, "event_id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testCsmsEvent_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "testA" {
+  name         = "%[1]s_a"
+  display_name = "The display nameA"
+}
+
+resource "huaweicloud_smn_topic" "testB" {
+  name         = "%[1]s_b"
+  display_name = "The display nameB"
+}
+`, name)
+}
+
+func testCsmsEvent_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_csms_event" "test" {
+  name                     = "%s"
+  event_types              = ["SECRET_VERSION_CREATED", "SECRET_ROTATED"]
+  status                   = "ENABLED"
+  notification_target_type = "SMN"
+  notification_target_id   = huaweicloud_smn_topic.testA.id
+  notification_target_name = huaweicloud_smn_topic.testA.name
+}
+`, testCsmsEvent_base(name), name)
+}
+
+func testCsmsEvent_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_csms_event" "test" {
+  name                     = "%s"
+  event_types              = ["SECRET_VERSION_EXPIRED"]
+  status                   = "DISABLED"
+  notification_target_type = "SMN"
+  notification_target_id   = huaweicloud_smn_topic.testB.id
+  notification_target_name = huaweicloud_smn_topic.testB.name
+}
+`, testCsmsEvent_base(name), name)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_csms_event.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_csms_event.go
@@ -1,0 +1,234 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DEW
+// ---------------------------------------------------------------
+
+package dew
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceCsmsEvent() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCsmsEventCreate,
+		UpdateContext: resourceCsmsEventUpdate,
+		ReadContext:   resourceCsmsEventRead,
+		DeleteContext: resourceCsmsEventDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the name of CSMS event.`,
+			},
+			"event_types": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Required:    true,
+				Description: `Specifies the event list.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the event status.`,
+			},
+			"notification_target_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the notification target type.`,
+			},
+			"notification_target_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the notification target ID.`,
+			},
+			"notification_target_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the notification target name.`,
+			},
+			"event_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The event ID.`,
+			},
+		},
+	}
+}
+
+func resourceCsmsEventCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/csms/events"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateCsmsEventBodyParams(d),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating CSMS event: %s", err)
+	}
+
+	name := d.Get("name").(string)
+	d.SetId(name)
+
+	return resourceCsmsEventRead(ctx, d, meta)
+}
+
+func buildCreateCsmsEventBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":         d.Get("name"),
+		"event_types":  d.Get("event_types"),
+		"state":        d.Get("status"),
+		"notification": buildNotificationBodyParam(d),
+	}
+	return bodyParams
+}
+
+func buildNotificationBodyParam(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"target_type": d.Get("notification_target_type"),
+		"target_id":   d.Get("notification_target_id"),
+		"target_name": d.Get("notification_target_name"),
+	}
+}
+
+func resourceCsmsEventRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/{project_id}/csms/events/{event_name}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{event_name}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CSMS event")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("event.name", getRespBody, nil)),
+		d.Set("event_types", utils.PathSearch("event.event_types", getRespBody, nil)),
+		d.Set("status", utils.PathSearch("event.state", getRespBody, nil)),
+		d.Set("notification_target_type", utils.PathSearch("event.notification.target_type", getRespBody, nil)),
+		d.Set("notification_target_id", utils.PathSearch("event.notification.target_id", getRespBody, nil)),
+		d.Set("notification_target_name", utils.PathSearch("event.notification.target_name", getRespBody, nil)),
+		d.Set("event_id", utils.PathSearch("event.event_id", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCsmsEventUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/csms/events/{event_name}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{event_name}", d.Id())
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateCsmsEventBodyParams(d),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating CSMS event: %s", err)
+	}
+	return resourceCsmsEventRead(ctx, d, meta)
+}
+
+func buildUpdateCsmsEventBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"event_types":  d.Get("event_types"),
+		"state":        d.Get("status"),
+		"notification": buildNotificationBodyParam(d),
+	}
+}
+
+func resourceCsmsEventDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/csms/events/{event_name}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{event_name}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CSMS event: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

DEW support a new resource to manage CSMS event

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The API response status code is `404` when the resource is not exist.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/e69128d4-b67e-4ab2-9af6-4be62833eae8)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run TestAccCsmsEvent_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccCsmsEvent_basic -timeout 360m -parallel 4
=== RUN   TestAccCsmsEvent_basic
=== PAUSE TestAccCsmsEvent_basic
=== CONT  TestAccCsmsEvent_basic
--- PASS: TestAccCsmsEvent_basic (27.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       27.397s
```
