### PR TITLE
feat(VPCEP): add datasource to query the list of VPC endpoint services

### DIFF
--- a/docs/data-sources/vpcep_services.md
+++ b/docs/data-sources/vpcep_services.md
@@ -1,0 +1,85 @@
+---
+subcategory: "VPC Endpoint (VPCEP)"
+---
+
+# huaweicloud_vpcep_services
+
+Use this data source to get VPC endpoint services.
+
+## Example Usage
+
+```hcl
+variable service_name {}
+variable server_type {}
+variable service_statusname {}
+
+data "huaweicloud_vpcep_public_services" "services" {
+  service_name = var.service_name
+  server_type  = var.server_type
+  status       = var.status
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the VPC endpoint services. If omitted, the
+  provider-level region will be used.
+
+* `id` - (Optional, String) Specifies the ID of VPC endpoint service.
+
+* `service_name` - (Optional, String) Specifies the full name of the VPC endpoint service in the
+  format: *region.name.id* or *region.id*.
+
+* `status` - (Optional, String) Specifies the status of the VPC endpoint service.
+  The value can be **available** or **failed**.
+
+* `server_type` - (Optional, String) Specifies the backend resource type. The valid values are as follows:
+  + **VM**: Indicates the cloud server, which can be used as a server.
+  + **LB**: Indicates the shared load balancer, which is applicable to services with high access traffic and services
+
+* `public_border_group` - (Optional, String) Specifies the VPC endpoint service that matches the edge
+  attribute in the filtering result.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `endpoint_services` - The list of VPC endpoint service.
+
+The `endpoint_services` block supports:
+
+* `id` - The ID of VPC endpoint service.
+
+* `service_name` - The full name of the VPC endpoint service in the format: *region.name.id* or *region.id*.
+
+* `server_type` - The backend resource type.
+
+* `vpc_id` - The ID of the VPC to which the backend resource of the VPC endpoint service belongs. 
+
+* `approval_enabled` - Whether connection approval is required. The default value is false.
+
+* `service_type` - The type of VPC endpoint service.
+
+* `created_at` - The creation time of VPC endpoint service.
+
+* `updated_at` - The latest update time of VPC endpoint service.
+
+* `connection_count` - The latest update time of VPC endpoint service.
+
+* `tcp_proxy` - The latest update time of VPC endpoint service.
+
+* `description` - The description of the VPC endpoint service.
+
+* `enable_policy` - Whether the VPC endpoint policy is enabled. Defaults to **false**.
+
+* `public_border_group` - The VPC endpoint service that matches the edge attribute in the filtering result.
+
+* `tags` - The key/value pairs to associate with the VPC endpoint service.
+
+The `tags` block supports:
+
+* `key` - The tag key.
+
+* `value` - The tag value.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231207092945-17836db4283b
+	github.com/chnsz/golangsdk v0.0.0-20231218032934-228370eb4498
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231207092945-17836db4283b h1:wVQLEuPOL1/7/5gSR+vG4ytpx1PBv59WmiAK1DEYmqU=
-github.com/chnsz/golangsdk v0.0.0-20231207092945-17836db4283b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231218032934-228370eb4498 h1:FaBrNLIsE4JRaL+sufpu29gxrwQUKDFuqdx+sgvG/Pk=
+github.com/chnsz/golangsdk v0.0.0-20231218032934-228370eb4498/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -330,7 +330,6 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -621,6 +621,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_subnet_ids":         vpc.DataSourceVpcSubnetIdsV1(),
 
 			"huaweicloud_vpcep_public_services": vpcep.DataSourceVPCEPPublicServices(),
+			"huaweicloud_vpcep_services":        vpcep.DataSourceVPCEPServices(),
 
 			"huaweicloud_vpn_gateway_availability_zones": vpn.DataSourceVpnGatewayAZs(),
 			"huaweicloud_vpn_gateways":                   vpn.DataSourceGateways(),

--- a/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_services_test.go
+++ b/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_services_test.go
@@ -1,0 +1,103 @@
+package vpcep
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceVpcepServices_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_vpcep_services.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceVpcepServices_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.service_name"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.server_type"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.approval_enabled"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.service_type"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.connection_count"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.tcp_proxy"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.public_border_group"),
+					resource.TestCheckResourceAttrSet(rName, "endpoint_services.0.enable_policy"),
+
+					resource.TestCheckOutput("service_name_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("server_type_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceVpcepServices_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpcep_services" "test" {
+  depends_on = [huaweicloud_vpcep_service.test]
+}
+
+data "huaweicloud_vpcep_services" "service_name_filter" {
+  service_name = data.huaweicloud_vpcep_services.test.endpoint_services.0.service_name
+}
+
+locals {
+  service_name = data.huaweicloud_vpcep_services.test.endpoint_services.0.service_name
+}
+
+output "service_name_filter_is_useful" {
+  value = length(data.huaweicloud_vpcep_services.service_name_filter.endpoint_services) > 0 && alltrue(
+    [for v in data.huaweicloud_vpcep_services.service_name_filter.endpoint_services[*].service_name : v == local.service_name]
+  )  
+}
+
+data "huaweicloud_vpcep_services" "server_type_filter" {
+  server_type  = data.huaweicloud_vpcep_services.test.endpoint_services.0.server_type
+}
+
+locals {
+  server_type = data.huaweicloud_vpcep_services.test.endpoint_services.0.server_type
+}
+
+output "server_type_filter_is_useful" {
+  value = length(data.huaweicloud_vpcep_services.server_type_filter.endpoint_services) > 0 && alltrue(
+    [for v in data.huaweicloud_vpcep_services.server_type_filter.endpoint_services[*].server_type : v == local.server_type]
+  )  
+}
+
+data "huaweicloud_vpcep_services" "status_filter" {
+  status  = data.huaweicloud_vpcep_services.test.endpoint_services.0.status
+}
+  
+locals {
+  status = data.huaweicloud_vpcep_services.test.endpoint_services.0.status
+}
+  
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_vpcep_services.status_filter.endpoint_services) > 0 && alltrue(
+    [for v in data.huaweicloud_vpcep_services.status_filter.endpoint_services[*].status : v == local.status]
+  )  
+}
+`, testAccVPCEPService_Basic(name))
+}

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
@@ -152,13 +152,13 @@ func testAccVPCEPService_Basic(rName string) string {
 %s
 
 resource "huaweicloud_vpcep_service" "test" {
-  name        = "%s"
-  server_type = "VM"
-  vpc_id      = data.huaweicloud_vpc.myvpc.id
-  port_id     = huaweicloud_compute_instance.ecs.network[0].port
-  approval    = false
-  description = "test description"
-  permissions = ["iam:domain::1234", "iam:domain::5678"]
+  name                     = "%s"
+  server_type              = "VM"
+  vpc_id                   = data.huaweicloud_vpc.myvpc.id
+  port_id                  = huaweicloud_compute_instance.ecs.network[0].port
+  approval                 = false
+  description              = "test description"
+  permissions              = ["iam:domain::6e9dfd5d1124e8d8498dce894923a0dd", "iam:domain::6e9dfd5d1124e8d8498dce894923a0de"]
   organization_permissions = ["organizations:orgPath::1234", "organizations:orgPath::5678"]
 
   port_mapping {
@@ -177,13 +177,13 @@ func testAccVPCEPService_Update(rName string) string {
 %s
 
 resource "huaweicloud_vpcep_service" "test" {
-  name        = "tf-%s"
-  server_type = "VM"
-  vpc_id      = data.huaweicloud_vpc.myvpc.id
-  port_id     = huaweicloud_compute_instance.ecs.network[0].port
-  approval    = true
-  description = "test description update"
-  permissions = ["*"]
+  name                     = "tf-%s"
+  server_type              = "VM"
+  vpc_id                   = data.huaweicloud_vpc.myvpc.id
+  port_id                  = huaweicloud_compute_instance.ecs.network[0].port
+  approval                 = true
+  description              = "test description update"
+  permissions              = ["*"]
   organization_permissions = ["organizations:orgPath::*"]
 
   port_mapping {
@@ -209,7 +209,7 @@ resource "huaweicloud_vpcep_service" "test" {
   approval      = false
   description   = "test description"
   enable_policy = true
-  permissions   = ["iam:domain::1234", "iam:domain::5678"]
+  permissions   = ["iam:domain::6e9dfd5d1124e8d8498dce894923a0dd", "iam:domain::6e9dfd5d1124e8d8498dce894923a0de"]
 
   port_mapping {
     service_port  = 8080

--- a/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_services.go
+++ b/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_services.go
@@ -1,0 +1,212 @@
+package vpcep
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/services"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func DataSourceVPCEPServices() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVpcepServicesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_border_group": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"server_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"endpoint_services": {
+				Type:     schema.TypeList,
+				Elem:     servicesSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func servicesSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"server_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"approval_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeList,
+				Elem:     tagsInfoSchema(),
+				Computed: true,
+			},
+			"connection_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"tcp_proxy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_border_group": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_policy": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func tagsInfoSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceVpcepServicesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC endpoint client: %s", err)
+	}
+
+	listOpts := services.ListOpts{
+		ServiceName:       d.Get("service_name").(string),
+		ID:                d.Get("id").(string),
+		Status:            d.Get("status").(string),
+		ServerType:        d.Get("server_type").(string),
+		PublicBorderGroup: d.Get("public_border_group").(string),
+	}
+
+	allServices, err := services.ListAllServices(vpcepClient, listOpts)
+	if err != nil {
+		return diag.Errorf("unable to retrieve VPC endpoint services: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("endpoint_services", flattenListVpcepServices(allServices)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListVpcepServices(allServices []services.Service) []map[string]interface{} {
+	if allServices == nil {
+		return nil
+	}
+	endpointServices := make([]map[string]interface{}, len(allServices))
+	for i, v := range allServices {
+		endpointServices[i] = map[string]interface{}{
+			"id":                  v.ID,
+			"service_name":        v.ServiceName,
+			"service_type":        v.ServiceType,
+			"server_type":         v.ServerType,
+			"vpc_id":              v.VpcID,
+			"approval_enabled":    v.Approval,
+			"status":              v.Status,
+			"created_at":          v.Created,
+			"updated_at":          v.Updated,
+			"tags":                flattenGetServiceTags(v),
+			"tcp_proxy":           v.TCPProxy,
+			"description":         v.Description,
+			"enable_policy":       v.EnablePolicy,
+			"public_border_group": v.PublicBorderGroup,
+			"connection_count":    v.ConnectionCount,
+		}
+	}
+	return endpointServices
+}
+
+func flattenGetServiceTags(service services.Service) []map[string]interface{} {
+	tags := service.Tags
+	rst := make([]map[string]interface{}, len(tags))
+	for i, v := range tags {
+		rst[i] = map[string]interface{}{
+			"key":   v.Key,
+			"value": v.Value,
+		}
+	}
+	return rst
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
@@ -151,6 +151,12 @@ type ListOpts struct {
 	// asc: VPC endpoint services are sorted in ascending order. The default method is desc.
 	// Default: desc
 	SortDir string `q:"sort_dir"`
+	// Specifies the VPC endpoint service that matches the edge attribute in the filtering result.
+	PublicBorderGroup string `q:"public_border_group"`
+	// Specifies the resource type, which can be:
+	// VM: indicates a cloud server.
+	// LB: indicates a shared load balancer.
+	ServerType string `q:"server_type"`
 }
 
 // ToListQuery formats a ListOpts into a query string.
@@ -224,6 +230,25 @@ func ListAllPublics(client *golangsdk.ServiceClient, opts ListOpts) ([]PublicSer
 		return nil, err
 	}
 	return extractPublicService(pages)
+}
+
+// ListAllServices is a method to query the supported Service list using given parameters with **pagination**.
+func ListAllServices(client *golangsdk.ServiceClient, opts ListOpts) ([]Service, error) {
+	url := rootURL(client)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := PublicServicePage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	return extractService(pages)
 }
 
 // ConnActionOpts used to receive or reject a VPC endpoint for a VPC endpoint service.

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
@@ -46,6 +46,10 @@ type Service struct {
 	Created string `json:"created_at"`
 	// the update time of the VPC endpoint service
 	Updated string `json:"updated_at"`
+	// the VPC endpoint service that matches the edge attribute in the filtering result.
+	PublicBorderGroup string `json:"public_border_group"`
+	// the number of VPC endpoints that are in the Creating or Accepted status.
+	ConnectionCount int `json:"connection_count"`
 }
 
 // PortMapping contains the port mappings opened to the VPC endpoint service
@@ -234,6 +238,13 @@ type PublicServicePage struct {
 // extractPublicService is a method to extract the list of tags supported PublicService.
 func extractPublicService(r pagination.Page) ([]PublicService, error) {
 	var s []PublicService
+	err := r.(PublicServicePage).Result.ExtractIntoSlicePtr(&s, "endpoint_services")
+	return s, err
+}
+
+// extractService is a method to extract the list of tags supported Services.
+func extractService(r pagination.Page) ([]Service, error) {
+	var s []Service
 	err := r.(PublicServicePage).Result.ExtractIntoSlicePtr(&s, "endpoint_services")
 	return s, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231207092945-17836db4283b
+# github.com/chnsz/golangsdk v0.0.0-20231218032934-228370eb4498
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

 make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccDatasourceVpcepServices_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccDatasourceVpcepServices_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceVpcepServices_basic
=== PAUSE TestAccDatasourceVpcepServices_basic
=== CONT  TestAccDatasourceVpcepServices_basic
--- PASS: TestAccDatasourceVpcepServices_basic (218.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     218.584s
