### PR TITLE
feat(DMS): add attribute description for resource consumer group

### DIFF
--- a/docs/resources/dms_rocketmq_consumer_group.md
+++ b/docs/resources/dms_rocketmq_consumer_group.md
@@ -18,6 +18,7 @@ resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
   broadcast       = true
   brokers         = ["broker-0","broker-1"]
   retry_max_times = 3
+  description     = "the description of the consumer group"
 }
 ```
 
@@ -45,6 +46,8 @@ The following arguments are supported:
 * `enabled` - (Optional, Bool) Specifies the consumer group is enabled or not. Default to true.
 
 * `broadcast` - (Optional, Bool) Specifies whether to broadcast of the consumer group.
+
+* `description` - (Optional, String) Specifies the description of the consumer group.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumer_group_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumer_group_test.go
@@ -79,6 +79,7 @@ func TestAccDmsRocketMQConsumerGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "broadcast", "true"),
 					resource.TestCheckResourceAttr(resourceName, "retry_max_times", "3"),
+					resource.TestCheckResourceAttr(resourceName, "description", "add description."),
 				),
 			},
 			{
@@ -89,6 +90,7 @@ func TestAccDmsRocketMQConsumerGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "broadcast", "false"),
 					resource.TestCheckResourceAttr(resourceName, "retry_max_times", "5"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 				),
 			},
 			{
@@ -139,6 +141,7 @@ resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
 
   name            = "%s"
   retry_max_times = "3"
+  description     = "add description."
 }
 `, testAccDmsRocketmqConsumerGroup_Base(name), name)
 }
@@ -158,6 +161,7 @@ resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
   name            = "%s"
   retry_max_times = "5"
   enabled         = false
+  description     = ""
 }
 `, testAccDmsRocketmqConsumerGroup_Base(name), name)
 }

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
@@ -78,6 +78,11 @@ func ResourceDmsRocketMQConsumerGroup() *schema.Resource {
 				Computed:    true,
 				Description: `Specifies whether to broadcast of the consumer group.`,
 			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the description of the consumer group.`,
+			},
 		},
 	}
 }
@@ -141,6 +146,7 @@ func buildCreateRocketmqConsumerGroupBodyParams(d *schema.ResourceData, _ *confi
 		"brokers":        utils.ValueIngoreEmpty(d.Get("brokers")),
 		"name":           utils.ValueIngoreEmpty(d.Get("name")),
 		"retry_max_time": utils.ValueIngoreEmpty(d.Get("retry_max_times")),
+		"group_desc":     utils.ValueIngoreEmpty(d.Get("description")),
 	}
 	return bodyParams
 }
@@ -153,6 +159,7 @@ func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.Resou
 		"enabled",
 		"broadcast",
 		"retry_max_times",
+		"description",
 	}
 
 	if d.HasChanges(updateRocketmqConsumerGroupHasChanges...) {
@@ -199,6 +206,7 @@ func buildUpdateRocketmqConsumerGroupBodyParams(d *schema.ResourceData) map[stri
 	bodyParams := map[string]interface{}{
 		"broadcast":      utils.ValueIngoreEmpty(d.Get("broadcast")),
 		"retry_max_time": utils.ValueIngoreEmpty(d.Get("retry_max_times")),
+		"group_desc":     utils.ValueIngoreEmpty(d.Get("description")),
 	}
 	enabled := utils.ValueIngoreEmpty(d.Get("enabled"))
 	if enabled != nil {
@@ -262,6 +270,7 @@ func resourceDmsRocketMQConsumerGroupRead(_ context.Context, d *schema.ResourceD
 		d.Set("brokers", utils.PathSearch("brokers", getRocketmqConsumerGroupRespBody, nil)),
 		d.Set("name", name),
 		d.Set("retry_max_times", utils.PathSearch("retry_max_time", getRocketmqConsumerGroupRespBody, nil)),
+		d.Set("description", utils.PathSearch("group_desc", getRocketmqConsumerGroupRespBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add attribute description for resource consumer group
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccDmsRocketMQConsumerGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQConsumerGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQConsumerGroup_basic
=== PAUSE TestAccDmsRocketMQConsumerGroup_basic
=== CONT  TestAccDmsRocketMQConsumerGroup_basic
--- PASS: TestAccDmsRocketMQConsumerGroup_basic (751.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       751.237s
```
