### PR TITLE
feat(CodeArts): Add CodeArts inspector website scan resource

### DIFF
--- a/docs/resources/codearts_inspector_website_scan.md
+++ b/docs/resources/codearts_inspector_website_scan.md
@@ -1,0 +1,154 @@
+---
+subcategory: "CodeArts Inspector"
+---
+
+# huaweicloud_codearts_inspector_website_scan
+
+Manages a CodeArts inspector website scan resource within HuaweiCloud.
+
+## Example Usage
+
+### With normal task type
+
+```hcl
+variable "url" {}
+variable "timer" {}
+
+resource "huaweicloud_codearts_inspector_website_scan" "test" {
+  task_name = "normal-name"
+  task_type = "normal"
+  url       = var.url
+  timer     = var.timer
+  scan_mode = "deep"
+  port_scan = true
+}
+```
+
+### With monitor task type
+
+```hcl
+variable "url" {}
+variable "trigger_time" {}
+
+resource "huaweicloud_codearts_inspector_website_scan" "test" {
+  task_name    = "monitor-name"
+  task_type    = "monitor"
+  url          = var.url
+  trigger_time = var.trigger_time
+  task_period  = "everyweek"
+  scan_mode    = "normal"
+  port_scan    = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `task_name` - (Required, String, ForceNew) Specifies the task name. Changing this parameter will create a new resource.
+  The valid length is limited from `1` to `24`. Only Chinese characters, letters, digits, hyphens (-) and underscores (_)
+  are allowed, and cannot start with a hyphen (-).
+
+* `url` - (Required, String, ForceNew) Specifies the destination URL to scan. Changing this parameter will create a new
+  resource. The maximum length is `256`. The format should be `http(s)://example.com` or
+  `http(s)://{public IPv4 address}:{PORT}`. The value can only be the website address of CodeArts inspector website,
+  and the website address must be authorized before it can be used.
+
+* `task_type` - (Optional, String, ForceNew) Specifies the scan task type. Changing this parameter will create a new
+  resource. Valid values are:
+  + **normal**: Normal task type.
+  + **monitor**: Monitor task type. The prerequisite for using **monitor** task type is to upgrade the vulnerability
+  management service to the Professional editions or above.
+
+  Defaults to **normal**.
+
+* `timer` - (Optional, String, ForceNew) Specifies the scheduled trigger time of the normal task. Changing this parameter
+  will create a new resource. This field is valid only when `task_type` is set to **normal**. The field format is
+  **yyyy-mm-dd hh:mm:ss**. The trigger time needs to be after the current time. The normal task will start immediately
+  when this field is not configured.
+
+* `trigger_time` - (Optional, String, ForceNew) Specifies the scheduled trigger time of the monitor task. Changing this
+  parameter will create a new resource. This field is required when `task_type` is set to **monitor**. The field format
+  is **yyyy-mm-dd hh:mm:ss**.
+
+* `task_period` - (Optional, String, ForceNew) Specifies the scheduled trigger period of the monitor task. Changing this
+  parameter will create a new resource. This field is required when `task_type` is set to **monitor**. Valid values are:
+  + **everyday**: Trigger monitor task every day.
+  + **threedays**: Trigger monitor task every three days.
+  + **everyweek**: Trigger monitor task every week.
+  + **everymonth**: Trigger monitor task every month.
+
+* `scan_mode` - (Optional, String, ForceNew) Specifies the task scan mode. Changing this parameter will create a new
+  resource. Valid values are:
+  + **fast**: Quick scan.
+  + **normal**: Normal scan.
+  + **deep**: Deep scan.
+  
+  Defaults to **normal**.
+
+* `port_scan` - (Optional, Bool, ForceNew) Specifies whether to perform port scanning. Changing this parameter will
+  create a new resource. Defaults to **false**. Basic, Professional, Advanced and Enterprise editions of vulnerability
+  management services support configuring this parameter.
+
+* `weak_pwd_scan` - (Optional, Bool, ForceNew) Specifies whether to scan for weak passwords. Changing this parameter will
+  create a new resource. Defaults to **false**.
+
+* `cve_check` - (Optional, Bool, ForceNew) Specifies whether to perform CVE vulnerability scanning. Changing this parameter
+  will create a new resource. Defaults to **false**.
+
+* `text_check` - (Optional, Bool, ForceNew) Specifies whether to conduct website content compliance text detection.
+  Changing this parameter will create a new resource. Defaults to **false**.
+
+-> Fields `weak_pwd_scan`, `cve_check` and `text_check` are only supported by the Professional, Advanced and Enterprise
+editions of the vulnerability management service.
+
+* `picture_check` - (Optional, Bool, ForceNew) Specifies whether to conduct website content compliance image detection.
+  Changing this parameter will create a new resource. Defaults to **false**.
+
+* `malicious_code` - (Optional, Bool, ForceNew) Specifies whether to perform malicious code scanning.
+  Changing this parameter will create a new resource. Defaults to **false**.
+
+* `malicious_link` - (Optional, Bool, ForceNew) Specifies whether to perform link health detection.
+  Changing this parameter will create a new resource. Defaults to **false**.
+
+-> Fields `picture_check`, `malicious_code` and `malicious_link` are only supported by the Enterprise editions of the
+vulnerability management service.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `created_at` - The creation time of the task.
+
+* `task_status` - The task status. Valid values are **running**, **success**, **waiting**, **ready** and **failure**.
+
+* `schedule_status` - The monitor task status. Valid values are **running**, **waiting** and **finished**. This field is
+  valid only when `task_type` is **monitor**.
+
+* `progress` - The task progress.
+
+* `reason` - The description of task status.
+
+* `pack_num` - The total number of packages.
+
+* `score` - The safety score.
+
+* `safe_level` - The security level. Valid values are **safety**, **average** and **highrisk**.
+
+* `high` - The number of high-risk vulnerabilities.
+
+* `middle` - The number of medium-risk vulnerabilities.
+
+* `low` - The number of low-severity vulnerabilities.
+
+* `hint` - The number of hint-risk vulnerabilities.
+
+## Import
+
+The CodeArts inspector website scan can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_codearts_inspector_website_scan.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1244,7 +1244,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_codearts_deploy_group":       codearts.ResourceDeployGroup(),
 			"huaweicloud_codearts_deploy_host":        codearts.ResourceDeployHost(),
 
