### PR TITLE
feat(CCM): add ccm private certificate export data source

### DIFF
--- a/docs/data-sources/ccm_private_certificate_export.md
+++ b/docs/data-sources/ccm_private_certificate_export.md
@@ -1,0 +1,64 @@
+---
+subcategory: "Cloud Certificate Manager (CCM)"
+---
+
+# huaweicloud_ccm_private_certificate_export
+
+Use this data source export a Certificate resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "certificate_id" {}
+
+data "huaweicloud_ccm_private_certificate_export" "test3" {
+  region         = "cn-north-4"
+  type           = "OTHER"
+  certificate_id = var.certificate_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the certificate region. Changing this creates a new
+  private certificate resource. Now only support cn-north-4 (china) and ap-southeast-3 (international).
+
+* `certificate_id` - (Required, String, ForceNew) Specifies the certificate ID of the private certificate
+  you want to export.
+
+* `type` - (Required, String, ForceNew) Specifies the Type of the server on which the certificate is installed.
+  The options are as follows:
+  + **APACHE**: This parameter is recommended if you want to use the certificate for an Apache server.
+  + **NGINX**: This parameter is recommended if you want to use the certificate for an Nginx server.
+  + **OTHER**: This parameter is recommended if you want to download a certificate in PEM format.
+
+* `sm_standard` - (Optional, String) Specifies the GB/T GMT0009 standard specifications and
+  GB/T GMT0010 standard. When the certificate algorithm is SM2,
+  it is only valid when it is passed in. If it is not passed in, it defaults to false.
+
+* `password` - (Optional, String) Specifies the password used to encrypt the private key. Support the use of uppercase
+  and lowercase English letters, numbers, special characters (such as.+- _ #), etc. The maximum length is 32 bytes.
+  If not passed in, encryption will not be used for export by default.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `private_key` - Indicates the certificate private key in PEM format.
+
+* `certificate` - Indicates the certificate content in PEM format.
+
+* `certificate_chain` - Indicates the certificate chain in PEM format.
+
+* `enc_certificate` - Indicates the encryption certificate content in PEM format.
+
+* `enc_private_key` - Indicates the encryption certificate private key in PEM format.
+
+* `enc_sm2_enveloped_key` - Indicates the National Security GMT0009 Standard Specification for Encrypting Private
+  Keys SM2 Digital Envelope.
+  
+* `signed_and_enveloped_data` - Indicates the National Security GMT0010 Standard Specification for
+  Encrypting Private Keys - Signature Digital Envelope.
+  

--- a/docs/data-sources/ccm_private_certificate_export.md
+++ b/docs/data-sources/ccm_private_certificate_export.md
@@ -4,7 +4,7 @@ subcategory: "Cloud Certificate Manager (CCM)"
 
 # huaweicloud_ccm_private_certificate_export
 
-Use this data source export a Certificate resource within HuaweiCloud.
+Use this data source export a private Certificate within HuaweiCloud.
 
 ## Example Usage
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -416,6 +416,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cce_node_pool":      cce.DataSourceCCENodePoolV3(),
 			"huaweicloud_cci_namespaces":     cci.DataSourceCciNamespaces(),
 
+			"huaweicloud_ccm_private_certificate_export": ccm.DataSourceCcmPrivateCertificateExport(),
+
 			"huaweicloud_cdm_flavors": DataSourceCdmFlavorV1(),
 
 			"huaweicloud_cdn_domain_statistics": cdn.DataSourceStatistics(),

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go
@@ -1,0 +1,128 @@
+package ccm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCcmPrivateCertificateExport_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceName()
+	expEesourceName := "data.huaweicloud_ccm_private_certificate_export.test3"
+	resourceName := "huaweicloud_ccm_private_certificate.test"
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCertificateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcmPrivateCertificateExport_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(expEesourceName, "private_key"),
+					resource.TestCheckResourceAttrSet(expEesourceName, "certificate"),
+					resource.TestCheckResourceAttrSet(expEesourceName, "certificate_chain"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCcmPrivateCertificateExport_SM2(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceName()
+	expEesourceSM2Name := "data.huaweicloud_ccm_private_certificate_export.test4"
+	resourceName := "huaweicloud_ccm_private_certificate.test"
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCertificateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcmPrivateCertificateSM2Export_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "private_key"),
+					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "certificate"),
+					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "certificate_chain"),
+					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "enc_certificate"),
+					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "enc_sm2_enveloped_key"),
+					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "signed_and_enveloped_data"),
+				),
+			},
+		},
+	})
+}
+
+// lintignore:AT004
+func testAccCcmPrivateCertificateExport_basic(commonName string) string {
+	return fmt.Sprintf(`
+  %s
+
+data "huaweicloud_ccm_private_certificate_export" "test3" {
+    type           = "other"
+    certificate_id = huaweicloud_ccm_private_certificate.test.id
+}`, tesCmdbCertificate_basic(commonName))
+}
+
+// lintignore:AT004
+func testAccCcmPrivateCertificateSM2Export_basic(commonName string) string {
+	return fmt.Sprintf(`
+provider "huaweicloud" {
+  endpoints = {
+    ccm = "https://ccm.cn-north-4.myhuaweicloud.com/"
+  }
+}
+
+resource "huaweicloud_ccm_private_ca" "test_root" {
+  type   = "ROOT"
+  distinguished_name {
+    common_name         = "%s-root"
+    country             = "CN"
+    state               = "GD"
+    locality            = "SZ"
+    organization        = "huawei"
+    organizational_unit = "cloud"
+  }
+  key_algorithm       = "SM2"
+  signature_algorithm = "SM3"
+  pending_days        = "7"
+  validity {
+    type  = "DAY"
+    value = 2
+  }
+}
+
+resource "huaweicloud_ccm_private_certificate" "test2" {
+  distinguished_name {
+    common_name = "%s"
+  }
+  issuer_id           = huaweicloud_ccm_private_ca.test_root.id
+  key_algorithm       = "SM2"
+  signature_algorithm = "SM3"
+  validity {
+    type  = "DAY"
+    value = "1"
+  }
+}
+	  
+data "huaweicloud_ccm_private_certificate_export" "test4" {
+  type           = "other"
+  certificate_id = huaweicloud_ccm_private_certificate.test2.id
+  sm_standard    = "true"
+}`, commonName, commonName)
+}

