### PR TITLE
chore(dataarts): modify dataarts permission set resource name

### DIFF
--- a/docs/resources/dataarts_security_permission_set.md
+++ b/docs/resources/dataarts_security_permission_set.md
@@ -2,9 +2,9 @@
 subcategory: "DataArts Studio"
 ---
 
-# huaweicloud_dataarts_studio_permission_set
+# huaweicloud_dataarts_security_permission_set
 
-Manages DataArts Studio permission set resource within HuaweiCloud.
+Manages DataArts Security permission set resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -13,17 +13,17 @@ variable "workspace_id" {}
 variable "name" {}
 variable "manager_id" {}
 
-resource "huaweicloud_dataarts_studio_permission_set" "test" {
+resource "huaweicloud_dataarts_security_permission_set" "test" {
   workspace_id = var.workspace_id
   name         = var.name
   parent_id    = "0"
   manager_id   = var.manager_id
 }
 
-resource "huaweicloud_dataarts_studio_permission_set" "sub_test" {
+resource "huaweicloud_dataarts_security_permission_set" "sub_test" {
   workspace_id = var.workspace_id
   name         = var.name
-  parent_id    = huaweicloud_dataarts_studio_permission_set.test.id
+  parent_id    = huaweicloud_dataarts_security_permission_set.test.id
   manager_id   = var.manager_id
 }
 ```
@@ -80,8 +80,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The DataArts Studio permission set can be imported using the `workspace_id` and `id` separated by a slash, e.g.
+The DataArts Security permission set can be imported using the `workspace_id` and `id` separated by a slash, e.g.
 
 ```bash
-$ terraform import huaweicloud_dataarts_studio_permission_set.test <workspace_id>/<id>
+$ terraform import huaweicloud_dataarts_security_permission_set.test <workspace_id>/<id>
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1106,7 +1106,7 @@ func Provider() *schema.Provider {
 			// DataArts Factory
 			"huaweicloud_dataarts_studio_resource": dataarts.ResourceStudioResource(),
 			// DataArts Security
-			"huaweicloud_dataarts_studio_permission_set":        dataarts.ResourcePermissionSet(),
+			"huaweicloud_dataarts_security_permission_set":      dataarts.ResourceSecurityPermissionSet(),
 			"huaweicloud_dataarts_studio_data_recognition_rule": dataarts.ResourceStudioRule(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_app": dataarts.ResourceDataServiceApp(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_permission_set_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_permission_set_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getPermissionSetResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getSecurityPermissionSetResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	getPermissionSetClient, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
@@ -32,27 +32,27 @@ func getPermissionSetResourceFunc(conf *config.Config, state *terraform.Resource
 	}
 	getPermissionSetResp, err := getPermissionSetClient.Request("GET", getPermissionSetPath, &getPermissionSetOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving DataArts Studio permission set: %s", err)
+		return nil, fmt.Errorf("error retrieving DataArts Security permission set: %s", err)
 	}
 
 	getPermissionSetRespBody, err := utils.FlattenResponse(getPermissionSetResp)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving DataArts Studio permission set: %s", err)
+		return nil, fmt.Errorf("error retrieving DataArts Security permission set: %s", err)
 	}
 
 	return getPermissionSetRespBody, nil
 }
 
-func TestAccResourcePermissionSet_basic(t *testing.T) {
+func TestAccResourceSecurityPermissionSet_basic(t *testing.T) {
 	var obj interface{}
 
-	resourceName := "huaweicloud_dataarts_studio_permission_set.test"
+	resourceName := "huaweicloud_dataarts_security_permission_set.test"
 	rName := acceptance.RandomAccResourceName()
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&obj,
-		getPermissionSetResourceFunc,
+		getSecurityPermissionSetResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -65,7 +65,7 @@ func TestAccResourcePermissionSet_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPermissionSet_basic(rName),
+				Config: testAccSecurityPermissionSet_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -81,7 +81,7 @@ func TestAccResourcePermissionSet_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccPermissionSet_update(rName),
+				Config: testAccSecurityPermissionSet_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
@@ -100,13 +100,13 @@ func TestAccResourcePermissionSet_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccResourcePermissionSetImportStateIDFunc(resourceName),
+				ImportStateIdFunc: testAccResourceSecurityPermissionSetImportStateIDFunc(resourceName),
 			},
 		},
 	})
 }
 
-func testAccResourcePermissionSetImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func testAccResourceSecurityPermissionSetImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -123,9 +123,9 @@ func testAccResourcePermissionSetImportStateIDFunc(resourceName string) resource
 	}
 }
 
