### PR TITLE
feat(CCM): update certificate export

### DIFF
--- a/docs/data-sources/ccm_private_certificate_export.md
+++ b/docs/data-sources/ccm_private_certificate_export.md
@@ -33,6 +33,10 @@ The following arguments are supported:
   + **APACHE**: This parameter is recommended if you want to use the certificate for an Apache server.
   + **NGINX**: This parameter is recommended if you want to use the certificate for an Nginx server.
   + **OTHER**: This parameter is recommended if you want to download a certificate in PEM format.
+  + **IIS**: This parameter is recommended if you want to use the certificate for an IIS server.
+  + **TOMCAT**: This parameter is recommended if you want to use the certificate for a TOMCAT server.
+
+  -> **NOTE:** When the **type** is "IIS" or "TOMCAT" the export certificate file is different everytime.
 
 * `sm_standard` - (Optional, String) Specifies the GB/T GMT0009 standard specifications and
   GB/T GMT0010 standard. When the certificate algorithm is SM2,
@@ -61,4 +65,9 @@ In addition to all arguments above, the following attributes are exported:
   
 * `signed_and_enveloped_data` - Indicates the National Security GMT0010 Standard Specification for
   Encrypting Private Keys - Signature Digital Envelope.
-  
+
+* `keystore_pass` - Indicates the keystore password. If argument "password" passed in, it will be empty.
+
+* `server_pfx` - Indicates the certificate file for IIS server. Encoding by base64.
+
+* `server_jks` - Indicates the certificate file for TOMCAT server. Encoding by base64.

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go
@@ -10,27 +10,20 @@ import (
 )
 
 func TestAccCcmPrivateCertificateExport_basic(t *testing.T) {
-	var obj interface{}
 	rName := acceptance.RandomAccResourceName()
-	expEesourceName := "data.huaweicloud_ccm_private_certificate_export.test3"
-	resourceName := "huaweicloud_ccm_private_certificate.test"
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getCertificateResourceFunc,
-	)
-
+	dataSourceName := "data.huaweicloud_ccm_private_certificate_export.basiccert"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCcmPrivateCertificateExport_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(expEesourceName, "private_key"),
-					resource.TestCheckResourceAttrSet(expEesourceName, "certificate"),
-					resource.TestCheckResourceAttrSet(expEesourceName, "certificate_chain"),
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "private_key"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "certificate"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "certificate_chain"),
 				),
 			},
 		},
@@ -38,30 +31,52 @@ func TestAccCcmPrivateCertificateExport_basic(t *testing.T) {
 }
 
 func TestAccCcmPrivateCertificateExport_SM2(t *testing.T) {
-	var obj interface{}
 	rName := acceptance.RandomAccResourceName()
-	expEesourceSM2Name := "data.huaweicloud_ccm_private_certificate_export.test4"
-	resourceName := "huaweicloud_ccm_private_certificate.test"
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getCertificateResourceFunc,
-	)
-
+	dataSourceSM2Name := "data.huaweicloud_ccm_private_certificate_export.sm2cert"
+	dc := acceptance.InitDataSourceCheck(dataSourceSM2Name)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCcmPrivateCertificateSM2Export_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "private_key"),
-					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "certificate"),
-					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "certificate_chain"),
-					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "enc_certificate"),
-					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "enc_sm2_enveloped_key"),
-					resource.TestCheckResourceAttrSet(expEesourceSM2Name, "signed_and_enveloped_data"),
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "private_key"),
+					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "certificate"),
+					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "certificate_chain"),
+					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "enc_certificate"),
+					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "enc_sm2_enveloped_key"),
+					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "signed_and_enveloped_data"),
+				),
+			},
+		},
+	})
+}
+func TestAccCcmPrivateCertificateExport_compressed(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	tomcatDataSourceName := "data.huaweicloud_ccm_private_certificate_export.tomcatcert"
+	iisDataSourceName := "data.huaweicloud_ccm_private_certificate_export.iiscert"
+	dcTomcat := acceptance.InitDataSourceCheck(tomcatDataSourceName)
+	dcIIS := acceptance.InitDataSourceCheck(iisDataSourceName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCcmPrivateCertificateExport_TOMCAT(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dcTomcat.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(tomcatDataSourceName, "keystore_pass"),
+					resource.TestCheckResourceAttrSet(tomcatDataSourceName, "server_jks"),
+				),
+			},
+			{
+				Config: testAccCcmPrivateCertificateExport_IIS(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dcIIS.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(iisDataSourceName, "keystore_pass"),
+					resource.TestCheckResourceAttrSet(iisDataSourceName, "server_pfx"),
 				),
 			},
 		},
