### PR TITLE
fix(workspace): status transform lowercase character

### DIFF
--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -601,7 +602,7 @@ func refreshDesktopStatusFunc(client *golangsdk.ServiceClient, desktopId string)
 			return resp, "deleting", nil
 		}
 
-		return resp, resp.TaskStatus, nil
+		return resp, strings.ToLower(resp.TaskStatus), nil
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The current deleted flag of the `Workspace` desktop has changed. The original query details API returned a 404 status code, but now, the query returning a `DELETED` status (it is not sure whether all regions have changed, and this status is not explained in the API documentation).
```
[DEBUG] API Response Body: {
  "desktop": {
    "attach_state": "DEATTACHED",
    "availability_zone": "cn-north-4a",
    "computer_name": "tf-test-d03tz-1",
    "created": "2023-11-10T12:02:11.451Z",
    "creation_type": "MANUALLY",
    "data_volumes": [
      {
        "cluster_id": "",
        "create_time": "2023-11-10T12:07:38.182Z",
        "device": "/dev/vdb",
        "display_name": "tf-test-d03tz-1-volume-0001",
        "id": "bd9f7f877fc111ee9fc0fa163e7a1ec2",
        "size": 50,
        "type": "SAS",
        "volume_id": "4a593f9c-1ca3-49f2-b203-506e07d2ac86"
      }
    ],
    "desktop_id": "fc9823c6-4c82-45d0-9bd7-a8904b9b2517",
    "desktop_isv": "DEFAULT",
    "desktop_type": "DEDICATED",
    "enterprise_project_id": "0",
    "flavor": {
      "id": "s6.large.2",
      "links": []
    },
    "in_maintenance_mode": false,
    "ip_addresses": [
      "192.168.0.184",
      "172.26.10.132"
    ],
    "is_attaching_eip": false,
    "is_support_internet": false,
    "join_domain": "0",
    "login_status": "PRE_CONNECT",
    "metadata": {},
    "os_version": "Windows Server 2019 Standard 64bit",
    "platform_kind": 2,
    "product": {
      "architecture": "x86",
      "charge_mode": "1",
      "cloud_service_type": "hws.service.type.vdi",
      "contain_data_disk": false,
      "cpu": "2",
      "descriptions": "尊享办公|2核|4GB内存",
      "flavor_id": "s6.large.2",
      "is_gpu": false,
      "memory": "4096",
      "package_type": "ultimate",
      "product_id": "workspace.x86.ultimate.large2",
      "resource_type": "hws.resource.type.workspace.desktop",
      "status": "normal",
      "sub_product_list": [],
      "system_disk_size": "80",
      "system_disk_type": "SAS",
      "type": "BASE",
      "volume_product_type": "workspace"
    },
    "product_id": "workspace.x86.ultimate.large2",
    "root_volume": {
      "cluster_id": "",
      "create_time": "2023-11-10T12:07:37.934Z",
      "device": "/dev/vda",
      "display_name": "tf-test-d03tz-1",
      "id": "bd79b5747fc111ee9fc0fa163e7a1ec2",
      "size": 80,
      "type": "SAS",
      "volume_id": "b8a2c3f8-05ec-4266-a3a5-2645949f024a"
    },
    "security_groups": [],
    "sid": "b54b1032-10f5-4b98-b8d1-b9dbed2b634b",
    "site_name": "华北北京四中心站",
    "site_type": "CENTER",
    "status": "DELETED",
    "tags": [],
    "task_status": "",
    "user_group_list": [],
    "user_list": []
  }
}
```
This will cause the status refresh loop to fail to interrupt until it times out.
```
Error: error updating the vault: Bad request with: [PUT https://cbr.cn-north-4.myhuaweicloud.com/v3/0970dd7a1300f5672ff2c003c60ae115/vaults/d12330f4-b8bf-4c29-926a-44d0708bfc18], request_id: aafd900be5c3e47e870cf93daea2951b, error message: {"error_code": "BackupService.9900", "error_msg": "workspace vault not support app_consistent"}
        
          with huaweicloud_cbr_vault.test,
          on terraform_plugin_test.tf line 74, in resource "huaweicloud_cbr_vault" "test":
          74: resource "huaweicloud_cbr_vault" "test" {
        
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: an error occur when delete desktop: unexpected state '', wanted target 'deleted'. last error: %!s(<nil>)
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. deal with the deleted status.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/workspace' TESTARGS='-run=TestAccDesktop_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run=TestAccDesktop_basic -timeout 360m -parallel 4
=== RUN   TestAccDesktop_basic
=== PAUSE TestAccDesktop_basic
=== CONT  TestAccDesktop_basic
--- PASS: TestAccDesktop_basic (894.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 894.441s
```
