### PR TITLE
fix(waf): waf domain supports editing field 'policy_id'

### DIFF
--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -71,8 +71,8 @@ The following arguments are supported:
 * `certificate_name` - (Optional, String) Specifies the certificate name. This parameter is mandatory
   when `client_protocol` is set to HTTPS.
 
-* `policy_id` - (Optional, String, ForceNew) Specifies the policy ID associated with the domain. If not specified, a new
-  policy will be created automatically. Changing this create a new domain.
+* `policy_id` - (Optional, String) Specifies the policy ID associated with the domain. If not specified, a new
+  policy will be created automatically.
 
 * `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
   Defaults to true.

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
@@ -649,7 +649,7 @@ func buildHostFlag(d *schema.ResourceData) (*domains.Flag, error) {
 	}, nil
 }
 
-func updateWafDedicatedDomainPolicyHost(d *schema.ResourceData, cfg *config.Config) error {
+func updateWafDomainPolicyHost(d *schema.ResourceData, cfg *config.Config) error {
 	client, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
 		return fmt.Errorf("error creating WAF client: %s", err)
@@ -664,7 +664,7 @@ func updateWafDedicatedDomainPolicyHost(d *schema.ResourceData, cfg *config.Conf
 		Hosts:               []string{d.Id()},
 		EnterpriseProjectId: epsID,
 	}
-	log.Printf("[DEBUG] Bind WAF dedicated domain %s to policy %s", d.Id(), newPolicyId)
+	log.Printf("[DEBUG] Bind WAF domain %s to policy %s", d.Id(), newPolicyId)
 
 	if _, err := policies.UpdateHosts(client, newPolicyId, updateHostsOpts).Extract(); err != nil {
 		return fmt.Errorf("error updating WAF policy hosts: %s", err)
@@ -840,7 +840,7 @@ func resourceWafDedicatedDomainUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if d.HasChanges("policy_id") {
-		if err := updateWafDedicatedDomainPolicyHost(d, cfg); err != nil {
+		if err := updateWafDomainPolicyHost(d, cfg); err != nil {
 			return diag.FromErr(err)
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
WAF domain supports editing field 'policy_id'

**Special notes for your reviewer**:
+ add field 'policy_id' in creatDomain function
+ Change the policy_id field to editable
+ Modify the basic unit test to test whether ’policy_id‘ has been successfully updated
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_basic
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (153.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       153.602s
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withEpsID -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_withEpsID
=== PAUSE TestAccWafDomainV1_withEpsID
=== CONT  TestAccWafDomainV1_withEpsID
--- PASS: TestAccWafDomainV1_withEpsID (111.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       112.031s
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withPolicy -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_withPolicy
=== PAUSE TestAccWafDomainV1_withPolicy
=== CONT  TestAccWafDomainV1_withPolicy
--- PASS: TestAccWafDomainV1_withPolicy (115.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       115.667s
```