@@ -71,10 +86,32 @@ func TestAccCcmPrivateCertificateExport_SM2(t *testing.T) {
 // lintignore:AT004
 func testAccCcmPrivateCertificateExport_basic(commonName string) string {
 	return fmt.Sprintf(`
-  %s
+%s
 
-data "huaweicloud_ccm_private_certificate_export" "test3" {
+data "huaweicloud_ccm_private_certificate_export" "basiccert" {
     type           = "other"
+    certificate_id = huaweicloud_ccm_private_certificate.test.id
+}`, tesCmdbCertificate_basic(commonName))
+}
+
+// lintignore:AT004
+func testAccCcmPrivateCertificateExport_TOMCAT(commonName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_ccm_private_certificate_export" "tomcatcert" {
+    type           = "TOMCAT"
+    certificate_id = huaweicloud_ccm_private_certificate.test.id
+}`, tesCmdbCertificate_basic(commonName))
+}
+
+// lintignore:AT004
+func testAccCcmPrivateCertificateExport_IIS(commonName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_ccm_private_certificate_export" "iiscert" {
+    type           = "IIS"
     certificate_id = huaweicloud_ccm_private_certificate.test.id
 }`, tesCmdbCertificate_basic(commonName))
 }
@@ -120,7 +157,7 @@ resource "huaweicloud_ccm_private_certificate" "test2" {
   }
 }
 	  
