### PR TITLE
fix(vpc): allow create security group rule without remote params

### DIFF
--- a/docs/resources/networking_secgroup_rule.md
+++ b/docs/resources/networking_secgroup_rule.md
@@ -131,7 +131,8 @@ The following arguments are supported:
   Changing this creates a new security group rule.
 
 * `remote_ip_prefix` - (Optional, String, ForceNew) Specifies the remote CIDR, the value needs to be a valid CIDR (i.e.
-  192.168.0.0/16). Changing this creates a new security group rule.
+  192.168.0.0/16). If not specified, the empty value means all IP addresses, which is same as the value `0.0.0.0/0`.
+  Changing this creates a new security group rule.
 
 * `remote_group_id` - (Optional, String, ForceNew) Specifies the remote group ID. Changing this creates a new security
   group rule.

--- a/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup_rule.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_networking_secgroup_rule.go
@@ -102,11 +102,10 @@ func ResourceNetworkingSecGroupRule() *schema.Resource {
 				),
 			},
 			"remote_group_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{"remote_address_group_id", "remote_ip_prefix"},
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 			"remote_address_group_id": {
 				Type:          schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

both `remote_ip_prefix`, `remote_address_group_id` and  `remote_group_id` can be empty when creating the ingress and egress rule. In this case, it will be 0.0.0.0/0 which means all IP addresses.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccNetworkingSecGroupRule_noRemote"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccNetworkingSecGroupRule_noRemote -timeout 360m -parallel 4
=== RUN   TestAccNetworkingSecGroupRule_noRemote
=== PAUSE TestAccNetworkingSecGroupRule_noRemote
=== CONT  TestAccNetworkingSecGroupRule_noRemote
--- PASS: TestAccNetworkingSecGroupRule_noRemote (40.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       40.209s
```
