### PR TITLE
feat(CCM): update private certificate for tags

### DIFF
--- a/docs/resources/ccm_private_certificate.md
+++ b/docs/resources/ccm_private_certificate.md
@@ -87,6 +87,8 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of private certificate.
   Changing this parameter will create a new resource.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs associating with the private certificate.
+
 <a name="block-distinguished_name"></a>
 The `distinguished_name` block supports:
 

--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go
@@ -70,12 +70,23 @@ func TestAccCcmPrivateCertificate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.country", "CN"),
 					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.organization", "huawei"),
 
+					resource.TestCheckResourceAttr(resourceName, "tags.fooo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.keye", "value"),
+
 					resource.TestCheckResourceAttrSet(resourceName, "issuer_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 					resource.TestCheckResourceAttrSet(resourceName, "start_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "gen_mode"),
 					resource.TestCheckResourceAttrSet(resourceName, "expired_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				),
+			},
+			{
+				Config: tesCmdbCertificate_tagsUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 			{
@@ -103,30 +114,7 @@ func TestAccCcmPrivateCertificate_basic(t *testing.T) {
 // lintignore:AT004
 func tesCmdbCertificate_basic(commonName string) string {
 	return fmt.Sprintf(`
-provider "huaweicloud" {
-  endpoints = {
-    ccm = "https://ccm.cn-north-4.myhuaweicloud.com/"
-  }
-}
-	  
-resource "huaweicloud_ccm_private_ca" "test_root" {
-  type   = "ROOT"
-  distinguished_name {
-      common_name         = "%s-root"
-      country             = "CN"
-      state               = "GD"
-      locality            = "SZ"
-      organization        = "huawei"
-      organizational_unit = "cloud"
-    }
-    key_algorithm       = "RSA2048"
-    signature_algorithm = "SHA512"
-    pending_days        = "7"
-    validity {
-      type  = "DAY"
-      value = 2
-    }
-}
+%s
 
 resource "huaweicloud_ccm_private_certificate" "test" {
   issuer_id           = huaweicloud_ccm_private_ca.test_root.id
@@ -144,5 +132,37 @@ resource "huaweicloud_ccm_private_certificate" "test" {
     type  = "DAY"
     value = "1"
   }
-}`, commonName, commonName)
+  tags = {
+    fooo = "bar"
+    keye = "value"
+  }
+}`, tesPrivateCA_base(commonName), commonName)
+}
+
+// lintignore:AT004
+func tesCmdbCertificate_tagsUpdate(commonName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_ccm_private_certificate" "test" {
+  issuer_id           = huaweicloud_ccm_private_ca.test_root.id
+  key_algorithm       = "RSA2048"
+  signature_algorithm = "SHA256"
+  distinguished_name {
+    common_name         = "%s"
+    country             = "CN"
+    state               = "GD"
+    locality            = "SZ"
+    organization        = "huawei"
+    organizational_unit = "cloud"
+  }
+  validity {
+    type  = "DAY"
+    value = "1"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}`, tesPrivateCA_base(commonName), commonName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
feat(CCM): update private certificate for tags

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
./scripts/codecheck.sh ./huaweicloud/services/ccm

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3      1352      109        15     1228        168            34.04
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ccm/resource_huaweicloud_ccm_private_ca.go       741       58        11      672        117            17.41
~rce_huaweicloud_ccm_private_certificate.go       484       41         4      439         43             9.79
~weicloud_ccm_private_certificate_export.go       127       10         0      117          8             6.84
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3      1352      109        15     1228        168            34.04
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 41617 bytes, 0.042 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
20 ccm resourcePrivateCACreate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:211:1
12 ccm resourcePrivateCADelete huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:537:1
8 ccm resourcePrivateCARead huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:435:1
7 ccm resourceCcmPrivateCertificateRead huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:384:1
7 ccm resourceCcmPrivateCertificateUpdate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:349:1
7 ccm resourcePrivateCAUpdate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:637:1
6 ccm resourceCcmPrivateCertificateCreate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:236:1
6 ccm buildOrderPrivateCABodyParams huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:326:1
5 ccm hasErrorCode huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:468:1
5 ccm privateCAStatusRefreshFunc huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:610:1
Average: 3.66

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in ccm...

==> Checking for misspell in ccm...

==> Checking for code complexity in ./huaweicloud/services/acceptance/ccm...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        3       589       45         8      536         14             6.99
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~esource_huaweicloud_ccm_private_ca_test.go       293       19         4      270          8             2.96
~uaweicloud_ccm_private_certificate_test.go       168       17         2      149          6             4.03
~oud_ccm_private_certificate_export_test.go       128        9         2      117          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     3       589       45         8      536         14             6.99
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 17722 bytes, 0.018 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
5 ccm getPrivateCAResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:18:1
4 ccm getCertificateResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:18:1
1 ccm tesCmdbCertificate_tagsUpdate huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:143:1
1 ccm tesCmdbCertificate_basic huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:115:1
1 ccm TestAccCcmPrivateCertificate_basic huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:46:1
Average: 1.47

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/ccm...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/ccm...
./huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go:71:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go:82:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:106:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:135:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:165:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:244:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:114:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:142:// lintignore:AT004

==> Cleanup patch...

Check Completed!


## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/ccm TESTARGS='-run TestAccCcmPrivateCertificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCcmPrivateCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccCcmPrivateCertificate_basic
=== PAUSE TestAccCcmPrivateCertificate_basic
=== CONT  TestAccCcmPrivateCertificate_basic
--- PASS: TestAccCcmPrivateCertificate_basic (32.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       32.043s

