### PR TITLE
feat(OBS): obs support SSE-OBS encryption mode

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -142,6 +142,22 @@ resource "huaweicloud_obs_bucket" "bucket" {
 }
 ```
 
+### using encryption
+
+```hcl
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket        = "my-tf-encryption-bucket"
+  storage_class = "STANDARD"
+  acl           = "private"
+  encryption    = true
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -207,9 +223,16 @@ The following arguments are supported:
   bucket, but the name of a deleted bucket can be reused for another bucket at least 30 minutes after the deletion.
   Exercise caution when changing this field.
 
-* `encryption` - (Optional, Bool) Whether enable default server-side encryption of the bucket in SSE-KMS mode.
+* `encryption` - (Optional, Bool) Whether to enable default server-side encryption of the bucket.
 
-* `kms_key_id` - (Optional, String) Specifies the ID of a KMS key. If omitted, the default master key will be used.
+* `sse_algorithm` - (Optional, String) Specifies the mode of encryption algorithm. The valid values are:
+  + **kms**: Server-side encryption with keys hosted by KMS are used to encrypt your objects.
+  + **AES256**: Server-side encryption with keys managed by OBS are used to encrypt your objects.
+
+  Defaults to **kms**.
+
+* `kms_key_id` - (Optional, String) Specifies the ID of a KMS key. If omitted, the default master key will be used. This
+  field is used only when `sse_algorithm` value is **kms**.
 
 * `kms_key_project_id` - (Optional, String) Specifies the project ID to which the KMS key belongs. This field is valid
   only when `kms_key_id` is specified.

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -206,6 +206,34 @@ func TestAccObsBucket_encryption(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kms_key_id", ""),
 				),
 			},
+			{
+				Config: testAccObsBucket_encryptionBySSEObsMode(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", "AES256"),
+				),
+			},
+			{
+				Config: testAccObsBucket_updateEncryptionToSSEKMSMode(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", "kms"),
+				),
+			},
+			{
+				Config: testAccObsBucket_basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bucket", testAccObsBucketName(rInt)),
+					resource.TestCheckResourceAttr(resourceName, "bucket_domain_name", testAccObsBucketDomainName(rInt)),
+					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
+					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "sse_algorithm", ""),
+				),
+			},
 		},
 	})
 }
@@ -583,6 +611,40 @@ resource "huaweicloud_obs_bucket" "bucket" {
   storage_class = "STANDARD"
   acl           = "private"
   encryption    = true
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, randInt)
+}
+
+func testAccObsBucket_encryptionBySSEObsMode(randInt int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket        = "tf-test-bucket-%d"
+  storage_class = "STANDARD"
+  acl           = "private"
+  encryption    = true
+  sse_algorithm = "AES256"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, randInt)
+}
+
+func testAccObsBucket_updateEncryptionToSSEKMSMode(randInt int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "bucket" {
+  bucket        = "tf-test-bucket-%d"
+  storage_class = "STANDARD"
+  acl           = "private"
+  encryption    = true
+  sse_algorithm = "kms"
 
   tags = {
     foo = "bar"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
obs support SSE-OBS encryption mode

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs/' TESTARGS='-run TestAccObsBucket_encryption'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs/ -v -run TestAccObsBucket_encryption -timeout 360m -parallel 4 
=== RUN   TestAccObsBucket_encryption 
=== PAUSE TestAccObsBucket_encryption 
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_encryption (101.01s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       101.049s
```
