### PR TITLE
feat(workspace): Support the OTP auxiliary authentication

### DIFF
--- a/docs/resources/workspace_service.md
+++ b/docs/resources/workspace_service.md
@@ -22,6 +22,13 @@ resource "huaweicloud_workspace_service" "test" {
   access_mode = "INTERNET"
   vpc_id      = var.vpc_id
   network_ids = var.network_ids
+
+  otp_config_info {
+    enable       = true
+    receive_mode = "VMFA"
+    rule_type    = "ACCESS_MODE"
+    rule         = "PRIVATE"
+  }
 }
 ```
 
@@ -53,6 +60,13 @@ resource "huaweicloud_workspace_service" "test" {
     active_domain_ip   = var.ad_master_domain_ip
     active_domain_name = format("%s.%s", var.ad_server_name, var.ad_domain_name)
     active_dns_ip      = var.ad_master_dns_ip
+  }
+
+  otp_config_info {
+    enable       = true
+    receive_mode = "VMFA"
+    rule_type    = "ACCESS_MODE"
+    rule         = "PRIVATE"
   }
 }
 ```
@@ -111,6 +125,9 @@ The following arguments are supported:
 
 * `management_subnet_cidr` - (Optional, String, ForceNew) The subnet segment of the management component.
 
+* `otp_config_info` - (Optional, List) Specifies the configuration of auxiliary authentication.
+  The [object](#config_info) structure is documented below.
+
 <a name="service_domain"></a>
 The `ad_domain` block supports:
 
@@ -136,6 +153,35 @@ The `ad_domain` block supports:
 
 * `delete_computer_object` - (Optional, Bool) Specifies whether to delete the corresponding computer object on AD
   while deleting the desktop.
+
+<a name="config_info"></a>
+The `otp_config_info` block supports:
+
+* `enable` - (Required, Bool) Specifies whether to enable auxiliary authentication.
+
+* `receive_mode` - (Required, String) Specifies the verification code receiving mode.
+  + **VMFA**: Indicates virtual MFA device.
+  + **HMFA**: Indicates hardware MFA device.
+  
+* `auth_url` - (Optional, String) Specifies the auxiliary authentication server address.
+
+* `app_id` - (Optional, String) Specifies the auxiliary authentication server access account.
+
+* `app_secret` - (Optional, String) Specifies the authentication service access password.
+
+* `auth_server_access_mode` - (Optional, String) Specifies the authentication service access mode.
+  + **INTERNET**: Indicates internet access.
+  + **DEDICATED**: Indicates dedicated access.
+  + **SYSTEM_DEFAULT**: Indicates system default.
+
+* `cert_content` - (Optional, String) Specifies the PEM format certificate content.
+
+* `rule_type` - (Optional, String) Specifies authentication application object type.
+  + **ACCESS_MODE**: Indicates access type.
+
+* `rule` - (Optional, String) Specifies authentication application object.
+  + **INTERNET**: Indicates Internet access. Optional only when rule_type is **ACCESS_MODE**.
+  + **PRIVATE**: Indicates dedicated line access. Optional only when rule_type is **ACCESS_MODE**.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231213050150-2843d895cbb4
+	github.com/chnsz/golangsdk v0.0.0-20231214112327-68985475922f
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231213050150-2843d895cbb4 h1:o88mzsYf/+wQ0tqWpyraScB21gM5Juczr+MV+raB7mg=
-github.com/chnsz/golangsdk v0.0.0-20231213050150-2843d895cbb4/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231214112327-68985475922f h1:piBqgmMzgLXXyE66IGDRgaHMpx/idTS/Bdu6eKu8XnM=
+github.com/chnsz/golangsdk v0.0.0-20231214112327-68985475922f/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/requests.go
@@ -156,3 +156,71 @@ func Delete(c *golangsdk.ServiceClient) (*DeleteResp, error) {
 	})
 	return &r, err
 }
