### PR TITLE
chore: rename the dataarts studio resource to dataarts factory resource

### DIFF
--- a/docs/resources/dataarts_factory_resource.md
+++ b/docs/resources/dataarts_factory_resource.md
@@ -2,9 +2,9 @@
 subcategory: "DataArts Studio"
 ---
 
-# huaweicloud_dataarts_studio_resource
+# huaweicloud_dataarts_factory_resource
 
-Manages DataArts Studio resource within HuaweiCloud.
+Manages DataArts Factory resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -15,7 +15,7 @@ variable "workspace_id" {}
 variable "name" {}
 variable "directory" {}
 
-resource "huaweicloud_dataarts_studio_resource" "test" {
+resource "huaweicloud_dataarts_factory_resource" "test" {
   workspace_id = var.workspace_id
   name         = var.name
   type         = "jar"
@@ -31,7 +31,7 @@ variable "workspace_id" {}
 variable "name" {}
 variable "directory" {}
 
-resource "huaweicloud_dataarts_studio_resource" "test" {
+resource "huaweicloud_dataarts_factory_resource" "test" {
   workspace_id = var.workspace_id
   name         = var.name
   type         = "jar"
@@ -61,11 +61,11 @@ The following arguments are supported:
   are supported.
 
 * `depend_packages` - (Optional, List) Specifies an array of dependent files.
-  The [depend_packages](#DataArts_Studio_Resource_Depend_Packages) structure is documented below.
+  The [depend_packages](#DataArts_Factory_Resource_Depend_Packages) structure is documented below.
 
 * `description` - (Optional, String) Specifies the resource description.
 
-<a name="DataArts_Studio_Resource_Depend_Packages"></a>
+<a name="DataArts_Factory_Resource_Depend_Packages"></a>
 The `depend_packages` block supports:
 
 * `location` - (Required, String) Specifies the path of the dependent file. Currently, only OBS paths is
@@ -82,8 +82,8 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-DataArts Studio resource can be imported using `<workspace_id>/<id>`, e.g.
+DataArts Factory resource can be imported using `<workspace_id>/<id>`, e.g.
 
 ```bash
-$ terraform import huaweicloud_dataarts_studio_resource.test <workspace_id>/<id>
+$ terraform import huaweicloud_dataarts_Factory_resource.test <workspace_id>/<id>
 ```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1104,7 +1104,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_subject":         dataarts.ResourceArchitectureSubject(),
 			"huaweicloud_dataarts_architecture_business_metric": dataarts.ResourceBusinessMetric(),
 			// DataArts Factory
-			"huaweicloud_dataarts_studio_resource": dataarts.ResourceStudioResource(),
+			"huaweicloud_dataarts_factory_resource": dataarts.ResourceFactoryResource(),
 			// DataArts Security
 			"huaweicloud_dataarts_security_permission_set":      dataarts.ResourceSecurityPermissionSet(),
 			"huaweicloud_dataarts_studio_data_recognition_rule": dataarts.ResourceStudioRule(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_resource_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-func getStudioResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+func getFactoryResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	getResourceClient, err := conf.NewServiceClient("dataarts-dlf", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
@@ -44,15 +44,15 @@ func getStudioResourceFunc(conf *config.Config, state *terraform.ResourceState) 
 	return getResourceRespBody, nil
 }
 
-func TestAccStudioResource_basic(t *testing.T) {
+func TestAccFactoryResource_basic(t *testing.T) {
 	var obj interface{}
-	resourceName := "huaweicloud_dataarts_studio_resource.test"
+	resourceName := "huaweicloud_dataarts_factory_resource.test"
 	rName := acceptance.RandomAccResourceName()
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&obj,
-		getStudioResourceFunc,
+		getFactoryResourceFunc,
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -119,7 +119,7 @@ func testAccResourceImportStateIDFunc(resourceName string) resource.ImportStateI
 
 func testAccResource_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_resource" "test" {
+resource "huaweicloud_dataarts_factory_resource" "test" {
   workspace_id = "%[1]s"
   name         = "%[2]s"
   type         = "jar"
@@ -137,7 +137,7 @@ resource "huaweicloud_dataarts_studio_resource" "test" {
 
 func testAccResource_update(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dataarts_studio_resource" "test" {
+resource "huaweicloud_dataarts_factory_resource" "test" {
   workspace_id = "%[1]s"
   name         = "%[2]s_update"
   type         = "jar"

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_resource.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_resource.go
@@ -20,15 +20,15 @@ import (
 // API: DataArtsStudio DELETE /v1/{project_id}/resources/{resource_id}
 // API: DataArtsStudio GET /v1/{project_id}/resources/{resource_id}
 // API: DataArtsStudio PUT /v1/{project_id}/resources/{resource_id}
-func ResourceStudioResource() *schema.Resource {
+func ResourceFactoryResource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceStudioResourceCreate,
-		ReadContext:   resourceStudioResourceRead,
-		UpdateContext: resourceStudioResourceUpdate,
-		DeleteContext: resourceStudioResourceDelete,
+		CreateContext: resourceFactoryResourceCreate,
+		ReadContext:   resourceFactoryResourceRead,
+		UpdateContext: resourceFactoryResourceUpdate,
+		DeleteContext: resourceFactoryResourceDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: resourceStudioResourceImportState,
+			StateContext: resourceFactoryResourceImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -83,7 +83,7 @@ func ResourceStudioResource() *schema.Resource {
 	}
 }
 
-func resourceStudioResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFactoryResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -104,7 +104,7 @@ func resourceStudioResourceCreate(ctx context.Context, d *schema.ResourceData, m
 	createResourceOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateResourceBodyParams(d))
 	createResourceResp, err := createResourceClient.Request("POST", createResourcePath, &createResourceOpt)
 	if err != nil {
-		return diag.Errorf("error creating DataArts Studio resource: %s", err)
+		return diag.Errorf("error creating DataArts Factory resource: %s", err)
 	}
 
 	createResourceRespBody, err := utils.FlattenResponse(createResourceResp)
@@ -114,10 +114,10 @@ func resourceStudioResourceCreate(ctx context.Context, d *schema.ResourceData, m
 
 	id := utils.PathSearch("resourceId", createResourceRespBody, nil)
 	if id == nil {
-		return diag.Errorf("error creating DataArts Studio resource: %s is not found in API response", "id")
+		return diag.Errorf("error creating DataArts Factory resource: %s is not found in API response", "id")
 	}
 	d.SetId(id.(string))
-	return resourceStudioResourceRead(ctx, d, meta)
+	return resourceFactoryResourceRead(ctx, d, meta)
 }
 
 func buildCreateOrUpdateResourceBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -149,7 +149,7 @@ func buildDependPackagesParams(d *schema.ResourceData) []map[string]string {
 	return dependPackages
 }
 
-func resourceStudioResourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFactoryResourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	workspaceID := d.Get("workspace_id").(string)
@@ -173,7 +173,7 @@ func resourceStudioResourceRead(_ context.Context, d *schema.ResourceData, meta 
 	}
 	getResourceResp, err := getResourceClient.Request("GET", getResourcePath, &getResourceOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving DataArts Studio resource")
+		return common.CheckDeletedDiag(d, err, "error retrieving DataArts Factory resource")
 	}
 
 	getResourceRespBody, err := utils.FlattenResponse(getResourceResp)
@@ -214,7 +214,7 @@ func flattenDependPackagesInGetResourceResponseBody(getResourceRespBody interfac
 	return dependPackages
 }
 
-func resourceStudioResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFactoryResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -239,13 +239,13 @@ func resourceStudioResourceUpdate(ctx context.Context, d *schema.ResourceData, m
 	updateResourceOpt.JSONBody = utils.RemoveNil(buildCreateOrUpdateResourceBodyParams(d))
 	_, err = updateResourceClient.Request("PUT", updateResourcePath, &updateResourceOpt)
 	if err != nil {
-		return diag.Errorf("error updating DataArts Studio resource: %s", err)
+		return diag.Errorf("error updating DataArts Factory resource: %s", err)
 	}
 
-	return resourceStudioResourceRead(ctx, d, meta)
+	return resourceFactoryResourceRead(ctx, d, meta)
 }
 
-func resourceStudioResourceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFactoryResourceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -266,13 +266,13 @@ func resourceStudioResourceDelete(_ context.Context, d *schema.ResourceData, met
 	}
 	_, err = deleteResourceClient.Request("DELETE", deleteResourcePath, &deleteResourceOpt)
 	if err != nil {
-		return diag.Errorf("error deleting DataArts Studio resource: %s", err)
+		return diag.Errorf("error deleting DataArts Factory resource: %s", err)
 	}
 
 	return nil
 }
 
-func resourceStudioResourceImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+func resourceFactoryResourceImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
 	[]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
rename the dataarts studio resource to dataarts factory resource

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccFactoryResource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccFactoryResource_basic                                                                  -timeout 360m -parallel 4
=== RUN   TestAccFactoryResource_basic
=== PAUSE TestAccFactoryResource_basic
=== CONT  TestAccFactoryResource_basic
--- PASS: TestAccFactoryResource_basic (25.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/da                                                                 taarts  25.479s
```
