### PR TITLE
feat(dns): add resouce huaweicloud_dns_resolver_rule_associate

### DIFF
--- a/docs/resources/dns_resolver_rule_associate.md
+++ b/docs/resources/dns_resolver_rule_associate.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Domain Name Service (DNS)"
+---
+
+# huaweicloud_dns_resolver_rule_associate
+
+Manages a DNS resolver rule associate resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable vpc_id {}
+variable subnet_id {}
+variable ip {}
+variable domain_name {}
+
+resource "huaweicloud_dns_endpoint" "test" {
+  name      = "test"
+  direction = "inbound"
+
+  ip_addresses {
+    subnet_id = var.subnet_id
+    ip        = var.ip
+  }
+  ip_addresses {
+    subnet_id = var.subnet_id
+  }
+}
+
+resource "huaweicloud_dns_resolver_rule" "test" {
+  name        = "test"
+  domain_name = var.domain_name
+  endpoint_id = huaweicloud_dns_endpoint.test.id
+  ip_addresses {
+    ip = huaweicloud_dns_endpoint.test.ip_addresses[0].ip
+  }
+}
+
+resource "huaweicloud_dns_resolver_rule_associate" "test" {
+  resolver_rule_id = huaweicloud_dns_resolver_rule.test.id
+  vpc_id           = var.vpc_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the DNS resolver rule associate.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new DNS resolver rule associate.
+
+* `resolver_rule_id` - (Required, String, ForceNew) Specifies the DNS resolver rule ID.
+  Changing this parameter will create a new DNS resolver rule associate.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID.
+  Changing this parameter will create a new DNS resolver rule associate.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is the `resolver_rule_id` and `vpc_id` separated by a slash.
+
+* `status` - The status of the resolver rule associate.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+DNS resolver rule associate can be imported using the `resolver_rule_id` and `vpc_id` separated by a slash e.g.
+
+```
+$ terraform import huaweicloud_dns_resolver_rule_associate.test ff8080828b0e8c29018bfb599512069d/46fa7c9d-d047-47d9-b5b7-c8d0c0fccc08
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -878,12 +878,13 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_rocketmq_topic":          dms.ResourceDmsRocketMQTopic(),
 			"huaweicloud_dms_rocketmq_user":           dms.ResourceDmsRocketMQUser(),
 
-			"huaweicloud_dns_custom_line":   dns.ResourceDNSCustomLine(),
-			"huaweicloud_dns_ptrrecord":     dns.ResourceDNSPtrRecord(),
-			"huaweicloud_dns_recordset":     dns.ResourceDNSRecordset(),
-			"huaweicloud_dns_zone":          dns.ResourceDNSZone(),
-			"huaweicloud_dns_endpoint":      dns.ResourceDNSEndpoint(),
-			"huaweicloud_dns_resolver_rule": dns.ResourceDNSResolverRule(),
+			"huaweicloud_dns_custom_line":             dns.ResourceDNSCustomLine(),
+			"huaweicloud_dns_ptrrecord":               dns.ResourceDNSPtrRecord(),
+			"huaweicloud_dns_recordset":               dns.ResourceDNSRecordset(),
+			"huaweicloud_dns_zone":                    dns.ResourceDNSZone(),
+			"huaweicloud_dns_endpoint":                dns.ResourceDNSEndpoint(),
+			"huaweicloud_dns_resolver_rule":           dns.ResourceDNSResolverRule(),
+			"huaweicloud_dns_resolver_rule_associate": dns.ResourceDNSResolverRuleAssociate(),
 
 			"huaweicloud_drs_job": drs.ResourceDrsJob(),
 

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_resolver_rule_associate_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_resolver_rule_associate_test.go
@@ -1,0 +1,121 @@
+package dns
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/dns/v2/resolverrule"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDNSResolverRuleAssociateResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.DNSV21Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating dns client: %s", err)
+	}
+
+	arr := strings.Split(state.Primary.ID, "/")
+	if len(arr) != 2 {
+		return nil, fmt.Errorf("error getting resolver ruler ID and VPC ID, resource ID is: %s", state.Primary.ID)
+	}
+	ruleID := arr[0]
+	vpcID := arr[1]
+
+	rule, err := resolverrule.Get(client, ruleID).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, router := range rule.Routers {
+		if router.RouterID == vpcID {
+			return router, nil
+		}
+	}
+	return nil, fmt.Errorf("the resolver rule associate does not exist")
+}
+
+func TestAccDNSResolverRuleAssociate_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_dns_resolver_rule_associate.test"
+	)
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDNSResolverRuleAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDNSResolverRuleAssociate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(rName, "resolver_rule_id",
+						"huaweicloud_dns_resolver_rule.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "vpc_id",
+						"huaweicloud_vpc.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDNSResolverRuleAssociate_basic(rName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name              = "%[1]s"
+  cidr              = "192.168.0.0/24"
+  gateway_ip        = "192.168.0.1"
+  vpc_id            = huaweicloud_vpc.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
+resource "huaweicloud_dns_endpoint" "test" {
+  name      = "%[1]s"
+  direction = "inbound"
+  ip_addresses {
+    subnet_id = huaweicloud_vpc_subnet.test.id
+  }
+  ip_addresses {
+    subnet_id = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_dns_resolver_rule" "test" {
+  name        = "%[1]s"
+  domain_name = "terraform.test.com."
+  endpoint_id = huaweicloud_dns_endpoint.test.id
+  ip_addresses {
+    ip = huaweicloud_dns_endpoint.test.ip_addresses[0].ip
+  }
+}
+
+resource "huaweicloud_dns_resolver_rule_associate" "test" {
+  resolver_rule_id = huaweicloud_dns_resolver_rule.test.id
+  vpc_id           = huaweicloud_vpc.test.id
+}`, rName)
+}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_resolver_rule_associate.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_resolver_rule_associate.go
@@ -1,0 +1,203 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dns/v2/associate"
+	"github.com/chnsz/golangsdk/openstack/dns/v2/resolverrule"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceDNSResolverRuleAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDNSResolverRuleAssociateCreate,
+		ReadContext:   resourceDNSResolverRuleAssociateRead,
+		DeleteContext: resourceDNSResolverRuleAssociateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"resolver_rule_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDNSResolverRuleAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	dnsClient, err := cfg.DNSV21Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	ruleID := d.Get("resolver_rule_id").(string)
+	vpcID := d.Get("vpc_id").(string)
+	opts := associate.RouterOpts{
+		RouterID: vpcID,
+	}
+
+	body, err := associate.Associate(dnsClient, ruleID, opts).Extract()
+	if err != nil {
+		return diag.Errorf("error creating DNS resolver rule associate: %s", err)
+	}
+
+	id := fmt.Sprintf("%s/%s", ruleID, vpcID)
+	d.SetId(id)
+
+	log.Printf("[DEBUG] Waiting for DNS resolver rule associate (%s) to become available", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Target:       []string{"ACTIVE"},
+		Pending:      []string{"PENDING"},
+		Refresh:      waitForDNSResolverRuleAssociate(dnsClient, ruleID, body.RouterID),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf(
+			"error waiting for DNS resolver rule associate (%s) to become ACTIVE for creation: %s",
+			d.Id(), err)
+	}
+
+	return resourceDNSResolverRuleAssociateRead(ctx, d, meta)
+}
+
+func resourceDNSResolverRuleAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	dnsClient, err := cfg.DNSV21Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	arr := strings.Split(d.Id(), "/")
+	if len(arr) != 2 {
+		return diag.Errorf("error getting resolver rule ID and VPC ID, DNS resolver rule associate ID: %s", d.Id())
+	}
+	ruleID := arr[0]
+	vpcID := arr[1]
+
+	rule, err := resolverrule.Get(dnsClient, ruleID).Extract()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DNS resolver rule")
+	}
+
+	for _, r := range rule.Routers {
+		if r.RouterID == vpcID {
+			mErr := multierror.Append(nil,
+				d.Set("vpc_id", vpcID),
+				d.Set("resolver_rule_id", ruleID),
+				d.Set("status", r.Status),
+			)
+			return diag.FromErr(mErr.ErrorOrNil())
+		}
+	}
+
+	return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+}
+
+func resourceDNSResolverRuleAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	dnsClient, err := cfg.DNSV21Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DNS client: %s", err)
+	}
+
+	arr := strings.Split(d.Id(), "/")
+	if len(arr) != 2 {
+		return diag.Errorf("error getting resolver rule ID and VPC ID, DNS resolver rule associate resource ID: %s", d.Id())
+	}
+	ruleID := arr[0]
+	vpcID := arr[1]
+
+	opts := associate.RouterOpts{
+		RouterID: vpcID,
+	}
+	body, err := associate.DisAssociate(dnsClient, ruleID, opts).Extract()
+
+	if err != nil {
+		return diag.Errorf("error deleting DNS resolver rule associate: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for DNS resolver rule associate (%s) to become DELETED", d.Id())
+
+	stateConf := &resource.StateChangeConf{
+		Target: []string{"DELETED"},
+		// we allow to try to delete ERROR resolver rule associate
+		Pending:      []string{"ACTIVE", "PENDING", "ERROR"},
+		Refresh:      waitForDNSResolverRuleAssociate(dnsClient, ruleID, body.RouterID),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf(
+			"error waiting for DNS resolver rule associate (%s) to delete: %s",
+			d.Id(), err)
+	}
+
+	return nil
+}
+
+func waitForDNSResolverRuleAssociate(client *golangsdk.ServiceClient, resolverRuleID string, vpcID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		rule, err := resolverrule.Get(client, resolverRuleID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil, "DELETED", nil
+			}
+			return nil, "", err
+		}
+
+		for _, router := range rule.Routers {
+			if router.RouterID == vpcID {
+				log.Printf("[DEBUG] DNS resolver rule associate (%s) current status: %s", resolverRuleID, router.Status)
+				return router, parseStatus(router.Status), nil
+			}
+		}
+
+		return rule.Routers, "DELETED", nil
+	}
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/associate/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/associate/requests.go
@@ -1,0 +1,30 @@
+package associate
+
+import "github.com/chnsz/golangsdk"
+
+type RouterOpts struct {
+	RouterID     string `json:"router_id" required:"true"`
+	RouterRegion string `json:"router_region,omitempty"`
+}
+
+func Associate(client *golangsdk.ServiceClient, resolverRuleID string, opts RouterOpts) (r AssociateResult) {
+	b, err := golangsdk.BuildRequestBody(opts, "router")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(associateURL(client, resolverRuleID), b, &r.Body, nil)
+	return
+}
+
+func DisAssociate(client *golangsdk.ServiceClient, resolverRuleID string, opts RouterOpts) (r DisAssociateResult) {
+	b, err := golangsdk.BuildRequestBody(opts, "router")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(disAssociateURL(client, resolverRuleID), b, &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/associate/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/associate/results.go
@@ -1,0 +1,27 @@
+package associate
+
+import "github.com/chnsz/golangsdk"
+
+type AssociateResult struct {
+	commonResult
+}
+
+type DisAssociateResult struct {
+	commonResult
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type ResponseRouter struct {
+	RouterID     string `json:"router_id"`
+	RouterRegion string `json:"router_region"`
+	Status       string `json:"status"`
+}
+
+func (r commonResult) Extract() (*ResponseRouter, error) {
+	var s *ResponseRouter
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/associate/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/associate/urls.go
@@ -1,0 +1,11 @@
+package associate
+
+import "github.com/chnsz/golangsdk"
+
+func associateURL(c *golangsdk.ServiceClient, resolverRuleID string) string {
+	return c.ServiceURL("resolverrules", resolverRuleID, "associaterouter")
+}
+
+func disAssociateURL(c *golangsdk.ServiceClient, resolverRuleID string) string {
+	return c.ServiceURL("resolverrules", resolverRuleID, "disassociaterouter")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -134,6 +134,7 @@ github.com/chnsz/golangsdk/openstack/dms/v2/kafka/topics
 github.com/chnsz/golangsdk/openstack/dms/v2/maintainwindows
 github.com/chnsz/golangsdk/openstack/dms/v2/products
 github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances
+github.com/chnsz/golangsdk/openstack/dns/v2/associate
 github.com/chnsz/golangsdk/openstack/dns/v2/endpoints
 github.com/chnsz/golangsdk/openstack/dns/v2/ipaddress
 github.com/chnsz/golangsdk/openstack/dns/v2/nameservers


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 add resouce huaweicloud_dns_resolver_rule_associate resource


**the UT is depends on the resource [huaweicloud_dns_resolver_rule](https://github.com/huaweicloud/terraform-provider-huaweicloud/pull/3714),which is  in reviewing**


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
huawei@terrafoirm-0004:/mnt/d/workspace/terraform-provider-huaweicloud$ make testacc TEST="./huaweicloud/services/acceptance/dns" TESTARGS="-run TestAccDNSResolverRuleAssociate_basic" 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSResolverRuleAssociate_basic -timeout 360m -parallel 4 
=== RUN   TestAccDNSResolverRuleAssociate_basic 
=== PAUSE TestAccDNSResolverRuleAssociate_basic
=== CONT  TestAccDNSResolverRuleAssociate_basic
--- PASS: TestAccDNSResolverRuleAssociate_basic (111.36s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       111.395s

```
