### PR TITLE
feat(DMS): add consumer group resource

### DIFF
--- a/docs/resources/dms_kafka_consumer_group.md
+++ b/docs/resources/dms_kafka_consumer_group.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_kafka_consumer_group
+
+Manages DMS Kafka consumer group resources within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_kafka_consumer_group" "test" {
+  instance_id = var.instance_id
+  name        = "consumer_group_test"
+  description = "the description of the consumer group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the kafka instance.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the consumer group.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of the consumer group.
+
+* `state` - Indicates the state of the consumer group.
+  Value options: **DEAD**, **EMPTY**, **PreparingRebalance**, **CompletingRebalance**, **Stable**.
+
+* `coordinator_id` - Indicates the coordinator id of the consumer group.
+
+* `lag` - Indicates the lag number of the consumer group.
+
+* `created_at` - Indicates the creation time of the consumer group.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The kafka consumer group can be imported using the kafka `instance_id` and `name` separated by a slash, e.g.
+
+```
+$ terraform import huaweicloud_dms_kafka_consumer_group.test <instance_id>/<name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -870,10 +870,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_dli_template_spark":        dli.ResourceSparkTemplate(),
 			"huaweicloud_dli_agency":                dli.ResourceDliAgency(),
 
-			"huaweicloud_dms_kafka_user":        dms.ResourceDmsKafkaUser(),
-			"huaweicloud_dms_kafka_permissions": dms.ResourceDmsKafkaPermissions(),
-			"huaweicloud_dms_kafka_instance":    dms.ResourceDmsKafkaInstance(),
-			"huaweicloud_dms_kafka_topic":       dms.ResourceDmsKafkaTopic(),
+			"huaweicloud_dms_kafka_user":           dms.ResourceDmsKafkaUser(),
+			"huaweicloud_dms_kafka_permissions":    dms.ResourceDmsKafkaPermissions(),
+			"huaweicloud_dms_kafka_instance":       dms.ResourceDmsKafkaInstance(),
+			"huaweicloud_dms_kafka_topic":          dms.ResourceDmsKafkaTopic(),
+			"huaweicloud_dms_kafka_consumer_group": dms.ResourceDmsKafkaConsumerGroup(),
+
 			"huaweicloud_dms_rabbitmq_instance": dms.ResourceDmsRabbitmqInstance(),
 
 			"huaweicloud_dms_rocketmq_instance":       dms.ResourceDmsRocketMQInstance(),

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_consumer_group_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_consumer_group_test.go
@@ -1,0 +1,139 @@
+package dms
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDmsKafkaConsumerGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getKafkaConsumerGroup: query DMS kafka consumer group
+	var (
+		getKafkaConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
+		getKafkaConsumerGroupProduct = "dms"
+	)
+	getKafkaConsumerGroupClient, err := cfg.NewServiceClient(getKafkaConsumerGroupProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS Client: %s", err)
+	}
+
+	// Split instance_id and group from resource id
+	parts := strings.SplitN(state.Primary.ID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+	}
+	instanceID := parts[0]
+	name := parts[1]
+	getKafkaConsumerGroupPath := getKafkaConsumerGroupClient.Endpoint + getKafkaConsumerGroupHttpUrl
+	getKafkaConsumerGroupPath = strings.ReplaceAll(getKafkaConsumerGroupPath, "{project_id}",
+		getKafkaConsumerGroupClient.ProjectID)
+	getKafkaConsumerGroupPath = strings.ReplaceAll(getKafkaConsumerGroupPath, "{instance_id}", instanceID)
+	getKafkaConsumerGroupPath = strings.ReplaceAll(getKafkaConsumerGroupPath, "{group}", name)
+
+	getKafkaConsumerGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getKafkaConsumerGroupResp, err := getKafkaConsumerGroupClient.Request("GET", getKafkaConsumerGroupPath,
+		&getKafkaConsumerGroupOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DMS Kafka consumer group: %s", err)
+	}
+
+	getKafkaConsumerGroupRespBody, err := utils.FlattenResponse(getKafkaConsumerGroupResp)
+	if err != nil {
+		return nil, err
+	}
+	groupJson := utils.PathSearch("group", getKafkaConsumerGroupRespBody, nil)
+	groupState := utils.PathSearch("state", groupJson, nil)
+	if groupState == "DEAD" {
+		return nil, fmt.Errorf("error retrieving DMS Kafka consumer group")
+	}
+	return getKafkaConsumerGroupRespBody, nil
+}
+
+func TestAccDmsKafkaConsumerGroup_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_kafka_consumer_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDmsKafkaConsumerGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsKafkaConsumerGroup_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrSet(resourceName, "state"),
+					resource.TestCheckResourceAttrSet(resourceName, "lag"),
+					resource.TestCheckResourceAttrSet(resourceName, "coordinator_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "add"),
+					resource.TestCheckResourceAttr(resourceName, "state", "EMPTY"),
+					resource.TestCheckResourceAttr(resourceName, "lag", "0"),
+				),
+			},
+			{
+				Config: testDmsKafkaConsumerGroup_basic_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDmsKafkaConsumerGroup_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_consumer_group" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%s"
+  description = "add"
+}
+`, testAccKafkaInstance_compatible(name), name)
+}
+
+func testDmsKafkaConsumerGroup_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_consumer_group" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id  
+  name        = "%s"  
+  description = ""
+}
+`, testAccKafkaInstance_compatible(name), name)
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_consumer_group.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_consumer_group.go
@@ -1,0 +1,289 @@
+package dms
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDmsKafkaConsumerGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsKafkaConsumerGroupCreate,
+		UpdateContext: resourceDmsKafkaConsumerGroupUpdate,
+		ReadContext:   resourceDmsKafkaConsumerGroupRead,
+		DeleteContext: resourceDmsKafkaConsumerGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the Kafka instance.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the name of the consumer group.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the description of the consumer group.`,
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Specifies the state of the consumer group.`,
+			},
+			"coordinator_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Specifies the coordinator id of the consumer group.`,
+			},
+			"lag": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Specifies the lag number of the consumer group.`,
+			},
+			"created_at": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Specifies the created time of the consumer group.`,
+			},
+		},
+	}
+}
+
+func resourceDmsKafkaConsumerGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	// createKafkaConsumerGroup: create DMS Kafka consumer group
+	var (
+		createKafkaConsumerGroupHttpUrl = "v2/{project_id}/kafka/instances/{instance_id}/group"
+		createKafkaConsumerGroupProduct = "dms"
+	)
+	createKafkaConsumerGroupClient, err := cfg.NewServiceClient(createKafkaConsumerGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	createKafkaConsumerGroupPath := createKafkaConsumerGroupClient.Endpoint + createKafkaConsumerGroupHttpUrl
+	createKafkaConsumerGroupPath = strings.ReplaceAll(createKafkaConsumerGroupPath, "{project_id}",
+		createKafkaConsumerGroupClient.ProjectID)
+	createKafkaConsumerGroupPath = strings.ReplaceAll(createKafkaConsumerGroupPath, "{instance_id}", instanceID)
+
+	createKafkaConsumerGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	createKafkaConsumerGroupOpt.JSONBody = utils.RemoveNil(buildCreateKafkaConsumerGroupBodyParams(d, cfg))
+	_, createErr := createKafkaConsumerGroupClient.Request("POST",
+		createKafkaConsumerGroupPath, &createKafkaConsumerGroupOpt)
+
+	if createErr != nil {
+		return diag.Errorf("error creating DMS Kafka consumer group: %s", createErr)
+	}
+
+	d.SetId(instanceID + "/" + d.Get("name").(string))
+	return resourceDmsKafkaConsumerGroupRead(ctx, d, meta)
+}
+
+func buildCreateKafkaConsumerGroupBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"group_name": d.Get("name"),
+		"group_desc": utils.ValueIngoreEmpty(d.Get("description")),
+	}
+	return bodyParams
+}
+
+func resourceDmsKafkaConsumerGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateKafkaConsumerGroupHasChanges := []string{
+		"description",
+	}
+
+	if d.HasChanges(updateKafkaConsumerGroupHasChanges...) {
+		// updateKafkaConsumerGroup: update DMS Kafka consumer group
+		var (
+			updateKafkaConsumerGroupHttpUrl = "v2/{engine}/{project_id}/instances/{instance_id}/groups/{group}"
+			updateKafkaConsumerGroupProduct = "dms"
+		)
+		updateKafkaConsumerGroupClient, err := cfg.NewServiceClient(updateKafkaConsumerGroupProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating DMS Client: %s", err)
+		}
+
+		parts := strings.Split(d.Id(), "/")
+		if len(parts) != 2 {
+			return diag.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+		}
+		instanceID := parts[0]
+		name := parts[1]
+		updateKafkaConsumerGroupPath := updateKafkaConsumerGroupClient.Endpoint + updateKafkaConsumerGroupHttpUrl
+		updateKafkaConsumerGroupPath = strings.ReplaceAll(updateKafkaConsumerGroupPath, "{engine}", "kafka")
+		updateKafkaConsumerGroupPath = strings.ReplaceAll(updateKafkaConsumerGroupPath, "{project_id}",
+			updateKafkaConsumerGroupClient.ProjectID)
+		updateKafkaConsumerGroupPath = strings.ReplaceAll(updateKafkaConsumerGroupPath, "{instance_id}", instanceID)
+		updateKafkaConsumerGroupPath = strings.ReplaceAll(updateKafkaConsumerGroupPath, "{group}", name)
+
+		updateKafkaConsumerGroupOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				204,
+			},
+		}
+		updateKafkaConsumerGroupOpt.JSONBody = utils.RemoveNil(buildUpdateKafkaConsumerGroupBodyParams(d))
+		_, err = updateKafkaConsumerGroupClient.Request("PUT", updateKafkaConsumerGroupPath,
+			&updateKafkaConsumerGroupOpt)
+		if err != nil {
+			return diag.Errorf("error updating DMS Kafka consumer group: %s", err)
+		}
+	}
+
+	return resourceDmsKafkaConsumerGroupRead(ctx, d, meta)
+}
+
+func buildUpdateKafkaConsumerGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"group_name": utils.ValueIngoreEmpty(d.Get("name")),
+		"group_desc": d.Get("description"),
+	}
+	return bodyParams
+}
+
+func resourceDmsKafkaConsumerGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getKafkaConsumerGroup: query DMS Kafka consumer group
+	var (
+		getKafkaConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/{group}"
+		getKafkaConsumerGroupProduct = "dms"
+	)
+	getKafkaConsumerGroupClient, err := cfg.NewServiceClient(getKafkaConsumerGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+	}
+	instanceID := parts[0]
+	name := parts[1]
+	getKafkaConsumerGroupPath := getKafkaConsumerGroupClient.Endpoint + getKafkaConsumerGroupHttpUrl
+	getKafkaConsumerGroupPath = strings.ReplaceAll(getKafkaConsumerGroupPath, "{project_id}",
+		getKafkaConsumerGroupClient.ProjectID)
+	getKafkaConsumerGroupPath = strings.ReplaceAll(getKafkaConsumerGroupPath, "{instance_id}", instanceID)
+	getKafkaConsumerGroupPath = strings.ReplaceAll(getKafkaConsumerGroupPath, "{group}", name)
+
+	getKafkaConsumerGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getKafkaConsumerGroupResp, err := getKafkaConsumerGroupClient.Request("GET", getKafkaConsumerGroupPath,
+		&getKafkaConsumerGroupOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DMS Kafka consumer group")
+	}
+
+	getKafkaConsumerGroupRespBody, err := utils.FlattenResponse(getKafkaConsumerGroupResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	groupJson := utils.PathSearch("group", getKafkaConsumerGroupRespBody, nil)
+	state := utils.PathSearch("state", groupJson, nil)
+	if state == "DEAD" {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", instanceID),
+		d.Set("name", name),
+		d.Set("description", utils.PathSearch("group_desc", groupJson, nil)),
+		d.Set("state", utils.PathSearch("state", groupJson, nil)),
+		d.Set("coordinator_id", utils.PathSearch("coordinator_id", groupJson, nil)),
+		d.Set("lag", utils.PathSearch("lag", groupJson, nil)),
+		d.Set("created_at", utils.PathSearch("createdAt", groupJson, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDmsKafkaConsumerGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteKafkaConsumerGroup: delete DMS Kafka consumer group
+	var (
+		deleteKafkaConsumerGroupHttpUrl = "v2/{project_id}/instances/{instance_id}/groups/batch-delete"
+		deleteKafkaConsumerGroupProduct = "dms"
+	)
+	deleteKafkaConsumerGroupClient, err := cfg.NewServiceClient(deleteKafkaConsumerGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return diag.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+	}
+	instanceID := parts[0]
+	deleteKafkaConsumerGroupPath := deleteKafkaConsumerGroupClient.Endpoint + deleteKafkaConsumerGroupHttpUrl
+	deleteKafkaConsumerGroupPath = strings.ReplaceAll(deleteKafkaConsumerGroupPath, "{project_id}",
+		deleteKafkaConsumerGroupClient.ProjectID)
+	deleteKafkaConsumerGroupPath = strings.ReplaceAll(deleteKafkaConsumerGroupPath, "{instance_id}", instanceID)
+
+	deleteKafkaConsumerGroupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	deleteKafkaConsumerGroupOpt.JSONBody = utils.RemoveNil(buildBatchDeleteKafkaConsumerGroupBodyParams(d))
+	_, err = deleteKafkaConsumerGroupClient.Request("POST", deleteKafkaConsumerGroupPath, &deleteKafkaConsumerGroupOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DMS Kafka consumer group: %s", err)
+	}
+	return resourceDmsKafkaConsumerGroupRead(ctx, d, meta)
+}
+
+func buildBatchDeleteKafkaConsumerGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"group_ids": []string{d.Get("name").(string)},
+	}
+	return bodyParams
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add resource kafka consumer group
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccDmsKafkaConsumerGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsKafkaConsumerGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaConsumerGroup_basic
=== PAUSE TestAccDmsKafkaConsumerGroup_basic
=== CONT  TestAccDmsKafkaConsumerGroup_basic
--- PASS: TestAccDmsKafkaConsumerGroup_basic (815.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       815.849s

```