--- a/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_certificate_export.go
+++ b/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_certificate_export.go
@@ -1,0 +1,127 @@
+package ccm
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceCcmPrivateCertificateExport() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: ccmPrivateCertificateExport,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"certificate_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"sm_standard": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"password": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"private_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_chain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enc_certificate": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enc_private_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enc_sm2_enveloped_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"signed_and_enveloped_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+func ccmPrivateCertificateExport(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	product := "ccm"
+
+	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
+	}
+
+	expCertificateHttpUrl := "v1/private-certificates/{certificate_id}/export"
+	expCertificatePath := client.Endpoint + expCertificateHttpUrl
+	expCertificatePath = strings.ReplaceAll(expCertificatePath, "{certificate_id}", d.Get("certificate_id").(string))
+
+	expCertificateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	expCertificateOpt.JSONBody = utils.RemoveNil(buildExpCertificateBodyParams(d))
+	expCertificateResp, err := client.Request("POST", expCertificatePath, &expCertificateOpt)
+	if err != nil {
+		return diag.Errorf("error export CCM private certificate: %s", err)
+	}
+	expCertificateRespBody, err := utils.FlattenResponse(expCertificateResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("certificate_id").(string))
+	mErr := multierror.Append(nil,
+		d.Set("private_key", utils.PathSearch("private_key", expCertificateRespBody, nil)),
+		d.Set("certificate", utils.PathSearch("certificate", expCertificateRespBody, nil)),
+		d.Set("certificate_chain", utils.PathSearch("certificate_chain", expCertificateRespBody, nil)),
+		d.Set("enc_private_key", utils.PathSearch("enc_private_key", expCertificateRespBody, nil)),
+		d.Set("enc_certificate", utils.PathSearch("enc_certificate", expCertificateRespBody, nil)),
+		d.Set("enc_sm2_enveloped_key", utils.PathSearch("enc_sm2_enveloped_key", expCertificateRespBody, nil)),
+		d.Set("signed_and_enveloped_data", utils.PathSearch("signed_and_enveloped_data", expCertificateRespBody, nil)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting CCM private certificate export fields: %s", err)
+	}
+	return nil
+}
+
+func buildExpCertificateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"is_compressed":  "false",
+		"type":           d.Get("type"),
+		"is_sm_standard": d.Get("sm_standard"),
+		"password":       d.Get("password"),
+	}
+	return bodyParams
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
feat(CCM): add ccm private certificate export data source

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

