### PR TITLE
chore(DataArts): modify DataArts Security rule resource name

### DIFF
--- a/docs/resources/dataarts_security_data_recognition_rule.md
+++ b/docs/resources/dataarts_security_data_recognition_rule.md
@@ -2,9 +2,9 @@
 subcategory: "DataArts Studio"
 ---
 
-# huaweicloud_dataarts_studio_data_recognition_rule
+# huaweicloud_dataarts_security_data_recognition_rule
 
-Manages a DataArts Studio data recognition rule resource within HuaweiCloud.
+Manages a data recognition rule resource of DataArts Security within HuaweiCloud.
 
 ## Example Usage
 
@@ -15,7 +15,7 @@ variable "workspace_id" {}
 variable "secrecy_level_id" {}
 variable "category_id" {}
 
-resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
   workspace_id       = var.workspace_id
   rule_type          = "CUSTOM"
   name               = "ruleName"
@@ -38,7 +38,7 @@ variable "secrecy_level_id" {}
 variable "category_id" {}
 variable "builtin_rule_id" {}
 
-resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
   workspace_id      = var.workspace_id
   rule_type         = "BUILTIN"
   name              = var.name
@@ -130,10 +130,10 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-DataArts Studio rule can be imported using `<workspace_id>/<id>`, e.g.
+The DataArts Security data recognition rule can be imported using `<workspace_id>/<id>`, e.g.
 
 ```sh
-terraform import huaweicloud_dataarts_studio_data_recognition_rule.test <workspace_id>/<id>
+terraform import huaweicloud_dataarts_security_data_recognition_rule.test <workspace_id>/<id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
@@ -143,7 +143,7 @@ You can then decide if changes should be applied to the resource, or the resourc
 with the resource. Also, you can ignore changes as below.
 
 ```hcl
-resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
   ...
   
   lifecycle {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1106,8 +1106,8 @@ func Provider() *schema.Provider {
 			// DataArts Factory
 			"huaweicloud_dataarts_studio_resource": dataarts.ResourceStudioResource(),
 			// DataArts Security
-			"huaweicloud_dataarts_security_permission_set":      dataarts.ResourceSecurityPermissionSet(),
-			"huaweicloud_dataarts_studio_data_recognition_rule": dataarts.ResourceStudioRule(),
+			"huaweicloud_dataarts_security_permission_set":        dataarts.ResourceSecurityPermissionSet(),
+			"huaweicloud_dataarts_security_data_recognition_rule": dataarts.ResourceSecurityRule(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_app": dataarts.ResourceDataServiceApp(),
 

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getSecurityRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	getRuleClient, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DataArts Studio V1 client: %s", err)
@@ -38,15 +38,15 @@ func getRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (i
 	return utils.FlattenResponse(getRuleResp)
 }
 
-func TestAccResourceRecognitionRule_custom(t *testing.T) {
+func TestAccResourceSecurityRule_custom(t *testing.T) {
 	var obj interface{}
-	resourceName := "huaweicloud_dataarts_studio_data_recognition_rule.test"
+	resourceName := "huaweicloud_dataarts_security_data_recognition_rule.test"
 	rName := acceptance.RandomAccResourceName()
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&obj,
-		getRuleResourceFunc,
+		getSecurityRuleResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -59,7 +59,7 @@ func TestAccResourceRecognitionRule_custom(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRule_custom(rName),
+				Config: testAccSecurityRule_custom(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -76,7 +76,7 @@ func TestAccResourceRecognitionRule_custom(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRule_custom_update1(rName),
+				Config: testAccSecurityRule_custom_update1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -97,7 +97,7 @@ func TestAccResourceRecognitionRule_custom(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRule_custom_update2(rName),
+				Config: testAccSecurityRule_custom_update2(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -128,14 +128,14 @@ func TestAccResourceRecognitionRule_custom(t *testing.T) {
 	})
 }
 
-func TestAccResourceRecognitionRule_builtin(t *testing.T) {
+func TestAccResourceSecurityRule_builtin(t *testing.T) {
 	var obj interface{}
-	resourceName := "huaweicloud_dataarts_studio_data_recognition_rule.test"
+	resourceName := "huaweicloud_dataarts_security_data_recognition_rule.test"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&obj,
-		getRuleResourceFunc,
+		getSecurityRuleResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -149,7 +149,7 @@ func TestAccResourceRecognitionRule_builtin(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRule_builtin(),
+				Config: testAccSecurityRule_builtin(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_DATAARTS_BUILTIN_RULE_NAME),
@@ -166,7 +166,7 @@ func TestAccResourceRecognitionRule_builtin(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRule_builtin_update(),
+				Config: testAccSecurityRule_builtin_update(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
@@ -187,9 +187,9 @@ func TestAccResourceRecognitionRule_builtin(t *testing.T) {
 	})
 }
 
-func testAccRule_custom(name string) string {
+func testAccSecurityRule_custom(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
   workspace_id     = "%[1]s"
   rule_type        = "CUSTOM"
   name             = "%[2]s"
@@ -200,9 +200,9 @@ resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_SECRECY_LEVEL_ID, acceptance.HW_DATAARTS_CATEGORY_ID)
 }
 
-func testAccRule_custom_update1(name string) string {
+func testAccSecurityRule_custom_update1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
   workspace_id       = "%[1]s"
   rule_type          = "CUSTOM"
   name               = "%[2]s"
@@ -217,9 +217,9 @@ resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_SECRECY_LEVEL_ID_UPDATE, acceptance.HW_DATAARTS_CATEGORY_ID_UPDATE)
 }
 
-func testAccRule_custom_update2(name string) string {
+func testAccSecurityRule_custom_update2(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
   workspace_id       = "%[1]s"
   rule_type          = "CUSTOM"
   name               = "%[2]s"
@@ -234,9 +234,9 @@ resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
 `, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_SECRECY_LEVEL_ID, acceptance.HW_DATAARTS_CATEGORY_ID)
 }
 
-func testAccRule_builtin() string {
+func testAccSecurityRule_builtin() string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
   workspace_id     = "%[1]s"
   rule_type        = "BUILTIN"
   name             = "%[2]s"
@@ -248,9 +248,9 @@ resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
 		acceptance.HW_DATAARTS_SECRECY_LEVEL_ID, acceptance.HW_DATAARTS_CATEGORY_ID)
 }
 
-func testAccRule_builtin_update() string {
+func testAccSecurityRule_builtin_update() string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_data_recognition_rule" "test" {
+resource "huaweicloud_dataarts_security_data_recognition_rule" "test" {
   workspace_id     = "%[1]s"
   rule_type        = "BUILTIN"
   name             = "%[2]s"

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule.go
@@ -22,12 +22,12 @@ import (
 // API: DataArtsStudio DELETE /v1/{project_id}/security/data-classification/rule/{id}
 // API: DataArtsStudio GET /v1/{project_id}/security/data-classification/rule/{id}
 // API: DataArtsStudio PUT /v1/{project_id}/security/data-classification/rule/{id}
-func ResourceStudioRule() *schema.Resource {
+func ResourceSecurityRule() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceRuleCreate,
-		ReadContext:   resourceRuleRead,
-		UpdateContext: resourceRuleUpdate,
-		DeleteContext: resourceRuleDelete,
+		CreateContext: resourceSecurityRuleCreate,
+		ReadContext:   resourceSecurityRuleRead,
+		UpdateContext: resourceSecurityRuleUpdate,
+		DeleteContext: resourceSecurityRuleDelete,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceDataArtsStudioImportState,
@@ -121,7 +121,7 @@ func ResourceStudioRule() *schema.Resource {
 	}
 }
 
-func buildCreateOrUpdateRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+func buildCreateOrUpdateSecurityRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"rule_type":          d.Get("rule_type").(string),
 		"secrecy_level_id":   d.Get("secrecy_level_id").(string),
@@ -137,7 +137,7 @@ func buildCreateOrUpdateRuleBodyParams(d *schema.ResourceData) map[string]interf
 	return bodyParams
 }
 
-func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 	createRuleHttpUrl := "v1/{project_id}/security/data-classification/rule"
@@ -156,10 +156,10 @@ func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
 	}
-	createRuleOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateRuleBodyParams(d))
+	createRuleOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateSecurityRuleBodyParams(d))
 	createRuleResp, err := createRuleClient.Request("POST", createRulePath, &createRuleOpt)
 	if err != nil {
-		return diag.Errorf("error creating DataArts Studio data recognition rule: %s", err)
+		return diag.Errorf("error creating DataArts Security data recognition rule: %s", err)
 	}
 
 	createRuleRespBody, err := utils.FlattenResponse(createRuleResp)
@@ -169,15 +169,15 @@ func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	id, err := jmespath.Search("uuid", createRuleRespBody)
 	if err != nil || id == nil {
-		return diag.Errorf("error creating DataArts Studio data recognition rule: ID is not found in API response")
+		return diag.Errorf("error creating DataArts Security data recognition rule: ID is not found in API response")
 	}
 
 	d.SetId(id.(string))
 
-	return resourceRuleRead(ctx, d, meta)
+	return resourceSecurityRuleRead(ctx, d, meta)
 }
 
-func resourceRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	workspaceID := d.Get("workspace_id").(string)
@@ -200,7 +200,7 @@ func resourceRuleRead(_ context.Context, d *schema.ResourceData, meta interface{
 	}
 	getRuleResp, err := getRuleClient.Request("GET", getRulePath, &getRuleOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseRecognitionRuleError(err), "error retrieving DataArts Studio data recognition rule")
+		return common.CheckDeletedDiag(d, parseSecurityRuleError(err), "error retrieving DataArts Security data recognition rule")
 	}
 
 	getRuleRespBody, err := utils.FlattenResponse(getRuleResp)
@@ -232,7 +232,7 @@ func resourceRuleRead(_ context.Context, d *schema.ResourceData, meta interface{
 }
 
 // The example of error message is: {"error_code": "DLS.4106","error_msg": "Rule is not exist."}
-func parseRecognitionRuleError(err error) error {
+func parseSecurityRuleError(err error) error {
 	var errCode golangsdk.ErrDefault400
 	if errors.As(err, &errCode) {
 		var apiError interface{}
@@ -251,7 +251,7 @@ func parseRecognitionRuleError(err error) error {
 	return err
 }
 
-func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -271,16 +271,16 @@ func resourceRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
 	}
 
-	updateRuleOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateRuleBodyParams(d))
+	updateRuleOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateSecurityRuleBodyParams(d))
 	_, err = updateRuleClient.Request("PUT", updateRulePath, &updateRuleOpt)
 	if err != nil {
-		return diag.Errorf("error updating DataArts Studio data recognition rule: %s", err)
+		return diag.Errorf("error updating DataArts Security data recognition rule: %s", err)
 	}
 
-	return resourceRuleRead(ctx, d, meta)
+	return resourceSecurityRuleRead(ctx, d, meta)
 }
 
-func resourceRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -302,7 +302,7 @@ func resourceRuleDelete(_ context.Context, d *schema.ResourceData, meta interfac
 
 	_, err = deleteRuleClient.Request("DELETE", deleteRulePath, &deleteRuleOpt)
 	if err != nil {
-		return diag.Errorf("error deleting DataArts Studio data recognition rule: %s", err)
+		return diag.Errorf("error deleting DataArts Security data recognition rule: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
When the rule is not exist, the detail API response body is: {"error_code": "DLS.4106","error_msg": "Rule is not exist."}
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/106511595/4433461f-7486-467e-89e1-9a962e50e4a3)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourceSecurityRule_custom"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceSecurityRule_custom -timeout 360m -parallel 4
=== RUN   TestAccResourceSecurityRule_custom
=== PAUSE TestAccResourceSecurityRule_custom
=== CONT  TestAccResourceSecurityRule_custom
--- PASS: TestAccResourceSecurityRule_custom (31.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  31.704s
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourceSecurityRule_builtin"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceSecurityRule_builtin -timeout 360m -parallel 4
=== RUN   TestAccResourceSecurityRule_builtin
=== PAUSE TestAccResourceSecurityRule_builtin
=== CONT  TestAccResourceSecurityRule_builtin
--- PASS: TestAccResourceSecurityRule_builtin (21.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  21.118s
```
