### PR TITLE
feat(cbr/backup): support the share accepter resource

### DIFF
--- a/docs/resources/cbr_backup_share_accepter.md
+++ b/docs/resources/cbr_backup_share_accepter.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# huaweicloud_cbr_backup_share_accepter
+
+Using this resource to accept a shared backup within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "backup_id" {}
+variable "stored_vault_id" {}
+
+resource "huaweicloud_cbr_backup_share_accepter" "test" {
+  backup_id = var.backup_id
+  vault_id  = var.stored_vault_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the backup will be stored.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `backup_id` - (Required, String, ForceNew) Specifies the ID of the shared source backup.  
+  Changing this will create a new resource.
+
+* `vault_id` - (Required, String, ForceNew) Specifies the ID of the vault which the backup will be stored.  
+  Changing this will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also backup ID) in UUID format.
+
+* `source_project_id` - The ID of the project to which the source backup belongs.
+
+## Import
+
+Resources can be imported by their `id` or `backup_id`, e.g.
+
+```bash
+$ terraform import huaweicloud_cbr_backup_share_accepter.test <id>
+```

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231218032934-228370eb4498 h1:FaBrNLIsE4JRaL+sufpu29gxrwQUKDFuqdx+sgvG/Pk=
-github.com/chnsz/golangsdk v0.0.0-20231218032934-228370eb4498/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/chnsz/golangsdk v0.0.0-20231225122148-76712b35cbb2 h1:NseVxGzV0xjQna26hfEX7NDePlZjE1v9JxeWu79Pk6A=
 github.com/chnsz/golangsdk v0.0.0-20231225122148-76712b35cbb2/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -775,10 +775,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_instance": bms.ResourceBmsInstance(),
 			"huaweicloud_bcs_instance": resourceBCSInstanceV2(),
 
