### PR TITLE
chore(DataArts): modify DataArts directory and subject resource name

### DIFF
--- a/docs/resources/dataarts_architecture_directory.md
+++ b/docs/resources/dataarts_architecture_directory.md
@@ -2,9 +2,9 @@
 subcategory: "DataArts Studio"
 ---
 
-# huaweicloud_dataarts_studio_directory
+# huaweicloud_dataarts_architecture_directory
 
-Manages DataArts Studio directory resource within HuaweiCloud.
+Manages DataArts Architecture directory resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -13,13 +13,13 @@ variable "workspace_id" {}
 variable "name" {}
 variable "directory_id" {}
 
-resource "huaweicloud_dataarts_studio_directory" "test-root" {
+resource "huaweicloud_dataarts_architecture_directory" "test-root" {
   workspace_id = var.workspace_id
   name         = var.name
   type         = "STANDARD_ELEMENT"
 }
 
-resource "huaweicloud_dataarts_studio_directory" "test-sub" {
+resource "huaweicloud_dataarts_architecture_directory" "test-sub" {
   workspace_id = var.workspace_id
   name         = var.name
   type         = "STANDARD_ELEMENT"
@@ -68,8 +68,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-DataArts Studio directory can be imported using `<workspace_id>/<type>/<qualified_name>`, e.g.
+DataArts Architecture directory can be imported using `<workspace_id>/<type>/<qualified_name>`, e.g.
 
 ```sh
-terraform import huaweicloud_dataarts_studio_directory.test b606cd4a47b645108a122857204b360f/STANDARD_ELEMENT/root.sub
+terraform import huaweicloud_dataarts_architecture_directory.test b606cd4a47b645108a122857204b360f/STANDARD_ELEMENT/root
 ```

--- a/docs/resources/dataarts_architecture_subject.md
+++ b/docs/resources/dataarts_architecture_subject.md
@@ -2,9 +2,9 @@
 subcategory: "DataArts Studio"
 ---
 
-# huaweicloud_dataarts_studio_subject
+# huaweicloud_dataarts_architecture_subject
 
-Manages DataArts Studio subject resource within HuaweiCloud.
+Manages DataArts Architecture subject resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -15,7 +15,7 @@ variable "code" {}
 variable "owner" {}
 variable "subject_id" {}
 
-resource "huaweicloud_dataarts_studio_subject" "test-L1" {
+resource "huaweicloud_dataarts_architecture_subject" "test-L1" {
   workspace_id = var.workspace_id
   name         = var.name
   code         = var.code
@@ -23,7 +23,7 @@ resource "huaweicloud_dataarts_studio_subject" "test-L1" {
   level        = 1
 }
 
-resource "huaweicloud_dataarts_studio_subject" "test-L2" {
+resource "huaweicloud_dataarts_architecture_subject" "test-L2" {
   workspace_id = var.workspace_id
   name         = var.name
   code         = var.code
@@ -82,8 +82,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-DataArts Studio subject can be imported using `<workspace_id>/<path>`, e.g.
+DataArts Architecture subject can be imported using `<workspace_id>/<path>`, e.g.
 
 ```sh
-terraform import huaweicloud_dataarts_studio_subject.test b606cd4a47b645108a122857204b360f/test-L1.test-L2
+terraform import huaweicloud_dataarts_architecture_subject.test b606cd4a47b645108a122857204b360f/test-L1.test-L2
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1100,8 +1100,8 @@ func Provider() *schema.Provider {
 			// DataArts Studio - Management Center
 			"huaweicloud_dataarts_studio_instance": dataarts.ResourceStudioInstance(),
 			// DataArts Architecture
-			"huaweicloud_dataarts_studio_directory":             dataarts.ResourceDataArtsStudioDirectory(),
-			"huaweicloud_dataarts_studio_subject":               dataarts.ResourceDataArtsStudioSubject(),
+			"huaweicloud_dataarts_architecture_directory":       dataarts.ResourceArchitectureDirectory(),
+			"huaweicloud_dataarts_architecture_subject":         dataarts.ResourceArchitectureSubject(),
 			"huaweicloud_dataarts_architecture_business_metric": dataarts.ResourceBusinessMetric(),
 			// DataArts Factory
 			"huaweicloud_dataarts_studio_resource": dataarts.ResourceStudioResource(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_directory_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_directory_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getDirectoryResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getArchitectureDirectoryResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	getDirectoryClient, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DataArts Studio V2 client: %s", err)
@@ -59,15 +59,15 @@ func getDirectoryResourceFunc(conf *config.Config, state *terraform.ResourceStat
 	return nil, golangsdk.ErrDefault404{}
 }
 
-func TestAccResourceDirectory_basic(t *testing.T) {
+func TestAccResourceArchitectureDirectory_basic(t *testing.T) {
 	var obj interface{}
-	resourceName := "huaweicloud_dataarts_studio_directory.test"
+	resourceName := "huaweicloud_dataarts_architecture_directory.test"
 	rName := acceptance.RandomAccResourceName()
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&obj,
-		getDirectoryResourceFunc,
+		getArchitectureDirectoryResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -79,7 +79,7 @@ func TestAccResourceDirectory_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDirectory_basic(rName),
+				Config: testAccArchitectureDirectory_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -93,7 +93,7 @@ func TestAccResourceDirectory_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDirectory_update(rName),
+				Config: testAccArchitectureDirectory_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -110,13 +110,13 @@ func TestAccResourceDirectory_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccResourceDirectoryImportStateIDFunc(resourceName),
+				ImportStateIdFunc: testAccResourceArchitectureDirectoryImportStateIDFunc(resourceName),
 			},
 		},
 	})
 }
 
-func testAccResourceDirectoryImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func testAccResourceArchitectureDirectoryImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -135,9 +135,9 @@ func testAccResourceDirectoryImportStateIDFunc(resourceName string) resource.Imp
 	}
 }
 
-func testAccDirectory_basic(name string) string {
+func testAccArchitectureDirectory_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_directory" "test" {
+resource "huaweicloud_dataarts_architecture_directory" "test" {
   workspace_id = "%s"
   name         = "%s"
   type         = "STANDARD_ELEMENT"
@@ -145,9 +145,9 @@ resource "huaweicloud_dataarts_studio_directory" "test" {
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
 }
 
-func testAccDirectory_update(name string) string {
+func testAccArchitectureDirectory_update(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_directory" "test" {
+resource "huaweicloud_dataarts_architecture_directory" "test" {
   workspace_id = "%s"
   name         = "%s"
   type         = "CODE"

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_subject_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_subject_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getSubjectResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getArchitectureSubjectResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	getSubjectClient, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
@@ -77,15 +77,15 @@ func getSubjectResourceFunc(conf *config.Config, state *terraform.ResourceState)
 	return nil, golangsdk.ErrDefault404{}
 }
 
-func TestAccResourceSubject_basic(t *testing.T) {
+func TestAccResourceArchitectureSubject_basic(t *testing.T) {
 	var obj interface{}
-	resourceName := "huaweicloud_dataarts_studio_subject.test"
+	resourceName := "huaweicloud_dataarts_architecture_subject.test"
 	rName := acceptance.RandomAccResourceName()
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&obj,
-		getSubjectResourceFunc,
+		getArchitectureSubjectResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -97,7 +97,7 @@ func TestAccResourceSubject_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSubject_basic(rName),
+				Config: testAccArchitectureSubject_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -114,7 +114,7 @@ func TestAccResourceSubject_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSubject_update(rName),
+				Config: testAccArchitectureSubject_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -134,13 +134,13 @@ func TestAccResourceSubject_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccResourceSubjectImportStateIDFunc(resourceName),
+				ImportStateIdFunc: testAccResourceArchitectureSubjectImportStateIDFunc(resourceName),
 			},
 		},
 	})
 }
 
-func testAccResourceSubjectImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+func testAccResourceArchitectureSubjectImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -157,9 +157,9 @@ func testAccResourceSubjectImportStateIDFunc(resourceName string) resource.Impor
 	}
 }
 
-func testAccSubject_basic(name string) string {
+func testAccArchitectureSubject_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_subject" "test" {
+resource "huaweicloud_dataarts_architecture_subject" "test" {
   workspace_id = "%s"
   name         = "%s"
   code         = "%s"
@@ -170,9 +170,9 @@ resource "huaweicloud_dataarts_studio_subject" "test" {
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name, name, name)
 }
 
-func testAccSubject_update(name string) string {
+func testAccArchitectureSubject_update(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_subject" "test" {
+resource "huaweicloud_dataarts_architecture_subject" "test" {
   workspace_id = "%s"
   name         = "%s"
   code         = "%s"

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_directory.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_directory.go
@@ -21,15 +21,15 @@ import (
 // API: DataArtsStudio DELETE /v2/{project_id}/design/directorys
 // API: DataArtsStudio GET /v2/{project_id}/design/directorys
 // API: DataArtsStudio PUT /v2/{project_id}/design/directorys
-func ResourceDataArtsStudioDirectory() *schema.Resource {
+func ResourceArchitectureDirectory() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceStudioDirectoryCreate,
-		ReadContext:   resourceStudioDirectoryRead,
-		UpdateContext: resourceStudioDirectoryUpdate,
-		DeleteContext: resourceStudioDirectoryDelete,
+		CreateContext: resourceArchitectureDirectoryCreate,
+		ReadContext:   resourceArchitectureDirectoryRead,
+		UpdateContext: resourceArchitectureDirectoryUpdate,
+		DeleteContext: resourceArchitectureDirectoryDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceStudioDirectoryImportState,
+			StateContext: resourceArchitectureDirectoryImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -93,7 +93,7 @@ func ResourceDataArtsStudioDirectory() *schema.Resource {
 	}
 }
 
-func resourceStudioDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceArchitectureDirectoryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -112,7 +112,7 @@ func resourceStudioDirectoryCreate(ctx context.Context, d *schema.ResourceData, 
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
 	}
-	createDirectoryOpt.JSONBody = utils.RemoveNil(buildCreateDirectoryBodyParams(d))
+	createDirectoryOpt.JSONBody = utils.RemoveNil(buildCreateArchitectureDirectoryBodyParams(d))
 	createDirectoryResp, err := createDirectoryClient.Request("POST", createDirectoryPath, &createDirectoryOpt)
 	if err != nil {
 		return diag.FromErr(err)
@@ -126,21 +126,21 @@ func resourceStudioDirectoryCreate(ctx context.Context, d *schema.ResourceData, 
 
 	id, err := jmespath.Search("id", directory)
 	if err != nil {
-		return diag.Errorf("error creating DataArts Studio directory: %s is not found in API response", "id")
+		return diag.Errorf("error creating DataArts Architecture directory: %s is not found in API response", "id")
 	}
 
 	// need to set qualified name to filter result in READ.
 	qualifiedName, err := jmespath.Search("qualified_name", directory)
 	if err != nil {
-		return diag.Errorf("error creating DataArts Studio directory: %s is not found in API response", "qualifiedName")
+		return diag.Errorf("error creating DataArts Architecture directory: %s is not found in API response", "qualifiedName")
 	}
 	d.SetId(id.(string))
 	d.Set("qualified_name", qualifiedName)
 
-	return resourceStudioDirectoryRead(ctx, d, meta)
+	return resourceArchitectureDirectoryRead(ctx, d, meta)
 }
 
-func buildCreateDirectoryBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildCreateArchitectureDirectoryBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"name":        d.Get("name"),
 		"type":        d.Get("type"),
@@ -150,7 +150,7 @@ func buildCreateDirectoryBodyParams(d *schema.ResourceData) map[string]interface
 	return bodyParams
 }
 
-func resourceStudioDirectoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceArchitectureDirectoryRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	workspaceID := d.Get("workspace_id").(string)
@@ -193,7 +193,7 @@ func resourceStudioDirectoryRead(_ context.Context, d *schema.ResourceData, meta
 
 	directories := utils.PathSearch(jsonPaths, getDirectoryRespBody, make([]interface{}, 0)).([]interface{})
 	if len(directories) == 0 {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "DataArts Studio directory")
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "DataArts Architecture directory")
 	}
 
 	directory := directories[0]
@@ -215,13 +215,13 @@ func resourceStudioDirectoryRead(_ context.Context, d *schema.ResourceData, meta
 		d.Set("children", utils.PathSearch(`children[*].name`, directory, make([]interface{}, 0))),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting DataArts Studio directory fields: %s", err)
+		return diag.Errorf("error setting DataArts Architecture directory fields: %s", err)
 	}
 
 	return nil
 }
 
-func resourceStudioDirectoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceArchitectureDirectoryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -241,7 +241,7 @@ func resourceStudioDirectoryUpdate(ctx context.Context, d *schema.ResourceData, 
 		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
 	}
 
-	updateDirectoryOpt.JSONBody = utils.RemoveNil(buildUpdateDirectoryBodyParams(d))
+	updateDirectoryOpt.JSONBody = utils.RemoveNil(buildUpdateArchitectureDirectoryBodyParams(d))
 	updateDirectoryResp, err := updateDirectoryClient.Request("PUT", updateDirectoryPath, &updateDirectoryOpt)
 	if err != nil {
 		return diag.FromErr(err)
@@ -256,17 +256,17 @@ func resourceStudioDirectoryUpdate(ctx context.Context, d *schema.ResourceData, 
 	// if you change the parent id, the qualified name will be changed, need to set to filter result in READ.
 	qualifiedName, err := jmespath.Search("qualified_name", directory)
 	if err != nil {
-		return diag.Errorf("error updating DataArts Studio directory: %s is not found in API response", "qualifiedName")
+		return diag.Errorf("error updating DataArts Architecture directory: %s is not found in API response", "qualifiedName")
 	}
 	if qualifiedName == nil {
 		qualifiedName = d.Get("qualified_name")
 	}
 	d.Set("qualified_name", qualifiedName)
 
-	return resourceStudioDirectoryRead(ctx, d, meta)
+	return resourceArchitectureDirectoryRead(ctx, d, meta)
 }
 
-func buildUpdateDirectoryBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildUpdateArchitectureDirectoryBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"id":          d.Id(),
 		"name":        d.Get("name"),
@@ -277,7 +277,7 @@ func buildUpdateDirectoryBodyParams(d *schema.ResourceData) map[string]interface
 	return bodyParams
 }
 
-func resourceStudioDirectoryDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceArchitectureDirectoryDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -306,7 +306,7 @@ func resourceStudioDirectoryDelete(_ context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func resourceStudioDirectoryImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+func resourceArchitectureDirectoryImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
 	[]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 3 {

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_subject.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_subject.go
@@ -21,15 +21,15 @@ import (
 // API: DataArtsStudio DELETE /v3/{project_id}/design/subjects
 // API: DataArtsStudio GET /v3/{project_id}/design/subjects
 // API: DataArtsStudio PUT /v3/{project_id}/design/subjects
-func ResourceDataArtsStudioSubject() *schema.Resource {
+func ResourceArchitectureSubject() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceStudioSubjectCreate,
-		ReadContext:   resourceStudioSubjectRead,
-		UpdateContext: resourceStudioSubjectUpdate,
-		DeleteContext: resourceStudioSubjectDelete,
+		CreateContext: resourceArchitectureSubjectCreate,
+		ReadContext:   resourceArchitectureSubjectRead,
+		UpdateContext: resourceArchitectureSubjectUpdate,
+		DeleteContext: resourceArchitectureSubjectDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceStudioSubjectImportState,
+			StateContext: resourceArchitectureSubjectImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -105,7 +105,7 @@ func ResourceDataArtsStudioSubject() *schema.Resource {
 	}
 }
 
-func resourceStudioSubjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceArchitectureSubjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -123,7 +123,7 @@ func resourceStudioSubjectCreate(ctx context.Context, d *schema.ResourceData, me
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
 	}
-	createSubjectOpt.JSONBody = utils.RemoveNil(buildCreateSubjectBodyParams(d))
+	createSubjectOpt.JSONBody = utils.RemoveNil(buildCreateArchitectureSubjectBodyParams(d))
 	createSubjectResp, err := createSubjectClient.Request("POST", createSubjectPath, &createSubjectOpt)
 	if err != nil {
 		return diag.FromErr(err)
@@ -136,15 +136,15 @@ func resourceStudioSubjectCreate(ctx context.Context, d *schema.ResourceData, me
 
 	id, err := jmespath.Search("data.value.id", createSubjectRespBody)
 	if err != nil || id == nil {
-		return diag.Errorf("error creating DataArts Studio subject: %s is not found in API response", "id")
+		return diag.Errorf("error creating DataArts Architecture subject: %s is not found in API response", "id")
 	}
 
 	d.SetId(id.(string))
 
-	return resourceStudioSubjectRead(ctx, d, meta)
+	return resourceArchitectureSubjectRead(ctx, d, meta)
 }
 
-func buildCreateSubjectBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildCreateArchitectureSubjectBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"name_ch":         d.Get("name"),
 		"name_en":         d.Get("code"),
@@ -157,7 +157,7 @@ func buildCreateSubjectBodyParams(d *schema.ResourceData) map[string]interface{}
 	return bodyParams
 }
 
-func resourceStudioSubjectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceArchitectureSubjectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	workspaceID := d.Get("workspace_id").(string)
@@ -189,7 +189,7 @@ func resourceStudioSubjectRead(_ context.Context, d *schema.ResourceData, meta i
 	for {
 		getSubjectResp, err := getSubjectClient.Request("GET", getSubjectPath, &getSubjectOpt)
 		if err != nil {
-			return common.CheckDeletedDiag(d, err, "error retrieving DataArts Studio subject")
+			return common.CheckDeletedDiag(d, err, "error retrieving DataArts Architecture subject")
 		}
 		getSubjectRespBody, err := utils.FlattenResponse(getSubjectResp)
 		if err != nil {
@@ -246,7 +246,7 @@ func resourceStudioSubjectRead(_ context.Context, d *schema.ResourceData, meta i
 	return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 }
 
-func resourceStudioSubjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceArchitectureSubjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -265,7 +265,7 @@ func resourceStudioSubjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
 	}
 
-	updateSubjectOpt.JSONBody = utils.RemoveNil(buildUpdateSubjectBodyParams(d))
+	updateSubjectOpt.JSONBody = utils.RemoveNil(buildUpdateArchitectureSubjectBodyParams(d))
 	updateSubjectResp, err := updateSubjectClient.Request("PUT", updateSubjectPath, &updateSubjectOpt)
 	if err != nil {
 		return diag.FromErr(err)
@@ -278,10 +278,10 @@ func resourceStudioSubjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	path := strings.ReplaceAll(utils.PathSearch("data.value.path", updateSubjectRespBody, "").(string), "/", ".")
 	d.Set("path", path)
 
-	return resourceStudioSubjectRead(ctx, d, meta)
+	return resourceArchitectureSubjectRead(ctx, d, meta)
 }
 
-func buildUpdateSubjectBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildUpdateArchitectureSubjectBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"id":              d.Id(),
 		"name_ch":         d.Get("name"),
@@ -295,7 +295,7 @@ func buildUpdateSubjectBodyParams(d *schema.ResourceData) map[string]interface{}
 	return bodyParams
 }
 
-func resourceStudioSubjectDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceArchitectureSubjectDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -326,7 +326,7 @@ func resourceStudioSubjectDelete(_ context.Context, d *schema.ResourceData, meta
 	return nil
 }
 
-func resourceStudioSubjectImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+func resourceArchitectureSubjectImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
 	[]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
modify DataArts directory and subject resource name

## PR Checklist

* [ ] Tests added/passed.
* [√] Documentation updated.
* [√] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourceArchitectureDirectory_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceArchitectureDirectory_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceArchitectureDirectory_basic
=== PAUSE TestAccResourceArchitectureDirectory_basic
=== CONT  TestAccResourceArchitectureDirectory_basic
--- PASS: TestAccResourceArchitectureDirectory_basic (29.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  29.209s

make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourceArchitectureSubject_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceArchitectureSubject_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceArchitectureSubject_basic
=== PAUSE TestAccResourceArchitectureSubject_basic
=== CONT  TestAccResourceArchitectureSubject_basic
--- PASS: TestAccResourceArchitectureSubject_basic (26.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  27.059s
```
