### PR TITLE
feat(DEW): DEW support a new resource to manage KMS dedicated keystore

### DIFF
--- a/docs/resources/kms_dedicated_keystore.md
+++ b/docs/resources/kms_dedicated_keystore.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+---
+
+# huaweicloud_kms_dedicated_keystore
+
+Manages a KMS (Key Management Service) dedicated keystore resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "hsm_cluster_id" {}
+variable "hsm_ca_cert" {}
+
+resource "huaweicloud_kms_dedicated_keystore" "test" {
+  alias          = "test_name"
+  hsm_cluster_id = var.hsm_cluster_id
+  hsm_ca_cert    = var.hsm_ca_cert
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `alias` - (Required, String, ForceNew) Specifies the alias of a dedicated keystore. The valid length is limited from
+  `1` to `255`. Only digits, uppercase letters, lowercase letters, underscores (_), hyphens (-), colons (:) and
+  forward slashes (/) are allowed.
+
+  Changing this parameter will create a new resource.
+
+* `hsm_cluster_id` - (Required, String, ForceNew) Specifies the ID of a dedicated HSM cluster that has no dedicated keystore.
+  Changing this parameter will create a new resource.
+
+  -> The dedicated HSM cluster must be active. The cluster can be activated only after adding the master cryptographic
+  machine and non-master cryptographic machine. Currently, only some encryption machine models are supported. Support
+  work order consultation for details.
+
+* `hsm_ca_cert` - (Required, String, ForceNew) Specifies the CA certificate of the dedicated HSM cluster.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The KMS dedicated keystore can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_kms_dedicated_keystore.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `hsm_ca_cert`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_kms_dedicated_keystore" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      hsm_ca_cert,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -990,9 +990,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_device_certificate":  iotda.ResourceDeviceCertificate(),
 			"huaweicloud_iotda_device_linkage_rule": iotda.ResourceDeviceLinkageRule(),
 
-			"huaweicloud_kms_key":     dew.ResourceKmsKey(),
-			"huaweicloud_kps_keypair": dew.ResourceKeypair(),
-			"huaweicloud_kms_grant":   dew.ResourceKmsGrant(),
+			"huaweicloud_kms_key":                dew.ResourceKmsKey(),
+			"huaweicloud_kps_keypair":            dew.ResourceKeypair(),
+			"huaweicloud_kms_grant":              dew.ResourceKmsGrant(),
+			"huaweicloud_kms_dedicated_keystore": dew.ResourceKmsDedicatedKeystore(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -122,7 +122,8 @@ var (
 
 	HW_FGS_TRIGGER_LTS_AGENCY = os.Getenv("HW_FGS_TRIGGER_LTS_AGENCY")
 
-	HW_KMS_ENVIRONMENT = os.Getenv("HW_KMS_ENVIRONMENT")
+	HW_KMS_ENVIRONMENT    = os.Getenv("HW_KMS_ENVIRONMENT")
+	HW_KMS_HSM_CLUSTER_ID = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
 
 	HW_MULTI_ACCOUNT_ENVIRONMENT            = os.Getenv("HW_MULTI_ACCOUNT_ENVIRONMENT")
 	HW_ORGANIZATIONS_OPEN                   = os.Getenv("HW_ORGANIZATIONS_OPEN")
@@ -693,6 +694,13 @@ func TestAccPreCheckScmCertificateName(t *testing.T) {
 func TestAccPreCheckKms(t *testing.T) {
 	if HW_KMS_ENVIRONMENT == "" {
 		t.Skip("This environment does not support KMS tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKmsHsmClusterId(t *testing.T) {
+	if HW_KMS_HSM_CLUSTER_ID == "" {
+		t.Skip("HW_KMS_HSM_CLUSTER_ID must be set for KMS dedicated keystore acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_dedicated_keystore_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_dedicated_keystore_test.go
@@ -1,0 +1,103 @@
+package dew
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getKmsDedicatedKeystoreResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1.0/{project_id}/keystores/{keystore_id}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{keystore_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving KMS dedicated keystore: %s", err)
+	}
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccKmsDedicatedKeystore_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_kms_dedicated_keystore.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getKmsDedicatedKeystoreResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckKmsHsmClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testKmsDedicatedKeystore_basic(name),
+				ExpectError: regexp.MustCompile(` error creating KMS dedicated keystore: Internal Server Error`),
+			},
+		},
+	})
+}
+
+func testKmsDedicatedKeystore_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_dedicated_keystore" "test" {
+  alias          = "%s"
+  hsm_cluster_id = "%s"
+  hsm_ca_cert    = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
+MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
+JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
+QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
+DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
+n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
+TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
++BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
+A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
+XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
+RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
+ZoURg5WiRskhtHEvBsLF
+-----END CERTIFICATE-----
+EOT
+}
+`, name, acceptance.HW_KMS_HSM_CLUSTER_ID)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_dedicated_keystore.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_dedicated_keystore.go
@@ -1,0 +1,196 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DEW
+// ---------------------------------------------------------------
+
+package dew
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceKmsDedicatedKeystore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKmsDedicatedKeystoreCreate,
+		ReadContext:   resourceKmsDedicatedKeystoreRead,
+		DeleteContext: resourceKmsDedicatedKeystoreDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"alias": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the alias of a dedicated keystore.`,
+			},
+			"hsm_cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of a dedicated HSM cluster that has no dedicated keystore.`,
+			},
+			"hsm_ca_cert": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the CA certificate of the dedicated HSM cluster.`,
+			},
+		},
+	}
+}
+
+func resourceKmsDedicatedKeystoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/keystores"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+		JSONBody:         buildCreateDedicatedKeystoreBodyParams(d),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating KMS dedicated keystore: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("keystore.keystore_id", createRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating KMS dedicated keystore: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceKmsDedicatedKeystoreRead(ctx, d, meta)
+}
+
+func buildCreateDedicatedKeystoreBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"keystore_alias": d.Get("alias"),
+		"hsm_cluster_id": d.Get("hsm_cluster_id"),
+		"hsm_ca_cert":    d.Get("hsm_ca_cert"),
+	}
+}
+
+func resourceKmsDedicatedKeystoreRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1.0/{project_id}/keystores/{keystore_id}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{keystore_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, parseErrorToError404(err), "error retrieving KMS dedicated keystore")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("alias", utils.PathSearch("keystore.keystore_alias", getRespBody, nil)),
+		d.Set("hsm_cluster_id", utils.PathSearch("keystore.hsm_cluster_id", getRespBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func parseErrorToError404(err error) error {
+	var errCode golangsdk.ErrDefault400
+	if errors.As(err, &errCode) {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return err
+		}
+
+		errorCode, errorCodeErr := jmespath.Search("error.error_code", apiError)
+		if errorCodeErr != nil {
+			return err
+		}
+
+		if errorCode == "KMS.8003" {
+			return golangsdk.ErrDefault404(errCode)
+		}
+	}
+	return err
+}
+
+func resourceKmsDedicatedKeystoreDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1.0/{project_id}/keystores/{keystore_id}"
+		product = "kms"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{keystore_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting KMS dedicated keystore: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

DEW support a new resource to manage KMS dedicated keystore.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Due to environmental reasons, the interface cannot be called currently.
- Only one test case is configured to test interface error scenarios.
- This resource has not been fully functionally tested.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run TestAccKmsDedicatedKeystore_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKmsDedicatedKeystore_basic -timeout 360m -parallel 4
=== RUN   TestAccKmsDedicatedKeystore_basic
=== PAUSE TestAccKmsDedicatedKeystore_basic
=== CONT  TestAccKmsDedicatedKeystore_basic
--- PASS: TestAccKmsDedicatedKeystore_basic (2.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       2.610s
```