./scripts/codecheck.sh ./huaweicloud/services/ccm

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3      1017       69         1      947         82            24.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ccm/resource_huaweicloud_ccm_private_ca.go       456       28         1      427         44            10.30
~rce_huaweicloud_ccm_private_certificate.go       430       31         0      399         30             7.52
~weicloud_ccm_private_certificate_export.go       131       10         0      121          8             6.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3      1017       69         1      947         82            24.43
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 30739 bytes, 0.031 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
8 ccm resourcePrivateCADelete huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:408:1
7 ccm resourcePrivateCACreate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:208:1
6 ccm resourceCcmPrivateCertificateRead huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:338:1
6 ccm resourcePrivateCARead huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:318:1
5 ccm hasErrorCode huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:414:1
5 ccm resourceCcmPrivateCertificateCreate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:234:1
5 ccm ccmPrivateCertificateExport huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_certificate_export.go:80:1
4 ccm resourceCcmPrivateCertificateDelete huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:393:1
4 ccm buildPrivateCARequestBodyCrlConfiguration huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:298:1
3 ccm buildPrivateCARequestBodyKeyUsages huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:290:1
Average: 2.57

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in ccm...

==> Checking for misspell in ccm...

==> Checking for code complexity in ./huaweicloud/services/acceptance/ccm...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3       419       36         2      381         14            10.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~esource_huaweicloud_ccm_private_ca_test.go       146       13         1      132          8             6.06
~uaweicloud_ccm_private_certificate_test.go       148       15         1      132          6             4.55
~oud_ccm_private_certificate_export_test.go       125        8         0      117          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3       419       36         2      381         14            10.61
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 12755 bytes, 0.013 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
5 ccm getPrivateCAResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:18:1
4 ccm getCertificateResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:18:1
1 ccm tesCmdbCertificate_basic huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:104:1
1 ccm TestAccCcmPrivateCertificate_basic huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:46:1
1 ccm tesPrivateCA_basic huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:100:1
Average: 1.7

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/ccm...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/ccm...
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:99:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:103:// lintignore:AT004

==> Cleanup patch...

Check Completed!



## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/ccm TESTARGS='-run TestAccCcmPrivateCertificateExport'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCcmPrivateCertificateExport -timeout 360m -parallel 4
=== RUN   TestAccCcmPrivateCertificateExport_basic
=== PAUSE TestAccCcmPrivateCertificateExport_basic
=== RUN   TestAccCcmPrivateCertificateExport_SM2
=== PAUSE TestAccCcmPrivateCertificateExport_SM2
=== CONT  TestAccCcmPrivateCertificateExport_basic
=== CONT  TestAccCcmPrivateCertificateExport_SM2
--- PASS: TestAccCcmPrivateCertificateExport_basic (24.67s)
--- PASS: TestAccCcmPrivateCertificateExport_SM2 (24.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       24.792s


