### PR TITLE
fix(ecs): select the correct filter server in data source

### DIFF
--- a/huaweicloud/services/ecs/data_source_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/data_source_huaweicloud_compute_instance.go
@@ -249,7 +249,7 @@ func dataSourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, me
 		return diag.Errorf("your query returned more than one result, please try a more specific search criteria.")
 	}
 
-	server := allServers[0]
+	server := filterServers[0].(cloudservers.CloudServer)
 	log.Printf("[DEBUG] fetching the ECS instance: %#v", server)
 
 	d.SetId(server.ID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

 in [data.huaweicloud_compute_instance](https://registry.terraform.io/providers/huaweicloud/huaweicloud/latest/docs/data-sources/compute_instance) we use the first item in `allServers` rather than `filterServers`, so let's fix it.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstanceDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (165.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       165.672s
```
