### PR TITLE
chore(DataArts): modify DataArts business metric resource name

### DIFF
--- a/docs/resources/dataarts_architecture_business_metric.md
+++ b/docs/resources/dataarts_architecture_business_metric.md
@@ -2,9 +2,9 @@
 subcategory: "DataArts Studio"
 ---
 
-# huaweicloud_dataarts_studio_business_metric
+# huaweicloud_dataarts_architecture_business_metric
 
-Manages a DataArts Studio business metric resource within HuaweiCloud.
+Manages a DataArts Architecture business metric resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -14,7 +14,7 @@ variable "biz_catalog_id" {}
 variable "owner" {}
 variable "owner_department" {}
 
-resource "huaweicloud_dataarts_studio_business_metric" "test" {
+resource "huaweicloud_dataarts_architecture_business_metric" "test" {
   workspace_id     = var.workspace_id
   biz_catalog_id   = var.biz_catalog_id
   owner            = var.owner
@@ -122,8 +122,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The DataArts Studio business metric resource can be imported using the `workspace_id` and `id`, separated by a slash, e.g.
+The DataArts Architecture business metric resource can be imported using the `workspace_id` and `id`, separated by a
+slash, e.g.
 
 ```bash
-$ terraform import huaweicloud_dataarts_studio_business_metric.test <workspace_id>/<id>
+$ terraform import huaweicloud_dataarts_architecture_business_metric.test <workspace_id>/<id>
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1102,10 +1102,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_studio_subject":               dataarts.ResourceDataArtsStudioSubject(),
 			"huaweicloud_dataarts_studio_service_app":           dataarts.ResourceServiceApp(),
 			"huaweicloud_dataarts_studio_permission_set":        dataarts.ResourcePermissionSet(),
-			"huaweicloud_dataarts_studio_business_metric":       dataarts.ResourceBusinessMetric(),
 			"huaweicloud_dataarts_studio_data_recognition_rule": dataarts.ResourceStudioRule(),
 			// DataArts Factory --- Data Development
 			"huaweicloud_dataarts_studio_resource": dataarts.ResourceStudioResource(),
+
+			// DataArts Architecture
+			"huaweicloud_dataarts_architecture_business_metric": dataarts.ResourceBusinessMetric(),
 
 			"huaweicloud_mpc_transcoding_template":       mpc.ResourceTranscodingTemplate(),
 			"huaweicloud_mpc_transcoding_template_group": mpc.ResourceTranscodingTemplateGroup(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_business_metric_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_business_metric_test.go
@@ -36,7 +36,7 @@ func getBusinessMetricResourceFunc(cfg *config.Config, state *terraform.Resource
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving DataArts Studio business metric: %s", err)
+		return nil, fmt.Errorf("error retrieving DataArts Architecture business metric: %s", err)
 	}
 
 	return utils.FlattenResponse(getResp)
@@ -46,7 +46,7 @@ func TestAccBusinessMetric_basic(t *testing.T) {
 	var obj interface{}
 
 	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_dataarts_studio_business_metric.test"
+	rName := "huaweicloud_dataarts_architecture_business_metric.test"
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -171,7 +171,7 @@ func TestAccBusinessMetric_basic(t *testing.T) {
 
 func testBusinessMetric_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_business_metric" "test" {
+resource "huaweicloud_dataarts_architecture_business_metric" "test" {
   name             = "%[1]s"
   workspace_id     = "%[2]s"
   biz_catalog_id   = "%[3]s"
@@ -197,7 +197,7 @@ resource "huaweicloud_dataarts_studio_business_metric" "test" {
 
 func testBusinessMetric_basic_update1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_business_metric" "test" {
+resource "huaweicloud_dataarts_architecture_business_metric" "test" {
   name             = "%[1]s"
   workspace_id     = "%[2]s"
   biz_catalog_id   = "%[3]s"
@@ -223,7 +223,7 @@ resource "huaweicloud_dataarts_studio_business_metric" "test" {
 
 func testBusinessMetric_basic_update2(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_business_metric" "test" {
+resource "huaweicloud_dataarts_architecture_business_metric" "test" {
   name             = "%[1]s"
   workspace_id     = "%[2]s"
   biz_catalog_id   = "%[3]s"

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_business_metric.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_business_metric.go
@@ -235,7 +235,7 @@ func resourceBusinessMetricCreate(ctx context.Context, d *schema.ResourceData, m
 
 	createResp, err := client.Request("POST", createPath, &createOpt)
 	if err != nil {
-		return diag.Errorf("error creating DataArts Studio business metric: %s", err)
+		return diag.Errorf("error creating DataArts Architecture business metric: %s", err)
 	}
 
 	createRespBody, err := utils.FlattenResponse(createResp)
@@ -245,7 +245,7 @@ func resourceBusinessMetricCreate(ctx context.Context, d *schema.ResourceData, m
 
 	id, err := jmespath.Search("data.value.id", createRespBody)
 	if err != nil || id == nil {
-		return diag.Errorf("error creating DataArts Studio business metric: ID is not found in API response")
+		return diag.Errorf("error creating DataArts Architecture business metric: ID is not found in API response")
 	}
 	d.SetId(id.(string))
 
@@ -290,7 +290,7 @@ func resourceBusinessMetricRead(_ context.Context, d *schema.ResourceData, meta 
 
 	getResp, err := readBusinessMetric(client, d)
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseBusinessMetricError(err), "error retrieving DataArts Studio business metric")
+		return common.CheckDeletedDiag(d, parseBusinessMetricError(err), "error retrieving DataArts Architecture business metric")
 	}
 
 	getRespBody, err := utils.FlattenResponse(getResp)
@@ -399,7 +399,7 @@ func resourceBusinessMetricUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	_, err = client.Request("PUT", updatePath, &updateOpt)
 	if err != nil {
-		return diag.Errorf("error updating DataArts Studio business metric: %s", err)
+		return diag.Errorf("error updating DataArts Architecture business metric: %s", err)
 	}
 	return resourceBusinessMetricRead(ctx, d, meta)
 }
@@ -426,17 +426,17 @@ func resourceBusinessMetricDelete(_ context.Context, d *schema.ResourceData, met
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting DataArts Studio business metric: %s", err)
+		return diag.Errorf("error deleting DataArts Architecture business metric: %s", err)
 	}
 
 	// Successful deletion API call does not guarantee that the resource is successfully deleted.
 	// Call the details API to confirm that the resource has been successfully deleted.
 	_, err = readBusinessMetric(client, d)
 	if err == nil {
-		return diag.Errorf("error deleting DataArts Studio business metric: the business metric still exists")
+		return diag.Errorf("error deleting DataArts Architecture business metric: the business metric still exists")
 	}
 
-	return common.CheckDeletedDiag(d, parseBusinessMetricError(err), "error deleting DataArts Studio business metric")
+	return common.CheckDeletedDiag(d, parseBusinessMetricError(err), "error deleting DataArts Architecture business metric")
 }
 
 func buildDeleteBusinessMetricBodyParams(d *schema.ResourceData) map[string]interface{} {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

rename resource name from `huaweicloud_dataarts_studio_business_metric` to `huaweicloud_dataarts_architecture_business_metric`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dataarts' TESTARGS='-run TestAccBusinessMetric_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccBusinessMetric_basic -timeout 360m -parallel 4
=== RUN   TestAccBusinessMetric_basic
=== PAUSE TestAccBusinessMetric_basic
=== CONT  TestAccBusinessMetric_basic
--- PASS: TestAccBusinessMetric_basic (22.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  22.191s
```
