### PR TITLE
fix(fgs): fix fgs instance resource lint error 

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -218,7 +218,8 @@ The following arguments are supported:
 
 -> If the function is created using an SWR image, keep `code_type` empty and use **-** to set the handler.
 
-* `functiongraph_version` - (Optional, String, ForceNew) Specifies the FunctionGraph version, defaults to **v1**.
+* `functiongraph_version` - (Optional, String, ForceNew) Specifies the FunctionGraph version, default value is **v2**.
+  Some regions support only v1, the default value is **v1**.
   + **v1**: Hosts event-driven functions in a serverless context.
   + **v2**: Next-generation function hosting service powered by Huawei YuanRong architecture.
 

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
@@ -1,7 +1,6 @@
 package fgs
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
@@ -18,7 +17,7 @@ func TestAccFunctionGraphDependencies_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionGraphDependencies_basic(),
+				Config: testAccFunctionGraphDependenciesBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "packages.#", regexp.MustCompile(`[1-9][0-9]*`)),
 				),
@@ -35,7 +34,7 @@ func TestAccFunctionGraphDependencies_name(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionGraphDependencies_name(),
+				Config: testAccFunctionGraphDependenciesName,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", "obssdk-3.0.2"),
@@ -54,7 +53,7 @@ func TestAccFunctionGraphDependencies_runtime(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionGraphDependencies_runtime(),
+				Config: testAccFunctionGraphDependenciesRuntime,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
 					resource.TestCheckResourceAttr(dataSourceName, "runtime", "Python2.7"),
@@ -65,26 +64,15 @@ func TestAccFunctionGraphDependencies_runtime(t *testing.T) {
 	})
 }
 
-func testAccFunctionGraphDependencies_basic() string {
-	return fmt.Sprintf(`
-data "huaweicloud_fgs_dependencies" "test" {}
-`)
-}
+const testAccFunctionGraphDependenciesBasic = `data "huaweicloud_fgs_dependencies" "test" {}`
 
