### PR TITLE
fix(EVS): Fixed parameter input error in function Detach and replace function in golangsdk to get response field ’job_id’

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231225075921-588b949b08d9
+	github.com/chnsz/golangsdk v0.0.0-20231225122148-76712b35cbb2
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,10 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231225075921-588b949b08d9 h1:jm7E90rdPgUbkzSGikpF++q7/aGZMKRFvkVXrUsH6z0=
-github.com/chnsz/golangsdk v0.0.0-20231225075921-588b949b08d9/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231218032934-228370eb4498 h1:FaBrNLIsE4JRaL+sufpu29gxrwQUKDFuqdx+sgvG/Pk=
+github.com/chnsz/golangsdk v0.0.0-20231218032934-228370eb4498/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231225122148-76712b35cbb2 h1:NseVxGzV0xjQna26hfEX7NDePlZjE1v9JxeWu79Pk6A=
+github.com/chnsz/golangsdk v0.0.0-20231225122148-76712b35cbb2/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -330,6 +332,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -562,7 +562,7 @@ func resourceEvsVolumeDelete(ctx context.Context, d *schema.ResourceData, meta i
 			opts := block_devices.DetachOpts{
 				ServerId: attachment.ServerID,
 			}
-			job, err := block_devices.Detach(computeClient, attachment.AttachmentID, opts)
+			job, err := block_devices.Detach(computeClient, attachment.VolumeID, opts)
 			if err != nil {
 				return diag.FromErr(err)
 			}

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices/requests.go
@@ -84,7 +84,7 @@ func Detach(c *golangsdk.ServiceClient, volumeId string, opts DetachOpts) (*jobs
 	url += query.String()
 
 	var r jobs.Job
-	_, err = c.DeleteWithBody(url, &r, &golangsdk.RequestOpts{
+	_, err = c.DeleteWithResponse(url, &r, &golangsdk.RequestOpts{
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
 	return &r, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231225075921-588b949b08d9
+# github.com/chnsz/golangsdk v0.0.0-20231225122148-76712b35cbb2
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
…oudserver and replace function in golangsdk to get response field ’job_id’

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
+ The field 'volume_id' should be passed in the function Detach when detach a cloudvolume, not 'attachment_id'.
+ The function ‘DeleteWithBody‘’ called in the Detach method in golangsdk cannot return the response body with the parameter 'job_id', so it is replaced by the 'DeleteWithResponse' method.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeVolumeAttach_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeVolumeAttach_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeVolumeAttach_basic
=== PAUSE TestAccComputeVolumeAttach_basic
=== CONT  TestAccComputeVolumeAttach_basic
--- PASS: TestAccComputeVolumeAttach_basic (221.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       221.185s
```
