### PR TITLE
feat(Vpcep): vpcep resource add organization_permissions field

### DIFF
--- a/docs/resources/vpcep_service.md
+++ b/docs/resources/vpcep_service.md
@@ -56,8 +56,12 @@ The following arguments are supported:
 
 * `approval` - (Optional, Bool) Specifies whether connection approval is required. The default value is false.
 
-* `permissions` - (Optional, List) Specifies the list of accounts to access the VPC endpoint service. The record is in
-  the `iam:domain::domain_id` format, while `*` allows all users to access the VPC endpoint service.
+* `permissions` - (Optional, List) Specifies the list of accounts to access the VPC endpoint service.
+  The record is in the `iam:domain::domain_id` format, while `*` allows all users to access the VPC endpoint service.
+
+* `organization_permissions` - (Optional, List) Specifies the list of organizations to access the VPC endpoint service.
+  The record is in the `organizations:orgPath::org_path` format, while `organizations:orgPath::*` allows all users in
+  organizations to access the VPC endpoint service.
 
 * `description` - (Optional, String) Specifies the description of the VPC endpoint service.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231103032017-ed0e526911d5
+	github.com/chnsz/golangsdk v0.0.0-20231110095352-1b6ebc1f4e8e
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231103032017-ed0e526911d5 h1:CTjY2iKJqzsA8zrPYttHasMVQZUDZHPXZPCW+fNSv0A=
-github.com/chnsz/golangsdk v0.0.0-20231103032017-ed0e526911d5/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231110095352-1b6ebc1f4e8e h1:MVYvd8mFF4X0PY/lnqWBupV0uDktAE7opFaq9RGgNLU=
+github.com/chnsz/golangsdk v0.0.0-20231110095352-1b6ebc1f4e8e/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -330,7 +330,6 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
@@ -46,6 +46,7 @@ func TestAccVPCEPService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.service_port", "8080"),
 					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.terminal_port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "organization_permissions.#", "2"),
 				),
 			},
 			{
@@ -59,7 +60,8 @@ func TestAccVPCEPService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.protocol", "TCP"),
 					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.service_port", "8088"),
 					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.terminal_port", "80"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.0", "*"),
+					resource.TestCheckResourceAttr(resourceName, "organization_permissions.0", "organizations:orgPath::*"),
 				),
 			},
 			{
@@ -157,6 +159,7 @@ resource "huaweicloud_vpcep_service" "test" {
   approval    = false
   description = "test description"
   permissions = ["iam:domain::1234", "iam:domain::5678"]
+  organization_permissions = ["organizations:orgPath::1234", "organizations:orgPath::5678"]
 
   port_mapping {
     service_port  = 8080
@@ -180,7 +183,8 @@ resource "huaweicloud_vpcep_service" "test" {
   port_id     = huaweicloud_compute_instance.ecs.network[0].port
   approval    = true
   description = "test description update"
-  permissions = ["iam:domain::abcd"]
+  permissions = ["*"]
+  organization_permissions = ["organizations:orgPath::*"]
 
   port_mapping {
     service_port  = 8088

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
@@ -256,10 +256,12 @@ func ListConnections(client *golangsdk.ServiceClient, serviceID string, opts Lis
 
 // PermActionOpts used to add to or delete whitelist records from a VPC endpoint service.
 type PermActionOpts struct {
-	// Specifies the operation to be performed: dd or remove.
+	// Specifies the operation to be performed: add or remove.
 	Action string `json:"action" required:"true"`
-	// Lists the whitelist records. The record is in the iam:domain::domain_id format.
+	// Lists the whitelist records. The record is in the iam:domain::domain_id format or organizations:orgPath::org_path.
 	Permissions []string `json:"permissions" required:"true"`
+	// Specifies the type of the whitelist: domainId or orgPath.
+	PermissionType string `json:"permission_type,omitempty"`
 }
 
 // ToServicePostMap assembles a request body based on the contents of a PermActionOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
@@ -196,6 +196,8 @@ type Permission struct {
 	ID string `json:"id"`
 	// the whitelist records.
 	Permission string `json:"permission"`
+	// the type of the whitelist.
+	PermissionType string `json:"permission_type"`
 	// the time of adding the whitelist record
 	Created string `json:"created_at"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231103032017-ed0e526911d5
+# github.com/chnsz/golangsdk v0.0.0-20231110095352-1b6ebc1f4e8e
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
vpcep resource add organization_permissions field

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
Note: The new organization_permissions field indicates that the service parameter of the terminal node that all users of all organizations can connect to should be "organizations:orgPath::\*", which is different from the original permissions field that the service parameter of the terminal node that all users can connect to is "\*".

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep/' TESTARGS='-run TestAccVPCEPService_Basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep/ -v -run TestAccVPCEPService_Basic -timeout 360m -parallel 4 
=== RUN   TestAccVPCEPService_Basic 
=== PAUSE TestAccVPCEPService_Basic
=== CONT  TestAccVPCEPService_Basic
--- PASS: TestAccVPCEPService_Basic (242.50s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     242.536s
```
