### PR TITLE
feat(er/attachment): support the associated and resource_id attributes

### DIFF
--- a/docs/data-sources/er_attachments.md
+++ b/docs/data-sources/er_attachments.md
@@ -70,6 +70,10 @@ The `attachments` block supports:
 
 * `status` - The current status of the attachment.
 
+* `associated` - Whether this attachment has been associated.
+
+* `resource_id` - The associated resource ID.
+
 * `created_at` - The creation time of the attachment.
 
 * `updated_at` - The latest update time of the attachment.

--- a/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
@@ -82,6 +82,16 @@ func DataSourceAttachments() *schema.Resource {
 							Computed:    true,
 							Description: `The current status of the attachment.`,
 						},
+						"associated": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether this attachment has been associated.`,
+						},
+						"resource_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Associated resource ID.`,
+						},
 						"created_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -169,6 +179,8 @@ func flattenAttachments(all []attachments.Attachment) []map[string]interface{} {
 			"name":           attachment.Name,
 			"description":    attachment.Description,
 			"status":         attachment.Status,
+			"associated":     attachment.Associated,
+			"resource_id":    attachment.ResourceId,
 			"created_at":     attachment.CreatedAt,
 			"updated_at":     attachment.UpdatedAt,
 			"tags":           utils.TagsToMap(attachment.Tags),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support two attributes: associated and resource_id

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support two attributes: associated and resource_id
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAttachmentsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAttachmentsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_basic
=== PAUSE TestAccAttachmentsDataSource_basic
=== CONT  TestAccAttachmentsDataSource_basic
--- PASS: TestAccAttachmentsDataSource_basic (156.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        156.854s
```
