### PR TITLE
feat(DMS): add datasource smart connect tasks

### DIFF
--- a/docs/data-sources/dms_kafka_smart_connect_tasks.md
+++ b/docs/data-sources/dms_kafka_smart_connect_tasks.md
@@ -1,0 +1,59 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_kafka_smart_connect_tasks
+
+Use this data source to get the list of DMS kafka smart connect task.
+
+## Example Usage
+
+```hcl
+var "connector_id" {}
+
+data "huaweicloud_dms_kafka_smart_connect_tasks" "test" {
+  connector_id     = var.connector_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `connector_id` - (Required, String) Specifies the connector id of the kafka instance.
+
+* `task_id` - (Optional, String) Specifies the id of the smart connect task.
+
+* `task_name` - (Optional, String) Specifies the name of the smart connect task.
+
+* `destination_type` - (Optional, String) Specifies the destination type of the smart connect task.
+
+* `status` - (Optional, String) Specifies the status of the smart connect task.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tasks` - The list of smart connector task.
+  The [tasks](#DMS_kafka_smart_connect_tasks) structure is documented below.
+
+<a name="DMS_kafka_smart_connect_tasks"></a>
+The `groups` block supports:
+
+* `task_id` - Indicates the id of the smart connector task.
+
+* `task_name` - Indicates the name of the smart connector task.
+
+* `destination_type` - Indicates the destination type of the smart connector task.
+
+* `created_at` - Indicates the creation time of the smart connector task.
+
+* `status` - Indicates the status of the smart connector task. The value can be **RUNNING**, **PAUSED**.
+
+* `topics` - Indicates the topic names string or topic regular expression.
+

--- a/docs/resources/dms_kafka_smart_connect_task.md
+++ b/docs/resources/dms_kafka_smart_connect_task.md
@@ -1,0 +1,114 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# huaweicloud_dms_kafka_smart_connect_task
+
+Manage DMS kafka smart connect task resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "connector_id" {}
+
+resource "huaweicloud_dms_kafka_smart_connect_task" "test" {
+  connector_id     = var.connector_id
+  source_type      = "BLOB"
+  task_name        = "task12"
+  destination_type = "OBS"
+
+  obs_destination_descriptor {   
+    topics                = "topic-test"
+    consumer_strategy     = "latest"
+    destination_file_type = "TEXT"
+    access_key            = ""
+    secret_key            = ""
+    obs_bucket_name       = "afdafd"
+    obs_path              = "afdasfd"
+    partition_format      = "yyyy/MM/dd/HH/mm"
+    record_delimiter      = "\n"
+    deliver_time_interval = 300
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `connector_id` - (Required, String, ForceNew) Specifies the connector_id of the kafka instance.
+
+  Changing this parameter will create a new resource.
+
+* `source_type` - (Required, String, ForceNew) Specifies the source type of the smart connect task.
+  Defaults to **BLOB**.
+
+  Changing this parameter will create a new resource.
+
+* `task_name` - (Required, String, ForceNew) Specifies the name of the smart connect task.
+
+  Changing this parameter will create a new resource.
+
+* `destination_type` - (Required, String, ForceNew) Specifies the destination type of the smart connect task.
+  Defaults to **OBS**.
+
+  Changing this parameter will create a new resource.
+
+* `obs_destination_descriptor` - The list of obs destination descriptor.
+  The [obs_destination_descriptor](#smart_connect_obs_destination_descriptor) structure is documented below.
+
+<a name="smart_connect_obs_destination_descriptor"></a>
+  The `obs_destination_descriptor` block supports:
+
+* `access_key` - (Required, String, ForceNew) Specifies the access key of the HuaweiCloud.
+
+* `secret_key` - (Required, String, ForceNew) Specifies the secret_key key of the HuaweiCloud.
+
+* `consumer_strategy` - (Required, String, ForceNew) Specifies the consumer strategy of the smart connect task.
+  The value can be : **latest**, **earliest**. Defaults to **latest**.
+
+* `deliver_time_interval` - (Required, Int, ForceNew) Specifies the deliver time interval of the smart connect task.
+  The value should be between 30 and 900.
+
+* `obs_bucket_name` - (Required, String, ForceNew) Specifies the obs bucket name of the smart connect task.
+
+* `partiton_format` - (Required, String, ForceNew) Specifies the time directory format of the smart connect task.
+  The value can be : **yyyy**, **yyyy/MM**, **yyyy/MM/dd**, **yyyy/MM/dd/HH**, **yyyy/MM/dd/HH/mm**.
+
+* `obs_path` - (Optional, String, ForceNew) Specifies the obs path of the smart connect task.
+  Obs path is separated by a slash.
+
+* `topics` - (Optional, String, ForceNew) Specifies the topic names separated by a comma of the smart connect task.
+  One of topics and topics_regex is required.
+
+* `topics_regex` - (Optional, String, ForceNew) Specifies the regular expression of topic name for the smart connect task.
+  One of topics and topics_regex is required.
+
+* `destination_file_type` - (Optional, String, ForceNew) Specifies the file type of the smart connect task. Defaults to **TEXT**.
+
+* `record_delimiter` - (Optional, String, ForceNew) Specifies the file type of the smart connect task.
+  The value can be : **,**, **;**, **|**, **\n**, **""**. Defaults to **\n**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `topics` - Indicates the topic config of the smart connect task. There are 2 kinds of values.
+  One is topic name string separated by a comma, the other is a regular expression of topic name.
+
+* `status` - Indicates the status of the smart connect task. The value can be : **RUNNING**, **PAUSED**.
+
+* `created_at` - Indicates the creation time of the smart connect task.
+
+## Import
+
+The kafka smart connect task can be imported using the kafka instance `connector_id` and `id` separated by a slash, e.g.
+
+```
+$ terraform import huaweicloud_dms_kafka_smart_connect_task.test <connector_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -882,12 +882,13 @@ func Provider() *schema.Provider {
 			"huaweicloud_dli_template_spark":        dli.ResourceSparkTemplate(),
 			"huaweicloud_dli_agency":                dli.ResourceDliAgency(),
 
-			"huaweicloud_dms_kafka_user":           dms.ResourceDmsKafkaUser(),
-			"huaweicloud_dms_kafka_permissions":    dms.ResourceDmsKafkaPermissions(),
-			"huaweicloud_dms_kafka_instance":       dms.ResourceDmsKafkaInstance(),
-			"huaweicloud_dms_kafka_topic":          dms.ResourceDmsKafkaTopic(),
-			"huaweicloud_dms_kafka_consumer_group": dms.ResourceDmsKafkaConsumerGroup(),
-			"huaweicloud_dms_kafka_smart_connect":  dms.ResourceDmsKafkaSmartConnect(),
+			"huaweicloud_dms_kafka_user":               dms.ResourceDmsKafkaUser(),
+			"huaweicloud_dms_kafka_permissions":        dms.ResourceDmsKafkaPermissions(),
+			"huaweicloud_dms_kafka_instance":           dms.ResourceDmsKafkaInstance(),
+			"huaweicloud_dms_kafka_topic":              dms.ResourceDmsKafkaTopic(),
+			"huaweicloud_dms_kafka_consumer_group":     dms.ResourceDmsKafkaConsumerGroup(),
+			"huaweicloud_dms_kafka_smart_connect":      dms.ResourceDmsKafkaSmartConnect(),
+			"huaweicloud_dms_kafka_smart_connect_task": dms.ResourceDmsKafkaSmartConnectTask(),
 
 			"huaweicloud_dms_rabbitmq_instance": dms.ResourceDmsRabbitmqInstance(),
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -454,10 +454,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_flavors":   dds.DataSourceDDSFlavorV3(),
 			"huaweicloud_dds_instances": dds.DataSourceDdsInstance(),
 
-			"huaweicloud_dms_kafka_flavors":   dms.DataSourceKafkaFlavors(),
-			"huaweicloud_dms_kafka_instances": dms.DataSourceDmsKafkaInstances(),
-			"huaweicloud_dms_product":         dms.DataSourceDmsProduct(),
-			"huaweicloud_dms_maintainwindow":  dms.DataSourceDmsMaintainWindow(),
+			"huaweicloud_dms_kafka_flavors":             dms.DataSourceKafkaFlavors(),
+			"huaweicloud_dms_kafka_instances":           dms.DataSourceDmsKafkaInstances(),
+			"huaweicloud_dms_product":                   dms.DataSourceDmsProduct(),
+			"huaweicloud_dms_maintainwindow":            dms.DataSourceDmsMaintainWindow(),
+			"huaweicloud_dms_kafka_smart_connect_tasks": dms.DataSourceDmsKafkaSmartConnectTasks(),
 
 			"huaweicloud_dms_rabbitmq_flavors": dms.DataSourceRabbitMQFlavors(),
 

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_smart_connect_tasks_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_kafka_smart_connect_tasks_test.go
@@ -1,0 +1,163 @@
+package dms
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDmsKafkaSmartConnectTasksResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getKafkaSmartConnectTasks: query DMS kafka smart connect tasks
+	var (
+		getKafkaSmartConnectTasksHttpUrl = "v2/{project_id}/connectors/{connector_id}/sink-tasks"
+		getKafkaSmartConnectTasksProduct = "dms"
+	)
+	getKafkaSmartConnectTasksClient, err := cfg.NewServiceClient(getKafkaSmartConnectTasksProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS Client: %s", err)
+	}
+
+	connnectorID := state.Primary.Attributes["connector_id"]
+	getKafkaSmartConnectTasksPath := getKafkaSmartConnectTasksClient.Endpoint + getKafkaSmartConnectTasksHttpUrl
+	getKafkaSmartConnectTasksPath = strings.ReplaceAll(getKafkaSmartConnectTasksPath, "{project_id}",
+		getKafkaSmartConnectTasksClient.ProjectID)
+	getKafkaSmartConnectTasksPath = strings.ReplaceAll(getKafkaSmartConnectTasksPath, "{connector_id}", connnectorID)
+
+	getKafkaSmartConnectTasksOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getKafkaSmartConnectTasksResp, err := getKafkaSmartConnectTasksClient.Request("GET", getKafkaSmartConnectTasksPath,
+		&getKafkaSmartConnectTasksOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DMS smart connect tasks: %s", err)
+	}
+
+	getKafkaSmartConnectTasksBody, err := utils.FlattenResponse(getKafkaSmartConnectTasksResp)
+	if err != nil {
+		return nil, err
+	}
+	return getKafkaSmartConnectTasksBody, nil
+}
+
+func TestAccDmsKafkaSmartConnectTasks_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_dms_kafka_smart_connect_tasks.test"
+
+	rc := acceptance.InitResourceCheck(
+		dataSourceName,
+		&obj,
+		getDmsKafkaSmartConnectTasksResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsKafkaSmartConnectTasks_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tasks.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tasks.0.task_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tasks.0.task_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tasks.0.destination_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tasks.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tasks.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tasks.0.topics"),
+					resource.TestCheckOutput("task_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("task_name_filter_is_useful", "true"),
+					resource.TestCheckOutput("destination_type_filter_is_useful", "true"),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDmsKafkaSmartConnectTasks_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_dms_kafka_smart_connect_tasks" "test" {
+  depends_on   = [huaweicloud_dms_kafka_smart_connect_task.test]
+  connector_id = huaweicloud_dms_kafka_smart_connect.test.id
+}
+  
+data "huaweicloud_dms_kafka_smart_connect_tasks" "task_id_filter" {
+  depends_on   = [huaweicloud_dms_kafka_smart_connect_task.test]
+  connector_id = huaweicloud_dms_kafka_smart_connect.test.id
+  task_id      = huaweicloud_dms_kafka_smart_connect_task.test.id
+}
+
+locals {
+  task_id = huaweicloud_dms_kafka_smart_connect_task.test.id
+}
+
+output "task_id_filter_is_useful" {
+  value = length(data.huaweicloud_dms_kafka_smart_connect_tasks.task_id_filter.tasks) > 0 && alltrue(
+  [for v in data.huaweicloud_dms_kafka_smart_connect_tasks.task_id_filter.tasks[*].task_id : v == local.task_id]
+  )  
+}
+
+data "huaweicloud_dms_kafka_smart_connect_tasks" "task_name_filter" {
+  depends_on   = [huaweicloud_dms_kafka_smart_connect_task.test]
+  connector_id = huaweicloud_dms_kafka_smart_connect.test.id
+  task_name    = huaweicloud_dms_kafka_smart_connect_task.test.task_name
+}
+  
+locals {
+  task_name = huaweicloud_dms_kafka_smart_connect_task.test.task_name
+}
+  
+output "task_name_filter_is_useful" {
+  value = length(data.huaweicloud_dms_kafka_smart_connect_tasks.task_name_filter.tasks) > 0 && alltrue(
+  [for v in data.huaweicloud_dms_kafka_smart_connect_tasks.task_name_filter.tasks[*].task_name : v == local.task_name]
+  )
+}
+
+data "huaweicloud_dms_kafka_smart_connect_tasks" "destination_type_filter" {
+  depends_on       = [huaweicloud_dms_kafka_smart_connect_task.test]
+  connector_id     = huaweicloud_dms_kafka_smart_connect.test.id
+  destination_type = huaweicloud_dms_kafka_smart_connect_task.test.destination_type
+}
+	
+locals {
+  destination_type = huaweicloud_dms_kafka_smart_connect_task.test.destination_type
+}
+	
+output "destination_type_filter_is_useful" {
+  value = length(data.huaweicloud_dms_kafka_smart_connect_tasks.destination_type_filter.tasks) > 0 && alltrue(
+  [for v in data.huaweicloud_dms_kafka_smart_connect_tasks.destination_type_filter.tasks[*].destination_type : v == local.destination_type]
+  ) 
+}
+
+data "huaweicloud_dms_kafka_smart_connect_tasks" "status_filter" {
+  depends_on   = [huaweicloud_dms_kafka_smart_connect_task.test]
+  connector_id = huaweicloud_dms_kafka_smart_connect.test.id
+  status       = huaweicloud_dms_kafka_smart_connect_task.test.status
+}
+	  
+locals {
+  status = huaweicloud_dms_kafka_smart_connect_task.test.status
+}
+	  
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_dms_kafka_smart_connect_tasks.status_filter.tasks) > 0 && alltrue(
+  [for v in data.huaweicloud_dms_kafka_smart_connect_tasks.status_filter.tasks[*].status : v == local.status]
+  ) 
+}
+
+`, testDmsKafkaSmartConnectTask_basic(name))
+}

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_smart_connect_task_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_smart_connect_task_test.go
@@ -1,0 +1,163 @@
+package dms
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDmsKafkaSmartConnectTaskResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getKafkaSmartConnectTask: query DMS kafka smart connect task
+	var (
+		getKafkaSmartConnectTaskHttpUrl = "v2/{project_id}/connectors/{connector_id}/sink-tasks/{task_id}"
+		getKafkaSmartConnectTaskProduct = "dms"
+	)
+	getKafkaSmartConnectTaskClient, err := cfg.NewServiceClient(getKafkaSmartConnectTaskProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS Client: %s", err)
+	}
+
+	connectorID := state.Primary.Attributes["connector_id"]
+	getKafkaSmartConnectTaskPath := getKafkaSmartConnectTaskClient.Endpoint + getKafkaSmartConnectTaskHttpUrl
+	getKafkaSmartConnectTaskPath = strings.ReplaceAll(getKafkaSmartConnectTaskPath, "{project_id}",
+		getKafkaSmartConnectTaskClient.ProjectID)
+	getKafkaSmartConnectTaskPath = strings.ReplaceAll(getKafkaSmartConnectTaskPath, "{connector_id}", connectorID)
+	getKafkaSmartConnectTaskPath = strings.ReplaceAll(getKafkaSmartConnectTaskPath, "{task_id}", state.Primary.ID)
+
+	getKafkaSmartConnectTaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getKafkaSmartConnectTaskResp, err := getKafkaSmartConnectTaskClient.Request("GET", getKafkaSmartConnectTaskPath,
+		&getKafkaSmartConnectTaskOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DMS kafka smart connect task: %s", err)
+	}
+
+	getKafkaSmartConnectTaskRespBody, err := utils.FlattenResponse(getKafkaSmartConnectTaskResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return getKafkaSmartConnectTaskRespBody, nil
+}
+
+func TestAccDmsKafkaSmartConnectTask_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_kafka_smart_connect_task.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDmsKafkaSmartConnectTaskResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsKafkaSmartConnectTask_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "source_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "task_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "destination_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "source_type", "BLOB"),
+					resource.TestCheckResourceAttr(resourceName, "task_name", "test_task"),
+					resource.TestCheckResourceAttr(resourceName, "destination_type", "OBS"),
+					resource.TestCheckResourceAttr(resourceName, "topics", "test_topic"),
+					resource.TestCheckResourceAttr(resourceName, "obs_destination_descriptor.0.consumer_strategy", "latest"),
+					resource.TestCheckResourceAttr(resourceName, "obs_destination_descriptor.0.destination_file_type", "TEXT"),
+					resource.TestCheckResourceAttr(resourceName, "obs_destination_descriptor.0.record_delimiter", ";"),
+					resource.TestCheckResourceAttr(resourceName, "obs_destination_descriptor.0.deliver_time_interval", "300"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source_type"},
+				ImportStateIdFunc:       testKafkaSmartConnectTaskResourceImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testDmsKafkaSmartConnectTask_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "tf-test-bucket"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+
+resource "huaweicloud_dms_kafka_smart_connect" "test" {
+  instance_id       = huaweicloud_dms_kafka_instance.test.id
+  storage_spec_code = "dms.physical.storage.high.v2"
+  node_count        = 2
+  bandwidth         = "100MB"
+}
+
+resource "huaweicloud_dms_kafka_topic" "test" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "test_topic"
+  partitions  = 10
+  aging_time  = 36
+}
+
+resource "huaweicloud_dms_kafka_smart_connect_task" "test" {
+  connector_id     = huaweicloud_dms_kafka_smart_connect.test.id
+  source_type      = "BLOB"
+  task_name        = "test_task"
+  destination_type = "OBS"
+
+  obs_destination_descriptor {
+	topics                = huaweicloud_dms_kafka_topic.test.name
+	consumer_strategy     = "latest"
+	destination_file_type = "TEXT"
+	access_key            = "%[2]s"
+	secret_key            = "%[3]s"
+	obs_bucket_name       = huaweicloud_obs_bucket.test.bucket
+	obs_path              = "afobsTransfer-1689777685asfd"
+	partition_format      = "yyyy/MM/dd/HH/mm"
+	record_delimiter      = ";"
+	deliver_time_interval = 300
+  }
+
+  lifecycle {
+	ignore_changes = [
+	  created_at, id, region, status, topics, obs_destination_descriptor[0].access_key, obs_destination_descriptor[0].secret_key
+	]
+  }
+}
+
+`, testAccKafkaInstance_newFormat(rName), acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY)
+}
+
+// testKafkaSmartConnectTaskResourceImportState is used to return an import id with format <connector_id>/<id>
+func testKafkaSmartConnectTaskResourceImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		connector_id := rs.Primary.Attributes["connector_id"]
+		return fmt.Sprintf("%s/%s", connector_id, rs.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_smart_connect_tasks.go
+++ b/huaweicloud/services/dms/data_source_huaweicloud_dms_kafka_smart_connect_tasks.go
@@ -1,0 +1,206 @@
+package dms
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceDmsKafkaSmartConnectTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceDmsKafkaSmartConnectTasksRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"connector_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the connector id of the kafka instance.`,
+			},
+			"task_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the id of the smart connect task.`,
+			},
+			"task_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the smart connect task.`,
+			},
+			"destination_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the destination type of the smart connect task.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the status of the smart connect task.`,
+			},
+			"tasks": {
+				Type:        schema.TypeList,
+				Elem:        tasksSchema(),
+				Computed:    true,
+				Description: `Indicates the list of the smart connect task.`,
+			},
+		},
+	}
+}
+
+func tasksSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"task_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the id of the smart connect task.`,
+			},
+			"task_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the name of the smart connect task.`,
+			},
+			"destination_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the destination type of the smart connect task.`,
+			},
+			"created_at": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Indicates the creation time of the smart connect task.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the status of the smart connect task.`,
+			},
+			"topics": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the topics of the smart connect task.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDmsKafkaSmartConnectTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getKafkaSmartConnectTasks: query DMS kafka smart connect tasks
+	var (
+		getKafkaSmartConnectTasksHttpUrl = "v2/{project_id}/connectors/{connector_id}/sink-tasks"
+		getKafkaSmartConnectTasksProduct = "dms"
+	)
+	getKafkaSmartConnectTasksClient, err := cfg.NewServiceClient(getKafkaSmartConnectTasksProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	connectorID := d.Get("connector_id").(string)
+	getKafkaSmartConnectTasksPath := getKafkaSmartConnectTasksClient.Endpoint + getKafkaSmartConnectTasksHttpUrl
+	getKafkaSmartConnectTasksPath = strings.ReplaceAll(getKafkaSmartConnectTasksPath, "{project_id}",
+		getKafkaSmartConnectTasksClient.ProjectID)
+	getKafkaSmartConnectTasksPath = strings.ReplaceAll(getKafkaSmartConnectTasksPath, "{connector_id}", connectorID)
+
+	getKafkaSmartConnectTasksOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getKafkaSmartConnectTasksResp, err := getKafkaSmartConnectTasksClient.Request("GET", getKafkaSmartConnectTasksPath,
+		&getKafkaSmartConnectTasksOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DMS kafka smart connect tasks")
+	}
+
+	getKafkaSmartConnectTasksRespBody, respBodyerr := utils.FlattenResponse(getKafkaSmartConnectTasksResp)
+	if respBodyerr != nil {
+		return diag.FromErr(respBodyerr)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("connector_id", connectorID),
+		d.Set("tasks", flattenTasks(filterTasks(d, getKafkaSmartConnectTasksRespBody))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTasks(taskRespBody []interface{}) []interface{} {
+	if taskRespBody == nil {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(taskRespBody))
+	for _, v := range taskRespBody {
+		rst = append(rst, map[string]interface{}{
+			"task_id":          utils.PathSearch("task_id", v, nil),
+			"task_name":        utils.PathSearch("task_name", v, nil),
+			"destination_type": utils.PathSearch("destination_type", v, nil),
+			"created_at":       utils.PathSearch("create_time", v, nil),
+			"status":           utils.PathSearch("status", v, nil),
+			"topics":           utils.PathSearch("topics", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterTasks(d *schema.ResourceData, resp interface{}) []interface{} {
+	taskJson := utils.PathSearch("tasks", resp, make([]interface{}, 0))
+	taskArray := taskJson.([]interface{})
+	if len(taskArray) < 1 {
+		return nil
+	}
+	result := make([]interface{}, 0, len(taskArray))
+
+	rawTaskId, rawTaskIdOK := d.GetOk("task_id")
+	rawTaskName, rawTaskNameOK := d.GetOk("task_name")
+	rawDestinationType, rawDestinationTypeOK := d.GetOk("destination_type")
+	rawStatus, rawStatusOK := d.GetOk("status")
+
+	for _, task := range taskArray {
+		taskId := utils.PathSearch("task_id", task, nil)
+		taskName := utils.PathSearch("task_name", task, nil)
+		destinationType := utils.PathSearch("destination_type", task, nil)
+		status := utils.PathSearch("status", task, nil)
+
+		if rawTaskIdOK && rawTaskId != taskId {
+			continue
+		}
+		if rawTaskNameOK && rawTaskName != taskName {
+			continue
+		}
+		if rawDestinationTypeOK && rawDestinationType != destinationType {
+			continue
+		}
+		if rawStatusOK && rawStatus != status {
+			continue
+		}
+		result = append(result, task)
+	}
+
+	return result
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_smart_connect_task.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_smart_connect_task.go
@@ -1,0 +1,388 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDmsKafkaSmartConnectTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsKafkaSmartConnectTaskCreate,
+		ReadContext:   resourceDmsKafkaSmartConnectTaskRead,
+		DeleteContext: resourceDmsKafkaSmartConnectTaskDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDmsKafkaSmartConnectTaskImportState,
+		},
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"connector_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the connector id of the kafka instance.`,
+			},
+			"source_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the source type of the smart connect task.`,
+			},
+			"task_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the name of the smart connect task.`,
+			},
+			"destination_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the destination type of the smart connect task.`,
+			},
+			"obs_destination_descriptor": {
+				Type:        schema.TypeList,
+				Elem:        obsDestinationDescriptorSchema(),
+				MaxItems:    1,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the destination parameters of the smart connect task.`,
+			},
+			"topics": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the topics of the smart connect task.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the status of the smart connect task.`,
+			},
+			"created_at": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Indicates the creation time of the smart connect task.`,
+			},
+		},
+	}
+}
+
+func obsDestinationDescriptorSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"access_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the access key of the smart connect task.`,
+			},
+			"secret_key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Sensitive:   true,
+				Description: `Specifies the secret key of the smart connect task.`,
+			},
+			"consumer_strategy": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the consumer strategy of the smart connect task.`,
+			},
+			"deliver_time_interval": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the deliver time interval of the smart connect task.`,
+			},
+			"obs_bucket_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the obs bucket name of the smart connect task.`,
+			},
+			"partition_format": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the partiton format of the smart connect task.`,
+			},
+			"obs_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the obs path of the smart connect task.`,
+			},
+			"destination_file_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "TEXT",
+				Description: `Specifies the destination file type of the smart connect task.`,
+			},
+			"record_delimiter": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "\n",
+				Description: `Specifies the record delimiter of the smart connect task.`,
+			},
+			"topics": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the topics of the task.`,
+			},
+			"topics_regex": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the topics regular expression of the smart connect task.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDmsKafkaSmartConnectTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	// createKafkaSmartConnectTask: create DMS kafka smart connect task
+	var (
+		createKafkaSmartConnectTaskHttpUrl = "v2/{project_id}/connectors/{connector_id}/sink-tasks"
+		createKafkaSmartConnectTaskProduct = "dms"
+	)
+	createKafkaSmartConnectTaskClient, err := cfg.NewServiceClient(createKafkaSmartConnectTaskProduct, region)
+
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	connectorID := d.Get("connector_id").(string)
+	createKafkaSmartConnectTaskPath := createKafkaSmartConnectTaskClient.Endpoint + createKafkaSmartConnectTaskHttpUrl
+	createKafkaSmartConnectTaskPath = strings.ReplaceAll(createKafkaSmartConnectTaskPath, "{project_id}",
+		createKafkaSmartConnectTaskClient.ProjectID)
+	createKafkaSmartConnectTaskPath = strings.ReplaceAll(createKafkaSmartConnectTaskPath, "{connector_id}", connectorID)
+
+	createKafkaSmartConnectTaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createKafkaSmartConnectTaskOpt.JSONBody = utils.RemoveNil(buildCreateKafkaSmartConnectTaskBodyParams(d))
+
+	createKafkaSmartConnectTaskResp, createErr := createKafkaSmartConnectTaskClient.Request("POST",
+		createKafkaSmartConnectTaskPath, &createKafkaSmartConnectTaskOpt)
+
+	if createErr != nil {
+		return diag.Errorf("error creating DMS kafka smart connect task: %v", createErr)
+	}
+
+	kafkaSmartConnectTaskRespBody, err := utils.FlattenResponse(createKafkaSmartConnectTaskResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	taskID := utils.PathSearch("task_id", kafkaSmartConnectTaskRespBody, nil)
+	d.SetId(taskID.(string))
+	return resourceDmsKafkaSmartConnectTaskRead(ctx, d, meta)
+}
+
+func buildCreateKafkaSmartConnectTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	obsDestinationDescriptorStruct, err := buildObsDestinationDescriptorStruct(d)
+	if err != nil {
+		log.Printf("[DEBUG] obsDestinationDescriptorConfig: %v", err)
+	}
+
+	bodyParams := map[string]interface{}{
+		"source_type":                d.Get("source_type"),
+		"task_name":                  d.Get("task_name"),
+		"destination_type":           d.Get("destination_type"),
+		"obs_destination_descriptor": obsDestinationDescriptorStruct,
+	}
+	return bodyParams
+}
+
+// obs_destination_descriptor struct
+type ObsDestinationDescriptorStruct struct {
+	Topics              string `json:"topics,omitempty"`
+	TopicsRegex         string `json:"topics_regex,omitempty"`
+	ConsumerStrategy    string `json:"consumer_strategy,omitempty"`
+	DestinationFileType string `json:"destination_file_type"`
+	AccessKey           string `json:"access_key,omitempty"`
+	SecretKey           string `json:"secret_key,omitempty"`
+	ObsBucketName       string `json:"obs_bucket_name,omitempty"`
+	ObsPath             string `json:"obs_path,omitempty"`
+	PartitionFormat     string `json:"partition_format,omitempty"`
+	RecordDelimiter     string `json:"record_delimiter,omitempty"`
+	DeliverTimeInterval int    `json:"deliver_time_interval"`
+}
+
+func buildObsDestinationDescriptorStruct(d *schema.ResourceData) (*ObsDestinationDescriptorStruct, diag.Diagnostics) {
+	var obsDestinationDescriptorStruct *ObsDestinationDescriptorStruct
+	obsDestinationDescriptorRaw := d.Get("obs_destination_descriptor").([]interface{})
+	if len(obsDestinationDescriptorRaw) == 1 {
+		if v, ok := obsDestinationDescriptorRaw[0].(map[string]interface{}); ok {
+			obsDestinationDescriptorStruct = &ObsDestinationDescriptorStruct{
+				ConsumerStrategy:    v["consumer_strategy"].(string),
+				DestinationFileType: v["destination_file_type"].(string),
+				AccessKey:           v["access_key"].(string),
+				SecretKey:           v["secret_key"].(string),
+				ObsBucketName:       v["obs_bucket_name"].(string),
+				ObsPath:             v["obs_path"].(string),
+				PartitionFormat:     v["partition_format"].(string),
+				RecordDelimiter:     v["record_delimiter"].(string),
+				DeliverTimeInterval: v["deliver_time_interval"].(int),
+			}
+			// one of topics and topics_regex is required
+			topicsRaw := v["topics"].(string)
+			topicsRegexRaw := v["topics_regex"].(string)
+			if topicsRaw == "" && topicsRegexRaw == "" {
+				return nil, diag.Errorf("error building destination descriptor config: topics or topics_regex is required")
+			}
+			if v["topics"] != "" {
+				obsDestinationDescriptorStruct.Topics = v["topics"].(string)
+			} else {
+				obsDestinationDescriptorStruct.TopicsRegex = v["topics_regex"].(string)
+			}
+		}
+	}
+	return obsDestinationDescriptorStruct, nil
+}
+
+func resourceDmsKafkaSmartConnectTaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getKafkaSmartConnectTask: query DMS kafka smart connect task
+	var (
+		getKafkaSmartConnectTaskHttpUrl = "v2/{project_id}/connectors/{connector_id}/sink-tasks/{task_id}"
+		getKafkaSmartConnectTaskProduct = "dms"
+	)
+	getKafkaSmartConnectTaskClient, err := cfg.NewServiceClient(getKafkaSmartConnectTaskProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	connectorID := d.Get("connector_id").(string)
+	getKafkaSmartConnectTaskPath := getKafkaSmartConnectTaskClient.Endpoint + getKafkaSmartConnectTaskHttpUrl
+	getKafkaSmartConnectTaskPath = strings.ReplaceAll(getKafkaSmartConnectTaskPath, "{project_id}",
+		getKafkaSmartConnectTaskClient.ProjectID)
+	getKafkaSmartConnectTaskPath = strings.ReplaceAll(getKafkaSmartConnectTaskPath, "{connector_id}", connectorID)
+	getKafkaSmartConnectTaskPath = strings.ReplaceAll(getKafkaSmartConnectTaskPath, "{task_id}", d.Id())
+
+	getKafkaSmartConnectTaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getKafkaSmartConnectTaskResp, err := getKafkaSmartConnectTaskClient.Request("GET", getKafkaSmartConnectTaskPath,
+		&getKafkaSmartConnectTaskOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DMS kafka smart connect task")
+	}
+
+	getKafkaSmartConnectTaskRespBody, respBodyerr := utils.FlattenResponse(getKafkaSmartConnectTaskResp)
+	if respBodyerr != nil {
+		return diag.FromErr(respBodyerr)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("connector_id", connectorID),
+		d.Set("task_name", utils.PathSearch("task_name", getKafkaSmartConnectTaskRespBody, nil)),
+		d.Set("destination_type", utils.PathSearch("destination_type", getKafkaSmartConnectTaskRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", getKafkaSmartConnectTaskRespBody, nil)),
+		d.Set("status", utils.PathSearch("status", getKafkaSmartConnectTaskRespBody, nil)),
+		d.Set("topics", utils.PathSearch("topics", getKafkaSmartConnectTaskRespBody, nil)),
+		d.Set("obs_destination_descriptor", flattenObsDestinationDescriptor(
+			utils.PathSearch("obs_destination_descriptor", getKafkaSmartConnectTaskRespBody, nil).(map[string]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenObsDestinationDescriptor(obsDestinationDescriptorStruct map[string]interface{}) []map[string]interface{} {
+	var obsDestinationDescriptorList []map[string]interface{}
+	if obsDestinationDescriptorStruct != nil {
+		obsDestinationDescriptorList = make([]map[string]interface{}, 1)
+		params := make(map[string]interface{})
+		params["topics"] = utils.PathSearch("topics", obsDestinationDescriptorStruct, nil)
+		params["topics_regex"] = utils.PathSearch("topics_regex", obsDestinationDescriptorStruct, nil)
+		params["consumer_strategy"] = utils.PathSearch("consumer_strategy", obsDestinationDescriptorStruct, nil)
+		params["destination_file_type"] = utils.PathSearch("destination_file_type", obsDestinationDescriptorStruct, nil)
+		params["obs_bucket_name"] = utils.PathSearch("obs_bucket_name", obsDestinationDescriptorStruct, nil)
+		params["obs_path"] = utils.PathSearch("obs_path", obsDestinationDescriptorStruct, nil)
+		params["partition_format"] = utils.PathSearch("partition_format", obsDestinationDescriptorStruct, nil)
+		params["record_delimiter"] = utils.PathSearch("record_delimiter", obsDestinationDescriptorStruct, nil)
+		params["deliver_time_interval"] = utils.PathSearch("deliver_time_interval", obsDestinationDescriptorStruct, nil).(float64)
+		obsDestinationDescriptorList[0] = params
+	}
+	return obsDestinationDescriptorList
+}
+
+func resourceDmsKafkaSmartConnectTaskDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteKafkaSmartConnectTask: delete DMS kafka smart connect task
+	var (
+		deleteKafkaSmartConnectTaskHttpUrl = "v2/{project_id}/connectors/{connector_id}/sink-tasks/{task_id}"
+		deleteKafkaSmartConnectTaskProduct = "dms"
+	)
+	deleteKafkaSmartConnectTaskClient, err := cfg.NewServiceClient(deleteKafkaSmartConnectTaskProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DMS Client: %s", err)
+	}
+
+	connectorID := d.Get("connector_id").(string)
+	deleteKafkaSmartConnectTaskPath := deleteKafkaSmartConnectTaskClient.Endpoint + deleteKafkaSmartConnectTaskHttpUrl
+	deleteKafkaSmartConnectTaskPath = strings.ReplaceAll(deleteKafkaSmartConnectTaskPath, "{project_id}",
+		deleteKafkaSmartConnectTaskClient.ProjectID)
+	deleteKafkaSmartConnectTaskPath = strings.ReplaceAll(deleteKafkaSmartConnectTaskPath, "{connector_id}", connectorID)
+	deleteKafkaSmartConnectTaskPath = strings.ReplaceAll(deleteKafkaSmartConnectTaskPath, "{task_id}", d.Id())
+
+	deleteKafkaSmartConnectTaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	_, deleteErr := deleteKafkaSmartConnectTaskClient.Request("DELETE",
+		deleteKafkaSmartConnectTaskPath, &deleteKafkaSmartConnectTaskOpt)
+
+	if deleteErr != nil {
+		return diag.Errorf("error deleting DMS kafka smart connect task: %v", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+// resourceDmsKafkaSmartConnectTaskImportState is used to import an id with format <connector_id>/<id>
+func resourceDmsKafkaSmartConnectTaskImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import id, must be <connector_id>/<id>")
+	}
+
+	d.Set("connector_id", parts[0])
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add datasource smart connect tasks
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccDmsKafkaSmartConnectTasks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsKafkaSmartConnectTasks_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaSmartConnectTasks_basic
=== PAUSE TestAccDmsKafkaSmartConnectTasks_basic
=== CONT  TestAccDmsKafkaSmartConnectTasks_basic
--- PASS: TestAccDmsKafkaSmartConnectTasks_basic (1274.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1274.168s

```
