### PR TITLE
fix(WAF): fix waf datasource lint error

### DIFF
--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_certificate.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_certificate.go
@@ -1,33 +1,35 @@
 package waf
 
 import (
+	"context"
+	"log"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 const (
-	// EXP_STATUS_NOT_EXPIRED not expired
-	EXP_STATUS_NOT_EXPIRED = 0
-	// EXP_STATUS_EXPIRED has expired
-	EXP_STATUS_EXPIRED = 1
-	// EXP_STATUS_EXPIRED_SOON will expire soon
-	EXP_STATUS_EXPIRED_SOON = 2
+	// ExpStatusNotExpired not expired
+	ExpStatusNotExpired = 0
+	// ExpStatusExpired has expired
+	ExpStatusExpired = 1
+	// ExpStatusExpiredSoon will expire soon
+	ExpStatusExpiredSoon = 2
 
-	DEFAULT_PAGE_NUM  = 1
-	DEFAULT_PAGE_SIZE = 5
+	DefaultPageNum  = 1
+	DefaultPageSize = 5
 )
 
 func DataSourceWafCertificateV1() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceWafCertificateV1Read,
+		ReadContext: dataSourceWafCertificateV1Read,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -42,9 +44,9 @@ func DataSourceWafCertificateV1() *schema.Resource {
 			"expire_status": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Default:  EXP_STATUS_NOT_EXPIRED,
+				Default:  ExpStatusNotExpired,
 				ValidateFunc: validation.IntInSlice([]int{
-					EXP_STATUS_NOT_EXPIRED, EXP_STATUS_EXPIRED, EXP_STATUS_EXPIRED_SOON,
+					ExpStatusNotExpired, ExpStatusExpired, ExpStatusExpiredSoon,
 				}),
 			},
 			"enterprise_project_id": {
@@ -59,42 +61,46 @@ func DataSourceWafCertificateV1() *schema.Resource {
 	}
 }
 
-func dataSourceWafCertificateV1Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	wafClient, err := config.WafV1Client(config.GetRegion(d))
+func dataSourceWafCertificateV1Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	wafClient, err := conf.WafV1Client(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF Client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	expStatus := d.Get("expire_status").(int)
 	listOpts := certificates.ListOpts{
-		Page:                DEFAULT_PAGE_NUM,
-		Pagesize:            DEFAULT_PAGE_SIZE,
+		Page:                DefaultPageNum,
+		Pagesize:            DefaultPageSize,
 		Name:                d.Get("name").(string),
 		ExpStatus:           &expStatus,
-		EnterpriseProjectID: config.GetEnterpriseProjectID(d),
+		EnterpriseProjectID: conf.GetEnterpriseProjectID(d),
 	}
 
 	page, err := certificates.List(wafClient, listOpts).AllPages()
+	if err != nil {
+		return diag.Errorf("error restrieving WAF certificates: %s", err)
+	}
 
 	listCertificates, err := certificates.ExtractCertificates(page)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve certificates: %s", err)
+		return diag.Errorf("Unable to retrieve certificates: %s", err)
 	}
-	logp.Printf("[DEBUG] Get certificate list: %#v", listCertificates)
+	log.Printf("[DEBUG] Get certificate list: %#v", listCertificates)
 
-	if len(listCertificates) > 0 {
-		c := listCertificates[0]
-		d.SetId(c.Id)
-		d.Set("name", c.Name)
-		d.Set("expire_status", c.ExpStatus)
-
-		expires := time.Unix(int64(c.ExpireTime/1000), 0).UTC().Format("2006-01-02 15:04:05 MST")
-		d.Set("expiration", expires)
-	} else {
-		return fmtp.Errorf("Your query returned no results. " +
+	if len(listCertificates) == 0 {
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
+	c := listCertificates[0]
+	d.SetId(c.Id)
+	expires := time.Unix(int64(c.ExpireTime/1000), 0).UTC().Format("2006-01-02 15:04:05 MST")
+	mErr := multierror.Append(
+		nil,
+		d.Set("name", c.Name),
+		d.Set("expire_status", c.ExpStatus),
+		d.Set("expiration", expires),
+	)
 
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_dedicated_instances.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_dedicated_instances.go
@@ -13,7 +13,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func DataSourceWafDedicatedInstancesV1() *schema.Resource {
@@ -109,10 +108,10 @@ func DataSourceWafDedicatedInstancesV1() *schema.Resource {
 }
 
 func dataSourceWafDedicatedInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.WafDedicatedV1Client(config.GetRegion(d))
+	conf := meta.(*config.Config)
+	client, err := conf.WafDedicatedV1Client(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("error creating HuaweiCloud WAF dedicated client: %s", err)
+		return diag.Errorf("error creating WAF dedicated client: %s", err)
 	}
 
 	instanceId, hasId := d.GetOk("id")
@@ -121,7 +120,7 @@ func dataSourceWafDedicatedInstanceRead(_ context.Context, d *schema.ResourceDat
 	if hasId {
 		instance, err := instances.GetWithEpsId(client, instanceId.(string), epsId)
 		if err != nil {
-			return fmtp.DiagErrorf("Your query returned no results. " +
+			return diag.Errorf("Your query returned no results. " +
 				"Please change your search criteria and try again.")
 		}
 		d.SetId(instanceId.(string))
@@ -148,12 +147,12 @@ func dataSourceWafDedicatedInstanceRead(_ context.Context, d *schema.ResourceDat
 	}
 
 	if len(items) == 0 {
-		return fmtp.DiagErrorf("Your query returned no results. " +
+		return diag.Errorf("Your query returned no results. " +
 			"Please change your search criteria and try again.")
 	}
 
 	ids := make([]string, 0, len(items))
-	instances := make([]map[string]interface{}, 0, len(items))
+	insts := make([]map[string]interface{}, 0, len(items))
 
 	for _, r := range items {
 		eng := map[string]interface{}{
@@ -172,7 +171,7 @@ func dataSourceWafDedicatedInstanceRead(_ context.Context, d *schema.ResourceDat
 			"upgradable":       r.Upgradable,
 			"group_id":         r.PoolId,
 		}
-		instances = append(instances, eng)
+		insts = append(insts, eng)
 		ids = append(ids, r.Id)
 	}
 
@@ -180,12 +179,12 @@ func dataSourceWafDedicatedInstanceRead(_ context.Context, d *schema.ResourceDat
 		d.SetId(hashcode.Strings(ids))
 	}
 	mErr := multierror.Append(nil,
-		d.Set("instances", instances),
-		d.Set("region", config.GetRegion(d)),
+		d.Set("instances", insts),
+		d.Set("region", conf.GetRegion(d)),
 	)
 
 	if mErr.ErrorOrNil() != nil {
-		return fmtp.DiagErrorf("error setting WAF dedicated instance fields: %s", mErr)
+		return diag.Errorf("error setting WAF dedicated instance fields: %s", mErr)
 	}
 
 	return nil

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_instance_groups.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_instance_groups.go
@@ -12,7 +12,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func DataSourceWafInstanceGroups() *schema.Resource {
@@ -124,7 +123,7 @@ func DataSourceWafInstanceGroupsRead(_ context.Context, d *schema.ResourceData, 
 	conf := meta.(*config.Config)
 	client, err := conf.WafDedicatedV1Client(conf.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("error creating HuaweiCloud WAF dedicated client : %s", err)
+		return diag.Errorf("error creating WAF dedicated client : %s", err)
 	}
 
 	opts := pools.ListPoolOpts{
@@ -139,15 +138,15 @@ func DataSourceWafInstanceGroupsRead(_ context.Context, d *schema.ResourceData, 
 
 	p, err := page.AllPages()
 	if err != nil {
-		return fmtp.DiagErrorf("error querying WAF instance group: %s", err)
+		return diag.Errorf("error querying WAF instance group: %s", err)
 	}
 	groups, err := pools.ExtractGroups(p)
 	if err != nil {
-		return fmtp.DiagErrorf("error querying WAF instance group: %s", err)
+		return diag.Errorf("error querying WAF instance group: %s", err)
 	}
 
 	if len(groups) == 0 {
-		return fmtp.DiagErrorf("Your query returned no results.  " +
+		return diag.Errorf("Your query returned no results.  " +
 			"Please change your search criteria and try again.")
 	}
 
@@ -192,7 +191,7 @@ func DataSourceWafInstanceGroupsRead(_ context.Context, d *schema.ResourceData, 
 	)
 
 	if err = mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("error setting WAF instance group attributes: %s", err)
+		return diag.Errorf("error setting WAF instance group attributes: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix waf datasource lint error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf/' TESTARGS='-run TestAccDataSourceWafCertificateV1_basic'...
```
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf/ -v -run TestAccDataSourceWafCertificateV1_basic -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceWafCertificateV1_basic 
=== PAUSE TestAccDataSourceWafCertificateV1_basic
=== CONT  TestAccDataSourceWafCertificateV1_basic
--- PASS: TestAccDataSourceWafCertificateV1_basic (385.40s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       385.444s
```
make testacc TEST='./huaweicloud/services/acceptance/waf/' TESTARGS='-run TestAccDataSourceWafDedicatedInstances_basic'
```
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf/ -v -run TestAccDataSourceWafDedicatedInstances_basic -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceWafDedicatedInstances_basic 
=== PAUSE TestAccDataSourceWafDedicatedInstances_basic
=== CONT  TestAccDataSourceWafDedicatedInstances_basic
--- PASS: TestAccDataSourceWafDedicatedInstances_basic (367.02s) 
PASS 
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       367.057s
```
make testacc TEST='./huaweicloud/services/acceptance/waf/' TESTARGS='-run TestAccDataSourceReferenceTablesV1_basic'
```
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf/ -v -run TestAccDataSourceReferenceTablesV1_basic -timeout 360m -parallel 4 
=== RUN   TestAccDataSourceReferenceTablesV1_basic 
--- PASS: TestAccDataSourceReferenceTablesV1_basic (368.86s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       368.900s
```