### PR TITLE
feat(cbr/backup): add new resource to share backups

### DIFF
--- a/docs/resources/cbr_backup_share.md
+++ b/docs/resources/cbr_backup_share.md
@@ -1,0 +1,81 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# huaweicloud_cbr_backup_share
+
+Using this resource to share backups with other members within HuaweiCloud (in the same region).
+
+-> Currently, only Server backup type support to manage shared members.
+   And a backup can only create one of this resource.
+
+## Example Usage
+
+```hcl
+variable "backup_id" {}
+variable "shared_project_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_cbr_backup_share" "test" {
+  backup_id = var.backup_id
+
+  dynamic "members" {
+    for_each = var.shared_project_ids
+
+    content {
+      dest_project_id = members.value
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region to which the backup and sharing project belong.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `backup_id` - (Required, String, ForceNew) Specifies the backup ID.  
+  Changing this will create a new resource.
+
+* `members` - (Required, List) Specifies the list of shared members configuration.
+  The [members](#cbr_backup_share_members_args) structure is documented below.  
+
+<a name="cbr_backup_share_members_args"></a>
+The `members` block supports:
+
+* `dest_project_id` - (Required, String) Specifies the ID of the project with which the backup is shared.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also backup ID) in UUID format.
+
+* `members` - The list of shared members configuration.
+  The [members](#cbr_checkpoint_backup_attr) structure is documented below.  
+
+<a name="cbr_checkpoint_backup_attr"></a>
+The `members` block supports:
+
+* `id` - The ID of the backup shared member record.
+
+* `status` - The backup sharing status.
+
+* `created_at` - The creation time of the backup shared member.
+
+* `updated_at` - The latest update time of the backup shared member.
+
+* `image_id` - The ID of the image registered with the shared backup copy.
+
+* `vault_id` - The ID of the vault where the shared backup is stored.
+
+## Import
+
+Share resources can be imported by their `id` or `backup_id`, e.g.
+
+```bash
+terraform import huaweicloud_cbr_backup_share.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -744,9 +744,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_instance": bms.ResourceBmsInstance(),
 			"huaweicloud_bcs_instance": resourceBCSInstanceV2(),
 
