### PR TITLE
feat(dataarts): add resource dataarts studio permission set

### DIFF
--- a/docs/resources/dataarts_studio_permission_set.md
+++ b/docs/resources/dataarts_studio_permission_set.md
@@ -1,0 +1,87 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_studio_permission_set
+
+Manages DataArts Studio permission set resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "name" {}
+variable "manager_id" {}
+
+resource "huaweicloud_dataarts_studio_permission_set" "test" {
+  workspace_id = var.workspace_id
+  name         = var.name
+  parent_id    = "0"
+  manager_id   = var.manager_id
+}
+
+resource "huaweicloud_dataarts_studio_permission_set" "sub_test" {
+  workspace_id = var.workspace_id
+  name         = var.name
+  parent_id    = huaweicloud_dataarts_studio_permission_set.test.id
+  manager_id   = var.manager_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the permission set resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID in which the permission set.
+  Changing this creates a new permission set.
+
+* `name` - (Required, String) Specifies the name of the permission set. The name can contain `1` to `128` characters.
+  Only letters, digits, and underscores (_) are allowed.
+
+* `parent_id` - (Required, String, ForceNew) Specifies the parent ID of the permission set.
+  The parent ID can contain `1` to `128` characters. The value of parent_id is `0`
+  when we want to create a workspace permission set.
+
+* `manager_id` - (Required, String) Specifies the manager ID of the permission set. The manager can choose from
+  member management under the workspace. The manager ID cancontain
+  `1` to `128` characters.
+
+* `manager_name` - (Optional, String) Specifies the manager name of the permission set. The manager name can
+  contain `1` to `128` characters.
+
+* `manager_type` - (Optional, String) Specifies the manager type of the permission set. The valid
+  values are **USER** and **USER_GROUP**.
+
+* `description` - (Optional, String) Specifies the description of the permission set. The description can contain
+  `0` to `10240` characters.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also the ID of the permission set.
+
+* `datasource_type` - The data source type managed by permission sets.
+
+* `instance_id` - The ID of the instance to which the permission set belongs.
+
+* `type` - The type of the permission set.
+
+* `created_at` - The create time of the permission set.
+
+* `created_by` - The creator of the permission set.
+
+* `updated_at` - The update time of the permission set.
+
+* `updated_by` - The updator of the permission set.
+
+## Import
+
+The DataArts Studio permission set can be imported using the `workspace_id` and `id` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_studio_permission_set.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1084,9 +1084,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_network":                modelarts.ResourceModelartsNetwork(),
 			"huaweicloud_modelarts_resource_pool":          modelarts.ResourceModelartsResourcePool(),
 
-			"huaweicloud_dataarts_studio_instance":  dataarts.ResourceStudioInstance(),
-			"huaweicloud_dataarts_studio_directory": dataarts.ResourceDataArtsStudioDirectory(),
-			"huaweicloud_dataarts_service_app":      dataarts.ResourceServiceApp(),
+			"huaweicloud_dataarts_studio_instance":       dataarts.ResourceStudioInstance(),
+			"huaweicloud_dataarts_studio_directory":      dataarts.ResourceDataArtsStudioDirectory(),
+			"huaweicloud_dataarts_service_app":           dataarts.ResourceServiceApp(),
+			"huaweicloud_dataarts_studio_permission_set": dataarts.ResourcePermissionSet(),
 
 			"huaweicloud_mpc_transcoding_template":       mpc.ResourceTranscodingTemplate(),
 			"huaweicloud_mpc_transcoding_template_group": mpc.ResourceTranscodingTemplateGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -979,6 +979,6 @@ func TestAccPreCheckDataArtsWorkSpaceID(t *testing.T) {
 // lintignore:AT003
 func TestAccPreCheckDataArtsManagerID(t *testing.T) {
 	if HW_DATAARTS_MANAGER_ID == "" {
-		t.Skip("This environment does not support DataArts Studio tests")
+		t.Skip("This environment does not support DataArts Studio permission set tests")
 	}
 }

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -215,6 +215,7 @@ var (
 	HW_CERT_BATCH_PUSH_ID = os.Getenv("HW_CERT_BATCH_PUSH_ID")
 
 	HW_DATAARTS_WORKSPACE_ID = os.Getenv("HW_DATAARTS_WORKSPACE_ID")
+	HW_DATAARTS_MANAGER_ID   = os.Getenv("HW_DATAARTS_MANAGER_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -971,6 +972,13 @@ func TestAccPreCheckCERT(t *testing.T) {
 // lintignore:AT003
 func TestAccPreCheckDataArtsWorkSpaceID(t *testing.T) {
 	if HW_DATAARTS_WORKSPACE_ID == "" {
+		t.Skip("This environment does not support DataArts Studio tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDataArtsManagerID(t *testing.T) {
+	if HW_DATAARTS_MANAGER_ID == "" {
 		t.Skip("This environment does not support DataArts Studio tests")
 	}
 }

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_permission_set_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_permission_set_test.go
@@ -1,0 +1,148 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getPermissionSetResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	getPermissionSetClient, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPermissionSetHttpUrl := "v1/{project_id}/security/permission-sets/{permission_set_id}"
+	getPermissionSetPath := getPermissionSetClient.Endpoint + getPermissionSetHttpUrl
+	getPermissionSetPath = strings.ReplaceAll(getPermissionSetPath, "{project_id}", getPermissionSetClient.ProjectID)
+	getPermissionSetPath = strings.ReplaceAll(getPermissionSetPath, "{permission_set_id}", state.Primary.ID)
+
+	getPermissionSetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": state.Primary.Attributes["workspace_id"]},
+	}
+	getPermissionSetResp, err := getPermissionSetClient.Request("GET", getPermissionSetPath, &getPermissionSetOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DataArts Studio permission set: %s", err)
+	}
+
+	getPermissionSetRespBody, err := utils.FlattenResponse(getPermissionSetResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DataArts Studio permission set: %s", err)
+	}
+
+	return getPermissionSetRespBody, nil
+}
+
+func TestAccResourcePermissionSet_basic(t *testing.T) {
+	var obj interface{}
+
+	resourceName := "huaweicloud_dataarts_studio_permission_set.test"
+	rName := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getPermissionSetResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsManagerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPermissionSet_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "parent_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "manager_id", acceptance.HW_DATAARTS_MANAGER_ID),
+					resource.TestCheckResourceAttr(resourceName, "description", "test_create"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "type"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+				),
+			},
+			{
+				Config: testAccPermissionSet_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "parent_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "manager_id", acceptance.HW_DATAARTS_MANAGER_ID),
+					resource.TestCheckResourceAttr(resourceName, "description", "test_update"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "type"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourcePermissionSetImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccResourcePermissionSetImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		workspaceID := rs.Primary.Attributes["workspace_id"]
+		permissionSetID := rs.Primary.ID
+		if workspaceID == "" || permissionSetID == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, " +
+				"want '<workspace_id>/<id>'")
+		}
+		return fmt.Sprintf("%s/%s", workspaceID, permissionSetID), nil
+	}
+}
+
+func testAccPermissionSet_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_studio_permission_set" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  parent_id    = "0"
+  manager_id   = "%[3]s"
+  description  = "test_create"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_MANAGER_ID)
+}
+
+func testAccPermissionSet_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_studio_permission_set" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s_update"
+  parent_id    = "0"
+  manager_id   = "%[3]s"
+  description  = "test_update"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_MANAGER_ID)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_permission_set.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_permission_set.go
@@ -1,0 +1,326 @@
+package dataarts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio POST /v1/{project_id}/security/permission-sets
+// API: DataArtsStudio DELETE /v1/{project_id}/security/permission-sets/{permission_set_id}
+// API: DataArtsStudio GET /v1/{project_id}/security/permission-sets/{permission_set_id}
+// API: DataArtsStudio PUT /v1/{project_id}/security/permission-sets/{permission_set_id}
+func ResourcePermissionSet() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePermissionSetCreate,
+		ReadContext:   resourcePermissionSetRead,
+		UpdateContext: resourcePermissionSetUpdate,
+		DeleteContext: resourcePermissionSetDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePermissionSetImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"parent_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"manager_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"manager_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"manager_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"datasource_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePermissionSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	workspaceID := d.Get("workspace_id").(string)
+
+	// createDataArtsStudioPermissionSet: create a permission set.
+	var (
+		createPermissionSetUrl     = "v1/{project_id}/security/permission-sets"
+		createPermissionSetProduct = "dataarts"
+	)
+
+	createPermissionSetClient, err := conf.NewServiceClient(createPermissionSetProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	createPermissionSetPath := createPermissionSetClient.Endpoint + createPermissionSetUrl
+	createPermissionSetPath = strings.ReplaceAll(createPermissionSetPath, "{project_id}", createPermissionSetClient.ProjectID)
+
+	createPermissionSetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	createPermissionSetOpt.JSONBody = utils.RemoveNil(buildCreatePermissionSetBodyParams(d))
+	createPermissionSetResp, err := createPermissionSetClient.Request("POST", createPermissionSetPath, &createPermissionSetOpt)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio permissions set: %s", err)
+	}
+
+	createPermissionSetRespBody, err := utils.FlattenResponse(createPermissionSetResp)
+	if err != nil {
+		return diag.Errorf("error retrieving DataArts Studio permission set: %s", err)
+	}
+
+	id, err := jmespath.Search("id", createPermissionSetRespBody)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio permission set: ID is not found in API response")
+	}
+
+	d.SetId(id.(string))
+	return resourcePermissionSetRead(ctx, d, meta)
+}
+
+func buildCreatePermissionSetBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":         d.Get("name"),
+		"parent_id":    d.Get("parent_id"),
+		"manager_id":   d.Get("manager_id"),
+		"manager_name": utils.ValueIngoreEmpty(d.Get("manager_name")),
+		"manager_type": utils.ValueIngoreEmpty(d.Get("manager_type")),
+		"description":  utils.ValueIngoreEmpty(d.Get("description")),
+	}
+	return bodyParams
+}
+
+func resourcePermissionSetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	workspaceID := d.Get("workspace_id").(string)
+
+	// getDataArtsPermissionSet: Query the DataArts permission set detail.
+	var (
+		getPermissionSetHttpUrl = "v1/{project_id}/security/permission-sets/{permission_set_id}"
+		getPermissionSetProduct = "dataarts"
+	)
+
+	getPermissionSetClient, err := conf.NewServiceClient(getPermissionSetProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPermissionSetPath := getPermissionSetClient.Endpoint + getPermissionSetHttpUrl
+	getPermissionSetPath = strings.ReplaceAll(getPermissionSetPath, "{project_id}", getPermissionSetClient.ProjectID)
+	getPermissionSetPath = strings.ReplaceAll(getPermissionSetPath, "{permission_set_id}", d.Id())
+
+	getPermissionSetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	getPermissionSetResp, err := getPermissionSetClient.Request("GET", getPermissionSetPath, &getPermissionSetOpt)
+	if err != nil {
+		if hasErrorCode(err, "DLS.3027") {
+			err = golangsdk.ErrDefault404{}
+		}
+		return common.CheckDeletedDiag(d, err, "error retrieving DataArts Studio permission set")
+	}
+
+	getPermissionSetRespBody, err := utils.FlattenResponse(getPermissionSetResp)
+	if err != nil {
+		return diag.Errorf("error retrieving DataArts Studio permission set: %s", err)
+	}
+
+	createAt := utils.PathSearch("create_time", getPermissionSetRespBody, 0).(float64)
+	updateAt := utils.PathSearch("update_time", getPermissionSetRespBody, 0).(float64)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("workspace_id", workspaceID),
+		d.Set("name", utils.PathSearch("name", getPermissionSetRespBody, nil)),
+		d.Set("parent_id", utils.PathSearch("parent_id", getPermissionSetRespBody, nil)),
+		d.Set("manager_id", utils.PathSearch("manager_id", getPermissionSetRespBody, nil)),
+		d.Set("manager_name", utils.PathSearch("manager_name", getPermissionSetRespBody, nil)),
+		d.Set("manager_type", utils.PathSearch("manager_type", getPermissionSetRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getPermissionSetRespBody, nil)),
+		d.Set("type", utils.PathSearch("type", getPermissionSetRespBody, nil)),
+		d.Set("instance_id", utils.PathSearch("instance_id", getPermissionSetRespBody, nil)),
+		d.Set("datasource_type", utils.PathSearch("datasource_type", getPermissionSetRespBody, nil)),
+		d.Set("created_by", utils.PathSearch("create_user", getPermissionSetRespBody, nil)),
+		d.Set("updated_by", utils.PathSearch("update_user", getPermissionSetRespBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(createAt), false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(updateAt), false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourcePermissionSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+
+	// updateDataArtsPermissionSet: Update the DataArts permission set detail.
+	var (
+		updatePermissionSetHttpUrl = "v1/{project_id}/security/permission-sets/{permission_set_id}"
+		updatePermissionSetProduct = "dataarts"
+	)
+
+	updatePermissionSetClient, err := conf.NewServiceClient(updatePermissionSetProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	updatePermissionSetPath := updatePermissionSetClient.Endpoint + updatePermissionSetHttpUrl
+	updatePermissionSetPath = strings.ReplaceAll(updatePermissionSetPath, "{project_id}", updatePermissionSetClient.ProjectID)
+	updatePermissionSetPath = strings.ReplaceAll(updatePermissionSetPath, "{permission_set_id}", d.Id())
+
+	updatePermissionSetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+
+	updatePermissionSetOpt.JSONBody = utils.RemoveNil(buildUpdatePermissionSetBodyParams(d))
+	_, err = updatePermissionSetClient.Request("PUT", updatePermissionSetPath, &updatePermissionSetOpt)
+	if err != nil {
+		return diag.Errorf("error updating DataArts Studio permission set: %s", err)
+	}
+
+	return resourcePermissionSetRead(ctx, d, meta)
+}
+
+func buildUpdatePermissionSetBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":         d.Get("name"),
+		"manager_id":   d.Get("manager_id"),
+		"manager_name": utils.ValueIngoreEmpty(d.Get("manager_name")),
+		"manager_type": utils.ValueIngoreEmpty(d.Get("manager_type")),
+		"description":  utils.ValueIngoreEmpty(d.Get("description")),
+	}
+	return bodyParams
+}
+
+func resourcePermissionSetDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+
+	// delateDataArtsPermissionSet: Delete the DataArts permission set detail.
+	var (
+		deletePermissionSetHttpUrl = "v1/{project_id}/security/permission-sets/{permission_set_id}"
+		deletePermissionSetProduct = "dataarts"
+	)
+
+	deletePermissionSetClient, err := conf.NewServiceClient(deletePermissionSetProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	deletePermissionSetPath := deletePermissionSetClient.Endpoint + deletePermissionSetHttpUrl
+	deletePermissionSetPath = strings.ReplaceAll(deletePermissionSetPath, "{project_id}", deletePermissionSetClient.ProjectID)
+	deletePermissionSetPath = strings.ReplaceAll(deletePermissionSetPath, "{permission_set_id}", d.Id())
+
+	deletePermissionSetOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+
+	_, err = deletePermissionSetClient.Request("DELETE", deletePermissionSetPath, &deletePermissionSetOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DataArts Studio permission set: %s", err)
+	}
+
+	return nil
+}
+
+func resourcePermissionSetImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format of import ID, must be <workspace_id>/<id>")
+	}
+
+	d.Set("workspace_id", parts[0])
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func hasErrorCode(err error, expectCode string) bool {
+	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
+		var response interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &response); jsonErr == nil {
+			errorCode, parseErr := jmespath.Search("error_code", response)
+			if parseErr != nil {
+				log.Printf("[WARN] failed to parse error_code from response body: %s", parseErr)
+			}
+
+			if errorCode == expectCode {
+				return true
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource dataarts studio permission set

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourcePermissionSet_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourcePermissionSet_basic -timeout 360m -parallel 4
=== RUN   TestAccResourcePermissionSet_basic
=== PAUSE TestAccResourcePermissionSet_basic
=== CONT  TestAccResourcePermissionSet_basic
--- PASS: TestAccResourcePermissionSet_basic (28.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  28.099s
```
