### PR TITLE
fix(lts): fix lts resource lint  errors

### DIFF
--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_struct_template_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_struct_template_test.go
@@ -26,9 +26,9 @@ func getLtsStructTemplateFunc(conf *config.Config, state *terraform.ResourceStat
 		return nil, fmt.Errorf("error getting HuaweiCloud Resource")
 	}
 	body = body[1 : len(body)-1]
-	body2 := strings.Replace(string(body), `\\\`, "**", -1)
-	body3 := strings.Replace(body2, `\`, "", -1)
-	body4 := strings.Replace(body3, "**", `\`, -1)
+	body2 := strings.ReplaceAll(string(body), `\\\`, "**")
+	body3 := strings.ReplaceAll(body2, `\`, "")
+	body4 := strings.ReplaceAll(body3, "**", `\`)
 	rlt := &entity.ShowStructTemplateResponse{}
 	err = json.Unmarshal([]byte(body4), rlt)
 

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_access_rule.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_access_rule.go
@@ -218,14 +218,14 @@ func resourceAomMappingRuleDelete(_ context.Context, d *schema.ResourceData, met
 	return diag.Errorf("error delete AomMappingRule %s:  %s", d.Id(), string(body))
 }
 
-func resourceAomMappingRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAomMappingRuleUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := httpclient_go.NewHttpClientGo(cfg, "lts", region)
 	if err != nil {
 		return diag.Errorf("err creating Client: %s", err)
 	}
-	Opts := entity.AomMappingRequestInfo{
+	opts := entity.AomMappingRequestInfo{
 		ProjectId: cfg.GetProjectID(region),
 		RuleId:    d.Id(),
 		RuleName:  d.Get("rule_name").(string),
@@ -237,12 +237,12 @@ func resourceAomMappingRuleUpdate(ctx context.Context, d *schema.ResourceData, m
 			Files:       buildFileOpts(d.Get("files").([]interface{})),
 		},
 	}
-	client.WithMethod(httpclient_go.MethodPut).WithUrl("v2/" + cfg.GetProjectID(region) + "/lts/aom-mapping").WithBody(Opts)
+	client.WithMethod(httpclient_go.MethodPut).WithUrl("v2/" + cfg.GetProjectID(region) + "/lts/aom-mapping").WithBody(opts)
 	response, err := client.Do()
 	if err != nil {
-		return diag.Errorf("error update AomMappingRule fields %s: %s", Opts.RuleName, err)
+		return diag.Errorf("error update AomMappingRule fields %s: %s", opts.RuleName, err)
 	}
-	d.SetId(Opts.RuleId)
+	d.SetId(opts.RuleId)
 
 	defer response.Body.Close()
 	body, err := io.ReadAll(response.Body)
@@ -252,9 +252,9 @@ func resourceAomMappingRuleUpdate(ctx context.Context, d *schema.ResourceData, m
 	if response.StatusCode == 200 {
 		return nil
 	}
-	return diag.Errorf("error update AomMappingRule %s:  %s", Opts.RuleName, string(body))
+	return diag.Errorf("error update AomMappingRule %s:  %s", opts.RuleName, string(body))
 }
 
-func SuppressCaseDiffs(k, old, new string, d *schema.ResourceData) bool {
+func SuppressCaseDiffs(_, old, new string, _ *schema.ResourceData) bool {
 	return strings.Split(old, "_")[0] == strings.Split(new, "_")[0]
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_dashboard.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_dashboard.go
@@ -231,7 +231,8 @@ func ltsResourceImportState(_ context.Context, d *schema.ResourceData,
 	_ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 5)
 	if len(parts) != 5 {
-		return nil, fmt.Errorf("invalid format specified for import id, must be <id>/<log_group_id>/<log_group_name>/<log_stream_id>/<log_stream_name>")
+		return nil, fmt.Errorf("invalid format specified for import id, " +
+			"must be <id>/<log_group_id>/<log_group_name>/<log_stream_id>/<log_stream_name>")
 	}
 
 	d.SetId(parts[0])

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_elb_log.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_elb_log.go
@@ -56,19 +56,19 @@ func resourceLtsElbCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 	header := make(map[string]string)
 	header["content-type"] = "application/json;charset=UTF8"
-	LogTank := entity.CreateLogTankOption{
+	logTank := entity.CreateLogTankOption{
 		LogGroupId:     d.Get("log_group_id").(string),
 		LoadBalancerId: d.Get("loadbalancer_id").(string),
 		LogTopicId:     d.Get("log_topic_id").(string),
 	}
-	LogTankRequest := entity.CreateLogtankRequestBody{
-		Logtank: &LogTank,
+	logTankRequest := entity.CreateLogtankRequestBody{
+		Logtank: &logTank,
 	}
 	client.WithMethod(httpclient_go.MethodPost).WithUrl("v3/" + cfg.GetProjectID(region) + "/elb/logtanks").WithHeader(header).
-		WithBody(LogTankRequest).WithTransport()
+		WithBody(logTankRequest).WithTransport()
 	response, err := client.Do()
 	if err != nil {
-		return diag.Errorf("error creating LogTank fields %s: %s", LogTankRequest.Logtank.LogGroupId, err)
+		return diag.Errorf("error creating LogTank fields %s: %s", logTankRequest.Logtank.LogGroupId, err)
 	}
 	defer response.Body.Close()
 	body, err := io.ReadAll(response.Body)
@@ -84,7 +84,7 @@ func resourceLtsElbCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		d.SetId(rlt.Logtank.ID)
 		return resourceLtsElbRead(ctx, d, meta)
 	}
-	return diag.Errorf("error creating LogTank fields %s: %s", LogTankRequest.Logtank.LogGroupId, string(body))
+	return diag.Errorf("error creating LogTank fields %s: %s", logTankRequest.Logtank.LogGroupId, string(body))
 }
 
 func resourceLtsElbRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -145,7 +145,7 @@ func resourceLtsElbDelete(_ context.Context, d *schema.ResourceData, meta interf
 	return diag.Errorf("error delete LogTank %s:  %s", d.Id(), string(body))
 }
 
-func resourceLtsElbUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLtsElbUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := httpclient_go.NewHttpClientGo(cfg, "elb", region)
@@ -154,15 +154,15 @@ func resourceLtsElbUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 	header := make(map[string]string)
 	header["content-type"] = "application/json;charset=UTF8"
-	LogTankRequest := entity.CreateLogTankOption{
+	logTankRequest := entity.CreateLogTankOption{
 		LogGroupId: d.Get("log_group_id").(string),
 		LogTopicId: d.Get("log_topic_id").(string),
 	}
 	client.WithMethod(httpclient_go.MethodPut).WithUrl("v3/" + cfg.GetProjectID(region) + "/elb/logtanks/" + d.Id()).
-		WithHeader(header).WithBody(LogTankRequest).WithTransport()
+		WithHeader(header).WithBody(logTankRequest).WithTransport()
 	response, err := client.Do()
 	if err != nil {
-		return diag.Errorf("error update LogTank fields %s: %s", LogTankRequest, err)
+		return diag.Errorf("error update LogTank fields %s: %s", logTankRequest, err)
 	}
 	defer response.Body.Close()
 	body, err := io.ReadAll(response.Body)

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_struct_template.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_struct_template.go
@@ -202,9 +202,9 @@ func resourceLtsStructTemplateRead(_ context.Context, d *schema.ResourceData, me
 		return diags
 	}
 	body = body[1 : len(body)-1]
-	body2 := strings.Replace(string(body), `\\\`, "**", -1)
-	body3 := strings.Replace(body2, `\`, "", -1)
-	body4 := strings.Replace(body3, "**", `\`, -1)
+	body2 := strings.ReplaceAll(string(body), `\\\`, "**")
+	body3 := strings.ReplaceAll(body2, `\`, "")
+	body4 := strings.ReplaceAll(body3, "**", `\`)
 	rlt := &entity.ShowStructTemplateResponse{}
 	err = json.Unmarshal([]byte(body4), rlt)
 	if err != nil {
@@ -255,7 +255,7 @@ func resourceLtsStructTemplateDelete(_ context.Context, d *schema.ResourceData, 
 	return diag.Errorf("error delete StructTemplate %s:  %s", d.Id(), string(body))
 }
 
-func resourceLtsStructTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLtsStructTemplateUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := httpclient_go.NewHttpClientGo(cfg, "lts", region)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
./scripts/codecheck.sh ./huaweicloud/services/lts 

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                       18      6269      636        98     5535        659           237.20
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~resource_huaweicloud_lts_sql_alarm_rule.go       733       64        10      659         55             8.35
~rce_huaweicloud_lts_keywords_alarm_rule.go       725       64        10      651         55             8.45
~ts/resource_huaweicloud_lts_host_access.go       549       66         6      477         55            11.53
~s/lts/resource_huaweicloud_lts_transfer.go       652       58         7      587         50             8.52
~/lts/resource_huaweicloud_lts_dashboard.go       247       11         0      236         45            19.07
~esource_huaweicloud_lts_struct_template.go       313       25         0      288         44            15.28
~aweicloud_lts_structuring_configuration.go       342       37        12      293         42            14.33
~ts/resource_huaweicloud_lts_access_rule.go       260       13         0      247         39            15.79
~lts/resource_huaweicloud_lts_aom_access.go       354       37         8      309         38            12.30
~es/lts/resource_huaweicloud_lts_elb_log.go       177       10         0      167         37            22.16
~lts/resource_huaweicloud_lts_waf_access.go       261       35         7      219         32            14.61
~e_huaweicloud_lts_notification_template.go       310       42         8      260         28            10.77
~ud_lts_structuring_custom_configuration.go       308       28         5      275         27             9.82
~lts/resource_huaweicloud_lts_host_group.go       281       42         8      231         26            11.26
~ces/lts/resource_huaweicloud_lts_stream.go       201       28         7      166         25            15.06
~esource_huaweicloud_lts_search_criteria.go       232       35         3      194         22            11.34
~ices/lts/resource_huaweicloud_lts_group.go       151       23         3      125         20            16.00
~icloud_lts_structuring_custom_templates.go       173       18         4      151         19            12.58
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                    18      6269      636        98     5535        659           237.20
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 202058 bytes, 0.202 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
11 lts buildHostAccessConfigFormatRequestBody huaweicloud/services/lts/resource_huaweicloud_lts_host_access.go:292:1
9 lts resourceStreamRead huaweicloud/services/lts/resource_huaweicloud_lts_stream.go:110:1
8 lts flattenAndFilterCustomTemplates huaweicloud/services/lts/data_source_huaweicloud_lts_structuring_custom_templates.go:133:1
7 lts resourceWAFAccessCreate huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go:67:1
7 lts resourceLtsStructTemplateCreate huaweicloud/services/lts/resource_huaweicloud_lts_struct_template.go:137:1
7 lts resourceSQLAlarmRuleUpdate huaweicloud/services/lts/resource_huaweicloud_lts_sql_alarm_rule.go:592:1
7 lts resourceSQLAlarmRuleCreate huaweicloud/services/lts/resource_huaweicloud_lts_sql_alarm_rule.go:303:1
7 lts resourceKeywordsAlarmRuleUpdate huaweicloud/services/lts/resource_huaweicloud_lts_keywords_alarm_rule.go:586:1
7 lts resourceKeywordsAlarmRuleCreate huaweicloud/services/lts/resource_huaweicloud_lts_keywords_alarm_rule.go:298:1
7 lts resourceLtsDashBoardCreate huaweicloud/services/lts/resource_huaweicloud_lts_dashboard.go:89:1
Average: 2.92

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in lts...

==> Checking for misspell in lts...

==> Checking for code complexity in ./huaweicloud/services/acceptance/lts...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                       18      3796      312        10     3474        152           101.76
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~resource_huaweicloud_lts_dashboard_test.go       111       10         0      101         21            20.79
~loud_lts_structuring_configuration_test.go       310       23         1      286         14             4.90
~ce_huaweicloud_lts_struct_template_test.go       115       11         0      104         13            12.50
~esource_huaweicloud_lts_waf_access_test.go       317       27         2      288         12             4.17
~source_huaweicloud_lts_host_access_test.go       289       26         0      263         11             4.18
~ce_huaweicloud_lts_search_criteria_test.go       133       19         1      113          9             7.96
~esource_huaweicloud_lts_aom_access_test.go       389       27         1      361          9             2.49
~rce_huaweicloud_lts_sql_alarm_rule_test.go       167       16         1      150          8             5.33
~esource_huaweicloud_lts_host_group_test.go       286       19         1      266          8             3.01
~/resource_huaweicloud_lts_transfer_test.go       499       27         1      471          8             1.70
~uaweicloud_lts_keywords_alarm_rule_test.go       166       16         1      149          8             5.37
~ts/resource_huaweicloud_lts_stream_test.go       159       19         0      140          8             5.71
~lts/resource_huaweicloud_lts_group_test.go       109       13         0       96          7             7.29
~source_huaweicloud_lts_access_rule_test.go        96       10         0       86          6             6.98
~weicloud_lts_notification_template_test.go       181       16         1      164          6             3.66
~s/resource_huaweicloud_lts_elb_log_test.go        81       11         0       70          4             5.71
~d_lts_structuring_custom_templates_test.go        78        7         0       71          0             0.00
~s_structuring_custom_configuration_test.go       310       15         0      295          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                    18      3796      312        10     3474        152           101.76
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 123974 bytes, 0.124 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
8 lts testAccDashboardImportStateIdFunc huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_dashboard_test.go:81:1
6 lts getWAFAccessResourceFunc huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_waf_access_test.go:19:1
6 lts getStructConfigResourceFunc huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_structuring_configuration_test.go:18:1
6 lts testAccLtsStructImportStateIdFunc huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_struct_template_test.go:82:1
6 lts getAOMAccessResourceFunc huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_aom_access_test.go:18:1
Average: 1.83

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/lts...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/lts...

==> Cleanup patch...

Check Completed!
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccessRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccessRule_basic -timeout 360m -parallel 4
=== RUN   TestAccessRule_basic
=== PAUSE TestAccessRule_basic
=== CONT  TestAccessRule_basic
    acceptance.go:337: HW_INTERNAL_USED must be set for internal acceptance tests
--- SKIP: TestAccessRule_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       (cached)
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccDashboard_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccDashboard_basic -timeout 360m -parallel 4
=== RUN   TestAccDashboard_basic
=== PAUSE TestAccDashboard_basic
=== CONT  TestAccDashboard_basic
    acceptance.go:337: HW_INTERNAL_USED must be set for internal acceptance tests
--- SKIP: TestAccDashboard_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       (cached)
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccLtsElbComp_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccLtsElbComp_basic -timeout 360m -parallel 4
=== RUN   TestAccLtsElbComp_basic
=== PAUSE TestAccLtsElbComp_basic
=== CONT  TestAccLtsElbComp_basic
    acceptance.go:337: HW_INTERNAL_USED must be set for internal acceptance tests
--- SKIP: TestAccLtsElbComp_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       (cached)
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run TestAccLtsStructTemplate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccLtsStructTemplate_basic -timeout 360m -parallel 4
=== RUN   TestAccLtsStructTemplate_basic
=== PAUSE TestAccLtsStructTemplate_basic
=== CONT  TestAccLtsStructTemplate_basic
--- PASS: TestAccLtsStructTemplate_basic (25.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       (cached)
```
