### PR TITLE
fix(workspace/desktop): raise error if security groups not found

### DIFF
--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
@@ -407,7 +407,6 @@ func resourceDesktopRead(_ context.Context, d *schema.ResourceData, meta interfa
 		d.Set("root_volume", flattenDesktopRootVolume(resp.RootVolume)),
 		d.Set("data_volume", flattenDesktopDataVolumes(resp.DataVolumes)),
 		d.Set("availability_zone", resp.AvailabilityZone),
-		d.Set("security_groups", flattenDesktopSecurityGroups(resp.SecurityGroups)),
 		d.Set("user_group", resp.UserGroup),
 		d.Set("name", resp.Name),
 		d.Set("tags", utils.TagsToMap(resp.Tags)),
@@ -418,6 +417,13 @@ func resourceDesktopRead(_ context.Context, d *schema.ResourceData, meta interfa
 		mErr = multierror.Append(mErr, d.Set("image_id", imageId))
 	} else {
 		mErr = multierror.Append(mErr, fmt.Errorf("the image_id field does not found in metadata structure"))
+	}
+
+	securityGroups := resp.SecurityGroups
+	if len(securityGroups) < 1 {
+		mErr = multierror.Append(mErr, fmt.Errorf("the security_groups field does not found in API response"))
+	} else {
+		mErr = multierror.Append(mErr, d.Set("security_groups", flattenDesktopSecurityGroups(securityGroups)))
 	}
 
 	if err = mErr.ErrorOrNil(); err != nil {


### PR DESCRIPTION
This is a temporary solution for the issue that api response sometimes not include security groups information.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/workspace/ TESTARGS='-run=TestAccDesktop_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace/ -v -run=TestAccDesktop_basic -timeout 360m -parallel 4
=== RUN   TestAccDesktop_basic
=== PAUSE TestAccDesktop_basic
=== CONT  TestAccDesktop_basic
--- PASS: TestAccDesktop_basic (1314.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1314.739s

```