-			"huaweicloud_codearts_inspector_website": codearts.ResourceInspectorWebsite(),
+			"huaweicloud_codearts_inspector_website":      codearts.ResourceInspectorWebsite(),
+			"huaweicloud_codearts_inspector_website_scan": codearts.ResourceInspectorWebsiteScan(),
 
 			"huaweicloud_dsc_instance":  dsc.ResourceDscInstance(),
 			"huaweicloud_dsc_asset_obs": dsc.ResourceAssetObs(),

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_inspector_website_scan_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_inspector_website_scan_test.go
@@ -1,0 +1,285 @@
+package codearts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getInspectorWebsiteScanResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v3/{project_id}/webscan/tasks"
+		product = "vss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += fmt.Sprintf("?task_id=%s", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CodeArts inspector website scan: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+	taskStatus := utils.PathSearch("task_status", getRespBody, "")
+	if taskStatus == "" {
+		return nil, fmt.Errorf("error retrieving CodeArts inspector website scan: field `task_status` is not found" +
+			" in detail API response")
+	}
+
+	if taskStatus == "canceled" {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccInspectorWebsiteScan_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_inspector_website_scan.test"
+	// The normal trigger time needs to be after the current time.
+	timer := utils.FormatTimeStampUTC(time.Now().Add(1 * time.Hour).Unix())
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getInspectorWebsiteScanResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testInspectorWebsiteScan_basic(name, timer),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "task_name", name),
+					resource.TestCheckResourceAttr(rName, "task_type", "normal"),
+					resource.TestCheckResourceAttrPair(rName, "url",
+						"huaweicloud_codearts_inspector_website.test", "website_address"),
+					resource.TestCheckResourceAttr(rName, "timer", timer),
+					resource.TestCheckResourceAttr(rName, "scan_mode", "deep"),
+					resource.TestCheckResourceAttr(rName, "port_scan", "true"),
+					resource.TestCheckResourceAttr(rName, "weak_pwd_scan", "false"),
+					resource.TestCheckResourceAttr(rName, "cve_check", "false"),
+					resource.TestCheckResourceAttr(rName, "text_check", "false"),
+					resource.TestCheckResourceAttr(rName, "picture_check", "false"),
+					resource.TestCheckResourceAttr(rName, "malicious_code", "false"),
+					resource.TestCheckResourceAttr(rName, "malicious_link", "false"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "task_status"),
+					resource.TestCheckResourceAttrSet(rName, "progress"),
+					resource.TestCheckResourceAttrSet(rName, "reason"),
+					resource.TestCheckResourceAttrSet(rName, "pack_num"),
+					resource.TestCheckResourceAttrSet(rName, "score"),
+					resource.TestCheckResourceAttrSet(rName, "safe_level"),
+					resource.TestCheckResourceAttrSet(rName, "high"),
+					resource.TestCheckResourceAttrSet(rName, "middle"),
+					resource.TestCheckResourceAttrSet(rName, "low"),
+					resource.TestCheckResourceAttrSet(rName, "hint"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccInspectorWebsiteScan_monitor(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_inspector_website_scan.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getInspectorWebsiteScanResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testInspectorWebsiteScan_monitor(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "task_name", name),
+					resource.TestCheckResourceAttr(rName, "task_type", "monitor"),
+					resource.TestCheckResourceAttrPair(rName, "url",
+						"huaweicloud_codearts_inspector_website.test", "website_address"),
+					resource.TestCheckResourceAttr(rName, "trigger_time", "2023-11-26 16:10:53"),
+					resource.TestCheckResourceAttr(rName, "task_period", "everyweek"),
+					resource.TestCheckResourceAttr(rName, "scan_mode", "normal"),
+					resource.TestCheckResourceAttr(rName, "port_scan", "true"),
+					resource.TestCheckResourceAttr(rName, "weak_pwd_scan", "false"),
+					resource.TestCheckResourceAttr(rName, "cve_check", "false"),
+					resource.TestCheckResourceAttr(rName, "text_check", "false"),
+					resource.TestCheckResourceAttr(rName, "picture_check", "false"),
+					resource.TestCheckResourceAttr(rName, "malicious_code", "false"),
+					resource.TestCheckResourceAttr(rName, "malicious_link", "false"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "task_status"),
+					resource.TestCheckResourceAttrSet(rName, "schedule_status"),
+					resource.TestCheckResourceAttrSet(rName, "progress"),
+					resource.TestCheckResourceAttrSet(rName, "reason"),
+					resource.TestCheckResourceAttrSet(rName, "pack_num"),
+					resource.TestCheckResourceAttrSet(rName, "score"),
+					resource.TestCheckResourceAttrSet(rName, "safe_level"),
+					resource.TestCheckResourceAttrSet(rName, "high"),
+					resource.TestCheckResourceAttrSet(rName, "middle"),
+					resource.TestCheckResourceAttrSet(rName, "low"),
+					resource.TestCheckResourceAttrSet(rName, "hint"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Before testing this test, upgrade the vulnerability management service version to the professional version.
+func TestAccInspectorWebsiteScan_professional(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_codearts_inspector_website_scan.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getInspectorWebsiteScanResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCodeArtsEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testInspectorWebsiteScan_professional(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "task_name", name),
+					resource.TestCheckResourceAttr(rName, "task_type", "monitor"),
+					resource.TestCheckResourceAttrPair(rName, "url",
+						"huaweicloud_codearts_inspector_website.test", "website_address"),
+					resource.TestCheckResourceAttr(rName, "trigger_time", "2023-11-26 16:10:53"),
+					resource.TestCheckResourceAttr(rName, "task_period", "everyweek"),
+					resource.TestCheckResourceAttr(rName, "scan_mode", "normal"),
+					resource.TestCheckResourceAttr(rName, "port_scan", "true"),
+					resource.TestCheckResourceAttr(rName, "weak_pwd_scan", "true"),
+					resource.TestCheckResourceAttr(rName, "cve_check", "true"),
+					resource.TestCheckResourceAttr(rName, "text_check", "true"),
+					resource.TestCheckResourceAttr(rName, "picture_check", "false"),
+					resource.TestCheckResourceAttr(rName, "malicious_code", "false"),
+					resource.TestCheckResourceAttr(rName, "malicious_link", "false"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "task_status"),
+					resource.TestCheckResourceAttrSet(rName, "schedule_status"),
+					resource.TestCheckResourceAttrSet(rName, "progress"),
+					resource.TestCheckResourceAttrSet(rName, "reason"),
+					resource.TestCheckResourceAttrSet(rName, "pack_num"),
+					resource.TestCheckResourceAttrSet(rName, "score"),
+					resource.TestCheckResourceAttrSet(rName, "safe_level"),
+					resource.TestCheckResourceAttrSet(rName, "high"),
+					resource.TestCheckResourceAttrSet(rName, "middle"),
+					resource.TestCheckResourceAttrSet(rName, "low"),
+					resource.TestCheckResourceAttrSet(rName, "hint"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testInspectorWebsiteScan_basic(name, timer string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_inspector_website_scan" "test" {
+  task_name = "%s"
+  task_type = "normal"
+  url       = huaweicloud_codearts_inspector_website.test.website_address
+  timer     = "%s"
+  scan_mode = "deep"
+  port_scan = true
+}
+`, testInspectorWebsite_basic(name), name, timer)
+}
+
+func testInspectorWebsiteScan_monitor(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_inspector_website_scan" "test" {
+  task_name    = "%s"
+  task_type    = "monitor"
+  url          = huaweicloud_codearts_inspector_website.test.website_address
+  trigger_time = "2023-11-26 16:10:53"
+  task_period  = "everyweek"
+  scan_mode    = "normal"
+  port_scan    = true
+}
+`, testInspectorWebsite_basic(name), name)
+}
+
+func testInspectorWebsiteScan_professional(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_codearts_inspector_website_scan" "test" {
+  task_name     = "%s"
+  task_type     = "monitor"
+  url           = huaweicloud_codearts_inspector_website.test.website_address
+  trigger_time  = "2023-11-26 16:10:53"
+  task_period   = "everyweek"
+  scan_mode     = "normal"
+  port_scan     = true
+  weak_pwd_scan = true
+  cve_check     = true
+  text_check    = true
+}
+`, testInspectorWebsite_basic(name), name)
+}

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website_scan.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website_scan.go
@@ -1,0 +1,389 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CodeArts
+// ---------------------------------------------------------------
+
+package codearts
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceInspectorWebsiteScan() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInspectorWebsiteScanCreate,
+		ReadContext:   resourceInspectorWebsiteScanRead,
+		DeleteContext: resourceInspectorWebsiteScanDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"task_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the task name.`,
+			},
+			"url": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the URL.`,
+			},
+			"task_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the task type.`,
+			},
+			"timer": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the scheduled trigger time of the normal task.`,
+			},
+			"trigger_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the scheduled trigger time of the monitor task.`,
+			},
+			"task_period": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the scheduled trigger period of the monitor task.`,
+			},
+			"scan_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the task scan mode.`,
+			},
+			"port_scan": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies whether to perform port scanning.`,
+			},
+			"weak_pwd_scan": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies whether to scan for weak passwords.`,
+			},
+			"cve_check": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies whether to perform CVE vulnerability scanning.`,
+			},
+			"text_check": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies whether to conduct website content compliance text detection.`,
+			},
+			"picture_check": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies whether to conduct website content compliance image detection.`,
+			},
+			"malicious_code": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies whether to perform malicious code scanning.`,
+			},
+			"malicious_link": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies whether to perform link health detection.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The create time of the task.`,
+			},
+			"task_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The task status.`,
+			},
+			"schedule_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The monitor task status.`,
+			},
+			"progress": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The task progress.`,
+			},
+			"reason": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Task status description.`,
+			},
+			"pack_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total number of packages.`,
+			},
+			"score": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The safety score.`,
+			},
+			"safe_level": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The security level.`,
+			},
+			"high": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of high-risk vulnerabilities.`,
+			},
+			"middle": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of medium-risk vulnerabilities.`,
+			},
+			"low": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of low-severity vulnerabilities.`,
+			},
+			"hint": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of hint-risk vulnerabilities.`,
+			},
+		},
+	}
+}
+
+func resourceInspectorWebsiteScanCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/webscan/tasks"
+		product = "vss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateInspectorWebsiteScanBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts inspector website scan: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err = checkInspectorWebsiteResponse(createRespBody); err != nil {
+		return diag.Errorf("error creating CodeArts inspector website scan: %s", err)
+	}
+
+	id, err := jmespath.Search("task_id", createRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating CodeArts inspector website scan: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceInspectorWebsiteScanRead(ctx, d, meta)
+}
+
+func buildCreateInspectorWebsiteScanBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"task_name":    d.Get("task_name"),
+		"url":          d.Get("url"),
+		"task_type":    utils.ValueIngoreEmpty(d.Get("task_type")),
+		"timer":        utils.ValueIngoreEmpty(d.Get("timer")),
+		"trigger_time": utils.ValueIngoreEmpty(d.Get("trigger_time")),
+		"task_period":  utils.ValueIngoreEmpty(d.Get("task_period")),
+		"task_config":  buildCreateInspectorWebsiteScanTaskConfig(d),
+	}
+}
+
+func buildCreateInspectorWebsiteScanTaskConfig(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"scan_mode":      utils.ValueIngoreEmpty(d.Get("scan_mode")),
+		"port_scan":      d.Get("port_scan"),
+		"weak_pwd_scan":  d.Get("weak_pwd_scan"),
+		"cve_check":      d.Get("cve_check"),
+		"text_check":     d.Get("text_check"),
+		"picture_check":  d.Get("picture_check"),
+		"malicious_code": d.Get("malicious_code"),
+		"malicious_link": d.Get("malicious_link"),
+	}
+}
+
+func resourceInspectorWebsiteScanRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v3/{project_id}/webscan/tasks"
+		product = "vss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildGetInspectorWebsiteScanQueryParams(d)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CodeArts inspector website scan: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	taskStatus := utils.PathSearch("task_status", getRespBody, "")
+	if taskStatus == "" {
+		return diag.Errorf("error retrieving CodeArts inspector website scan: field `task_status` is not found" +
+			" in detail API response")
+	}
+
+	if taskStatus == "canceled" {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("task_name", utils.PathSearch("task_name", getRespBody, nil)),
+		d.Set("url", utils.PathSearch("url", getRespBody, nil)),
+		d.Set("task_type", utils.PathSearch("task_type", getRespBody, nil)),
+		d.Set("timer", utils.PathSearch("task_settings.timer", getRespBody, nil)),
+		d.Set("trigger_time", utils.PathSearch("task_settings.trigger_time", getRespBody, nil)),
+		d.Set("task_period", utils.PathSearch("task_settings.task_period", getRespBody, nil)),
+		d.Set("scan_mode", utils.PathSearch("task_settings.task_config.scan_mode", getRespBody, nil)),
+		d.Set("port_scan", utils.PathSearch("task_settings.task_config.port_scan", getRespBody, nil)),
+		d.Set("weak_pwd_scan", utils.PathSearch("task_settings.task_config.weak_pwd_scan", getRespBody, nil)),
+		d.Set("cve_check", utils.PathSearch("task_settings.task_config.cve_check", getRespBody, nil)),
+		d.Set("text_check", utils.PathSearch("task_settings.task_config.text_check", getRespBody, nil)),
+		d.Set("picture_check", utils.PathSearch("task_settings.task_config.picture_check", getRespBody, nil)),
+		d.Set("malicious_code", utils.PathSearch("task_settings.task_config.malicious_code", getRespBody, nil)),
+		d.Set("malicious_link", utils.PathSearch("task_settings.task_config.malicious_link", getRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", getRespBody, nil)),
+		d.Set("task_status", taskStatus),
+		d.Set("schedule_status", utils.PathSearch("schedule_status", getRespBody, nil)),
+		d.Set("progress", utils.PathSearch("progress", getRespBody, nil)),
+		d.Set("reason", utils.PathSearch("reason", getRespBody, nil)),
+		d.Set("pack_num", utils.PathSearch("pack_num", getRespBody, nil)),
+		d.Set("score", utils.PathSearch("score", getRespBody, nil)),
+		d.Set("safe_level", utils.PathSearch("safe_level", getRespBody, nil)),
+		d.Set("high", utils.PathSearch("statistics.high", getRespBody, nil)),
+		d.Set("middle", utils.PathSearch("statistics.middle", getRespBody, nil)),
+		d.Set("low", utils.PathSearch("statistics.low", getRespBody, nil)),
+		d.Set("hint", utils.PathSearch("statistics.hint", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetInspectorWebsiteScanQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("?task_id=%s", d.Id())
+}
+
+func resourceInspectorWebsiteScanDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	taskStatus := d.Get("task_status").(string)
+	ignoreStatuses := []string{"success", "canceled", "failure"}
+	// When the task status is `success`, `canceled`, `failure`, the task cancellation operation is not performed.
+	if utils.StrSliceContains(ignoreStatuses, taskStatus) {
+		log.Printf("[DEBUG] The current task status is `%s`, the task (%s) cancellation operation is not performed.",
+			taskStatus, d.Id())
+		return nil
+	}
+
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/webscan/tasks"
+		product = "vss"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CodeArts inspector client: %s", err)
+	}
+
+	cancelPath := client.Endpoint + httpUrl
+	cancelPath = strings.ReplaceAll(cancelPath, "{project_id}", client.ProjectID)
+	cancelOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDeleteInspectorWebsiteScanBodyParams(d),
+	}
+
+	cancelResp, err := client.Request("PUT", cancelPath, &cancelOpt)
+	if err != nil {
+		return diag.Errorf("error canceling CodeArts inspector website scan: %s", err)
+	}
+
+	cancelRespBody, err := utils.FlattenResponse(cancelResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := checkInspectorWebsiteResponse(cancelRespBody); err != nil {
+		return diag.Errorf("error canceling CodeArts inspector website scan: %s", err)
+	}
+	return nil
+}
+
+func buildDeleteInspectorWebsiteScanBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"task_id": d.Id(),
+		"action":  "cancel",
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add CodeArts inspector website scan resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The resource do not support update operation.
- For delete operation, just return nil when the `task_status` is success, canceled, failure.
- Running `terraform plan` when resource is not exist.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/65364679-fdc1-49dc-a1b4-566de9334f08)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccInspectorWebsiteScan_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccInspectorWebsiteScan_basic -timeout 360m -parallel 4
=== RUN   TestAccInspectorWebsiteScan_basic
=== PAUSE TestAccInspectorWebsiteScan_basic
=== CONT  TestAccInspectorWebsiteScan_basic
--- PASS: TestAccInspectorWebsiteScan_basic (16.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  16.252s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccInspectorWebsiteScan_monitor'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccInspectorWebsiteScan_monitor -timeout 360m -parallel 4
=== RUN   TestAccInspectorWebsiteScan_monitor
=== PAUSE TestAccInspectorWebsiteScan_monitor
=== CONT  TestAccInspectorWebsiteScan_monitor
--- PASS: TestAccInspectorWebsiteScan_monitor (13.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  13.611s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccInspectorWebsiteScan_professional'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccInspectorWebsiteScan_professional -timeout 360m -parallel 4
=== RUN   TestAccInspectorWebsiteScan_professional
=== PAUSE TestAccInspectorWebsiteScan_professional
=== CONT  TestAccInspectorWebsiteScan_professional
--- PASS: TestAccInspectorWebsiteScan_professional (14.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  14.276s
```
