### PR TITLE
fix(live): fix live domain and  record callback config resource lint error

### DIFF
--- a/huaweicloud/services/live/resource_huaweicloud_live_domain.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_domain.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	v1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1"
+	livev1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -129,7 +129,7 @@ func resourceDomainCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return resourceDomainRead(ctx, d, meta)
 }
 
-func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
 	client, err := c.HcLiveV1Client(region)
@@ -232,7 +232,7 @@ func resourceDomainDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	return nil
 }
 
-func associatingDomain(d *schema.ResourceData, client *v1.LiveClient) error {
+func associatingDomain(d *schema.ResourceData, client *livev1.LiveClient) error {
 	if v, ok := d.GetOk("ingest_domain_name"); ok {
 		domainType := d.Get("type").(string)
 		if domainType == domainTypePush {
@@ -251,10 +251,9 @@ func associatingDomain(d *schema.ResourceData, client *v1.LiveClient) error {
 	}
 
 	return nil
-
 }
 
-func deleteAssociation(client *v1.LiveClient, pullDomain, pushDomain string) error {
+func deleteAssociation(client *livev1.LiveClient, pullDomain, pushDomain string) error {
 	_, err := client.DeleteDomainMapping(&model.DeleteDomainMappingRequest{
 		PullDomain: pullDomain,
 		PushDomain: pushDomain,
@@ -264,7 +263,6 @@ func deleteAssociation(client *v1.LiveClient, pullDomain, pushDomain string) err
 	}
 
 	return nil
-
 }
 
 func buildCreateParams(d *schema.ResourceData, region string) (*model.CreateDomainRequest, error) {
@@ -283,10 +281,9 @@ func buildCreateParams(d *schema.ResourceData, region string) (*model.CreateDoma
 		},
 	}
 	return &req, nil
-
 }
 
-func waitingForDomainStatus(ctx context.Context, client *v1.LiveClient, name string,
+func waitingForDomainStatus(ctx context.Context, client *livev1.LiveClient, name string,
 	status model.DecoupledLiveDomainInfoStatus, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Pending"},
@@ -319,7 +316,7 @@ func waitingForDomainStatus(ctx context.Context, client *v1.LiveClient, name str
 	return nil
 }
 
-func updateStatus(ctx context.Context, d *schema.ResourceData, client *v1.LiveClient) error {
+func updateStatus(ctx context.Context, d *schema.ResourceData, client *livev1.LiveClient) error {
 	var reqStatus model.LiveDomainModifyReqStatus
 	var respStatus model.DecoupledLiveDomainInfoStatus
 

--- a/huaweicloud/services/live/resource_huaweicloud_live_record_callback.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_record_callback.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	v1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1"
+	livev1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/live/v1/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -84,7 +84,7 @@ func resourceRecordCallbackCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating Live v1 client: %s", err)
 	}
 
-	createBody, err := buildCallbackConfigParams(d, region)
+	createBody, err := buildCallbackConfigParams(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -109,7 +109,7 @@ func resourceRecordCallbackCreate(ctx context.Context, d *schema.ResourceData, m
 	return resourceRecordCallbackRead(ctx, d, meta)
 }
 
-func resourceRecordCallbackRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRecordCallbackRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
 	client, err := c.HcLiveV1Client(region)
@@ -140,7 +140,7 @@ func resourceRecordCallbackUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error creating Live v1 client: %s", err)
 	}
 
-	updateBody, err := buildCallbackConfigParams(d, region)
+	updateBody, err := buildCallbackConfigParams(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -157,7 +157,7 @@ func resourceRecordCallbackUpdate(ctx context.Context, d *schema.ResourceData, m
 	return resourceRecordCallbackRead(ctx, d, meta)
 }
 
-func resourceRecordCallbackDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRecordCallbackDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
 	client, err := c.HcLiveV1Client(region)
@@ -176,7 +176,7 @@ func resourceRecordCallbackDelete(ctx context.Context, d *schema.ResourceData, m
 	return nil
 }
 
-func buildCallbackConfigParams(d *schema.ResourceData, region string) (*model.RecordCallbackConfigRequest, error) {
+func buildCallbackConfigParams(d *schema.ResourceData) (*model.RecordCallbackConfigRequest, error) {
 	v := d.Get("types").([]interface{})
 	events := make([]model.RecordCallbackConfigRequestNotifyEventSubscription, len(v))
 	for i, v := range v {
@@ -196,10 +196,9 @@ func buildCallbackConfigParams(d *schema.ResourceData, region string) (*model.Re
 	}
 
 	return &req, nil
-
 }
 
-func getRecordCallBackId(client *v1.LiveClient, publishDomain, appName string) (string, error) {
+func getRecordCallBackId(client *livev1.LiveClient, publishDomain, appName string) (string, error) {
 	resp, err := client.ListRecordCallbackConfigs(&model.ListRecordCallbackConfigsRequest{
 		PublishDomain: &publishDomain,
 		App:           &appName,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
./scripts/codecheck.sh ./huaweicloud/services/live

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        6      1736      254        22     1460        248            96.52
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~s/live/resource_huaweicloud_live_domain.go       343       53         6      284         66            23.24
~e/resource_huaweicloud_live_transcoding.go       315       48         1      266         61            22.93
~ive/resource_huaweicloud_live_recording.go       389       54         0      335         55            16.42
~source_huaweicloud_live_record_callback.go       229       36         1      192         35            18.23
~live/resource_huaweicloud_live_snapshot.go       323       42         8      273         23             8.42
~e_huaweicloud_live_bucket_authorization.go       137       21         6      110          8             7.27
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     6      1736      254        22     1460        248            96.52
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 51686 bytes, 0.052 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
19 live buildTranscodingParams huaweicloud/services/live/resource_huaweicloud_live_transcoding.go:216:1
8 live resourceDomainCreate huaweicloud/services/live/resource_huaweicloud_live_domain.go:88:1
7 live buildRecordingParams huaweicloud/services/live/resource_huaweicloud_live_recording.go:272:1
7 live resourceDomainUpdate huaweicloud/services/live/resource_huaweicloud_live_domain.go:164:1
6 live resourceTranscodingRead huaweicloud/services/live/resource_huaweicloud_live_transcoding.go:135:1
6 live resourceLiveSnapshotRead huaweicloud/services/live/resource_huaweicloud_live_snapshot.go:156:1
6 live waitingForDomainStatus huaweicloud/services/live/resource_huaweicloud_live_domain.go:286:1
5 live setTemplatesToState huaweicloud/services/live/resource_huaweicloud_live_transcoding.go:278:1
5 live flattenMp4 huaweicloud/services/live/resource_huaweicloud_live_recording.go:378:1
5 live flattenFlv huaweicloud/services/live/resource_huaweicloud_live_recording.go:365:1
Average: 3.6

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in live...
  -> resource_huaweicloud_live_bucket_authorization.go: please use common.CheckDeletedDiag in ReadContext


==> Checking for misspell in live...

==> Checking for code complexity in ./huaweicloud/services/acceptance/live...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        6       710       70         1      639         18            13.87
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~resource_huaweicloud_live_snapshot_test.go       193       19         1      173         10             5.78
~e/resource_huaweicloud_live_domain_test.go       106       12         0       94          2             2.13
~esource_huaweicloud_live_recording_test.go       146       12         0      134          2             1.49
~e_huaweicloud_live_record_callback_test.go        80       10         0       70          2             2.86
~ource_huaweicloud_live_transcoding_test.go       135       11         0      124          2             1.61
~weicloud_live_bucket_authorization_test.go        50        6         0       44          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     6       710       70         1      639         18            13.87
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 21933 bytes, 0.022 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 live getLiveSnapshotResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_snapshot_test.go:18:1
2 live getTranscodingResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_transcoding_test.go:16:1
2 live getRecordingResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_recording_test.go:16:1
2 live getRecordCallbackResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_record_callback_test.go:16:1
2 live getDomainResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_domain_test.go:16:1
Average: 1.39

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/live...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/live...

==> Cleanup patch...

Check Completed!
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/live' TESTARGS='-run TestAccDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccDomain_basic

--- PASS: TestAccDomain_basic (625.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      625.354s

make testacc TEST='./huaweicloud/services/acceptance/live' TESTARGS='-run TestAccRecordCallback_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccRecordCallback_basic -timeout 360m -parallel 4
=== RUN   TestAccRecordCallback_basic
--- PASS: TestAccRecordCallback_basic (341.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live 

```
