### PR TITLE
feat(EVS): add datasource to query the list of EVS snapshots

### DIFF
--- a/docs/data-sources/evs_snapshots.md
+++ b/docs/data-sources/evs_snapshots.md
@@ -1,0 +1,91 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+---
+
+# huaweicloud_evs_snapshots
+
+Use this data source to get a list of EVS cloudvolume snapshots.
+
+## Example Usage
+
+```hcl
+variable "volume_id" {}
+
+data "huaweicloud_evs_snapshots" "snapshots" {
+  volume_id = var.volume_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to query the WAF dedicated domains.
+  If omitted, the provider-level region will be used.
+  
+* `enterprise_project_id` - (Optional, String) Specify the enterprise project ID to filter.
+  If this field value is not specified, cloudvolume snapshots of all enterprise projects within
+  authority scope will be queried.
+
+* `name` - (Optional, String)  The name of cloudvolume snapshot. Maximum supported is 64 characters.
+
+* `status` - (Optional, String) The status of cloudvolume snapshot. Valid values are as follows:
+  + **creating**: The cloudvolume snapshot is in the process of being created.
+  + **available**: The cloudvolume snapshot is created successfully and can be used.
+  + **error**: An error occurred during the creation process of the cloudvolume snapshot.
+  + **deleting**: The cloudvolume snapshot is in the process of being deleted.
+  + **error_deleting**: An error occurred during the deletion process of the cloudvolume snapshot.
+  + **rollbacking**: The cloudvolume snapshot is in the process of rolling back data.
+  + **backing-up**: The status of the following two snapshots is **backing_up**:
+  The snapshots that can create backup directly through the OpenStack native API.
+  The snapshots created automatically during the process of creating a backup.
+
+* `volume_id` - (Optional, String) The ID of the cloudvolume to which the snapshot belongs.
+
+* `availability_zone` - (Optional, String) The availability zone of the cloudvolume to which the snapshot belongs.
+
+* `snapshot_id` - (Optional, String) Specify the snapshot ID to filter.
+  You can pass in multiple ids to filter the query, for example: id=id1&id=id2&id=id3.
+
+* `dedicated_storage_name` - (Optional, String) The name of the dedicated storage.
+
+* `dedicated_storage_id` - (Optional, String) The ID of the dedicated storage.
+
+* `service_type` - (Optional, String) Service type. Only **EVS**, **DSS**, and **DESS** are supported.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `snapshots` - A list of EVS cloudvolume snapshots.
+
+The `snapshots` block supports:
+
+* `id` - The resource ID of EVS cloudvolume snapshot.
+
+* `name` - The name of cloudvolume snapshot. Maximum supported is 64 characters.
+
+* `size` - The cloudvolume snapshot size. Unit is GiB.
+
+* `status` - The status of cloudvolume snapshot. Valid values are as follows:
+  + **creating**: The cloudvolume snapshot is in the process of being created.
+  + **available**: The cloudvolume snapshot is created successfully and can be used.
+  + **error**: An error occurred during the creation process of the cloudvolume snapshot.
+  + **deleting**: The cloudvolume snapshot is in the process of being deleted.
+  + **error_deleting**: An error occurred during the deletion process of the cloudvolume snapshot.
+  + **rollbacking**: The cloudvolume snapshot is in the process of rolling back data.
+  + **backing-up**: The status of the following two snapshots is **backing_up**:
+  The snapshots that can create backup directly through the OpenStack native API.
+  The snapshots created automatically during the process of creating a backup.
+
+* `description` - The cloudvolume snapshot description information.
+
+* `created_at` - The cloudvolume snapshot creation time.
+
+* `updated_at` - The cloudvolume snapshot update time.
+
+* `volume_id` - The ID of the cloudvolume to which the snapshot belongs.
+
+* `service_type` - Service type. Valid values can be **EVS**, **DSS**, and **DESS**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -485,6 +485,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_er_availability_zones": er.DataSourceAvailabilityZones(),
 
 			"huaweicloud_evs_volumes":      evs.DataSourceEvsVolumesV2(),
+			"huaweicloud_evs_snapshots":    evs.DataSourceEvsSnapshots(),
 			"huaweicloud_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),
 			"huaweicloud_fgs_functions":    fgs.DataSourceFunctionGraphFunctions(),
 

--- a/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_snapshots_test.go
+++ b/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_snapshots_test.go
@@ -1,0 +1,144 @@
+package evs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceEVSsnapshots_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_evs_snapshots.test"
+	epsIDTestName := "data.huaweicloud_evs_snapshots.enterprise_project_id_filter"
+	serviceTypeTestName := "data.huaweicloud_evs_snapshots.service_type_filter"
+	availabilityZoneTestName := "data.huaweicloud_evs_snapshots.availability_zone_filter"
+	dedicatedStorageNameTestName := "data.huaweicloud_evs_snapshots.dedicated_storage_name_filter"
+	dedicatedStorageIDTestName := "data.huaweicloud_evs_snapshots.dedicated_storage_id_filter"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceSnapshots_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "snapshots.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "snapshots.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "snapshots.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "snapshots.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "snapshots.0.size"),
+					resource.TestCheckResourceAttrSet(rName, "snapshots.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "snapshots.0.updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "snapshots.0.volume_id"),
+					resource.TestCheckResourceAttrSet(rName, "snapshots.0.service_type"),
+					resource.TestCheckResourceAttrSet(epsIDTestName, "snapshots.#"),
+					resource.TestCheckResourceAttrSet(serviceTypeTestName, "snapshots.#"),
+					resource.TestCheckResourceAttrSet(availabilityZoneTestName, "snapshots.#"),
+					resource.TestCheckResourceAttrSet(dedicatedStorageNameTestName, "snapshots.#"),
+					resource.TestCheckResourceAttrSet(dedicatedStorageIDTestName, "snapshots.#"),
+
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("volume_id_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("snapshot_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceSnapshots_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_evs_snapshots" "test" {
+  depends_on = [huaweicloud_evs_snapshot.test]
+}
+
+data "huaweicloud_evs_snapshots" "enterprise_project_id_filter" {
+  enterprise_project_id = huaweicloud_evs_volume.test.enterprise_project_id
+}
+
+data "huaweicloud_evs_snapshots" "name_filter" {
+  name = data.huaweicloud_evs_snapshots.test.snapshots.0.name
+}
+
+locals {
+  name = data.huaweicloud_evs_snapshots.test.snapshots.0.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_evs_snapshots.name_filter.snapshots) > 0 && alltrue(
+    [for v in data.huaweicloud_evs_snapshots.name_filter.snapshots[*].name : v == local.name]
+  )  
+}
+
+data "huaweicloud_evs_snapshots" "status_filter" {
+  status = data.huaweicloud_evs_snapshots.test.snapshots.0.status
+}
+
+locals {
+  status = data.huaweicloud_evs_snapshots.test.snapshots.0.status
+}
+
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_evs_snapshots.status_filter.snapshots) > 0 && alltrue(
+    [for v in data.huaweicloud_evs_snapshots.status_filter.snapshots[*].status : v == local.status]
+  )  
+}
+
+data "huaweicloud_evs_snapshots" "volume_id_filter" {
+  volume_id = data.huaweicloud_evs_snapshots.test.snapshots.0.volume_id
+}
+
+locals {
+  volume_id = data.huaweicloud_evs_snapshots.test.snapshots.0.volume_id
+}
+
+output "volume_id_filter_is_useful" {
+  value = length(data.huaweicloud_evs_snapshots.volume_id_filter.snapshots) > 0 && alltrue(
+    [for v in data.huaweicloud_evs_snapshots.volume_id_filter.snapshots[*].volume_id : v == local.volume_id]
+  )  
+}
+
+data "huaweicloud_evs_snapshots" "snapshot_id_filter" {
+  snapshot_id = data.huaweicloud_evs_snapshots.test.snapshots.0.id
+}
+
+locals {
+  snapshot_id = data.huaweicloud_evs_snapshots.test.snapshots.0.id
+}
+
+output "snapshot_id_filter_is_useful" {
+  value = length(data.huaweicloud_evs_snapshots.snapshot_id_filter.snapshots) > 0 && alltrue(
+    [for v in data.huaweicloud_evs_snapshots.snapshot_id_filter.snapshots[*].id : v == local.snapshot_id]
+  )  
+}
+
+data "huaweicloud_evs_snapshots" "service_type_filter" {
+  service_type = "evs"
+}
+
+data "huaweicloud_evs_snapshots" "availability_zone_filter" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
+data "huaweicloud_evs_snapshots" "dedicated_storage_name_filter" {
+  dedicated_storage_name = huaweicloud_evs_volume.test.dedicated_storage_name
+}
+
+data "huaweicloud_evs_snapshots" "dedicated_storage_id_filter" {
+  dedicated_storage_id = huaweicloud_evs_volume.test.dedicated_storage_id
+}
+`, testAccEvsSnapshotV2_basic(name))
+}

