### PR TITLE
feat(cts/notification): add filter parameter support

### DIFF
--- a/docs/resources/cts_notification.md
+++ b/docs/resources/cts_notification.md
@@ -20,6 +20,23 @@ resource "huaweicloud_cts_notification" "notify" {
 }
 ```
 
+### Complete Notification and Enable Filtering
+
+```hcl
+variable "topic_urn" {}
+
+resource "huaweicloud_cts_notification" "notify" {
+  name           = "keyOperate_test"
+  operation_type = "complete"
+  smn_topic      = var.topic_urn
+  
+  filter {
+    condition = "AND"
+    rule      = ["code = 200","resource_name = test"]
+  }
+}
+```
+
 ### Customized Notification
 
 ```hcl
@@ -55,15 +72,18 @@ The following arguments are supported:
 
 * `operations` - (Optional, List) Specifies an array of operations that will trigger notifications.
   For details, see [Supported Services and Operations](https://support.huaweicloud.com/intl/en-us/usermanual-cts/cts_03_0022.html).
-  The [object](#notification_operations_object) structure is documented below.
+  The [operations](#CTS_Notification_Operations) structure is documented below.
 
 * `operation_users` - (Optional, List) Specifies an array of users. Notifications will be sent when specified users
   perform specified operations. All users are selected by default.
-  The [object](#notification_operation_users_object) structure is documented below.
+  The [operation_users](#CTS_Notification_OperationUsers) structure is documented below.
 
 * `enabled` - (Optional, Bool) Specifies whether notification is enabled, defaults to true.
 
-<a name="notification_operations_object"></a>
+* `filter` - (Optional, List) Specifies the filtering rules for notification.
+  The [filter](#CTS_Notification_Filter) structure is documented below.
+
+<a name="CTS_Notification_Operations"></a>
 The `operations` block supports:
 
 * `service` - (Required, String) Specifies the cloud service.
@@ -72,19 +92,41 @@ The `operations` block supports:
 
 * `trace_names` - (Required, List) Specifies an array of trace names.
 
-<a name="notification_operation_users_object"></a>
+<a name="CTS_Notification_OperationUsers"></a>
 The `operation_users` block supports:
 
 * `group` - (Required, String) Specifies the IAM user group name.
 
 * `users` - (Required, List) Specifies an array of IAM users in the group.
 
+<a name="CTS_Notification_Filter"></a>
+The `filter` block supports:
+
+* `condition` - (Required, String) Specifies the relationship between multiple rules. The valid values are as follows:
+  + **AND**: Effective after all filtering conditions are met.
+  + **OR**: Effective when any one of the conditions is met.
+
+* `rule` - (Required, List) Specifies an array of filtering rules. It consists of three parts,
+  the first part is the **key**, the second part is the **rule**, and the third part is the **value**,
+  the format is: **key != value**.
+  + The **key** can be: **api_version**, **code**, **trace_rating**, **trace_type**, **resource_id** and
+  **resource_name**.  
+  When the key is **api_version**, the value needs to follow the regular constraint: **^ (a-zA-Z0-9_ -.) {1,64}$**.  
+  When the key is **code**, the length range of value is from `1` to `256`.  
+  When the key is **trace_rating**, the value can be **normal**, **warning** or **incident**.  
+  When the key is **trace_type**, the value can be **ConsoleAction**, **ApiCall** or **SystemAction**.  
+  When the key is **resource_id**, the length range of value is from `1` to `350`.  
+  When the key is **resource_name**, the length range of value is from `1` to `256`.
+  + The **rule** can be: **!=** or **=**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID which equals the notification name.
+
 * `notification_id` - The notification ID in UUID format.
+
 * `status` - The notification status, the value can be **enabled** or **disabled**.
 
 ## Timeouts

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
@@ -64,6 +64,8 @@ func TestAccCTSNotification_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "operation_type", "complete"),
 					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.condition", "AND"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.rule.#", "2"),
 					resource.TestCheckResourceAttrPair(resourceName, "smn_topic",
 						"huaweicloud_smn_topic.topic_1", "id"),
 				),
@@ -73,6 +75,8 @@ func TestAccCTSNotification_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "operation_type", "customized"),
 					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.condition", "OR"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.rule.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "operations.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "operations.0.service", "ECS"),
 					resource.TestCheckResourceAttrPair(resourceName, "smn_topic",
@@ -106,6 +110,11 @@ resource "huaweicloud_cts_notification" "notify" {
   name           = "%[1]s"
   operation_type = "complete"
   smn_topic      = huaweicloud_smn_topic.topic_1.id
+
+  filter {
+    condition = "AND"
+    rule      = ["code = 200","resource_name = test"]
+  }
 }
 `, rName)
 }
@@ -120,6 +129,11 @@ resource "huaweicloud_cts_notification" "notify" {
   name           = "%[1]s"
   operation_type = "customized"
   smn_topic      = huaweicloud_smn_topic.topic_1.id
+
+  filter {
+    condition = "OR"
+    rule      = ["code = 400","resource_name = name","api_version = 1.0"]
+  }
 
   operations {
     service     = "ECS"

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
@@ -2,6 +2,7 @@ package cts
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"regexp"
 	"time"
@@ -109,7 +110,27 @@ func ResourceCTSNotification() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
-
+			"filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"condition": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"rule": {
+							Type:     schema.TypeList,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 			"notification_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -122,7 +143,7 @@ func ResourceCTSNotification() *schema.Resource {
 	}
 }
 
-func buildNotificationCreateRequestBody(d *schema.ResourceData) *cts.CreateNotificationRequestBody {
+func buildNotificationCreateRequestBody(d *schema.ResourceData) (*cts.CreateNotificationRequestBody, error) {
 	reqBody := cts.CreateNotificationRequestBody{
 		NotificationName: d.Get("name").(string),
 		OperationType:    formatCreateNotificationType(d.Get("operation_type").(string)),
@@ -130,9 +151,42 @@ func buildNotificationCreateRequestBody(d *schema.ResourceData) *cts.CreateNotif
 		NotifyUserList:   buildNotifyUserOpts(d),
 		TopicId:          utils.String(d.Get("smn_topic").(string)),
 	}
-
+	filter, err := buildKeyFilterOpts(d)
+	if err != nil {
+		return &reqBody, err
+	}
+	reqBody.Filter = filter
 	log.Printf("[DEBUG] creating CTS key events notification options: %#v", reqBody)
-	return &reqBody
+	return &reqBody, nil
+}
+
+func buildKeyFilterOpts(d *schema.ResourceData) (*cts.Filter, error) {
+	rawFilter := d.Get("filter").([]interface{})
+	if len(rawFilter) == 0 {
+		return nil, nil
+	}
+
+	filterData := rawFilter[0].(map[string]interface{})
+	filter := cts.Filter{
+		IsSupportFilter: true,
+		Rule:            utils.ExpandToStringList(filterData["rule"].([]interface{})),
+	}
+
+	conditionStr := filterData["condition"].(string)
+	conditionAnd := cts.GetFilterConditionEnum().AND
+	conditionOr := cts.GetFilterConditionEnum().OR
+	switch conditionStr {
+	case "AND":
+		filter.Condition = conditionAnd
+	case "OR":
+		filter.Condition = conditionOr
+	default:
+		return &filter, fmt.Errorf("invalid condition, want '%v' or '%v', but got '%v'",
+			conditionAnd.Value(), conditionOr.Value(), conditionStr)
+	}
+
+	log.Printf("[DEBUG] CTS key events notification filter: %#v", filter)
+	return &filter, nil
 }
 
 func buildKeyOperationOpts(d *schema.ResourceData) *[]cts.Operations {
@@ -195,8 +249,12 @@ func resourceCTSNotificationCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating CTS client: %s", err)
 	}
 
+	createRequestBody, err := buildNotificationCreateRequestBody(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	createOpts := cts.CreateNotificationRequest{
-		Body: buildNotificationCreateRequestBody(d),
+		Body: createRequestBody,
 	}
 
 	notification, err := ctsClient.CreateNotification(&createOpts)
@@ -254,6 +312,7 @@ func resourceCTSNotificationRead(_ context.Context, d *schema.ResourceData, meta
 		d.Set("name", ctsNotification.NotificationName),
 		d.Set("notification_id", ctsNotification.NotificationId),
 		d.Set("smn_topic", ctsNotification.TopicId),
+		d.Set("filter", flattenNotificationFilter(ctsNotification.Filter)),
 	)
 
 	if ctsNotification.Operations != nil {
@@ -306,6 +365,12 @@ func resourceCTSNotificationUpdate(ctx context.Context, d *schema.ResourceData, 
 		Status:           enabledStatus,
 		TopicId:          utils.String(d.Get("smn_topic").(string)),
 	}
+
+	filter, err := buildKeyFilterOpts(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	updateReq.Filter = filter
 
 	log.Printf("[DEBUG] updating CTS key events notification options: %#v", updateReq)
 	updateOpts := cts.UpdateNotificationRequest{
@@ -391,4 +456,16 @@ func flattenNotificationOperations(ops []cts.Operations) []map[string]interface{
 	}
 
 	return ret
+}
+
+func flattenNotificationFilter(filter *cts.Filter) []map[string]interface{} {
+	if filter == nil {
+		return nil
+	}
+	result := map[string]interface{}{
+		"condition": filter.Condition.Value(),
+		"rule":      filter.Rule,
+	}
+
+	return []map[string]interface{}{result}
 }

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
@@ -153,7 +153,7 @@ func buildNotificationCreateRequestBody(d *schema.ResourceData) (*cts.CreateNoti
 	}
 	filter, err := buildKeyFilterOpts(d)
 	if err != nil {
-		return &reqBody, err
+		return nil, err
 	}
 	reqBody.Filter = filter
 	log.Printf("[DEBUG] creating CTS key events notification options: %#v", reqBody)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add filter parameter support for notification. Do not display the is_support_filter parameter to the user, only handle it internally within the function.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add filter parameter support for notification
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSNotification_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSNotification_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSNotification_basic
=== PAUSE TestAccCTSNotification_basic
=== CONT  TestAccCTSNotification_basic
--- PASS: TestAccCTSNotification_basic (35.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       35.510s
```
