### PR TITLE
fix(elb): try to set charing_mode according to bill info

### DIFF
--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -447,6 +447,17 @@ func resourceLoadBalancerV3Read(_ context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
+	// set charging_mode according to billing_info
+	if len(lb.BillingInfo) > 0 {
+		mErr = multierror.Append(mErr,
+			d.Set("charging_mode", "prePaid"),
+		)
+	} else {
+		mErr = multierror.Append(mErr,
+			d.Set("charging_mode", "postPaid"),
+		)
+	}
+
 	// fetch tags
 	if resourceTags, err := tags.Get(elbV2Client, "loadbalancers", d.Id()).Extract(); err == nil {
 		tagMap := utils.TagsToMap(resourceTags.Tags)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run=TestAccElbV3LoadBalancer_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run=TestAccElbV3LoadBalancer_ -timeout 360m -parallel 4
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== PAUSE TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid
=== CONT  TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== CONT  TestAccElbV3LoadBalancer_withEIP
=== CONT  TestAccElbV3LoadBalancer_withEpsId
--- PASS: TestAccElbV3LoadBalancer_withEpsId (48.56s)
=== CONT  TestAccElbV3LoadBalancer_prePaid
    acceptance.go:521: This environment does not support prepaid tests
--- SKIP: TestAccElbV3LoadBalancer_prePaid (0.00s)
--- PASS: TestAccElbV3LoadBalancer_withEIP (54.80s)
--- PASS: TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id (65.27s)
--- PASS: TestAccElbV3LoadBalancer_basic (147.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       147.282s
```