-data "huaweicloud_ccm_private_certificate_export" "test4" {
+data "huaweicloud_ccm_private_certificate_export" "sm2cert" {
   type           = "other"
   certificate_id = huaweicloud_ccm_private_certificate.test2.id
   sm_standard    = "true"

--- a/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_certificate_export.go
+++ b/huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_certificate_export.go
@@ -1,7 +1,11 @@
 package ccm
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"fmt"
+	"io"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -70,6 +74,18 @@ func DataSourceCcmPrivateCertificateExport() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"keystore_pass": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"server_pfx": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"server_jks": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -82,44 +98,94 @@ func ccmPrivateCertificateExport(_ context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating CCM client: %s", err)
 	}
 
+	certId := d.Get("certificate_id").(string)
 	expCertificateHttpUrl := "v1/private-certificates/{certificate_id}/export"
 	expCertificatePath := client.Endpoint + expCertificateHttpUrl
-	expCertificatePath = strings.ReplaceAll(expCertificatePath, "{certificate_id}", d.Get("certificate_id").(string))
+	expCertificatePath = strings.ReplaceAll(expCertificatePath, "{certificate_id}", certId)
 
 	expCertificateOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
-	expCertificateOpt.JSONBody = utils.RemoveNil(buildExpCertificateBodyParams(d))
+	// get the server type, iis and tomcat export zip certificate file
+	serverType := d.Get("type").(string)
+	isCompressed := false
+	if strings.ToUpper(serverType) == "IIS" || strings.ToUpper(serverType) == "TOMCAT" {
+		isCompressed = true
+	}
+	expCertificateOpt.JSONBody = utils.RemoveNil(buildExpCertificateBodyParams(d, serverType, isCompressed))
 	expCertificateResp, err := client.Request("POST", expCertificatePath, &expCertificateOpt)
 	if err != nil {
 		return diag.Errorf("error export CCM private certificate: %s", err)
 	}
-	expCertificateRespBody, err := utils.FlattenResponse(expCertificateResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	d.SetId(certId)
 
-	d.SetId(d.Get("certificate_id").(string))
-	mErr := multierror.Append(nil,
-		d.Set("private_key", utils.PathSearch("private_key", expCertificateRespBody, nil)),
-		d.Set("certificate", utils.PathSearch("certificate", expCertificateRespBody, nil)),
-		d.Set("certificate_chain", utils.PathSearch("certificate_chain", expCertificateRespBody, nil)),
-		d.Set("enc_private_key", utils.PathSearch("enc_private_key", expCertificateRespBody, nil)),
-		d.Set("enc_certificate", utils.PathSearch("enc_certificate", expCertificateRespBody, nil)),
-		d.Set("enc_sm2_enveloped_key", utils.PathSearch("enc_sm2_enveloped_key", expCertificateRespBody, nil)),
-		d.Set("signed_and_enveloped_data", utils.PathSearch("signed_and_enveloped_data", expCertificateRespBody, nil)),
-	)
-	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting CCM private certificate export fields: %s", err)
+	if isCompressed {
+		// save certificate file from file stream
+		data, err := io.ReadAll(expCertificateResp.Body)
+		if err != nil {
+			return diag.Errorf("error reading response certificate: %s", err)
+		}
+		zipReader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+		if err != nil {
+			return diag.Errorf("error reading zip certificate: %s", err)
+		}
+		for _, f := range zipReader.File {
+			err := saveCertificateFromZipFile(f, d)
+			if err != nil {
+				return diag.Errorf("error reading unzip certificate: %s", err)
+			}
+		}
+	} else {
+		expCertificateRespBody, err := utils.FlattenResponse(expCertificateResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		// save certificate file from json
+		mErr := multierror.Append(nil,
+			d.Set("private_key", utils.PathSearch("private_key", expCertificateRespBody, nil)),
+			d.Set("certificate", utils.PathSearch("certificate", expCertificateRespBody, nil)),
+			d.Set("certificate_chain", utils.PathSearch("certificate_chain", expCertificateRespBody, nil)),
+			d.Set("enc_private_key", utils.PathSearch("enc_private_key", expCertificateRespBody, nil)),
+			d.Set("enc_certificate", utils.PathSearch("enc_certificate", expCertificateRespBody, nil)),
+			d.Set("enc_sm2_enveloped_key", utils.PathSearch("enc_sm2_enveloped_key", expCertificateRespBody, nil)),
+			d.Set("signed_and_enveloped_data", utils.PathSearch("signed_and_enveloped_data", expCertificateRespBody, nil)),
+		)
+		if err := mErr.ErrorOrNil(); err != nil {
+			return diag.Errorf("error setting CCM private certificate export fields: %s", err)
+		}
 	}
 	return nil
 }
 
-func buildExpCertificateBodyParams(d *schema.ResourceData) map[string]interface{} {
+func saveCertificateFromZipFile(f *zip.File, d *schema.ResourceData) error {
+	fileName := f.Name
+	inFile, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("error openning certificate file: %s", err)
+	}
+	defer inFile.Close()
+	content, err := io.ReadAll(inFile)
+	if err != nil {
+		return fmt.Errorf("error reading unzip certificate file: %s", err)
+	}
+	var mErr *multierror.Error
+	if fileName == "keystorePass.txt" {
+		mErr = multierror.Append(mErr, d.Set("keystore_pass", string(content)))
+	}
+	if fileName == "server.pfx" {
+		mErr = multierror.Append(mErr, d.Set("server_pfx", utils.Base64EncodeString(string(content))))
+	}
+	if fileName == "server.jks" {
+		mErr = multierror.Append(mErr, d.Set("server_jks", utils.Base64EncodeString(string(content))))
+	}
+	return mErr.ErrorOrNil()
+}
+
+func buildExpCertificateBodyParams(d *schema.ResourceData, serverType string, isCompressed bool) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"is_compressed":  "false",
-		"type":           d.Get("type"),
+		"is_compressed":  isCompressed,
+		"type":           serverType,
 		"is_sm_standard": d.Get("sm_standard"),
 		"password":       d.Get("password"),
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
feat(CCM): update certificate export

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

 ./scripts/codecheck.sh ./huaweicloud/services/ccm

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        4      1749      138        23     1588        261            66.97
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ccm/resource_huaweicloud_ccm_private_ca.go       741       58        11      672        117            17.41
~source_huaweicloud_ccm_certificate_push.go       344       29         5      310         75            24.19
~rce_huaweicloud_ccm_private_certificate.go       484       41         4      439         43             9.79
~weicloud_ccm_private_certificate_export.go       180       10         3      167         26            15.57
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     4      1749      138        23     1588        261            66.97
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 53704 bytes, 0.054 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
20 ccm resourcePrivateCACreate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:211:1
14 ccm resourceCcmCertificateRead huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go:170:1
14 ccm ccmPrivateCertificateExport huaweicloud/services/ccm/data_source_huaweicloud_ccm_private_certificate_export.go:92:1
13 ccm rmPushedCert huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go:301:1
12 ccm resourcePrivateCADelete huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:537:1
8 ccm resourcePrivateCARead huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:435:1
7 ccm resourceCcmPrivateCertificateRead huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:384:1
7 ccm resourceCcmPrivateCertificateUpdate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go:349:1
7 ccm resourcePrivateCAUpdate huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go:637:1
7 ccm rePushOrDelete huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go:244:1
Average: 4.11

==> Checking for golangci-lint...

==> Checking for Nolint directives...

==> Checking for TF features in ccm...
  -> the resource in resource_huaweicloud_ccm_certificate_push.go should can be imported


==> Checking for misspell in ccm...

==> Checking for code complexity in ./huaweicloud/services/acceptance/ccm...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        4       765       60        10      695         22            13.29
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~e_huaweicloud_ccm_certifiacte_push_test.go       140       13         0      127          8             6.30
~esource_huaweicloud_ccm_private_ca_test.go       293       19         4      270          8             2.96
~uaweicloud_ccm_private_certificate_test.go       168       17         2      149          6             4.03
~oud_ccm_private_certificate_export_test.go       164       11         4      149          0             0.00
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     4       765       60        10      695         22            13.29
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 23571 bytes, 0.024 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
5 ccm getPrivateCAResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:18:1
5 ccm getCertificatePushResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certifiacte_push_test.go:22:1
4 ccm getCertificateResourceFunc huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:18:1
1 ccm tesCmdbCertificate_tagsUpdate huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:143:1
1 ccm tesCmdbCertificate_basic huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:115:1
Average: 1.52

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/ccm...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/ccm...
./huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go:85:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go:96:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go:107:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go:118:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:106:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:135:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:165:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go:244:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:114:// lintignore:AT004
./huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go:142:// lintignore:AT004

==> Cleanup patch...

Check Completed!


## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

 make testacc TEST=./huaweicloud/services/acceptance/ccm TESTARGS='-run TestAccCcmPrivateCertificateExport_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCcmPrivateCertificateExport_basic -timeout 360m -parallel 4
=== RUN   TestAccCcmPrivateCertificateExport_basic
=== PAUSE TestAccCcmPrivateCertificateExport_basic
=== CONT  TestAccCcmPrivateCertificateExport_basic
--- PASS: TestAccCcmPrivateCertificateExport_basic (47.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       47.925s
