### PR TITLE
fix(iotda): fix iotda resource lint errors

### DIFF
--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	v5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
+	iotdav5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -326,8 +326,8 @@ func ResourceDataForwardingRuleCreate(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	for _, v := range targets {
-		_, err := client.CreateRuleAction(&v)
+	for i := range targets {
+		_, err := client.CreateRuleAction(&targets[i])
 		if err != nil {
 			return diag.Errorf("error add targets to IoTDA data forwarding rule: %s", err)
 		}
@@ -433,7 +433,6 @@ func ResourceDataForwardingRuleUpdate(ctx context.Context, d *schema.ResourceDat
 					return diag.Errorf("error updating targets of IoTDA data forwarding rule: %s", err)
 				}
 			}
-
 		}
 	}
 
@@ -466,7 +465,7 @@ func ResourceDataForwardingRuleDelete(_ context.Context, d *schema.ResourceData,
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
 
-	//delete targets
+	// delete targets
 	targets := d.Get("targets").(*schema.Set)
 	for _, v := range targets.List() {
 		ruleAction := v.(map[string]interface{})
@@ -630,7 +629,7 @@ func buildChannelDetail(target map[string]interface{}, channel, projectId string
 	}
 }
 
-func setTargetsToState(d *schema.ResourceData, client *v5.IoTDAClient, id string) error {
+func setTargetsToState(d *schema.ResourceData, client *iotdav5.IoTDAClient, id string) error {
 	var rst []model.RoutingRuleAction
 	var marker *string
 	for {

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	v5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
+	iotdav5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -73,7 +73,7 @@ func ResourceDevice() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"device_id": { //keep same with console
+			"device_id": { // keep same with console
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -319,7 +319,7 @@ func ResourceDeviceDelete(_ context.Context, d *schema.ResourceData, meta interf
 	return nil
 }
 
-func bindDeviceTags(client *v5.IoTDAClient, deviceId string, oMap, nMap map[string]interface{}) error {
+func bindDeviceTags(client *iotdav5.IoTDAClient, deviceId string, oMap, nMap map[string]interface{}) error {
 	// remove old tags
 	if len(oMap) > 0 {
 		keys := ExpandKeyOfTags(oMap)
@@ -432,7 +432,7 @@ func flattenTags(s *[]model.TagV5Dto) map[string]interface{} {
 	return rst
 }
 
-func updateDeviceStatus(client *v5.IoTDAClient, deviceId, status string, isFrozen bool) error {
+func updateDeviceStatus(client *iotdav5.IoTDAClient, deviceId, status string, isFrozen bool) error {
 	if isFrozen && status != deviceStatusFrozen {
 		_, err := client.FreezeDevice(&model.FreezeDeviceRequest{
 			DeviceId: deviceId,

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_certificate.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_certificate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr"
-	v5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
+	iotdav5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -187,7 +187,7 @@ func resourceDeviceCertificateDelete(_ context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func QueryDeviceCertificate(client *v5.IoTDAClient, id string, spaceId *string) (*model.CertificatesRspDto, error) {
+func QueryDeviceCertificate(client *iotdav5.IoTDAClient, id string, spaceId *string) (*model.CertificatesRspDto, error) {
 	var marker *string
 	for {
 		resp, err := client.ListCertificates(&model.ListCertificatesRequest{

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_group.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_group.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-	v5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
+	iotdav5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
@@ -212,7 +212,7 @@ func resourceDeviceGroupDelete(_ context.Context, d *schema.ResourceData, meta i
 	return nil
 }
 
-func addDevicesToGroup(client *v5.IoTDAClient, groupId string, addIds *schema.Set) error {
+func addDevicesToGroup(client *iotdav5.IoTDAClient, groupId string, addIds *schema.Set) error {
 	for _, v := range addIds.List() {
 		_, err := client.CreateOrDeleteDeviceInGroup(&model.CreateOrDeleteDeviceInGroupRequest{
 			GroupId:  groupId,
@@ -227,7 +227,7 @@ func addDevicesToGroup(client *v5.IoTDAClient, groupId string, addIds *schema.Se
 	return nil
 }
 
-func deleteDevicesFromGroup(client *v5.IoTDAClient, groupId string, addIds *schema.Set) error {
+func deleteDevicesFromGroup(client *iotdav5.IoTDAClient, groupId string, addIds *schema.Set) error {
 	for _, v := range addIds.List() {
 		_, err := client.CreateOrDeleteDeviceInGroup(&model.CreateOrDeleteDeviceInGroupRequest{
 			GroupId:  groupId,
@@ -242,7 +242,7 @@ func deleteDevicesFromGroup(client *v5.IoTDAClient, groupId string, addIds *sche
 	return nil
 }
 
-func setDeviceIdsToState(d *schema.ResourceData, client *v5.IoTDAClient, groupId string) error {
+func setDeviceIdsToState(d *schema.ResourceData, client *iotdav5.IoTDAClient, groupId string) error {
 	var rst []string
 	var marker *string
 	for {

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_product.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_product.go
@@ -206,7 +206,7 @@ func ResourceProduct() *schema.Resource {
 
 // propertySchema get the schema define for services.properties; services.commands.paras; services.commands.responses
 func propertySchema(category string) *schema.Resource {
-	common := schema.Resource{
+	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -276,13 +276,13 @@ func propertySchema(category string) *schema.Resource {
 	}
 
 	if category == "services.properties" {
-		common.Schema["method"] = &schema.Schema{
+		sc.Schema["method"] = &schema.Schema{
 			Type:         schema.TypeString,
 			Required:     true,
 			ValidateFunc: validation.StringInSlice([]string{"RW", "W", "R"}, false),
 		}
 	}
-	return &common
+	return &sc
 }
 
 func ResourceProductCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 ./scripts/codecheck.sh ./huaweicloud/services/iotda  

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        8      3339      409        24     2906        404           120.57
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~e_huaweicloud_iotda_dataforwarding_rule.go       752       74         7      671        101            15.05
~e_huaweicloud_iotda_device_linkage_rule.go       826       88         2      736         93            12.64
~iotda/resource_huaweicloud_iotda_device.go       454       62         9      383         66            17.23
~resource_huaweicloud_iotda_device_group.go       263       37         4      222         42            18.92
~otda/resource_huaweicloud_iotda_product.go       586       71         1      514         39             7.59
~ce_huaweicloud_iotda_device_certificate.go       215       36         0      179         31            17.32
~s/iotda/resource_huaweicloud_iotda_amqp.go       123       21         1      101         18            17.82
~/iotda/resource_huaweicloud_iotda_space.go       120       20         0      100         14            14.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     8      3339      409        24     2906        404           120.57
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 92446 bytes, 0.092 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
17 iotda flattenTargets huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go:651:1
15 iotda buildChannelDetail huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go:528:1
13 iotda ResourceDataForwardingRuleUpdate huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go:381:1
12 iotda flattenLinkageActions huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go:740:1
12 iotda flattenLinkageTriggers huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go:679:1
12 iotda ResourceDeviceUpdate huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go:239:1
9 iotda ResourceDataForwardingRuleCreate huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go:301:1
8 iotda buildlinkageAction huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go:601:1
7 iotda buildlinkageTrigger huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go:523:1
7 iotda resourceDeviceGroupUpdate huaweicloud/services/iotda/resource_huaweicloud_iotda_device_group.go:144:1
Average: 4.04

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in iotda...

==> Checking for misspell in iotda...

==> Checking for code complexity in ./huaweicloud/services/acceptance/iotda...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        8      1108       92         1     1015         20            23.95
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~da/resource_huaweicloud_iotda_amqp_test.go        70       12         1       57          6            10.53
~rce_huaweicloud_iotda_device_group_test.go       101       12         0       89          2             2.25
~/resource_huaweicloud_iotda_device_test.go       149       12         0      137          2             1.46
~weicloud_iotda_dataforwarding_rule_test.go       118       12         0      106          2             1.89
~aweicloud_iotda_device_certificate_test.go        88        8         0       80          2             2.50
~resource_huaweicloud_iotda_product_test.go       261       12         0      249          2             0.80
~a/resource_huaweicloud_iotda_space_test.go        65       11         0       54          2             3.70
~weicloud_iotda_device_linkage_rule_test.go       256       13         0      243          2             0.82
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     8      1108       92         1     1015         20            23.95
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 37762 bytes, 0.038 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
4 iotda getAmqpResourceFunc huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go:16:1
2 iotda getSpaceResourceFunc huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_space_test.go:16:1
2 iotda getProductResourceFunc huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_product_test.go:16:1
2 iotda getDeviceResourceFunc huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go:16:1
2 iotda getDeviceLinkageRuleResourceFunc huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go:16:1
Average: 1.34

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/iotda...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/iotda...

==> Cleanup patch...

Check Completed!
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```

```
