### PR TITLE
feat(DataArts): add dataarts data standard template optionals data source

### DIFF
--- a/docs/data-sources/dataarts_architecture_ds_template_optionals.md
+++ b/docs/data-sources/dataarts_architecture_ds_template_optionals.md
@@ -1,0 +1,54 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_architecture_ds_template_optionals
+
+Use this data source to get the list of DataArts Architecture data standard template optionals.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_architecture_ds_template_optionals" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID of DataArts Architecture.
+
+* `fd_name` - (Optional, String) Specifies the name of the optional field.
+
+* `required` - (Optional, Bool) Specifies whether the field is required. Defaults to **false**.
+
+* `searchable` - (Optional, Bool) Specifies whether the field is search supported. Defaults to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `optional_fields` - Indicates the list of DataArts Architecture data standard template optional fields.
+  The [optional_fields](#TemplateOptionalFields_OptionalField) structure is documented below.
+
+<a name="TemplateOptionalFields_OptionalField"></a>
+The `optional_fields` block supports:
+
+* `fd_name` - Indicates the name of the optional field.
+
+* `description` - Indicates the description of the field.
+
+* `description_en` - Indicates the English description of the field.
+
+* `required` - Indicates whether the field is required.
+
+* `searchable` - Indicates whether the field is search supported.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -443,7 +443,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_csms_secret_version": dew.DataSourceDewCsmsSecret(),
 			"huaweicloud_css_flavors":         css.DataSourceCssFlavors(),
 
-			"huaweicloud_dataarts_studio_workspaces": dataarts.DataSourceDataArtsStudioWorkspaces(),
+			"huaweicloud_dataarts_studio_workspaces":                  dataarts.DataSourceDataArtsStudioWorkspaces(),
+			"huaweicloud_dataarts_architecture_ds_template_optionals": dataarts.DataSourceTemplateOptionalFields(),
 
 			"huaweicloud_dbss_flavors": dbss.DataSourceDbssFlavors(),
 

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_ds_template_optionals_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_architecture_ds_template_optionals_test.go
@@ -1,0 +1,90 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceTemplateOptionalFields_basic(t *testing.T) {
+	rName := "data.huaweicloud_dataarts_architecture_ds_template_optionals.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceTemplateOptionalFields_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "optional_fields.0.fd_name"),
+					resource.TestCheckResourceAttrSet(rName, "optional_fields.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "optional_fields.0.description_en"),
+					resource.TestCheckResourceAttrSet(rName, "optional_fields.0.required"),
+					resource.TestCheckResourceAttrSet(rName, "optional_fields.0.searchable"),
+
+					resource.TestCheckOutput("fd_name_filter_is_useful", "true"),
+					resource.TestCheckOutput("required_filter_is_useful", "true"),
+					resource.TestCheckOutput("searchable_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceTemplateOptionalFields_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_architecture_ds_template_optionals" "test" {
+  workspace_id = "%[1]s"
+}
+
+data "huaweicloud_dataarts_architecture_ds_template_optionals" "fd_name_filter" {
+  workspace_id = "%[1]s"
+  fd_name      = data.huaweicloud_dataarts_architecture_ds_template_optionals.test.optional_fields.0.fd_name
+}
+locals{
+  fd_name = data.huaweicloud_dataarts_architecture_ds_template_optionals.test.optional_fields.0.fd_name
+}
+output "fd_name_filter_is_useful" {
+  value = length(data.huaweicloud_dataarts_architecture_ds_template_optionals.fd_name_filter.optional_fields) > 0 && alltrue(
+    [for v in data.huaweicloud_dataarts_architecture_ds_template_optionals.fd_name_filter.optional_fields[*].fd_name : 
+    v == local.fd_name]
+  )  
+}
+
+data "huaweicloud_dataarts_architecture_ds_template_optionals" "required_filter" {
+  workspace_id = "%[1]s"
+  required     = data.huaweicloud_dataarts_architecture_ds_template_optionals.test.optional_fields.0.required
+}
+locals{
+  required = data.huaweicloud_dataarts_architecture_ds_template_optionals.test.optional_fields.0.required
+}
+output "required_filter_is_useful" {
+  value = length(data.huaweicloud_dataarts_architecture_ds_template_optionals.required_filter.optional_fields) > 0 && alltrue(
+    [for v in data.huaweicloud_dataarts_architecture_ds_template_optionals.required_filter.optional_fields[*].required : 
+    v == local.required]
+  )  
+}
+
+data "huaweicloud_dataarts_architecture_ds_template_optionals" "searchable_filter" {
+  workspace_id = "%[1]s"
+  searchable   = data.huaweicloud_dataarts_architecture_ds_template_optionals.test.optional_fields.0.searchable
+}
+locals{
+  searchable = data.huaweicloud_dataarts_architecture_ds_template_optionals.test.optional_fields.0.searchable
+}
+output "searchable_filter_is_useful" {
+  value = length(data.huaweicloud_dataarts_architecture_ds_template_optionals.searchable_filter.optional_fields) > 0 && alltrue(
+    [for v in data.huaweicloud_dataarts_architecture_ds_template_optionals.searchable_filter.optional_fields[*].searchable : 
+    v == local.searchable]
+  )  
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_ds_template_optionals.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_architecture_ds_template_optionals.go
@@ -1,0 +1,189 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DataArts
+// ---------------------------------------------------------------
+
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio GET /v2/{project_id}/design/standards/templates
+func DataSourceTemplateOptionalFields() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceTemplateOptionalFieldsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the workspace ID of DataArts Architecture.`,
+			},
+			"fd_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the optional field.`,
+			},
+			"required": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether the field is required.`,
+			},
+			"searchable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether the field is search supported.`,
+			},
+			"optional_fields": {
+				Type:        schema.TypeList,
+				Elem:        templateOptionalFieldsOptionalFieldSchema(),
+				Computed:    true,
+				Description: `Indicates the list of DataArts Architecture data standard template optional fields.`,
+			},
+		},
+	}
+}
+
+func templateOptionalFieldsOptionalFieldSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"fd_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the name of the field.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the description of the field.`,
+			},
+			"description_en": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the English description of the field.`,
+			},
+			"required": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the field is required.`,
+			},
+			"searchable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the field is search supported.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceTemplateOptionalFieldsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getTemplateOptionalFields: Query the List of DataArts Architecture data standard template optional fields
+	var (
+		getTemplateOptionalFieldsHttpUrl = "v2/{project_id}/design/standards/templates"
+		getTemplateOptionalFieldsProduct = "dataarts"
+	)
+	getTemplateOptionalFieldsClient, err := cfg.NewServiceClient(getTemplateOptionalFieldsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getTemplateOptionalFieldsPath := getTemplateOptionalFieldsClient.Endpoint + getTemplateOptionalFieldsHttpUrl
+	getTemplateOptionalFieldsPath = strings.ReplaceAll(getTemplateOptionalFieldsPath, "{project_id}",
+		getTemplateOptionalFieldsClient.ProjectID)
+
+	getTemplateFieldsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+
+	getTemplateOptionalFieldsResp, err := getTemplateOptionalFieldsClient.Request("GET",
+		getTemplateOptionalFieldsPath, &getTemplateFieldsOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DataArts Architecture data standard template optional fields")
+	}
+
+	getTemplateOptionalFieldsRespBody, err := utils.FlattenResponse(getTemplateOptionalFieldsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("optional_fields", filterGetTemplateOptionalFieldsResponseBodyOptional(
+			flattenGetTemplateOptionalFieldsResponseBodyOptional(getTemplateOptionalFieldsRespBody), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenGetTemplateOptionalFieldsResponseBodyOptional(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("data.value.preFields_optional", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"fd_name":        utils.PathSearch("fd_name", v, nil),
+			"description":    utils.PathSearch("description", v, nil),
+			"description_en": utils.PathSearch("descriptionEn", v, nil),
+			"required":       utils.PathSearch("required", v, nil),
+			"searchable":     utils.PathSearch("searchable", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterGetTemplateOptionalFieldsResponseBodyOptional(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	rawRequired, _ := d.GetOk("required")
+	rawSearchable, _ := d.GetOk("searchable")
+	for _, v := range all {
+		if param, ok := d.GetOk("fd_name"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("fd_name", v, nil)) {
+			continue
+		}
+		if fmt.Sprint(rawRequired) != fmt.Sprint(utils.PathSearch("required", v, nil)) {
+			continue
+		}
+		if fmt.Sprint(rawSearchable) != fmt.Sprint(utils.PathSearch("searchable", v, nil)) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add dataarts data standard template optionals data  source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add dataarts data standard template optionals data source
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dataarts/ TESTARGS='-run TestAccDatasourceTemplateOptionals_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts/ -v -run TestAccDatasourceTemplateOptionals_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceTemplateOptionals_basic
=== PAUSE TestAccDatasourceTemplateOptionals_basic
=== CONT  TestAccDatasourceTemplateOptionals_basic
--- PASS: TestAccDatasourceTemplateOptionals_basic (20.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  20.439s
```
