### PR TITLE
feat(vpn): huaweicloud_vpn_customer_gateway support ca_certificate

### DIFF
--- a/docs/resources/vpn_customer_gateway.md
+++ b/docs/resources/vpn_customer_gateway.md
@@ -8,6 +8,8 @@ Manages a VPN customer gateway resource within HuaweiCloud.
 
 ## Example Usage
 
+### Manages a common VPN customer gateway
+
 ```hcl
 variable "name" {}
 variable "ip" {}
@@ -15,6 +17,20 @@ variable "ip" {}
 resource "huaweicloud_vpn_customer_gateway" "test" {
   name = var.name
   ip   = var.ip
+}
+```
+
+### Manages a VPN customer gateway with CA certificate
+
+```hcl
+variable "name" {}
+variable "ip" {}
+variable "certificate_content" {}
+
+resource "huaweicloud_vpn_customer_gateway" "test" {
+  name                = var.name
+  ip                  = var.ip
+  certificate_content = var.certificate_content
 }
 ```
 
@@ -41,11 +57,25 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
+* `certificate_content` - (Optional, String)  The CA certificate content of the customer gateway.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
+* `serial_number` - Indicates the serial number of the customer gateway certificate.
+
+* `signature_algorithm` - Indicates the signature algorithm of the customer gateway certificate.
+
+* `issuer` - Indicates the issuer of the customer gateway certificate.
+
+* `subject` - Indicates the subject of the customer gateway certificate.
+
+* `expire_time` - Indicates the expire time of the customer gateway certificate.
+
+* `is_updatable` - Indicates whether the customer gateway certificate is updatable.
 
 * `created_at` - The create time.
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -196,6 +196,7 @@ var (
 	HW_IMAGE_SHARE_SOURCE_IMAGE_ID = os.Getenv("HW_IMAGE_SHARE_SOURCE_IMAGE_ID")
 
 	HW_CERTIFICATE_CONTENT         = os.Getenv("HW_CERTIFICATE_CONTENT")
+	HW_CERTIFICATE_CONTENT_UPDATE  = os.Getenv("HW_CERTIFICATE_CONTENT_UPDATE")
 	HW_CERTIFICATE_PRIVATE_KEY     = os.Getenv("HW_CERTIFICATE_PRIVATE_KEY")
 	HW_CERTIFICATE_ROOT_CA         = os.Getenv("HW_CERTIFICATE_ROOT_CA")
 	HW_NEW_CERTIFICATE_CONTENT     = os.Getenv("HW_NEW_CERTIFICATE_CONTENT")
@@ -838,6 +839,13 @@ func TestAccPreCheckCcePartitionAz(t *testing.T) {
 func TestAccPreCheckCnEast3(t *testing.T) {
 	if HW_REGION_NAME != "cn-east-3" {
 		t.Skip("HW_REGION_NAME must be cn-east-3 for this test.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckUpdateCertificateContent(t *testing.T) {
+	if HW_CERTIFICATE_CONTENT == "" || HW_CERTIFICATE_CONTENT_UPDATE == "" {
+		t.Skip("HW_CERTIFICATE_CONTENT, HW_CERTIFICATE_CONTENT_UPDATE must be set for this test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_customer_gateway_test.go
+++ b/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_customer_gateway_test.go
@@ -68,7 +68,7 @@ func TestAccCustomerGateway_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "ip", "172.16.1.1"),
+					resource.TestCheckResourceAttr(rName, "ip", ipAddress),
 				),
 			},
 			{
@@ -76,7 +76,7 @@ func TestAccCustomerGateway_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", nameUpdate),
-					resource.TestCheckResourceAttr(rName, "ip", "172.16.1.1"),
+					resource.TestCheckResourceAttr(rName, "ip", ipAddress),
 				),
 			},
 			{
@@ -88,11 +88,81 @@ func TestAccCustomerGateway_basic(t *testing.T) {
 	})
 }
 
+func TestAccCustomerGateway_certificate(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_vpn_customer_gateway.test"
+	ipAddress := "172.16.2.1"
+	certificateContent := acceptance.HW_CERTIFICATE_CONTENT
+	certificateContentUpdate := acceptance.HW_CERTIFICATE_CONTENT_UPDATE
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getCustomerGatewayResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckUpdateCertificateContent(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCustomerGateway_certificate(name, ipAddress, certificateContent),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "ip", ipAddress),
+					resource.TestCheckResourceAttrSet(rName, "serial_number"),
+					resource.TestCheckResourceAttrSet(rName, "signature_algorithm"),
+					resource.TestCheckResourceAttrSet(rName, "issuer"),
+					resource.TestCheckResourceAttrSet(rName, "subject"),
+					resource.TestCheckResourceAttrSet(rName, "expire_time"),
+					resource.TestCheckResourceAttrSet(rName, "is_updatable"),
+				),
+			},
+			{
+				Config: testCustomerGateway_certificate(name, ipAddress, certificateContentUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "ip", ipAddress),
+					resource.TestCheckResourceAttrSet(rName, "serial_number"),
+					resource.TestCheckResourceAttrSet(rName, "signature_algorithm"),
+					resource.TestCheckResourceAttrSet(rName, "issuer"),
+					resource.TestCheckResourceAttrSet(rName, "subject"),
+					resource.TestCheckResourceAttrSet(rName, "expire_time"),
+					resource.TestCheckResourceAttrSet(rName, "is_updatable"),
+				),
+			},
+			{
+				ResourceName: rName,
+				ImportState:  true,
+				ImportStateVerifyIgnore: []string{
+					"content",
+				},
+			},
+		},
+	})
+}
+
 func testCustomerGateway_basic(name, ipAddress string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpn_customer_gateway" "test" {
   name = "%s"
   ip   = "%s"
+}`, name, ipAddress)
 }
-`, name, ipAddress)
+
+func testCustomerGateway_certificate(name, ipAddress string, certificateContent string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpn_customer_gateway" "test" {
+  name                = "%s"
+  ip                  = "%s"
+  certificate_content = "%s"
+}`, name, ipAddress, certificateContent)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support vpn customer gateway binding certificates


depend on ccm [export ca certificate](https://console.huaweicloud.com/apiexplorer/#/openapi/CCM/doc?api=ExportCertificateAuthorityCertificate), but not supported yet. So the example use variable to bind the certificate


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccCustomerGateway_basic"                                   
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccCustomerGateway_basic -timeout 360m -parallel 4 
=== RUN   TestAccCustomerGateway_basic 
=== PAUSE TestAccCustomerGateway_basic
=== CONT  TestAccCustomerGateway_basic
--- PASS: TestAccCustomerGateway_basic (22.69s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       22.727s

```

```
 make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccCustomerGateway_certificate" 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccCustomerGateway_certificate -timeout 360m -parallel 4 
=== RUN   TestAccCustomerGateway_certificate 
=== PAUSE TestAccCustomerGateway_certificate
=== CONT  TestAccCustomerGateway_certificate
--- PASS: TestAccCustomerGateway_certificate (26.29s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       26.330s
```
