### PR TITLE
fix(cdn/domain): set id after create request send

### DIFF
--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -681,6 +681,7 @@ func resourceCdnDomainV1Create(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.Errorf("error creating CDN Domain: %s", err)
 	}
+	d.SetId(v.ID)
 
 	// Wait for CDN domain to become active again before continuing
 	opts := getResourceExtensionOpts(d, cfg)
@@ -690,9 +691,6 @@ func resourceCdnDomainV1Create(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	// Store the ID now
-	d.SetId(v.ID)
 
 	return resourceCdnDomainV1Update(ctx, d, meta)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Record the resource ID even domain create failed, that we can destroy it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Set id after create request send.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
