### PR TITLE
fix(waf): waf domain supports fields:description,lb_algorithom,website_name,forward_header_map

### DIFF
--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -43,6 +43,13 @@ resource "huaweicloud_waf_domain" "domain_1" {
   certificate_name      = huaweicloud_waf_certificate.certificate_1.name
   proxy                 = true
   enterprise_project_id = var.enterprise_project_id
+  description           = "test description"
+  website_name          = "websiteName"
+  
+  forward_header_map = {
+    "key1" = "$time_local"
+    "key2" = "$tenant_id"
+  }
 
   custom_page {
     http_return_code = "404"
@@ -127,6 +134,46 @@ The following arguments are supported:
   Enable IPv6 protection if the domain name is accessible using an IPv6 address.
   After you enable it, WAF assigns an IPv6 address to the domain name.
   Defaults to **false**.
+
+* `website_name` - (Optional, String) Specifies the website name.
+  This website name must start with a letter and only letters, digits, underscores (_),
+  hyphens (-), colons (:) and periods (.) are allowed.
+  The value contains 1 to 128 characters.
+  The website name must be unique within this account.
+
+* `description` - (Optional, String) Specifies the description of the WAF domain.
+
+* `lb_algorithm` - (Optional, String) Specifies the load balancing algorithms used to
+  distribute requests across origin servers.
+  Only the professional edition (original enterprise edition) and platinum edition
+  (original ultimate edition) support configuring the load balancing algorithm.
+  The options of value are as follows:
+  + **ip_hash** : Requests from the same IP address are routed to the same backend server.
+  + **round_robin** : Requests are distributed across backend servers in turn based on the
+  weight you assign to each server.
+  + **session_hash** : Direct requests with the same session ID to the same origin server.
+  Before using this configuration, please make sure to configure the traffic identifier for
+  attack punishment after adding the domain name, otherwise the session hash configuration will not take effect.
+
+* `forward_header_map` - (Optional, Map) Specifies the field forwarding configuration. WAF inserts the added fields into
+  the header and forwards the header to the origin server. The key cannot be the same as the native Nginx field.
+  The options of value are as follows:
+  + **$time_local**
+  + **$request_id**
+  + **$connection_requests**
+  + **$tenant_id**
+  + **$project_id**
+  + **$remote_addr**
+  + **$remote_port**
+  + **$scheme**
+  + **$request_method**
+  + **$http_host**
+  + **$origin_uri**
+  + **$request_length**
+  + **$ssl_server_name**
+  + **$ssl_protocol**
+  + **$ssl_curves**
+  + **$ssl_session_reused**
 
 * `timeout_settings` - (Optional, List) Specifies the timeout setting. Only supports one timeout setting.
   The [timeout_settings](#Domain_timeout_settings) structure is documented below.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b
+	github.com/chnsz/golangsdk v0.0.0-20231204022125-8e25a0c901ae
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b h1:HdQqladAqLkzzRkx435FF5LhmTN6fepC5OwOqHmta00=
-github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231204022125-8e25a0c901ae h1:SA8zkij1YE8hfwtDHOXcSDSU2bQqehHRC/IqeijvA5E=
+github.com/chnsz/golangsdk v0.0.0-20231204022125-8e25a0c901ae/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -57,6 +57,11 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "50"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "200"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "200"),
+					resource.TestCheckResourceAttr(resourceName, "description", "web_description_1"),
+					resource.TestCheckResourceAttr(resourceName, "lb_algorithm", "ip_hash"),
+					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key1", "$time_local"),
+					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key2", "$tenant_id"),
+					resource.TestCheckResourceAttr(resourceName, "website_name", "websiteName"),
 				),
 			},
 			{
@@ -73,6 +78,11 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "100"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "100"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "100"),
+					resource.TestCheckResourceAttr(resourceName, "description", "web_description_2"),
+					resource.TestCheckResourceAttr(resourceName, "lb_algorithm", "round_robin"),
+					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key2", "$request_length"),
+					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key3", "$remote_addr"),
+					resource.TestCheckResourceAttr(resourceName, "website_name", "websiteNameUpdate"),
 				),
 			},
 			{
@@ -85,6 +95,7 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "180"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "3600"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "lb_algorithm", "session_hash"),
 				),
 			},
 			{
@@ -128,6 +139,7 @@ func TestAccWafDomainV1_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "website_name", ""),
 				),
 			},
 			{
@@ -309,6 +321,9 @@ resource "huaweicloud_waf_domain" "domain_1" {
   certificate_id   = huaweicloud_waf_certificate.certificate_1.id
   certificate_name = huaweicloud_waf_certificate.certificate_1.name
   proxy            = false
+  description      = "web_description_1"
+  website_name     = "websiteName"
+  lb_algorithm     = "ip_hash"
 
   custom_page {
     http_return_code = "400"
@@ -325,6 +340,11 @@ EOF
     connection_timeout = 50
     read_timeout       = 200
     write_timeout      = 200
+  }
+
+  forward_header_map = {
+    "key1" = "$time_local"
+    "key2" = "$tenant_id"
   }
 
   server {
@@ -349,11 +369,19 @@ resource "huaweicloud_waf_domain" "domain_1" {
   http2_enable     = true
   ipv6_enable      = true
   redirect_url     = "$${http_host}/error.html"
+  description      = "web_description_2"
+  lb_algorithm     = "round_robin"
+  website_name   = "websiteNameUpdate"
   
   timeout_settings {
     connection_timeout = 100
     read_timeout       = 100
     write_timeout      = 100
+  }
+
+  forward_header_map = {
+    "key2" = "$request_length"
+    "key3" = "$remote_addr"
   }
 
   server {
@@ -384,6 +412,7 @@ resource "huaweicloud_waf_domain" "domain_1" {
   certificate_name = huaweicloud_waf_certificate.certificate_1.name
   policy_id        = huaweicloud_waf_policy.policy_1.id
   proxy            = true
+  lb_algorithm     = "session_hash"
 
   timeout_settings {
     connection_timeout = 180

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
@@ -384,7 +384,7 @@ func buildCreatePremiumHostOpts(d *schema.ResourceData, cfg *config.Config, cert
 		Servers:             buildCreatePremiumHostServerOpts(d),
 		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
 		BlockPage:           buildPremiumHostBlockPageOpts(d),
-		ForwardHeaderMap:    buildPremiumHostForwardHeaderMapOpts(d),
+		ForwardHeaderMap:    buildHostForwardHeaderMapOpts(d),
 		Description:         d.Get("description").(string),
 	}
 }
@@ -421,7 +421,7 @@ func buildPremiumHostBlockPageOpts(d *schema.ResourceData) *domains.BlockPage {
 	}
 }
 
-func buildPremiumHostForwardHeaderMapOpts(d *schema.ResourceData) map[string]string {
+func buildHostForwardHeaderMapOpts(d *schema.ResourceData) map[string]string {
 	if v, ok := d.GetOk("forward_header_map"); ok {
 		return utils.ExpandToStringMap(v.(map[string]interface{}))
 	}
@@ -621,7 +621,7 @@ func updateWafDedicatedDomain(dedicatedClient *golangsdk.ServiceClient, d *schem
 	}
 
 	if d.HasChange("forward_header_map") && !d.IsNewResource() {
-		updateOpts.ForwardHeaderMap = buildPremiumHostForwardHeaderMapOpts(d)
+		updateOpts.ForwardHeaderMap = buildHostForwardHeaderMapOpts(d)
 	}
 
 	_, err := domains.Update(dedicatedClient, d.Id(), updateOpts)

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains/requests.go
@@ -91,6 +91,8 @@ type UpdateOpts struct {
 	TimeoutConfig       *TimeoutConfig    `json:"timeout_config,omitempty"`
 	ForwardHeaderMap    map[string]string `json:"forward_header_map,omitempty"`
 	EnterpriseProjectId string            `q:"enterprise_project_id" json:"-"`
+	Description         *string           `json:"description,omitempty"`
+	LbAlgorithm         *string           `json:"lb_algorithm,omitempty"`
 }
 
 // BlockPage contains the alarm page information

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b
+# github.com/chnsz/golangsdk v0.0.0-20231204022125-8e25a0c901ae
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_basic
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (151.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       151.669s
[huawei@ecs-zhangting ~/go/src/github.com/huaweicloud/terraform-provider-huaweicloud 17:25:35]$ make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withEpsID -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_withEpsID
=== PAUSE TestAccWafDomainV1_withEpsID
=== CONT  TestAccWafDomainV1_withEpsID
--- PASS: TestAccWafDomainV1_withEpsID (109.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       109.805s
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withEpsID -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_withEpsID
=== PAUSE TestAccWafDomainV1_withEpsID
=== CONT  TestAccWafDomainV1_withEpsID
--- PASS: TestAccWafDomainV1_withEpsID (109.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       109.805s
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withPolicy -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_withPolicy
=== PAUSE TestAccWafDomainV1_withPolicy
=== CONT  TestAccWafDomainV1_withPolicy
--- PASS: TestAccWafDomainV1_withPolicy (114.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       114.134s
```
