### PR TITLE
feat(dataarts): add dataarts architecture reviewer resource

### DIFF
--- a/docs/resources/dataarts_architecture_reviewer.md
+++ b/docs/resources/dataarts_architecture_reviewer.md
@@ -1,0 +1,84 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_studio_architecture_reviewer
+
+Manages DataArts Studio architecture reviewer resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "user_name" {}
+variable "user_id" {}
+variable "email" {}
+variable "phone_number" {}
+
+resource "huaweicloud_dataarts_studio_architecture_reviewer" "test" {
+  workspace_id = var.workspace_id
+  user_name    = var.user_name
+  user_id      = var.user_id
+  email        = var.email
+  phone_number = var.phone_number
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the architecture reviewer resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID to which the architecture reviewer belongs.
+ Changing this parameter will create a new resource.
+
+* `user_name` - (Required, String, ForceNew) Specifies the user name of the architecture reviewer.
+ Changing this parameter will create a new resource.
+
+* `user_id` - (Required, String, ForceNew) Specifies the user ID of the architecture reviewer.
+ Changing this parameter will create a new resource.
+
+* `email` - (Optional, String, ForceNew) Specifies the email of the architecture reviewer.
+ Changing this parameter will create a new resource.
+
+* `phone_number` - (Optional, String, ForceNew) Specifies the phone number of the architecture reviewer.
+ Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, the value is the `user_name`.
+
+* `reviewer_id` - The ID of the reviewer.
+
+## Import
+
+The DataArts architecture reviewer can be imported using the `workspace_id` and `user_name` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_architecture_reviewer.test <workspace_id>/<user_name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `email` and `phone_number`.
+It is generally recommended running `terraform plan` after importing an instance.
+You can then decide if changes should be applied to the instance, or the resource definition should be updated to
+align with the instance. Also you can ignore changes as below.
+
+```
+resource "huaweicloud_dataarts_studio_architecture_reviewer" "test"{
+    ...
+
+  data {
+    value {
+      records = [
+        email, phone_number,
+      ]
+    }
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1122,6 +1122,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_code_table":             dataarts.ResourceArchitectureCodeTable(),
 			"huaweicloud_dataarts_architecture_data_standard":          dataarts.ResourceDataStandard(),
 			"huaweicloud_dataarts_architecture_data_standard_template": dataarts.ResourceDataStandardTemplate(),
+			"huaweicloud_dataarts_architecture_reviewer":               dataarts.ResourceDataArtsArchitectureReviewer(),
 			// DataArts Factory
 			"huaweicloud_dataarts_factory_resource": dataarts.ResourceFactoryResource(),
 			"huaweicloud_dataarts_factory_job":      dataarts.ResourceFactoryJob(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -245,6 +245,8 @@ var (
 	HW_DATAARTS_BUILTIN_RULE_NAME       = os.Getenv("HW_DATAARTS_BUILTIN_RULE_NAME")
 	HW_DATAARTS_SUBJECT_ID              = os.Getenv("HW_DATAARTS_SUBJECT_ID")
 	HW_DATAARTS_CONNECTION_NAME         = os.Getenv("HW_DATAARTS_CONNECTION_NAME")
+	HW_DATAARTS_ARCHITECTURE_USER_ID    = os.Getenv("HW_DATAARTS_ARCHITECTURE_USER_ID")
+	HW_DATAARTS_ARCHITECTURE_USER_NAME  = os.Getenv("HW_DATAARTS_ARCHITECTURE_USER_NAME")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -1106,5 +1108,12 @@ func TestAccPreCheckDataArtsSubjectID(t *testing.T) {
 func TestAccPreCheckDataArtsConnectionName(t *testing.T) {
 	if HW_DATAARTS_CONNECTION_NAME == "" {
 		t.Skip("HW_DATAARTS_CONNECTION_NAME must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDataArtsArchitectureReviewer(t *testing.T) {
+	if HW_DATAARTS_ARCHITECTURE_USER_ID == "" || HW_DATAARTS_ARCHITECTURE_USER_NAME == "" {
+		t.Skip("HW_DATAARTS_ARCHITECTURE_USER_ID and HW_DATAARTS_ARCHITECTURE_USER_NAME must be set for the acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_reviewer_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_reviewer_test.go
@@ -1,0 +1,132 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getArchitectureReviewerResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/design/approvals/users?approver_name={user_name}"
+		product = "dataarts"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{user_name}", state.Primary.ID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": state.Primary.Attributes["workspace_id"]},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DataArts Architecture reviewer: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	jsonPaths := "data.value.records"
+	reviewers := utils.PathSearch(jsonPaths, getRespBody, make([]interface{}, 0)).([]interface{})
+	if len(reviewers) > 0 {
+		return reviewers, nil
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func TestAccResourceArchitectureReviewer_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_dataarts_architecture_reviewer.test"
+	)
+	workspaceId := acceptance.HW_DATAARTS_WORKSPACE_ID
+	userId := acceptance.HW_DATAARTS_ARCHITECTURE_USER_ID
+	userName := acceptance.HW_DATAARTS_ARCHITECTURE_USER_NAME
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getArchitectureReviewerResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsArchitectureReviewer(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArchitectureReviewer_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "workspace_id", workspaceId),
+					resource.TestCheckResourceAttr(resourceName, "user_id", userId),
+					resource.TestCheckResourceAttr(resourceName, "user_name", userName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"email", "phone_number",
+				},
+				ImportStateIdFunc: testAccResourceArchitectureReviewerImportFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccArchitectureReviewer_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_reviewer" "test" {
+  workspace_id = "%s"
+  user_id      = "%s"
+  user_name    = "%s"
+  email        = "test@example.com"
+  phone_number = "12345678901"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_ARCHITECTURE_USER_ID, acceptance.HW_DATAARTS_ARCHITECTURE_USER_NAME)
+}
+
+func testAccResourceArchitectureReviewerImportFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		workspaceID := rs.Primary.Attributes["workspace_id"]
+		userName := rs.Primary.ID
+		if workspaceID == "" || userName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want '<workspace_id>/<id>', but got '%s/%s'",
+				workspaceID, userName)
+		}
+		return fmt.Sprintf("%s/%s", workspaceID, userName), nil
+	}
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_reviewer.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_reviewer.go
@@ -1,0 +1,205 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio POST v2/{project_id}/design/approvals/users
+// API: DataArtsStudio GET v2/{project_id}/design/approvals/users
+// API: DataArtsStudio DELETE v2/{project_id}/design/approvals/users
+func ResourceDataArtsArchitectureReviewer() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceArchitectureReviewerCreate,
+		ReadContext:   resourceArchitectureReviewerRead,
+		DeleteContext: resourceArchitectureReviewerDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceArchitectureReviewerImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"phone_number": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"reviewer_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceArchitectureReviewerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	createReviewerHttpUrl := "v2/{project_id}/design/approvals/users"
+	createReviewerProduct := "dataarts"
+
+	reviewerClient, err := cfg.NewServiceClient(createReviewerProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio Client: %s", err)
+	}
+	createReviewerPath := reviewerClient.Endpoint + createReviewerHttpUrl
+	createReviewerPath = strings.ReplaceAll(createReviewerPath, "{project_id}", reviewerClient.ProjectID)
+	createReviewerOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+	createReviewerOpt.JSONBody = utils.RemoveNil(buildCreateReviewerParams(d))
+	createReviewerResp, err := reviewerClient.Request("POST", createReviewerPath, &createReviewerOpt)
+	if err != nil {
+		return diag.Errorf("DataArts Studio architecture reviewer: %s", err)
+	}
+	createReviewerBody, err := utils.FlattenResponse(createReviewerResp)
+	reviewer := utils.PathSearch("data.value", createReviewerBody, nil)
+	userName, err := jmespath.Search("user_name", reviewer)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio architecture Reviewer: %s is not found in API response", "user_name")
+	}
+	d.SetId(userName.(string))
+
+	return resourceArchitectureReviewerRead(ctx, d, meta)
+}
+
+func buildCreateReviewerParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"approver_name": d.Get("user_name"),
+		"user_id":       d.Get("user_id"),
+		"email":         utils.ValueIngoreEmpty(d.Get("email")),
+		"phone_number":  utils.ValueIngoreEmpty(d.Get("phone_number")),
+		"email_notify":  checkBoolValueIgnoreEmpty(d, "email"),
+		"sms_notify":    checkBoolValueIgnoreEmpty(d, "phone_number"),
+	}
+	return bodyParams
+}
+
+func checkBoolValueIgnoreEmpty(d *schema.ResourceData, key string) interface{} {
+	_, ok := d.GetOk(key)
+	return ok
+}
+
+func resourceArchitectureReviewerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	workspaceID := d.Get("workspace_id").(string)
+
+	getArchitectureReviewerHttpUrl := "v2/{project_id}/design/approvals/users?approver_name={user_name}"
+	getArchitectureReviewerProduct := "dataarts"
+
+	getArchitectureReviewerClient, err := cfg.NewServiceClient(getArchitectureReviewerProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getArchitectureReviewerPath := getArchitectureReviewerClient.Endpoint + getArchitectureReviewerHttpUrl
+	getArchitectureReviewerPath = strings.ReplaceAll(getArchitectureReviewerPath, "{project_id}", getArchitectureReviewerClient.ProjectID)
+	getArchitectureReviewerPath = strings.ReplaceAll(getArchitectureReviewerPath, "{user_name}", d.Id())
+
+	getArchitectureReviewerOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	getArchitectureReviewerResp, err := getArchitectureReviewerClient.Request("GET", getArchitectureReviewerPath, &getArchitectureReviewerOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "DataArts Studio architecture reviewer")
+	}
+
+	getArchitectureReviewerRespBody, err := utils.FlattenResponse(getArchitectureReviewerResp)
+	jsonPaths := "data.value.records"
+	reviewers := utils.PathSearch(jsonPaths, getArchitectureReviewerRespBody, make([]interface{}, 0)).([]interface{})
+	if len(reviewers) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "DataArts Studio architecture reviewer")
+	}
+
+	reviewer := reviewers[0]
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("user_name", utils.PathSearch("approver_name", reviewer, nil)),
+		d.Set("user_id", utils.PathSearch("user_id", reviewer, nil)),
+		d.Set("reviewer_id", utils.PathSearch("id", reviewer, nil)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting DataArts Studio reviewer fields: %s", err)
+	}
+
+	return nil
+}
+
+func resourceArchitectureReviewerDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	reviewerProduct := "dataarts"
+	reviewerClient, err := cfg.NewServiceClient(reviewerProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio Client: %s", err)
+	}
+	delReviewerHttpUrl := "v2/{project_id}/design/approvals/users?approver_ids={reviewer_id}"
+	delReviewerPath := reviewerClient.Endpoint + delReviewerHttpUrl
+	delReviewerPath = strings.ReplaceAll(delReviewerPath, "{project_id}", reviewerClient.ProjectID)
+	delReviewerPath = strings.ReplaceAll(delReviewerPath, "{reviewer_id}", d.Get("reviewer_id").(string))
+
+	workspaceID := d.Get("workspace_id").(string)
+	delReviewerOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceID},
+	}
+	_, err = reviewerClient.Request("DELETE", delReviewerPath, &delReviewerOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "DataArts Studio architecture reviewer")
+	}
+	return nil
+}
+
+func resourceArchitectureReviewerImport(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format of import ID, must be <workspace_id>/<user_name>")
+	}
+	d.Set("workspace_id", parts[0])
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: add dataarts architecture reviewer resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourceArchitectureReviewer_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceArchitectureReviewer_builtin -timeout 360m -parallel 4
=== RUN   TestAccResourceArchitectureReviewer_builtin
=== PAUSE TestAccResourceArchitectureReviewer_builtin
=== CONT  TestAccResourceArchitectureReviewer_builtin
--- PASS: TestAccResourceArchitectureReviewer_builtin (14.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  14.536s
```
