### PR TITLE
feat(SFS): add a new resource to manage SFS Turbo directory quota

### DIFF
--- a/docs/resources/sfs_turbo_dir_quota.md
+++ b/docs/resources/sfs_turbo_dir_quota.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Scalable File Service (SFS)"
+---
+
+# huaweicloud_sfs_turbo_dir_quota
+
+Provides a Shared File System (SFS) Turbo directory quota resource.
+
+## Example Usage
+
+```hcl
+variable "share_id" {}
+variable "path" {}
+
+resource "huaweicloud_sfs_turbo_dir_quota" "test" {
+  path      = var.path
+  share_id  = var.share_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the SFS Turbo directory resource. If omitted, the
+  provider-level region will be used. Changing this creates a new SFS Turbo directory resource.
+
+* `share_id` - (Required, String, ForceNew) Specifies the SFS Turbo ID. Changing this will create a new resource.
+
+* `path` - (Required, String, ForceNew) Specifies the valid full path of existing SFS Turbo directory. The parameter
+  starts with "/", otherwise the parameter is illegal. Changing this will create a new resource.
+
+* `capacity` - (Optional, Int) Specifies the size of the directory. The default value is `0`, this value means that
+  there is no quota assigned to this directory. The value can not exceed the remaining available capacity of the
+  file system. The unit is `MB`.
+
+* `inode` - (Optional, Int) Specifies the maximum number of inodes allowed in the directory. The default value is `0`,
+  this value means that there is no quota assigned to this directory.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `used_capacity` - The size of the used directory. The unit is `MB`. This parameter is returned only for SFS Turbo
+  HPC file systems.
+
+* `used_inode` - The number of used inodes in the directory. This parameter is returned only for SFS Turbo
+  HPC file systems.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1153,10 +1153,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestage_repo_token_authorization":    servicestage.ResourceRepoTokenAuth(),
 			"huaweicloud_servicestage_repo_password_authorization": servicestage.ResourceRepoPwdAuth(),
 
-			"huaweicloud_sfs_access_rule": sfs.ResourceSFSAccessRuleV2(),
-			"huaweicloud_sfs_file_system": sfs.ResourceSFSFileSystemV2(),
-			"huaweicloud_sfs_turbo":       sfs.ResourceSFSTurbo(),
-			"huaweicloud_sfs_turbo_dir":   sfs.ResourceSfsTurboDir(),
+			"huaweicloud_sfs_access_rule":     sfs.ResourceSFSAccessRuleV2(),
+			"huaweicloud_sfs_file_system":     sfs.ResourceSFSFileSystemV2(),
+			"huaweicloud_sfs_turbo":           sfs.ResourceSFSTurbo(),
+			"huaweicloud_sfs_turbo_dir":       sfs.ResourceSfsTurboDir(),
+			"huaweicloud_sfs_turbo_dir_quota": sfs.ResourceSfsTurboDirQuota(),
 
 			"huaweicloud_smn_topic":            smn.ResourceTopic(),
 			"huaweicloud_smn_subscription":     smn.ResourceSubscription(),

--- a/huaweicloud/services/acceptance/sfs/resource_huaweicloud_sfs_turbo_dir_quota_test.go
+++ b/huaweicloud/services/acceptance/sfs/resource_huaweicloud_sfs_turbo_dir_quota_test.go
@@ -1,0 +1,108 @@
+package sfs
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func sfsTurboDirQuotaReadfunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/dir-quota"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	getPath := sfsClient.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", sfsClient.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{share_id}", state.Primary.Attributes["share_id"])
+	getPath += fmt.Sprintf("?path=%s", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := sfsClient.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving SFS Turbo directory quota %s", err)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccSfsTurboDirQuota_basic(t *testing.T) {
+	var obj interface{}
+	name := acceptance.RandomAccResourceName()
+	path := "/tmp" + acctest.RandString(10)
+	resourceName := "huaweicloud_sfs_turbo_dir_quota.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		sfsTurboDirQuotaReadfunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSfsTurboDirQuotaBasic(name, path),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "100"),
+					resource.TestCheckResourceAttr(resourceName, "inode", "100"),
+				),
+			},
+			{
+				Config: testSfsTurboDirQuotaUpdateBasic(name, path),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "50"),
+					resource.TestCheckResourceAttr(resourceName, "inode", "30"),
+				),
+			},
+		},
+	})
+}
+
+func testSfsTurboDirQuotaBasic(rName string, path string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_sfs_turbo_dir_quota" "test" {
+  path     = "%[2]s"
+  share_id = huaweicloud_sfs_turbo_dir.test.share_id
+  capacity = 100
+  inode    = 100
+}
+`, testSfsTurboDirBasic(rName, path), path)
+}
+
+func testSfsTurboDirQuotaUpdateBasic(rName string, path string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_sfs_turbo_dir_quota" "test" {
+  path     = "%[2]s"
+  share_id = huaweicloud_sfs_turbo_dir.test.share_id
+  capacity = 50
+  inode    = 30
+}
+`, testSfsTurboDirBasic(rName, path), path)
+}

--- a/huaweicloud/services/sfs/resource_huaweicloud_sfs_turbo_dir_quota.go
+++ b/huaweicloud/services/sfs/resource_huaweicloud_sfs_turbo_dir_quota.go
@@ -1,0 +1,213 @@
+package sfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceSfsTurboDirQuota() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSfsTurboDirQuotaCreate,
+		ReadContext:   resourceSfsTurboDirQuotaRead,
+		UpdateContext: resourceSfsTurboDirQuotaUpdate,
+		DeleteContext: resourceSfsTurboDirQuotaDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"share_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the SFS Turbo ID.`,
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the valid full path of an existing directory.`,
+			},
+			"capacity": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the size of the directory.`,
+			},
+			"inode": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the maximum number of inodes allowed in the directory.`,
+			},
+			"used_capacity": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Specifies the size of the used directory.`,
+			},
+			"used_inode": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Specifies the number of used inodes in the directory.`,
+			},
+		},
+	}
+}
+
+func resourceSfsTurboDirQuotaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/dir-quota"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	createPath := sfsClient.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", sfsClient.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{share_id}", d.Get("share_id").(string))
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildSfsTurboDirQuotaBodyParams(d)),
+	}
+
+	_, err = sfsClient.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo directory quota: %s", err)
+	}
+
+	path := d.Get("path").(string)
+	d.SetId(path)
+
+	return resourceSfsTurboDirQuotaRead(ctx, d, meta)
+}
+
+func resourceSfsTurboDirQuotaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/dir-quota"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	updatePath := sfsClient.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", sfsClient.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{share_id}", d.Get("share_id").(string))
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildSfsTurboDirQuotaBodyParams(d)),
+	}
+
+	_, err = sfsClient.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating SFS Turbo directory quota: %s", err)
+	}
+
+	return resourceSfsTurboDirQuotaRead(ctx, d, meta)
+}
+
+func buildSfsTurboDirQuotaBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"path":     d.Get("path"),
+		"capacity": d.Get("capacity"),
+		"inode":    d.Get("inode"),
+	}
+
+	return params
+}
+
+func resourceSfsTurboDirQuotaRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/dir-quota"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	getPath := sfsClient.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", sfsClient.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{share_id}", d.Get("share_id").(string))
+	getPath += fmt.Sprintf("?path=%s", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := sfsClient.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving SFS Turbo directory quota")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("path", utils.PathSearch("path", getRespBody, nil)),
+		d.Set("capacity", utils.PathSearch("capacity", getRespBody, nil)),
+		d.Set("inode", utils.PathSearch("inode", getRespBody, nil)),
+		d.Set("used_capacity", utils.PathSearch("used_capacity", getRespBody, nil)),
+		d.Set("used_inode", utils.PathSearch("used_inode", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildDeleteSfsTurboQuotaDirBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"path": d.Id(),
+	}
+}
+
+func resourceSfsTurboDirQuotaDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/dir-quota"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	deletePath := sfsClient.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", sfsClient.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{share_id}", d.Get("share_id").(string))
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildDeleteSfsTurboQuotaDirBodyParams(d),
+	}
+
+	_, err = sfsClient.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		if utils.IsResourceNotFound(err) {
+			return nil
+		}
+		return diag.Errorf("error deleting SFS Turbo directory quota: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST='./huaweicloud/services/acceptance/sfs' TESTARGS='-run TestAccSfsTurboDirQuota_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/sfs -v -run TestAccSfsTurboDirQuota_basic -timeout 360m -parallel 4
=== RUN   TestAccSfsTurboDirQuota_basic
=== PAUSE TestAccSfsTurboDirQuota_basic
=== CONT  TestAccSfsTurboDirQuota_basic
--- PASS: TestAccSfsTurboDirQuota_basic (461.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfs       461.798s
