### PR TITLE
fix(waf): waf domain supports fields:server.type,server.weight,cipher,tls,pci_3ds,pci_dss,traffic_mark

### DIFF
--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -43,6 +43,13 @@ resource "huaweicloud_waf_domain" "domain_1" {
   certificate_name      = huaweicloud_waf_certificate.certificate_1.name
   proxy                 = true
   enterprise_project_id = var.enterprise_project_id
+  description           = "test description"
+  website_name          = "websiteName"
+  
+  forward_header_map = {
+    "key1" = "$time_local"
+    "key2" = "$tenant_id"
+  }
 
   custom_page {
     http_return_code = "404"
@@ -127,6 +134,46 @@ The following arguments are supported:
   Enable IPv6 protection if the domain name is accessible using an IPv6 address.
   After you enable it, WAF assigns an IPv6 address to the domain name.
   Defaults to **false**.
+
+* `website_name` - (Optional, String) Specifies the website name.
+  This website name must start with a letter and only letters, digits, underscores (_),
+  hyphens (-), colons (:) and periods (.) are allowed.
+  The value contains 1 to 128 characters.
+  The website name must be unique within this account.
+
+* `description` - (Optional, String) Specifies the description of the WAF domain.
+
+* `lb_algorithm` - (Optional, String) Specifies the load balancing algorithms used to
+  distribute requests across origin servers.
+  Only the professional edition (original enterprise edition) and platinum edition
+  (original ultimate edition) support configuring the load balancing algorithm.
+  The options of value are as follows:
+  + **ip_hash** : Requests from the same IP address are routed to the same backend server.
+  + **round_robin** : Requests are distributed across backend servers in turn based on the
+  weight you assign to each server.
+  + **session_hash** : Direct requests with the same session ID to the same origin server.
+  Before using this configuration, please make sure to configure the traffic identifier for
+  attack punishment after adding the domain name, otherwise the session hash configuration will not take effect.
+
+* `forward_header_map` - (Optional, Map) Specifies the field forwarding configuration. WAF inserts the added fields into
+  the header and forwards the header to the origin server. The key cannot be the same as the native Nginx field.
+  The options of value are as follows:
+  + **$time_local**
+  + **$request_id**
+  + **$connection_requests**
+  + **$tenant_id**
+  + **$project_id**
+  + **$remote_addr**
+  + **$remote_port**
+  + **$scheme**
+  + **$request_method**
+  + **$http_host**
+  + **$origin_uri**
+  + **$request_length**
+  + **$ssl_server_name**
+  + **$ssl_protocol**
+  + **$ssl_curves**
+  + **$ssl_session_reused**
 
 * `timeout_settings` - (Optional, List) Specifies the timeout setting. Only supports one timeout setting.
   The [timeout_settings](#Domain_timeout_settings) structure is documented below.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b
+	github.com/chnsz/golangsdk v0.0.0-20231204022125-8e25a0c901ae
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b h1:HdQqladAqLkzzRkx435FF5LhmTN6fepC5OwOqHmta00=
-github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231204022125-8e25a0c901ae h1:SA8zkij1YE8hfwtDHOXcSDSU2bQqehHRC/IqeijvA5E=
+github.com/chnsz/golangsdk v0.0.0-20231204022125-8e25a0c901ae/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -57,6 +57,11 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "50"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "200"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "200"),
+					resource.TestCheckResourceAttr(resourceName, "description", "web_description_1"),
+					resource.TestCheckResourceAttr(resourceName, "lb_algorithm", "ip_hash"),
+					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key1", "$time_local"),
+					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key2", "$tenant_id"),
+					resource.TestCheckResourceAttr(resourceName, "website_name", "websiteName"),
 				),
 			},
 			{
@@ -73,6 +78,11 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "100"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "100"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "100"),
+					resource.TestCheckResourceAttr(resourceName, "description", "web_description_2"),
+					resource.TestCheckResourceAttr(resourceName, "lb_algorithm", "round_robin"),
+					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key2", "$request_length"),
+					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key3", "$remote_addr"),
+					resource.TestCheckResourceAttr(resourceName, "website_name", "websiteNameUpdate"),
 				),
 			},
 			{
@@ -85,6 +95,7 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.connection_timeout", "180"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.read_timeout", "3600"),
 					resource.TestCheckResourceAttr(resourceName, "timeout_settings.0.write_timeout", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "lb_algorithm", "session_hash"),
 				),
 			},
 			{
@@ -128,6 +139,7 @@ func TestAccWafDomainV1_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "website_name", ""),
 				),
 			},
 			{
@@ -309,6 +321,9 @@ resource "huaweicloud_waf_domain" "domain_1" {
   certificate_id   = huaweicloud_waf_certificate.certificate_1.id
   certificate_name = huaweicloud_waf_certificate.certificate_1.name
   proxy            = false
+  description      = "web_description_1"
+  website_name     = "websiteName"
+  lb_algorithm     = "ip_hash"
 
   custom_page {
     http_return_code = "400"
@@ -325,6 +340,11 @@ EOF
     connection_timeout = 50
     read_timeout       = 200
     write_timeout      = 200
+  }
+
+  forward_header_map = {
+    "key1" = "$time_local"
+    "key2" = "$tenant_id"
   }
 
   server {
@@ -349,11 +369,19 @@ resource "huaweicloud_waf_domain" "domain_1" {
   http2_enable     = true
   ipv6_enable      = true
   redirect_url     = "$${http_host}/error.html"
+  description      = "web_description_2"
+  lb_algorithm     = "round_robin"
+  website_name   = "websiteNameUpdate"
   
   timeout_settings {
     connection_timeout = 100
     read_timeout       = 100
     write_timeout      = 100
+  }
+
+  forward_header_map = {
+    "key2" = "$request_length"
+    "key3" = "$remote_addr"
   }
 
   server {
@@ -384,6 +412,7 @@ resource "huaweicloud_waf_domain" "domain_1" {
   certificate_name = huaweicloud_waf_certificate.certificate_1.name
   policy_id        = huaweicloud_waf_policy.policy_1.id
   proxy            = true
+  lb_algorithm     = "session_hash"
 
   timeout_settings {
     connection_timeout = 180

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -2,6 +2,7 @@ package waf
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -50,6 +51,8 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "1"),
 					resource.TestCheckResourceAttr(resourceName, "http2_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "custom_page.0.http_return_code", "400"),
 					resource.TestCheckResourceAttr(resourceName, "custom_page.0.block_page_type", "application/json"),
@@ -65,12 +68,24 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 				),
 			},
 			{
+				Config:      testAccWafDomainV1_withIpv6Enable(randName, domainName),
+				ExpectError: regexp.MustCompile(`when type in server contains ipv6`),
+			},
+			{
 				Config: testAccWafDomainV1_update1(randName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv6"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.0"),
+					resource.TestCheckResourceAttr(resourceName, "cipher", "cipher_1"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.0", "ip_tag"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.1", "$remote_addr"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.session_tag", "session_tag"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.user_tag", "user_tag"),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
 					resource.TestCheckResourceAttr(resourceName, "http2_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_enable", "true"),
@@ -82,13 +97,23 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "lb_algorithm", "round_robin"),
 					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key2", "$request_length"),
 					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key3", "$remote_addr"),
-					resource.TestCheckResourceAttr(resourceName, "website_name", "websiteNameUpdate"),
+					resource.TestCheckResourceAttr(resourceName, "website_name", "newname"),
 				),
 			},
 			{
 				Config: testAccWafDomainV1_update2(randName, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tls", "TLS v1.2"),
+					resource.TestCheckResourceAttr(resourceName, "cipher", "cipher_2"),
+					resource.TestCheckResourceAttr(resourceName, "pci_3ds", "true"),
+					resource.TestCheckResourceAttr(resourceName, "pci_dss", "true"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.0", "ip_tag_update"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.ip_tags.1", "ip_tag_another"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.session_tag", "session_tag_update"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_mark.0.user_tag", "user_tag_update"),
 					resource.TestCheckResourceAttrPair(resourceName, "policy_id", "huaweicloud_waf_policy.policy_1", "id"),
 					resource.TestCheckResourceAttr(resourceName, "custom_page.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "redirect_url", ""),
@@ -136,9 +161,12 @@ func TestAccWafDomainV1_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "domain", domainName),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv6"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "1"),
 					resource.TestCheckResourceAttr(resourceName, "website_name", ""),
 				),
 			},
@@ -149,6 +177,8 @@ func TestAccWafDomainV1_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "3"),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
 				),
 			},
