### PR TITLE
docs(lts): fix a misspell in keywords_alarm_rule doc

### DIFF
--- a/docs/resources/lts_keywords_alarm_rule.md
+++ b/docs/resources/lts_keywords_alarm_rule.md
@@ -51,7 +51,7 @@ The following arguments are supported:
   The [Frequency](#KeywordsAlarmRule_Frequency) structure is documented below.
 
 * `alarm_level` - (Required, String) Specifies the alarm level.
-  The value can be: **INFO**, **MINOR**, **MAJOR** and **CRIRICAL**.
+  The value can be: **INFO**, **MINOR**, **MAJOR** and **CRITICAL**.
 
 * `description` - (Optional, String) Specifies the description of the keywords alarm rule.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