-			"huaweicloud_cbr_backup_share": cbr.ResourceBackupShare(),
-			"huaweicloud_cbr_checkpoint":   cbr.ResourceCheckpoint(),
-			"huaweicloud_cbr_policy":       cbr.ResourcePolicy(),
-			"huaweicloud_cbr_vault":        cbr.ResourceVault(),
+			"huaweicloud_cbr_backup_share_accepter": cbr.ResourceBackupShareAccepter(),
+			"huaweicloud_cbr_backup_share":          cbr.ResourceBackupShare(),
+			"huaweicloud_cbr_checkpoint":            cbr.ResourceCheckpoint(),
+			"huaweicloud_cbr_policy":                cbr.ResourcePolicy(),
+			"huaweicloud_cbr_vault":                 cbr.ResourceVault(),
 
 			"huaweicloud_cbh_instance": cbh.ResourceCBHInstance(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -175,6 +175,8 @@ var (
 
 	// The ID of the CBR backup
 	HW_IMS_BACKUP_ID = os.Getenv("HW_IMS_BACKUP_ID")
+	// The shared backup ID wants to accept.
+	HW_SHARED_BACKUP_ID = os.Getenv("HW_SHARED_BACKUP_ID")
 
 	// The SecMaster workspace ID
 	HW_SECMASTER_WORKSPACE_ID = os.Getenv("HW_SECMASTER_WORKSPACE_ID")
@@ -840,6 +842,13 @@ func TestAccPreCheckSwrTargetOrigination(t *testing.T) {
 func TestAccPreCheckImsBackupId(t *testing.T) {
 	if HW_IMS_BACKUP_ID == "" {
 		t.Skip("HW_IMS_BACKUP_ID must be set for IMS whole image with CBR backup id")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckAcceptBackup(t *testing.T) {
+	if HW_SHARED_BACKUP_ID == "" {
+		t.Skip("HW_SHARED_BACKUP_ID must be set for CBR backup share acceptance")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_backup_share_accepter_test.go
+++ b/huaweicloud/services/acceptance/cbr/resource_huaweicloud_cbr_backup_share_accepter_test.go
@@ -1,0 +1,78 @@
+package cbr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/backups"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getBackupShareAccepterResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.CbrV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	return backups.Get(client, state.Primary.ID)
+}
+
+func TestAccBackupShareAccepter_basic(t *testing.T) {
+	var (
+		obj          *backups.BackupResp
+		name         = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_cbr_backup_share_accepter.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getBackupShareAccepterResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAcceptBackup(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupShareAccepter_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "backup_id", acceptance.HW_SHARED_BACKUP_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "vault_id", "huaweicloud_cbr_vault.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccBackupShareAccepter_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cbr_vault" "test" {
+  name             = "%[1]s"
+  type             = "server"
+  consistent_level = "crash_consistent"
+  protection_type  = "backup"
+  size             = 100
+}
+
+resource "huaweicloud_cbr_backup_share_accepter" "test" {
+  backup_id = "%[2]s"
+  vault_id  = huaweicloud_cbr_vault.test.id
+}
+`, name, acceptance.HW_SHARED_BACKUP_ID)
+}

--- a/huaweicloud/services/cbr/resource_huaweicloud_cbr_backup_share_accepter.go
+++ b/huaweicloud/services/cbr/resource_huaweicloud_cbr_backup_share_accepter.go
@@ -1,0 +1,131 @@
+package cbr
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/backups"
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/members"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceBackupShareAccepter() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBackupShareAccepterCreate,
+		ReadContext:   resourceBackupShareAccepterRead,
+		DeleteContext: resourceBackupShareAccepterDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the backup will be stored.",
+			},
+			"backup_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the shared source backup.",
+			},
+			"vault_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the vault which the backup will be stored.",
+			},
+			"source_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the project to which the source backup belongs.",
+			},
+		},
+	}
+}
+
+func resourceBackupShareAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.CbrV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	var (
+		backupId = d.Get("backup_id").(string)
+		opts     = members.UpdateOpts{
+			BackupId: backupId,
+			MemberId: client.ProjectID,
+			Status:   "accepted",
+			VaultId:  d.Get("vault_id").(string),
+		}
+	)
+
+	_, err = members.Update(client, opts)
+	if err != nil {
+		return diag.Errorf("error modifying backup share (%s) status: %s", backupId, err)
+	}
+	// Use the backup ID as the ID of this resource.
+	// Note: One backup can only manage one resource.
+	d.SetId(backupId)
+
+	return resourceBackupShareAccepterRead(ctx, d, meta)
+}
+
+func resourceBackupShareAccepterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.CbrV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	resp, err := backups.Get(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "CBR backup share accepter")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("backup_id", resp.ID),
+		d.Set("vault_id", resp.VaultId),
+		d.Set("source_project_id", resp.ProjectId),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving resource fields of the CBR backup share accepter: %s", err)
+	}
+	return nil
+}
+
+func resourceBackupShareAccepterDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.CbrV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	var (
+		backupId = d.Id()
+		opts     = members.UpdateOpts{
+			BackupId: backupId,
+			MemberId: client.ProjectID,
+			Status:   "rejected",
+		}
+	)
+	_, err = members.Update(client, opts)
+	if err != nil {
+		return diag.Errorf("error denying backup share: %s", err)
+	}
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/members/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cbr/v3/members/requests.go
@@ -81,6 +81,42 @@ func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Member, error) {
 	return ExtractMembers(pages)
 }
 
+// UpdateOpts is the structure that used to modify the shared member status.
+type UpdateOpts struct {
+	// Backup ID.
+	BackupId string `json:"-" required:"true"`
+	// Member ID.
+	MemberId string `json:"-" required:"true"`
+	// Status of a shared backup
+	// The valid values are as follows:
+	// + accepted
+	// + pending
+	// + rejected
+	Status string `json:"status" required:"true"`
+	// Vault in which the shared backup is to be stored.
+	// Only UUID is supported.
+	// When updating the status of a backup sharing member:
+	// + If the backup is accepted, vault_id must be specified.
+	// + If the backup is rejected, vault_id is not required.
+	VaultId string `json:"vault_id,omitempty"`
+}
+
+// Update is a method used to modify the specified shared member using given parameters.
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*Member, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r struct {
+		Member Member `json:"member"`
+	}
+	_, err = client.Put(resourceURL(client, opts.BackupId, opts.MemberId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Member, err
+}
+
 // Delete is a method to remove a specified member from the specified backup.
 func Delete(client *golangsdk.ServiceClient, backupId, memberId string) error {
 	_, err := client.Delete(resourceURL(client, backupId, memberId), &golangsdk.RequestOpts{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support  a new resource to accept a shared backup.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support the share accepter resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccBackupShareAccepter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccBackupShareAccepter_basic -timeout 360m -parallel 4
=== RUN   TestAccBackupShareAccepter_basic
=== PAUSE TestAccBackupShareAccepter_basic
=== CONT  TestAccBackupShareAccepter_basic
--- PASS: TestAccBackupShareAccepter_basic (19.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       19.888s
```
