### PR TITLE
docs(lts): remove the limitation of group tags

### DIFF
--- a/docs/resources/lts_group.md
+++ b/docs/resources/lts_group.md
@@ -29,8 +29,6 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the log group.
 
-  -> Currently, the key in tags can not be removed.
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

 the limitation was fixed by LTS service team, so we can remove the NOTE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
$ make testacc TEST="./huaweicloud/services/acceptance/lts" TESTARGS="-run TestAccLtsGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccLtsGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccLtsGroup_basic
=== PAUSE TestAccLtsGroup_basic
=== CONT  TestAccLtsGroup_basic
--- PASS: TestAccLtsGroup_basic (27.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       27.171s
```
