### PR TITLE
feat(DATAARTS): add resource dataarts architecture model

### DIFF
--- a/docs/resources/dataarts_architecture_model.md
+++ b/docs/resources/dataarts_architecture_model.md
@@ -1,0 +1,86 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_architecture_model
+
+Manages DataArts Architecture ER Model resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "name" {}
+
+resource "huaweicloud_dataarts_architecture_model" "physical_model"{
+  workspace_id = var.workspace_id
+  name         = var.name
+  type         = "THIRD_NF"
+  physical     = true
+  dw_type      = "DWS"
+}
+
+resource "huaweicloud_dataarts_architecture_model" "logic_model"{
+  workspace_id = var.workspace_id
+  name         = var.name
+  type         = "THIRD_NF"
+  physical     = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the model.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new model.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID which the model in.
+  Changing this parameter will create a new model.
+
+* `physical` - (Required, Bool, ForceNew) Specifies the model is physical or logical.
+  When the value is **true**, it means physical model.
+  Changing this parameter will create a new model.
+
+* `name` - (Required, String) Specifies the model name.
+
+* `type` - (Required, String) Specifies the model type. The valid values are **THIRD_NF** and **DIMENSION**.
+
+* `description` - (Optional, String) Specifies the description of model.
+
+* `dw_type` - (Optional, String) Specifies the data connection type. This parameter should specify when
+  **physical** is **true**. The valid values are:
+  + **DWS**
+  + **DLI**
+  + **MRS_HIVE**
+  + **POSTGRESQL**
+  + **MRS_SPARK**
+  + **CLICKHOUSE**
+  + **MYSQL**
+  + **ORACLE**
+
+* `level` - (Optional, String) Specifies the data warehouse layer. Valid values are **SDI** and **DWI**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `dw_type` - The data connection type.
+
+* `created_at` - The create time of the model.
+
+* `updated_at` - The update time of the model.
+
+* `created_by` - The person creating the model.
+
+* `updated_by` - The person updating the model.
+
+## Import
+
+DataArts Studio architecture model can be imported using `<workspace_id>/<name>`, e.g.
+
+```sh
+terraform import huaweicloud_dataarts_architecture_model.test <workspace_id>/<name>
+```

--- a/docs/resources/dataarts_architecture_model.md
+++ b/docs/resources/dataarts_architecture_model.md
@@ -48,8 +48,8 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of model.
 
-* `dw_type` - (Optional, String) Specifies the data connection type. This parameter should specify when
-  **physical** is **true**. The valid values are:
+* `dw_type` - (Optional, String) Specifies the data connection type. This parameter is mandatory when
+  `physical` is **true**. The valid values are:
   + **DWS**
   + **DLI**
   + **MRS_HIVE**

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1101,6 +1101,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_studio_instance": dataarts.ResourceStudioInstance(),
 			// DataArts Architecture
 			"huaweicloud_dataarts_architecture_directory":       dataarts.ResourceArchitectureDirectory(),
+			"huaweicloud_dataarts_architecture_model":           dataarts.ResourceArchitectureModel(),
 			"huaweicloud_dataarts_architecture_subject":         dataarts.ResourceArchitectureSubject(),
 			"huaweicloud_dataarts_architecture_business_metric": dataarts.ResourceBusinessMetric(),
 			// DataArts Factory

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_model_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_model_test.go
@@ -1,0 +1,135 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getModelResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	modelClient, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	readModelHttpUrl := "v2/{project_id}/design/workspaces/{model_id}"
+	readModelPath := modelClient.Endpoint + readModelHttpUrl
+	readModelPath = strings.ReplaceAll(readModelPath, "{project_id}", modelClient.ProjectID)
+	readModelPath = strings.ReplaceAll(readModelPath, "{model_id}", state.Primary.ID)
+	workspaceID := state.Primary.Attributes["workspace_id"]
+	readModelOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	readModelResp, err := modelClient.Request("GET", readModelPath, &readModelOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(readModelResp)
+}
+func TestAccResourceModel_basic(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_dataarts_architecture_model.test"
+	rName := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getModelResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccModel_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "THIRD_NF"),
+					resource.TestCheckResourceAttr(resourceName, "dw_type", "DWS"),
+					resource.TestCheckResourceAttr(resourceName, "physical", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+				),
+			},
+			{
+				Config: testAccModel_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "type", "THIRD_NF"),
+					resource.TestCheckResourceAttr(resourceName, "dw_type", "DWS"),
+					resource.TestCheckResourceAttr(resourceName, "physical", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceModelImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccResourceModelImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		workspaceID := rs.Primary.Attributes["workspace_id"]
+		name := rs.Primary.Attributes["name"]
+		if workspaceID == "" || name == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want '<workspace_id>/<name>', but got '%s/%s'",
+				workspaceID, name)
+		}
+		return fmt.Sprintf("%s/%s", workspaceID, name), nil
+	}
+}
+func testAccModel_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_model" "test"{
+  workspace_id = "%s"
+  name         = "%s"
+  type         = "THIRD_NF"
+  physical     = true
+  dw_type      = "DWS"
+}`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccModel_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_model" "test"{
+  workspace_id = "%s"
+  name         = "%s"
+  type         = "THIRD_NF"
+  physical     = true
+  dw_type      = "DWS"
+  description  = "test description"
+}`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_model.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_model.go
@@ -1,0 +1,323 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio POST v2/{project_id}/design/workspaces
+// API: DataArtsStudio GET v2/{project_id}/design/workspaces
+// API: DataArtsStudio PUT v2/{project_id}/design/workspaces
+// API: DataArtsStudio GET v2/{project_id}/design/workspaces/{model_id}
+// API: DataArtsStudio DELETE v2/{project_id}/design/workspaces
+func ResourceArchitectureModel() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceArchitectureModelCreate,
+		ReadContext:   resourceArchitectureModelRead,
+		UpdateContext: resourceArchitectureModelUpdate,
+		DeleteContext: resourceArchitectureModelDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceArchitectureModelImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"physical": {
+				Type:     schema.TypeBool,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dw_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreateModelParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"type":        d.Get("type"),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"dw_type":     d.Get("dw_type"),
+		"level":       utils.ValueIngoreEmpty(d.Get("level")),
+		"is_physical": d.Get("physical"),
+	}
+	return bodyParams
+}
+
+func resourceArchitectureModelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	createModelHttpUrl := "v2/{project_id}/design/workspaces"
+	createModelProduct := "dataarts"
+
+	modelClient, err := cfg.NewServiceClient(createModelProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	createModelPath := modelClient.Endpoint + createModelHttpUrl
+	createModelPath = strings.ReplaceAll(createModelPath, "{project_id}", modelClient.ProjectID)
+	createModelOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+	createModelOpt.JSONBody = utils.RemoveNil(buildCreateModelParams(d))
+	createModelResp, err := modelClient.Request("POST", createModelPath, &createModelOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	createModelBody, err := utils.FlattenResponse(createModelResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	model := utils.PathSearch("data.value", createModelBody, nil)
+	id, err := jmespath.Search("id", model)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio architecture model: %s is not found in API response", "id")
+	}
+	d.SetId(id.(string))
+
+	return resourceArchitectureModelRead(ctx, d, meta)
+}
+
+func resourceArchitectureModelRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	readModelProduct := "dataarts"
+	modelClient, err := cfg.NewServiceClient(readModelProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	var model interface{}
+	if strings.Contains(d.Id(), "/") {
+		// if id contains name, it is for import
+		model, err = getModelByName(modelClient, d)
+	} else {
+		model, err = getModelById(modelClient, d)
+	}
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DataArts Architecture model")
+	}
+	d.SetId(utils.PathSearch("id", model, "").(string))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("workspace_id", d.Get("workspace_id").(string)),
+		d.Set("name", utils.PathSearch("name", model, "")),
+		d.Set("type", utils.PathSearch("type", model, "")),
+		d.Set("dw_type", utils.PathSearch("dw_type", model, "")),
+		d.Set("level", utils.PathSearch("level", model, "")),
+		d.Set("description", utils.PathSearch("description", model, "")),
+		d.Set("physical", utils.PathSearch("is_physical", model, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", model, "")),
+		d.Set("updated_at", utils.PathSearch("update_time", model, "")),
+		d.Set("created_by", utils.PathSearch("create_by", model, "")),
+		d.Set("updated_by", utils.PathSearch("update_by", model, "")),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getModelByName(modelClient *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	readModelHttpUrl := "v2/{project_id}/design/workspaces"
+	readModelPath := modelClient.Endpoint + readModelHttpUrl
+	readModelPath = strings.ReplaceAll(readModelPath, "{project_id}", modelClient.ProjectID)
+	workspaceID := d.Get("workspace_id").(string)
+	readModelOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	currentTotal := 0
+	readModelPath += fmt.Sprintf("?limit=50&offset=%v", currentTotal)
+	for {
+		readModelResp, err := modelClient.Request("GET", readModelPath, &readModelOpt)
+		if err != nil {
+			return nil, err
+		}
+		readModelBody, err := utils.FlattenResponse(readModelResp)
+		if err != nil {
+			return nil, err
+		}
+		models := utils.PathSearch("data.value.records", readModelBody, make([]interface{}, 0)).([]interface{})
+		total := utils.PathSearch("data.value.total", readModelBody, 0)
+		if len(models) == 0 {
+			return nil, golangsdk.ErrDefault404{}
+		}
+		for _, model := range models {
+			// using name to filter result for import, because ID can not be get from console
+			name := utils.PathSearch("name", model, "")
+			if name != d.Get("name") {
+				continue
+			}
+			return model, nil
+		}
+		currentTotal += len(models)
+		// type of `total` is float64
+		if float64(currentTotal) == total {
+			break
+		}
+		index := strings.Index(readModelPath, "offset")
+		readModelPath = fmt.Sprintf("%soffset=%v", readModelPath[:index], currentTotal)
+	}
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func getModelById(modelClient *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	readModelHttpUrl := "v2/{project_id}/design/workspaces/{model_id}"
+	readModelPath := modelClient.Endpoint + readModelHttpUrl
+	readModelPath = strings.ReplaceAll(readModelPath, "{project_id}", modelClient.ProjectID)
+	readModelPath = strings.ReplaceAll(readModelPath, "{model_id}", d.Id())
+	workspaceID := d.Get("workspace_id").(string)
+	readModelOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	readModelResp, err := modelClient.Request("GET", readModelPath, &readModelOpt)
+	if err != nil {
+		if hasErrorCode(err, "DLG.6026") || hasErrorCode(err, "DLG.3902") {
+			err = golangsdk.ErrDefault404{}
+		}
+		return nil, err
+	}
+	readModelBody, err := utils.FlattenResponse(readModelResp)
+	if err != nil {
+		return nil, err
+	}
+	model := utils.PathSearch("data.value", readModelBody, nil)
+	return model, nil
+}
+
+func resourceArchitectureModelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	modelProduct := "dataarts"
+	modelClient, err := cfg.NewServiceClient(modelProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	updateModelHttpUrl := "v2/{project_id}/design/workspaces"
+	updateModelPath := modelClient.Endpoint + updateModelHttpUrl
+	updateModelPath = strings.ReplaceAll(updateModelPath, "{project_id}", modelClient.ProjectID)
+	workspaceID := d.Get("workspace_id").(string)
+	readModelOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	readModelOpt.JSONBody = utils.RemoveNil(buildUpdateModelBodyParams(d))
+	_, err = modelClient.Request("PUT", updateModelPath, &readModelOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceArchitectureModelRead(ctx, d, meta)
+}
+
+func buildUpdateModelBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"id":          d.Id(),
+		"name":        d.Get("name"),
+		"type":        d.Get("type"),
+		"dw_type":     d.Get("dw_type"),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"level":       utils.ValueIngoreEmpty(d.Get("level")),
+		"is_physical": utils.ValueIngoreEmpty(d.Get("physical")),
+	}
+	return bodyParams
+}
+
+func resourceArchitectureModelDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	modelProduct := "dataarts"
+	modelClient, err := cfg.NewServiceClient(modelProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	delModelHttpUrl := "v2/{project_id}/design/workspaces?ids="
+	delModelPath := modelClient.Endpoint + delModelHttpUrl
+	delModelPath = strings.ReplaceAll(delModelPath, "{project_id}", modelClient.ProjectID)
+	delModelPath += d.Id()
+	workspaceID := d.Get("workspace_id").(string)
+	delModelOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	_, err = modelClient.Request("DELETE", delModelPath, &delModelOpt)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceArchitectureModelImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format of import ID, must be <workspace_id>/<name>")
+	}
+	d.Set("workspace_id", parts[0])
+	d.Set("name", parts[1])
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
feat(DATAARTS): add resource dataarts studio model

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
./scripts/codecheck.sh ./huaweicloud/services/dataarts

==> Checking for running environment...

==> Applying patch...

==> Checking for code complexity...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        8      2694      316        56     2322        294           103.19
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~ource_huaweicloud_dataarts_studio_model.go       357       26         9      322         50            15.53
~e_huaweicloud_dataarts_studio_directory.go       321       45        10      266         39            14.66
~ce_huawei_cloud_dataarts_studio_subject.go       343       46         9      288         39            13.54
~ce_huaweicloud_dataarts_studio_instance.go       281       33         1      247         37            14.98
~eicloud_dataarts_studio_business_metric.go       459       36         7      416         35             8.41
~source_huaweicloud_dataarts_service_app.go       321       44         8      269         32            11.90
~weicloud_dataarts_studio_permission_set.go       326       45         8      273         32            11.72
~ce_huaweicloud_dataarts_studio_resource.go       286       41         4      241         30            12.45
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     8      2694      316        56     2322        294           103.19
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 88242 bytes, 0.088 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP10 most complex functions:
11 dataarts resourceStudioSubjectRead huaweicloud/services/dataarts/resource_huawei_cloud_dataarts_studio_subject.go:160:1
8 dataarts getModelByName huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_model.go:168:1
8 dataarts resourceStudioInstanceCreate huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go:140:1
8 dataarts resourceStudioDirectoryRead huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_directory.go:153:1
6 dataarts getModelById huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_model.go:230:1
6 dataarts resourceStudioDirectoryUpdate huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_directory.go:224:1
6 dataarts resourceStudioDirectoryCreate huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_directory.go:96:1
6 dataarts resourceBusinessMetricCreate huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_business_metric.go:216:1
6 dataarts resourceStudioSubjectCreate huaweicloud/services/dataarts/resource_huawei_cloud_dataarts_studio_subject.go:108:1
5 dataarts resourceStudioResourceCreate huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_resource.go:86:1
Average: 3.2

==> Checking for golangci-lint...

==> Checking for Nolint directives...
./huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_directory.go:100:  //nolint:misspell
./huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_directory.go:158:  //nolint:misspell
./huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_directory.go:228:  //nolint:misspell
./huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_directory.go:284:  //nolint:misspell
./docs/resources/dataarts_studio_instance.md:36:<!--markdownlint-disable MD033-->

==> Checking for TF features in dataarts...

==> Checking for misspell in dataarts...

==> Checking for code complexity in ./huaweicloud/services/acceptance/dataarts...
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Language                              Files     Lines   Blanks  Comments     Code Complexity Complexity/Lines
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Go                                        8      1290      130         7     1153         99            71.37
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
~uaweicloud_dataarts_studio_subject_test.go       184       19         4      161         24            14.91
~weicloud_dataarts_studio_directory_test.go       156       19         1      136         17            12.50
~e_huaweicloud_dataarts_service_app_test.go       153       18         1      134         13             9.70
~oud_dataarts_studio_permission_set_test.go       148       17         0      131         11             8.40
~aweicloud_dataarts_studio_resource_test.go       154       17         0      137         11             8.03
~_huaweicloud_dataarts_studio_model_test.go       135       10         0      125          9             7.20
~aweicloud_dataarts_studio_instance_test.go       103       12         0       91          7             7.69
~ud_dataarts_studio_business_metric_test.go       257       18         1      238          7             2.94
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Total                                     8      1290      130         7     1153         99            71.37
─────────────────────────────────────────────────────────────────────────────────────────────────────────────
Processed 46781 bytes, 0.047 megabytes (SI)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────

the TOP5 most complex functions:
12 dataarts getSubjectResourceFunc huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_subject_test.go:18:1
7 dataarts getDirectoryResourceFunc huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_directory_test.go:18:1
5 dataarts getInstanceResourceFunc huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_instance_test.go:18:1
5 dataarts testAccResourceDirectoryImportStateIDFunc huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_directory_test.go:119:1
5 dataarts testServiceAppImportState huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_service_app_test.go:133:1
Average: 2.44

==> Checking for golangci-lint in ./huaweicloud/services/acceptance/dataarts...

==> Checking for Nolint directives in ./huaweicloud/services/acceptance/dataarts...
./huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_studio_directory_test.go:24:   //nolint:misspell

==> Cleanup patch...

Check Completed!


## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/dataarts TESTARGS='-run TestAccResourceModel_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceModel_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceModel_basic
=== PAUSE TestAccResourceModel_basic
=== CONT  TestAccResourceModel_basic
--- PASS: TestAccResourceModel_basic (23.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  23.263s

