### PR TITLE
feat(nat): add a new datasource to query the list of transit ip

### DIFF
--- a/docs/data-sources/nat_private_transit_ips.md
+++ b/docs/data-sources/nat_private_transit_ips.md
@@ -1,0 +1,69 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# huaweicloud_nat_private_transit_ips
+
+Use this data source to get the list of transit IPs.
+
+## Example Usage
+
+```hcl
+variable "ip_address" {}
+
+data "huaweicloud_nat_private_transit_ips" "test" {
+  ip_address = var.ip_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the transit IPs are located.  
+  If omitted, the provider-level region will be used.
+
+* `transit_ip_id` - (Optional, String) Specifies the ID of the transit IP.
+
+* `ip_address` - (Optional, String) Specifies the IP address of the transit IP.  
+
+* `gateway_id` - (Optional, String) Specifies the ID of the private NAT gateway to which the transit IP belongs.
+
+* `subnet_id` - (Optional, String) Specifies the ID of the subnet to which the transit IPs belong.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate the transit IPs used for filter.
+
+* `network_interface_id` - (Optional, String) Specifies the network interface ID of the transit IP for private NAT.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the transit
+  IPs belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `transit_ips` - The list ot the transit IPs.
+  The [transit_ips](#private_transitIps) structure is documented below.
+
+<a name="private_transitIps"></a>
+The `transit_ips` block supports:
+
+* `id` - The ID of the transit IP.
+
+* `ip_address` - The IP address of the transit IP.
+
+* `subnet_id` - The ID of the subnet to which the transit IP belongs.
+
+* `tags` - The key/value pairs to associate with the transit IP.
+
+* `gateway_id` - The ID of the private NAT gateway to which the transit IP belongs.
+
+* `created_at` - The creation time of the transit IP.
+
+* `updated_at` - The latest update time of the transit IP.
+
+* `network_interface_id` - The network interface ID of the transit IP for private NAT.
+
+* `enterprise_project_id` - The ID of the enterprise project to which the transit IP belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -554,9 +554,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_elb_l7policies":        elb.DataSourceElbL7policies(),
 			"huaweicloud_elb_security_policies": elb.DataSourceElbSecurityPolicies(),
 
-			"huaweicloud_nat_gateway":          nat.DataSourcePublicGateway(),
-			"huaweicloud_nat_gateways":         nat.DataSourcePublicGateways(),
-			"huaweicloud_nat_private_gateways": nat.DataSourcePrivateGateways(),
+			"huaweicloud_nat_gateway":             nat.DataSourcePublicGateway(),
+			"huaweicloud_nat_gateways":            nat.DataSourcePublicGateways(),
+			"huaweicloud_nat_private_gateways":    nat.DataSourcePrivateGateways(),
+			"huaweicloud_nat_private_transit_ips": nat.DataSourcePrivateTransitIps(),
 
 			"huaweicloud_networking_port":      vpc.DataSourceNetworkingPortV2(),
 			"huaweicloud_networking_secgroup":  vpc.DataSourceNetworkingSecGroup(),

--- a/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_transit_ips_test.go
+++ b/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_transit_ips_test.go
@@ -1,0 +1,236 @@
+package nat
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDatasourcePrivateTransitIps_basic(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceName()
+		baseConfig     = testAccPrivateTransitIpsDataSource_base()
+		dataSourceName = "data.huaweicloud_nat_private_transit_ips.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byTransitIpId   = "data.huaweicloud_nat_private_transit_ips.filter_by_transit_ip_id"
+		dcByTransitIpId = acceptance.InitDataSourceCheck(byTransitIpId)
+
+		byIpAddress   = "data.huaweicloud_nat_private_transit_ips.filter_by_ip_address"
+		dcByIpAddress = acceptance.InitDataSourceCheck(byIpAddress)
+
+		byGatewayId   = "data.huaweicloud_nat_private_transit_ips.filter_by_gateway_id"
+		dcByGatewayId = acceptance.InitDataSourceCheck(byGatewayId)
+
+		bySubnetId   = "data.huaweicloud_nat_private_transit_ips.filter_by_subnet_id"
+		dcBySubnetId = acceptance.InitDataSourceCheck(bySubnetId)
+
+		byTags   = "data.huaweicloud_nat_private_transit_ips.filter_by_tags"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
+
+		byNetWorkInterfaceId   = "data.huaweicloud_nat_private_transit_ips.filter_by_network_interface_id"
+		dcByNetWorkInterfaceId = acceptance.InitDataSourceCheck(byNetWorkInterfaceId)
+
+		byEps   = "data.huaweicloud_nat_private_transit_ips.filter_by_eps"
+		dcByEps = acceptance.InitDataSourceCheck(byEps)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourcePrivateTransitIps_basic(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					dcByTransitIpId.CheckResourceExists(),
+					resource.TestCheckOutput("transit_ip_id_filter_is_useful", "true"),
+
+					dcByIpAddress.CheckResourceExists(),
+					resource.TestCheckOutput("ip_address_filter_is_useful", "true"),
+
+					dcByGatewayId.CheckResourceExists(),
+					resource.TestCheckOutput("gateway_id_filter_is_useful", "true"),
+
+					dcBySubnetId.CheckResourceExists(),
+					resource.TestCheckOutput("subnet_id_filter_is_useful", "true"),
+
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
+
+					dcByNetWorkInterfaceId.CheckResourceExists(),
+					resource.TestCheckOutput("network_interface_id_filter_is_useful", "true"),
+
+					dcByEps.CheckResourceExists(),
+					resource.TestCheckOutput("eps_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPrivateTransitIpsDataSource_base() string {
+	name := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_private_transit_ip" "test" {
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = "0"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccDatasourcePrivateTransitIps_basic(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_nat_private_transit_ips" "test" {
+  depends_on = [
+    huaweicloud_nat_private_transit_ip.test
+  ]  
+}
+
+locals {
+  transit_ip_id = data.huaweicloud_nat_private_transit_ips.test.transit_ips[0].id
+}
+
+data "huaweicloud_nat_private_transit_ips" "filter_by_transit_ip_id" {
+  transit_ip_id = local.transit_ip_id
+}
+
+locals {
+  transit_ip_id_filter_result = [
+    for v in data.huaweicloud_nat_private_transit_ips.filter_by_transit_ip_id.transit_ips[*].id : 
+    v == local.transit_ip_id
+  ]
+}
+
+output "transit_ip_id_filter_is_useful" {
+  value = alltrue(local.transit_ip_id_filter_result) && length(local.transit_ip_id_filter_result) > 0
+}
+
+locals {
+  ip_address = data.huaweicloud_nat_private_transit_ips.test.transit_ips[0].ip_address
+}
+
+data "huaweicloud_nat_private_transit_ips" "filter_by_ip_address" {
+  ip_address = local.ip_address
+}
+
+locals {
+  ip_address_filter_result = [
+    for v in data.huaweicloud_nat_private_transit_ips.filter_by_ip_address.transit_ips[*].ip_address : 
+    v == local.ip_address
+  ]
+}
+
+output "ip_address_filter_is_useful" {
+  value = alltrue(local.ip_address_filter_result) && length(local.ip_address_filter_result) > 0
+}
+
+locals {
+  gateway_id = data.huaweicloud_nat_private_transit_ips.test.transit_ips[0].gateway_id
+}
+
+data "huaweicloud_nat_private_transit_ips" "filter_by_gateway_id" {
+  gateway_id = local.gateway_id
+}
+
+locals {
+  gateway_id_filter_result = [
+    for v in data.huaweicloud_nat_private_transit_ips.filter_by_gateway_id.transit_ips[*].gateway_id : 
+    v == local.gateway_id
+  ]
+}
+
+output "gateway_id_filter_is_useful" {
+  value = alltrue(local.gateway_id_filter_result) && length(local.gateway_id_filter_result) > 0
+}
+
+locals {
+  subnet_id = data.huaweicloud_nat_private_transit_ips.test.transit_ips[0].subnet_id
+}
+
+data "huaweicloud_nat_private_transit_ips" "filter_by_subnet_id" {
+  subnet_id = local.subnet_id
+}
+
+locals {
+  subnet_id_filter_result = [
+    for v in data.huaweicloud_nat_private_transit_ips.filter_by_subnet_id.transit_ips[*].subnet_id : 
+    v == local.subnet_id
+  ]
+}
+
+output "subnet_id_filter_is_useful" {
+  value = alltrue(local.subnet_id_filter_result) && length(local.subnet_id_filter_result) > 0
+}
+
+locals {
+  network_interface_id = data.huaweicloud_nat_private_transit_ips.test.transit_ips[0].network_interface_id
+}
+
+data "huaweicloud_nat_private_transit_ips" "filter_by_network_interface_id" {
+  network_interface_id = local.network_interface_id
+}
+
+locals {
+  network_interface_id_filter_result = [
+    for v in data.huaweicloud_nat_private_transit_ips.filter_by_network_interface_id.transit_ips[*].
+    network_interface_id : v == local.network_interface_id
+  ]
+}
+
+output "network_interface_id_filter_is_useful" {
+  value = alltrue(local.network_interface_id_filter_result) && length(local.network_interface_id_filter_result) > 0
+}
+
+locals {
+  enterprise_project_id = data.huaweicloud_nat_private_transit_ips.test.transit_ips[0].enterprise_project_id
+}
+
+data "huaweicloud_nat_private_transit_ips" "filter_by_eps" {
+  enterprise_project_id = local.enterprise_project_id
+}
+
+locals {
+  eps_filter_result = [
+    for v in data.huaweicloud_nat_private_transit_ips.filter_by_eps.transit_ips[*].enterprise_project_id : 
+    v == local.enterprise_project_id
+  ]
+}
+
+output "eps_filter_is_useful" {
+  value = alltrue(local.eps_filter_result) && length(local.eps_filter_result) > 0
+}
+
+locals {
+  tags = data.huaweicloud_nat_private_transit_ips.test.transit_ips[0].tags
+}
+
+data "huaweicloud_nat_private_transit_ips" "filter_by_tags" {
+  tags = local.tags
+}
+
+locals {
+  tags_filter_result = [
+    for v in data.huaweicloud_nat_private_transit_ips.filter_by_tags.transit_ips[*].tags : v == local.tags
+  ]
+}
+
+output "tags_filter_is_useful" {
+  value = alltrue(local.tags_filter_result) && length(local.tags_filter_result) > 0
+}
+`, baseConfig, name)
+}

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_private_transit_ips.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_private_transit_ips.go
@@ -1,0 +1,262 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product NAT
+// ---------------------------------------------------------------
+
+package nat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: NAT GET /v3/{project_id}/private-nat/transit-ips
+func DataSourcePrivateTransitIps() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePrivateTransitIpsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The region where the transit IPs are located.",
+			},
+			"transit_ip_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the transit IP.",
+			},
+			"ip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The IP address of the transit IP.",
+			},
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the private NAT gateway to which the transit IP belongs.",
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the subnet to which the transit IPs belong.",
+			},
+			"tags": {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "The key/value pairs to associate with the transit IPs.",
+			},
+			"network_interface_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The network interface ID of the transit IP for private NAT.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the enterprise project to which the transit IPs belong.",
+			},
+			"transit_ips": {
+				Type:        schema.TypeList,
+				Elem:        transitIpSchema(),
+				Computed:    true,
+				Description: "The list of the transit IPs.",
+			},
+		},
+	}
+}
+
+func transitIpSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the transit IP.",
+			},
+			"ip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IP address of the transit IP",
+			},
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the private NAT gateway to which the transit IP belongs.",
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the subnet to which the transit IP belongs.",
+			},
+			"tags": {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: "The key/value pairs to associate the transit IPs used for filter.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the transit IP.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the transit IP.",
+			},
+			"network_interface_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The network interface ID of the transit IP for private NAT.",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the enterprise project to which the transit IP belongs.",
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourcePrivateTransitIpsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// listTransitIps: Query the transit IP list
+	var (
+		listTransitIpsHttpUrl = "v3/{project_id}/private-nat/transit-ips"
+		listTransitIpsProduct = "nat"
+	)
+	listTransitIpsClient, err := cfg.NewServiceClient(listTransitIpsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating NAT client: %s", err)
+	}
+
+	listTransitIpsPath := listTransitIpsClient.Endpoint + listTransitIpsHttpUrl
+	listTransitIpsPath = strings.ReplaceAll(listTransitIpsPath, "{project_id}", listTransitIpsClient.ProjectID)
+
+	listTransitIpsQueryParams := buildListTransitIpsQueryParams(d, cfg)
+	listTransitIpsPath += listTransitIpsQueryParams
+
+	listTransitIpsResp, err := pagination.ListAllItems(
+		listTransitIpsClient,
+		"marker",
+		listTransitIpsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving transit IPs")
+	}
+
+	listTransitIpsRespJson, err := json.Marshal(listTransitIpsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listTransitIpsRespBody interface{}
+	err = json.Unmarshal(listTransitIpsRespJson, &listTransitIpsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	curJson := utils.PathSearch("transit_ips", listTransitIpsRespBody, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("transit_ips", flattenListTransitIpsResponseBody(filterListTransitIpsResponseBody(curArray, d))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListTransitIpsResponseBody(resp []interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"id":                    utils.PathSearch("id", v, nil),
+			"ip_address":            utils.PathSearch("ip_address", v, nil),
+			"subnet_id":             utils.PathSearch("virsubnet_id", v, nil),
+			"gateway_id":            utils.PathSearch("gateway_id", v, nil),
+			"tags":                  utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
+			"created_at":            utils.PathSearch("created_at", v, nil),
+			"updated_at":            utils.PathSearch("updated_at", v, nil),
+			"network_interface_id":  utils.PathSearch("network_interface_id", v, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterListTransitIpsResponseBody(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	tagFilter := d.Get("tags").(map[string]interface{})
+	if len(tagFilter) == 0 {
+		return all
+	}
+
+	for _, v := range all {
+		tags := utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil))
+		tagmap := utils.ExpandToStringMap(tags)
+		if !utils.HasMapContains(tagmap, tagFilter) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func buildListTransitIpsQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	res := ""
+	epsID := cfg.GetEnterpriseProjectID(d)
+
+	if v, ok := d.GetOk("transit_ip_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("ip_address"); ok {
+		res = fmt.Sprintf("%s&ip_address=%v", res, v)
+	}
+	if v, ok := d.GetOk("subnet_id"); ok {
+		res = fmt.Sprintf("%s&virsubnet_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("gateway_id"); ok {
+		res = fmt.Sprintf("%s&gateway_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("network_interface_id"); ok {
+		res = fmt.Sprintf("%s&network_interface_id=%v", res, v)
+	}
+	if epsID != "" {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsID)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new datasource to query the list of transit ip.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add a new datasource.
1.1 the datasource is used to query the list of transit ip.
1.2 add the datasource documentation (docs/datasource/nat_private_transit_ips).
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_transitlist)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourcePrivateTransitIps_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourcePrivateTransitIps_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePrivateTransitIps_basic
=== PAUSE TestAccDatasourcePrivateTransitIps_basic
=== CONT  TestAccDatasourcePrivateTransitIps_basic
--- PASS: TestAccDatasourcePrivateTransitIps_basic (97.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       97.671s
```
