### PR TITLE
fix(SecMaster): add precheck and update the docs

### DIFF
--- a/docs/resources/secmaster_alert.md
+++ b/docs/resources/secmaster_alert.md
@@ -6,6 +6,8 @@ subcategory: "SecMaster"
 
 Manages a SecMaster alert resource within HuaweiCloud.
 
+~> This resource can only be used in region **cn-east-3** for now.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/secmaster_alert_rule.md
+++ b/docs/resources/secmaster_alert_rule.md
@@ -6,6 +6,8 @@ subcategory: "SecMaster"
 
 Manages a SecMaster alert rule resource within HuaweiCloud.
 
+~> This resource can only be used in region **cn-east-3** for now.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/secmaster_playbook.md
+++ b/docs/resources/secmaster_playbook.md
@@ -6,6 +6,8 @@ subcategory: "SecMaster"
 
 Manages a SecMaster playbook resource within HuaweiCloud.
 
+~> This resource can only be used in region **cn-east-3** for now.
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/secmaster_playbook_version.md
+++ b/docs/resources/secmaster_playbook_version.md
@@ -6,6 +6,8 @@ subcategory: "SecMaster"
 
 Manages a SecMaster playbook version resource within HuaweiCloud.
 
+~> This resource can only be used in region **cn-east-3** for now.
+
 ## Example Usage
 
 ```hcl

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_alert_rule_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_alert_rule_test.go
@@ -66,7 +66,10 @@ func TestAccAlertRule_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMaster(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_playbook_version_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_playbook_version_test.go
@@ -72,7 +72,10 @@ func TestAccPlaybookVersion_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMaster(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/secmaster' TESTARGS='-run TestAcc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAcc -timeout 360m -parallel 4
=== RUN   TestAccAlertRule_basic
=== PAUSE TestAccAlertRule_basic
=== RUN   TestAccAlert_basic
=== PAUSE TestAccAlert_basic
=== RUN   TestAccIncident_basic
=== PAUSE TestAccIncident_basic
=== RUN   TestAccIndicator_basic
=== PAUSE TestAccIndicator_basic
=== RUN   TestAccPlaybook_basic
=== PAUSE TestAccPlaybook_basic
=== RUN   TestAccPlaybookVersion_basic
=== PAUSE TestAccPlaybookVersion_basic
=== CONT  TestAccAlertRule_basic
=== CONT  TestAccIndicator_basic
=== CONT  TestAccPlaybookVersion_basic
=== CONT  TestAccIncident_basic
    acceptance.go:820: HW_SECMASTER_WORKSPACE_ID must be set for SecMaster acceptance tests
=== CONT  TestAccPlaybookVersion_basic
    acceptance.go:820: HW_SECMASTER_WORKSPACE_ID must be set for SecMaster acceptance tests
=== CONT  TestAccIndicator_basic
    acceptance.go:820: HW_SECMASTER_WORKSPACE_ID must be set for SecMaster acceptance tests
=== CONT  TestAccPlaybook_basic
--- SKIP: TestAccIncident_basic (0.00s)
--- SKIP: TestAccPlaybookVersion_basic (0.00s)
--- SKIP: TestAccIndicator_basic (0.00s)
=== CONT  TestAccAlert_basic
=== CONT  TestAccAlertRule_basic
    acceptance.go:820: HW_SECMASTER_WORKSPACE_ID must be set for SecMaster acceptance tests
--- SKIP: TestAccAlertRule_basic (0.00s)
=== CONT  TestAccPlaybook_basic
    acceptance.go:820: HW_SECMASTER_WORKSPACE_ID must be set for SecMaster acceptance tests
--- SKIP: TestAccPlaybook_basic (0.01s)
=== CONT  TestAccAlert_basic
    acceptance.go:820: HW_SECMASTER_WORKSPACE_ID must be set for SecMaster acceptance tests
--- SKIP: TestAccAlert_basic (0.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 0.051s
```
