### PR TITLE
fix(SWR): fix swr resources lint errors

### DIFF
--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_auto_sync_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_auto_sync_test.go
@@ -24,7 +24,7 @@ func getSwrImageAutoSyncResourceFunc(cfg *config.Config, state *terraform.Resour
 	)
 	getSwrImageAutoSyncClient, err := cfg.NewServiceClient(getSwrImageAutoSyncProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating SWR Client: %s", err)
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
 	}
 
 	parts := strings.SplitN(state.Primary.ID, "/", 4)
@@ -50,7 +50,7 @@ func getSwrImageAutoSyncResourceFunc(cfg *config.Config, state *terraform.Resour
 	getSwrImageAutoSyncResp, err := getSwrImageAutoSyncClient.Request("GET",
 		getSwrImageAutoSyncPath, &getSwrImageSyncOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving SwrImageSync: %s", err)
+		return nil, fmt.Errorf("error retrieving SWR image sync: %s", err)
 	}
 
 	getSwrImageAutoSyncRespBody, err := utils.FlattenResponse(getSwrImageAutoSyncResp)

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_permissions_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_permissions_test.go
@@ -24,7 +24,7 @@ func getSwrImagePermissionsResourceFunc(cfg *config.Config, state *terraform.Res
 	)
 	getSwrImagePermissionsClient, err := cfg.NewServiceClient(getSwrImagePermissionsProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating SWR Client: %s", err)
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
 	}
 
 	parts := strings.SplitN(state.Primary.ID, "/", 2)
@@ -147,42 +147,42 @@ func testSwrImagePermissions_basic(name string) string {
 %[1]s
 
 resource "huaweicloud_identity_user" "user_1" {
- name     = "%[2]s_1"
- enabled  = true
- password = "password12345!"
+  name     = "%[2]s_1"
+  enabled  = true
+  password = "password12345!"
 }
 
 resource "huaweicloud_identity_user" "user_2" {
- name     = "%[2]s_2"
- enabled  = true
- password = "password12345!"
+  name     = "%[2]s_2"
+  enabled  = true
+  password = "password12345!"
 }
 
 resource "huaweicloud_identity_user" "user_3" {
- name     = "%[2]s_3"
- enabled  = true
- password = "password12345!"
+  name     = "%[2]s_3"
+  enabled  = true
+  password = "password12345!"
 }
 
 resource "huaweicloud_swr_image_permissions" "test" {
- organization = huaweicloud_swr_organization.test.name
- repository   = huaweicloud_swr_repository.test.name
+  organization = huaweicloud_swr_organization.test.name
+  repository   = huaweicloud_swr_repository.test.name
 
- users {
-   user_id    = huaweicloud_identity_user.user_1.id
-   user_name  = huaweicloud_identity_user.user_1.name
-   permission = "Read"
- }
+  users {
+    user_id    = huaweicloud_identity_user.user_1.id
+    user_name  = huaweicloud_identity_user.user_1.name
+    permission = "Read"
+  }
 
- users {
-   user_id    = huaweicloud_identity_user.user_2.id
-   permission = "Write"
- }
+  users {
+    user_id    = huaweicloud_identity_user.user_2.id
+    permission = "Write"
+  }
 
- users {
-   user_id    = huaweicloud_identity_user.user_3.id
-   permission = "Manage"
- }
+  users {
+    user_id    = huaweicloud_identity_user.user_3.id
+    permission = "Manage"
+  }
 }
 `, testAccSWRRepository_basic(name), name)
 }
@@ -192,53 +192,53 @@ func testSwrImagePermissions_basic_update(name string) string {
 %[1]s
 
 resource "huaweicloud_identity_user" "user_1" {
- name     = "%[2]s_1"
- enabled  = true
- password = "password12345!"
+  name     = "%[2]s_1"
+  enabled  = true
+  password = "password12345!"
 }
 
 resource "huaweicloud_identity_user" "user_2" {
- name     = "%[2]s_2"
- enabled  = true
- password = "password12345!"
+  name     = "%[2]s_2"
+  enabled  = true
+  password = "password12345!"
 }
 
 resource "huaweicloud_identity_user" "user_4" {
- name     = "%[2]s_4"
- enabled  = true
- password = "password12345!"
+  name     = "%[2]s_4"
+  enabled  = true
+  password = "password12345!"
 }
 
 resource "huaweicloud_identity_user" "user_5" {
- name     = "%[2]s_5"
- enabled  = true
- password = "password12345!"
+  name     = "%[2]s_5"
+  enabled  = true
+  password = "password12345!"
 }
 
 resource "huaweicloud_swr_image_permissions" "test" {
- organization = huaweicloud_swr_organization.test.name
- repository   = huaweicloud_swr_repository.test.name
+  organization = huaweicloud_swr_organization.test.name
+  repository   = huaweicloud_swr_repository.test.name
 
- users {
-   user_id    = huaweicloud_identity_user.user_1.id
-   user_name  = huaweicloud_identity_user.user_1.name
-   permission = "Write"
- }
+  users {
+    user_id    = huaweicloud_identity_user.user_1.id
+    user_name  = huaweicloud_identity_user.user_1.name
+    permission = "Write"
+  }
 
- users {
-   user_id    = huaweicloud_identity_user.user_2.id
-   permission = "Read"
- }
+  users {
+    user_id    = huaweicloud_identity_user.user_2.id
+    permission = "Read"
+  }
 
- users {
-   user_id    = huaweicloud_identity_user.user_4.id
-   permission = "Manage"
- }
+  users {
+    user_id    = huaweicloud_identity_user.user_4.id
+    permission = "Manage"
+  }
 
- users {
-   user_id    = huaweicloud_identity_user.user_5.id
-   permission = "Write"
- }
+  users {
+    user_id    = huaweicloud_identity_user.user_5.id
+    permission = "Write"
+  }
 } 
 `, testAccSWRRepository_basic(name), name)
 }

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_retention_policy_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_retention_policy_test.go
@@ -24,7 +24,7 @@ func getSwrImageRetentionPolicyResourceFunc(cfg *config.Config, state *terraform
 	)
 	getSwrImageRetentionPolicyClient, err := cfg.NewServiceClient(getSwrImageRetentionPolicyProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating SWR Client: %s", err)
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
 	}
 
 	parts := strings.SplitN(state.Primary.ID, "/", 3)

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_trigger_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_trigger_test.go
@@ -24,7 +24,7 @@ func getSwrImageTriggerResourceFunc(cfg *config.Config, state *terraform.Resourc
 	)
 	getSwrImageTriggerClient, err := cfg.NewServiceClient(getSwrImageTriggerProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating SWR Client: %s", err)
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
 	}
 
 	parts := strings.SplitN(state.Primary.ID, "/", 3)

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_organization_permissions_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_organization_permissions_test.go
@@ -16,7 +16,7 @@ import (
 func getResourcePermissions(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	swrClient, err := conf.SwrV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating HuaweiCloud SWR client: %s", err)
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
 	}
 
 	return namespaces.GetAccess(swrClient, state.Primary.ID).Extract()

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_organization_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_organization_test.go
@@ -16,7 +16,7 @@ import (
 func getResourceOrganization(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	swrClient, err := conf.SwrV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating HuaweiCloud SWR client: %s", err)
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
 	}
 
 	return namespaces.Get(swrClient, state.Primary.ID).Extract()

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_repository_sharing_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_repository_sharing_test.go
@@ -11,13 +11,12 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func getResourceRepositorySharing(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	swrClient, err := conf.SwrV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating HuaweiCloud SWR client: %s", err)
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
 	}
 
 	return domains.Get(swrClient, state.Primary.Attributes["organization"],
@@ -85,16 +84,17 @@ func testAccSWRRepositorySharingImportStateIdFunc() resource.ImportStateIdFunc {
 		var repositoryID string
 		var sharingAccount string
 		for _, rs := range s.RootModule().Resources {
-			if rs.Type == "huaweicloud_swr_organization" {
+			switch rs.Type {
+			case "huaweicloud_swr_organization":
 				organization = rs.Primary.Attributes["name"]
-			} else if rs.Type == "huaweicloud_swr_repository" {
+			case "huaweicloud_swr_repository":
 				repositoryID = rs.Primary.ID
-			} else if rs.Type == "huaweicloud_swr_repository_sharing" {
+			case "huaweicloud_swr_repository_sharing":
 				sharingAccount = rs.Primary.ID
 			}
 		}
 		if organization == "" || repositoryID == "" || sharingAccount == "" {
-			return "", fmtp.Errorf("resource not found: %s/%s/%s", organization, repositoryID, sharingAccount)
+			return "", fmt.Errorf("resource not found: %s/%s/%s", organization, repositoryID, sharingAccount)
 		}
 		return fmt.Sprintf("%s/%s/%s", organization, repositoryID, sharingAccount), nil
 	}

--- a/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_repository_test.go
+++ b/huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_repository_test.go
@@ -11,13 +11,12 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func getResourceRepository(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	swrClient, err := conf.SwrV2Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating HuaweiCloud SWR client: %s", err)
+		return nil, fmt.Errorf("error creating SWR client: %s", err)
 	}
 
 	return repositories.Get(swrClient, state.Primary.Attributes["organization"], state.Primary.ID).Extract()
@@ -83,7 +82,7 @@ func testAccSWRRepositoryImportStateIdFunc() resource.ImportStateIdFunc {
 			}
 		}
 		if organization == "" || repositoryID == "" {
-			return "", fmtp.Errorf("resource not found: %s/%s", organization, repositoryID)
+			return "", fmt.Errorf("resource not found: %s/%s", organization, repositoryID)
 		}
 		return fmt.Sprintf("%s/%s", organization, repositoryID), nil
 	}

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_image_auto_sync.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_image_auto_sync.go
@@ -93,7 +93,7 @@ func resourceSwrImageAutoSyncCreate(ctx context.Context, d *schema.ResourceData,
 	)
 	createSwrImageAutoSyncClient, err := cfg.NewServiceClient(createSwrImageAutoSyncProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating SWR Client: %s", err)
+		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
 	organization := d.Get("organization").(string)
@@ -146,7 +146,7 @@ func resourceSwrImageAutoSyncRead(_ context.Context, d *schema.ResourceData, met
 	)
 	getSwrImageAutoSyncClient, err := cfg.NewServiceClient(getSwrImageAutoSyncProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating SWR Client: %s", err)
+		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
 	parts := strings.SplitN(d.Id(), "/", 4)
@@ -214,7 +214,7 @@ func resourceSwrImageAutoSyncDelete(_ context.Context, d *schema.ResourceData, m
 	)
 	deleteSwrImageAutoSyncClient, err := cfg.NewServiceClient(deleteSwrImageAutoSyncProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating SWR Client: %s", err)
+		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
 	deleteSwrImageAutoSyncPath := deleteSwrImageAutoSyncClient.Endpoint + deleteSwrImageAutoSyncHttpUrl

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_image_permissions.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_image_permissions.go
@@ -203,7 +203,7 @@ func flattenGetImagePermissionsSelfPermissionResponseBody(resp interface{}) []in
 	var rst []interface{}
 	curJson, err := jmespath.Search("self_auth", resp)
 	if err != nil {
-		log.Printf("[ERROR] error parsing self_permission from response= %#v", resp)
+		log.Printf("[ERROR] error parsing self_permission from response: %#v", resp)
 		return rst
 	}
 

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_image_retention_policy.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_image_retention_policy.go
@@ -105,7 +105,7 @@ func resourceSwrImageRetentionPolicyCreate(ctx context.Context, d *schema.Resour
 	)
 	createSwrImageRetentionPolicyClient, err := cfg.NewServiceClient(createSwrImageRetentionPolicyProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating SWR Client: %s", err)
+		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
 	organization := d.Get("organization").(string)
@@ -200,7 +200,7 @@ func resourceSwrImageRetentionPolicyRead(_ context.Context, d *schema.ResourceDa
 	)
 	getSwrImageRetentionPolicyClient, err := cfg.NewServiceClient(getSwrImageRetentionPolicyProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating SWR Client: %s", err)
+		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
 	parts := strings.SplitN(d.Id(), "/", 3)
@@ -295,7 +295,7 @@ func resourceSwrImageRetentionPolicyUpdate(ctx context.Context, d *schema.Resour
 		)
 		updateSwrImageRetentionPolicyClient, err := cfg.NewServiceClient(updateSwrImageRetentionPolicyProduct, region)
 		if err != nil {
-			return diag.Errorf("error creating SWR Client: %s", err)
+			return diag.Errorf("error creating SWR client: %s", err)
 		}
 
 		parts := strings.SplitN(d.Id(), "/", 3)
@@ -337,7 +337,7 @@ func resourceSwrImageRetentionPolicyDelete(_ context.Context, d *schema.Resource
 	)
 	deleteSwrImageRetentionPolicyClient, err := cfg.NewServiceClient(deleteSwrImageRetentionPolicyProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating SWR Client: %s", err)
+		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
 	parts := strings.SplitN(d.Id(), "/", 3)

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_image_trigger.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_image_trigger.go
@@ -230,7 +230,7 @@ func resourceSwrImageTriggerRead(_ context.Context, d *schema.ResourceData, meta
 	)
 	getSwrImageTriggerClient, err := cfg.NewServiceClient(getSwrImageTriggerProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating SWR Client: %s", err)
+		return diag.Errorf("error creating SWR client: %s", err)
 	}
 
 	parts := strings.SplitN(d.Id(), "/", 3)
@@ -303,7 +303,7 @@ func resourceSwrImageTriggerUpdate(ctx context.Context, d *schema.ResourceData, 
 		)
 		updateSwrImageTriggerClient, err := cfg.NewServiceClient(updateSwrImageTriggerProduct, region)
 		if err != nil {
-			return diag.Errorf("error creating SWR Client: %s", err)
+			return diag.Errorf("error creating SWR client: %s", err)
 		}
 
 		updateSwrImageTriggerPath := updateSwrImageTriggerClient.Endpoint + updateSwrImageTriggerHttpUrl
@@ -348,7 +348,7 @@ func resourceSwrImageTriggerDelete(_ context.Context, d *schema.ResourceData, me
 	)
 	deleteSwrImageTriggerClient, err := cfg.NewServiceClient(deleteSwrImageTriggerProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating SwrImageTrigger Client: %s", err)
+		return diag.Errorf("error creating SWR image trigger client: %s", err)
 	}
 
 	deleteSwrImageTriggerPath := deleteSwrImageTriggerClient.Endpoint + deleteSwrImageTriggerHttpUrl

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_repository.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_repository.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func ResourceSWRRepository() *schema.Resource {
@@ -35,7 +34,7 @@ func ResourceSWRRepository() *schema.Resource {
 			Delete: schema.DefaultTimeout(2 * time.Minute),
 		},
 
-		//request and response parameters
+		// request and response parameters
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -60,7 +59,8 @@ func ResourceSWRRepository() *schema.Resource {
 					),
 					validation.StringDoesNotMatch(
 						regexp.MustCompile(`_{3,}?|\.{2,}?|-{2,}?`),
-						"Periods, underscores, and hyphens cannot be placed next to each other. A maximum of two consecutive underscores are allowed.",
+						"Periods, underscores, and hyphens cannot be placed next to each other. "+
+							"A maximum of two consecutive underscores are allowed.",
 					),
 				),
 			},
@@ -105,10 +105,10 @@ func ResourceSWRRepository() *schema.Resource {
 }
 
 func resourceSWRRepositoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.SwrV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.SwrV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud SWR client : %s", err)
+		return diag.Errorf("unable to create SWR client: %s", err)
 	}
 
 	name := d.Get("name").(string)
@@ -123,7 +123,7 @@ func resourceSWRRepositoryCreate(ctx context.Context, d *schema.ResourceData, me
 
 	err = repositories.Create(client, organization, opts).ExtractErr()
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud SWR Repository: %s", err)
+		return diag.Errorf("error creating SWR repository: %s", err)
 	}
 	d.SetId(name)
 
@@ -131,21 +131,21 @@ func resourceSWRRepositoryCreate(ctx context.Context, d *schema.ResourceData, me
 }
 
 func resourceSWRRepositoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.SwrV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.SwrV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud SWR client : %s", err)
+		return diag.Errorf("unable to create SWR client: %s", err)
 	}
 
 	organization := d.Get("organization").(string)
 
 	repo, err := repositories.Get(client, organization, d.Id()).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error retrieving HuaweiCloud SWR Repository")
+		return common.CheckDeletedDiag(d, err, "error retrieving SWR repository")
 	}
 
 	mErr := multierror.Append(
-		d.Set("region", config.GetRegion(d)),
+		d.Set("region", cfg.GetRegion(d)),
 		d.Set("name", repo.Name),
 		d.Set("repository_id", repo.ID),
 		d.Set("description", repo.Description),
@@ -157,17 +157,17 @@ func resourceSWRRepositoryRead(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("size", repo.Size),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("error setting HuaweiCloud SWR Repository fields: %s", err)
+		return diag.Errorf("error setting SWR repository fields: %s", err)
 	}
 
 	return nil
 }
 
 func resourceSWRRepositoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.SwrV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.SwrV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud SWR client : %s", err)
+		return diag.Errorf("unable to create SWR client: %s", err)
 	}
 
 	opts := repositories.UpdateOpts{
@@ -180,26 +180,25 @@ func resourceSWRRepositoryUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	err = repositories.Update(client, organization, d.Id(), opts).ExtractErr()
 	if err != nil {
-		return fmtp.DiagErrorf("Error updating HuaweiCloud SWR Repository: %s", err)
+		return diag.Errorf("error updating SWR repository: %s", err)
 	}
 
 	return resourceSWRRepositoryRead(ctx, d, meta)
 }
 
 func resourceSWRRepositoryDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.SwrV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.SwrV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud SWR client : %s", err)
+		return diag.Errorf("unable to create SWR client: %s", err)
 	}
 
 	organization := d.Get("organization").(string)
 	err = repositories.Delete(client, organization, d.Id()).ExtractErr()
 	if err != nil {
-		fmtp.DiagErrorf("error deleting HuaweiCloud SWR Repository: %s", err)
+		diag.Errorf("error deleting SWR repository: %s", err)
 	}
 
-	d.SetId("")
 	return nil
 }
 

--- a/huaweicloud/services/swr/resource_huaweicloud_swr_repository_sharing.go
+++ b/huaweicloud/services/swr/resource_huaweicloud_swr_repository_sharing.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 var (
@@ -94,17 +93,17 @@ func ResourceSWRRepositorySharing() *schema.Resource {
 }
 
 func resourceSWRRepositorySharingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.SwrV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.SwrV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud SWR client : %s", err)
+		return diag.Errorf("unable to create SWR client: %s", err)
 	}
 
 	permission := d.Get("permission").(string)
 
 	permit, ok := permissions[permission]
 	if !ok {
-		return fmtp.DiagErrorf("The permission type (%s) is not available", permission)
+		return diag.Errorf("the permission type (%s) is not available", permission)
 	}
 
 	domain := d.Get("sharing_account").(string)
@@ -120,7 +119,7 @@ func resourceSWRRepositorySharingCreate(ctx context.Context, d *schema.ResourceD
 
 	err = domains.Create(client, organization, repository, opts).ExtractErr()
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud SWR repository sharing: %w", err)
+		return diag.Errorf("error creating SWR repository sharing: %s", err)
 	}
 	d.SetId(domain)
 
@@ -128,10 +127,10 @@ func resourceSWRRepositorySharingCreate(ctx context.Context, d *schema.ResourceD
 }
 
 func resourceSWRRepositorySharingRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.SwrV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.SwrV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud SWR client : %s", err)
+		return diag.Errorf("unable to create SWR client: %s", err)
 	}
 
 	organization := d.Get("organization").(string)
