### PR TITLE
feat(dns): add resouce huaweicloud_dns_endpoint

### DIFF
--- a/docs/resources/dns_endpoint.md
+++ b/docs/resources/dns_endpoint.md
@@ -1,0 +1,96 @@
+---
+subcategory: "Domain Name Service (DNS)"
+---
+
+# huaweicloud_dns_endpoint
+
+Manages a DNS Endpoint in the HuaweiCloud DNS Service.
+
+## Example Usage
+
+```hcl
+variable subnet_id {}
+variable ip {}
+
+resource "huaweicloud_dns_endpoint" "test" {
+  name      = "test"
+  direction = "inbound"
+
+  ip_addresses {
+    subnet_id = var.subnet_id
+    ip        = var.ip
+  }
+  ip_addresses {
+    subnet_id = var.subnet_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the DNS endpoint. If omitted,
+  the `region` argument of the provider will be used. Changing this creates a new DNS endpoint.
+
+* `name` - (Required, String) Specifies the name of the DNS endpoint resource.
+
+* `direction` - (Required, String, ForceNew) Specifies the direction of the endpoint. The value can be *inbound* or *outbound*.
+  Changing this creates a new DNS endpoint.
+
+* `ip_addresses` - (Required, List, ForceNew) Specifies the IP address list of the DNS endpoint.
+  The List length limit range form 2 to 6. Changing this creates a new DNS endpoint.
+  The [ip_address](#Address) structure is documented below.
+
+<a name="Address"></a>
+The `ip_address` block supports:
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the subnet id of the IP address. Changing this creates a new DNS endpoint.
+
+* `ip` - (Optional, String, ForceNew) Specifies the IP of the IP address. Changing this creates a new DNS endpoint.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `vpc_id` - The VPC ID which the subnet belongs.
+
+* `resolver_rule_count` - The number of resolver rules.
+
+* `status` - The status of endpoint.
+
+* `created_at` - The created time.
+
+* `updated_at` - The last updated time.
+
+* `ip_addresses` - The IP address list of the DNS endpoint.
+
+The `ip_address` block supports:
+
+* `ip_address_id` - The ID of the IP address.
+
+* `ip` - The IP which is associated to the endpoint.
+
+* `status` - The status of IP address.
+
+* `created_at` - The created time of the IP address.
+
+* `updated_at` - The last updated time of the IP address.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+Endpoint can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_dns_endpoint.test ff8080828a94313a018bdc88d3f3447d
+```

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -697,6 +697,10 @@ func (c *Config) DnsWithRegionClient(region string) (*golangsdk.ServiceClient, e
 	return c.NewServiceClient("dns_region", region)
 }
 
