### PR TITLE
feat(er/attachment): support resource id parameter to query result

### DIFF
--- a/docs/data-sources/er_attachments.md
+++ b/docs/data-sources/er_attachments.md
@@ -41,6 +41,8 @@ The following arguments are supported:
 
 * `name` - (Optional, String) Specifies the name used to filter the attachments.
 
+* `resource_id` - (Optional, String) Specifies the associated resource ID used to filter the attachments.
+
 * `status` - (Optional, String) Specifies the status used to filter the attachments.
   The valid values are as follows:
   + **available**

--- a/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
@@ -45,6 +45,11 @@ func DataSourceAttachments() *schema.Resource {
 				Optional:    true,
 				Description: `The name used to filter the attachments.`,
 			},
+			"resource_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The associated resource ID.`,
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -90,7 +95,7 @@ func DataSourceAttachments() *schema.Resource {
 						"resource_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: `Associated resource ID.`,
+							Description: `The associated resource ID.`,
 						},
 						"created_at": {
 							Type:        schema.TypeString,
@@ -195,6 +200,7 @@ func buildAttachmentListOpts(d *schema.ResourceData) attachments.ListOpts {
 	return attachments.ListOpts{
 		Statuses:      buildSliceIgnoreEmptyElement(d.Get("status").(string)),
 		ResourceTypes: buildSliceIgnoreEmptyElement(d.Get("type").(string)),
+		ResourceIds:   buildSliceIgnoreEmptyElement(d.Get("resource_id").(string)),
 		SortKey:       []string{"name"},
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new query parameter:
- resource_id

Accept VPC attachments, other types attachments cannot be obtained without resource ID.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new parameter resource_id.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccAttachmentsDataSource_filterByResourceId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccAttachmentsDataSource_filterByResourceId -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_filterByResourceId
=== PAUSE TestAccAttachmentsDataSource_filterByResourceId
=== CONT  TestAccAttachmentsDataSource_filterByResourceId
--- PASS: TestAccAttachmentsDataSource_filterByResourceId (110.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        110.777s
```
