### PR TITLE
feat(DataArts): add dataarts data standard resource

### DIFF
--- a/docs/resources/dataarts_architecture_data_standard.md
+++ b/docs/resources/dataarts_architecture_data_standard.md
@@ -1,0 +1,130 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_architecture_data_standard
+
+Manages DataArts Architecture data standard resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "directory_id" {}
+
+resource "huaweicloud_dataarts_architecture_data_standard" "test"{
+  workspace_id = var.workspace_id
+  directory_id = var.directory_id
+
+  values {
+    fd_name  = "nameCh"
+    fd_value = "test_name"
+  }
+
+  values {
+    fd_name  = "nameEn"
+    fd_value = "test_name"
+  }
+
+  values {
+    fd_name  = "description"
+    fd_value = "this is a test"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID of DataArts Architecture. Changing this parameter will
+  create a new resource.
+
+* `directory_id` - (Required, String) Specifies the directory ID that the data standard belongs to.
+
+* `values` - (Required, List) Specifies the value of data standard attributes.
+The [values](#DataStandard_Value) structure is documented below.
+
+<a name="DataStandard_Value"></a>
+The `values` block supports:
+
+* `fd_name` - (Required, String) Specifies the name of the data standard attribute.
+
+* `fd_value` - (Optional, String) Specifies the value of the data standard attribute.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `values` - Indicates the value of data standard attributes.
+  The [values](#DataStandard_Value) structure is documented below.
+
+* `directory_path` - Indicates the path of the directory.
+
+* `status` - Indicates the status of the data standard. The value can be: **DRAFT**, **PUBLISH_DEVELOPING**,
+  **PUBLISHED**, **OFFLINE_DEVELOPING**, **OFFLINE**, **REJECT**.
+
+* `created_by` - Indicates the name of creator.
+
+* `updated_by` - Indicates the name of updater.
+
+* `created_at` - Indicates the creation time of the data standard.
+
+* `updated_at` - Indicates the latest update time of the data standard.
+
+* `new_biz` - Specifies the biz info of manager.
+  The [new_biz](#DataStandard_NewBiz) structure is documented below.
+
+<a name="DataStandard_Value"></a>
+The `values` block supports:
+
+* `id` - Indicates the ID of the data standard attribute.
+
+* `fd_id` - Indicates the ID of the data standard attribute definition.
+
+* `directory_id` - Indicates the directory ID that the attribute belongs to.
+
+* `row_id` - Indicates the ID of data standard.
+
+* `status` - Indicates the status of the data standard. The value can be: **DRAFT**, **PUBLISH_DEVELOPING**,
+  **PUBLISHED**, **OFFLINE_DEVELOPING**, **OFFLINE**, **REJECT**.
+
+* `created_by` - Indicates the name of creator.
+
+* `updated_by` - Indicates the name of updater.
+
+* `created_at` - Indicates the creation time of the data standard.
+
+* `updated_at` - Indicates the latest update time of the data standard.
+
+<a name="DataStandard_NewBiz"></a>
+The `new_biz` block supports:
+
+* `id` - Indicates the ID of the new biz.
+
+* `biz_type` - Indicates the type of the new biz.
+
+* `biz_id` - Indicates the ID of data standard.
+
+* `biz_info` - Indicates the info of the new biz.
+
+* `status` - Indicates the status of the new biz.
+
+* `biz_version` - Indicates the version of the new biz.
+
+* `created_by` - Indicates the creation time of the new biz.
+
+* `updated_at` - Indicates the latest update time of the new biz.
+
+## Import
+
+The DataArts Architecture data standard can be imported using the `workspace_id` and `id` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_architecture_data_standard.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1108,6 +1108,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_subject":         dataarts.ResourceArchitectureSubject(),
 			"huaweicloud_dataarts_architecture_business_metric": dataarts.ResourceBusinessMetric(),
 			"huaweicloud_dataarts_architecture_process":         dataarts.ResourceArchitectureProcess(),
+			"huaweicloud_dataarts_architecture_data_standard":   dataarts.ResourceDataStandard(),
 			// DataArts Factory
 			"huaweicloud_dataarts_factory_resource": dataarts.ResourceFactoryResource(),
 			"huaweicloud_dataarts_factory_job":      dataarts.ResourceFactoryJob(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_data_standard_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_data_standard_test.go
@@ -1,0 +1,203 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDataStandardResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	// getDataStandard: query DataArts Architecture data standard
+	var (
+		getDataStandardHttpUrl = "v2/{project_id}/design/standards"
+		getDataStandardProduct = "dataarts"
+	)
+	getDataStandardClient, err := cfg.NewServiceClient(getDataStandardProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getDataStandardBasePath := getDataStandardClient.Endpoint + getDataStandardHttpUrl
+	getDataStandardBasePath = strings.ReplaceAll(getDataStandardBasePath, "{project_id}", getDataStandardClient.ProjectID)
+
+	var currentTotal int
+	var dataStandard interface{}
+	directoryID := state.Primary.Attributes["directory_id"]
+	getDataStandardPath := getDataStandardBasePath + buildGetDataStandardQueryParams(directoryID, currentTotal)
+	for {
+		getDataStandardOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"workspace": state.Primary.Attributes["workspace_id"],
+			},
+		}
+
+		getDataStandardResp, err := getDataStandardClient.Request("GET", getDataStandardPath, &getDataStandardOpt)
+
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving DataArts Architecture data standard")
+		}
+
+		getDataStandardRespBody, err := utils.FlattenResponse(getDataStandardResp)
+		if err != nil {
+			return nil, err
+		}
+
+		records := utils.PathSearch("data.value.records", getDataStandardRespBody, make([]interface{}, 0))
+		dataStandard = utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0]", state.Primary.ID), records, nil)
+		if dataStandard != nil {
+			break
+		}
+		total := utils.PathSearch("data.value.total", getDataStandardRespBody, 0).(float64)
+		currentTotal += len(records.([]interface{}))
+		if currentTotal == int(total) {
+			break
+		}
+		getDataStandardPath = getDataStandardBasePath + buildGetDataStandardQueryParams(directoryID, currentTotal)
+	}
+
+	if dataStandard == nil {
+		return nil, fmt.Errorf("error retrieving DataArts Architecture data standard")
+	}
+
+	return dataStandard, nil
+}
+
+func buildGetDataStandardQueryParams(directoryID string, offset int) string {
+	return fmt.Sprintf("?directory_id=%v&limit=100&offset=%v", directoryID, offset)
+}
+
+func TestAccDataStandard_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dataarts_architecture_data_standard.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDataStandardResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDataStandard_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "directory_id",
+						"huaweicloud_dataarts_architecture_directory.test", "id"),
+					resource.TestCheckResourceAttr(rName, "values.#", "3"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_by"),
+					resource.TestCheckResourceAttrSet(rName, "updated_by"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testDataStandard_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "directory_id",
+						"huaweicloud_dataarts_architecture_directory.test", "id"),
+					resource.TestCheckResourceAttr(rName, "values.#", "4"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDataStandardImportState(rName),
+			},
+		},
+	})
+}
+
+func testDataStandard_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_architecture_data_standard" "test" {
+  workspace_id = "%[2]s"
+  directory_id = huaweicloud_dataarts_architecture_directory.test.id
+
+  values {
+    fd_name  = "nameCh"
+    fd_value = "%[3]s"
+  }
+
+  values {
+    fd_name  = "nameEn"
+    fd_value = "%[3]s"
+  }
+
+  values {
+    fd_name  = "description"
+    fd_value = "this is a terraform"
+  }
+}
+`, testAccArchitectureDirectory_basic(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testDataStandard_basic_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_architecture_data_standard" "test" {
+  workspace_id = "%[2]s"
+  directory_id = huaweicloud_dataarts_architecture_directory.test.id
+
+  values {
+    fd_name  = "nameCh"
+    fd_value = "%[3]s"
+  }
+
+  values {
+    fd_name  = "nameEn"
+    fd_value = "%[3]s"
+  }
+
+  values {
+    fd_name  = "dataType"
+    fd_value = "STRING"
+  }
+
+  values {
+    fd_name  = "description"
+    fd_value = ""
+  }
+}
+`, testAccArchitectureDirectory_basic(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testDataStandardImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		dataStandard, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, dataStandard)
+		}
+
+		var workspaceID string
+		if workspaceID = dataStandard.Primary.Attributes["workspace_id"]; workspaceID == "" {
+			return "", fmt.Errorf("attribute (workspace_id) of Resource (%s) not found: %s", name, dataStandard)
+		}
+		return fmt.Sprintf("%s/%s", workspaceID, dataStandard.Primary.ID), nil
+	}
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_data_standard.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_data_standard.go
@@ -1,0 +1,576 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DataArts
+// ---------------------------------------------------------------
+
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio POST /v2/{project_id}/design/standards
+// API: DataArtsStudio GET /v2/{project_id}/design/standards
+// API: DataArtsStudio PUT /v2/{project_id}/design/standards/{id}
+// API: DataArtsStudio GET //v2/{project_id}/design/standards/{id}
+// API: DataArtsStudio DELETE /v2/{project_id}/design/standards
+func ResourceDataStandard() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDataStandardCreate,
+		UpdateContext: resourceDataStandardUpdate,
+		ReadContext:   resourceDataStandardRead,
+		DeleteContext: resourceDataStandardDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDataStandardImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the workspace ID of DataArts Architecture.`,
+			},
+			"directory_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the directory ID that the data standard belongs to.`,
+			},
+			"values": {
+				Type:        schema.TypeSet,
+				Elem:        dataStandardValueSchema(),
+				Required:    true,
+				Description: `Specifies the value of data standard attributes.`,
+			},
+			"directory_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the path of the directory.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the status of the data standard.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the name of creator.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the name of updater.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creation time of the data standard.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the latest update time of the data standard.`,
+			},
+			"new_biz": {
+				Type:        schema.TypeList,
+				Elem:        dataStandardNewBizSchema(),
+				Computed:    true,
+				Description: `Indicates the biz info of manager.`,
+			},
+		},
+	}
+}
+
+func dataStandardValueSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"fd_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the name of the data standard attribute.`,
+			},
+			"fd_value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the value of the data standard attribute.`,
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the ID of the data standard attribute.`,
+			},
+			"fd_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the ID of the data standard attribute.`,
+			},
+			"directory_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the directory ID that the attribute belongs to.`,
+			},
+			"row_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the ID of data standard.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the status of the data standard.`,
+			},
+			"created_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the name of creator.`,
+			},
+			"updated_by": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the name of updater.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creation time of the data standard.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the latest update time of the data standard.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataStandardNewBizSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the ID of the new biz.`,
+			},
+			"biz_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the type of the new biz.`,
+			},
+			"biz_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the ID of data standard.`,
+			},
+			"biz_info": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the info of the new biz.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the status of the new biz.`,
+			},
+			"biz_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the version of the new biz.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the creation time of the new biz.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the latest update time of the new biz.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDataStandardCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// createDataStandard: create DataArts Architecture data standard
+	var (
+		createDataStandardHttpUrl = "v2/{project_id}/design/standards"
+		createDataStandardProduct = "dataarts"
+	)
+	createDataStandardClient, err := cfg.NewServiceClient(createDataStandardProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	createDataStandardPath := createDataStandardClient.Endpoint + createDataStandardHttpUrl
+	createDataStandardPath = strings.ReplaceAll(createDataStandardPath, "{project_id}", createDataStandardClient.ProjectID)
+
+	createDataStandardOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"workspace": d.Get("workspace_id").(string),
+		},
+	}
+
+	createDataStandardOpt.JSONBody = utils.RemoveNil(buildCreateDataStandardBodyParams(d))
+	createDataStandardResp, err := createDataStandardClient.Request("POST", createDataStandardPath, &createDataStandardOpt)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Architecture data standard: %s", err)
+	}
+
+	createDataStandardRespBody, err := utils.FlattenResponse(createDataStandardResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("data.value.id", createDataStandardRespBody)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Architecture data standard: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceDataStandardRead(ctx, d, meta)
+}
+
+func buildCreateDataStandardBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"directory_id": d.Get("directory_id"),
+		"values":       buildCreateDataStandardRequestBodyValue(d.Get("values").(*schema.Set).List()),
+	}
+	return bodyParams
+}
+
+func buildCreateDataStandardRequestBodyValue(rawArray []interface{}) []map[string]interface{} {
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, len(rawArray))
+	for i, v := range rawArray {
+		raw := v.(map[string]interface{})
+		rst[i] = map[string]interface{}{
+			"fd_name":  raw["fd_name"],
+			"fd_value": raw["fd_value"],
+		}
+	}
+	return rst
+}
+
+func resourceDataStandardRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getDataStandard: query DataArts Architecture data standard
+	var (
+		getDataStandardHttpUrl = "v2/{project_id}/design/standards"
+		getDataStandardProduct = "dataarts"
+	)
+	getDataStandardClient, err := cfg.NewServiceClient(getDataStandardProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getDataStandardBasePath := getDataStandardClient.Endpoint + getDataStandardHttpUrl
+	getDataStandardBasePath = strings.ReplaceAll(getDataStandardBasePath, "{project_id}", getDataStandardClient.ProjectID)
+
+	var currentTotal int
+	var dataStandard interface{}
+	for {
+		getDataStandardPath := getDataStandardBasePath + buildGetDataStandardQueryParams(d, currentTotal)
+		getDataStandardOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"workspace": d.Get("workspace_id").(string),
+			},
+		}
+
+		getDataStandardResp, err := getDataStandardClient.Request("GET", getDataStandardPath, &getDataStandardOpt)
+
+		if err != nil {
+			return common.CheckDeletedDiag(d, err, "error retrieving DataStandard")
+		}
+
+		getDataStandardRespBody, err := utils.FlattenResponse(getDataStandardResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		records := utils.PathSearch("data.value.records", getDataStandardRespBody, make([]interface{}, 0))
+		dataStandard = utils.PathSearch(fmt.Sprintf("[?id=='%s']|[0]", d.Id()), records, nil)
+		if dataStandard != nil {
+			break
+		}
+		total := utils.PathSearch("data.value.total", getDataStandardRespBody, 0).(float64)
+		currentTotal += len(records.([]interface{}))
+		if currentTotal == int(total) {
+			break
+		}
+	}
+
+	if dataStandard == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("directory_id", utils.PathSearch("directory_id", dataStandard, nil)),
+		d.Set("directory_path", utils.PathSearch("directory_path", dataStandard, nil)),
+		d.Set("status", utils.PathSearch("status", dataStandard, nil)),
+		d.Set("created_by", utils.PathSearch("create_by", dataStandard, nil)),
+		d.Set("updated_by", utils.PathSearch("update_by", dataStandard, nil)),
+		d.Set("created_at", utils.PathSearch("create_time", dataStandard, nil)),
+		d.Set("updated_at", utils.PathSearch("update_time", dataStandard, nil)),
+		d.Set("values", flattenGetDataStandardResponseBodyValue(dataStandard)),
+		d.Set("new_biz", flattenGetDataStandardResponseBodyNewBiz(dataStandard)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetDataStandardQueryParams(d *schema.ResourceData, offset int) string {
+	return fmt.Sprintf("?directory_id=%v&limit=100&offset=%v", d.Get("directory_id"), offset)
+}
+
+func flattenGetDataStandardResponseBodyValue(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("values", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":           utils.PathSearch("id", v, nil),
+			"fd_id":        utils.PathSearch("fd_id", v, nil),
+			"fd_name":      utils.PathSearch("fd_name", v, nil),
+			"fd_value":     utils.PathSearch("fd_value", v, nil),
+			"directory_id": utils.PathSearch("directory_id", v, nil),
+			"row_id":       utils.PathSearch("row_id", v, nil),
+			"status":       utils.PathSearch("status", v, nil),
+			"created_by":   utils.PathSearch("create_by", v, nil),
+			"updated_by":   utils.PathSearch("update_by", v, nil),
+			"created_at":   utils.PathSearch("create_time", v, nil),
+			"updated_at":   utils.PathSearch("update_time", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenGetDataStandardResponseBodyNewBiz(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("new_biz", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":          utils.PathSearch("id", v, nil),
+			"biz_type":    utils.PathSearch("biz_type", v, nil),
+			"biz_id":      utils.PathSearch("biz_id", v, nil),
+			"biz_info":    utils.PathSearch("biz_info", v, nil),
+			"status":      utils.PathSearch("status", v, nil),
+			"biz_version": utils.PathSearch("biz_version", v, nil),
+			"created_at":  utils.PathSearch("create_time", v, nil),
+			"updated_at":  utils.PathSearch("update_time", v, nil),
+		})
+	}
+	return rst
+}
+
+func resourceDataStandardUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateDataStandardChanges := []string{
+		"directory_id",
+		"values",
+	}
+
+	if d.HasChanges(updateDataStandardChanges...) {
+		// updateDataStandard: update DataArts Architecture data standard
+		var (
+			updateDataStandardHttpUrl = "v2/{project_id}/design/standards/{id}"
+			updateDataStandardProduct = "dataarts"
+		)
+		updateDataStandardClient, err := cfg.NewServiceClient(updateDataStandardProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating DataArts Studio client: %s", err)
+		}
+
+		updateDataStandardPath := updateDataStandardClient.Endpoint + updateDataStandardHttpUrl
+		updateDataStandardPath = strings.ReplaceAll(updateDataStandardPath, "{project_id}", updateDataStandardClient.ProjectID)
+		updateDataStandardPath = strings.ReplaceAll(updateDataStandardPath, "{id}", d.Id())
+
+		updateDataStandardOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"workspace": d.Get("workspace_id").(string),
+			},
+		}
+
+		dataStandardRespBody, err := getDataStandard(d, updateDataStandardClient)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		dataStandardNameToIdMap := buildDataStandardNameToIdMap(dataStandardRespBody)
+		updateDataStandardOpt.JSONBody = utils.RemoveNil(buildUpdateDataStandardBodyParams(d, dataStandardNameToIdMap))
+		_, err = updateDataStandardClient.Request("PUT", updateDataStandardPath, &updateDataStandardOpt)
+		if err != nil {
+			return diag.Errorf("error updating DataArts Architecture data standard: %s", err)
+		}
+	}
+	return resourceDataStandardRead(ctx, d, meta)
+}
+
+func getDataStandard(d *schema.ResourceData, client *golangsdk.ServiceClient) (interface{}, error) {
+	var (
+		getDataStandardHttpUrl = "v2/{project_id}/design/standards/{id}"
+	)
+	getDataStandardPath := client.Endpoint + getDataStandardHttpUrl
+	getDataStandardPath = strings.ReplaceAll(getDataStandardPath, "{project_id}", client.ProjectID)
+	getDataStandardPath = strings.ReplaceAll(getDataStandardPath, "{id}", d.Id())
+
+	getDataStandardOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"workspace": d.Get("workspace_id").(string),
+		},
+	}
+
+	getDataStandardResp, err := client.Request("GET", getDataStandardPath, &getDataStandardOpt)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getDataStandardResp)
+}
+
+func buildDataStandardNameToIdMap(resp interface{}) map[string]string {
+	rst := make(map[string]string)
+	if resp == nil {
+		return rst
+	}
+	curJson := utils.PathSearch("data.value.values", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	for _, v := range curArray {
+		id := utils.PathSearch("id", v, "").(string)
+		fdName := utils.PathSearch("fd_name", v, "").(string)
+		rst[fdName] = id
+	}
+	return rst
+}
+
+func buildUpdateDataStandardBodyParams(d *schema.ResourceData, dataStandardNameToIdMap map[string]string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"id":           d.Id(),
+		"directory_id": d.Get("directory_id"),
+		"values":       buildUpdateDataStandardRequestBodyValue(d, dataStandardNameToIdMap),
+	}
+	return bodyParams
+}
+
+func buildUpdateDataStandardRequestBodyValue(d *schema.ResourceData, dataStandardNameToIdMap map[string]string) []map[string]interface{} {
+	rawArray := d.Get("values").(*schema.Set).List()
+	if len(rawArray) == 0 {
+		return nil
+	}
+
+	rst := make([]map[string]interface{}, len(rawArray))
+	for i, v := range rawArray {
+		raw := v.(map[string]interface{})
+		rst[i] = map[string]interface{}{
+			"id":           dataStandardNameToIdMap[raw["fd_name"].(string)],
+			"fd_name":      raw["fd_name"],
+			"fd_value":     raw["fd_value"],
+			"directory_id": d.Get("directory_id"),
+		}
+	}
+	return rst
+}
+
+func resourceDataStandardDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// deleteDataStandard: delete DataArts Architecture data standard
+	var (
+		deleteDataStandardHttpUrl = "v2/{project_id}/design/standards"
+		deleteDataStandardProduct = "dataarts"
+	)
+	deleteDataStandardClient, err := cfg.NewServiceClient(deleteDataStandardProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	deleteDataStandardPath := deleteDataStandardClient.Endpoint + deleteDataStandardHttpUrl
+	deleteDataStandardPath = strings.ReplaceAll(deleteDataStandardPath, "{project_id}", deleteDataStandardClient.ProjectID)
+	deleteDataStandardPath = strings.ReplaceAll(deleteDataStandardPath, "{id}", d.Id())
+
+	deleteDataStandardOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"workspace": d.Get("workspace_id").(string),
+		},
+	}
+
+	deleteDataStandardOpt.JSONBody = utils.RemoveNil(buildDeleteDataStandardBodyParams(d))
+	_, err = deleteDataStandardClient.Request("DELETE", deleteDataStandardPath, &deleteDataStandardOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DataArts Architecture data standard: %s", err)
+	}
+
+	return nil
+}
+
+func buildDeleteDataStandardBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"ids": []string{d.Id()},
+	}
+	return bodyParams
+}
+
+// resourceDataStandardImportState use to import an id with format <workspace_id>/<id>
+func resourceDataStandardImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, must be <workspace_id>/<id>")
+	}
+
+	d.SetId(parts[1])
+	mErr := multierror.Append(
+		nil,
+		d.Set("workspace_id", parts[0]),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return nil, fmt.Errorf("failed to set values in import state, %s", err)
+	}
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add dataarts data standard resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add dataarts data standard resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dataarts/ TESTARGS='-run TestAccDataStandard_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts/ -v -run TestAccDataStandard_basic -timeout 360m -parallel 4
=== RUN   TestAccDataStandard_basic
=== PAUSE TestAccDataStandard_basic
=== CONT  TestAccDataStandard_basic
--- PASS: TestAccDataStandard_basic (26.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  26.406s
```