-func testAccPermissionSet_basic(name string) string {
+func testAccSecurityPermissionSet_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_permission_set" "test" {
+resource "huaweicloud_dataarts_security_permission_set" "test" {
   workspace_id = "%[1]s"
   name         = "%[2]s"
   parent_id    = "0"
@@ -135,9 +135,9 @@ resource "huaweicloud_dataarts_studio_permission_set" "test" {
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_MANAGER_ID)
 }
 
-func testAccPermissionSet_update(name string) string {
+func testAccSecurityPermissionSet_update(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_permission_set" "test" {
+resource "huaweicloud_dataarts_security_permission_set" "test" {
   workspace_id = "%[1]s"
   name         = "%[2]s_update"
   parent_id    = "0"

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set.go
@@ -23,15 +23,15 @@ import (
 // API: DataArtsStudio DELETE /v1/{project_id}/security/permission-sets/{permission_set_id}
 // API: DataArtsStudio GET /v1/{project_id}/security/permission-sets/{permission_set_id}
 // API: DataArtsStudio PUT /v1/{project_id}/security/permission-sets/{permission_set_id}
-func ResourcePermissionSet() *schema.Resource {
+func ResourceSecurityPermissionSet() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourcePermissionSetCreate,
-		ReadContext:   resourcePermissionSetRead,
-		UpdateContext: resourcePermissionSetUpdate,
-		DeleteContext: resourcePermissionSetDelete,
+		CreateContext: resourceSecurityPermissionSetCreate,
+		ReadContext:   resourceSecurityPermissionSetRead,
+		UpdateContext: resourceSecurityPermissionSetUpdate,
+		DeleteContext: resourceSecurityPermissionSetDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: resourcePermissionSetImportState,
+			StateContext: resourceSecurityPermissionSetImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -103,7 +103,7 @@ func ResourcePermissionSet() *schema.Resource {
 	}
 }
 
-func resourcePermissionSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityPermissionSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	workspaceID := d.Get("workspace_id").(string)
@@ -128,21 +128,21 @@ func resourcePermissionSetCreate(ctx context.Context, d *schema.ResourceData, me
 	createPermissionSetOpt.JSONBody = utils.RemoveNil(buildCreatePermissionSetBodyParams(d))
 	createPermissionSetResp, err := createPermissionSetClient.Request("POST", createPermissionSetPath, &createPermissionSetOpt)
 	if err != nil {
-		return diag.Errorf("error creating DataArts Studio permissions set: %s", err)
+		return diag.Errorf("error creating DataArts Security permissions set: %s", err)
 	}
 
 	createPermissionSetRespBody, err := utils.FlattenResponse(createPermissionSetResp)
 	if err != nil {
-		return diag.Errorf("error retrieving DataArts Studio permission set: %s", err)
+		return diag.Errorf("error retrieving DataArts Security permission set: %s", err)
 	}
 
 	id, err := jmespath.Search("id", createPermissionSetRespBody)
 	if err != nil {
-		return diag.Errorf("error creating DataArts Studio permission set: ID is not found in API response")
+		return diag.Errorf("error creating DataArts Security permission set: ID is not found in API response")
 	}
 
 	d.SetId(id.(string))
-	return resourcePermissionSetRead(ctx, d, meta)
+	return resourceSecurityPermissionSetRead(ctx, d, meta)
 }
 
 func buildCreatePermissionSetBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -157,7 +157,7 @@ func buildCreatePermissionSetBodyParams(d *schema.ResourceData) map[string]inter
 	return bodyParams
 }
 
-func resourcePermissionSetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityPermissionSetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	workspaceID := d.Get("workspace_id").(string)
@@ -186,12 +186,12 @@ func resourcePermissionSetRead(_ context.Context, d *schema.ResourceData, meta i
 		if hasErrorCode(err, "DLS.3027") {
 			err = golangsdk.ErrDefault404{}
 		}
-		return common.CheckDeletedDiag(d, err, "error retrieving DataArts Studio permission set")
+		return common.CheckDeletedDiag(d, err, "error retrieving DataArts Security permission set")
 	}
 
 	getPermissionSetRespBody, err := utils.FlattenResponse(getPermissionSetResp)
 	if err != nil {
-		return diag.Errorf("error retrieving DataArts Studio permission set: %s", err)
+		return diag.Errorf("error retrieving DataArts Security permission set: %s", err)
 	}
 
 	createAt := utils.PathSearch("create_time", getPermissionSetRespBody, 0).(float64)
@@ -218,7 +218,7 @@ func resourcePermissionSetRead(_ context.Context, d *schema.ResourceData, meta i
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourcePermissionSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityPermissionSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 
@@ -245,10 +245,10 @@ func resourcePermissionSetUpdate(ctx context.Context, d *schema.ResourceData, me
 	updatePermissionSetOpt.JSONBody = utils.RemoveNil(buildUpdatePermissionSetBodyParams(d))
 	_, err = updatePermissionSetClient.Request("PUT", updatePermissionSetPath, &updatePermissionSetOpt)
 	if err != nil {
-		return diag.Errorf("error updating DataArts Studio permission set: %s", err)
+		return diag.Errorf("error updating DataArts Security permission set: %s", err)
 	}
 
-	return resourcePermissionSetRead(ctx, d, meta)
+	return resourceSecurityPermissionSetRead(ctx, d, meta)
 }
 
 func buildUpdatePermissionSetBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -262,7 +262,7 @@ func buildUpdatePermissionSetBodyParams(d *schema.ResourceData) map[string]inter
 	return bodyParams
 }
 
-func resourcePermissionSetDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityPermissionSetDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 
@@ -288,13 +288,13 @@ func resourcePermissionSetDelete(_ context.Context, d *schema.ResourceData, meta
 
 	_, err = deletePermissionSetClient.Request("DELETE", deletePermissionSetPath, &deletePermissionSetOpt)
 	if err != nil {
-		return diag.Errorf("error deleting DataArts Studio permission set: %s", err)
+		return diag.Errorf("error deleting DataArts Security permission set: %s", err)
 	}
 
 	return nil
 }
 
-func resourcePermissionSetImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+func resourceSecurityPermissionSetImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
 	error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {


### PR DESCRIPTION
**Which issue this PR fixes**:
modify dataarts permission set resource name

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourcePermissionSet_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourcePermissionSet_basic -timeout 360m -parallel 4
=== RUN   TestAccResourcePermissionSet_basic
=== PAUSE TestAccResourcePermissionSet_basic
=== CONT  TestAccResourcePermissionSet_basic
--- PASS: TestAccResourcePermissionSet_basic (26.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  26.188s
```