@@ -139,11 +138,11 @@ func resourceSWRRepositorySharingRead(_ context.Context, d *schema.ResourceData,
 
 	domain, err := domains.Get(client, organization, repository, d.Id()).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error retrieving HuaweiCloud SWR repository sharing")
+		return common.CheckDeletedDiag(d, err, "error retrieving SWR repository sharing")
 	}
 
 	mErr := multierror.Append(
-		d.Set("region", config.GetRegion(d)),
+		d.Set("region", cfg.GetRegion(d)),
 		d.Set("sharing_account", domain.AccessDomain),
 		d.Set("repository", domain.Repository),
 		d.Set("organization", domain.Organization),
@@ -156,17 +155,17 @@ func resourceSWRRepositorySharingRead(_ context.Context, d *schema.ResourceData,
 		mErr = multierror.Append(mErr, d.Set("permission", permission))
 	}
 	if err := mErr.ErrorOrNil(); err != nil {
-		return fmtp.DiagErrorf("error setting HuaweiCloud SWR repository sharing fields: %w", err)
+		return diag.Errorf("error setting SWR repository sharing fields: %v", err)
 	}
 
 	return nil
 }
 
 func resourceSWRRepositorySharingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.SwrV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.SwrV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud SWR client : %s", err)
+		return diag.Errorf("unable to create SWR client: %s", err)
 	}
 
 	description := d.Get("description").(string)