--- a/huaweicloud/services/evs/data_source_huaweicloud_evs_snapshots.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evs_snapshots.go
@@ -1,0 +1,232 @@
+package evs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceEvsSnapshots() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceSnapshotsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snapshot_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dedicated_storage_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dedicated_storage_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"service_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snapshots": {
+				Type:     schema.TypeList,
+				Elem:     snapshotSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func snapshotSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceSnapshotsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getEVSSnapshots: Query EVS snapshots
+	var (
+		getEVSSnapshotsHttpUrl = "v2/{project_id}/cloudsnapshots/detail"
+		getEVSSnapshotsProduct = "evs"
+	)
+	getEVSSnapshotsClient, err := cfg.NewServiceClient(getEVSSnapshotsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	getEVSSnapshotsPath := getEVSSnapshotsClient.Endpoint + getEVSSnapshotsHttpUrl
+	getEVSSnapshotsPath = strings.ReplaceAll(getEVSSnapshotsPath, "{project_id}",
+		getEVSSnapshotsClient.ProjectID)
+	getEVSSnapshotsPath += buildEVSSnapshotsQueryParams(d, cfg)
+
+	getEVSSnapshotsResp, err := pagination.ListAllItems(
+		getEVSSnapshotsClient,
+		"offset",
+		getEVSSnapshotsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving snapshots, %s", err)
+	}
+
+	listEVSSnapshotsRespJson, err := json.Marshal(getEVSSnapshotsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listEVSSnapshotsRespBody interface{}
+	err = json.Unmarshal(listEVSSnapshotsRespJson, &listEVSSnapshotsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("snapshots", flattenListSnapshotsBody(listEVSSnapshotsRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildEVSSnapshotsQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	res := ""
+	epsId := cfg.DataGetEnterpriseProjectID(d)
+	if epsId != "" {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsId)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("volume_id"); ok {
+		res = fmt.Sprintf("%s&volume_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("availability_zone"); ok {
+		res = fmt.Sprintf("%s&availability_zone=%v", res, v)
+	}
+	if v, ok := d.GetOk("snapshot_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("dedicated_storage_id"); ok {
+		res = fmt.Sprintf("%s&dedicated_storage_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("dedicated_storage_name"); ok {
+		res = fmt.Sprintf("%s&dedicated_storage_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("service_type"); ok {
+		res = fmt.Sprintf("%s&service_type=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func flattenListSnapshotsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("snapshots", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":           utils.PathSearch("id", v, nil),
+			"name":         utils.PathSearch("name", v, nil),
+			"status":       utils.PathSearch("status", v, nil),
+			"description":  utils.PathSearch("description", v, nil),
+			"size":         utils.PathSearch("size", v, nil),
+			"created_at":   utils.PathSearch("created_at", v, nil),
+			"updated_at":   utils.PathSearch("updated_at", v, nil),
+			"volume_id":    utils.PathSearch("volume_id", v, nil),
+			"service_type": utils.PathSearch("service_type", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccDatasourceEVSsnapshots_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccDatasourceEVSsnapshots_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceEVSsnapshots_basic
=== PAUSE TestAccDatasourceEVSsnapshots_basic
=== CONT  TestAccDatasourceEVSsnapshots_basic
--- PASS: TestAccDatasourceEVSsnapshots_basic (119.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       120.028s
```
