### PR TITLE
fix(VPCEP): set value only when `enable_policy` is true

### DIFF
--- a/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
+++ b/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
@@ -252,17 +252,22 @@ func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	createOpts := services.CreateOpts{
-		VpcID:        d.Get("vpc_id").(string),
-		PortID:       d.Get("port_id").(string),
-		ServerType:   d.Get("server_type").(string),
-		ServiceName:  d.Get("name").(string),
-		ServiceType:  d.Get("service_type").(string),
-		Description:  d.Get("description").(string),
-		Approval:     utils.Bool(d.Get("approval").(bool)),
-		Ports:        buildPortMappingOpts(d),
-		Tags:         utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
-		EnablePolicy: utils.Bool(d.Get("enable_policy").(bool)),
+		VpcID:       d.Get("vpc_id").(string),
+		PortID:      d.Get("port_id").(string),
+		ServerType:  d.Get("server_type").(string),
+		ServiceName: d.Get("name").(string),
+		ServiceType: d.Get("service_type").(string),
+		Description: d.Get("description").(string),
+		Approval:    utils.Bool(d.Get("approval").(bool)),
+		Ports:       buildPortMappingOpts(d),
+		Tags:        utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
 	}
+
+	// The European station does not support this parameter, so set it separately.
+	if d.Get("enable_policy").(bool) {
+		createOpts.EnablePolicy = utils.Bool(true)
+	}
+
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	n, err := services.Create(vpcepClient, createOpts).Extract()
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

set value only when `enable_policy` is true

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEPService_Basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEPService_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEPService_Basic
=== PAUSE TestAccVPCEPService_Basic
=== CONT  TestAccVPCEPService_Basic
--- PASS: TestAccVPCEPService_Basic (216.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     216.243s
```
