### PR TITLE
refactor(ecs): upgrade api version for source_dest_check param

### DIFF
--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -66,6 +66,7 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata.key2", "value2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "network.0.source_dest_check", "true"),
 				),
 			},
 			{
@@ -459,7 +460,7 @@ resource "huaweicloud_compute_instance" "test" {
 
   network {
     uuid              = data.huaweicloud_vpc_subnet.test.id
-    source_dest_check = false
+    source_dest_check = true
   }
 
   system_disk_type = "SAS"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
the openstack API (v2.0) has been deprecated, we are using v1 API to update source destination check now.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. upgrade api version for source_dest_check param.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ecs' TESTARGS='-run=TestAccComputeInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run=TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (315.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       315.967s
```
