### PR TITLE
feat(SFS): add resource sfs turbo perm rule

### DIFF
--- a/docs/resources/sfs_turbo_perm_rule.md
+++ b/docs/resources/sfs_turbo_perm_rule.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Scalable File Service (SFS)"
+---
+
+# huaweicloud_sfs_turbo_perm_rule
+
+Provides a Shared File System (SFS) Turbo permission rule resource.
+
+## Example Usage
+
+```hcl
+variable "share_id" {}
+
+resource "huaweicloud_sfs_turbo_perm_rule" "test" {
+  share_id  = var.share_id
+  ip_cidr   = "192.168.0.0/16"
+  rw_type   = "rw"
+  user_type = "no_root_squash"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the SFS Turbo permission rule resource.
+  If omitted, the provider-level region will be used. Changing this creates a new SFS Turbo permission rule resource.
+
+* `share_id` - (Required, String, ForceNew) Specifies the SFS Turbo ID. Changing this will create a new resource.
+
+* `ip_cidr` - (Required, String, ForceNew) Specifies the IP address or IP address range of the object to be authorized.
+  Changing this will create a new SFS Turbo permission rule resource.
+
+* `rw_type` - (Required, String) Specifies the read/write permission of the object to be authorized.
+  The value can be **rw** (read and write permission) or **ro** (read only permission).
+
+* `user_type` - (Required, String) Specifies the file system access permission granted to the user of the object to be
+  authorized. The value can be **no_root_squash**, **root_squash** or **all_squash**.
+  + **no_root_squash** allows the root user on the client to access the file system as **root**.
+  + **root_squash** allows the root user on the client to access the file system as **nfsnobody**.
+  + **all_squash** allows any user on the client to access the file system as **nfsnobody**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1198,6 +1198,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_sfs_turbo":           sfs.ResourceSFSTurbo(),
 			"huaweicloud_sfs_turbo_dir":       sfs.ResourceSfsTurboDir(),
 			"huaweicloud_sfs_turbo_dir_quota": sfs.ResourceSfsTurboDirQuota(),
+			"huaweicloud_sfs_turbo_perm_rule": sfs.ResourceSFSTurboPermRule(),
 
 			"huaweicloud_smn_topic":            smn.ResourceTopic(),
 			"huaweicloud_smn_subscription":     smn.ResourceSubscription(),

--- a/huaweicloud/services/acceptance/sfs/resource_huaweicloud_sfs_turbo_perm_rule_test.go
+++ b/huaweicloud/services/acceptance/sfs/resource_huaweicloud_sfs_turbo_perm_rule_test.go
@@ -1,0 +1,105 @@
+package sfs
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func sfsTurboPermRuleReadfunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/perm-rules/{rule_id}"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	getPath := sfsClient.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", sfsClient.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{share_id}", state.Primary.Attributes["share_id"])
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := sfsClient.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving SFS Turbo permission rule %s", err)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccSFSTruboPermRule_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_sfs_turbo_perm_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		sfsTurboPermRuleReadfunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSFSTruboPermRuleBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "ip_cidr", "192.168.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "rw_type", "rw"),
+					resource.TestCheckResourceAttr(resourceName, "user_type", "no_root_squash"),
+				),
+			},
+			{
+				Config: testSFSTruboPermRuleUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "rw_type", "ro"),
+					resource.TestCheckResourceAttr(resourceName, "user_type", "root_squash"),
+				),
+			},
+		},
+	})
+}
+
+func testSFSTruboPermRuleBasic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_sfs_turbo_perm_rule" "test" {
+  share_id  = huaweicloud_sfs_turbo.test.id
+  ip_cidr   = "192.168.0.0/16"
+  rw_type   = "rw"
+  user_type = "no_root_squash"
+}
+`, testAccSFSTurbo_basic(rName))
+}
+
+func testSFSTruboPermRuleUpdate(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_sfs_turbo_perm_rule" "test" {
+  share_id  = huaweicloud_sfs_turbo.test.id
+  ip_cidr   = "192.168.0.0/16"
+  rw_type   = "ro"
+  user_type = "root_squash"
+}
+`, testAccSFSTurbo_basic(rName))
+}

--- a/huaweicloud/services/sfs/resource_huaweicloud_sfs_turbo_perm_rule.go
+++ b/huaweicloud/services/sfs/resource_huaweicloud_sfs_turbo_perm_rule.go
@@ -1,0 +1,245 @@
+package sfs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: SFSTurbo POST /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/perm-rules
+// API: SFSTurbo GET /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/perm-rules/{rule_id}
+// API: SFSTurbo PUT /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/perm-rules/{rule_id}
+// API: SFSTurbo DELETE /v1/{project_id}/sfs-turbo/shares/{share_id}/fs/perm-rules/{rule_id}
+func ResourceSFSTurboPermRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSFSTurboPermRuleCreate,
+		ReadContext:   resourceSFSTurboPermRuleRead,
+		UpdateContext: resourceSFSTurboPermRuleUpdate,
+		DeleteContext: resourceSFSTurboPermRuleDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"share_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ip_cidr": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"rw_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"user_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func buildCreateSFSTurboPermRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"rules": buildPermRuleListBodyParam(d),
+	}
+	return params
+}
+
+func buildPermRuleListBodyParam(d *schema.ResourceData) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"ip_cidr":   d.Get("ip_cidr"),
+			"rw_type":   d.Get("rw_type"),
+			"user_type": d.Get("user_type"),
+		},
+	}
+}
+
+func resourceSFSTurboPermRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/perm-rules"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	createPath := sfsClient.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", sfsClient.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{share_id}", d.Get("share_id").(string))
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateSFSTurboPermRuleBodyParams(d),
+	}
+
+	createResp, err := sfsClient.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating SFS Turbo permission rule: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// When the creation interface is called for the first time, the response body in addition to the permission rules
+	// added by the user, an additional default permission rule will be added.
+	id := utils.PathSearch(fmt.Sprintf("rules[?ip_cidr=='%s'].id|[0]", d.Get("ip_cidr")),
+		createRespBody, "").(string)
+
+	if id == "" {
+		return diag.Errorf("error creating SFS Turbo permission rule:" +
+			" ID is not found in API response")
+	}
+
+	d.SetId(id)
+
+	return resourceSFSTurboPermRuleRead(ctx, d, meta)
+}
+
+func parsePermRuleError(respErr error) error {
+	var apiErr interface{}
+	if errCode, ok := respErr.(golangsdk.ErrDefault400); ok {
+		pErr := json.Unmarshal(errCode.Body, &apiErr)
+		if pErr != nil {
+			return pErr
+		}
+		errCode, err := jmespath.Search(`errCode`, apiErr)
+		if err != nil {
+			return fmt.Errorf("error parsing errorCode from response body: %s", err.Error())
+		}
+
+		if errCode == `SFS.TURBO.0001` {
+			return golangsdk.ErrDefault404{}
+		}
+	}
+
+	return respErr
+}
+
+func resourceSFSTurboPermRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/perm-rules/{rule_id}"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	getPath := sfsClient.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", sfsClient.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{share_id}", d.Get("share_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{rule_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := sfsClient.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, parsePermRuleError(err), "error retrieving SFS Turbo permission rule")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("ip_cidr", utils.PathSearch("ip_cidr", getRespBody, nil)),
+		d.Set("rw_type", utils.PathSearch("rw_type", getRespBody, nil)),
+		d.Set("user_type", utils.PathSearch("user_type", getRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateSFSTurboPermRuleBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"rw_type":   d.Get("rw_type"),
+		"user_type": d.Get("user_type"),
+	}
+
+	return params
+}
+
+func resourceSFSTurboPermRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/perm-rules/{rule_id}"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	updatePath := sfsClient.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", sfsClient.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{share_id}", d.Get("share_id").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{rule_id}", d.Id())
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateSFSTurboPermRuleBodyParams(d),
+	}
+
+	_, err = sfsClient.Request("PUT", updatePath, &updateOpt)
+	if err != nil {
+		return diag.Errorf("error updating SFS Turbo permission rule: %s", err)
+	}
+
+	return resourceSFSTurboPermRuleRead(ctx, d, meta)
+}
+
+func resourceSFSTurboPermRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/sfs-turbo/shares/{share_id}/fs/perm-rules/{rule_id}"
+	)
+	sfsClient, err := cfg.SfsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating SFS v1 client: %s", err)
+	}
+
+	deletePath := sfsClient.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", sfsClient.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{share_id}", d.Get("share_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{rule_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = sfsClient.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting SFS Turbo permission rule: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource sfs turbo perm rule

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
When SFS Turbo does not exist, calling the query API returns a 404 status code. When the SFS Turbo permission rule does not exist, a 400 status code is returned.
```
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/145308253/972b6d91-8b92-42aa-b6ee-ed7713f0b335)

![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/145308253/ad383d41-d73b-4884-bb5b-c12c6b8f47d3)



## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/sfs/' TESTARGS='-run TestAccSFSTruboPermRule_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/sfs/ -v -run TestAccSFSTruboPermRule_basic -timeout 360m -parallel 4 
=== RUN   TestAccSFSTruboPermRule_basic 
=== PAUSE TestAccSFSTruboPermRule_basic
=== CONT  TestAccSFSTruboPermRule_basic
--- PASS: TestAccSFSTruboPermRule_basic (460.08s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfs       460.120s
```