@@ -192,6 +222,8 @@ func TestAccWafDomainV1_withPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.weight", "3"),
 					resource.TestCheckResourceAttrPair(resourceName, "policy_id", "huaweicloud_waf_policy.policy_1", "id"),
 				),
 			},
@@ -258,7 +290,7 @@ GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
 MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
 HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
 AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
-z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8Orcllsjns92XITVDpFW0ThGyjhT
 ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
 Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
 JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
@@ -352,6 +384,7 @@ EOF
     server_protocol = "HTTP"
     address         = "119.8.0.14"
     port            = 8080
+	type            = "ipv4"
   }
 }
 `, testAccWafDomainV1_base(randName), domainName)
@@ -371,7 +404,9 @@ resource "huaweicloud_waf_domain" "domain_1" {
   redirect_url     = "$${http_host}/error.html"
   description      = "web_description_2"
   lb_algorithm     = "round_robin"
-  website_name   = "websiteNameUpdate"
+  website_name     = "newname"
+  tls              = "TLS v1.0"
+  cipher           = "cipher_1"
   
   timeout_settings {
     connection_timeout = 100
@@ -384,11 +419,19 @@ resource "huaweicloud_waf_domain" "domain_1" {
     "key3" = "$remote_addr"
   }
 
+  traffic_mark {
+    ip_tags     = ["ip_tag", "$remote_addr"]
+    session_tag = "session_tag"
+    user_tag    = "user_tag"
+  }
+
   server {
     client_protocol = "HTTPS"
     server_protocol = "HTTP"
-    address         = "119.8.0.14"
+    address         = "3ffe:1900:fe21:4545:0000:0000:0000:0000"
     port            = 8443
+	type            = "ipv6"
+	weight          = 2
   }
 }
 `, testAccWafDomainV1_base(randName), domainName)
