### PR TITLE
feat(DMS): add resource kafka smart connect

### DIFF
--- a/docs/resources/dms_kafka_smart_connect.md
+++ b/docs/resources/dms_kafka_smart_connect.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_kafka_smart_connect
+
+Manage DMS kafka smart connect resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_kafka_smart_connect" "test" {
+  instance_id       = var.instance_id
+  storage_spec_code = "dms.physical.storage.ultra.v2"
+  bandwidth         = "100MB"
+  node_count        = 2
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the kafka instance.
+
+  Changing this parameter will create a new resource.
+
+* `storage_spec_code` - (Required, String, ForceNew) Specifies the storage specification code of the connector.
+
+  Changing this parameter will create a new resource.
+
+* `bandwidth` - (Optional, String, ForceNew) Specifies the bandwidth of the connector.
+
+  Changing this parameter will create a new resource.
+
+* `node_count` - (Optional, Int, ForceNew) Specifies the node count of the connector. Defaults to 2 and minimum is 2.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attribute is exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The kafka smart connect can be imported using the kafka `instance_id` and `id` separated by a slash, e.g.
+
+```
+$ terraform import huaweicloud_dms_kafka_smart_connect.test <instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -886,6 +886,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_instance":       dms.ResourceDmsKafkaInstance(),
 			"huaweicloud_dms_kafka_topic":          dms.ResourceDmsKafkaTopic(),
 			"huaweicloud_dms_kafka_consumer_group": dms.ResourceDmsKafkaConsumerGroup(),
+			"huaweicloud_dms_kafka_smart_connect":  dms.ResourceDmsKafkaSmartConnect(),
 
 			"huaweicloud_dms_rabbitmq_instance": dms.ResourceDmsRabbitmqInstance(),
 

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_smart_connect_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_smart_connect_test.go
@@ -1,0 +1,119 @@
+package dms
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDmsKafkaSmartConnectResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getKafkaSmartConnect: query DMS kafka smart connect
+	var (
+		getKafkaSmartConnectHttpUrl = "v2/{project_id}/instances/{instance_id}"
+		getKafkaSmartConnectProduct = "dms"
+	)
+	getKafkaSmartConnectClient, err := cfg.NewServiceClient(getKafkaSmartConnectProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS Client: %s", err)
+	}
+
+	instanceID := state.Primary.Attributes["instance_id"]
+	getKafkaSmartConnectPath := getKafkaSmartConnectClient.Endpoint + getKafkaSmartConnectHttpUrl
+	getKafkaSmartConnectPath = strings.ReplaceAll(getKafkaSmartConnectPath, "{project_id}",
+		getKafkaSmartConnectClient.ProjectID)
+	getKafkaSmartConnectPath = strings.ReplaceAll(getKafkaSmartConnectPath, "{instance_id}", instanceID)
+
+	getKafkaSmartConnectOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getKafkaSmartConnectResp, err := getKafkaSmartConnectClient.Request("GET", getKafkaSmartConnectPath,
+		&getKafkaSmartConnectOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DMS kafka smart connect: %s", err)
+	}
+
+	getKafkaSmartConnectRespBody, err := utils.FlattenResponse(getKafkaSmartConnectResp)
+	if err != nil {
+		return nil, err
+	}
+	connectorId := utils.PathSearch("connector_id", getKafkaSmartConnectRespBody, nil)
+	if connectorId != state.Primary.ID {
+		return nil, fmt.Errorf("error retrieving DMS kafka smart connect: the connector can not be found")
+	}
+	return getKafkaSmartConnectRespBody, nil
+}
+
+func TestAccDmsKafkaSmartConnect_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_kafka_smart_connect.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDmsKafkaSmartConnectResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsKafkaSmartConnect_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "storage_spec_code"),
+					resource.TestCheckResourceAttrSet(resourceName, "bandwidth"),
+					resource.TestCheckResourceAttrSet(resourceName, "node_count"),
+					resource.TestCheckResourceAttr(resourceName, "storage_spec_code", "dms.physical.storage.high.v2"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth", "100MB"),
+					resource.TestCheckResourceAttr(resourceName, "node_count", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"storage_spec_code", "bandwidth", "node_count"},
+				ImportStateIdFunc:       testKafkaSmartConnectResourceImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testDmsKafkaSmartConnect_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_smart_connect" "test" {
+  instance_id       = huaweicloud_dms_kafka_instance.test.id
+  storage_spec_code = "dms.physical.storage.high.v2"
+  node_count        = 2
+  bandwidth         = "100MB"
+}
+`, testAccKafkaInstance_newFormat(name))
+}
+
+// testKafkaSmartConnectResourceImportState is used to return an import id with format <instance_id>/<id>
+func testKafkaSmartConnectResourceImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		instance_id := rs.Primary.Attributes["instance_id"]
+		return fmt.Sprintf("%s/%s", instance_id, rs.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_smart_connect.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_smart_connect.go
@@ -1,0 +1,283 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDmsKafkaSmartConnect() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsKafkaSmartConnectCreate,
+		ReadContext:   resourceDmsKafkaSmartConnectRead,
+		DeleteContext: resourceDmsKafkaSmartConnectDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDmsKafkaSmartConnectImportState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(50 * time.Minute),
+			Delete: schema.DefaultTimeout(50 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the Kafka instance.`,
+			},
+			"storage_spec_code": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the specification code of the smart connect.`,
+			},
+			"bandwidth": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the bandwidth of the smart connect.`,
+			},
+			"node_count": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the node count of the smart connect.`,
+			},
+		},
+	}
+}
+
+func resourceDmsKafkaSmartConnectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	// createKafkaSmartConnect: create DMS kafka smart connect
+	var (
+		createKafkaSmartConnectHttpUrl = "v2/{project_id}/instances/{instance_id}/connector"
+		createKafkaSmartConnectProduct = "dmsv2"
+	)
+	createKafkaSmartConnectClient, err := cfg.NewServiceClient(createKafkaSmartConnectProduct, region)
+
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	createKafkaSmartConnectPath := createKafkaSmartConnectClient.Endpoint + createKafkaSmartConnectHttpUrl
+	createKafkaSmartConnectPath = strings.ReplaceAll(createKafkaSmartConnectPath, "{project_id}",
+		createKafkaSmartConnectClient.ProjectID)
+	createKafkaSmartConnectPath = strings.ReplaceAll(createKafkaSmartConnectPath, "{instance_id}", instanceID)
+
+	createKafkaSmartConnectOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createKafkaSmartConnectOpt.JSONBody = utils.RemoveNil(buildCreateKafkaSmartConnectBodyParams(d))
+
+	// create kafka smart connect is allowd only when the instance status is RUNNING.
+	retryFunc := func() (interface{}, bool, error) {
+		createKafkaSmartConnectResp, createErr := createKafkaSmartConnectClient.Request("POST",
+			createKafkaSmartConnectPath, &createKafkaSmartConnectOpt)
+		retry, err := handleMultiOperationsError(createErr)
+		return createKafkaSmartConnectResp, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     KafkaInstanceStateRefreshFunc(createKafkaSmartConnectClient, instanceID),
+		WaitTarget:   []string{"RUNNING"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+
+	if err != nil {
+		return diag.Errorf("error creating DMS kafka smart connect: %v", err)
+	}
+
+	kafkaSmartConnectRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	connectorId := utils.PathSearch("connector_id", kafkaSmartConnectRespBody, nil)
+	d.SetId(connectorId.(string))
+
+	// enable smart connect, need to wait for the instance status to be RUNNING so that the job could be completed.
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"EXTENDING"},
+		Target:       []string{"RUNNING"},
+		Refresh:      KafkaInstanceStateRefreshFunc(createKafkaSmartConnectClient, instanceID),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for instance (%s) to become ready: %s", instanceID, err)
+	}
+
+	return resourceDmsKafkaSmartConnectRead(ctx, d, meta)
+}
+
+func buildCreateKafkaSmartConnectBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"spec_code":     d.Get("storage_spec_code"),
+		"specification": d.Get("bandwidth"),
+		"node_cnt":      utils.ValueIngoreEmpty(d.Get("node_count")),
+	}
+	return bodyParams
+}
+
+func resourceDmsKafkaSmartConnectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getKafkaSmartConnect: query DMS kafka smart connect
+	var (
+		getKafkaSmartConnectHttpUrl = "v2/{project_id}/instances/{instance_id}"
+		getKafkaSmartConnectProduct = "dms"
+	)
+	getKafkaSmartConnectClient, err := cfg.NewServiceClient(getKafkaSmartConnectProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	getKafkaSmartConnectPath := getKafkaSmartConnectClient.Endpoint + getKafkaSmartConnectHttpUrl
+	getKafkaSmartConnectPath = strings.ReplaceAll(getKafkaSmartConnectPath, "{project_id}",
+		getKafkaSmartConnectClient.ProjectID)
+	getKafkaSmartConnectPath = strings.ReplaceAll(getKafkaSmartConnectPath, "{instance_id}", instanceID)
+
+	getKafkaSmartConnectOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getKafkaSmartConnectResp, err := getKafkaSmartConnectClient.Request("GET", getKafkaSmartConnectPath,
+		&getKafkaSmartConnectOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DMS kafka smart connect")
+	}
+
+	getKafkaSmartConnectRespBody, respBodyerr := utils.FlattenResponse(getKafkaSmartConnectResp)
+	if respBodyerr != nil {
+		return diag.FromErr(respBodyerr)
+	}
+
+	connectorId := utils.PathSearch("connector_id", getKafkaSmartConnectRespBody, nil)
+	if connectorId != d.Id() {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", instanceID),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDmsKafkaSmartConnectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteKafkaSmartConnect: delete DMS kafka smart connect
+	var (
+		deleteKafkaSmartConnectHttpUrl = "v2/{project_id}/kafka/instances/{instance_id}/delete-connector"
+		deleteKafkaSmartConnectProduct = "dmsv2"
+	)
+	deleteKafkaSmartConnectClient, err := cfg.NewServiceClient(deleteKafkaSmartConnectProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	deleteKafkaSmartConnectPath := deleteKafkaSmartConnectClient.Endpoint + deleteKafkaSmartConnectHttpUrl
+	deleteKafkaSmartConnectPath = strings.ReplaceAll(deleteKafkaSmartConnectPath, "{project_id}",
+		deleteKafkaSmartConnectClient.ProjectID)
+	deleteKafkaSmartConnectPath = strings.ReplaceAll(deleteKafkaSmartConnectPath, "{instance_id}", instanceID)
+
+	deleteKafkaSmartConnectOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	deleteKafkaSmartConnectOpt.JSONBody = utils.RemoveNil(buildDeleteKafkaSmartConnectBodyParams(d))
+
+	// delete kafka smart connect is allowd only when the instance status is RUNNING.
+	retryFunc := func() (interface{}, bool, error) {
+		deleteKafkaSmartConnectResp, deleteErr := deleteKafkaSmartConnectClient.Request("POST",
+			deleteKafkaSmartConnectPath, &deleteKafkaSmartConnectOpt)
+		retry, err := handleMultiOperationsError(deleteErr)
+		return deleteKafkaSmartConnectResp, retry, err
+	}
+	_, retryErr := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     KafkaInstanceStateRefreshFunc(deleteKafkaSmartConnectClient, instanceID),
+		WaitTarget:   []string{"RUNNING"},
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		DelayTimeout: 1 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+
+	if retryErr != nil {
+		return diag.Errorf("error deleting DMS kafka smart connect: %v", err)
+	}
+
+	// delete smart connect, need to wait for the instance status to be RUNNING so that the job could be completed.
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"CONNECTOR_DELETING"},
+		Target:       []string{"RUNNING"},
+		Refresh:      KafkaInstanceStateRefreshFunc(deleteKafkaSmartConnectClient, instanceID),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for instance (%s) to become ready: %s", instanceID, err)
+	}
+
+	return resourceDmsKafkaSmartConnectRead(ctx, d, meta)
+}
+
+func buildDeleteKafkaSmartConnectBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"instance_id": d.Get("instance_id"),
+	}
+	return bodyParams
+}
+
+// resourceDmsKafkaSmartConnectImportState is used to import an id with format <instance_id>/<id>
+func resourceDmsKafkaSmartConnectImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import id, must be <instance_id>/<id>")
+	}
+	d.Set("instance_id", parts[0])
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   add resource kafka smart connect
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccDmsKafkaSmartConnect_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsKafkaSmartConnect_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaSmartConnect_basic
=== PAUSE TestAccDmsKafkaSmartConnect_basic
=== CONT  TestAccDmsKafkaSmartConnect_basic
--- PASS: TestAccDmsKafkaSmartConnect_basic (1222.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1222.942s
```