@@ -174,7 +173,7 @@ func resourceSWRRepositorySharingUpdate(ctx context.Context, d *schema.ResourceD
 
 	permit, ok := permissions[permission]
 	if !ok {
-		return fmtp.DiagErrorf("The permission type (%s) is not available", permission)
+		return diag.Errorf("the permission type (%s) is not available", permission)
 	}
 
 	opts := domains.UpdateOpts{
@@ -188,17 +187,17 @@ func resourceSWRRepositorySharingUpdate(ctx context.Context, d *schema.ResourceD
 
 	err = domains.Update(client, organization, repository, d.Id(), opts).ExtractErr()
 	if err != nil {
-		return fmtp.DiagErrorf("Error updating HuaweiCloud SWR repository sharing: %w", err)
+		return diag.Errorf("error updating SWR repository sharing: %v", err)
 	}
 
 	return resourceSWRRepositorySharingRead(ctx, d, meta)
 }
 
 func resourceSWRRepositorySharingDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	client, err := config.SwrV2Client(config.GetRegion(d))
+	cfg := meta.(*config.Config)
+	client, err := cfg.SwrV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to create HuaweiCloud SWR client : %s", err)
+		return diag.Errorf("unable to create SWR client: %s", err)
 	}
 
 	organization := d.Get("organization").(string)
@@ -206,10 +205,9 @@ func resourceSWRRepositorySharingDelete(_ context.Context, d *schema.ResourceDat
 
 	err = domains.Delete(client, organization, repository, d.Id()).ExtractErr()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error deleting HuaweiCloud SWR repository sharing")
+		return common.CheckDeletedDiag(d, err, "error deleting SWR repository sharing")
 	}
 
-	d.SetId("")
 	return nil
 }
 
