### PR TITLE
refactor(workspace): Image can be queried using dataSource

### DIFF
--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_test.go
@@ -123,6 +123,11 @@ resource "huaweicloud_workspace_service" "test" {
     huaweicloud_vpc_subnet.standby.id,
   ]
 }
+
+data "huaweicloud_images_images" "test" {
+  name_regex = "WORKSPACE"
+  visibility = "market"
+}
 `, common.TestBaseNetwork(rName), rName)
 }
 
@@ -137,7 +142,7 @@ locals {
 resource "huaweicloud_workspace_desktop" "test" {
   flavor_id         = "workspace.x86.ultimate.large2"
   image_type        = "market"
-  image_id          = "8451dedf-b353-43aa-b5fb-5bccadda2207"
+  image_id          = try(data.huaweicloud_images_images.test.images[0].id, "")
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   vpc_id            = huaweicloud_vpc.test.id
   security_groups   = [
@@ -188,7 +193,7 @@ locals {
 resource "huaweicloud_workspace_desktop" "test" {
   flavor_id         = "workspace.x86.ultimate.large4"
   image_type        = "market"
-  image_id          = "8451dedf-b353-43aa-b5fb-5bccadda2207"
+  image_id          = try(data.huaweicloud_images_images.test.images[0].id, "")
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   vpc_id            = huaweicloud_vpc.test.id
   security_groups   = [
@@ -239,7 +244,7 @@ locals {
 resource "huaweicloud_workspace_desktop" "test" {
   flavor_id         = "workspace.x86.ultimate.large4"
   image_type        = "market"
-  image_id          = "4d698843-d653-4ffd-80be-4f47a0cabce0"
+  image_id          = try(data.huaweicloud_images_images.test.images[1].id, "")
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   vpc_id            = huaweicloud_vpc.test.id
   security_groups   = [


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Images can be queried using dataSource.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
Ulanqab1
make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccDesktop_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccDesktop_basic -timeout 360m -parallel 4
=== RUN   TestAccDesktop_basic
=== PAUSE TestAccDesktop_basic
=== CONT  TestAccDesktop_basic
--- PASS: TestAccDesktop_basic (1660.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace    1660.943s

beijing4
make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccDesktop_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccDesktop_basic -timeout 360m -parallel 4
=== RUN   TestAccDesktop_basic
=== PAUSE TestAccDesktop_basic
=== CONT  TestAccDesktop_basic
--- PASS: TestAccDesktop_basic (1745.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace       1745.828s

```
