### PR TITLE
chore: rename the dataarts studio service app resource name in docs a…

### DIFF
--- a/docs/resources/dataarts_dataservice_app.md
+++ b/docs/resources/dataarts_dataservice_app.md
@@ -52,6 +52,8 @@ The following arguments are supported:
 
   Defaults to **APP**. Changing this parameter will create a new resource.
 
+  -> The IAM app can only have one.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/dataarts_dataservice_app.md
+++ b/docs/resources/dataarts_dataservice_app.md
@@ -2,7 +2,7 @@
 subcategory: "DataArts Studio"
 ---
 
-# huaweicloud_dataarts_service_app
+# huaweicloud_dataarts_dataservice_app
 
 Manages an app resource of DataArts DataService within HuaweiCloud.
 
@@ -14,7 +14,7 @@ Each app corresponds to a unique identity credential and can be classified based
 ```hcl
 variable "workspace_id" {}
 
-resource "huaweicloud_dataarts_service_app" "test" {
+resource "huaweicloud_dataarts_dataservice_app" "test" {
   workspace_id = var.workspace_id
   dlm_type     = "SHARED"
   app_type     = "APP"
@@ -29,27 +29,28 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `workspace_id` - (Required, String, ForceNew) The workspace ID.
+* `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID.
 
   Changing this parameter will create a new resource.
 
-* `dlm_type` - (Required, String, ForceNew) The type of DLM.  
+* `dlm_type` - (Required, String, ForceNew) Specifies the type of DLM engine.  
   The valid values are as follows:
-    - **SHARED**: Shared data service.
-    - **EXCLUSIVE**: The exclusive data service.
+  + **SHARED**: Shared data service.
+  + **EXCLUSIVE**: The exclusive data service.
 
   Changing this parameter will create a new resource.
 
-* `name` - (Required, String) The name of the app.  
-  The name must be the account name when the `app_type` is **IAM**.
+* `name` - (Required, String) Specifies the name of the application.  
+  The name must be the **account** name when the `app_type` is **IAM**.
 
-* `description` - (Optional, String) The description of the app.
+* `description` - (Optional, String) Specifies the description of the application.
 
-* `app_type` - (Optional, String, ForceNew) The type of the app.  
-  The valid values are **APP** and **IAM**.
-  Defaults to **APP**.
+* `app_type` - (Optional, String, ForceNew) Specifies the type of the application.  
+  The valid values are as follows:
+  + **APP**: access through app authentication.
+  + **IAM**: IAM authentication is used, which means access using a token.
 
-  Changing this parameter will create a new resource.
+  Defaults to **APP**. Changing this parameter will create a new resource.
 
 ## Attribute Reference
 
