### PR TITLE
fix(waf): waf domain support field 'keep_policy' and add a description for 'postPaid' unit test

### DIFF
--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -74,6 +74,9 @@ The following arguments are supported:
 * `policy_id` - (Optional, String, ForceNew) Specifies the policy ID associated with the domain. If not specified, a new
   policy will be created automatically. Changing this create a new domain.
 
+* `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
+  Defaults to true.
+  
 * `proxy` - (Optional, Bool) Specifies whether a proxy is configured.
 
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the domain. Valid values are *prePaid*

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -66,7 +66,7 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"charging_mode"},
+				ImportStateVerifyIgnore: []string{"keep_policy", "charging_mode"},
 			},
 		},
 	})
@@ -119,7 +119,7 @@ func TestAccWafDomainV1_withEpsID(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"charging_mode"},
+				ImportStateVerifyIgnore: []string{"keep_policy", "charging_mode"},
 				ImportStateIdFunc:       testWAFResourceImportState(resourceName),
 			},
 		},
@@ -164,6 +164,7 @@ func TestAccWafDomainV1_withPolicy(t *testing.T) {
 	})
 }
 
+// This test case can only be run on the international site. China site does not supprot postPaid
 func TestAccWafDomainV1_postPaid(t *testing.T) {
 	var domain domains.Domain
 	resourceName := "huaweicloud_waf_domain.domain_1"
@@ -276,6 +277,7 @@ resource "huaweicloud_waf_domain" "domain_1" {
   domain           = "%s"
   certificate_id   = huaweicloud_waf_certificate.certificate_1.id
   certificate_name = huaweicloud_waf_certificate.certificate_1.name
+  keep_policy      = false
   proxy            = false
 
   server {
@@ -296,6 +298,7 @@ resource "huaweicloud_waf_domain" "domain_1" {
   domain           = "%s"
   certificate_id   = huaweicloud_waf_certificate.certificate_1.id
   certificate_name = huaweicloud_waf_certificate.certificate_1.name
+  keep_policy      = false
   proxy            = true
 
   server {
@@ -325,6 +328,7 @@ resource "huaweicloud_waf_domain" "domain_1" {
   certificate_id   = huaweicloud_waf_certificate.certificate_1.id
   certificate_name = huaweicloud_waf_certificate.certificate_1.name
   policy_id        = huaweicloud_waf_policy.policy_1.id
+  keep_policy      = true
   proxy            = true
 
   server {
@@ -345,6 +349,7 @@ resource "huaweicloud_waf_domain" "domain_1" {
   domain           = "%s"
   certificate_id   = huaweicloud_waf_certificate.certificate_1.id
   certificate_name = huaweicloud_waf_certificate.certificate_1.name
+  keep_policy      = false
   proxy            = false
   charging_mode    = "postPaid"
 
@@ -438,6 +443,7 @@ resource "huaweicloud_waf_domain" "domain_1" {
   certificate_id        = huaweicloud_waf_certificate.certificate_1.id
   certificate_name      = huaweicloud_waf_certificate.certificate_1.name
   proxy                 = false
+  keep_policy           = false
   enterprise_project_id = "%s"
 
   server {
@@ -459,6 +465,7 @@ resource "huaweicloud_waf_domain" "domain_1" {
   certificate_id        = huaweicloud_waf_certificate.certificate_1.id
   certificate_name      = huaweicloud_waf_certificate.certificate_1.name
   proxy                 = true
+  keep_policy           = false
   enterprise_project_id = "%s"
 
   server {

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
@@ -69,9 +69,9 @@ func ResourceWafDomain() *schema.Resource {
 				Computed: true,
 			},
 			"keep_policy": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: `schema: Deprecated; This field is useless when deleting resource.`,
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
 			},
 			"proxy": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
+ Makes the ’keep_policy’ field valid
+ Add a annotationto the international Station test case '_postPaid'
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_basic
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (101.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       101.596s
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withEpsID -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_withEpsID
=== PAUSE TestAccWafDomainV1_withEpsID
=== CONT  TestAccWafDomainV1_withEpsID
--- PASS: TestAccWafDomainV1_withEpsID (108.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       108.441s
 make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withPolicy -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_withPolicy
=== PAUSE TestAccWafDomainV1_withPolicy
=== CONT  TestAccWafDomainV1_withPolicy
--- PASS: TestAccWafDomainV1_withPolicy (97.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       97.737s
```
