### PR TITLE
fix(VPCEP): modify the permission field length to solve unit test error

### DIFF
--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
@@ -152,13 +152,13 @@ func testAccVPCEPService_Basic(rName string) string {
 %s
 
 resource "huaweicloud_vpcep_service" "test" {
-  name        = "%s"
-  server_type = "VM"
-  vpc_id      = data.huaweicloud_vpc.myvpc.id
-  port_id     = huaweicloud_compute_instance.ecs.network[0].port
-  approval    = false
-  description = "test description"
-  permissions = ["iam:domain::1234", "iam:domain::5678"]
+  name                     = "%s"
+  server_type              = "VM"
+  vpc_id                   = data.huaweicloud_vpc.myvpc.id
+  port_id                  = huaweicloud_compute_instance.ecs.network[0].port
+  approval                 = false
+  description              = "test description"
+  permissions              = ["iam:domain::6e9dfd5d1124e8d8498dce894923a0dd", "iam:domain::6e9dfd5d1124e8d8498dce894923a0de"]
   organization_permissions = ["organizations:orgPath::1234", "organizations:orgPath::5678"]
 
   port_mapping {
@@ -177,13 +177,13 @@ func testAccVPCEPService_Update(rName string) string {
 %s
 
 resource "huaweicloud_vpcep_service" "test" {
-  name        = "tf-%s"
-  server_type = "VM"
-  vpc_id      = data.huaweicloud_vpc.myvpc.id
-  port_id     = huaweicloud_compute_instance.ecs.network[0].port
-  approval    = true
-  description = "test description update"
-  permissions = ["*"]
+  name                     = "tf-%s"
+  server_type              = "VM"
+  vpc_id                   = data.huaweicloud_vpc.myvpc.id
+  port_id                  = huaweicloud_compute_instance.ecs.network[0].port
+  approval                 = true
+  description              = "test description update"
+  permissions              = ["*"]
   organization_permissions = ["organizations:orgPath::*"]
 
   port_mapping {
@@ -209,7 +209,7 @@ resource "huaweicloud_vpcep_service" "test" {
   approval      = false
   description   = "test description"
   enable_policy = true
-  permissions   = ["iam:domain::1234", "iam:domain::5678"]
+  permissions   = ["iam:domain::6e9dfd5d1124e8d8498dce894923a0dd", "iam:domain::6e9dfd5d1124e8d8498dce894923a0de"]
 
   port_mapping {
     service_port  = 8080


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

The length check of the "permissions" field is added  to the interface, modify unit test cases synchronously. 
before fixing：
  permissions = ["iam:domain::1234", "iam:domain::5678"]
after modification：
permissions              = ["iam:domain::6e9dfd5d1124e8d8498dce894923a0dd", "iam:domain::6e9dfd5d1124e8d8498dce894923a0de"]




**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

 make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEPService_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEPService_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEPService_Basic
=== PAUSE TestAccVPCEPService_Basic
=== CONT  TestAccVPCEPService_Basic
--- PASS: TestAccVPCEPService_Basic (252.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     252.124s
