### PR TITLE
feat(WAF): add datasource to query the list of the address group

### DIFF
--- a/docs/data-sources/waf_address_groups.md
+++ b/docs/data-sources/waf_address_groups.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_address_groups
+
+Use this data source to get a list of WAF address groups.
+
+## Example Usage
+
+```hcl
+variable enterprise_project_id {}
+
+data "huaweicloud_waf_address_groups" "groups_1" {
+  name                  = "address_group_name"
+  enterprise_project_id = var.enterprise_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the address group.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+* `ip_address` - (Optional, String) Specifies the IP address or IP address ranges.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `groups` - The list of WAF address groups.
+
+The `groups` block supports:
+
+* `id` - The WAF address group ID.
+
+* `name` - The name of the address group.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `ip_addresses` - The IP addresses or IP address ranges.
+
+* `description` - The description of the address group.
+
+* `share_count` - The total number of the users share the address group.
+
+* `accept_count` - The number of the users accept the sharing.
+
+* `process_status` - The status of processing.
+
+* `rules` - The list of rules that use the IP address group.
+
+The `rules` block supports:
+
+* `rule_id` - The ID of rule.
+
+* `rule_name` - The name of rule.
+
+* `policy_id` - The ID of policy.
+
+* `policy_name` - The name of policy.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -631,6 +631,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_dedicated_instances": waf.DataSourceWafDedicatedInstancesV1(),
 			"huaweicloud_waf_reference_tables":    waf.DataSourceWafReferenceTablesV1(),
 			"huaweicloud_waf_instance_groups":     waf.DataSourceWafInstanceGroups(),
+			"huaweicloud_waf_address_groups":      waf.DataSourceWafAddressGroups(),
 			"huaweicloud_dws_flavors":             dws.DataSourceDwsFlavors(),
 
 			"huaweicloud_workspace_flavors": workspace.DataSourceWorkspaceFlavors(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_address_groups_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_address_groups_test.go
@@ -1,0 +1,98 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceWAFAddressGroups_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_waf_address_groups.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceAddressGroups_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "groups.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "groups.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "groups.0.ip_addresses"),
+					resource.TestCheckResourceAttrSet(rName, "groups.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(rName, "groups.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "groups.0.share_count"),
+					resource.TestCheckResourceAttrSet(rName, "groups.0.accept_count"),
+					resource.TestCheckResourceAttrSet(rName, "groups.0.process_status"),
+
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("ip_address_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("enterprise_project_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceAddressGroups_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_waf_address_groups" "test" {
+  depends_on = [huaweicloud_waf_address_group.test]
+}
+
+data "huaweicloud_waf_address_groups" "name_filter" {
+  name = data.huaweicloud_waf_address_groups.test.groups.0.name
+}
+
+locals {
+  name = data.huaweicloud_waf_address_groups.test.groups.0.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_waf_address_groups.name_filter.groups) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_address_groups.name_filter.groups[*].name : v == local.name]
+  )  
+}
+
+data "huaweicloud_waf_address_groups" "ip_address_filter" {
+  ip_address  = data.huaweicloud_waf_address_groups.test.groups.0.ip_addresses
+}
+
+locals {
+  ip_address = data.huaweicloud_waf_address_groups.test.groups.0.ip_addresses
+}
+
+output "ip_address_filter_is_useful" {
+  value = length(data.huaweicloud_waf_address_groups.ip_address_filter.groups) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_address_groups.ip_address_filter.groups[*].ip_addresses : v == local.ip_address]
+  )  
+}
+
+data "huaweicloud_waf_address_groups" "enterprise_project_id_filter" {
+  enterprise_project_id  = data.huaweicloud_waf_address_groups.test.groups.0.enterprise_project_id
+}
+  
+locals {
+  enterprise_project_id = data.huaweicloud_waf_address_groups.test.groups.0.enterprise_project_id
+}
+  
+output "enterprise_project_id_filter_is_useful" {
+  value = length(data.huaweicloud_waf_address_groups.enterprise_project_id_filter.groups) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_address_groups.enterprise_project_id_filter.groups[*].enterprise_project_id : v == local.enterprise_project_id]
+  )  
+}
+`, testAddressGroup_basic(name))
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_address_groups.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_address_groups.go
@@ -1,0 +1,232 @@
+package waf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceWafAddressGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceAddressGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the data source.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the address group.`,
+			},
+			"ip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the IP address or IP address ranges.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+			"groups": {
+				Type:        schema.TypeList,
+				Elem:        groupsSchema(),
+				Computed:    true,
+				Description: `Specifies the list of address group.`,
+			},
+		},
+	}
+}
+
+func groupsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Specifies the ID of the address group.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Specifies the name of the address group.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+			"ip_addresses": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Specifies the IP addresses or IP address ranges.`,
+			},
+			"rules": {
+				Type:        schema.TypeList,
+				Elem:        rulesInfoSchema(),
+				Computed:    true,
+				Description: `Specifies the list of rules that use the IP address group.`,
+			},
+			"share_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Specifies the number of the users share the address group.`,
+			},
+			"accept_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Specifies the number of users accept the address group.`,
+			},
+			"process_status": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Specifies the status of the processing.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Specifies the description of the address group.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func rulesInfoSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"rule_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of rule.`,
+			},
+			"rule_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of rule.`,
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of policy.`,
+			},
+			"policy_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of policy.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceAddressGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getWAFAddressGroup: Query WAF address group
+	var (
+		getWAFAddressGroupHttpUrl = "v1/{project_id}/waf/ip-groups"
+		getWAFAddressGroupProduct = "waf"
+	)
+	getWAFAddressGroupClient, err := cfg.NewServiceClient(getWAFAddressGroupProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	getWAFAddressGroupsPath := getWAFAddressGroupClient.Endpoint + getWAFAddressGroupHttpUrl
+	getWAFAddressGroupsPath = strings.ReplaceAll(getWAFAddressGroupsPath, "{project_id}",
+		getWAFAddressGroupClient.ProjectID)
+	getWAFAddressGroupsPath += buildWAFAddressGroupsQueryParams(d)
+
+	getWAFAddressGroupsResp, err := pagination.ListAllItems(
+		getWAFAddressGroupClient,
+		"page",
+		getWAFAddressGroupsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving address groups, %s", err)
+	}
+
+	listWAFAddressGroupsRespJson, err := json.Marshal(getWAFAddressGroupsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listWAFAddressGroupsRespBody interface{}
+	err = json.Unmarshal(listWAFAddressGroupsRespJson, &listWAFAddressGroupsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("groups", flattenListAddressGroupsBody(listWAFAddressGroupsRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListAddressGroupsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("items", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                    utils.PathSearch("id", v, nil),
+			"name":                  utils.PathSearch("name", v, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+			"ip_addresses":          utils.PathSearch("ips", v, nil),
+			"description":           utils.PathSearch("description", v, nil),
+			"share_count":           utils.PathSearch("share_count", v, nil),
+			"accept_count":          utils.PathSearch("accept_count", v, nil),
+			"process_status":        utils.PathSearch("process_status", v, nil),
+			"rules":                 flattenAddressGroupResponseBodyRules(resp),
+		})
+	}
+	return rst
+}
+
+func buildWAFAddressGroupsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("enterprise_project_id"); ok {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("ip_address"); ok {
+		res = fmt.Sprintf("%s&ip=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDatasourceWAFAddressGroups_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDatasourceWAFAddressGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceWAFAddressGroups_basic
=== PAUSE TestAccDatasourceWAFAddressGroups_basic
=== CONT  TestAccDatasourceWAFAddressGroups_basic
--- PASS: TestAccDatasourceWAFAddressGroups_basic (402.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       402.108s
