### PR TITLE
feat(dataarts): add resource huaweicloud_dataarts_factory_script

### DIFF
--- a/docs/resources/dataarts_factory_script.md
+++ b/docs/resources/dataarts_factory_script.md
@@ -1,0 +1,109 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_factory_script
+
+Manages DataArts Factory script resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "name" {}
+variable "connection_name" {}
+
+resource "huaweicloud_dataarts_factory_script" "test" {
+  workspace_id    = var.workspace_id
+  name            = var.name
+  type            = "DLISQL"
+  content         = "#content"
+  connection_name = var.connection_name
+  script          = "/"
+  queue_name      = "default"
+  description     = "test"
+  configuration   = {
+    "spark.sql.files.maxRecordsPerFile" = "1"
+    "dli.sql.job.timeout"               = "1"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to manage the script.
+  Changing this creates a new script.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID which the script in.
+  Changing this creates a new script.
+
+* `name` - (Required, String, ForceNew) Specifies the script name. The name contains a maximum of 128 characters,
+  including only letters, numbers, hyphens (-), and periods (.). The script name must be unique. Changing this creates
+  a new script.
+
+* `type` - (Required, String, ForceNew) Specifies the script type. The valid values are: **FlinkSQL**, **DLISQL**,
+  **SparkSQL**, **HiveSQL**, **DWSSQL**, **RDSSQL**, **Shell**, **PRESTO**, **ClickHouseSQL**, **HetuEngineSQL**,
+  **PYTHON**, **ImpalaSQL**. Changing this creates a new script.
+
+* `content` - (Required, String) Specifies the script content. A maximum of 4 MB is supported.
+
+* `connection_name` - (Required, String) Specifies the connection name of script.
+
+* `directory` - (Optional, String) Specifies the directory of script.
+
+* `database` - (Optional, String) Specifies the database of script.
+
+* `queue_name` - (Optional, String) Specifies the queue name of script.
+
+* `description` - (Optional, String) Specifies the description of script.
+
+* `target_status` - (Optional, String) Specifies the target status of script.
+
+* `configuration` - (Optional, Map) Specifies the configuration of script. Only valid key and value can take an effect.
+ if put the invalid key and value in the `configuration` map, it may proceed with an empty `configuration` map.
+
+* `approvers` - (Optional, List) Specifies the approvers of script.
+The [approvers](#approvers) structure is documented below.
+
+  <a name="approvers"></a>
+  The `approvers` block supports:
+* `approver_name` - (Required, String) Specifies the approver name of script.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The DataArts Factory script id. The format of the id is `<workspace_id>/<name>`.
+
+* `auto_acquire_lock` - Whether the resource automatically obtain edit lock parameters.
+
+* `created_by` - The person creating the script.
+
+## Import
+
+DataArts factory script can be imported using `<workspace_id>/<name>`, e.g.
+
+```bash
+terraform import huaweicloud_dataarts_factory_script.test b41a17b18a814b118730a867cecb9952/test
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `approvers`, `target_status`.
+
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dataarts_factory_script" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      approvers, target_status,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1116,6 +1116,7 @@ func Provider() *schema.Provider {
 			// DataArts Factory
 			"huaweicloud_dataarts_factory_resource": dataarts.ResourceFactoryResource(),
 			"huaweicloud_dataarts_factory_job":      dataarts.ResourceFactoryJob(),
+			"huaweicloud_dataarts_factory_script":   dataarts.ResourceDataArtsFactoryScript(),
 			// DataArts Security
 			"huaweicloud_dataarts_security_permission_set":        dataarts.ResourceSecurityPermissionSet(),
 			"huaweicloud_dataarts_security_data_recognition_rule": dataarts.ResourceSecurityRule(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -240,6 +240,7 @@ var (
 	HW_DATAARTS_BUILTIN_RULE_ID         = os.Getenv("HW_DATAARTS_BUILTIN_RULE_ID")
 	HW_DATAARTS_BUILTIN_RULE_NAME       = os.Getenv("HW_DATAARTS_BUILTIN_RULE_NAME")
 	HW_DATAARTS_SUBJECT_ID              = os.Getenv("HW_DATAARTS_SUBJECT_ID")
+	HW_DATAARTS_CONNECTION_NAME         = os.Getenv("HW_DATAARTS_CONNECTION_NAME")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -1080,5 +1081,12 @@ func TestAccPreCheckDataArtsBuiltinRule(t *testing.T) {
 func TestAccPreCheckDataArtsSubjectID(t *testing.T) {
 	if HW_DATAARTS_SUBJECT_ID == "" {
 		t.Skip("HW_DATAARTS_SUBJECT_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDataArtsConnectionName(t *testing.T) {
+	if HW_DATAARTS_CONNECTION_NAME == "" {
+		t.Skip("HW_DATAARTS_CONNECTION_NAME must be set for the acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_script_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_script_test.go
@@ -1,0 +1,174 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getScriptResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	var (
+		getScriptHttpUrl = "v1/{project_id}/scripts/{script_name}"
+		getScriptProduct = "dataarts-dlf"
+	)
+	client, err := cfg.NewServiceClient(getScriptProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts client: %s", err)
+	}
+
+	split := strings.Split(state.Primary.ID, "/")
+	if len(split) != 2 {
+		return nil, fmt.Errorf("error resolving the id: %s", state.Primary.ID)
+	}
+	scriptName := split[1]
+
+	getPath := client.Endpoint + getScriptHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{script_name}", scriptName)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": state.Primary.Attributes["workspace_id"]},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccResourceScript_basic(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_dataarts_factory_script.test"
+	rName := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getScriptResourceFunc,
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsConnectionName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScript_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "DLISQL"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_id",
+						acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(resourceName, "content", "#test"),
+					resource.TestCheckResourceAttr(resourceName, "connection_name",
+						acceptance.HW_DATAARTS_CONNECTION_NAME),
+					resource.TestCheckResourceAttr(resourceName, "directory", "/basic"),
+					resource.TestCheckResourceAttr(resourceName, "queue_name", "default"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.%", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+				),
+			},
+			{
+				Config: testAccScript_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "DLISQL"),
+					resource.TestCheckResourceAttr(resourceName, "workspace_id",
+						acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(resourceName, "content", "#test_update"),
+					resource.TestCheckResourceAttr(resourceName, "connection_name",
+						acceptance.HW_DATAARTS_CONNECTION_NAME),
+					resource.TestCheckResourceAttr(resourceName, "directory", "/update"),
+					resource.TestCheckResourceAttr(resourceName, "queue_name", "update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test_update"),
+					resource.TestCheckResourceAttr(resourceName, "configuration.%", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccResourceScriptImportStateIDFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"approvers", "target_status"},
+			},
+		},
+	})
+}
+
+func testAccScript_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_factory_script" "test" {
+  workspace_id    = "%s"
+  name            = "%s"
+  type            = "DLISQL"
+  content         = "#test"
+  connection_name = "%s"
+  directory       = "/basic"
+  queue_name      = "default"
+  description     = "test"
+  configuration   = {
+    "spark.sql.files.maxRecordsPerFile" = "1"
+  }
+}`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_CONNECTION_NAME)
+}
+
+func testAccScript_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_factory_script" "test" {
+  workspace_id    = "%s"
+  name            = "%s"
+  type            = "DLISQL"
+  content         = "#test_update"
+  connection_name = "%s"
+  directory       = "/update"
+  queue_name      = "update"
+  description     = "test_update"
+  configuration   = {
+    "spark.sql.files.maxRecordsPerFile" = "1"
+    "dli.sql.job.timeout"               = "1"
+  }
+}`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_CONNECTION_NAME)
+}
+
+func testAccResourceScriptImportStateIDFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		workspaceID := rs.Primary.Attributes["workspace_id"]
+		scriptName := rs.Primary.Attributes["name"]
+		if workspaceID == "" || scriptName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want '<workspace_id>/<name>', but got '%s/%s'",
+				workspaceID, scriptName)
+		}
+		return fmt.Sprintf("%s/%s", workspaceID, scriptName), nil
+	}
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_script.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_script.go
@@ -1,0 +1,306 @@
+package dataarts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio POST /v1/{project_id}/scripts
+// API: DataArtsStudio DELETE /v1/{project_id}/scripts/{script_name}
+// API: DataArtsStudio GET /v1/{project_id}/scripts/{script_name}
+// API: DataArtsStudio PUT /v1/{project_id}/scripts/{script_name}
+func ResourceDataArtsFactoryScript() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceScriptCreate,
+		ReadContext:   resourceScriptRead,
+		UpdateContext: resourceScriptUpdate,
+		DeleteContext: resourceScriptDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceScriptImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"connection_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"directory": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"database": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"queue_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// actually not in the GET response
+			"target_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			// actually not in the GET response
+			"approvers": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"approver_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"configuration": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_acquire_lock": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceScriptCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/scripts"
+		product = "dataarts-dlf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody:         utils.RemoveNil(buildCreateOrUpdateScriptBodyParams(d)),
+		OkCodes:          []int{204},
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DataArts script: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", d.Get("workspace_id"), d.Get("name").(string)))
+	return resourceScriptRead(ctx, d, meta)
+}
+
+func resourceScriptRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/{project_id}/scripts/{script_name}"
+		product = "dataarts-dlf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{script_name}", d.Get("name").(string))
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, parseScriptError(err),
+			"error retrieving DataArts script")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("name", utils.PathSearch("name", getRespBody, nil)),
+		d.Set("type", utils.PathSearch("type", getRespBody, nil)),
+		d.Set("content", utils.PathSearch("content", getRespBody, nil)),
+		d.Set("connection_name", utils.PathSearch("connectionName", getRespBody, nil)),
+		d.Set("directory", utils.PathSearch("directory", getRespBody, nil)),
+		d.Set("database", utils.PathSearch("database", getRespBody, nil)),
+		d.Set("queue_name", utils.PathSearch("queueName", getRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getRespBody, nil)),
+		d.Set("target_status", utils.PathSearch("targetStatus", getRespBody, nil)),
+		d.Set("approvers", utils.PathSearch("approvers", getRespBody, nil)),
+		d.Set("configuration", utils.PathSearch("configuration", getRespBody, nil)),
+		d.Set("created_by", utils.PathSearch("createUser", getRespBody, nil)),
+		d.Set("auto_acquire_lock", utils.PathSearch("autoAcquireLock", getRespBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceScriptUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/scripts/{script_name}"
+		product = "dataarts-dlf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{script_name}", d.Get("name").(string))
+
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody:         utils.RemoveNil(buildCreateOrUpdateScriptBodyParams(d)),
+		OkCodes:          []int{204},
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating DataArts script: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", d.Get("workspace_id"), d.Get("name").(string)))
+	return resourceScriptRead(ctx, d, meta)
+}
+
+func resourceScriptDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/scripts/{script_name}"
+		product = "dataarts-dlf"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{script_name}", d.Get("name").(string))
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceScriptImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	partLength := len(parts)
+
+	if partLength == 2 {
+		mErr := multierror.Append(nil,
+			d.Set("workspace_id", parts[0]),
+			d.Set("name", parts[1]),
+		)
+		return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+	}
+	return nil, fmt.Errorf("invalid format specified for import id, must be <workspace_id>/<name>")
+}
+
+func buildCreateOrUpdateScriptBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":           d.Get("name"),
+		"type":           d.Get("type"),
+		"content":        d.Get("content"),
+		"connectionName": d.Get("connection_name"),
+		"directory":      utils.ValueIngoreEmpty(d.Get("directory")),
+		"database":       utils.ValueIngoreEmpty(d.Get("database")),
+		"queueName":      utils.ValueIngoreEmpty(d.Get("queue_name")),
+		"configuration":  utils.ValueIngoreEmpty(d.Get("configuration")),
+		"description":    utils.ValueIngoreEmpty(d.Get("description")),
+		"targetStatus":   utils.ValueIngoreEmpty(d.Get("target_status")),
+		"approvers":      utils.ValueIngoreEmpty(d.Get("approvers")),
+	}
+}
+
+func parseScriptError(err error) error {
+	var errCode golangsdk.ErrDefault400
+	if errors.As(err, &errCode) {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return err
+		}
+		errorCode, errorCodeErr := jmespath.Search("errors|[0].error_code", apiError)
+		if errorCodeErr != nil {
+			return err
+		}
+
+		if errorCode == "DLF.0819" || errorCode == "DLF.6201" {
+			return golangsdk.ErrDefault404(errCode)
+		}
+	}
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource huaweicloud_dataarts_studio_factory_script
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/147232061/22bcfe88-5368-4ffc-9859-5d71ccec9e55)
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/147232061/187befbd-204a-4885-803a-5723c4d387ac)


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourceScript_basic" 
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceScript_basic -timeout 360m -parallel 4 
=== RUN   TestAccResourceScript_basic 
=== PAUSE TestAccResourceScript_basic
=== CONT  TestAccResourceScript_basic
--- PASS: TestAccResourceScript_basic (31.99s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  32.031s
```
