### PR TITLE
feat(RDS): add RDS PG plugin resource

### DIFF
--- a/docs/resources/rds_pg_plugin.md
+++ b/docs/resources/rds_pg_plugin.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_pg_plugin
+
+Manages RDS for PostgreSQL plugin on the databases within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "database_name" {}
+
+resource "huaweicloud_rds_pg_plugin" "test" {
+  instance_id   = var.instance_id
+  database_name = var.database_name
+  name          = "pgaudit"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the PostgreSQL instance ID.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the plugin name.
+  Changing this parameter will create a new resource.
+
+* `database_name` - (Required, String, ForceNew) Specifies the database name.
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID of PostgreSQL plugin which is formatted `<instance_id>/<database_name>/<name>`.
+
+* `version` - The plugin version.
+
+* `shared_preload_libraries` - Dependent preloaded library.
+
+* `description` - The plugin description.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+The RDS for PostgreSQL plugin can be imported using the `instance_id`, `database_name` and `name` separated by slashs, e.g.:
+
+```
+$ terraform import huaweicloud_rds_pg_plugin.test <instance_id>/<database_name>/<name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1105,6 +1105,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_backup":                       rds.ResourceBackup(),
 			"huaweicloud_rds_cross_region_backup_strategy": rds.ResourceBackupStrategy(),
 			"huaweicloud_rds_sql_audit":                    rds.ResourceSQLAudit(),
+			"huaweicloud_rds_pg_plugin":                    rds.ResourceRdsPgPlugin(),
 
 			"huaweicloud_rms_policy_assignment":                  rms.ResourcePolicyAssignment(),
 			"huaweicloud_rms_resource_aggregator":                rms.ResourceAggregator(),

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_plugin_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_plugin_test.go
@@ -1,0 +1,106 @@
+package rds
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getPgPluginResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	getPgPluginClient, err := cfg.NewServiceClient("rds", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	listPgPluginHttpUrl := "v3/{project_id}/instances/{instance_id}/extensions?database_name={database_name}"
+	listPgPluginPath := getPgPluginClient.Endpoint + listPgPluginHttpUrl
+	listPgPluginPath = strings.ReplaceAll(listPgPluginPath, "{project_id}", getPgPluginClient.ProjectID)
+	listPgPluginPath = strings.ReplaceAll(listPgPluginPath, "{instance_id}", state.Primary.Attributes["instance_id"])
+	listPgPluginPath = strings.ReplaceAll(listPgPluginPath, "{database_name}", state.Primary.Attributes["database_name"])
+
+	resp, err := getPgPluginClient.Request("GET", listPgPluginPath, &golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS PostgreSQL : %s", err)
+	}
+
+	body, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS PostgreSQL : %s", err)
+	}
+
+	name := state.Primary.Attributes["name"]
+	plugin := utils.PathSearch(fmt.Sprintf("extensions[?name=='%s']|[?created]|[0]", name), body, nil)
+
+	if plugin == nil {
+		return nil, fmt.Errorf("no RDS PostgreSQL plugin matching %s was found", name)
+	}
+
+	return plugin, nil
+}
+
+func TestAccPgPlugin_basic(t *testing.T) {
+	var obj interface{}
+
+	randName := acceptance.RandomAccResourceName()
+	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
+		acctest.RandIntRange(10, 99))
+
+	resourceName := "huaweicloud_rds_pg_plugin.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getPgPluginResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testPgPlugin_basic(randName, pwd),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_rds_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", "pgl_ddl_deploy"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", "postgres"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testPgPlugin_basic(randName, pwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_rds_pg_plugin" "test" {
+  instance_id   = huaweicloud_rds_instance.test.id
+  name          = "pgl_ddl_deploy"
+  database_name = "postgres"
+}
+`, testAccRdsInstance_basic(randName, pwd))
+}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_pg_plugin.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_pg_plugin.go
@@ -1,0 +1,285 @@
+package rds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceRdsPgPlugin() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRdsPgPluginCreate,
+		ReadContext:   resourceRdsPgPluginRead,
+		DeleteContext: resourceRdsPgPluginDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"shared_preload_libraries": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreatePgPluginBody(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"database_name":  d.Get("database_name"),
+		"extension_name": d.Get("name"),
+	}
+	return bodyParams
+}
+
+func queryPluginDetail(client *golangsdk.ServiceClient, instanceId, databaseName, name string) (interface{}, error) {
+	listPgPluginHttpUrl := "v3/{project_id}/instances/{instance_id}/extensions?database_name={database_name}"
+	listPgPluginPath := client.Endpoint + listPgPluginHttpUrl
+	listPgPluginPath = strings.ReplaceAll(listPgPluginPath, "{project_id}", client.ProjectID)
+	listPgPluginPath = strings.ReplaceAll(listPgPluginPath, "{instance_id}", instanceId)
+	listPgPluginPath = strings.ReplaceAll(listPgPluginPath, "{database_name}", databaseName)
+
+	resp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		listPgPluginPath,
+		&pagination.QueryOpts{MarkerField: ""})
+	if err != nil {
+		if errCode := parseErrCode(resp); errCode == "DBS.280238" || errCode == "DBS.200823" {
+			return nil, golangsdk.ErrDefault404{}
+		}
+		return nil, fmt.Errorf("error retrieving PostgreSQL plugin: %s", err)
+	}
+	bodyBytes, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling RDS PostgreSQL plugin: %s", err)
+	}
+
+	var bodyJson interface{}
+	err = json.Unmarshal(bodyBytes, &bodyJson)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshal PostgreSQL plugin: %s", err)
+	}
+
+	log.Printf("[DEBUG] Reading RDS PostgreSQL plugin response: %#v", bodyJson)
+
+	pluginDetail := utils.PathSearch(fmt.Sprintf("extensions[?name=='%s']|[?created]|[0]", name), bodyJson, nil)
+	if pluginDetail == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return pluginDetail, nil
+}
+
+func parseErrCode(resp interface{}) string {
+	bodyBytes, err := json.Marshal(resp)
+	if err != nil {
+		log.Printf("[ERROR] Error marshaling PostgreSQL plugin: %s", err)
+		return ""
+	}
+
+	var bodyJson interface{}
+	err = json.Unmarshal(bodyBytes, &bodyJson)
+	if err != nil {
+		log.Printf("[ERROR] Error unmarshal PostgreSQL plugin: %s", err)
+		return ""
+	}
+	errCode := utils.PathSearch("error.code", bodyJson, "")
+	return errCode.(string)
+}
+
+func resourceRdsPgPluginCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var createPgPluginProduct = "rds"
+	createPgPluginClient, err := cfg.NewServiceClient(createPgPluginProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	pluginDetail, err := queryPluginDetail(createPgPluginClient, instanceId, d.Get("database_name").(string), d.Get("name").(string))
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return diag.FromErr(err)
+		}
+	}
+
+	if pluginDetail != nil {
+		return diag.Errorf("The RDS PostgreSQL plugin already created: %#v", pluginDetail)
+	}
+
+	createPgPluginHttpUrl := "v3/{project_id}/instances/{instance_id}/extensions"
+	createPgPluginPath := createPgPluginClient.Endpoint + createPgPluginHttpUrl
+	createPgPluginPath = strings.ReplaceAll(createPgPluginPath, "{project_id}", createPgPluginClient.ProjectID)
+	createPgPluginPath = strings.ReplaceAll(createPgPluginPath, "{instance_id}", instanceId)
+
+	jsonBody := utils.RemoveNil(buildCreatePgPluginBody(d))
+	log.Printf("[DEBUG] Create RDS PostgreSQL plugin: %#v", jsonBody)
+
+	reqOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         jsonBody,
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		_, err = createPgPluginClient.Request("POST", createPgPluginPath, &reqOpt)
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
+	}
+	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(createPgPluginClient, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+
+	if err != nil {
+		return diag.Errorf("error creating RDS PostgreSQL plugin: %s", err)
+	}
+
+	id := fmt.Sprintf("%s/%s/%s", d.Get("instance_id").(string), d.Get("database_name").(string), d.Get("name").(string))
+	d.SetId(id)
+
+	return resourceRdsPgPluginRead(ctx, d, cfg)
+}
+
+func resourceRdsPgPluginRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	getPgPluginClient, err := cfg.NewServiceClient("rds", region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 3 {
+		return diag.Errorf("invalid ID format in ReadContext: %s", d.Id())
+	}
+	pluginDetail, err := queryPluginDetail(getPgPluginClient, parts[0], parts[1], parts[2])
+	log.Printf("[DEBUG] RDS PostgreSQL plugin detail: %#v", pluginDetail)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving PostgreSQL plugin")
+	}
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", cfg.GetRegion(d)),
+		d.Set("instance_id", parts[0]),
+		d.Set("name", utils.PathSearch("name", pluginDetail, "")),
+		d.Set("database_name", utils.PathSearch("database_name", pluginDetail, "")),
+		d.Set("version", utils.PathSearch("version", pluginDetail, "")),
+		d.Set("shared_preload_libraries", utils.PathSearch("shared_preload_libraries", pluginDetail, "")),
+		d.Set("description", utils.PathSearch("description", pluginDetail, "")),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildDeletePgPluginBody(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"database_name":  d.Get("database_name"),
+		"extension_name": d.Get("name"),
+	}
+	return bodyParams
+}
+
+func resourceRdsPgPluginDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	deletePgPluginClient, err := cfg.NewServiceClient("rds", region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	deletePgPluginHttpUrl := "v3/{project_id}/instances/{instance_id}/extensions"
+	deletePgPluginPath := deletePgPluginClient.Endpoint + deletePgPluginHttpUrl
+	deletePgPluginPath = strings.ReplaceAll(deletePgPluginPath, "{project_id}", deletePgPluginClient.ProjectID)
+	deletePgPluginPath = strings.ReplaceAll(deletePgPluginPath, "{instance_id}", d.Get("instance_id").(string))
+
+	jsonBody := utils.RemoveNil(buildDeletePgPluginBody(d))
+	log.Printf("[DEBUG] Delete RDS PostgreSQL plugin: %#v", jsonBody)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         jsonBody,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=UTF-8",
+		},
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		_, err = deletePgPluginClient.Request("DELETE", deletePgPluginPath, &deleteOpt)
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
+	}
+	_, err = common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(deletePgPluginClient, d.Get("instance_id").(string)),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+
+	if err != nil {
+		return diag.Errorf("error deleting RDS PostgreSQL plugin: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add RDS PG plugin resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run TestAccPgPlugin_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run TestAccPgPlugin_basic -timeout 360m -parallel 4
=== RUN   TestAccPgPlugin_basic                                           TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run TestAccPgPlugin_basic -timeout 360m -pa
rallel 4
=== RUN   TestAccPgPlugin_basic
=== PAUSE TestAccPgPlugin_basic
=== CONT  TestAccPgPlugin_basic
--- PASS: TestAccPgPlugin_basic (497.24s)
PASS
```