+func (c *Config) DNSV21Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("dnsv21", region)
+}
+
 func (c *Config) ErV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("er", region)
 }

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -28,7 +28,7 @@ var multiCatalogKeys = map[string][]string{
 	"cci":          {"cciv1_bata"},
 	"vpc":          {"networkv2", "vpcv3", "fwv2"},
 	"elb":          {"elbv2", "elbv3"},
-	"dns":          {"dns_region"},
+	"dns":          {"dns_region", "dnsv21"},
 	"kms":          {"kmsv1", "kmsv3"},
 	"mrs":          {"mrsv2"},
 	"nat":          {"natv3"},
@@ -339,6 +339,13 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"dns_region": {
 		Name:             "dns",
 		Version:          "v2",
+		WithOutProjectID: true,
+		Product:          "DNS",
+	},
+	"dnsv21": {
+		Name:             "dns",
+		Version:          "v2.1",
+		Scope:            "global",
 		WithOutProjectID: true,
 		Product:          "DNS",
 	},

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -874,6 +874,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_ptrrecord":   dns.ResourceDNSPtrRecord(),
 			"huaweicloud_dns_recordset":   dns.ResourceDNSRecordset(),
 			"huaweicloud_dns_zone":        dns.ResourceDNSZone(),
+			"huaweicloud_dns_endpoint":    dns.ResourceDNSEndpoint(),
 
 			"huaweicloud_drs_job": drs.ResourceDrsJob(),
 

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_endpoint_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_endpoint_test.go
@@ -1,0 +1,155 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/dns/v2/endpoints"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDNSEndpointResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.DNSV21Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating dns client: %s", err)
+	}
+
+	return endpoints.Get(client, state.Primary.ID).Extract()
+}
+
+func TestAccDNSEndpoint_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_dns_endpoint.test"
+	)
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDNSEndpointResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDNSEndpoint_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "direction", "inbound"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "resolver_rule_count", "0"),
+					resource.TestCheckResourceAttr(rName, "ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(rName, "ip_addresses.0.status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "ip_addresses.1.status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(rName, "ip_addresses.0.subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "ip_addresses.1.subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.0.ip"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.1.ip"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.0.ip_address_id"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.1.ip_address_id"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.1.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.0.updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.1.updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testDNSEndpoint_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttr(rName, "direction", "inbound"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "resolver_rule_count", "0"),
+					resource.TestCheckResourceAttr(rName, "ip_addresses.#", "2"),
+					resource.TestCheckResourceAttr(rName, "ip_addresses.0.status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "ip_addresses.1.status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(rName, "ip_addresses.0.subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "ip_addresses.1.subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.0.ip"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.1.ip"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.0.ip_address_id"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.1.ip_address_id"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.1.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.0.updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "ip_addresses.1.updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testVpcSubnet_basic(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name              = "%[1]s"
+  cidr              = "192.168.0.0/24"
+  gateway_ip        = "192.168.0.1"
+  vpc_id            = huaweicloud_vpc.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}`, rName)
+}
+
+func testDNSEndpoint_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dns_endpoint" "test" {
+  name      = "%s"
+  direction = "inbound"
+  ip_addresses {
+    subnet_id = huaweicloud_vpc_subnet.test.id
+  }
+  ip_addresses {
+    subnet_id = huaweicloud_vpc_subnet.test.id
+  }
+}`, testVpcSubnet_basic(rName), rName)
+}
+
+func testDNSEndpoint_basic_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dns_endpoint" "test" {
+  name      = "%s_update"
+  direction = "inbound"
+  ip_addresses {
+    subnet_id = huaweicloud_vpc_subnet.test.id
+  }
+  ip_addresses {
+    subnet_id = huaweicloud_vpc_subnet.test.id
+  }
+}`, testVpcSubnet_basic(rName), rName)
+}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_endpoint.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_endpoint.go
@@ -1,0 +1,319 @@
+package dns
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dns/v2/endpoints"
+	"github.com/chnsz/golangsdk/openstack/dns/v2/ipaddress"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/subnets"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceDNSEndpoint() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDNSEndpointCreate,
+		UpdateContext: resourceDNSEndpointUpdate,
+		ReadContext:   resourceDNSEndpointRead,
+		DeleteContext: resourceDNSEndpointDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"direction": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ip_addresses": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 6,
+				MinItems: 2,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"ip_address_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resolver_rule_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDNSEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	dnsClient, err := conf.DNSV21Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+	name := d.Get("name").(string)
+	direction := d.Get("direction").(string)
+	ipAddresses := d.Get("ip_addresses").([]interface{})
+	ipAddressesList := make([]endpoints.IPAddresses, len(ipAddresses))
+	for i, ipObject := range ipAddresses {
+		ip := ipObject.(map[string]interface{})
+		ipAddressesList[i] = endpoints.IPAddresses{
+			SubnetID: ip["subnet_id"].(string),
+			IP:       ip["ip"].(string),
+		}
+	}
+	opt := endpoints.CreateOpt{
+		Name:        name,
+		Direction:   direction,
+		Region:      region,
+		IPAddresses: ipAddressesList,
+	}
+
+	endpoint, err := endpoints.Create(dnsClient, opt).Extract()
+	if err != nil {
+		return diag.Errorf("err creating DNS endpoint: %s", err)
+	}
+	d.SetId(endpoint.ID)
+	log.Printf("[DEBUG] Waiting for DNS endpoint (%s) to become available", endpoint.ID)
+	stateConf := &resource.StateChangeConf{
+		Target:       []string{"ACTIVE"},
+		Pending:      []string{"PENDING"},
+		Refresh:      waitForDNSEndpoint(dnsClient, endpoint.ID),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf(
+			"error waiting for DNS endpoint (%s) to become ACTIVE for creation: %s",
+			endpoint.ID, err)
+	}
+
+	return resourceDNSEndpointRead(ctx, d, meta)
+}
+
+func waitForDNSEndpoint(client *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		endpoint, err := endpoints.Get(client, id).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return endpoint, "DELETED", nil
+			}
+			return nil, "", err
+		}
+
+		log.Printf("[DEBUG] DNS endpoint (%s) current status: %s", endpoint.ID, endpoint.Status)
+		return endpoint, parseStatus(endpoint.Status), nil
+	}
+}
+
+func resourceDNSEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	dnsClient, err := conf.DNSV21Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	name := d.Get("name").(string)
+
+	if d.HasChange("name") {
+		opts := endpoints.UpdateOpts{Name: name}
+		_, err = endpoints.Update(dnsClient, d.Id(), opts).Extract()
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	log.Printf("[DEBUG] Waiting for DNS endpoint (%s) to become available", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Target:       []string{"ACTIVE"},
+		Pending:      []string{"PENDING"},
+		Refresh:      waitForDNSEndpoint(dnsClient, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf(
+			"error waiting for DNS endpoint (%s) to become ACTIVE for update: %s",
+			d.Id(), err)
+	}
+
+	return resourceDNSEndpointRead(ctx, d, meta)
+}
+
+func resourceDNSEndpointRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	dnsClient, err := conf.DNSV21Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	id := d.Id()
+	endpointInfo, err := endpoints.Get(dnsClient, id).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DNS endpoint")
+	}
+	log.Printf("[DEBUG] Retrieved endpoint %s: %#v", id, endpointInfo)
+
+	ipAddress, err := ipaddress.List(dnsClient, id).Extract()
+	if err != nil {
+		return diag.Errorf("error retrieving ip addresses: %s", err)
+	}
+	log.Printf("[DEBUG] Retrieved ip address %s: %#v", id, ipAddress)
+
+	subnetClient, err := conf.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+	subnetList, err := subnets.List(subnetClient, subnets.ListOpts{VPC_ID: endpointInfo.VpcID})
+	if err != nil {
+		return diag.Errorf("unable to retrieve subnets: %s", err)
+	}
+
+	if len(subnetList) == 0 {
+		return diag.Errorf("no subnet found")
+	}
+
+	log.Printf("[DEBUG] Retrieved ip address %s: %#v", id, ipAddress)
+	var ipAddresses []interface{}
+	for _, ipObject := range ipAddress {
+		ipAddress := make(map[string]interface{}, 6)
+		ipAddress["ip_address_id"] = ipObject.ID
+		ipAddress["ip"] = ipObject.IP
+		ipAddress["status"] = ipObject.Status
+		ipAddress["created_at"] = ipObject.CreateTime
+		ipAddress["updated_at"] = ipObject.UpdateTime
+		for _, subnet := range subnetList {
+			if subnet.SubnetId == ipObject.SubnetID {
+				ipAddress["subnet_id"] = subnet.ID
+				break
+			}
+		}
+		ipAddresses = append(ipAddresses, ipAddress)
+	}
+	mErr := multierror.Append(nil,
+		d.Set("name", endpointInfo.Name),
+		d.Set("direction", endpointInfo.Direction),
+		d.Set("status", endpointInfo.Status),
+		d.Set("vpc_id", endpointInfo.VpcID),
+		d.Set("resolver_rule_count", endpointInfo.ResolverRuleCount),
+		d.Set("created_at", endpointInfo.CreateTime),
+		d.Set("updated_at", endpointInfo.UpdateTime),
+		d.Set("ip_addresses", ipAddresses),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting resource: %s", mErr)
+	}
+
+	return nil
+}
+
+func resourceDNSEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	dnsClient, err := conf.DNSV21Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	err = endpoints.Delete(dnsClient, d.Id()).ExtractErr()
+	if err != nil {
+		return diag.Errorf("error deleting DNS endpoint: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for DNS endpoint (%s) to become DELETED", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Target: []string{"DELETED"},
+		// we allow to try to delete ERROR endpoint
+		Pending:      []string{"ACTIVE", "PENDING", "ERROR"},
+		Refresh:      waitForDNSEndpoint(dnsClient, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf(
+			"error waiting for DNS endpoint (%s) to delete: %s",
+			d.Id(), err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/endpoints/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/endpoints/requests.go
@@ -1,0 +1,81 @@
+package endpoints
+
+import (
+	"encoding/json"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+type ListOpts struct {
+	Direction string `q:"direction" required:"true"`
+	VpcID     string `q:"vpc_id,omitempty"`
+	Limit     int    `q:"limit,omitempty"`
+	Offset    int    `q:"offset,omitempty"`
+}
+
+type CreateOpt struct {
+	Name        string        `json:"name" required:"true"`
+	Direction   string        `json:"direction" required:"true"`
+	Region      string        `json:"region" required:"true"`
+	IPAddresses []IPAddresses `json:"ipaddresses" required:"true"`
+}
+
+type IPAddresses struct {
+	SubnetID string `json:"subnet_id" required:"true"`
+	IP       string `json:"ip,omitempty"`
+}
+
+type UpdateOpts struct {
+	Name string `json:"name" required:"true"`
+}
+
+func Create(c *golangsdk.ServiceClient, opts CreateOpt) (r CreateResult) {
+	_, err := c.Post(baseUrl(c), opts, &r.Body, nil)
+	if err != nil {
+		r.Err = err
+	}
+	return r
+}
+
+func Get(c *golangsdk.ServiceClient, endpointID string) (r GetResult) {
+	_, r.Err = c.Get(resourceUrl(c, endpointID), &r.Body, nil)
+	return r
+}
+
+func Update(c *golangsdk.ServiceClient, endpointID string, opts UpdateOpts) (r UpdateResult) {
+	_, r.Err = c.Put(resourceUrl(c, endpointID), opts, &r.Body, nil)
+	return
+}
+
+func Delete(c *golangsdk.ServiceClient, endpointID string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceUrl(c, endpointID), nil)
+	return
+}
+
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Endpoint, error) {
+	url := baseUrl(c)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	resp, err := pagination.ListAllItems(c, pagination.Offset, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var e struct {
+		Instances []Endpoint `json:"endpoints"`
+	}
+	if err = json.Unmarshal(body, &e); err != nil {
+		return nil, err
+	}
+	return e.Instances, nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/endpoints/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/endpoints/results.go
@@ -1,0 +1,44 @@
+package endpoints
+
+import "github.com/chnsz/golangsdk"
+
+type CreateResult struct {
+	commonResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type Endpoint struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Direction         string `json:"direction"`
+	Status            string `json:"status"`
+	VpcID             string `json:"vpc_id"`
+	IPAddressCount    int    `json:"ipaddress_count"`
+	ResolverRuleCount int    `json:"resolver_rule_count"`
+	CreateTime        string `json:"create_time"`
+	UpdateTime        string `json:"update_time"`
+}
+
+func (r commonResult) Extract() (*Endpoint, error) {
+	type response struct {
+		Endpoint `json:"endpoint"`
+	}
+	var res response
+	err := r.ExtractInto(&res)
+	return &res.Endpoint, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/endpoints/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/endpoints/urls.go
@@ -1,0 +1,11 @@
+package endpoints
+
+import "github.com/chnsz/golangsdk"
+
+func baseUrl(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("endpoints")
+}
+
+func resourceUrl(c *golangsdk.ServiceClient, endpointID string) string {
+	return c.ServiceURL("endpoints", endpointID)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/ipaddress/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/ipaddress/requests.go
@@ -1,0 +1,32 @@
+package ipaddress
+
+import "github.com/chnsz/golangsdk"
+
+type CreateOpts struct {
+	IPAddress `json:"ipaddress" required:"true"`
+}
+
+type IPAddress struct {
+	SubnetID string `json:"subnet_id" required:"true"`
+	IP       string `json:"ip,omitempty"`
+}
+
+func Create(c *golangsdk.ServiceClient, opts CreateOpts, endpointID string) (r CreateResult) {
+	body, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(baseUrl(c, endpointID), body, &r.Body, nil)
+	return
+}
+
+func Delete(c *golangsdk.ServiceClient, endpointID string, ipaddressID string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceUrl(c, endpointID, ipaddressID), nil)
+	return
+}
+
+func List(c *golangsdk.ServiceClient, endpointID string) (r ListResult) {
+	_, r.Err = c.Get(baseUrl(c, endpointID), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/ipaddress/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/ipaddress/results.go
@@ -1,0 +1,58 @@
+package ipaddress
+
+import "github.com/chnsz/golangsdk"
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+type ListResult struct {
+	commonResult
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type ListObject struct {
+	Status     string `json:"status"`
+	ID         string `json:"id"`
+	IP         string `json:"ip"`
+	CreateTime string `json:"create_time"`
+	UpdateTime string `json:"update_time"`
+	SubnetID   string `json:"subnet_id"`
+	ErrorInfo  string `json:"error_info"`
+}
+
+type EndpointResp struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Status            string `json:"status"`
+	VpcID             string `json:"vpc_id"`
+	IPAddressCount    int    `json:"ipaddress_count"`
+	ResolverRuleCount int    `json:"resolver_rule_count"`
+	CreateTime        string `json:"create_time"`
+	UpdateTime        string `json:"update_time"`
+}
+
+func (c CreateResult) Extract() (EndpointResp, error) {
+	type responseBody struct {
+		EndpointResp `json:"endpoint"`
+	}
+	var r responseBody
+	err := c.ExtractInto(&r)
+	return r.EndpointResp, err
+}
+
+func (l ListResult) Extract() ([]ListObject, error) {
+	type result struct {
+		IPAddress []ListObject `json:"ipaddresses"`
+	}
+	var r result
+	err := l.ExtractInto(&r)
+	return r.IPAddress, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/ipaddress/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/ipaddress/urls.go
@@ -1,0 +1,11 @@
+package ipaddress
+
+import "github.com/chnsz/golangsdk"
+
+func baseUrl(c *golangsdk.ServiceClient, endpointID string) string {
+	return c.ServiceURL("endpoints", endpointID, "ipaddresses")
+}
+
+func resourceUrl(c *golangsdk.ServiceClient, endpointID string, ipaddress string) string {
+	return c.ServiceURL("endpoints", endpointID, "ipaddresses", ipaddress)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -132,6 +132,8 @@ github.com/chnsz/golangsdk/openstack/dms/v2/kafka/topics
 github.com/chnsz/golangsdk/openstack/dms/v2/maintainwindows
 github.com/chnsz/golangsdk/openstack/dms/v2/products
 github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances
+github.com/chnsz/golangsdk/openstack/dns/v2/endpoints
+github.com/chnsz/golangsdk/openstack/dns/v2/ipaddress
 github.com/chnsz/golangsdk/openstack/dns/v2/nameservers
 github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords
 github.com/chnsz/golangsdk/openstack/dns/v2/recordsets


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resouce huaweicloud_dns_endpoint

```release-note
1.ipaddress is forceNew, will support part update ipadress soon.
2.subnet id in CreateContext is not equal with subnet id in ReadContext.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
huawei@terrafoirm-0004:/mnt/d/workspace/terraform-provider-huaweicloud$ make testacc TEST="./huaweicloud/services/acceptance/dns" TESTARGS="-run TestAccDNSEndpoint_basic"    
==> Checking that code complies with gofmt requirements... 

TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSEndpoint_basic -timeout 360m -parallel 4 
=== RUN   TestAccDNSEndpoint_basic 
=== PAUSE TestAccDNSEndpoint_basic
=== CONT  TestAccDNSEndpoint_basic
--- PASS: TestAccDNSEndpoint_basic (167.12s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       167.171s
```
