### PR TITLE
feat(dataarts): add process resource support

### DIFF
--- a/docs/resources/dataarts_architecture_process.md
+++ b/docs/resources/dataarts_architecture_process.md
@@ -1,0 +1,93 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_architecture_process
+
+Manages a DataArts Architecture process resource within HuaweiCloud.
+
+## Example Usage
+
+### Create a root process
+
+```hcl
+variable "workspace_id" {}
+variable "process_name" {}
+variable "process_owner" {}
+
+resource "huaweicloud_dataarts_architecture_process" "test-root" {
+  workspace_id = var.workspace_id
+  name         = var.process_name
+  owner        = var.process_owner
+}
+```
+
+### Create a subordinate process
+
+```hcl
+variable "workspace_id" {}
+variable "process_name" {}
+variable "process_owner" {}
+variable "parent_process_id" {}
+
+resource "huaweicloud_dataarts_architecture_process" "test-sub" {
+  workspace_id = var.workspace_id
+  name         = var.process_name
+  owner        = var.process_owner
+  parent_id    = var.parent_process_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the ID of DataArts Studio workspace.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of process.
+
+* `owner` - (Required, String) Specifies the name of person responsible for process. The responsible person must exist
+  in the system.
+
+* `description` - (Optional, String) Specifies the description of process.
+
+* `parent_id` - (Optional, String) Specifies the parent catalog ID of process.  
+  It's **Required** when you create a subordinate process, and directory level cannot exceed `3` layer.
+
+* `prev_id` - (Optional, String) Specifies the ID of the previous node in the process.  
+  When querying the process, if the field is null, it means that is the first node in the current process directory.
+
+* `next_id` - (Optional, String) Specify the ID of the next node in the process.  
+  When querying the process, if the field is null, it means that is the last node in the current process directory.
+
+-> The `prev_id` and `next_id` will change with the position of the process in the current directory.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `qualified_id` - The ID of all superior processes. Format is `<root_process_id>.<sub_process_id1>.<sub_process_id2>`
+
+* `created_at` - The creation time of the process.
+
+* `updated_at` - The latest update time of the process.
+
+* `created_by` - The creator of the process.
+
+* `updated_by` - The last editor of the process.
+
+* `children` - The name list of subordinate process.
+
+## Import
+
+The DataArts architecture process can be imported using `workspace_id` and `qualified_id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_architecture_process.test <workspace_id>/<qualified_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1103,6 +1103,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_directory":       dataarts.ResourceArchitectureDirectory(),
 			"huaweicloud_dataarts_architecture_subject":         dataarts.ResourceArchitectureSubject(),
 			"huaweicloud_dataarts_architecture_business_metric": dataarts.ResourceBusinessMetric(),
