### PR TITLE
feat(DataArts): add a new resource dataarts studio business metric

### DIFF
--- a/docs/resources/dataarts_studio_business_metric.md
+++ b/docs/resources/dataarts_studio_business_metric.md
@@ -1,0 +1,129 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_studio_business_metric
+
+Manages a DataArts Studio business metric resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "biz_catalog_id" {}
+variable "owner" {}
+variable "owner_department" {}
+
+resource "huaweicloud_dataarts_studio_business_metric" "test" {
+  workspace_id     = var.workspace_id
+  biz_catalog_id   = var.biz_catalog_id
+  owner            = var.owner
+  owner_department = var.owner_department
+  name             = "test-name"
+  name_alias       = "alias-name"
+  time_filters     = "Monthly,Yearly"
+  interval_type    = "HOUR"
+  destination      = "test destination"
+  definition       = "test definition"
+  expression       = "a+b+c"
+  description      = "test description"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the ID of DataArts Studio workspace.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the indicator name. This value can contain only letters, digits, parentheses,
+  commas, spaces, and special characters `+#-_/[]`. The maximum length is 500 characters.
+
+* `biz_catalog_id` - (Required, String) Specifies the process architecture ID.
+
+* `time_filters` - (Required, String) Specifies the statistical frequency. Use commas to separate multiple fields.
+
+* `interval_type` - (Required, String) Specifies the refresh frequency. Value values are: **REAL_TIME**, **HOUR**,
+  **HALF_DAY**, **DAY**, **WEEK**, **DOUBLE_WEEK**, **MONTH**, **QUART**, **HALF_YEAR** and **YEAR**.
+
+* `owner` - (Required, String) Specifies the name of person responsible for the indicator. The owner must exist in the
+  system. The maximum length is 100 characters.
+
+* `owner_department` - (Required, String) Specifies the indicator management department name. The maximum length is 600
+  characters.
+
+* `destination` - (Required, String) Specifies the purpose of setting. The maximum length is 1000 characters.
+
+* `definition` - (Required, String) Specifies the indicator definition. The maximum length is 1000 characters.
+
+* `expression` - (Required, String) Specifies the calculation formula. The maximum length is 1000 characters.
+
+* `description` - (Optional, String) Specifies the description. The maximum length is 600 characters.
+
+* `apply_scenario` - (Optional, String) Specifies the application scenarios. The maximum length is 255 characters.
+
+* `technical_metric` - (Optional, Int) Specifies the related technical indicators.
+
+* `measure` - (Optional, String) Specifies the measurement object. The maximum length is 255 characters.
+
+* `dimensions` - (Optional, String) Specifies the statistical dimension. The maximum length is 1000 characters.
+
+* `general_filters` - (Optional, String) Specifies the statistical caliber and modifiers. The maximum length is 1000 characters.
+
+* `data_origin` - (Optional, String) Specifies the data sources. The value needs to be a descriptive value. The maximum
+  length is 1000 characters.
+
+* `unit` - (Optional, String) Specifies the unit of measurement. The value of this field needs to be a quantifier, for example,
+  **percentage**, **hour** or **minute**. The maximum length is 50 characters.
+
+* `name_alias` - (Optional, String) Specifies the indicator alias. The maximum length is 500 characters.
+
+* `code` - (Optional, String) Specifies the indicator encoding. If this field is not specified, an indicator code will
+  be automatically generated. The value of this field does not support changing to empty.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The status. Valid values are: **DRAFT**, **PUBLISH_DEVELOPING**, **PUBLISHED**, **OFFLINE_DEVELOPING**,
+  **OFFLINE** and **REJECT**.
+
+* `biz_catalog_path` - The process architecture path.
+
+* `created_by` - The creator.
+
+* `updated_by` - The editor.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The update time.
+
+* `technical_metric_type` - The related technical indicator type.
+
+* `technical_metric_name` - The related technical indicator name.
+
+* `l1` - The subject domain grouping Chinese name.
+
+* `l2` - The subject field Chinese name.
+
+* `l3` - The business object Chinese name.
+
+* `biz_metric` - The business indicator synchronization status. Valid values are: **NO_NEED**, **CREATE_SUCCESS**,
+  **CREATE_FAILED**, **UPDATE_SUCCESS**, **UPDATE_FAILED**, **SUMMARY_SUCCESS**, **SUMMARY_FAILED**, **RUNNING** and **OFFLINE**.
+
+* `summary_status` - The synchronize statistics status. Valid values are: **NO_NEED**, **CREATE_SUCCESS**,
+  **CREATE_FAILED**, **UPDATE_SUCCESS**, **UPDATE_FAILED**, **SUMMARY_SUCCESS**, **SUMMARY_FAILED**, **RUNNING** and **OFFLINE**.
+
+## Import
+
+The DataArts Studio business metric resource can be imported using the `workspace_id` and `id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_studio_business_metric.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1087,10 +1087,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_network":                modelarts.ResourceModelartsNetwork(),
 			"huaweicloud_modelarts_resource_pool":          modelarts.ResourceModelartsResourcePool(),
 
-			"huaweicloud_dataarts_studio_instance":       dataarts.ResourceStudioInstance(),
-			"huaweicloud_dataarts_studio_directory":      dataarts.ResourceDataArtsStudioDirectory(),
-			"huaweicloud_dataarts_service_app":           dataarts.ResourceServiceApp(),
-			"huaweicloud_dataarts_studio_permission_set": dataarts.ResourcePermissionSet(),
+			"huaweicloud_dataarts_studio_instance":        dataarts.ResourceStudioInstance(),
+			"huaweicloud_dataarts_studio_directory":       dataarts.ResourceDataArtsStudioDirectory(),
+			"huaweicloud_dataarts_service_app":            dataarts.ResourceServiceApp(),
+			"huaweicloud_dataarts_studio_permission_set":  dataarts.ResourcePermissionSet(),
+			"huaweicloud_dataarts_studio_business_metric": dataarts.ResourceBusinessMetric(),
 
 			"huaweicloud_mpc_transcoding_template":       mpc.ResourceTranscodingTemplate(),
 			"huaweicloud_mpc_transcoding_template_group": mpc.ResourceTranscodingTemplateGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -214,8 +214,9 @@ var (
 
 	HW_CERT_BATCH_PUSH_ID = os.Getenv("HW_CERT_BATCH_PUSH_ID")
 
-	HW_DATAARTS_WORKSPACE_ID = os.Getenv("HW_DATAARTS_WORKSPACE_ID")
-	HW_DATAARTS_MANAGER_ID   = os.Getenv("HW_DATAARTS_MANAGER_ID")
+	HW_DATAARTS_WORKSPACE_ID   = os.Getenv("HW_DATAARTS_WORKSPACE_ID")
+	HW_DATAARTS_MANAGER_ID     = os.Getenv("HW_DATAARTS_MANAGER_ID")
+	HW_DATAARTS_BIZ_CATALOG_ID = os.Getenv("HW_DATAARTS_BIZ_CATALOG_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -980,5 +981,12 @@ func TestAccPreCheckDataArtsWorkSpaceID(t *testing.T) {
 func TestAccPreCheckDataArtsManagerID(t *testing.T) {
 	if HW_DATAARTS_MANAGER_ID == "" {
 		t.Skip("This environment does not support DataArts Studio permission set tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDataArtsBizCatalogID(t *testing.T) {
+	if HW_DATAARTS_BIZ_CATALOG_ID == "" {
+		t.Skip("HW_DATAARTS_BIZ_CATALOG_ID must be set for the acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_business_metric_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_business_metric_test.go
@@ -1,0 +1,257 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getBusinessMetricResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/design/biz-metrics/{id}"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": state.Primary.Attributes["workspace_id"]},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DataArts Studio business metric: %s", err)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccBusinessMetric_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dataarts_studio_business_metric.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBusinessMetricResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsBizCatalogID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBusinessMetric_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "biz_catalog_id", acceptance.HW_DATAARTS_BIZ_CATALOG_ID),
+					resource.TestCheckResourceAttr(rName, "owner", "test-owner"),
+					resource.TestCheckResourceAttr(rName, "owner_department", "test-department"),
+					resource.TestCheckResourceAttr(rName, "time_filters", "双周"),
+					resource.TestCheckResourceAttr(rName, "interval_type", "HOUR"),
+					resource.TestCheckResourceAttr(rName, "destination", "test destination"),
+					resource.TestCheckResourceAttr(rName, "definition", "test definition"),
+					resource.TestCheckResourceAttr(rName, "expression", "a+b+c"),
+					resource.TestCheckResourceAttr(rName, "description", "test description"),
+					resource.TestCheckResourceAttr(rName, "apply_scenario", "test apply scenario"),
+					resource.TestCheckResourceAttr(rName, "technical_metric", "100"),
+					resource.TestCheckResourceAttr(rName, "measure", "test measure"),
+					resource.TestCheckResourceAttr(rName, "general_filters", "test general filters"),
+					resource.TestCheckResourceAttr(rName, "data_origin", "test data origin"),
+					resource.TestCheckResourceAttr(rName, "unit", "test unit"),
+					resource.TestCheckResourceAttr(rName, "name_alias", "alias-name"),
+					resource.TestCheckResourceAttr(rName, "code", "testCode"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "biz_catalog_path"),
+					resource.TestCheckResourceAttrSet(rName, "created_by"),
+					resource.TestCheckResourceAttrSet(rName, "updated_by"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "l1"),
+				),
+			},
+			{
+				Config: testBusinessMetric_basic_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "biz_catalog_id", acceptance.HW_DATAARTS_BIZ_CATALOG_ID),
+					resource.TestCheckResourceAttr(rName, "owner", "test-owner-update"),
+					resource.TestCheckResourceAttr(rName, "owner_department", "test-department-update"),
+					resource.TestCheckResourceAttr(rName, "time_filters", "周,季度,其他"),
+					resource.TestCheckResourceAttr(rName, "interval_type", "WEEK"),
+					resource.TestCheckResourceAttr(rName, "destination", "test destination update"),
+					resource.TestCheckResourceAttr(rName, "definition", "test definition update"),
+					resource.TestCheckResourceAttr(rName, "expression", "a+b+c+d"),
+					resource.TestCheckResourceAttr(rName, "description", "test description update"),
+					resource.TestCheckResourceAttr(rName, "apply_scenario", "test apply scenario update"),
+					resource.TestCheckResourceAttr(rName, "technical_metric", "200"),
+					resource.TestCheckResourceAttr(rName, "measure", "test measure update"),
+					resource.TestCheckResourceAttr(rName, "general_filters", "test general filters update"),
+					resource.TestCheckResourceAttr(rName, "data_origin", "test data origin update"),
+					resource.TestCheckResourceAttr(rName, "unit", "test unit update"),
+					resource.TestCheckResourceAttr(rName, "name_alias", "alias-name-update"),
+					resource.TestCheckResourceAttr(rName, "code", "testCodeUpdate"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "biz_catalog_path"),
+					resource.TestCheckResourceAttrSet(rName, "created_by"),
+					resource.TestCheckResourceAttrSet(rName, "updated_by"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "l1"),
+				),
+			},
+			{
+				Config: testBusinessMetric_basic_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "biz_catalog_id", acceptance.HW_DATAARTS_BIZ_CATALOG_ID),
+					resource.TestCheckResourceAttr(rName, "owner", "test-owner-update"),
+					resource.TestCheckResourceAttr(rName, "owner_department", "test-department-update"),
+					resource.TestCheckResourceAttr(rName, "time_filters", "周,季度,其他"),
+					resource.TestCheckResourceAttr(rName, "interval_type", "WEEK"),
+					resource.TestCheckResourceAttr(rName, "destination", "test destination update"),
+					resource.TestCheckResourceAttr(rName, "definition", "test definition update"),
+					resource.TestCheckResourceAttr(rName, "expression", "a+b+c+d"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "apply_scenario", ""),
+					resource.TestCheckResourceAttr(rName, "technical_metric", "0"),
+					resource.TestCheckResourceAttr(rName, "measure", ""),
+					resource.TestCheckResourceAttr(rName, "general_filters", ""),
+					resource.TestCheckResourceAttr(rName, "data_origin", ""),
+					resource.TestCheckResourceAttr(rName, "unit", ""),
+					resource.TestCheckResourceAttr(rName, "name_alias", ""),
+					resource.TestCheckResourceAttr(rName, "code", "testCodeUpdate"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "biz_catalog_path"),
+					resource.TestCheckResourceAttrSet(rName, "created_by"),
+					resource.TestCheckResourceAttrSet(rName, "updated_by"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "l1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDataArtsStudioImportState(rName),
+			},
+		},
+	})
+}
+
+func testBusinessMetric_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_studio_business_metric" "test" {
+  name             = "%[1]s"
+  workspace_id     = "%[2]s"
+  biz_catalog_id   = "%[3]s"
+  owner            = "test-owner"
+  owner_department = "test-department"
+  time_filters     = "双周"
+  interval_type    = "HOUR"
+  destination      = "test destination"
+  definition       = "test definition"
+  expression       = "a+b+c"
+  description      = "test description"
+  apply_scenario   = "test apply scenario"
+  technical_metric = 100
+  measure          = "test measure"
+  general_filters  = "test general filters"
+  data_origin      = "test data origin"
+  unit             = "test unit"
+  name_alias       = "alias-name"
+  code             = "testCode"
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_BIZ_CATALOG_ID)
+}
+
+func testBusinessMetric_basic_update1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_studio_business_metric" "test" {
+  name             = "%[1]s"
+  workspace_id     = "%[2]s"
+  biz_catalog_id   = "%[3]s"
+  owner            = "test-owner-update"
+  owner_department = "test-department-update"
+  time_filters     = "周,季度,其他"
+  interval_type    = "WEEK"
+  destination      = "test destination update"
+  definition       = "test definition update"
+  expression       = "a+b+c+d"
+  description      = "test description update"
+  apply_scenario   = "test apply scenario update"
+  technical_metric = 200
+  measure          = "test measure update"
+  general_filters  = "test general filters update"
+  data_origin      = "test data origin update"
+  unit             = "test unit update"
+  name_alias       = "alias-name-update"
+  code             = "testCodeUpdate"
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_BIZ_CATALOG_ID)
+}
+
+func testBusinessMetric_basic_update2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_studio_business_metric" "test" {
+  name             = "%[1]s"
+  workspace_id     = "%[2]s"
+  biz_catalog_id   = "%[3]s"
+  owner            = "test-owner-update"
+  owner_department = "test-department-update"
+  time_filters     = "周,季度,其他"
+  interval_type    = "WEEK"
+  destination      = "test destination update"
+  definition       = "test definition update"
+  expression       = "a+b+c+d"
+  code             = "testCodeUpdate"
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_BIZ_CATALOG_ID)
+}
+
+// testDataArtsStudioImportState use to return an id with format <workspace_id>/<id>
+func testDataArtsStudioImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		workspaceID := rs.Primary.Attributes["workspace_id"]
+		if workspaceID == "" {
+			return "", fmt.Errorf("attribute (workspace_id) of Resource (%s) not found", name)
+		}
+
+		return workspaceID + "/" + rs.Primary.ID, nil
+	}
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_business_metric.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_business_metric.go
@@ -1,0 +1,459 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DataArts
+// ---------------------------------------------------------------
+
+package dataarts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceBusinessMetric() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBusinessMetricCreate,
+		UpdateContext: resourceBusinessMetricUpdate,
+		ReadContext:   resourceBusinessMetricRead,
+		DeleteContext: resourceBusinessMetricDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDataArtsStudioImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of DataArts Studio workspace.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name.`,
+			},
+			"biz_catalog_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the process architecture ID.`,
+			},
+			"time_filters": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the statistical frequency.`,
+			},
+			"interval_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the refresh frequency.`,
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of person responsible for the indicator.`,
+			},
+			"owner_department": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the indicator management department name.`,
+			},
+			"destination": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the purpose of setting.`,
+			},
+			"definition": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the indicator definition.`,
+			},
+			"expression": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the calculation formula.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the description.`,
+			},
+			"apply_scenario": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the application scenarios.`,
+			},
+			"technical_metric": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the related technical indicators.`,
+			},
+			"measure": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the measurement object.`,
+			},
+			"dimensions": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the statistical dimension.`,
+			},
+			"general_filters": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the statistical caliber and modifiers.`,
+			},
+			"data_origin": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the data sources.`,
+			},
+			"unit": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the unit of measurement.`,
+			},
+			"name_alias": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the indicator alias.`,
+			},
+			"code": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the indicator encoding.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status.`,
+			},
+			"biz_catalog_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The process architecture path.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The editor.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The create time.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The update time.`,
+			},
+			"technical_metric_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The related technical indicator type.`,
+			},
+			"technical_metric_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The related technical indicator name.`,
+			},
+			"l1": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subject domain grouping Chinese name.`,
+			},
+			"l2": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The subject field Chinese name.`,
+			},
+			"l3": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The business object Chinese name.`,
+			},
+			"biz_metric": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The business indicator synchronization status.`,
+			},
+			"summary_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The synchronize statistics status.`,
+			},
+		},
+	}
+}
+
+func resourceBusinessMetricCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/design/biz-metrics"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody:         utils.RemoveNil(buildCreateOrUpdateBusinessMetricBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio business metric: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("data.value.id", createRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating DataArts Studio business metric: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceBusinessMetricRead(ctx, d, meta)
+}
+
+func buildCreateOrUpdateBusinessMetricBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":             d.Get("name"),
+		"biz_catalog_id":   d.Get("biz_catalog_id"),
+		"time_filters":     d.Get("time_filters"),
+		"interval_type":    d.Get("interval_type"),
+		"owner":            d.Get("owner"),
+		"owner_department": d.Get("owner_department"),
+		"destination":      d.Get("destination"),
+		"definition":       d.Get("definition"),
+		"expression":       d.Get("expression"),
+		"remark":           utils.ValueIngoreEmpty(d.Get("description")),
+		"apply_scenario":   utils.ValueIngoreEmpty(d.Get("apply_scenario")),
+		"technical_metric": utils.ValueIngoreEmpty(d.Get("technical_metric")),
+		"measure":          utils.ValueIngoreEmpty(d.Get("measure")),
+		"dimensions":       utils.ValueIngoreEmpty(d.Get("dimensions")),
+		"general_filters":  utils.ValueIngoreEmpty(d.Get("general_filters")),
+		"data_origin":      utils.ValueIngoreEmpty(d.Get("data_origin")),
+		"unit":             utils.ValueIngoreEmpty(d.Get("unit")),
+		"name_alias":       utils.ValueIngoreEmpty(d.Get("name_alias")),
+		"code":             utils.ValueIngoreEmpty(d.Get("code")),
+	}
+}
+
+func resourceBusinessMetricRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getResp, err := readBusinessMetric(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, parseBusinessMetricError(err), "error retrieving DataArts Studio business metric")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataValueBody := utils.PathSearch("data.value", getRespBody, make(map[string]interface{}))
+	technicalMetricResp := utils.PathSearch("technical_metric", dataValueBody, "").(string)
+	technicalMetric := utils.StringToInt(&technicalMetricResp)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", dataValueBody, nil)),
+		d.Set("biz_catalog_id", utils.PathSearch("biz_catalog_id", dataValueBody, nil)),
+		d.Set("time_filters", utils.PathSearch("time_filters", dataValueBody, nil)),
+		d.Set("interval_type", utils.PathSearch("interval_type", dataValueBody, nil)),
+		d.Set("owner", utils.PathSearch("owner", dataValueBody, nil)),
+		d.Set("owner_department", utils.PathSearch("owner_department", dataValueBody, nil)),
+		d.Set("destination", utils.PathSearch("destination", dataValueBody, nil)),
+		d.Set("definition", utils.PathSearch("definition", dataValueBody, nil)),
+		d.Set("expression", utils.PathSearch("expression", dataValueBody, nil)),
+		d.Set("description", utils.PathSearch("remark", dataValueBody, nil)),
+		d.Set("apply_scenario", utils.PathSearch("apply_scenario", dataValueBody, nil)),
+		d.Set("technical_metric", technicalMetric),
+		d.Set("measure", utils.PathSearch("measure", dataValueBody, nil)),
+		d.Set("dimensions", utils.PathSearch("dimensions", dataValueBody, nil)),
+		d.Set("general_filters", utils.PathSearch("general_filters", dataValueBody, nil)),
+		d.Set("data_origin", utils.PathSearch("data_origin", dataValueBody, nil)),
+		d.Set("unit", utils.PathSearch("unit", dataValueBody, nil)),
+		d.Set("name_alias", utils.PathSearch("name_alias", dataValueBody, nil)),
+		d.Set("code", utils.PathSearch("code", dataValueBody, nil)),
+		d.Set("status", utils.PathSearch("status", dataValueBody, nil)),
+		d.Set("biz_catalog_path", utils.PathSearch("biz_catalog_path", dataValueBody, nil)),
+		d.Set("created_by", utils.PathSearch("create_by", dataValueBody, nil)),
+		d.Set("updated_by", utils.PathSearch("update_by", dataValueBody, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", dataValueBody, nil)),
+		d.Set("updated_at", utils.PathSearch("update_time", dataValueBody, nil)),
+		d.Set("technical_metric_type", utils.PathSearch("technical_metric_type", dataValueBody, nil)),
+		d.Set("technical_metric_name", utils.PathSearch("technical_metric_name", dataValueBody, nil)),
+		d.Set("l1", utils.PathSearch("l1", dataValueBody, nil)),
+		d.Set("l2", utils.PathSearch("l2", dataValueBody, nil)),
+		d.Set("l3", utils.PathSearch("l3", dataValueBody, nil)),
+		d.Set("biz_metric", utils.PathSearch("biz_metric", dataValueBody, nil)),
+		d.Set("summary_status", utils.PathSearch("summary_status", dataValueBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func readBusinessMetric(client *golangsdk.ServiceClient, d *schema.ResourceData) (*http.Response, error) {
+	getPath := client.Endpoint + "v2/{project_id}/design/biz-metrics/{id}"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+
+	return client.Request("GET", getPath, &getOpt)
+}
+
+// The example of error message is: {"errors": [{"error_code": "DLG.3903","error_msg": "Definition [XXX] does not exist"}]}
+func parseBusinessMetricError(err error) error {
+	var errCode golangsdk.ErrDefault400
+	if errors.As(err, &errCode) {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return err
+		}
+		errorCode, errorCodeErr := jmespath.Search("errors|[0].error_code", apiError)
+		if errorCodeErr != nil {
+			return err
+		}
+
+		if errorCode == "DLG.3903" {
+			return golangsdk.ErrDefault404(errCode)
+		}
+	}
+	return err
+}
+
+func resourceBusinessMetricUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/design/biz-metrics"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+
+	updateBody := utils.RemoveNil(buildCreateOrUpdateBusinessMetricBodyParams(d))
+	updateBody["id"] = d.Id()
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody:         updateBody,
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating DataArts Studio business metric: %s", err)
+	}
+	return resourceBusinessMetricRead(ctx, d, meta)
+}
+
+func resourceBusinessMetricDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/design/biz-metrics"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody:         buildDeleteBusinessMetricBodyParams(d),
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DataArts Studio business metric: %s", err)
+	}
+
+	// Successful deletion API call does not guarantee that the resource is successfully deleted.
+	// Call the details API to confirm that the resource has been successfully deleted.
+	_, err = readBusinessMetric(client, d)
+	if err == nil {
+		return diag.Errorf("error deleting DataArts Studio business metric: the business metric still exists")
+	}
+
+	return common.CheckDeletedDiag(d, parseBusinessMetricError(err), "error deleting DataArts Studio business metric")
+}
+
+func buildDeleteBusinessMetricBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"ids": []string{d.Id()},
+	}
+	return bodyParams
+}
+
+func resourceDataArtsStudioImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	partLength := len(parts)
+
+	if partLength == 2 {
+		d.SetId(parts[1])
+		return []*schema.ResourceData{d}, d.Set("workspace_id", parts[0])
+	}
+	return nil, fmt.Errorf("invalid format specified for import id, must be <workspace_id>/<id>")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add a new resource dataarts studio business metric

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- You need to prepare workspace_id and biz_catalog_id before use.
- Because the document content is incomplete, the description of some fields is inaccurate.
- Successful deletion API call does not guarantee that the resource is successfully deleted. Call the details API to confirm that the resource has been successfully deleted.
- When the business metric is not exist, the detail API response body is: {"errors": [{"error_code": "DLG.3903","error_msg": "Definition [XXX] does not exist"}]}
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/03fbab38-18b6-4064-b538-b52dcc913b3c)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dataarts' TESTARGS='-run TestAccBusinessMetric_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccBusinessMetric_basic -timeout 360m -parallel 4
=== RUN   TestAccBusinessMetric_basic
=== PAUSE TestAccBusinessMetric_basic
=== CONT  TestAccBusinessMetric_basic
--- PASS: TestAccBusinessMetric_basic (18.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  18.595s
```
