### PR TITLE
feat(cbr/vault): new types are supported

### DIFF
--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -133,6 +133,48 @@ resource "huaweicloud_cbr_vault" "test" {
 }
 ```
 
+### Create a Workspace type vault
+
+```hcl
+variable "vault_name" {}
+
+resource "huaweicloud_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "workspace"
+  protection_type  = "backup"
+  size             = 100
+  consistent_level = "crash_consistent"
+}
+```
+
+### Create a VMware type vault
+
+```hcl
+variable "vault_name" {}
+
+resource "huaweicloud_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "vmware"
+  protection_type  = "backup"
+  size             = 100
+  consistent_level = "crash_consistent"
+}
+```
+
+### Create a file type vault
+
+```hcl
+variable "vault_name" {}
+
+resource "huaweicloud_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "file"
+  protection_type  = "backup"
+  size             = 100
+  consistent_level = "crash_consistent"
+}
+```
+
 ## Argument reference
 
 The following arguments are supported:
@@ -145,9 +187,12 @@ The following arguments are supported:
 
 * `type` - (Required, String, ForceNew) Specifies the object type of the CBR vault.
   Changing this will create a new vault. Vaild values are as follows:
-  + **server** (Cloud Servers)
-  + **disk** (EVS Disks)
-  + **turbo** (SFS Turbo file systems)
+  + **server** (Elastic Cloud Server)
+  + **disk** (EVS Disk)
+  + **turbo** (SFS Turbo file system)
+  + **workspace** (Workspace Desktop)
+  + **vmware** (VMware)
+  + **file** (File System)
 
 * `protection_type` - (Required, String, ForceNew) Specifies the protection type of the CBR vault.
   The valid values are **backup** and **replication**. Vaults of type **disk** don't support **replication**.
@@ -163,7 +208,8 @@ The following arguments are supported:
   + **[app_consistent](https://support.huaweicloud.com/intl/en-us/usermanual-cbr/cbr_03_0109.html)**
 
   Only **server** type vaults support application consistent and defaults to **crash_consistent**, and only
-  **crash_consistent** can be updated to **app_consistent**.
+  **crash_consistent** can be updated to **app_consistent**.  
+  The **workspace** type vaults does not support application consistent.
 
 * `auto_expand` - (Optional, Bool) Specifies to enable auto capacity expansion for the backup protection type vault.
   Defaults to **false**.
@@ -180,7 +226,8 @@ The following arguments are supported:
 * `policy` - (Optional, List) Specifies the policy details to associate with the CBR vault.
   The [object](#cbr_vault_policies) structure is documented below.
 
-* `resources` - (Optional, List) Specifies an array of one or more resources to attach to the CBR vault.
+* `resources` - (Optional, List) Specifies an array of one or more resources to attach to the CBR vault.  
+  This feature is not supported for the **vmware** type and the **file** type.  
   The [object](#cbr_vault_resources) structure is documented below.
 
 * `backup_name_prefix` - (Optional, String, ForceNew) Specifies the backup name prefix.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Vault support three types creation:
- workspace
- vmware
- file

Because the **vmware** type and **file** type do not support configuring backup resources, and API restrictions require them to be assigned a null value. Therefore, the return logic of the build function needs to be adjusted

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. three types are supported
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
pending workspace issue fix
```
