### PR TITLE
feat(dataarts): update resource architecture_reviewer

### DIFF
--- a/docs/resources/dataarts_architecture_reviewer.md
+++ b/docs/resources/dataarts_architecture_reviewer.md
@@ -2,7 +2,7 @@
 subcategory: "DataArts Studio"
 ---
 
-# huaweicloud_dataarts_studio_architecture_reviewer
+# huaweicloud_dataarts_architecture_reviewer
 
 Manages DataArts Studio architecture reviewer resource within HuaweiCloud.
 
@@ -15,7 +15,7 @@ variable "user_id" {}
 variable "email" {}
 variable "phone_number" {}
 
-resource "huaweicloud_dataarts_studio_architecture_reviewer" "test" {
+resource "huaweicloud_dataarts_architecture_reviewer" "test" {
   workspace_id = var.workspace_id
   user_name    = var.user_name
   user_id      = var.user_id
@@ -32,19 +32,19 @@ The following arguments are supported:
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
 * `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID to which the architecture reviewer belongs.
- Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
 * `user_name` - (Required, String, ForceNew) Specifies the user name of the architecture reviewer.
- Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
 * `user_id` - (Required, String, ForceNew) Specifies the user ID of the architecture reviewer.
- Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
 * `email` - (Optional, String, ForceNew) Specifies the email of the architecture reviewer.
- Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
 * `phone_number` - (Optional, String, ForceNew) Specifies the phone number of the architecture reviewer.
- Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
 ## Attribute Reference
 
@@ -65,20 +65,18 @@ $ terraform import huaweicloud_dataarts_architecture_reviewer.test <workspace_id
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason.
 The missing attributes include: `email` and `phone_number`.
-It is generally recommended running `terraform plan` after importing an instance.
-You can then decide if changes should be applied to the instance, or the resource definition should be updated to
-align with the instance. Also you can ignore changes as below.
+It is generally recommended running `terraform plan` after importing a reviewer.
+You can then decide if changes should be applied to the reviewer, or the resource definition should be updated to
+align with the reviewer. Also you can ignore changes as below.
 
 ```
-resource "huaweicloud_dataarts_studio_architecture_reviewer" "test"{
+resource "huaweicloud_dataarts_architecture_reviewer" "test"{
     ...
 
-  data {
-    value {
-      records = [
-        email, phone_number,
-      ]
-    }
+  lifecycle {
+    ignore_changes = [
+      email, phone_number,
+    ]
   }
 }
 ```

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_reviewer_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_reviewer_test.go
@@ -46,13 +46,12 @@ func getArchitectureReviewerResourceFunc(cfg *config.Config, state *terraform.Re
 		return nil, err
 	}
 
-	jsonPaths := "data.value.records"
-	reviewers := utils.PathSearch(jsonPaths, getRespBody, make([]interface{}, 0)).([]interface{})
-	if len(reviewers) > 0 {
-		return reviewers, nil
+	reviewer := utils.PathSearch("data.value.records|[0]", getRespBody, nil)
+	if reviewer == nil {
+		return nil, golangsdk.ErrDefault404{}
 	}
 
-	return nil, golangsdk.ErrDefault404{}
+	return reviewer, nil
 }
 
 func TestAccResourceArchitectureReviewer_basic(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dataarts' TESTARGS='
-run TestAccResourceArchitectureReviewer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceArchitectureReviewer_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceArchitectureReviewer_basic
=== PAUSE TestAccResourceArchitectureReviewer_basic
=== CONT  TestAccResourceArchitectureReviewer_basic
--- PASS: TestAccResourceArchitectureReviewer_basic (18.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  18.217s
```