@@ -413,6 +456,10 @@ resource "huaweicloud_waf_domain" "domain_1" {
   policy_id        = huaweicloud_waf_policy.policy_1.id
   proxy            = true
   lb_algorithm     = "session_hash"
+  tls              = "TLS v1.2"
+  cipher           = "cipher_2"
+  pci_3ds          = "true"
+  pci_dss          = "true"
 
   timeout_settings {
     connection_timeout = 180
@@ -420,11 +467,68 @@ resource "huaweicloud_waf_domain" "domain_1" {
     write_timeout      = 3600
   }
 
+  traffic_mark {
+    ip_tags     = ["ip_tag_update", "ip_tag_another"]
+    session_tag = "session_tag_update"
+    user_tag    = "user_tag_update"
+  }
+
   server {
     client_protocol = "HTTPS"
     server_protocol = "HTTP"
     address         = "119.8.0.14"
     port            = 8443
+	type            = "ipv4"
+	weight          = 3
+  }
+}
+`, testAccWafDomainV1_base(randName), domainName)
+}
+
+func testAccWafDomainV1_withIpv6Enable(randName, domainName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_waf_policy" "policy_1" {
+  name = "%[2]s"
+
+  depends_on = [
+    huaweicloud_waf_cloud_instance.test
+  ]
+}
+
+resource "huaweicloud_waf_domain" "domain_1" {
+  domain           = "%[2]s"
+  certificate_id   = huaweicloud_waf_certificate.certificate_1.id
+  certificate_name = huaweicloud_waf_certificate.certificate_1.name
+  policy_id        = huaweicloud_waf_policy.policy_1.id
+  proxy            = true
+  ipv6_enable      = false
+  lb_algorithm     = "session_hash"
+  tls              = "TLS v1.2"
+  cipher           = "cipher_2"
+  pci_3ds          = "true"
+  pci_dss          = "true"
+
+  timeout_settings {
+    connection_timeout = 180
+    read_timeout       = 3600
+    write_timeout      = 3600
+  }
+
+  traffic_mark {
+    ip_tags     = ["ip_tag_update", "ip_tag_another"]
+    session_tag = "session_tag_update"
+    user_tag    = "user_tag_update"
+  }
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "3ffe:1900:fe21:4545:0000:0000:0000:0000"
+    port            = 8443
+    type            = "ipv6"
+    weight          = 3
   }
 }
 `, testAccWafDomainV1_base(randName), domainName)