@@ -230,21 +228,22 @@ func resourceSWRRepositorySharingImport(ctx context.Context, d *schema.ResourceD
 	if err := mErr.ErrorOrNil(); err != nil {
 		return nil, err
 	}
+
 	return schema.ImportStatePassthroughContext(ctx, d, meta)
 }
 
 func deadlineTrans(deadline string) string {
 	if deadline == "forever" {
 		return deadline
-	} else {
-		return fmt.Sprintf("%sT00:00:00Z", deadline)
 	}
+
+	return fmt.Sprintf("%sT00:00:00Z", deadline)
 }
 
 func deadlineTransReverse(deadline string) string {
 	if deadline == "forever" {
 		return deadline
-	} else {
-		return deadline[:10]
 	}
+
+	return deadline[:10]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
fix(SWR): fix swr resources lint errors

**Special notes for your reviewer**:

**Release note**:

```
./scripts/codecheck.sh ./huaweicloud/services/swr

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        8      2287      295        35     1957        242            99.59
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ource_huaweicloud_swr_image_permissions.go       404       49        10      345         45            13.04
~_huaweicloud_swr_image_retention_policy.go       369       45         8      316         43            13.61
~uaweicloud_swr_organization_permissions.go       296       46         0      250         37            14.80
~/resource_huaweicloud_swr_image_trigger.go       374       36         8      330         31             9.39
~urce_huaweicloud_swr_repository_sharing.go       249       39         0      210         29            13.81
~swr/resource_huaweicloud_swr_repository.go       218       26         1      191         22            11.52
~esource_huaweicloud_swr_image_auto_sync.go       248       30         7      211         21             9.95
~r/resource_huaweicloud_swr_organization.go       129       24         1      104         14            13.46
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     8      2287      295        35     1957        242            99.59
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 71481 bytes, 0.071 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
8 swr resourceSwrImageAutoSyncRead huaweicloud/services/swr/resource_huaweicloud_swr_image_auto_sync.go:136:1
7 swr resourceSwrImageRetentionPolicyRead huaweicloud/services/swr/resource_huaweicloud_swr_image_retention_policy.go:190:1
6 swr addSwrOrganizationPermissions huaweicloud/services/swr/resource_huaweicloud_swr_organization_permissions.go:206:1
6 swr resourceSWROrganizationPermissionsRead huaweicloud/services/swr/resource_huaweicloud_swr_organization_permissions.go:123:1
6 swr buildSwrImagePermissionsUsersChildBody huaweicloud/services/swr/resource_huaweicloud_swr_image_permissions.go:374:1
5 swr resourceSWRRepositorySharingRead huaweicloud/services/swr/resource_huaweicloud_swr_repository_sharing.go:129:1
5 swr resourceSWROrganizationPermissionsUpdate huaweicloud/services/swr/resource_huaweicloud_swr_organization_permissions.go:174:1
5 swr resourceSwrImageTriggerRead huaweicloud/services/swr/resource_huaweicloud_swr_image_trigger.go:220:1
5 swr resourceSwrImageTriggerCreate huaweicloud/services/swr/resource_huaweicloud_swr_image_trigger.go:138:1
5 swr resourceSwrImageRetentionPolicyUpdate huaweicloud/services/swr/resource_huaweicloud_swr_image_retention_policy.go:281:1
Average: 3.15

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in swr...

==> Checking for misspell in swr...

==> Checking for code complexity in ./huaweicloud/services/acceptance/swr...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        8      1315      110         4     1201         57            45.05
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ce_huaweicloud_swr_image_auto_sync_test.go       131       16         1      114         13            11.40
~esource_huaweicloud_swr_repository_test.go       117       12         0      105         12            11.43
~huaweicloud_swr_repository_sharing_test.go       129       12         0      117         10             8.55
~eicloud_swr_image_retention_policy_test.go       275       20         1      254          6             2.36
~_huaweicloud_swr_image_permissions_test.go       244       15         1      228          6             2.63
~urce_huaweicloud_swr_image_trigger_test.go       166       14         1      151          6             3.97
~cloud_swr_organization_permissions_test.go       187       11         0      176          2             1.14
~ource_huaweicloud_swr_organization_test.go        66       10         0       56          2             3.57
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     8      1315      110         4     1201         57            45.05
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 43719 bytes, 0.044 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
8 swr testAccSWRRepositorySharingImportStateIdFunc huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_repository_sharing_test.go:81:1
8 swr getSwrImageAutoSyncResourceFunc huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_auto_sync_test.go:18:1
6 swr testAccSWRRepositoryImportStateIdFunc huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_repository_test.go:73:1
4 swr getSwrImageTriggerResourceFunc huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_trigger_test.go:18:1
4 swr getSwrImageRetentionPolicyResourceFunc huaweicloud/services/acceptance/swr/resource_huaweicloud_swr_image_retention_policy_test.go:18:1
Average: 1.91

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/swr...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/swr...

==> Cleanup patch...

Check Completed!
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/swr" TESTARGS="-run TestAccSwrImageAutoSync_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSwrImageAutoSync_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrImageAutoSync_basic
=== PAUSE TestAccSwrImageAutoSync_basic
=== CONT  TestAccSwrImageAutoSync_basic
--- PASS: TestAccSwrImageAutoSync_basic (28.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       29.014s
```
```
make testacc TEST="./huaweicloud/services/acceptance/swr" TESTARGS="-run TestAccSwrImagePermissions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSwrImagePermissions_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrImagePermissions_basic
=== PAUSE TestAccSwrImagePermissions_basic
=== CONT  TestAccSwrImagePermissions_basic
--- PASS: TestAccSwrImagePermissions_basic (88.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       88.749s
```
```
make testacc TEST="./huaweicloud/services/acceptance/swr" TESTARGS="-run TestAccSwrImageRetentionPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSwrImageRetentionPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrImageRetentionPolicy_basic
=== PAUSE TestAccSwrImageRetentionPolicy_basic
=== CONT  TestAccSwrImageRetentionPolicy_basic
--- PASS: TestAccSwrImageRetentionPolicy_basic (47.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       47.753s
```
```
make testacc TEST="./huaweicloud/services/acceptance/swr" TESTARGS="-run TestAccSwrImageTrigger_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSwrImageTrigger_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrImageTrigger_basic
=== PAUSE TestAccSwrImageTrigger_basic
=== CONT  TestAccSwrImageTrigger_basic
--- PASS: TestAccSwrImageTrigger_basic (49.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       49.329s
```
```
make testacc TEST="./huaweicloud/services/acceptance/swr" TESTARGS="-run TestAccSwrOrganizationPermissions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSwrOrganizationPermissions_basic -timeout 360m -parallel 4
=== RUN   TestAccSwrOrganizationPermissions_basic
=== PAUSE TestAccSwrOrganizationPermissions_basic
=== CONT  TestAccSwrOrganizationPermissions_basic
--- PASS: TestAccSwrOrganizationPermissions_basic (141.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       141.815s
```
```
make testacc TEST="./huaweicloud/services/acceptance/swr" TESTARGS="-run TestAccSWROrganization_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSWROrganization_basic -timeout 360m -parallel 4
=== RUN   TestAccSWROrganization_basic
=== PAUSE TestAccSWROrganization_basic
=== CONT  TestAccSWROrganization_basic
--- PASS: TestAccSWROrganization_basic (15.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       15.831s
```
```
make testacc TEST="./huaweicloud/services/acceptance/swr" TESTARGS="-run TestAccSWRRepositorySharing_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSWRRepositorySharing_basic -timeout 360m -parallel 4
=== RUN   TestAccSWRRepositorySharing_basic
=== PAUSE TestAccSWRRepositorySharing_basic
=== CONT  TestAccSWRRepositorySharing_basic
--- PASS: TestAccSWRRepositorySharing_basic (48.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       48.813s
```
```
make testacc TEST="./huaweicloud/services/acceptance/swr" TESTARGS="-run TestAccSWRRepository_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccSWRRepository_basic -timeout 360m -parallel 4
=== RUN   TestAccSWRRepository_basic
=== PAUSE TestAccSWRRepository_basic
=== CONT  TestAccSWRRepository_basic
--- PASS: TestAccSWRRepository_basic (35.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       35.784s
```
