### PR TITLE
feat(CCM): add ccm certificate push resource

### DIFF
--- a/docs/resources/ccm_certificate_push.md
+++ b/docs/resources/ccm_certificate_push.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Cloud Certificate Manager (CCM)"
+---
+
+# huaweicloud_ccm_certificate_push
+
+Push a **SSL** ceritificate to **ELB** or **WAF** within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "certificate_id" {}
+variable "project_name1" {}
+variable "project_name2" {}
+
+resource "huaweicloud_ccm_certificate_push" "test"{
+  region         = "cn-north-4"
+  certificate_id = var.certificate_id
+  service        = "ELB"
+  targets {
+    project_name = var.project_name1
+  }
+  targets {
+    project_name = var.project_name2
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the certificate region. Changing this creates a new
+  private certificate resource. Now only support cn-north-4 (china) and ap-southeast-1 (international).
+
+* `certificate_id` - (Required, String, ForceNew) Specifies the certificate which will be push.
+  Changing this parameter will create a new resource.
+
+* `service` - (Required, String, ForceNew) Specifies the service which certificate will be push to.
+  Changing this creates a new resource. Valid values are **ELB** and **WAF**.
+
+* `targets` - (Required, List) Specifies the projects which certificate will be push to.
+  The [targets](#block-targets) structure is documented below.
+
+<a name="block-targets"></a>
+The `targets` block supports:
+
+* `project_name` - (Required, String) Specifies the project which certificate will be push to.
+  Only the **default** projects with the same region name are supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the SSL certificate ID.
+
+* `targets` - Indicates the projects which certificate pushed to.
+  The [targets](#block-targets-attr) structure is documented below.
+
+<a name="block-targets-attr"></a>
+The `targets` block supports:
+
+* `cert_id` - Indicates the pushed certificate new ID.
+
+* `cert_name` - Indicates the pushed certificate name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -786,6 +786,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cci_network":      cci.ResourceCciNetworkV1(),
 			"huaweicloud_cci_pvc":          cci.ResourcePersistentVolumeClaimV1(),
 
+			"huaweicloud_ccm_certificate_push":    ccm.ResourceCcmCertificatePush(),
 			"huaweicloud_ccm_private_ca":          ccm.ResourcePrivateCertificateAuthority(),
 			"huaweicloud_ccm_private_certificate": ccm.ResourceCcmPrivateCertificate(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -208,6 +208,8 @@ var (
 	HW_KOOGALLERY_ASSET = os.Getenv("HW_KOOGALLERY_ASSET")
 
 	HW_CCI_NAMESPACE = os.Getenv("HW_CCI_NAMESPACE")
+
+	HW_CERT_BATCH_PUSH_ID = os.Getenv("HW_CERT_BATCH_PUSH_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.

--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certifiacte_push_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certifiacte_push_test.go
@@ -1,0 +1,140 @@
+package ccm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/elb/v3/certificates"
+	wafcertificates "github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+const (
+	targetServiceWaf = "WAF"
+	targetServiceElb = "ELB"
+)
+
+func getCertificatePushResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	projectName := state.Primary.Attributes["targets.1.project_name"]
+	certId := state.Primary.Attributes["targets.1.cert_id"]
+	targetService := state.Primary.Attributes["service"]
+	if targetService == targetServiceElb {
+		elbClient, err := conf.ElbV3Client(projectName)
+		if err != nil {
+			return nil, fmt.Errorf("error creating ELB client: %s", err)
+		}
+
+		return certificates.Get(elbClient, certId).Extract()
+	}
+	if targetService == targetServiceWaf {
+		wafClient, err := conf.WafV1Client(projectName)
+		if err != nil {
+			return nil, fmt.Errorf("error creating WAF client: %s", err)
+		}
+
+		return wafcertificates.Get(wafClient, certId).Extract()
+	}
+
+	return nil, fmt.Errorf("find certificate is failed")
+}
+func TestAccCcmCertificatePush_basic(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_ccm_certificate_push.test"
+	project := "cn-north-4"
+	project2 := "cn-east-3"
+	changeProject := "cn-south-1"
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCertificatePushResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: tesCcmCertificatePush_basic(targetServiceElb, project, project2),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.project_name", project2),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_name"),
+				),
+			},
+			{
+				Config: tesCcmCertificatePush_basic(targetServiceElb, project, changeProject),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.project_name", changeProject),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCcmCertificatePush_waf(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_ccm_certificate_push.test"
+	project := "cn-north-4"
+	project2 := "cn-east-3"
+	changeProject := "cn-south-1"
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCertificatePushResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: tesCcmCertificatePush_basic(targetServiceWaf, project, project2),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.project_name", project2),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_name"),
+				),
+			},
+			{
+				Config: tesCcmCertificatePush_basic(targetServiceWaf, project, changeProject),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "targets.1.project_name", changeProject),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_name"),
+				),
+			},
+		},
+	})
+}
+
+func tesCcmCertificatePush_basic(service string, project string, project2 string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_certificate_push" "test"{
+  region         = "cn-north-4"
+  certificate_id = "%s"
+  service        = "%s"
+  targets {
+    project_name = "%s"
+ }
+ targets {
+    project_name = "%s"
+ }
+}`, acceptance.HW_CERT_BATCH_PUSH_ID, service, project, project2)
+}

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go
@@ -1,0 +1,344 @@
+package ccm
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/elb/v3/certificates"
+	wafcertificates "github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	targetServiceWaf = "WAF"
+	targetServiceElb = "ELB"
+)
+
+func ResourceCcmCertificatePush() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCcmCertificateBatchPush,
+		ReadContext:   resourceCcmCertificateRead,
+		UpdateContext: resourceCcmCertificateUpdate,
+		DeleteContext: resourceCcmCertificateDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"certificate_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"service": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"targets": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"project_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"cert_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cert_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceCcmCertificateBatchPush(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	scmClient, err := conf.ScmV3Client(conf.GetRegion(d))
+
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
+	}
+	certId := d.Get("certificate_id").(string)
+	pushCertificateHttpUrl := "v3/scm/certificates/{certificate_id}/batch-push"
+	pushCertificatePath := scmClient.Endpoint + pushCertificateHttpUrl
+	pushCertificatePath = strings.ReplaceAll(pushCertificatePath, "{certificate_id}", certId)
+
+	pushCertificateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	service := d.Get("service").(string)
+	projects := d.Get("targets").(*schema.Set).List()
+	pushCertificateOpt.JSONBody = utils.RemoveNil(buildPushCertificateBodyParams(service, projects))
+	pushCertificateResp, err := scmClient.Request("POST", pushCertificatePath, &pushCertificateOpt)
+	if err != nil {
+		return diag.Errorf("error pushing certificate: %s", err)
+	}
+	pushCertificateRespBody, err := utils.FlattenResponse(pushCertificateResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(certId)
+	d.Set("targets", flattenResult(pushCertificateRespBody))
+
+	return resourceCcmCertificateRead(ctx, d, meta)
+}
+
+func buildPushCertificateBodyParams(service string, projectlist []interface{}) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"target_service":  service,
+		"target_projects": buildTargetProject(projectlist),
+	}
+	return bodyParams
+}
+
+func buildTargetProject(projectlist []interface{}) []string {
+	var projects []string
+	for _, v := range projectlist {
+		projects = append(projects, utils.PathSearch("project_name", v, "").(string))
+	}
+	return projects
+}
+
+func flattenResult(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("results", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"project_name": utils.PathSearch("project_name", v, ""),
+			"cert_id":      utils.PathSearch("cert_id", v, ""),
+		})
+	}
+	return rst
+}
+
+func flattenUpdateResult(d *schema.ResourceData, resp interface{}) []interface{} {
+	targets := d.Get("targets").(*schema.Set).List()
+	rst := make([]interface{}, 0, len(targets))
+	for _, v := range targets {
+		certId := utils.PathSearch("cert_id", v, "").(string)
+		projectName := utils.PathSearch("project_name", v, "").(string)
+		if certId == "" {
+			certId = getCertIdFromResult(projectName, resp)
+		}
+		rst = append(rst, map[string]interface{}{
+			"project_name": projectName,
+			"cert_id":      certId,
+			"cert_name":    utils.PathSearch("cert_name", v, ""),
+		})
+	}
+
+	return rst
+}
+
+func getCertIdFromResult(projectName string, resp interface{}) string {
+	certId := ""
+	curJson := utils.PathSearch("results", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	for _, v := range curArray {
+		resName := utils.PathSearch("project_name", v, "").(string)
+		if projectName == resName {
+			certId = utils.PathSearch("cert_id", v, "").(string)
+			break
+		}
+	}
+	return certId
+}
+func resourceCcmCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	projectList := d.Get("targets").(*schema.Set).List()
+	targetService := d.Get("service").(string)
+	rst := make([]interface{}, 0, len(projectList))
+	cfg := meta.(*config.Config)
+	// search elb certificate detail and set to targets
+	if targetService == targetServiceElb {
+		for _, val := range projectList {
+			projectName := utils.PathSearch("project_name", val, "").(string)
+			certId := utils.PathSearch("cert_id", val, "").(string)
+			elbClient, err := cfg.ElbV3Client(projectName)
+			if err != nil {
+				return diag.Errorf("error creating ELB client: %s", err)
+			}
+
+			cert, err := certificates.Get(elbClient, certId).Extract()
+			if err != nil {
+				log.Printf("[WARN] error retrieving ELB certificate: %s", certId)
+			}
+			if cert != nil {
+				rst = append(rst, map[string]interface{}{
+					"project_name": projectName,
+					"cert_id":      certId,
+					"cert_name":    cert.Name,
+				})
+			}
+		}
+	}
+
+	// search waf certificate detail and set to targets
+	if targetService == targetServiceWaf {
+		for _, val := range projectList {
+			projectName := utils.PathSearch("project_name", val, "").(string)
+			certId := utils.PathSearch("cert_id", val, "").(string)
+			wafClient, err := cfg.WafV1Client(projectName)
+			if err != nil {
+				return diag.Errorf("error creating WAF client: %s", err)
+			}
+
+			cert, err := wafcertificates.Get(wafClient, certId).Extract()
+			if err != nil {
+				log.Printf("[DEBUG] error retrieving WAF certificate: %s", certId)
+			}
+			if cert != nil && cert.Id != "" {
+				rst = append(rst, map[string]interface{}{
+					"project_name": projectName,
+					"cert_id":      certId,
+					"cert_name":    cert.Name,
+				})
+			}
+		}
+	}
+	if len(rst) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving certificate")
+	}
+	mErr := multierror.Append(nil,
+		d.Set("targets", rst),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting targets fields: %s", err)
+	}
+	return nil
+}
+func resourceCcmCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if d.HasChange("targets") {
+		err := rePushOrDelete(d, meta)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceCcmCertificateRead(ctx, d, meta)
+}
+
+func rePushOrDelete(d *schema.ResourceData, meta interface{}) error {
+	oRaw, nRaw := d.GetChange("targets")
+	addSet := nRaw.(*schema.Set).Difference(oRaw.(*schema.Set))
+	rmSet := oRaw.(*schema.Set).Difference(nRaw.(*schema.Set))
+	if rmSet.Len() > 0 {
+		// remve the pushed certificate
+		targetService := d.Get("service").(string)
+		_, err := rmPushedCert(targetService, rmSet.List(), meta, d)
+		if err != nil {
+			return err
+		}
+	}
+	if addSet.Len() > 0 {
+		// push to new project
+		conf := meta.(*config.Config)
+		scmClient, err := conf.ScmV3Client(conf.GetRegion(d))
+
+		if err != nil {
+			return err
+		}
+
+		pushCertificateHttpUrl := "v3/scm/certificates/{certificate_id}/batch-push"
+		pushCertificatePath := scmClient.Endpoint + pushCertificateHttpUrl
+		pushCertificatePath = strings.ReplaceAll(pushCertificatePath, "{certificate_id}", d.Get("certificate_id").(string))
+
+		pushCertificateOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		}
+		pushCertificateOpt.JSONBody = utils.RemoveNil(buildPushCertificateBodyParams(d.Get("service").(string), addSet.List()))
+		pushCertificateResp, err := scmClient.Request("POST", pushCertificatePath, &pushCertificateOpt)
+		if err != nil {
+			return fmt.Errorf("error pushing certificate: %s", err)
+		}
+		pushCertificateRespBody, err := utils.FlattenResponse(pushCertificateResp)
+		if err != nil {
+			return err
+		}
+		// save push result
+		d.Set("targets", flattenUpdateResult(d, pushCertificateRespBody))
+	}
+	return nil
+}
+
+func resourceCcmCertificateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	targetService := d.Get("service").(string)
+	oRaws := d.Get("targets").(*schema.Set).List()
+	if len(oRaws) == 0 {
+		return nil
+	}
+	_, err := rmPushedCert(targetService, oRaws, meta, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func rmPushedCert(targetService string, oRaws []interface{}, meta interface{}, d *schema.ResourceData) (bool, error) {
+	cfg := meta.(*config.Config)
+	if targetService == targetServiceElb {
+		for _, val := range oRaws {
+			strVal := utils.PathSearch("project_name", val, "").(string)
+			certId := utils.PathSearch("cert_id", val, "").(string)
+			if certId != "" {
+				elbClient, err := cfg.ElbV3Client(strVal)
+				if err != nil {
+					return true, fmt.Errorf("error creating ELB client: %s", err)
+				}
+				err = certificates.Delete(elbClient, certId).ExtractErr()
+				if err != nil {
+					if utils.IsResourceNotFound(err) {
+						return true, nil
+					}
+					return true, fmt.Errorf("error deleting certificate %s: %s", certId, err)
+				}
+			}
+		}
+	}
+
+	if targetService == targetServiceWaf {
+		for _, val := range oRaws {
+			strVal := utils.PathSearch("project_name", val, "").(string)
+			certId := utils.PathSearch("cert_id", val, "").(string)
+			if certId != "" {
+				client, err := cfg.WafV1Client(strVal)
+				if err != nil {
+					return true, fmt.Errorf("error creating WAF client: %s", err)
+				}
+				epsID := cfg.GetEnterpriseProjectID(d)
+				err = wafcertificates.DeleteWithEpsID(client, certId, epsID).ExtractErr()
+				if err != nil {
+					if utils.IsResourceNotFound(err) {
+						return true, nil
+					}
+					return true, fmt.Errorf("error deleting WAF certificate: %s", err)
+				}
+			}
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
feat(CCM): add ccm certificate push resource

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

 ./scripts/codecheck.sh ./huaweicloud/services/ccm

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        4      1679      134        13     1532        244            57.64
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ccm/resource_huaweicloud_ccm_private_ca.go       741       58        11      672        117            17.41
~source_huaweicloud_ccm_certificate_push.go       381       35         2      344         89            25.87
~rce_huaweicloud_ccm_private_certificate.go       430       31         0      399         30             7.52
~weicloud_ccm_private_certificate_export.go       127       10         0      117          8             6.84
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     4      1679      134        13     1532        244            57.64
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 51907 bytes, 0.052 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
20 ccm resourcePrivateCACreate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:211:1
13 ccm resourceCcmCertificateDelete huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go:333:1
13 ccm resourceCcmCertificateRead huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go:174:1
12 ccm resourcePrivateCADelete huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:537:1
12 ccm rmPushedCert huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go:287:1
8 ccm resourcePrivateCARead huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:435:1
7 ccm resourcePrivateCAUpdate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:637:1
7 ccm rePushOrDelete huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go:244:1
6 ccm resourceCcmPrivateCertificateRead huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:338:1
6 ccm buildOrderPrivateCABodyParams huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:326:1
Average: 3.91

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in ccm...
  -> the resource in resource_huaweicloud_ccm_certificate_push.go should can be imported


==> Checking for misspell in ccm...

==> Checking for code complexity in ./huaweicloud/services/acceptance/ccm...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        4       737       60         7      670         22            12.81
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~e_huaweicloud_ccm_certifiacte_push_test.go       168       17         0      151          8             5.30
~esource_huaweicloud_ccm_private_ca_test.go       293       19         4      270          8             2.96
~uaweicloud_ccm_private_certificate_test.go       148       15         1      132          6             4.55
~oud_ccm_private_certificate_export_test.go       128        9         2      117          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     4       737       60         7      670         22            12.81
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 22097 bytes, 0.022 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
5 ccm getPrivateCAResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:18:1
5 ccm getCertificatePushResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certifiacte_push_test.go:22:1
4 ccm getCertificateResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:18:1
1 ccm tesCmdbCertificate_basic huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:104:1
1 ccm TestAccCcmPrivateCertificate_basic huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:46:1
Average: 1.52

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/ccm...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/ccm...
./huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go:71:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go:82:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:106:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:135:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:165:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:244:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:103:// lintignore:AT004

==> Cleanup patch...

Check Completed!


## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
make testacc TEST=./huaweicloud/services/acceptance/ccm TESTARGS='-run TestAccCcmCertificatePush_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCcmCertificatePush_basic -timeout 360m -parallel 4
=== RUN   TestAccCcmCertificatePush_basic
=== PAUSE TestAccCcmCertificatePush_basic
=== CONT  TestAccCcmCertificatePush_basic
--- PASS: TestAccCcmCertificatePush_basic (22.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       22.831s

make testacc TEST=./huaweicloud/services/acceptance/ccm TESTARGS='-run TestAccCcmCertificatePush_waf'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCcmCertificatePush_waf -timeout 360m -parallel 4
=== RUN   TestAccCcmCertificatePush_waf
=== PAUSE TestAccCcmCertificatePush_waf
=== CONT  TestAccCcmCertificatePush_waf
--- PASS: TestAccCcmCertificatePush_waf (28.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       28.462s

