### PR TITLE
fix(OBS): fix the bug of obs encryption configuration

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -211,8 +211,8 @@ The following arguments are supported:
 
 * `kms_key_id` - (Optional, String) Specifies the ID of a KMS key. If omitted, the default master key will be used.
 
-* `kms_key_project_id` - (Optional, String) Specifies the project ID to which the KMS key belongs. If omitted, the ID
-  of the provider-level project will be used.
+* `kms_key_project_id` - (Optional, String) Specifies the project ID to which the KMS key belongs. This field is valid
+  only when `kms_key_id` is specified.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the OBS bucket.
   Defaults to `0`.

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -198,6 +198,14 @@ func TestAccObsBucket_encryption(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "kms_key_id"),
 				),
 			},
+			{
+				Config: testAccObsBucket_encryptionByDefaultKMSMasterKey(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
+				),
+			},
 		},
 	})
 }
@@ -566,6 +574,22 @@ resource "huaweicloud_obs_bucket" "bucket" {
   }
 }
 `, randInt, randInt)
+}
+
+func testAccObsBucket_encryptionByDefaultKMSMasterKey(randInt int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket        = "tf-test-bucket-%d"
+  storage_class = "STANDARD"
+  acl           = "private"
+  encryption    = true
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, randInt)
 }
 
 func testAccObsBucket_epsId(randInt int, enterpriseProjectId string) string {

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -740,10 +740,12 @@ func resourceObsBucketEncryptionUpdate(config *config.Config, obsClient *obs.Obs
 		input.SSEAlgorithm = obs.DEFAULT_SSE_KMS_ENCRYPTION_OBS
 		input.KMSMasterKeyID = d.Get("kms_key_id").(string)
 
-		if v, ok := d.GetOk("kms_key_project_id"); ok {
-			input.ProjectID = v.(string)
-		} else {
-			input.ProjectID = config.GetProjectID(config.GetRegion(d))
+		if _, ok := d.GetOk("kms_key_id"); ok {
+			if v, ok := d.GetOk("kms_key_project_id"); ok {
+				input.ProjectID = v.(string)
+			} else {
+				input.ProjectID = config.GetProjectID(config.GetRegion(d))
+			}
 		}
 
 		log.Printf("[DEBUG] enable default encryption of OBS bucket %s: %#v", bucket, input)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix the bug of obs encryption configuration

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs/' TESTARGS='-run TestAccObsBucket_encryption'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs/ -v -run TestAccObsBucket_encryption -timeout 360m -parallel 4 
=== RUN   TestAccObsBucket_encryption 
=== PAUSE TestAccObsBucket_encryption
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_encryption (69.56s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       69.605s
```