+
+// GetAuthConfig is the method that used to query the configuration information of secondary authentication.
+func GetAuthConfig(c *golangsdk.ServiceClient) (*OtpConfigResp, error) {
+	var r OtpConfigResp
+	_, err := c.Get(authConfigURL(c), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// UpdateAuthConfigOpts is the structure by the UpdateAuthConfig method to change auxiliary authentication.configuration.
+type UpdateAuthConfigOpts struct {
+	// Authentication type.
+	// + OTP: Indicates OTP assist authentication.
+	AuthType string `json:"auth_type" required:"true"`
+	// The OTP auxiliary authentication method configuration.
+	OptConfigInfo *OtpConfigInfo `json:"otp_config_info" required:"true"`
+}
+
+// OtpConfigInfo is the structure to specified the OTP auxiliary authentication configuration infomation.
+type OtpConfigInfo struct {
+	// Whether to enable OTP authentication mode.
+	Enable *bool `json:"enable" required:"true"`
+	// Verification code receiving mode.
+	// + VMFA Indicates virtual MFA device.
+	// + HMFA Indicates hardware MFA device.
+	ReceiveMode string `json:"receive_mode" required:"true"`
+	// Auxiliary authentication server address.
+	AuthUrl string `json:"auth_url,omitempty"`
+	// Auxiliary authentication service access account.
+	AppId string `json:"app_id,omitempty"`
+	// Auxiliary authentication service access password.
+	AppSecrte string `json:"app_secret,omitempty"`
+	// Auxiliary authentication service access mode.
+	// + INTERNET: Indicates Internet access.
+	// + DEDICATED: Indicates dedicated line access.
+	// + SYSTEM_DEFAULT：Indicates system default.
+	AuthServerAccessMode string `json:"auth_server_access_mode,omitempty"`
+	// PEM format certificate content.
+	CertContent string `json:"cert_content,omitempty"`
+	// Authentication application object information. If null, it means it is effective for all application objects.
+	ApplyRule *ApplyRule `json:"apply_rule,omitempty"`
+}
+
+// ApplyRule is the object to specified the OTP auxiliary authentication configuration infomation.
+type ApplyRule struct {
+	// Authentication application object type.
+	// + ACCESS_MODE: Indicates access type.
+	RuleType string `json:"rule_type,omitempty"`
+	// Authentication application object.
+	// + INTERNET: Indicates Internet access. Optional only when rule_type is "ACCESS_MODE".
+	// + PRIVATE: Indicates dedicated line access. Optional only when rule_type is "ACCESS_MODE".
+	Rule string `json:"rule,omitempty"`
+}
+
+// UpdateAssistAuthConfig is the method that used to modify the configuration information of auxiliary authentication
+func UpdateAssistAuthConfig(c *golangsdk.ServiceClient, opts UpdateAuthConfigOpts) error {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Put(authConfigURL(c), b, nil, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+		OkCodes:     []int{204},
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/results.go
@@ -150,3 +150,44 @@ type SecurityGroup struct {
 	// Security Group name.
 	Name string `json:"name"`
 }
+
+// OtpConfigResp represents that the GetAuthConfig method response details.
+type OtpConfigResp struct {
+	OptConfigInfo OtpConfig `json:"otp_config_info"`
+}
+
+// OtpConfig represents that the Auxiliary authentication configuration details.
+type OtpConfig struct {
+	// Whether to enable OTP authentication mode.
+	Enable bool `json:"enable"`
+	// Verification code receiving mode.
+	// + VMFA Indicates virtual MFA device.
+	// + HMFA Indicates hardware MFA device.
+	ReceiveMode string `json:"receive_mode"`
+	// Auxiliary authentication server address.
+	AuthUrl string `json:"auth_url"`
+	// Auxiliary authentication service access account.
+	AppId string `json:"app_id"`
+	// Auxiliary authentication service access password.
+	AppSecrte string `json:"app_secret"`
+	// Auxiliary authentication service access mode.
+	// + INTERNET: Indicates Internet access.
+	// + DEDICATED: Indicates dedicated line access.
+	// + SYSTEM_DEFAULT：Indicates system default.
+	AuthServerAccessMode string `json:"auth_server_access_mode"`
+	// PEM format certificate content.
+	CertContent string `json:"cert_content"`
+	// Authentication application object information. If null, it means it is effective for all application objects.
+	ApplyRule ApplyRuleInfo `json:"apply_rule"`
+}
+
+// ApplyRuleInfo is an object specified the detail of Authentication application object.
+type ApplyRuleInfo struct {
+	// Authentication application object type.
+	// + ACCESS_MODE: Indicates access type.
+	RuleType string `json:"rule_type"`
+	// Authentication application object.
+	// + INTERNET: Indicates Internet access. Optional only when rule_type is "ACCESS_MODE".
+	// + PRIVATE: Indicates dedicated line access. Optional only when rule_type is "ACCESS_MODE".
+	Rule string `json:"rule"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/workspace/v2/services/urls.go
@@ -5,3 +5,7 @@ import "github.com/chnsz/golangsdk"
 func rootURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("workspaces")
 }
+
+func authConfigURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("assist-auth-config/method-config")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231213050150-2843d895cbb4
+# github.com/chnsz/golangsdk v0.0.0-20231214112327-68985475922f
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 workspace support the OTP auxiliary authentication.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccService_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccService_basic -timeout 360m -parallel 4
=== RUN   TestAccService_basic
=== PAUSE TestAccService_basic
=== CONT  TestAccService_basic
--- PASS: TestAccService_basic (642.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 643.004s

$ make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccService_localAD'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccService_localAD -timeout 360m -parallel 4
=== RUN   TestAccService_localAD
=== PAUSE TestAccService_localAD
=== CONT  TestAccService_localAD
--- PASS: TestAccService_localAD (599.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 599.994s
```
