### PR TITLE
fix(cce): Fix scheme for node taints

### DIFF
--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -389,7 +389,7 @@ The following arguments are supported:
   + `key` - (Required, String, ForceNew) A key must contain 1 to 63 characters starting with a letter or digit.
     Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed. A DNS subdomain name can be used
     as the prefix of a key. Changing this parameter will create a new resource.
-  + `value` - (Required, String, ForceNew) A value must start with a letter or digit and can contain a maximum of 63
+  + `value` - (Optional, String, ForceNew) A value must start with a letter or digit and can contain a maximum of 63
     characters, including letters, digits, hyphens (-), underscores (_), and periods (.). Changing this parameter will
     create a new resource.
   + `effect` - (Required, String, ForceNew) Available options are NoSchedule, PreferNoSchedule, and NoExecute.

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
@@ -104,7 +104,7 @@ func ResourceNode() *schema.Resource {
 						},
 						"value": {
 							Type:     schema.TypeString,
-							Optional:  true,
+							Optional: true,
 							ForceNew: true,
 						},
 						"effect": {

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
@@ -104,7 +104,7 @@ func ResourceNode() *schema.Resource {
 						},
 						"value": {
 							Type:     schema.TypeString,
-							Required: true,
+							Required: false,
 							ForceNew: true,
 						},
 						"effect": {

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
@@ -104,7 +104,7 @@ func ResourceNode() *schema.Resource {
 						},
 						"value": {
 							Type:     schema.TypeString,
-							Required: false,
+							Optional:  true,
 							ForceNew: true,
 						},
 						"effect": {


### PR DESCRIPTION
Disable required attribute for taints.value

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When validating a request to create taints for a node pool, I receive a response from the API with the following content

`a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
`
An empty string can be a valid value, but when validated by the provider I get an error that the value attribute cannot be empty.

I would like to fix this in the scheme since the provider does not allow you to create a taint with a key and an empty value, for example `node-role.kubernetes.io/opensearch=:NoSchedule`


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