@@ -455,6 +559,8 @@ resource "huaweicloud_waf_domain" "domain_1" {
     server_protocol = "HTTP"
     address         = "119.8.0.14"
     port            = 8080
+	type            = "ipv4"
+	weight          = 3
   }
 }
 `, testAccWafDomainV1_base(randName), randName, domainName)
@@ -499,7 +605,7 @@ MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
 HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
 AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
 z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
-ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+ZdELj9LsbIcVzNPPclTjkbZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
 Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
 JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
 QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
@@ -564,12 +670,15 @@ resource "huaweicloud_waf_domain" "domain_1" {
   proxy                 = false
   keep_policy           = false
   enterprise_project_id = "%s"
+  ipv6_enable           = true
 
   server {
     client_protocol = "HTTPS"
     server_protocol = "HTTP"
-    address         = "119.8.0.14"
+    address         = "3ffe:1900:fe21:4545:0000:0000:0000:0000"
     port            = 8080
+	type            = "ipv6"
+	weight          = 1
   }
 }
 `, testAccWafDomainV1_base_withEpsID(randName, epsID), domainName, epsID)
@@ -592,6 +701,8 @@ resource "huaweicloud_waf_domain" "domain_1" {
     server_protocol = "HTTP"
     address         = "119.8.0.14"
     port            = 8443
+	type            = "ipv4"
+	weight          = 3
   }
 }
 `, testAccWafDomainV1_base_withEpsID(randName, epsID), domainName, epsID)

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
@@ -384,7 +384,7 @@ func buildCreatePremiumHostOpts(d *schema.ResourceData, cfg *config.Config, cert
 		Servers:             buildCreatePremiumHostServerOpts(d),
 		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
 		BlockPage:           buildPremiumHostBlockPageOpts(d),
-		ForwardHeaderMap:    buildPremiumHostForwardHeaderMapOpts(d),
+		ForwardHeaderMap:    buildHostForwardHeaderMapOpts(d),
 		Description:         d.Get("description").(string),
 	}
 }
@@ -421,7 +421,7 @@ func buildPremiumHostBlockPageOpts(d *schema.ResourceData) *domains.BlockPage {
 	}
 }
 
-func buildPremiumHostForwardHeaderMapOpts(d *schema.ResourceData) map[string]string {
+func buildHostForwardHeaderMapOpts(d *schema.ResourceData) map[string]string {
 	if v, ok := d.GetOk("forward_header_map"); ok {
 		return utils.ExpandToStringMap(v.(map[string]interface{}))
 	}
@@ -621,7 +621,7 @@ func updateWafDedicatedDomain(dedicatedClient *golangsdk.ServiceClient, d *schem
 	}
 
 	if d.HasChange("forward_header_map") && !d.IsNewResource() {
-		updateOpts.ForwardHeaderMap = buildPremiumHostForwardHeaderMapOpts(d)
+		updateOpts.ForwardHeaderMap = buildHostForwardHeaderMapOpts(d)
 	}
 
 	_, err := domains.Update(dedicatedClient, d.Id(), updateOpts)

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
@@ -3,6 +3,7 @@ package waf
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -102,6 +103,35 @@ func ResourceWafDomain() *schema.Resource {
 					"custom_page",
 				},
 			},
+			"pci_3ds": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"tls", "cipher"},
+			},
+			"pci_dss": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"tls", "cipher"},
+			},
+			"tls": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cipher": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"traffic_mark": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem:     dedicatedDomainTrafficMarkSchema(),
+			},
 			"website_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -184,6 +214,15 @@ func domainServerSchema() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 65535),
 				Required:     true,
 			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"weight": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+			},
 		},
 	}
 	return &sc
@@ -217,6 +256,8 @@ func buildWafDomainServers(d *schema.ResourceData) []domains.ServerOpts {
 			BackProtocol:  server["server_protocol"].(string),
 			Address:       server["address"].(string),
 			Port:          server["port"].(int),
+			Type:          server["type"].(string),
+			Weight:        server["weight"].(int),
 		}
 	}
 
@@ -231,6 +272,8 @@ func flattenDomainServerAttrs(dm *domains.Domain) []map[string]interface{} {
 			"server_protocol": server.BackProtocol,
 			"address":         server.Address,
 			"port":            server.Port,
+			"type":            server.Type,
+			"weight":          server.Weight,
 		}
 	}
 	return servers
@@ -258,6 +301,28 @@ func flattenDomainTimeoutSetting(dm *domains.Domain) []map[string]interface{} {
 			"connection_timeout": timeoutConfig.ConnectTimeout,
 			"read_timeout":       timeoutConfig.ReadTimeout,
 			"write_timeout":      timeoutConfig.SendTimeout,
+		},
+	}
+}
+
+func flattenDomainComplianceCertificationAttrs(dm *domains.Domain) map[string]interface{} {
+	f := dm.Flag
+
+	pciDss, _ := strconv.ParseBool(f.PciDss)
+	pci3ds, _ := strconv.ParseBool(f.Pci3ds)
+	return map[string]interface{}{
+		"pci_dss": pciDss,
+		"pci_3ds": pci3ds,
+	}
+}
+
+func flattenDomainTrafficMark(dm *domains.Domain) []map[string]interface{} {
+	trafficMark := dm.TrafficMark
+	return []map[string]interface{}{
+		{
+			"ip_tags":     trafficMark.Sip,
+			"session_tag": trafficMark.Cookie,
+			"user_tag":    trafficMark.Params,
 		},
 	}
 }
@@ -316,7 +381,56 @@ func buildUpdateDomainTimeoutSettingOpts(d *schema.ResourceData) *domains.Timeou
 	return nil
 }
 
+func buildDomainHostFlag(d *schema.ResourceData) (*domains.Flag, error) {
+	pci3ds := d.Get("pci_3ds").(bool)
+	pciDss := d.Get("pci_dss").(bool)
+	if !pci3ds && !pciDss {
+		return nil, nil
+	}
+
+	// required tls="TLS v1.2" && cipher="cipher_2"
+	if d.Get("tls").(string) != "TLS v1.2" || d.Get("cipher").(string) != "cipher_2" {
+		return nil, fmt.Errorf("pci_3ds and pci_dss must be used together with tls and cipher. " +
+			"Tls must be set to TLS v1.2, and cipher must be set to cipher_2")
+	}
+	return &domains.Flag{
+		Pci3ds: strconv.FormatBool(pci3ds),
+		PciDss: strconv.FormatBool(pciDss),
+	}, nil
+}
+
+func updatePremiumHostTrafficMarkOpts(d *schema.ResourceData) *domains.TrafficMark {
+	if v, ok := d.GetOk("traffic_mark"); ok {
+		rawArray, isArray := v.([]interface{})
+		if !isArray || len(rawArray) == 0 {
+			return nil
+		}
+
+		raw, isMap := rawArray[0].(map[string]interface{})
+		if !isMap {
+			return nil
+		}
+
+		return &domains.TrafficMark{
+			Sip:    utils.ExpandToStringList(raw["ip_tags"].([]interface{})),
+			Cookie: raw["session_tag"].(string),
+			Params: raw["user_tag"].(string),
+		}
+	}
+	return nil
+}
+
 func updateWafDomain(wafClient *golangsdk.ServiceClient, d *schema.ResourceData, cfg *config.Config) error {
+	// check is ipv6_enable valid
+	servers := buildWafDomainServers(d)
+	ipv6_enable := d.Get("ipv6_enable").(bool)
+	for _, server := range servers {
+		if server.Type == "ipv6" && !ipv6_enable {
+			diag.Errorf("ipv6cuowu")
+			return fmt.Errorf("when type in server contains ipv6, `ipv6_enable` should be true")
+		}
+	}
+
 	updateOpts := domains.UpdateOpts{
 		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 	}
@@ -325,9 +439,9 @@ func updateWafDomain(wafClient *golangsdk.ServiceClient, d *schema.ResourceData,
 	if d.HasChanges("certificate_id", "server", "proxy", "ipv6_enable") {
 		updateOpts.CertificateId = d.Get("certificate_id").(string)
 		updateOpts.CertificateName = d.Get("certificate_name").(string)
-		updateOpts.Servers = buildWafDomainServers(d)
+		updateOpts.Servers = servers
 		updateOpts.Proxy = utils.Bool(d.Get("proxy").(bool))
-		updateOpts.Ipv6Enable = utils.Bool(d.Get("ipv6_enable").(bool))
+		updateOpts.Ipv6Enable = utils.Bool(ipv6_enable)
 	}
 
 	if d.HasChanges("custom_page", "redirect_url") {
@@ -356,6 +470,23 @@ func updateWafDomain(wafClient *golangsdk.ServiceClient, d *schema.ResourceData,
 
 	if d.HasChange("website_name") && !d.IsNewResource() {
 		updateOpts.WebTag = utils.String(d.Get("website_name").(string))
+	}
+
+	if d.HasChanges("tls", "cipher", "pci_3ds", "pci_dss") {
+		updateOpts.Tls = d.Get("tls").(string)
+		updateOpts.Cipher = d.Get("cipher").(string)
+		// `pci_3ds` and `pci_dss` must be used together with `tls` and `cipher`.
+		if d.HasChanges("pci_3ds", "pci_dss") {
+			flag, err := buildDomainHostFlag(d)
+			if err != nil {
+				return err
+			}
+			updateOpts.Flag = flag
+		}
+	}
+
+	if d.HasChange("traffic_mark") {
+		updateOpts.TrafficMark = updatePremiumHostTrafficMarkOpts(d)
 	}
 
 	if _, err := domains.Update(wafClient, d.Id(), updateOpts).Extract(); err != nil {
@@ -419,7 +550,18 @@ func resourceWafDomainRead(_ context.Context, d *schema.ResourceData, meta inter
 		d.Set("forward_header_map", dm.ForwardHeaderMap),
 		d.Set("lb_algorithm", dm.LbAlgorithm),
 		d.Set("website_name", dm.WebTag),
+		d.Set("cipher", dm.Cipher),
+		d.Set("tls", dm.Tls),
+		d.Set("traffic_mark", flattenDomainTrafficMark(dm)),
 	)
+
+	if dm.Flag.Pci3ds != "" {
+		mErr = multierror.Append(mErr, d.Set("pci_3ds", utils.StringToBool(dm.Flag.Pci3ds)))
+	}
+
+	if dm.Flag.PciDss != "" {
+		mErr = multierror.Append(mErr, d.Set("pci_dss", utils.StringToBool(dm.Flag.PciDss)))
+	}
 
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error setting WAF domain fields: %s", err)

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains/requests.go
@@ -91,6 +91,8 @@ type UpdateOpts struct {
 	TimeoutConfig       *TimeoutConfig    `json:"timeout_config,omitempty"`
 	ForwardHeaderMap    map[string]string `json:"forward_header_map,omitempty"`
 	EnterpriseProjectId string            `q:"enterprise_project_id" json:"-"`
+	Description         *string           `json:"description,omitempty"`
+	LbAlgorithm         *string           `json:"lb_algorithm,omitempty"`
 }
 
 // BlockPage contains the alarm page information

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231130115815-5d9e3e666b0b
+# github.com/chnsz/golangsdk v0.0.0-20231204022125-8e25a0c901ae
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_basic
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (167.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       167.845s
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withPolicy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withPolicy -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_withPolicy
=== PAUSE TestAccWafDomainV1_withPolicy
=== CONT  TestAccWafDomainV1_withPolicy
--- PASS: TestAccWafDomainV1_withPolicy (112.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       113.065s
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_withEpsID'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_withEpsID -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_withEpsID
=== PAUSE TestAccWafDomainV1_withEpsID
=== CONT  TestAccWafDomainV1_withEpsID
--- PASS: TestAccWafDomainV1_withEpsID (118.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       118.419s
```