+			"huaweicloud_dataarts_architecture_process":         dataarts.ResourceArchitectureProcess(),
 			// DataArts Factory
 			"huaweicloud_dataarts_factory_resource": dataarts.ResourceFactoryResource(),
 			// DataArts Security

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_process_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_process_test.go
@@ -1,0 +1,145 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getArchitectureProcessResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/design/biz/catalogs/{id}"
+		product = "dataarts"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", state.Primary.ID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": state.Primary.Attributes["workspace_id"]},
+	}
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DataArts Architecture process: %s", err)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccResourceArchitectureProcess_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_dataarts_architecture_process.test"
+		name         = acceptance.RandomAccResourceName()
+		updateName   = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getArchitectureProcessResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArchitectureProcess_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "owner", "owner1"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttrSet(resourceName, "qualified_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+				),
+			},
+			{
+				Config: testAccArchitectureProcess_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "owner", "owner1,owner2"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "qualified_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccArchitectureProcessImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccArchitectureProcess_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_process" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  owner        = "owner1"
+  description  = "Created by script"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccArchitectureProcess_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_process" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  owner        = "owner1,owner2"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccArchitectureProcessImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		workspaceID := rs.Primary.Attributes["workspace_id"]
+		qualifiedID := rs.Primary.Attributes["qualified_id"]
+		if workspaceID == "" || qualifiedID == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want '<workspace_id>/<qualified_id>', but got '%s/%s'",
+				workspaceID, qualifiedID)
+		}
+		return fmt.Sprintf("%s/%s", workspaceID, qualifiedID), nil
+	}
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_process.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_process.go
@@ -1,0 +1,446 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DataArtsStudio
+// ---------------------------------------------------------------
+
+package dataarts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio POST /v2/{project_id}/design/biz/catalogs
+// API: DataArtsStudio DELETE /v2/{project_id}/design/biz/catalogs
+// API: DataArtsStudio GET /v2/{project_id}/design/biz/catalogs/tree
+// API: DataArtsStudio GET /v2/{project_id}/design/biz/catalogs/{id}
+// API: DataArtsStudio PUT /v2/{project_id}/design/biz/catalogs
+func ResourceArchitectureProcess() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceArchitectureProcessCreate,
+		ReadContext:   resourceArchitectureProcessRead,
+		UpdateContext: resourceArchitectureProcessUpdate,
+		DeleteContext: resourceArchitectureProcessDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceArchitectureProcessImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the process is located.",
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of DataArts Studio workspace.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of catalog.",
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of person responsible for process.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The description of process.",
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The parent process ID of process.",
+			},
+			"prev_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The ID of the previous node in the process.",
+			},
+			"next_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The ID of the next node in the process.",
+			},
+			"qualified_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of all superior processes.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the process.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the process.",
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creator of the process.",
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The last editor of the process.",
+			},
+			"children": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The name list of subordinate process.",
+			},
+		},
+	}
+}
+
+func resourceArchitectureProcessCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/design/biz/catalogs"
+		product = "dataarts"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody:         utils.RemoveNil(buildCreateOrUpdateArchitectureProcessBodyParams(d)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Architecture process: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	id, err := jmespath.Search("data.value.id", createRespBody)
+
+	if err != nil || id == nil {
+		return diag.Errorf("error creating DataArts Architecture process: ID is not found in API response")
+	}
+
+	// need to set qualified ID to filter result in READ.
+	qualifiedID, err := jmespath.Search("data.value.qualified_id", createRespBody)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Architecture process: qualifiedID is not found in API response")
+	}
+	d.SetId(id.(string))
+	d.Set("qualified_id", qualifiedID)
+
+	return resourceArchitectureProcessRead(ctx, d, meta)
+}
+
+func buildCreateOrUpdateArchitectureProcessBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"owner":       d.Get("owner"),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"parent_id":   utils.ValueIngoreEmpty(d.Get("parent_id")),
+		"prev_id":     utils.ValueIngoreEmpty(d.Get("prev_id")),
+		"next_id":     utils.ValueIngoreEmpty(d.Get("next_id")),
+	}
+}
+
+func resourceArchitectureProcessRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/design/biz/catalogs/tree"
+		product = "dataarts"
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "DataArts Architecture process")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	paths := strings.Split(d.Get("qualified_id").(string), ".")
+	jsonPaths := fmt.Sprintf("data.value[?id=='%s']", paths[0])
+	for _, path := range paths[1:] {
+		jsonPaths += fmt.Sprintf("[children][][?id=='%s'][]", path)
+	}
+
+	processes := utils.PathSearch(jsonPaths, getRespBody, make([]interface{}, 0)).([]interface{})
+	if len(processes) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "DataArts Architecture process")
+	}
+
+	process := processes[0]
+	mErr = multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", process, nil)),
+		d.Set("owner", utils.PathSearch("owner", process, nil)),
+		d.Set("description", utils.PathSearch("description", process, nil)),
+		d.Set("parent_id", utils.PathSearch("parent_id", process, nil)),
+		d.Set("prev_id", utils.PathSearch("prev_id", process, nil)),
+		d.Set("next_id", utils.PathSearch("next_id", process, nil)),
+		d.Set("qualified_id", utils.PathSearch("qualified_id", process, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", process, nil)),
+		d.Set("updated_at", utils.PathSearch("update_time", process, nil)),
+		d.Set("created_by", utils.PathSearch("create_by", process, nil)),
+		d.Set("updated_by", utils.PathSearch("update_by", process, nil)),
+		d.Set("children", utils.PathSearch(`children[*].name`, process, make([]interface{}, 0))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceArchitectureProcessUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/design/biz/catalogs"
+		product     = "dataarts"
+		workspaceID = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+
+	updateBody := utils.RemoveNil(buildCreateOrUpdateArchitectureProcessBodyParams(d))
+	updateBody["id"] = d.Id()
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+		JSONBody:         updateBody,
+	}
+
+	updateResp, err := client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating DataArts Architecture process: %s", err)
+	}
+
+	updateRespBody, err := utils.FlattenResponse(updateResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// After calling the update API, qualified ID always returns null.
+	// Therefore, it is necessary to recombine the values of this field to filter the result in READ.
+	parentID, err := jmespath.Search("data.value.parent_id", updateRespBody)
+	if err != nil {
+		return diag.Errorf("error updating DataArts Architecture process: parent ID is not found in API response")
+	}
+
+	var qualifiedID string
+	processID := d.Id()
+	if parentID != nil {
+		getResp, err := readArchitectureProcess(client, parentID.(string), workspaceID)
+		if err != nil {
+			return common.CheckDeletedDiag(d, parseArchitectureProcessError(err), "error retrieving DataArts Architecture process")
+		}
+
+		getRespBody, err := utils.FlattenResponse(getResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		parentProcessParentID, err := jmespath.Search("data.value.parent_id", getRespBody)
+		if err != nil {
+			return diag.Errorf("error retrieving DataArts Architecture process: parent ID is not found in API response")
+		}
+
+		if parentProcessParentID != nil {
+			qualifiedID = fmt.Sprintf("%v.%v.%v", parentProcessParentID, parentID, processID)
+		} else {
+			qualifiedID = fmt.Sprintf("%v.%v", parentID, processID)
+		}
+	} else {
+		qualifiedID = processID
+	}
+
+	d.Set("qualified_id", qualifiedID)
+
+	return resourceArchitectureProcessRead(ctx, d, meta)
+}
+
+func resourceArchitectureProcessDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/design/biz/catalogs"
+		product     = "dataarts"
+		workspaceID = d.Get("workspace_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+		JSONBody:         buildDeleteArchitectureProcessBodyParams(d),
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DataArts Architecture process: %s", err)
+	}
+
+	// Successful deletion API call does not guarantee that the resource is successfully deleted.
+	// Call the details API to confirm that the resource has been successfully deleted.
+	_, err = readArchitectureProcess(client, d.Id(), workspaceID)
+	if err == nil {
+		return diag.Errorf("error deleting DataArts Architecture process: the process still exists")
+	}
+
+	return common.CheckDeletedDiag(d, parseArchitectureProcessError(err), "error deleting DataArts Architecture process")
+}
+
+func buildDeleteArchitectureProcessBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"ids": []string{d.Id()},
+	}
+}
+
+func readArchitectureProcess(client *golangsdk.ServiceClient, catalogID, workspaceID string) (*http.Response, error) {
+	getPath := client.Endpoint + "v2/{project_id}/design/biz/catalogs/{id}"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", catalogID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+
+	return client.Request("GET", getPath, &getOpt)
+}
+
+// The example of error message is: {"errors": [{"error_code": "DLG.3903","error_msg": "Definition [XXX] does not exist"}]}
+func parseArchitectureProcessError(err error) error {
+	var errCode golangsdk.ErrDefault400
+	if errors.As(err, &errCode) {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return err
+		}
+		errorCode, errorCodeErr := jmespath.Search("errors|[0].error_code", apiError)
+		if errorCodeErr != nil {
+			return err
+		}
+
+		if errorCode == "DLG.3903" {
+			return golangsdk.ErrDefault404(errCode)
+		}
+	}
+	return err
+}
+
+func resourceArchitectureProcessImportState(_ context.Context, d *schema.ResourceData, meta interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format of import ID, must be <workspace_id>/<qualified_id>")
+	}
+
+	var (
+		workspaceID = parts[0]
+		qualifiedID = parts[1]
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/design/biz/catalogs/tree"
+		product     = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error query all DataArts Architecture process trees: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return []*schema.ResourceData{d}, err
+	}
+
+	paths := strings.Split(qualifiedID, ".")
+	jsonPaths := fmt.Sprintf("data.value[?id=='%s']", paths[0])
+	for _, path := range paths[1:] {
+		jsonPaths += fmt.Sprintf("[children][][?id=='%s'][]", path)
+	}
+
+	processes := utils.PathSearch(jsonPaths, getRespBody, make([]interface{}, 0)).([]interface{})
+	if len(processes) < 1 {
+		return []*schema.ResourceData{d}, fmt.Errorf("data process not found: %s", err)
+	}
+
+	d.SetId(utils.PathSearch("id", processes[0], nil).(string))
+	d.Set("qualified_id", qualifiedID)
+	d.Set("workspace_id", workspaceID)
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add process resource support for dataarts architecture
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add process resource support for dataarts architecture
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourceArchitectureProcess_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceArchitectureProcess_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceArchitectureProcess_basic
=== PAUSE TestAccResourceArchitectureProcess_basic
=== CONT  TestAccResourceArchitectureProcess_basic
--- PASS: TestAccResourceArchitectureProcess_basic (18.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  18.322s

```