-			"huaweicloud_cbr_checkpoint": cbr.ResourceCheckpoint(),
-			"huaweicloud_cbr_policy":     cbr.ResourcePolicy(),
-			"huaweicloud_cbr_vault":      cbr.ResourceVault(),
+			"huaweicloud_cbr_backup_share": cbr.ResourceBackupShare(),
+			"huaweicloud_cbr_checkpoint":   cbr.ResourceCheckpoint(),
+			"huaweicloud_cbr_policy":       cbr.ResourcePolicy(),
+			"huaweicloud_cbr_vault":        cbr.ResourceVault(),
 
 			"huaweicloud_cbh_instance": cbh.ResourceCBHInstance(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -474,6 +474,13 @@ func TestAccPreCheckProjectId(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckDestProjectIds(t *testing.T) {
+	if HW_DEST_PROJECT_ID == "" || HW_DEST_PROJECT_ID_TEST == "" {
+		t.Skip("HW_DEST_PROJECT_ID and HW_DEST_PROJECT_ID_TEST must be set for acceptance test.")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckProject(t *testing.T) {
 	if HW_ENTERPRISE_PROJECT_ID_TEST != "" {
 		t.Skip("This environment does not support project tests")

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_backup_share_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_backup_share_test.go
@@ -1,0 +1,138 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/members"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func getBackupShareResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CbrV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CBR v3 client: %s", err)
+	}
+	var (
+		backupId = state.Primary.ID
+		opts     = members.ListOpts{
+			BackupId: backupId,
+		}
+	)
+	memberList, err := members.List(client, opts)
+	if len(memberList) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return memberList, err
+}
+
+func TestAccBackupShare_basic(t *testing.T) {
+	var (
+		memberList   []members.Member
+		name         = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_cbr_backup_share.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&memberList,
+		getBackupShareResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDestProjectIds(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupShare_basic(name, acceptance.HW_DEST_PROJECT_ID),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "backup_id"),
+					resource.TestCheckResourceAttr(resourceName, "members.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "members.0.dest_project_id", acceptance.HW_DEST_PROJECT_ID),
+				),
+			},
+			{
+				Config: testAccBackupShare_basic(name, acceptance.HW_DEST_PROJECT_ID_TEST),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "backup_id"),
+					resource.TestCheckResourceAttr(resourceName, "members.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "members.0.dest_project_id", acceptance.HW_DEST_PROJECT_ID_TEST),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccBackupShare_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_cbr_vault" "test" {
+  name             = "%[2]s"
+  type             = "server"
+  consistent_level = "crash_consistent"
+  protection_type  = "backup"
+  size             = 10
+
+  resources {
+    server_id = huaweicloud_compute_instance.test.id
+  }
+}
+
+resource "huaweicloud_cbr_checkpoint" "test" {
+  vault_id = huaweicloud_cbr_vault.test.id
+  name     = "%[2]s"
+
+  backups {
+    type        = "OS::Nova::Server"
+    resource_id = huaweicloud_compute_instance.test.id
+  }
+}
+`, common.TestBaseComputeResources(name), name)
+}
+
+func testAccBackupShare_basic(name, destProjectId string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cbr_backup_share" "test" {
+  backup_id = try(tolist(huaweicloud_cbr_checkpoint.test.backups)[0].id, "")
+
+  members {
+    # Different user (ID) in the same region.
+    dest_project_id = "%[2]s"
+  }
+}
+`, testAccBackupShare_base(name), destProjectId)
+}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_backup_share.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_backup_share.go
@@ -1,0 +1,259 @@
+package cbr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/members"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceBackupShare() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBackupShareCreate,
+		ReadContext:   resourceBackupShareRead,
+		UpdateContext: resourceBackupShareUpdate,
+		DeleteContext: resourceBackupShareDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceBackupShareImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the shared backup is located.",
+			},
+			"backup_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The backup ID.",
+			},
+			"members": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"dest_project_id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The ID of the project with which the backup is shared.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the backup shared member record.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The backup shared status.",
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the backup shared member.",
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The latest update time of the backup shared member.",
+						},
+						"image_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the image registered with the shared backup copy.",
+						},
+						"vault_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the vault where the shared backup is stored.",
+						},
+					},
+				},
+				Description: "The list of shared members configuration.",
+			},
+		},
+	}
+}
+
+// Collect destination project IDs of all shared members.
+func buildBackupSharedMembersInfo(memberList *schema.Set) []string {
+	if memberList.Len() < 1 {
+		return nil
+	}
+	result := make([]string, memberList.Len())
+	for i, val := range memberList.List() {
+		member := val.(map[string]interface{})
+		result[i] = member["dest_project_id"].(string)
+	}
+	return result
+}
+
+func resourceBackupShareCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.CbrV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	var (
+		backupId      = d.Get("backup_id").(string)
+		sharedMembers = d.Get("members").(*schema.Set)
+		opts          = members.CreateOpts{
+			BackupId: backupId,
+			Members:  buildBackupSharedMembersInfo(sharedMembers),
+		}
+	)
+
+	_, err = members.Create(client, opts)
+	if err != nil {
+		return diag.Errorf("failed while adding shared member to specified backup (%s): %s", backupId, err)
+	}
+	// Use the backup ID as the ID of this resource.
+	// Note: One backup can only manage one resource.
+	d.SetId(backupId)
+
+	return resourceBackupShareRead(ctx, d, meta)
+}
+
+func flattenBackupSharedMembersInfo(memberList []members.Member) []map[string]interface{} {
+	if len(memberList) < 1 {
+		return nil
+	}
+	result := make([]map[string]interface{}, len(memberList))
+	for i, member := range memberList {
+		result[i] = map[string]interface{}{
+			"dest_project_id": member.DestProjectId,
+			"id":              member.ID,
+			"status":          member.Status,
+			"created_at":      member.CreatedAt,
+			"updated_at":      member.UpdatedAt,
+			"image_id":        member.ImageId,
+			"vault_id":        member.VaultId,
+		}
+	}
+	return result
+}
+
+func resourceBackupShareRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.CbrV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	var (
+		backupId = d.Id()
+		opts     = members.ListOpts{
+			BackupId: backupId,
+		}
+	)
+	// Query the shared member list under the specified backup.
+	memberList, err := members.List(client, opts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "CBR backup share")
+	}
+	if len(memberList) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "CBR backup share")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("members", flattenBackupSharedMembersInfo(memberList)),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving CBR backup shared: %s", err)
+	}
+	return nil
+}
+
+func resourceBackupShareUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.CbrV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	var (
+		backupId = d.Id()
+		mErr     *multierror.Error
+
+		oldRaws, newRaws = d.GetChange("members")
+		addSet           = newRaws.(*schema.Set).Difference(oldRaws.(*schema.Set))
+		rmSet            = oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set))
+	)
+
+	for _, val := range rmSet.List() {
+		member := val.(map[string]interface{})
+		err = members.Delete(client, backupId, member["dest_project_id"].(string))
+		if err != nil {
+			mErr = multierror.Append(mErr, fmt.Errorf("error delete shared member (%s) from a specified CBR backup (%s): %s",
+				member["id"].(string), backupId, err))
+		}
+	}
+
+	if addSet.Len() > 0 {
+		opts := members.CreateOpts{
+			BackupId: backupId,
+			Members:  buildBackupSharedMembersInfo(addSet),
+		}
+		_, err = members.Create(client, opts)
+		if err != nil {
+			mErr = multierror.Append(mErr, fmt.Errorf("failed while adding shared member to specified backup (%s): %s",
+				backupId, err))
+		}
+	}
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+	return resourceBackupShareRead(ctx, d, meta)
+}
+
+func resourceBackupShareDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.CbrV3Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	var (
+		backupId = d.Id()
+		mErr     *multierror.Error
+
+		listOpts = members.ListOpts{
+			BackupId: backupId,
+		}
+	)
+	memberList, err := members.List(client, listOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, parseBackupError(err), "CBR backup share")
+	}
+
+	for _, member := range memberList {
+		err = members.Delete(client, backupId, member.DestProjectId)
+		if err != nil {
+			mErr = multierror.Append(mErr, fmt.Errorf("error delete shared member (%s) from a specified CBR backup (%s): %s",
+				member.ID, backupId, err))
+		}
+	}
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceBackupShareImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	// The resource ID, which is also the backup ID.
+	return []*schema.ResourceData{d}, d.Set("backup_id", d.Id())
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/members/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/members/requests.go
@@ -1,0 +1,90 @@
+package members
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure that used to batch add shared members.
+type CreateOpts struct {
+	// Backup ID.
+	BackupId string `json:"-" required:"true"`
+	// The list of sharing members configuration.
+	Members []string `json:"members" required:"true"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method used to create a new checkpoint using given parameters.
+func Create(client *golangsdk.ServiceClient, opts CreateOpts) ([]Member, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r struct {
+		Members []Member `json:"members"`
+	}
+	_, err = client.Post(rootURL(client, opts.BackupId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return r.Members, err
+}
+
+// ListOpts is the structure that used to query backup shared list.
+type ListOpts struct {
+	// Backup ID.
+	BackupId string `json:"-" required:"true"`
+	// The ID of the project that accepts the backup share.
+	DestProjectId string `q:"dest_project_id"`
+	// The ID of the image registered with the shared backup copy.
+	ImageId string `q:"image_id"`
+	// Number of records displayed per page.
+	// The value must be a positive integer.
+	Limit int `q:"limit"`
+	// ID of the last record displayed on the previous page.
+	Marker string `q:"marker"`
+	// Offset value. The value must be a positive integer.
+	Offset int `q:"offset"`
+	// A group of properties separated by commas (,) and sorting directions.
+	// The value is in the format of <key1>[:<direction>],<key2>[:<direction>], where the value of direction is
+	// asc (ascending order) or desc (descending order).
+	// If a direction is not specified, the default sorting direction is desc.
+	// The value of sort can contain a maximum of 255 characters.
+	// The key can be as follows: created_at, updated_at, name, status, protected_at, id
+	Sort string `q:"sort"`
+	// The status of the backup share.
+	Status string `q:"status"`
+	// Vault ID.
+	VaultId string `q:"vault_id"`
+}
+
+// List is a method used to query shared member list for specified backup using given parameters.
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Member, error) {
+	url := rootURL(client, opts.BackupId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := MemberPage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractMembers(pages)
+}
+
+// Delete is a method to remove a specified member from the specified backup.
+func Delete(client *golangsdk.ServiceClient, backupId, memberId string) error {
+	_, err := client.Delete(resourceURL(client, backupId, memberId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/members/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/members/results.go
@@ -1,0 +1,41 @@
+package members
+
+import "github.com/chnsz/golangsdk/pagination"
+
+// Member is the structure that represents the backup shared member detail.
+type Member struct {
+	// The status of the backup share.
+	Status string `json:"status"`
+	// The creation time of the backup sharing member.
+	CreatedAt string `json:"created_at"`
+	// The latest update time of the backup sharing member.
+	UpdatedAt string `json:"updated_at"`
+	// The backup ID.
+	BackupId string `json:"backup_id"`
+	// The latest update time of the backup shared member.
+	ImageId string `json:"image_id"`
+	// The ID of the project with which the backup is shared.
+	DestProjectId string `json:"dest_project_id"`
+	// The ID of the vault where the shared backup is stored.
+	VaultId string `json:"vault_id"`
+	// The ID of the backup shared member record.
+	ID string `json:"id"`
+}
+
+// MemberPage is a single page maximum result representing a query by offset page.
+type MemberPage struct {
+	pagination.OffsetPageBase
+}
+
+// IsEmpty checks whether a MemberPage struct is empty.
+func (b MemberPage) IsEmpty() (bool, error) {
+	arr, err := ExtractMembers(b)
+	return len(arr) == 0, err
+}
+
+// ExtractMembers is a method to extract the list of sharing members.
+func ExtractMembers(r pagination.Page) ([]Member, error) {
+	var s []Member
+	err := r.(MemberPage).Result.ExtractIntoSlicePtr(&s, "members")
+	return s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/members/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/members/urls.go
@@ -1,0 +1,11 @@
+package members
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, backupId string) string {
+	return c.ServiceURL("backups", backupId, "members")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, backupId, memberId string) string {
+	return c.ServiceURL("backups", backupId, "members", memberId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -57,6 +57,7 @@ github.com/chnsz/golangsdk/openstack/bss/v2/orders
 github.com/chnsz/golangsdk/openstack/bss/v2/resources
 github.com/chnsz/golangsdk/openstack/cbr/v3/backups
 github.com/chnsz/golangsdk/openstack/cbr/v3/checkpoints
+github.com/chnsz/golangsdk/openstack/cbr/v3/members
 github.com/chnsz/golangsdk/openstack/cbr/v3/policies
 github.com/chnsz/golangsdk/openstack/cbr/v3/vaults
 github.com/chnsz/golangsdk/openstack/cce/v1/namespaces


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new resource to share a backup to other members in the same region.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to share backups
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccBackupShare_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccBackupShare_basic -timeout 360m -parallel 4
=== RUN   TestAccBackupShare_basic
=== PAUSE TestAccBackupShare_basic
=== CONT  TestAccBackupShare_basic
--- PASS: TestAccBackupShare_basic (674.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr   674.608s
```
