### PR TITLE
feat(WAF): add datasource to query the list of the dedicated domains

### DIFF
--- a/docs/data-sources/waf_dedicated_domains.md
+++ b/docs/data-sources/waf_dedicated_domains.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_dedicated_domains
+
+Use this data source to get a list of WAF dedicated domains.
+
+## Example Usage
+
+```hcl
+variable domain {}
+variable "enterprise_project_id" {}
+
+data "huaweicloud_waf_dedicated_domains" "domains" {
+  domain                = var.domain
+  enterprise_project_id = var.enterprise_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to query the WAF dedicated domains.
+  If omitted, the provider-level region will be used.
+
+* `domain` - (Optional, String) The protected domain name or IP address (port allowed).
+
+* `policy_name` - (Optional, String) The policy name associated with the domain.
+
+* `protect_status` - (Optional, Int) The protection status of domain.
+
+* `enterprise_project_id` - (Optional, String) The enterprise project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `domains` - A list of WAF dedicated domains.
+
+The `domains` block supports:
+
+* `id` - The ID of WAF dedicated domain.
+
+* `domain` - The protected domain name or IP address (port allowed).
+
+* `pci_3ds` - The status of the PCI 3DS compliance certification check.
+
+* `pci_dds` - The status of the PCI DSS compliance certification check.
+
+* `is_dual_az` - The status of the WAF support dual AZ mode.
+
+* `ipv6_enable` - Whether to support IPv6.
+
+* `description` - The description of WAF dedicated domain.
+
+* `policy_id` - The policy ID associated with the domain.
+
+* `protect_status` - The protection status of domain,  `0`: suspended, `1`: enabled. Default value is `0`.
+
+* `access_status` - Whether a domain name is connected to WAF. Valid values are:
+  + `0` - The domain name is not connected to WAF,
+  + `1` - The domain name is connected to WAF.
+
+* `website_name` - The website name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -633,6 +633,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_dedicated_instances": waf.DataSourceWafDedicatedInstancesV1(),
 			"huaweicloud_waf_reference_tables":    waf.DataSourceWafReferenceTablesV1(),
 			"huaweicloud_waf_instance_groups":     waf.DataSourceWafInstanceGroups(),
+			"huaweicloud_waf_dedicated_domains":   waf.DataSourceWafDedicatedDomains(),
 			"huaweicloud_waf_address_groups":      waf.DataSourceWafAddressGroups(),
 			"huaweicloud_dws_flavors":             dws.DataSourceDwsFlavors(),
 

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_domains_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_domains_test.go
@@ -1,0 +1,102 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceWAFDedicatedDomains_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_waf_dedicated_domains.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDedicatedDomains_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.domain"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.pci_3ds"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.pci_dds"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.is_dual_az"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.ipv6_enable"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.policy_id"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.protect_status"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.access_status"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.website_name"),
+
+					resource.TestCheckOutput("domain_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("protect_status_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("enterprise_project_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDedicatedDomains_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_waf_dedicated_domains" "test" {
+  depends_on = [huaweicloud_waf_dedicated_domain.domain_1]
+}
+
+data "huaweicloud_waf_dedicated_domains" "domain_filter" {
+  domain = data.huaweicloud_waf_dedicated_domains.test.domains.0.domain
+}
+
+locals {
+  domain = data.huaweicloud_waf_dedicated_domains.test.domains.0.domain
+}
+
+output "domain_filter_is_useful" {
+  value = length(data.huaweicloud_waf_dedicated_domains.domain_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_dedicated_domains.domain_filter.domains[*].domain : v == local.domain]
+  )  
+}
+
+data "huaweicloud_waf_dedicated_domains" "protect_status_filter" {
+  protect_status = data.huaweicloud_waf_dedicated_domains.test.domains.0.protect_status
+}
+  
+locals {
+  protect_status = data.huaweicloud_waf_dedicated_domains.test.domains.0.protect_status
+}
+  
+output "protect_status_filter_is_useful" {
+  value = length(data.huaweicloud_waf_dedicated_domains.protect_status_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_dedicated_domains.protect_status_filter.domains[*].protect_status : v == local.protect_status]
+  )  
+}
+
+data "huaweicloud_waf_dedicated_domains" "enterprise_project_id_filter" {
+  enterprise_project_id = data.huaweicloud_waf_dedicated_domains.test.domains.0.enterprise_project_id
+}
+	
+locals {
+  enterprise_project_id = data.huaweicloud_waf_dedicated_domains.test.domains.0.enterprise_project_id
+}
+
+output "enterprise_project_id_filter_is_useful" {
+  value = length(data.huaweicloud_waf_dedicated_domains.enterprise_project_id_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_dedicated_domains.enterprise_project_id_filter.domains[*].enterprise_project_id : v == local.enterprise_project_id]
+  )  
+}
+`, testAccWafDedicatedDomainV1_basic(name))
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_dedicated_domains.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_dedicated_domains.go
@@ -1,0 +1,212 @@
+package waf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceWafDedicatedDomains() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceDedicatedDomainsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protect_status": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"domains": {
+				Type:     schema.TypeList,
+				Elem:     domainSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func domainSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pci_3ds": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"pci_dds": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"is_dual_az": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ipv6_enable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"protect_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"access_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"website_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceDedicatedDomainsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getWAFDedicatedDomains: Query WAF dedicated domains
+	var (
+		getWAFDedicatedDomainsHttpUrl = "v1/{project_id}/premium-waf/host"
+		getWAFDedicatedDomainsProduct = "waf"
+	)
+	getWAFDedicatedDomainsClient, err := cfg.NewServiceClient(getWAFDedicatedDomainsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	getWAFDedicatedDomainsPath := getWAFDedicatedDomainsClient.Endpoint + getWAFDedicatedDomainsHttpUrl
+	getWAFDedicatedDomainsPath = strings.ReplaceAll(getWAFDedicatedDomainsPath, "{project_id}",
+		getWAFDedicatedDomainsClient.ProjectID)
+	getWAFDedicatedDomainsPath += buildWAFDedicatedDomainsQueryParams(d, cfg)
+
+	getWAFDedicatedDomainsResp, err := pagination.ListAllItems(
+		getWAFDedicatedDomainsClient,
+		"page",
+		getWAFDedicatedDomainsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving dedicated domains, %s", err)
+	}
+
+	listWAFDedicatedDomainsRespJson, err := json.Marshal(getWAFDedicatedDomainsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listWAFDedicatedDomainsRespBody interface{}
+	err = json.Unmarshal(listWAFDedicatedDomainsRespJson, &listWAFDedicatedDomainsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("domains", flattenListDedicatedDomainsBody(listWAFDedicatedDomainsRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListDedicatedDomainsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("items", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                    utils.PathSearch("id", v, nil),
+			"domain":                utils.PathSearch("hostname", v, nil),
+			"policy_id":             utils.PathSearch("policyid", v, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+			"description":           utils.PathSearch("description", v, nil),
+			"protect_status":        utils.PathSearch("protect_status", v, nil),
+			"website_name":          utils.PathSearch("web_tag", v, nil),
+			"access_status":         utils.PathSearch("access_status", v, nil),
+			"pci_3ds":               utils.StringToBool(utils.PathSearch("flag.pci_3ds", v, "")),
+			"pci_dds":               utils.StringToBool(utils.PathSearch("flag.pci_dds", v, "")),
+			"is_dual_az":            utils.StringToBool(utils.PathSearch("flag.is_dual_az", v, "")),
+			"ipv6_enable":           utils.StringToBool(utils.PathSearch("flag.ipv6", v, "")),
+		})
+	}
+	return rst
+}
+
+func buildWAFDedicatedDomainsQueryParams(d *schema.ResourceData, conf *config.Config) string {
+	res := ""
+	epsId := conf.GetEnterpriseProjectID(d)
+	if epsId != "" {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsId)
+	}
+	if v, ok := d.GetOk("domain"); ok {
+		res = fmt.Sprintf("%s&hostname=%v", res, v)
+	}
+	if v, ok := d.GetOk("policy_name"); ok {
+		res = fmt.Sprintf("%s&policyname=%v", res, v)
+	}
+	if v, ok := d.GetOk("protect_status"); ok {
+		res = fmt.Sprintf("%s&protect_status=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDatasourceWAFDedicatedDomains_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDatasourceWAFDedicatedDomains_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceWAFDedicatedDomains_basic
=== PAUSE TestAccDatasourceWAFDedicatedDomains_basic
=== CONT  TestAccDatasourceWAFDedicatedDomains_basic
--- PASS: TestAccDatasourceWAFDedicatedDomains_basic (389.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       389.357s
