### PR TITLE
feat(Vpcep): public VPC endpoint services datasource add pagination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231110095352-1b6ebc1f4e8e
+	github.com/chnsz/golangsdk v0.0.0-20231116072521-3b50f11b2a9c
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231110095352-1b6ebc1f4e8e h1:MVYvd8mFF4X0PY/lnqWBupV0uDktAE7opFaq9RGgNLU=
-github.com/chnsz/golangsdk v0.0.0-20231110095352-1b6ebc1f4e8e/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231116072521-3b50f11b2a9c h1:/GeRvSU1aubMvJzVCno//EDkcms3+oFjlw08egtQhMg=
+github.com/chnsz/golangsdk v0.0.0-20231116072521-3b50f11b2a9c/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_public_services.go
+++ b/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_public_services.go
@@ -76,7 +76,7 @@ func dataSourceVpcepPublicRead(_ context.Context, d *schema.ResourceData, meta i
 		ID:          d.Get("service_id").(string),
 	}
 
-	allServices, err := services.ListPublic(vpcepClient, listOpts)
+	allServices, err := services.ListAllPublics(vpcepClient, listOpts)
 	if err != nil {
 		return diag.Errorf("unable to retrieve VPC endpoint public services: %s", err)
 	}

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
@@ -3,6 +3,7 @@ package services
 import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/pagination"
 )
 
 // Service contains the response of the VPC endpoint service
@@ -223,4 +224,16 @@ func (r ListPermResult) ExtractPermissions() ([]Permission, error) {
 		return nil, err
 	}
 	return s.Permissions, nil
+}
+
+// PublicServicePage is a single page maximum result representing a query by offset page.
+type PublicServicePage struct {
+	pagination.OffsetPageBase
+}
+
+// extractPublicService is a method to extract the list of tags supported PublicService.
+func extractPublicService(r pagination.Page) ([]PublicService, error) {
+	var s []PublicService
+	err := r.(PublicServicePage).Result.ExtractIntoSlicePtr(&s, "endpoint_services")
+	return s, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231110095352-1b6ebc1f4e8e
+# github.com/chnsz/golangsdk v0.0.0-20231116072521-3b50f11b2a9c
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
public VPC endpoint services datasource add pagination

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep/' TESTARGS='-run TestAccVPCEPPublicServicesDataSource_Basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep/ -v -run TestAccVPCEPPublicServicesDataSource_Basic -timeout 360m -parallel 4 
=== RUN   TestAccVPCEPPublicServicesDataSource_Basic 
=== PAUSE TestAccVPCEPPublicServicesDataSource_Basic
=== CONT  TestAccVPCEPPublicServicesDataSource_Basic
--- PASS: TestAccVPCEPPublicServicesDataSource_Basic (11.44s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     11.474s
```
