### PR TITLE
fix(DMS): fix kafka instance

### DIFF
--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
@@ -241,7 +241,7 @@ func TestAccKafkaInstance_newFormat(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "engine", "kafka"),
 					resource.TestCheckResourceAttr(resourceName, "broker_num", "4"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor_id",
-						"data.huaweicloud_dms_kafka_flavors.test", "flavors.1.id"),
+						"data.huaweicloud_dms_kafka_flavors.test", "flavors.0.id"),
 					resource.TestCheckResourceAttrPair(resourceName, "storage_spec_code",
 						"data.huaweicloud_dms_kafka_flavors.test", "flavors.0.ios.0.storage_spec_code"),
 					resource.TestCheckResourceAttr(resourceName, "storage_space", "600"),
@@ -433,12 +433,11 @@ func testAccKafkaInstance_newFormat(rName string) string {
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_dms_kafka_flavors" "test" {
-  type = "cluster"
+  type      = "cluster"
+  flavor_id = "c6.2u4g.cluster"
 }
 
 locals {
-  query_results = data.huaweicloud_dms_kafka_flavors.test
-
   flavor = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
 }
 
@@ -455,7 +454,7 @@ resource "huaweicloud_dms_kafka_instance" "test" {
     data.huaweicloud_availability_zones.test.names[1],
     data.huaweicloud_availability_zones.test.names[2]
   ]
-  engine_version = element(local.query_results.versions, length(local.query_results.versions)-1)
+  engine_version = "2.7"
   storage_space  = local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node
   broker_num     = 3
 
@@ -485,14 +484,12 @@ func testAccKafkaInstance_newFormatUpdate(rName string) string {
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_dms_kafka_flavors" "test" {
-  type = "cluster"
+  type      = "cluster"
+  flavor_id = "c6.4u8g.cluster"
 }
 
 locals {
-  query_results = data.huaweicloud_dms_kafka_flavors.test
-
-  flavor    = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
-  newFlavor = data.huaweicloud_dms_kafka_flavors.test.flavors[1]
+  flavor = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
 }
 
 resource "huaweicloud_dms_kafka_instance" "test" {
@@ -501,14 +498,14 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   network_id        = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
 
-  flavor_id          = local.newFlavor.id
+  flavor_id          = local.flavor.id
   storage_spec_code  = local.flavor.ios[0].storage_spec_code
   availability_zones = [
     data.huaweicloud_availability_zones.test.names[0],
     data.huaweicloud_availability_zones.test.names[1],
     data.huaweicloud_availability_zones.test.names[2]
   ]
-  engine_version = element(local.query_results.versions, length(local.query_results.versions)-1)
+  engine_version = "2.7"
   storage_space  = 600
   broker_num     = 4
 
@@ -541,11 +538,11 @@ func testAccKafkaInstance_newFormat_prePaid(baseNetwork, rName string) string {
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_dms_kafka_flavors" "test" {
-  type = "cluster"
+  type      = "cluster"
+  flavor_id = "c6.2u4g.cluster"
 }
 
 locals {
-  query_results = data.huaweicloud_dms_kafka_flavors.test
   flavor = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
 }
 
@@ -561,7 +558,7 @@ resource "huaweicloud_dms_kafka_instance" "test" {
     data.huaweicloud_availability_zones.test.names[0]
   ]
 
-  engine_version = element(local.query_results.versions, length(local.query_results.versions)-1)
+  engine_version = "2.7"
   storage_space  = local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node
   broker_num     = 3
 
@@ -587,11 +584,11 @@ func testAccKafkaInstance_newFormat_prePaid_update(baseNetwork, updateName strin
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_dms_kafka_flavors" "test" {
-  type = "cluster"
+  type      = "cluster"
+  flavor_id = "c6.2u4g.cluster"
 }
 
 locals {
-  query_results = data.huaweicloud_dms_kafka_flavors.test
   flavor = data.huaweicloud_dms_kafka_flavors.test.flavors[0]
 }
 
@@ -608,7 +605,7 @@ resource "huaweicloud_dms_kafka_instance" "test" {
     data.huaweicloud_availability_zones.test.names[0]
   ]
 
-  engine_version = element(local.query_results.versions, length(local.query_results.versions)-1)
+  engine_version = "2.7"
   storage_space  = local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node
   broker_num     = 3
 

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
@@ -354,7 +354,7 @@ func resourceDmsRocketMQInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	d.SetId(id.(string))
 
 	if _, ok := d.GetOk("cross_vpc_accesses"); ok {
-		if err = updateCrossVpcAccess(createRocketmqInstanceClient, d); err != nil {
+		if err = updateCrossVpcAccess(ctx, createRocketmqInstanceClient, d); err != nil {
 			return diag.Errorf("failed to update default advertised IP: %v", err)
 		}
 	}
@@ -546,7 +546,7 @@ func resourceDmsRocketMQInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 		}
 
 		if d.HasChange("cross_vpc_accesses") {
-			if err = updateCrossVpcAccess(updateRocketmqInstanceClient, d); err != nil {
+			if err = updateCrossVpcAccess(ctx, updateRocketmqInstanceClient, d); err != nil {
 				return diag.Errorf("error updating DMS rocketMQ Cross-VPC access information: %s", err)
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. fix kafka instance test
2. add retry to update and delete
3. fix flavor regex

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix kafka instance
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccKafkaInstance_' TEST_PARALLELISM=5        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccKafkaInstance_ -timeout 360m -parallel 5
=== RUN   TestAccKafkaInstance_basic
=== PAUSE TestAccKafkaInstance_basic
=== RUN   TestAccKafkaInstance_prePaid
=== PAUSE TestAccKafkaInstance_prePaid
=== RUN   TestAccKafkaInstance_withEpsId
=== PAUSE TestAccKafkaInstance_withEpsId
=== RUN   TestAccKafkaInstance_compatible
=== PAUSE TestAccKafkaInstance_compatible
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_compatible
=== CONT  TestAccKafkaInstance_prePaid
=== CONT  TestAccKafkaInstance_withEpsId
=== CONT  TestAccKafkaInstance_newFormat
--- PASS: TestAccKafkaInstance_withEpsId (675.20s)
--- PASS: TestAccKafkaInstance_prePaid (1115.91s)
--- PASS: TestAccKafkaInstance_compatible (1163.91s)
--- PASS: TestAccKafkaInstance_basic (1862.92s)
--- PASS: TestAccKafkaInstance_newFormat (3063.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       3063.561s
```
