### PR TITLE
feat(OBS): obs lifecycle_rule add abort_incomplete_multipart_upload field

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -117,6 +117,9 @@ resource "huaweicloud_obs_bucket" "bucket" {
       days          = 180
       storage_class = "COLD"
     }
+    abort_incomplete_multipart_upload {
+      days = 360
+    }
   }
 
   lifecycle_rule {
@@ -288,9 +291,11 @@ The `lifecycle_rule` object supports the following:
   automatically deleted. (documented below).
 * `noncurrent_version_transition` - (Optional, List) Specifies a period when noncurrent object versions are
   automatically transitioned to `WARM` or `COLD` storage class (documented below).
+* `abort_incomplete_multipart_upload` - (Optional, List) Specifies a period when the not merged parts (fragments) in an
+  incomplete upload are automatically deleted. (documented below).
 
-At least one of `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be
-specified.
+At least one of `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition`,
+`abort_incomplete_multipart_upload` must be specified.
 
 The `expiration` object supports the following
 
@@ -314,6 +319,12 @@ The `noncurrent_version_transition` object supports the following
   to the specified storage class.
 * `storage_class` - (Required, String) The class of storage used to store the object. Only `WARM` and `COLD` are
   supported.
+
+The `abort_incomplete_multipart_upload` object supports the following
+
+* `days` - (Required, Int) Specifies the number of days since the initiation of an incomplete multipart upload that OBS
+  will wait before deleting the not merged parts (fragments) of the upload.
+  The valid value ranges from 1 to 2,147,483,647.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -318,6 +318,10 @@ func TestAccObsBucket_lifecycle(t *testing.T) {
 						resourceName, "lifecycle_rule.2.noncurrent_version_transition.0.days", "60"),
 					resource.TestCheckResourceAttr(
 						resourceName, "lifecycle_rule.2.noncurrent_version_transition.1.days", "180"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.0.abort_incomplete_multipart_upload.0.days", "360"),
+					resource.TestCheckResourceAttr(
+						resourceName, "lifecycle_rule.1.abort_incomplete_multipart_upload.0.days", "2147483647"),
 				),
 			},
 		},
@@ -671,6 +675,9 @@ resource "huaweicloud_obs_bucket" "bucket" {
     expiration {
       days = 365
     }
+    abort_incomplete_multipart_upload {
+      days = 360
+    }
   }
   lifecycle_rule {
     name    = "rule2"
@@ -688,6 +695,9 @@ resource "huaweicloud_obs_bucket" "bucket" {
     transition {
       days          = 180
       storage_class = "COLD"
+    }
+    abort_incomplete_multipart_upload {
+      days = 2147483647
     }
   }
   lifecycle_rule {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
obs lifecycle_rule add abort_incomplete_multipart_upload field

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.X
* [X] Schema updated.X

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs/' TESTARGS='-run TestAccObsBucket_lifecycle'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs/ -v -run TestAccObsBucket_lifecycle -timeout 360m -parallel 4 
=== RUN   TestAccObsBucket_lifecycle 
=== PAUSE TestAccObsBucket_lifecycle
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (18.56s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       18.608s
```
