### PR TITLE
fix(DMS): fix rabbitmq instance

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -881,6 +881,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_topic":          dms.ResourceDmsKafkaTopic(),
 			"huaweicloud_dms_kafka_consumer_group": dms.ResourceDmsKafkaConsumerGroup(),
 
+			"huaweicloud_dms_rabbitmq_instance": dms.ResourceDmsRabbitmqInstance(),
+
 			"huaweicloud_dms_rocketmq_instance":       dms.ResourceDmsRocketMQInstance(),
 			"huaweicloud_dms_rocketmq_consumer_group": dms.ResourceDmsRocketMQConsumerGroup(),
 			"huaweicloud_dms_rocketmq_topic":          dms.ResourceDmsRocketMQTopic(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. fix rabbitmq test
2. add retry to update and delete

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

#3754  this PR is based on

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rabbitmq instance
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccDmsRabbitmqInstances_' TEST_PARALLELISM=7
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRabbitmqInstances_ -timeout 360m -parallel 7
=== PAUSE TestAccDmsRabbitmqInstances_basic
=== RUN   TestAccDmsRabbitmqInstances_newFormat_cluster
=== PAUSE TestAccDmsRabbitmqInstances_newFormat_cluster
=== RUN   TestAccDmsRabbitmqInstances_newFormat_single
=== PAUSE TestAccDmsRabbitmqInstances_newFormat_single
=== RUN   TestAccDmsRabbitmqInstances_prePaid
=== PAUSE TestAccDmsRabbitmqInstances_prePaid
=== RUN   TestAccDmsRabbitmqInstances_withEpsId
=== PAUSE TestAccDmsRabbitmqInstances_withEpsId
=== RUN   TestAccDmsRabbitmqInstances_compatible
=== PAUSE TestAccDmsRabbitmqInstances_compatible
=== RUN   TestAccDmsRabbitmqInstances_single
=== PAUSE TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_basic
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
=== CONT  TestAccDmsRabbitmqInstances_newFormat_single
=== CONT  TestAccDmsRabbitmqInstances_prePaid
=== CONT  TestAccDmsRabbitmqInstances_single
=== CONT  TestAccDmsRabbitmqInstances_compatible
=== CONT  TestAccDmsRabbitmqInstances_newFormat_cluster
=== CONT  TestAccDmsRabbitmqInstances_withEpsId
    acceptance.go:351: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccDmsRabbitmqInstances_withEpsId (0.01s)
--- PASS: TestAccDmsRabbitmqInstances_single (622.43s)
--- PASS: TestAccDmsRabbitmqInstances_prePaid (847.70s)
--- PASS: TestAccDmsRabbitmqInstances_compatible (1036.76s)
--- PASS: TestAccDmsRabbitmqInstances_newFormat_single (1328.00s)
--- PASS: TestAccDmsRabbitmqInstances_basic (1613.79s)
--- PASS: TestAccDmsRabbitmqInstances_newFormat_cluster (2867.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       2867.336s
```