@@ -63,8 +64,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The DataArts app can be imported using **workspace_id**, **dlm_type** and **id**, separated by a slash, e.g.
+The DataArts DataService app can be imported using `workspace_id`, `dlm_type` and `id` separated by slashes, e.g.
 
 ```bash
-$ terraform import huaweicloud_dataarts_service_app.test <workspace_id>/<dlm_type>/<id>
+$ terraform import huaweicloud_dataarts_dataservice_app.test <workspace_id>/<dlm_type>/<id>
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1097,17 +1097,18 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_network":                modelarts.ResourceModelartsNetwork(),
 			"huaweicloud_modelarts_resource_pool":          modelarts.ResourceModelartsResourcePool(),
 
-			"huaweicloud_dataarts_studio_instance":              dataarts.ResourceStudioInstance(),
-			"huaweicloud_dataarts_studio_directory":             dataarts.ResourceDataArtsStudioDirectory(),
-			"huaweicloud_dataarts_studio_subject":               dataarts.ResourceDataArtsStudioSubject(),
-			"huaweicloud_dataarts_studio_service_app":           dataarts.ResourceServiceApp(),
+			"huaweicloud_dataarts_studio_instance":  dataarts.ResourceStudioInstance(),
+			"huaweicloud_dataarts_studio_directory": dataarts.ResourceDataArtsStudioDirectory(),
+			"huaweicloud_dataarts_studio_subject":   dataarts.ResourceDataArtsStudioSubject(),
+
 			"huaweicloud_dataarts_studio_permission_set":        dataarts.ResourcePermissionSet(),
 			"huaweicloud_dataarts_studio_data_recognition_rule": dataarts.ResourceStudioRule(),
-			// DataArts Factory --- Data Development
-			"huaweicloud_dataarts_studio_resource": dataarts.ResourceStudioResource(),
-
 			// DataArts Architecture
 			"huaweicloud_dataarts_architecture_business_metric": dataarts.ResourceBusinessMetric(),
+			// DataArts Factory
+			"huaweicloud_dataarts_studio_resource": dataarts.ResourceStudioResource(),
+			// DataArts DataService
+			"huaweicloud_dataarts_dataservice_app": dataarts.ResourceDataServiceApp(),
 
 			"huaweicloud_mpc_transcoding_template":       mpc.ResourceTranscodingTemplate(),
 			"huaweicloud_mpc_transcoding_template_group": mpc.ResourceTranscodingTemplateGroup(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1097,16 +1097,17 @@ func Provider() *schema.Provider {
 			"huaweicloud_modelarts_network":                modelarts.ResourceModelartsNetwork(),
 			"huaweicloud_modelarts_resource_pool":          modelarts.ResourceModelartsResourcePool(),
 
-			"huaweicloud_dataarts_studio_instance":  dataarts.ResourceStudioInstance(),
-			"huaweicloud_dataarts_studio_directory": dataarts.ResourceDataArtsStudioDirectory(),
-			"huaweicloud_dataarts_studio_subject":   dataarts.ResourceDataArtsStudioSubject(),
-
-			"huaweicloud_dataarts_studio_permission_set":        dataarts.ResourcePermissionSet(),
-			"huaweicloud_dataarts_studio_data_recognition_rule": dataarts.ResourceStudioRule(),
+			// DataArts Studio - Management Center
+			"huaweicloud_dataarts_studio_instance": dataarts.ResourceStudioInstance(),
 			// DataArts Architecture
+			"huaweicloud_dataarts_studio_directory":             dataarts.ResourceDataArtsStudioDirectory(),
+			"huaweicloud_dataarts_studio_subject":               dataarts.ResourceDataArtsStudioSubject(),
 			"huaweicloud_dataarts_architecture_business_metric": dataarts.ResourceBusinessMetric(),
 			// DataArts Factory
 			"huaweicloud_dataarts_studio_resource": dataarts.ResourceStudioResource(),
+			// DataArts Security
+			"huaweicloud_dataarts_studio_permission_set":        dataarts.ResourcePermissionSet(),
+			"huaweicloud_dataarts_studio_data_recognition_rule": dataarts.ResourceStudioRule(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_app": dataarts.ResourceDataServiceApp(),
 

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_app_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_app_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getServiceAppResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getDataServiceAppResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
 	// getApp: Query the app
 	var (
@@ -24,7 +24,7 @@ func getServiceAppResourceFunc(cfg *config.Config, state *terraform.ResourceStat
 	)
 	getAppClient, err := cfg.NewServiceClient(getAppProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating DataArtsStudio client: %s", err)
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
 	}
 
 	getAppPath := getAppClient.Endpoint + getAppHttpUrl
@@ -56,16 +56,16 @@ func getServiceAppResourceFunc(cfg *config.Config, state *terraform.ResourceStat
 	return getAppRespBody, nil
 }
 
-func TestAccServiceApp_basic(t *testing.T) {
+func TestAccDataServiceApp_basic(t *testing.T) {
 	var obj interface{}
 
 	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_dataarts_service_app.test"
+	rName := "huaweicloud_dataarts_dataservice_app.test"
 
 	rc := acceptance.InitResourceCheck(
 		rName,
 		&obj,
-		getServiceAppResourceFunc,
+		getDataServiceAppResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -77,7 +77,7 @@ func TestAccServiceApp_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testServiceApp_basic(name),
+				Config: testDataServiceApp_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
@@ -88,7 +88,7 @@ func TestAccServiceApp_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testServiceApp_basic_update(name + "update"),
+				Config: testDataServiceApp_basic_update(name + "update"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
@@ -103,15 +103,15 @@ func TestAccServiceApp_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testServiceAppImportState(rName),
+				ImportStateIdFunc: testDataServiceAppImportState(rName),
 			},
 		},
 	})
 }
 
-func testServiceApp_basic(name string) string {
+func testDataServiceApp_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_service_app" "test" {
+resource "huaweicloud_dataarts_dataservice_app" "test" {
   workspace_id = "%[1]s"
   dlm_type     = "SHARED"
   name         = "%[2]s"
@@ -119,9 +119,9 @@ resource "huaweicloud_dataarts_service_app" "test" {
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
 }
 
-func testServiceApp_basic_update(name string) string {
+func testDataServiceApp_basic_update(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_service_app" "test" {
+resource "huaweicloud_dataarts_dataservice_app" "test" {
   workspace_id = "%[1]s"
   dlm_type     = "SHARED"
   name         = "%[2]s"
@@ -130,7 +130,7 @@ resource "huaweicloud_dataarts_service_app" "test" {
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
 }
 
-func testServiceAppImportState(name string) resource.ImportStateIdFunc {
+func testDataServiceAppImportState(name string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_app_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_app_test.go
@@ -83,6 +83,8 @@ func TestAccDataServiceApp_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
 					resource.TestCheckResourceAttr(rName, "dlm_type", "SHARED"),
 					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "app_type", "APP"),
+					resource.TestCheckResourceAttrSet(rName, "description"),
 					resource.TestCheckResourceAttrSet(rName, "app_key"),
 					resource.TestCheckResourceAttrSet(rName, "app_secret"),
 				),
@@ -94,9 +96,52 @@ func TestAccDataServiceApp_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
 					resource.TestCheckResourceAttr(rName, "dlm_type", "SHARED"),
 					resource.TestCheckResourceAttr(rName, "name", name+"update"),
-					resource.TestCheckResourceAttr(rName, "description", name+"update"),
+					resource.TestCheckResourceAttr(rName, "app_type", "APP"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
 					resource.TestCheckResourceAttrSet(rName, "app_key"),
 					resource.TestCheckResourceAttrSet(rName, "app_secret"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDataServiceAppImportState(rName),
+			},
+		},
+	})
+}
+
+func TestAccDataServiceApp_iam(t *testing.T) {
+	var obj interface{}
+	rName := "huaweicloud_dataarts_dataservice_app.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDataServiceAppResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckDomainName(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDataServiceApp_iam(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "name", acceptance.HW_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(rName, "dlm_type", "EXCLUSIVE"),
+					resource.TestCheckResourceAttr(rName, "app_type", "IAM"),
+					resource.TestCheckResourceAttr(rName, "app_key", "NO DATA"),
+					resource.TestCheckResourceAttr(rName, "app_secret", "NO DATA"),
+					resource.TestCheckResourceAttrSet(rName, "description"),
 				),
 			},
 			{
@@ -115,6 +160,7 @@ resource "huaweicloud_dataarts_dataservice_app" "test" {
   workspace_id = "%[1]s"
   dlm_type     = "SHARED"
   name         = "%[2]s"
+  description  = "created by acceptance"
 }
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
 }
@@ -125,9 +171,20 @@ resource "huaweicloud_dataarts_dataservice_app" "test" {
   workspace_id = "%[1]s"
   dlm_type     = "SHARED"
   name         = "%[2]s"
-  description  = "%[2]s"
 }
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testDataServiceApp_iam() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_dataservice_app" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  dlm_type     = "EXCLUSIVE"
+  app_type     = "IAM"
+  description  = "IAM authentication with EXCLUSIVE DLM engine"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DOMAIN_NAME)
 }
 
 func testDataServiceAppImportState(name string) resource.ImportStateIdFunc {

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_app.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_app.go
@@ -244,8 +244,8 @@ func resourceDataServiceAppUpdate(ctx context.Context, d *schema.ResourceData, m
 
 func buildUpdateAppBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"name":        utils.ValueIngoreEmpty(d.Get("name")),
-		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"name":        d.Get("name"),
+		"description": d.Get("description"),
 	}
 	return bodyParams
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_app.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_app.go
@@ -23,12 +23,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func ResourceServiceApp() *schema.Resource {
+func ResourceDataServiceApp() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServiceAppCreate,
-		UpdateContext: resourceServiceAppUpdate,
-		ReadContext:   resourceServiceAppRead,
-		DeleteContext: resourceServiceAppDelete,
+		CreateContext: resourceDataServiceAppCreate,
+		UpdateContext: resourceDataServiceAppUpdate,
+		ReadContext:   resourceDataServiceAppRead,
+		DeleteContext: resourceDataServiceAppDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceAppImportState,
 		},
@@ -50,40 +50,40 @@ func ResourceServiceApp() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `The type of DLM.`,
+				Description: `The type of DLM engine.`,
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: `The name of the app.`,
+				Description: `The name of the application.`,
 			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: `The description of the app.`,
+				Description: `The description of the application.`,
 			},
 			"app_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: `The type of the app.`,
+				Description: `The type of the application.`,
 			},
 			"app_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `The key of the app.`,
+				Description: `The key of the application.`,
 			},
 			"app_secret": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `The secret of the app.`,
+				Description: `The secret of the application.`,
 			},
 		},
 	}
 }
 
-func resourceServiceAppCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataServiceAppCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -129,7 +129,7 @@ func resourceServiceAppCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	d.SetId(id.(string))
 
-	return resourceServiceAppRead(ctx, d, meta)
+	return resourceDataServiceAppRead(ctx, d, meta)
 }
 
 func buildCreateAppBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -141,7 +141,7 @@ func buildCreateAppBodyParams(d *schema.ResourceData) map[string]interface{} {
 	return bodyParams
 }
 
-func resourceServiceAppRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataServiceAppRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -197,7 +197,7 @@ func resourceServiceAppRead(_ context.Context, d *schema.ResourceData, meta inte
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceServiceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataServiceAppUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -239,7 +239,7 @@ func resourceServiceAppUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			return diag.Errorf("error updating app: %s", err)
 		}
 	}
-	return resourceServiceAppRead(ctx, d, meta)
+	return resourceDataServiceAppRead(ctx, d, meta)
 }
 
 func buildUpdateAppBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -250,7 +250,7 @@ func buildUpdateAppBodyParams(d *schema.ResourceData) map[string]interface{} {
 	return bodyParams
 }
 
-func resourceServiceAppDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataServiceAppDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 


### PR DESCRIPTION
…nd acceptance test

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
following up #3843 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ export HW_DATAARTS_WORKSPACE_ID=39ecc7c4b3f84*****3f8beab
$ export HW_DOMAIN_NAME=hwstaff_*****
$ make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccDataServiceApp"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccDataServiceApp -timeout 360m -parallel 4
=== RUN   TestAccDataServiceApp_basic
=== PAUSE TestAccDataServiceApp_basic
=== RUN   TestAccDataServiceApp_iam
=== PAUSE TestAccDataServiceApp_iam
=== CONT  TestAccDataServiceApp_basic
=== CONT  TestAccDataServiceApp_iam
--- PASS: TestAccDataServiceApp_iam (15.15s)
--- PASS: TestAccDataServiceApp_basic (24.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  24.233s
```
