### PR TITLE
feat(RDS): add a new datasource to query the list of MySQL accounts

### DIFF
--- a/docs/data-sources/rds_mysql_accounts.md
+++ b/docs/data-sources/rds_mysql_accounts.md
@@ -1,0 +1,50 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_mysql_accounts
+
+Use this data source to get the list of RDS MySQL accounts.
+
+## Example Usage
+
+```hcl
+var "instance_id" {}
+
+data "huaweicloud_rds_mysql_accounts" "test" {
+  instance_id   = var.instance_id
+  name          = "test"
+  host          = "10.10.10.10"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RDS instance.
+
+* `name` - (Optional, String) Specifies the username of the DB account.
+
+* `host` - (Optional, String) Specifies the IP address that is allowed to access your DB instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `users` - Indicates the list of users.
+  The [users](#RDS_mysql_users) structure is documented below.
+
+<a name="RDS_mysql_users"></a>
+The `users` block supports:
+
+* `name` - Indicates the username of the DB account.
+
+* `hosts` - Indicates the IP addresses that are allowed to access your DB instance.
+
+* `description` - Indicates remarks of the database account.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -586,6 +586,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_sqlserver_collations": rds.DataSourceSQLServerCollations(),
 			"huaweicloud_rds_pg_plugins":           rds.DataSourcePgPlugins(),
 			"huaweicloud_rds_mysql_databases":      rds.DataSourceRdsMysqlDatabases(),
+			"huaweicloud_rds_mysql_accounts":       rds.DataSourceRdsMysqlAccounts(),
 
 			"huaweicloud_rms_policy_definitions":           rms.DataSourcePolicyDefinitions(),
 			"huaweicloud_rms_assignment_package_templates": rms.DataSourceTemplates(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_accounts_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_accounts_test.go
@@ -1,0 +1,77 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccMysqlAccounts_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_rds_mysql_accounts.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMysqlAccounts_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "users.#"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.hosts.0"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("host_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMysqlAccounts_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rds_mysql_accounts" "test" {
+  depends_on  = [huaweicloud_rds_mysql_account.test]
+  instance_id = huaweicloud_rds_instance.test.id
+}
+
+data "huaweicloud_rds_mysql_accounts" "name_filter" {
+  depends_on  = [huaweicloud_rds_mysql_account.test]
+  instance_id = huaweicloud_rds_instance.test.id
+  name        = huaweicloud_rds_mysql_account.test.name
+}
+
+locals {
+  name = huaweicloud_rds_mysql_account.test.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_rds_mysql_accounts.name_filter.users) > 0 && alltrue(
+    [for v in data.huaweicloud_rds_mysql_accounts.name_filter.users[*].name : v == local.name]
+  )
+}
+
+data "huaweicloud_rds_mysql_accounts" "host_filter" {
+  depends_on  = [huaweicloud_rds_mysql_account.test]
+  instance_id = huaweicloud_rds_instance.test.id
+  host        = huaweicloud_rds_mysql_account.test.hosts.0
+}
+
+locals {
+  host = huaweicloud_rds_mysql_account.test.hosts.0
+}
+
+output "host_filter_is_useful" {
+  value = length(data.huaweicloud_rds_mysql_accounts.host_filter.users) > 0 && alltrue(
+    [for v in data.huaweicloud_rds_mysql_accounts.host_filter.users[*].hosts : contains(v, local.host)]
+  )
+}
+`, testMysqlAccount_basic(name, ""))
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_mysql_accounts.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_mysql_accounts.go
@@ -1,0 +1,171 @@
+package rds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: RDS GET /v3/{project_id}/instances/{instance_id}/db_user/detail
+func DataSourceRdsMysqlAccounts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsMysqlAccountsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the RDS instance.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the username of the DB account.`,
+			},
+			"host": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the IP address that is allowed to access your DB instance.`,
+			},
+			"users": {
+				Type:        schema.TypeList,
+				Elem:        accountsSchema(),
+				Computed:    true,
+				Description: `Indicates the list of users.`,
+			},
+		},
+	}
+}
+
+func accountsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the username of the DB account.`,
+			},
+			"hosts": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: `Indicates the IP addresses that are allowed to access your DB instance.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates remarks of the database account.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceRdsMysqlAccountsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		listMysqlAccountsHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user/detail?page=1&limit=100"
+		listMysqAccountsProduct  = "rds"
+	)
+	listMysqlAccountsClient, err := cfg.NewServiceClient(listMysqAccountsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	listMysqlAccountsPath := listMysqlAccountsClient.Endpoint + listMysqlAccountsHttpUrl
+	listMysqlAccountsPath = strings.ReplaceAll(listMysqlAccountsPath, "{project_id}", listMysqlAccountsClient.ProjectID)
+	listMysqlAccountsPath = strings.ReplaceAll(listMysqlAccountsPath, "{instance_id}", fmt.Sprintf("%v", d.Get("instance_id")))
+
+	listMysqlAccountsResp, err := pagination.ListAllItems(
+		listMysqlAccountsClient,
+		"page",
+		listMysqlAccountsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving RDS Mysql accounts")
+	}
+
+	listMysqlAccountsRespJson, err := json.Marshal(listMysqlAccountsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listMysqlAccountsRespBody interface{}
+	err = json.Unmarshal(listMysqlAccountsRespJson, &listMysqlAccountsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("users", flattenListAccountsBody(filterListAccounts(d, listMysqlAccountsRespBody))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListAccountsBody(resp []interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(resp))
+
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"name":        utils.PathSearch("name", v, nil),
+			"hosts":       utils.PathSearch("hosts", v, nil),
+			"description": utils.PathSearch("comment", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterListAccounts(d *schema.ResourceData, resp interface{}) []interface{} {
+	accountsJson := utils.PathSearch("users", resp, make([]interface{}, 0))
+	accountArray := accountsJson.([]interface{})
+	if len(accountArray) < 1 {
+		return nil
+	}
+	result := make([]interface{}, 0, len(accountArray))
+
+	rawName, rawNameOK := d.GetOk("name")
+	rawhost, rawhostOk := d.GetOk("host")
+
+	for _, account := range accountArray {
+		name := utils.PathSearch("name", account, nil)
+		hosts := utils.ExpandToStringList(utils.PathSearch("hosts", account, make([]interface{}, 0)).([]interface{}))
+		if rawNameOK && rawName != name {
+			continue
+		}
+		if rawhostOk && !utils.StrSliceContains(hosts, rawhost.(string)) {
+			continue
+		}
+		result = append(result, account)
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/rds' TESTARGS='-run TestAccMysqlAccounts_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds -v -run TestAccMysqlAccounts_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlAccounts_basic
=== PAUSE TestAccMysqlAccounts_basic
=== CONT  TestAccMysqlAccounts_basic
--- PASS: TestAccMysqlAccounts_basic (542.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       542.364s
```
