### PR TITLE
feat(CodeArts): CodeArts support a new resource to manage inspector website

### DIFF
--- a/docs/resources/codearts_inspector_website.md
+++ b/docs/resources/codearts_inspector_website.md
@@ -1,0 +1,121 @@
+---
+subcategory: "CodeArts Inspector"
+---
+
+# huaweicloud_codearts_inspector_website
+
+Manages a CodeArts inspector website resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "website_address" {}
+variable "login_url" {}
+variable "login_username" {}
+variable "login_password" {}
+variable "login_cookie" {}
+variable "verify_url" {}
+
+resource "huaweicloud_codearts_inspector_website" "test" {
+  website_name    = "test-name"
+  auth_type       = "free"
+  website_address = var.website_address
+  login_url       = var.login_url
+  login_username  = var.login_username
+  login_password  = var.login_password
+  login_cookie    = var.login_cookie
+  verify_url      = var.verify_url
+
+  http_headers = {
+    "test-key" = "test-value"
+  }  
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `website_name` - (Required, String, ForceNew) Specifies the website name. The valid length is limited from `1` to `50`.
+  Changing this parameter will create a new resource. Only Chinese characters, letters, digits, hyphens (-) and
+  underscores (_) are allowed, and cannot start with a hyphen (-).
+
+* `website_address` - (Required, String, ForceNew) Specifies the unique website address. The maximum length is `256`.
+  Changing this parameter will create a new resource.
+  The format should be `http(s)://example.com` or `http(s)://{public IPv4 address}:{PORT}`.
+
+* `auth_type` - (Required, String, ForceNew) Specifies the authentication type. Changing this parameter will create a
+  new resource. Valid values are:
+  + **free**: Verification Free. Before using this authentication method, please confirm the following instructions.
+  Please confirm that your account has completed real-name authentication and is not a restricted account. Please confirm
+  that you have obtained the relevant legal rights to scan the scanned objects. Please confirm that your scanning behavior
+  has legal and reasonable purposes and complies with applicable laws and regulations. Illegal scanning with this Service
+  is not allowed. If there are any violations to the terms and conditions described here, Huawei is entitled to immediately
+  terminate your use of this Service and you shall compensate us and any related third parties for any losses incurred therefrom.
+  + **auto**: One-Click Verification. Before using this authentication method, please confirm that the server of the site
+  to be detected is built in HuaweiCloud, and that the server is the asset of your current login account.
+
+* `login_url` - (Optional, String) Specifies the login URL. The login address and domain name must be the same as the field
+  `website_address`, for example: `http(s)://example.com/login`. The maximum length is `2048`.
+
+* `login_username` - (Optional, String) Specifies the login username. The maximum length is `256`.
+
+* `login_password` - (Optional, String) Specifies the login password. The maximum length is `50`.
+
+-> Fields `login_url`, `login_username` and `login_password` must be set simultaneously.
+
+* `login_cookie` - (Optional, String) Specifies the login cookie.
+
+* `http_headers` - (Optional, Map) Specifies the custom HTTP request headers, the format is key/value pairs.
+
+* `verify_url` - (Optional, String) Specifies the verify URL that can only be accessed after successful login.
+  CodeArts inspector will use this URL to quickly determine whether your login information is valid.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `high` - The number of high-risk vulnerabilities.
+
+* `middle` - The number of medium-risk vulnerabilities.
+
+* `low` - The number of low-severity vulnerabilities.
+
+* `hint` - The number of hint-risk vulnerabilities.
+
+* `created_at` - The time to create website.
+
+* `auth_status` - The auth status of website. Valid values are:
+  + **unauth**: Unauthorized.
+  + **auth**: Authorized.
+  + **invalid**: Authentication file is invalid.
+  + **manual**: Manual authentication.
+  + **skip**: Authentication free.
+
+## Import
+
+The CodeArts inspector website can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_codearts_inspector_website.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `auth_type`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_codearts_inspector_website" "test" {
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      auth_type,
+    ]
+  }
+}
+```

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -823,6 +823,13 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Product: "CodeArtsDeploy",
 	},
 
+	"vss": {
+		Name:    "vss",
+		Version: "v3",
+		Scope:   "global",
+		Product: "CodeArtsInspector",
+	},
+
 	// catalog for Data Security Center
 	"dsc": {
 		Name:    "sdg",

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1230,6 +1230,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_codearts_deploy_group":       codearts.ResourceDeployGroup(),
 			"huaweicloud_codearts_deploy_host":        codearts.ResourceDeployHost(),
 
+			"huaweicloud_codearts_inspector_website": codearts.ResourceInspectorWebsite(),
+
 			"huaweicloud_dsc_instance":  dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_asset_obs": dsc.ResourceAssetObs(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -196,8 +196,9 @@ var (
 	HW_NEW_CERTIFICATE_PRIVATE_KEY = os.Getenv("HW_NEW_CERTIFICATE_PRIVATE_KEY")
 	HW_NEW_CERTIFICATE_ROOT_CA     = os.Getenv("HW_NEW_CERTIFICATE_ROOT_CA")
 
-	HW_CODEARTS_RESOURCE_POOL_ID = os.Getenv("HW_CODEARTS_RESOURCE_POOL_ID")
-	HW_CODEARTS_ENABLE_FLAG      = os.Getenv("HW_CODEARTS_ENABLE_FLAG")
+	HW_CODEARTS_RESOURCE_POOL_ID  = os.Getenv("HW_CODEARTS_RESOURCE_POOL_ID")
+	HW_CODEARTS_ENABLE_FLAG       = os.Getenv("HW_CODEARTS_ENABLE_FLAG")
+	HW_CODEARTS_PUBLIC_IP_ADDRESS = os.Getenv("HW_CODEARTS_PUBLIC_IP_ADDRESS")
 
 	HW_EG_CHANNEL_ID = os.Getenv("HW_EG_CHANNEL_ID")
 
@@ -860,6 +861,13 @@ func TestAccPreCheckCodeArtsDeployResourcePoolID(t *testing.T) {
 func TestAccPreCheckCodeArtsEnableFlag(t *testing.T) {
 	if HW_CODEARTS_ENABLE_FLAG == "" {
 		t.Skip("Skip the CodeArts acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCodeArtsPublicIPAddress(t *testing.T) {
+	if HW_CODEARTS_PUBLIC_IP_ADDRESS == "" {
+		t.Skip("HW_CODEARTS_PUBLIC_IP_ADDRESS must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_inspector_website_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_inspector_website_test.go
@@ -1,0 +1,270 @@
+package codearts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getInspectorWebsiteResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v3/{project_id}/webscan/domains"
+		product = "vss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += fmt.Sprintf("?domain_id=%s", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CodeArts inspector website: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+	domainInfo := utils.PathSearch("domains|[0]", getRespBody, nil)
+	if domainInfo == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return domainInfo, nil
+}
+
+func TestAccInspectorWebsite_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_inspector_website.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getInspectorWebsiteResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testInspectorWebsite_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "website_name", name),
+					resource.TestCheckResourceAttr(rName, "auth_type", "free"),
+					resource.TestCheckResourceAttr(rName, "website_address", "https://demo.test.com"),
+					resource.TestCheckResourceAttr(rName, "login_url", "https://demo.test.com/login"),
+					resource.TestCheckResourceAttr(rName, "login_username", "test-name"),
+					resource.TestCheckResourceAttr(rName, "login_password", "test-password"),
+					resource.TestCheckResourceAttr(rName, "login_cookie", "test-cookie"),
+					resource.TestCheckResourceAttr(rName, "verify_url", "https://verify.cn"),
+					resource.TestCheckResourceAttr(rName, "http_headers.test-key1", "test-value1"),
+					resource.TestCheckResourceAttr(rName, "http_headers.test-key2", "test-value2"),
+					resource.TestCheckResourceAttrSet(rName, "high"),
+					resource.TestCheckResourceAttrSet(rName, "middle"),
+					resource.TestCheckResourceAttrSet(rName, "low"),
+					resource.TestCheckResourceAttrSet(rName, "hint"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "auth_status"),
+				),
+			},
+			{
+				Config: testInspectorWebsite_basic_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "website_name", name),
+					resource.TestCheckResourceAttr(rName, "auth_type", "free"),
+					resource.TestCheckResourceAttr(rName, "website_address", "https://demo.test.com"),
+					resource.TestCheckResourceAttr(rName, "login_url", "https://demo.test.com/register"),
+					resource.TestCheckResourceAttr(rName, "login_username", "name-update"),
+					resource.TestCheckResourceAttr(rName, "login_password", "password-update"),
+					resource.TestCheckResourceAttr(rName, "login_cookie", "cookie-update"),
+					resource.TestCheckResourceAttr(rName, "verify_url", "https://verify-update.cn"),
+					resource.TestCheckResourceAttr(rName, "http_headers.test-key3", "test-value3"),
+					resource.TestCheckResourceAttrSet(rName, "high"),
+					resource.TestCheckResourceAttrSet(rName, "middle"),
+					resource.TestCheckResourceAttrSet(rName, "low"),
+					resource.TestCheckResourceAttrSet(rName, "hint"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "auth_status"),
+				),
+			},
+			{
+				Config: testInspectorWebsite_basic_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "website_name", name),
+					resource.TestCheckResourceAttr(rName, "auth_type", "free"),
+					resource.TestCheckResourceAttr(rName, "website_address", "https://demo.test.com"),
+					resource.TestCheckResourceAttr(rName, "login_url", ""),
+					resource.TestCheckResourceAttr(rName, "login_username", ""),
+					resource.TestCheckResourceAttr(rName, "login_password", ""),
+					resource.TestCheckResourceAttr(rName, "login_cookie", ""),
+					resource.TestCheckResourceAttr(rName, "verify_url", ""),
+					resource.TestCheckResourceAttr(rName, "http_headers.#", "0"),
+					resource.TestCheckResourceAttrSet(rName, "high"),
+					resource.TestCheckResourceAttrSet(rName, "middle"),
+					resource.TestCheckResourceAttrSet(rName, "low"),
+					resource.TestCheckResourceAttrSet(rName, "hint"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "auth_status"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"auth_type",
+				},
+			},
+		},
+	})
+}
+
+func TestAccInspectorWebsite_publicIPAddress(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_inspector_website.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getInspectorWebsiteResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// make sure the IP address is a public IPv4 address
+			acceptance.TestAccPreCheckCodeArtsPublicIPAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testInspectorWebsite_publicIPAddress(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "website_name", name),
+					resource.TestCheckResourceAttr(rName, "auth_type", "free"),
+					resource.TestCheckResourceAttr(rName, "website_address", fmt.Sprintf("http://%s",
+						acceptance.HW_CODEARTS_PUBLIC_IP_ADDRESS)),
+					resource.TestCheckResourceAttr(rName, "login_url", fmt.Sprintf("http://%s/login",
+						acceptance.HW_CODEARTS_PUBLIC_IP_ADDRESS)),
+					resource.TestCheckResourceAttr(rName, "login_username", "test-name"),
+					resource.TestCheckResourceAttr(rName, "login_password", "test-password"),
+					resource.TestCheckResourceAttr(rName, "login_cookie", "test-cookie"),
+					resource.TestCheckResourceAttr(rName, "verify_url", "https://verify.cn"),
+					resource.TestCheckResourceAttr(rName, "http_headers.test-key1", "test-value1"),
+					resource.TestCheckResourceAttr(rName, "http_headers.test-key2", "test-value2"),
+					resource.TestCheckResourceAttrSet(rName, "high"),
+					resource.TestCheckResourceAttrSet(rName, "middle"),
+					resource.TestCheckResourceAttrSet(rName, "low"),
+					resource.TestCheckResourceAttrSet(rName, "hint"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "auth_status"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"auth_type",
+				},
+			},
+		},
+	})
+}
+
+func testInspectorWebsite_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_codearts_inspector_website" "test" {
+  website_name    = "%s"
+  auth_type       = "free"
+  website_address = "https://demo.test.com"
+  login_url       = "https://demo.test.com/login"
+  login_username  = "test-name"
+  login_password  = "test-password"
+  login_cookie    = "test-cookie"
+  verify_url      = "https://verify.cn"
+
+  http_headers = {
+    "test-key1" = "test-value1"
+    "test-key2" = "test-value2"
+  }
+}
+`, name)
+}
+
+func testInspectorWebsite_basic_update1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_codearts_inspector_website" "test" {
+  website_name    = "%s"
+  auth_type       = "free"
+  website_address = "https://demo.test.com"
+  login_url       = "https://demo.test.com/register"
+  login_username  = "name-update"
+  login_password  = "password-update"
+  login_cookie    = "cookie-update"
+  verify_url      = "https://verify-update.cn"
+
+  http_headers = {
+    "test-key3" = "test-value3"
+  }
+}
+`, name)
+}
+
+func testInspectorWebsite_basic_update2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_codearts_inspector_website" "test" {
+  website_name    = "%s"
+  auth_type       = "free"
+  website_address = "https://demo.test.com"
+}
+`, name)
+}
+
+func testInspectorWebsite_publicIPAddress(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_codearts_inspector_website" "test" {
+  website_name    = "%[1]s"
+  auth_type       = "free"
+  website_address = "http://%[2]s"
+  login_url       = "http://%[2]s/login"
+  login_username  = "test-name"
+  login_password  = "test-password"
+  login_cookie    = "test-cookie"
+  verify_url      = "https://verify.cn"
+
+  http_headers = {
+    "test-key1" = "test-value1"
+    "test-key2" = "test-value2"
+  }
+}
+`, name, acceptance.HW_CODEARTS_PUBLIC_IP_ADDRESS)
+}

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website.go
@@ -1,0 +1,424 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CodeArts
+// ---------------------------------------------------------------
+
+package codearts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceInspectorWebsite() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInspectorWebsiteCreate,
+		UpdateContext: resourceInspectorWebsiteUpdate,
+		ReadContext:   resourceInspectorWebsiteRead,
+		DeleteContext: resourceInspectorWebsiteDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"website_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the website name.`,
+			},
+			"website_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the website address.`,
+			},
+			"auth_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the authentication type.`,
+			},
+			"login_url": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"login_username", "login_password"},
+				Description:  `Specifies the login URL.`,
+			},
+			"login_username": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"login_url", "login_password"},
+				Description:  `Specifies the login username.`,
+			},
+			"login_password": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				RequiredWith: []string{"login_url", "login_username"},
+				Description:  `Specifies the login password.`,
+			},
+			"login_cookie": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: `Specifies the login cookies.`,
+			},
+			"http_headers": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: `Specifies the HTTP headers.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"verify_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the verify URL.`,
+			},
+			"high": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of high-risk vulnerabilities.`,
+			},
+			"middle": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of medium-risk vulnerabilities.`,
+			},
+			"low": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of low-severity vulnerabilities.`,
+			},
+			"hint": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of hint-risk vulnerabilities.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time to create website.`,
+			},
+			"auth_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The auth status.`,
+			},
+		},
+	}
+}
+
+func resourceInspectorWebsiteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	if err := createInspectorWebsite(client, d); err != nil {
+		return diag.Errorf("error creating CodeArts inspector website: %s", err)
+	}
+
+	if err := authorizeInspectorWebsite(client, d); err != nil {
+		return diag.Errorf("error authorizing CodeArts inspector website: %s", err)
+	}
+
+	if err := updateInspectorWebsiteSettings(client, d); err != nil {
+		return diag.Errorf("error updating CodeArts inspector website settings: %s", err)
+	}
+
+	return resourceInspectorWebsiteRead(ctx, d, meta)
+}
+
+func createInspectorWebsite(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	createPath := client.Endpoint + "v3/{project_id}/webscan/domains"
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateInspectorWebsiteBodyParams(d),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return err
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return err
+	}
+
+	if err = checkInspectorWebsiteResponse(createRespBody); err != nil {
+		return err
+	}
+
+	id, err := jmespath.Search("domain_id", createRespBody)
+	if err != nil || id == nil {
+		return fmt.Errorf("ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return nil
+}
+
+func buildCreateInspectorWebsiteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"alias":       d.Get("website_name"),
+		"domain_name": d.Get("website_address"),
+	}
+}
+
+func authorizeInspectorWebsite(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	authorizePath := client.Endpoint + "v3/{project_id}/webscan/domains/authenticate"
+	authorizePath = strings.ReplaceAll(authorizePath, "{project_id}", client.ProjectID)
+	authorizeOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildAuthenticateInspectorWebsiteBodyParams(d),
+	}
+
+	authorizeResp, err := client.Request("POST", authorizePath, &authorizeOpt)
+	if err != nil {
+		return err
+	}
+
+	authorizeRespBody, err := utils.FlattenResponse(authorizeResp)
+	if err != nil {
+		return err
+	}
+	return checkInspectorWebsiteResponse(authorizeRespBody)
+}
+
+func buildAuthenticateInspectorWebsiteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"domain_name": d.Get("website_address"),
+		"auth_mode":   d.Get("auth_type"),
+	}
+}
+
+func updateInspectorWebsiteSettings(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	updateSettingsChanges := []string{
+		"login_url",
+		"login_username",
+		"login_password",
+		"login_cookie",
+		"verify_url",
+		"http_headers",
+	}
+
+	if d.HasChanges(updateSettingsChanges...) {
+		updatePath := client.Endpoint + "v3/{project_id}/webscan/domains/settings"
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         utils.RemoveNil(buildUpdateInspectorWebsiteBodyParams(d)),
+		}
+
+		updateResp, err := client.Request("POST", updatePath, &updateOpt)
+		if err != nil {
+			return err
+		}
+
+		updateRespBody, err := utils.FlattenResponse(updateResp)
+		if err != nil {
+			return err
+		}
+		return checkInspectorWebsiteResponse(updateRespBody)
+	}
+	return nil
+}
+
+func buildUpdateInspectorWebsiteBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"domain_id":      d.Id(),
+		"login_url":      utils.ValueIngoreEmpty(d.Get("login_url")),
+		"login_username": utils.ValueIngoreEmpty(d.Get("login_username")),
+		"login_password": utils.ValueIngoreEmpty(d.Get("login_password")),
+		"login_cookies":  utils.ValueIngoreEmpty(d.Get("login_cookie")),
+		"verify_url":     utils.ValueIngoreEmpty(d.Get("verify_url")),
+		"http_headers":   utils.ValueIngoreEmpty(d.Get("http_headers")),
+	}
+}
+
+func resourceInspectorWebsiteRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	getResp, err := readInspectorWebsite(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CodeArts inspector website")
+	}
+
+	getSettingsResp, err := readInspectorWebsiteSettings(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving CodeArts inspector website settings: %s", err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("website_name", utils.PathSearch("alias", getResp, nil)),
+		d.Set("website_address", flattenWebsiteAddress(getResp)),
+		d.Set("high", utils.PathSearch("high", getResp, nil)),
+		d.Set("middle", utils.PathSearch("middle", getResp, nil)),
+		d.Set("low", utils.PathSearch("low", getResp, nil)),
+		d.Set("hint", utils.PathSearch("hint", getResp, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", getResp, nil)),
+		d.Set("auth_status", utils.PathSearch("auth_status", getResp, nil)),
+		d.Set("login_url", utils.PathSearch("login_url", getSettingsResp, nil)),
+		d.Set("login_username", utils.PathSearch("login_username", getSettingsResp, nil)),
+		d.Set("login_password", utils.PathSearch("login_password", getSettingsResp, nil)),
+		d.Set("login_cookie", utils.PathSearch("login_cookies", getSettingsResp, nil)),
+		d.Set("verify_url", utils.PathSearch("verify_url", getSettingsResp, nil)),
+		d.Set("http_headers", utils.PathSearch("http_headers", getSettingsResp, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenWebsiteAddress(resp interface{}) interface{} {
+	protocolType := utils.PathSearch("protocol_type", resp, "").(string)
+	domainName := utils.PathSearch("domain_name", resp, "").(string)
+	if protocolType == "" || domainName == "" {
+		return nil
+	}
+	return protocolType + domainName
+}
+
+// An example of response body is: {"total": 1, "domains":[{"alias":"XXX", "auth_status":"XXX", ...}]}.
+func readInspectorWebsite(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getPath := client.Endpoint + "v3/{project_id}/webscan/domains"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildGetInspectorWebsiteQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	domainInfo := utils.PathSearch("domains|[0]", getRespBody, nil)
+	if domainInfo == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return domainInfo, nil
+}
+
+func readInspectorWebsiteSettings(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getSettingsPath := client.Endpoint + "v3/{project_id}/webscan/domains/settings"
+	getSettingsPath = strings.ReplaceAll(getSettingsPath, "{project_id}", client.ProjectID)
+	getSettingsPath += buildGetInspectorWebsiteQueryParams(d)
+	getSettingsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getSettingsResp, err := client.Request("GET", getSettingsPath, &getSettingsOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(getSettingsResp)
+}
+
+func buildGetInspectorWebsiteQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?domain_id=%s", d.Id())
+}
+
+func resourceInspectorWebsiteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "vss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	if err := updateInspectorWebsiteSettings(client, d); err != nil {
+		return diag.Errorf("error updating CodeArts inspector website settings: %s", err)
+	}
+
+	return resourceInspectorWebsiteRead(ctx, d, meta)
+}
+
+func resourceInspectorWebsiteDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg           = meta.(*config.Config)
+		product       = "vss"
+		region        = cfg.GetRegion(d)
+		deleteHttpUrl = "v3/{project_id}/webscan/domains"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	deletePath := client.Endpoint + deleteHttpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath += buildDeleteInspectorWebsiteQueryParams(d)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	deleteResp, err := client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CodeArts inspector website: %s", err)
+	}
+
+	deleteRespBody, err := utils.FlattenResponse(deleteResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkInspectorWebsiteResponse(deleteRespBody); err != nil {
+		return diag.Errorf("error deleting CodeArts inspector website: %s", err)
+	}
+	return nil
+}
+
+func buildDeleteInspectorWebsiteQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?domain_name=%s", d.Get("website_address").(string))
+}
+
+// checkInspectorWebsiteResponse use to check whether the CodeArts inspector API response body contains error code.
+// An example of response body is: {"info_code": "XXX", "info_description": "XXX"}.
+// The valid values for `info_code` is "success" and "failure".
+func checkInspectorWebsiteResponse(respBody interface{}) error {
+	code := utils.PathSearch("info_code", respBody, "")
+	if code == "success" {
+		return nil
+	}
+
+	return fmt.Errorf("error code: %s, error message: %s", code,
+		utils.PathSearch("info_description", respBody, ""))
+}


### PR DESCRIPTION
…bsite

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CodeArts support a new resource to manage inspector sebsite.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Field `auth_type` has no return value.
- The 404 check is down below
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/6aedfc70-f650-4faa-89a2-41bf90c802e3)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccInspectorWebsite_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccInspectorWebsite_basic -timeout 360m -parallel 4
=== RUN   TestAccInspectorWebsite_basic
=== PAUSE TestAccInspectorWebsite_basic
=== CONT  TestAccInspectorWebsite_basic
--- PASS: TestAccInspectorWebsite_basic (20.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  20.566s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccInspectorWebsite_publicIPAddress'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccInspectorWebsite_publicIPAddress -timeout 360m -parallel 4
=== RUN   TestAccInspectorWebsite_publicIPAddress
=== PAUSE TestAccInspectorWebsite_publicIPAddress
=== CONT  TestAccInspectorWebsite_publicIPAddress
--- PASS: TestAccInspectorWebsite_publicIPAddress (10.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  10.907s
```
