### PR TITLE
feat(dataarts): add resource dataarts studio directory

### DIFF
--- a/docs/resources/dataarts_studio_directory.md
+++ b/docs/resources/dataarts_studio_directory.md
@@ -1,0 +1,75 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_studio_directory
+
+Manages DataArts Studio directory resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "name" {}
+variable "directory_id" {}
+
+resource "huaweicloud_dataarts_studio_directory" "test-root" {
+  workspace_id = var.workspace_id
+  name         = var.name
+  type         = "STANDARD_ELEMENT"
+}
+
+resource "huaweicloud_dataarts_studio_directory" "test-sub" {
+  workspace_id = var.workspace_id
+  name         = var.name
+  type         = "STANDARD_ELEMENT"
+  parent_id    = var.directory_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the directory.
+  Changing this creates a new directory.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID which the directory in.
+  Changing this creates a new directory
+
+* `name` - (Required, String) Specifies the directory name.
+
+* `type` - (Required, String) Specifies the directory type. The valid values are **STANDARD_ELEMENT** and **CODE**.
+
+* `description` - (Optional, String) Specifies the description of directory.
+
+* `parent_id` - (Optional, String) Specifies the parent ID of the directory.
+  It's **Required** when you created a subordinate directory.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `root_id` - The root directory ID.
+
+* `qualified_name` - The directory path. Format is `<root_directory_name>.<sub_directory_name1>.<sub_directory_name2>...`
+
+* `created_at` - The create time of the directory.
+
+* `updated_at` - The update time of the directory.
+
+* `created_by` - The person creating the directory.
+
+* `updated_by` - The person updating the directory.
+
+* `children` - The name list of sub-directory.
+
+## Import
+
+DataArts Studio directory can be imported using `<workspace_id>/<type>/<qualified_name>`, e.g.
+
+```sh
+terraform import huaweicloud_dataarts_studio_directory.test b606cd4a47b645108a122857204b360f/STANDARD_ELEMENT/root.sub
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1084,8 +1084,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_network":                modelarts.ResourceModelartsNetwork(),
 			"huaweicloud_modelarts_resource_pool":          modelarts.ResourceModelartsResourcePool(),
 
-			"huaweicloud_dataarts_studio_instance": dataarts.ResourceStudioInstance(),
-			"huaweicloud_dataarts_service_app":     dataarts.ResourceServiceApp(),
+			"huaweicloud_dataarts_studio_instance":  dataarts.ResourceStudioInstance(),
+			"huaweicloud_dataarts_studio_directory": dataarts.ResourceDataArtsStudioDirectory(),
+			"huaweicloud_dataarts_service_app":      dataarts.ResourceServiceApp(),
 
 			"huaweicloud_mpc_transcoding_template":       mpc.ResourceTranscodingTemplate(),
 			"huaweicloud_mpc_transcoding_template_group": mpc.ResourceTranscodingTemplateGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -969,8 +969,8 @@ func TestAccPreCheckCERT(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckDataartsWorkspace(t *testing.T) {
+func TestAccPreCheckDataArtsWorkSpaceID(t *testing.T) {
 	if HW_DATAARTS_WORKSPACE_ID == "" {
-		t.Skip("This environment does not support DataArts DataService tests")
+		t.Skip("This environment does not support DataArts Studio tests")
 	}
 }

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_service_app_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_service_app_test.go
@@ -71,7 +71,7 @@ func TestAccServiceApp_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckDataartsWorkspace(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_directory_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_directory_test.go
@@ -1,0 +1,156 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDirectoryResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	getDirectoryClient, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio V2 client: %s", err)
+	}
+
+	//nolint:misspell
+	getDirectoryHttpUrl := "v2/{project_id}/design/directorys?type={type}"
+
+	getDirectoryPath := getDirectoryClient.Endpoint + getDirectoryHttpUrl
+	getDirectoryPath = strings.ReplaceAll(getDirectoryPath, "{project_id}", getDirectoryClient.ProjectID)
+	getDirectoryPath = strings.ReplaceAll(getDirectoryPath, "{type}", state.Primary.Attributes["type"])
+
+	getDirectoryOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": state.Primary.Attributes["workspace_id"]},
+	}
+	getDirectoryResp, err := getDirectoryClient.Request("GET", getDirectoryPath, &getDirectoryOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	getDirectoryRespBody, err := utils.FlattenResponse(getDirectoryResp)
+	if err != nil {
+		return nil, err
+	}
+
+	paths := strings.Split(state.Primary.Attributes["qualified_name"], ".")
+	jsonPaths := fmt.Sprintf("data.value[?name=='%s']", paths[0])
+	for i, path := range paths {
+		if i == 0 {
+			continue
+		}
+		jsonPaths += fmt.Sprintf("[children][][?name=='%s'][]", path)
+	}
+
+	directories := utils.PathSearch(jsonPaths, getDirectoryRespBody, make([]interface{}, 0)).([]interface{})
+	if len(directories) > 0 {
+		return directories, nil
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func TestAccResourceDirectory_basic(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_dataarts_studio_directory.test"
+	rName := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDirectoryResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDirectory_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "STANDARD_ELEMENT"),
+					resource.TestCheckResourceAttrSet(resourceName, "qualified_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "root_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+				),
+			},
+			{
+				Config: testAccDirectory_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "CODE"),
+					resource.TestCheckResourceAttrSet(resourceName, "qualified_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "root_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceDirectoryImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccResourceDirectoryImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		workspaceID := rs.Primary.Attributes["workspace_id"]
+		dirType := rs.Primary.Attributes["type"]
+		qualifiedName := rs.Primary.Attributes["qualified_name"]
+		if workspaceID == "" || dirType == "" || qualifiedName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want '<workspace_id>/<type>/<qualified_name>', but got '%s/%s/%s'",
+				workspaceID, dirType, qualifiedName)
+		}
+		return fmt.Sprintf("%s/%s/%s", workspaceID, dirType, qualifiedName), nil
+	}
+}
+
+func testAccDirectory_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_studio_directory" "test" {
+  workspace_id = "%s"
+  name         = "%s"
+  type         = "STANDARD_ELEMENT"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccDirectory_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_studio_directory" "test" {
+  workspace_id = "%s"
+  name         = "%s"
+  type         = "CODE"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_directory.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_directory.go
@@ -1,0 +1,321 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio POST /v2/{project_id}/design/directorys
+// API: DataArtsStudio DELETE /v2/{project_id}/design/directorys
+// API: DataArtsStudio GET /v2/{project_id}/design/directorys
+// API: DataArtsStudio PUT /v2/{project_id}/design/directorys
+func ResourceDataArtsStudioDirectory() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStudioDirectoryCreate,
+		ReadContext:   resourceStudioDirectoryRead,
+		UpdateContext: resourceStudioDirectoryUpdate,
+		DeleteContext: resourceStudioDirectoryDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceStudioDirectoryImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parent_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"root_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"children": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"qualified_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceStudioDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	//nolint:misspell
+	createDirectoryHttpUrl := "v2/{project_id}/design/directorys"
+	createDirectoryProduct := "dataarts"
+
+	createDirectoryClient, err := cfg.NewServiceClient(createDirectoryProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio V2 Client: %s", err)
+	}
+	createDirectoryPath := createDirectoryClient.Endpoint + createDirectoryHttpUrl
+	createDirectoryPath = strings.ReplaceAll(createDirectoryPath, "{project_id}", createDirectoryClient.ProjectID)
+
+	createDirectoryOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+	createDirectoryOpt.JSONBody = utils.RemoveNil(buildCreateDirectoryBodyParams(d))
+	createDirectoryResp, err := createDirectoryClient.Request("POST", createDirectoryPath, &createDirectoryOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createDirectoryRespBody, err := utils.FlattenResponse(createDirectoryResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	directory := utils.PathSearch("data.value", createDirectoryRespBody, nil)
+
+	id, err := jmespath.Search("id", directory)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio directory: %s is not found in API response", "id")
+	}
+
+	// need to set qualified name to filter result in READ.
+	qualifiedName, err := jmespath.Search("qualified_name", directory)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio directory: %s is not found in API response", "qualifiedName")
+	}
+	d.SetId(id.(string))
+	d.Set("qualified_name", qualifiedName)
+
+	return resourceStudioDirectoryRead(ctx, d, meta)
+}
+
+func buildCreateDirectoryBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"type":        d.Get("type"),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"parent_id":   utils.ValueIngoreEmpty(d.Get("parent_id")),
+	}
+	return bodyParams
+}
+
+func resourceStudioDirectoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	workspaceID := d.Get("workspace_id").(string)
+
+	//nolint:misspell
+	getDirectoryHttpUrl := "v2/{project_id}/design/directorys?type={type}"
+	getDirectoryProduct := "dataarts"
+
+	getDirectoryClient, err := cfg.NewServiceClient(getDirectoryProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio V2 Client: %s", err)
+	}
+
+	getDirectoryPath := getDirectoryClient.Endpoint + getDirectoryHttpUrl
+	getDirectoryPath = strings.ReplaceAll(getDirectoryPath, "{project_id}", getDirectoryClient.ProjectID)
+	getDirectoryPath = strings.ReplaceAll(getDirectoryPath, "{type}", d.Get("type").(string))
+
+	getDirectoryOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	getDirectoryResp, err := getDirectoryClient.Request("GET", getDirectoryPath, &getDirectoryOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getDirectoryRespBody, err := utils.FlattenResponse(getDirectoryResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	paths := strings.Split(d.Get("qualified_name").(string), ".")
+	jsonPaths := fmt.Sprintf("data.value[?name=='%s']", paths[0])
+	for i, path := range paths {
+		if i == 0 {
+			continue
+		}
+		jsonPaths += fmt.Sprintf("[children][][?name=='%s'][]", path)
+	}
+
+	directories := utils.PathSearch(jsonPaths, getDirectoryRespBody, make([]interface{}, 0)).([]interface{})
+	if len(directories) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "DataArts Studio directory")
+	}
+
+	directory := directories[0]
+	d.SetId(utils.PathSearch("id", directory, "").(string))
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("workspace_id", workspaceID),
+		d.Set("name", utils.PathSearch("name", directory, nil)),
+		d.Set("type", utils.PathSearch("type", directory, nil)),
+		d.Set("description", utils.PathSearch("description", directory, nil)),
+		d.Set("parent_id", utils.PathSearch("parent_id", directory, nil)),
+		d.Set("root_id", utils.PathSearch("root_id", directory, nil)),
+		d.Set("qualified_name", utils.PathSearch("qualified_name", directory, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", directory, nil)),
+		d.Set("updated_at", utils.PathSearch("update_time", directory, nil)),
+		d.Set("created_by", utils.PathSearch("create_by", directory, nil)),
+		d.Set("updated_by", utils.PathSearch("update_by", directory, nil)),
+		d.Set("children", utils.PathSearch(`children[*].name`, directory, make([]interface{}, 0))),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting DataArts Studio directory fields: %s", err)
+	}
+
+	return nil
+}
+
+func resourceStudioDirectoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	//nolint:misspell
+	updateDirectoryHttpUrl := "v2/{project_id}/design/directorys"
+	updateDirectoryProduct := "dataarts"
+
+	updateDirectoryClient, err := cfg.NewServiceClient(updateDirectoryProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio V2 Client: %s", err)
+	}
+	updateDirectoryPath := updateDirectoryClient.Endpoint + updateDirectoryHttpUrl
+	updateDirectoryPath = strings.ReplaceAll(updateDirectoryPath, "{project_id}", updateDirectoryClient.ProjectID)
+
+	updateDirectoryOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+
+	updateDirectoryOpt.JSONBody = utils.RemoveNil(buildUpdateDirectoryBodyParams(d))
+	updateDirectoryResp, err := updateDirectoryClient.Request("PUT", updateDirectoryPath, &updateDirectoryOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	updateDirectoryRespBody, err := utils.FlattenResponse(updateDirectoryResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	directory := utils.PathSearch("data.value", updateDirectoryRespBody, nil)
+
+	// if you change the parent id, the qualified name will be changed, need to set to filter result in READ.
+	qualifiedName, err := jmespath.Search("qualified_name", directory)
+	if err != nil {
+		return diag.Errorf("error updating DataArts Studio directory: %s is not found in API response", "qualifiedName")
+	}
+	if qualifiedName == nil {
+		qualifiedName = d.Get("qualified_name")
+	}
+	d.Set("qualified_name", qualifiedName)
+
+	return resourceStudioDirectoryRead(ctx, d, meta)
+}
+
+func buildUpdateDirectoryBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"id":          d.Id(),
+		"name":        d.Get("name"),
+		"type":        d.Get("type"),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"parent_id":   utils.ValueIngoreEmpty(d.Get("parent_id")),
+	}
+	return bodyParams
+}
+
+func resourceStudioDirectoryDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	//nolint:misspell
+	deleteDirectoryHttpUrl := "v2/{project_id}/design/directorys?ids={id}"
+	deleteDirectoryProduct := "dataarts"
+
+	deleteDirectoryClient, err := cfg.NewServiceClient(deleteDirectoryProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio V2 Client: %s", err)
+	}
+	deleteDirectoryPath := deleteDirectoryClient.Endpoint + deleteDirectoryHttpUrl
+	deleteDirectoryPath = strings.ReplaceAll(deleteDirectoryPath, "{project_id}", deleteDirectoryClient.ProjectID)
+	deleteDirectoryPath = strings.ReplaceAll(deleteDirectoryPath, "{id}", d.Id())
+
+	deleteDirectoryOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+
+	_, err = deleteDirectoryClient.Request("DELETE", deleteDirectoryPath, &deleteDirectoryOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceStudioDirectoryImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format of import ID, must be <workspace_id>/<type>/<qualified_name>")
+	}
+
+	d.Set("workspace_id", parts[0])
+	d.Set("type", parts[1])
+	d.Set("qualified_name", parts[2])
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource dataarts studio directory

## PR Checklist

* [√] Tests added/passed.
* [√] Documentation updated.
* [√] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourceDirectory_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceDirectory_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDirectory_basic
=== PAUSE TestAccResourceDirectory_basic
=== CONT  TestAccResourceDirectory_basic
--- PASS: TestAccResourceDirectory_basic (14.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  14.071s
```
