### PR TITLE
fix(live): fix live lint error and modify quality field to userdefine

### DIFF
--- a/huaweicloud/services/live/resource_huaweicloud_live_transcoding.go
+++ b/huaweicloud/services/live/resource_huaweicloud_live_transcoding.go
@@ -132,7 +132,7 @@ func resourceTranscodingCreate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceTranscodingRead(ctx, d, meta)
 }
 
-func resourceTranscodingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTranscodingRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
 	client, err := c.HcLiveV1Client(region)
@@ -193,7 +193,7 @@ func resourceTranscodingUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceTranscodingRead(ctx, d, meta)
 }
 
-func resourceTranscodingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTranscodingDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
 	client, err := c.HcLiveV1Client(region)
@@ -257,7 +257,7 @@ func buildTranscodingParams(d *schema.ResourceData) (*model.StreamTranscodingTem
 
 		qualityInfo[i] = model.QualityInfo{
 			TemplateName:   utils.String(template["name"].(string)),
-			Quality:        template["name"].(string),
+			Quality:        "userdefine",
 			Width:          utils.Int32(int32(width)),
 			Height:         utils.Int32(int32(height)),
 			Bitrate:        int32(template["bitrate"].(int)),
@@ -306,7 +306,7 @@ func setTemplatesToState(d *schema.ResourceData, qualityInfo *[]model.QualityInf
 	return nil
 }
 
-func parseTranscodingId(id string) (string, string, error) {
+func parseTranscodingId(id string) (domainName string, appName string, err error) {
 	idArrays := strings.SplitN(id, "/", 2)
 	if len(idArrays) != 2 {
 		return "", "", fmt.Errorf("invalid format specified for import ID. Format must be <domain_name>/<app_name>")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
./scripts/codecheck.sh ./huaweicloud/services/live/

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        6      1736      254        22     1460        248            96.52
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~s/live/resource_huaweicloud_live_domain.go       343       53         6      284         66            23.24
~e/resource_huaweicloud_live_transcoding.go       315       48         1      266         61            22.93
~ive/resource_huaweicloud_live_recording.go       389       54         0      335         55            16.42
~source_huaweicloud_live_record_callback.go       229       36         1      192         35            18.23
~live/resource_huaweicloud_live_snapshot.go       323       42         8      273         23             8.42
~e_huaweicloud_live_bucket_authorization.go       137       21         6      110          8             7.27
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     6      1736      254        22     1460        248            96.52
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 51686 bytes, 0.052 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
19 live buildTranscodingParams huaweicloud/services/live/resource_huaweicloud_live_transcoding.go:216:1
8 live resourceDomainCreate huaweicloud/services/live/resource_huaweicloud_live_domain.go:88:1
7 live buildRecordingParams huaweicloud/services/live/resource_huaweicloud_live_recording.go:272:1
7 live resourceDomainUpdate huaweicloud/services/live/resource_huaweicloud_live_domain.go:164:1
6 live resourceTranscodingRead huaweicloud/services/live/resource_huaweicloud_live_transcoding.go:135:1
6 live resourceLiveSnapshotRead huaweicloud/services/live/resource_huaweicloud_live_snapshot.go:156:1
6 live waitingForDomainStatus huaweicloud/services/live/resource_huaweicloud_live_domain.go:286:1
5 live setTemplatesToState huaweicloud/services/live/resource_huaweicloud_live_transcoding.go:278:1
5 live flattenMp4 huaweicloud/services/live/resource_huaweicloud_live_recording.go:378:1
5 live flattenFlv huaweicloud/services/live/resource_huaweicloud_live_recording.go:365:1
Average: 3.6

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in live...
  -> resource_huaweicloud_live_bucket_authorization.go: please use common.CheckDeletedDiag in ReadContext


==> Checking for misspell in live...

==> Checking for code complexity in ./huaweicloud/services/acceptance/live...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        6       710       70         1      639         18            13.87
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~resource_huaweicloud_live_snapshot_test.go       193       19         1      173         10             5.78
~e/resource_huaweicloud_live_domain_test.go       106       12         0       94          2             2.13
~esource_huaweicloud_live_recording_test.go       146       12         0      134          2             1.49
~e_huaweicloud_live_record_callback_test.go        80       10         0       70          2             2.86
~ource_huaweicloud_live_transcoding_test.go       135       11         0      124          2             1.61
~weicloud_live_bucket_authorization_test.go        50        6         0       44          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     6       710       70         1      639         18            13.87
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 21909 bytes, 0.022 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
6 live getLiveSnapshotResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_snapshot_test.go:18:1
2 live getTranscodingResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_transcoding_test.go:16:1
2 live getRecordingResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_recording_test.go:16:1
2 live getRecordCallbackResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_record_callback_test.go:16:1
2 live getDomainResourceFunc huaweicloud/services/acceptance/live/resource_huaweicloud_live_domain_test.go:16:1
Average: 1.39

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/live...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/live...

==> Cleanup patch...

Check Completed!

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/live' TESTARGS='-run TestAccTranscoding_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/live -v -run TestAccTranscoding_basic -timeout 360m -parallel 4
=== RUN   TestAccTranscoding_basic
--- PASS: TestAccTranscoding_basic (206.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/live      206.817s
```