-func testAccFunctionGraphDependencies_name() string {
-	return fmt.Sprintf(`
+const testAccFunctionGraphDependenciesName = `
 data "huaweicloud_fgs_dependencies" "test" {
   type = "public"
   name = "obssdk-3.0.2"
-}
-`)
-}
+}`
 
-func testAccFunctionGraphDependencies_runtime() string {
-	return fmt.Sprintf(`
-data "huaweicloud_fgs_dependencies" "test" {
+const testAccFunctionGraphDependenciesRuntime = `data "huaweicloud_fgs_dependencies" "test" {
   type    = "public"
   runtime = "Python2.7"
-}
-`)
-}
+}`

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -2,6 +2,7 @@ package fgs
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -42,7 +43,8 @@ func TestAccFgsV2Function_basic(t *testing.T) {
 				Config: testAccFgsV2Function_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "functiongraph_version", "v1"),
+					// Default value is v2. Some regions support only v1, the default value is v1
+					resource.TestMatchResourceAttr(resourceName, "functiongraph_version", regexp.MustCompile(`v1|v2`)),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttrSet(resourceName, "urn"),
@@ -284,6 +286,7 @@ func TestAccFgsV2Function_logConfig(t *testing.T) {
 }
 
 func testAccFgsV2Function_basic(rName string) string {
+	//nolint:revive
 	return fmt.Sprintf(`
 resource "huaweicloud_fgs_function" "test" {
   name        = "%s"
@@ -305,6 +308,7 @@ resource "huaweicloud_fgs_function" "test" {
 }
 
 func testAccFgsV2Function_update(rName string) string {
+	//nolint:revive
 	return fmt.Sprintf(`
 %[1]s
 
@@ -360,6 +364,7 @@ EOF
 }
 
 func testAccFgsV2Function_withEpsId(rName string) string {
+	//nolint:revive
 	return fmt.Sprintf(`
 resource "huaweicloud_fgs_function" "test" {
   name                  = "%s"

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func getTriggerResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -183,6 +182,7 @@ func TestAccFunctionGraphTrigger_lts(t *testing.T) {
 }
 
 func testAccFunctionGraphTimingTrigger_base(rName string) string {
+	//nolint:revive
 	return fmt.Sprintf(`
 resource "huaweicloud_fgs_function" "test" {
   name        = "%s"
@@ -285,6 +285,7 @@ resource "huaweicloud_fgs_trigger" "test" {
 }
 
 func testAccFunctionGraphLtsTrigger_basic(rName string) string {
+	//nolint:revive
 	return fmt.Sprintf(`
 resource "huaweicloud_lts_group" "test" {
   group_name  = "%[1]s"
@@ -327,58 +328,4 @@ resource "huaweicloud_fgs_trigger" "test" {
     log_topic_id = huaweicloud_lts_stream.test.id
   }
 }`, rName, acceptance.HW_REGION_NAME, acceptance.HW_FGS_TRIGGER_LTS_AGENCY)
-}
-
-func testAccNetwork_config(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_availability_zones" "test" {}
-
-resource "huaweicloud_networking_secgroup_rule" "test" {
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 9092
-  port_range_max    = 9092
-  remote_ip_prefix  = "0.0.0.0/0"
-}`, common.TestBaseNetwork(rName))
-}
-
-func testAccDmsKafka_config(rName, password string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_dms_az" "test" {}
-
-data "huaweicloud_dms_product" "test" {
-  engine            = "kafka"
-  version           = "1.1.0"
-  instance_type     = "cluster"
-  partition_num     = 300
-  storage           = 600
-  storage_spec_code = "dms.physical.storage.high"
-}
-
-resource "huaweicloud_dms_kafka_instance" "test" {
-  name              = "%s"
-  vpc_id            = huaweicloud_vpc.test.id
-  network_id        = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  available_zones   = [data.huaweicloud_dms_az.test.id]
-  product_id        = data.huaweicloud_dms_product.test.id
-  engine_version    = data.huaweicloud_dms_product.test.version
-  bandwidth         = data.huaweicloud_dms_product.test.bandwidth
-  storage_space     = data.huaweicloud_dms_product.test.storage
-  storage_spec_code = data.huaweicloud_dms_product.test.storage_spec_code
-  manager_user      = "%s"
-  manager_password  = "%s"
-}
-
-resource "huaweicloud_dms_kafka_topic" "test" {
-  instance_id = huaweicloud_dms_kafka_instance.test.id
-  name        = "%s"
-  partitions  = 20
-}`, testAccNetwork_config(rName), rName, rName, password, rName)
 }

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_functions.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_functions.go
@@ -172,7 +172,7 @@ func dataSourceFunctionGraphFunctionsRead(_ context.Context, d *schema.ResourceD
 
 	fgsClient, err := conf.FgsV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating FGS V2 client: %s", err)
+		return diag.Errorf("error creating FunctionGraph V2 client: %s", err)
 	}
 
 	// MaxItems and Marker use default values.
@@ -203,7 +203,7 @@ func dataSourceFunctionGraphFunctionsRead(_ context.Context, d *schema.ResourceD
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error saving datas of FGS functions: %s", err)
+		return diag.Errorf("error saving datas of FunctionGraph functions: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
 ./scripts/codecheck.sh ./huaweicloud/services/fgs           
==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        6      2651      209        69     2373        289            64.49
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~s/fgs/resource_huaweicloud_fgs_function.go       942       74        34      834        123            14.75
~es/fgs/resource_huaweicloud_fgs_trigger.go       919       64        23      832        100            12.02
~weicloud_fgs_async_invoke_configuration.go       221       23         0      198         24            12.12
~fgs/resource_huaweicloud_fgs_dependency.go       164       19         2      143         18            12.59
~s/data_source_huaweicloud_fgs_functions.go       265       17         8      240         16             6.67
~ata_source_huaweicloud_fgs_dependencies.go       140       12         2      126          8             6.35
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     6      2651      209        69     2373        289            64.49
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 79006 bytes, 0.079 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
13 fgs resourceFgsFunctionV2Create huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go:392:1
12 fgs resourceFgsFunctionV2Update huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go:722:1
10 fgs resourceFgsFunctionV2MetadataUpdate huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go:789:1
9 fgs buildFunctionGraphTriggerParameters huaweicloud/services/fgs/resource_huaweicloud_fgs_trigger.go:566:1
8 fgs setTriggerEventData huaweicloud/services/fgs/resource_huaweicloud_fgs_trigger.go:759:1
8 fgs resourceFunctionGraphTriggerCreate huaweicloud/services/fgs/resource_huaweicloud_fgs_trigger.go:601:1
8 fgs buildFgsFunctionV2Parameters huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go:335:1
7 fgs triggerV2StateRefreshFunc huaweicloud/services/fgs/resource_huaweicloud_fgs_trigger.go:862:1
7 fgs resourceFunctionGraphTriggerRead huaweicloud/services/fgs/resource_huaweicloud_fgs_trigger.go:792:1
7 fgs dataSourceFunctionGraphFunctionsRead huaweicloud/services/fgs/data_source_huaweicloud_fgs_functions.go:169:1
Average: 3.32

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go:413:    // lintignore:R019
./huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go:731:    // lintignore:R019
./huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go:738:    // lintignore:R019

==> Checking for TF features in fgs...
  -> the resource in resource_huaweicloud_fgs_trigger.go should can be imported


==> Checking for misspell in fgs...
examples/fgs/obs-download/main.tf:46:64: "directoty" is a misspelling of "directory"

==> Checking for code complexity in ./huaweicloud/services/acceptance/fgs...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        6      1976      130         8     1838          8             4.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~oud_fgs_async_invoke_configuration_test.go       186       10         2      174          2             1.15
~esource_huaweicloud_fgs_dependency_test.go        94       10         0       84          2             2.38
~/resource_huaweicloud_fgs_function_test.go       872       49         3      820          2             0.24
~s/resource_huaweicloud_fgs_trigger_test.go       331       24         2      305          2             0.66
~ource_huaweicloud_fgs_dependencies_test.go        86       12         0       74          0             0.00
~a_source_huaweicloud_fgs_functions_test.go       407       25         1      381          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     6      1976      130         8     1838          8             4.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 58783 bytes, 0.059 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
2 fgs getTriggerResourceFunc huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go:16:1
2 fgs getResourceObj huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go:17:1
2 fgs getDependencyResourceFunc huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_test.go:16:1
2 fgs getAsyncInvokeConfigFunc huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_invoke_configuration_test.go:17:1
1 fgs testAccFunctionGraphLtsTrigger_basic huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go:287:1
Average: 1.06

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/fgs...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/fgs...
./huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_functions_test.go:50: //nolint:revive
./huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go:287:    //nolint:revive
./huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go:309:    //nolint:revive
./huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go:365:    //nolint:revive
./huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go:185:     //nolint:revive
./huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go:288:     //nolint:revive

==> Cleanup patch...

Check Completed!



```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

 make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run TestAccFgsV2Function_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccFgsV2Function_basic -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic
--- PASS: TestAccFgsV2Function_basic (88.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       88.848s
 make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run TestAccFunctionGraphTrigger_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccFunctionGraphTrigger_basic -timeout 360m -parallel 4
=== RUN   TestAccFunctionGraphTrigger_basic
=== PAUSE TestAccFunctionGraphTrigger_basic
=== CONT  TestAccFunctionGraphTrigger_basic
--- PASS: TestAccFunctionGraphTrigger_basic (37.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       37.504s
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run TestAccAsyncInvokeConfig_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccAsyncInvokeConfig_basic -timeout 360m -parallel 4
=== RUN   TestAccAsyncInvokeConfig_basic
=== PAUSE TestAccAsyncInvokeConfig_basic
=== CONT  TestAccAsyncInvokeConfig_basic
    acceptance.go:389: HW_FGS_TRIGGER_LTS_AGENCY must be set for FGS trigger acceptance tests
--- SKIP: TestAccAsyncInvokeConfig_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       0.045s
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run TestAccFunctionGraphResourceDependency_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccFunctionGraphResourceDependency_basic -timeout 360m -parallel 4
=== RUN   TestAccFunctionGraphResourceDependency_basic
=== PAUSE TestAccFunctionGraphResourceDependency_basic
=== CONT  TestAccFunctionGraphResourceDependency_basic
    acceptance.go:492: HW_OBS_BUCKET_NAME must be set for OBS object acceptance tests
--- SKIP: TestAccFunctionGraphResourceDependency_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       0.043s
