### PR TITLE
feat(utils): support a new function to convert unit

### DIFF
--- a/huaweicloud/utils/math.go
+++ b/huaweicloud/utils/math.go
@@ -1,0 +1,10 @@
+package utils
+
+// Power is a method for calculating powers of exponents.
+// The result is base^exponent (^ is the exponential operator).
+func Power(base int, exponent int) int {
+	if exponent == 0 {
+		return 1
+	}
+	return base * Power(base, exponent-1)
+}

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -542,3 +542,32 @@ func SchemaDesc(description string, schemaDescInput SchemaDescInput) string {
 
 	return description
 }
+
+// ConvertMemoryUnit is a method that used to convert the memory unit.
+// Parameters:
+// + memory: The memory size of the current unit, only supports int value or string corresponding to int value.
+// + diffLevel: Difference level between units before and after conversion.
+// diffLevel greater than 0 means that the unit is converted to a higher level, and vice versa to a lower level, e.g.
+// the unit of memory input is MB, -2 means it is converted from MB to B, and 2 means it is converted from MB to TB.
+func ConvertMemoryUnit(memory interface{}, diffLevel int) int {
+	var memoryInt int
+	switch memory := memory.(type) {
+	case int:
+		memoryInt = memory
+	case string:
+		var err error
+		memoryInt, err = strconv.Atoi(memory)
+		if err != nil {
+			log.Printf("convert string value (%v) to int fail: %s", memory, err)
+			return -1
+		}
+	default:
+		log.Printf("unsupported memory unit type, want 'int' or 'string', but got '%T'", memory)
+		return -1
+	}
+
+	if diffLevel >= 0 {
+		return memoryInt / Power(1024, diffLevel)
+	}
+	return memoryInt * Power(1024, -diffLevel)
+}

--- a/huaweicloud/utils/utils_test.go
+++ b/huaweicloud/utils/utils_test.go
@@ -100,3 +100,19 @@ func TestAccFunction_PasswordEncrypt(t *testing.T) {
 		t.Fatalf("The encrypted string is not as expected, want %s, but %s", green(encrypted), yellow(newEncrypted))
 	}
 }
+
+func TestAccFunction_ConvertMemoryUnit(t *testing.T) {
+	var (
+		memories   = []interface{}{2097152, 2048, 2, "2097152", "2048", "2", 2.048, "2.048", 0}
+		diffLevels = []int{2, 0, -2, 2, 0, -2, -2, -2, 1}
+		expected   = []int{2, 2048, 2097152, 2, 2048, 2097152, -1, -1, 0}
+	)
+
+	for i, memory := range memories {
+		testOutput := ConvertMemoryUnit(memory, diffLevels[i])
+		if !reflect.DeepEqual(testOutput, expected[i]) {
+			t.Fatalf("The processing result of ConvertMemoryUnit method is not as expected, want %s, but %s", green(expected[i]), yellow(testOutput))
+		}
+		t.Logf("The processing result of ConvertMemoryUnit method meets expectation: %s", green(expected[i]))
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some resources/data sources need a public method to convert their parameter units, such as the vcpus value.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
support a new function to convert memory unit
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
go test -v -run=TestAccFunction_ConvertMemoryUnit
=== RUN   TestAccFunction_ConvertMemoryUnit
    utils_test.go:116: The processing result of ConvertMemoryUnit method meets expectation: 2
    utils_test.go:116: The processing result of ConvertMemoryUnit method meets expectation: 2048
    utils_test.go:116: The processing result of ConvertMemoryUnit method meets expectation: 2097152
    utils_test.go:116: The processing result of ConvertMemoryUnit method meets expectation: 2
    utils_test.go:116: The processing result of ConvertMemoryUnit method meets expectation: 2048
    utils_test.go:116: The processing result of ConvertMemoryUnit method meets expectation: 2097152
2023/11/28 15:03:38 unsupported memory unit type, want 'int' or 'string', but got 'float64'
    utils_test.go:116: The processing result of ConvertMemoryUnit method meets expectation: -1
2023/11/28 15:03:38 convert string value (2.048) to int fail: strconv.Atoi: parsing "2.048": invalid syntax
    utils_test.go:116: The processing result of ConvertMemoryUnit method meets expectation: -1
    utils_test.go:116: The processing result of ConvertMemoryUnit method meets expectation: 0
--- PASS: TestAccFunction_ConvertMemoryUnit (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.009s
```
