### PR TITLE
feat(CC): add a new resource to manage central network attachment

### DIFF
--- a/docs/resources/cc_central_network_attachment.md
+++ b/docs/resources/cc_central_network_attachment.md
@@ -1,0 +1,111 @@
+---
+subcategory: "Cloud Connect (CC)"
+---
+
+# huaweicloud_cc_central_network_attachment
+
+Manages a central network attachment resource of Cloud Connect within HuaweiCloud.
+
+To allow network instances such as enterprise routers and global DC gateways to communicate with each other
+across regions, you need to add these network instances to the central network.
+
+## Example Usage
+
+```hcl
+variable "central_network_id" {}
+variable "enterprise_router_id" {}
+variable "enterprise_router_project_id" {}
+variable "enterprise_router_region_id" {}
+variable "global_dc_gateway_id" {}
+variable "global_dc_gateway_project_id" {}
+variable "global_dc_gateway_region_id" {}
+
+resource "huaweicloud_cc_central_network_attachment" "test" {
+  name                         = "demo"
+  description                  = "This is a demo"
+  central_network_id           = var.central_network_id
+  enterprise_router_id         = var.enterprise_router_id
+  enterprise_router_project_id = var.enterprise_router_project_id
+  enterprise_router_region_id  = var.enterprise_router_region_id
+  global_dc_gateway_id         = var.global_dc_gateway_id
+  global_dc_gateway_project_id = var.global_dc_gateway_project_id
+  global_dc_gateway_region_id  = var.global_dc_gateway_region_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `central_network_id` - (Required, String, ForceNew) The central network ID.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) The name of the attachment.
+
+* `enterprise_router_id` - (Required, String, ForceNew) The enterprise router ID.
+
+  Changing this parameter will create a new resource.
+
+* `enterprise_router_project_id` - (Required, String, ForceNew) The project ID to which the enterprise router belongs.
+
+  Changing this parameter will create a new resource.
+
+* `enterprise_router_region_id` - (Required, String, ForceNew) The region ID to which the enterprise router belongs.
+
+  Changing this parameter will create a new resource.
+
+* `global_dc_gateway_id` - (Required, String, ForceNew) The global DC gateway ID.
+
+  Changing this parameter will create a new resource.
+
+* `global_dc_gateway_project_id` - (Required, String, ForceNew) The project ID to which the global DC gateway belongs.
+
+  Changing this parameter will create a new resource.
+
+* `global_dc_gateway_region_id` - (Required, String, ForceNew) The region ID to which the global DC gateway belongs.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) The description of the attachment.
+
+* `central_network_plane_id` - (Optional, String, ForceNew) The central network plane ID.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `state` - Central network attachment status.
+  The valid values are as follows:
+    - **AVAILABLE**
+    - **CREATING**
+    - **UPDATING**
+    - **DELETING**
+    - **FREEZING**
+    - **UNFREEZING**
+    - **RECOVERING**
+    - **FAILED**
+    - **DELETED**
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `update` - Default is 20 minutes.
+* `delete` - Default is 20 minutes.
+
+## Import
+
+The central network attachment can be imported using `central_network_id`, `id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_cc_central_network_attachment.test <central_network_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -794,6 +794,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cc_central_network":              cc.ResourceCentralNetwork(),
 			"huaweicloud_cc_central_network_policy":       cc.ResourceCentralNetworkPolicy(),
 			"huaweicloud_cc_central_network_policy_apply": cc.ResourceCentralNetworkPolicyApply(),
+			"huaweicloud_cc_central_network_attachment":   cc.ResourceCentralNetworkAttachment(),
 
 			"huaweicloud_cce_cluster":     cce.ResourceCluster(),
 			"huaweicloud_cce_node":        cce.ResourceNode(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -229,6 +229,8 @@ var (
 
 	HW_CCI_NAMESPACE = os.Getenv("HW_CCI_NAMESPACE")
 
+	HW_CC_GLOBAL_GATEWAY_ID = os.Getenv("HW_CC_GLOBAL_GATEWAY_ID")
+
 	HW_CERT_BATCH_PUSH_ID = os.Getenv("HW_CERT_BATCH_PUSH_ID")
 
 	HW_AS_SCALING_GROUP_ID = os.Getenv("HW_AS_SCALING_GROUP_ID")
@@ -1041,6 +1043,13 @@ func TestAccPreCheckCDN(t *testing.T) {
 func TestAccPreCheckCERT(t *testing.T) {
 	if HW_CDN_CERT_PATH == "" || HW_CDN_PRIVATE_KEY_PATH == "" {
 		t.Skip("This environment does not support CDN certificate tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCCGlobalGateway(t *testing.T) {
+	if HW_CC_GLOBAL_GATEWAY_ID == "" {
+		t.Skip("HW_CC_GLOBAL_GATEWAY_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_central_network_attachment_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_central_network_attachment_test.go
@@ -1,0 +1,178 @@
+package cc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAttachmentResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	var (
+		getAttachmentHttpUrl = "v3/{domain_id}/gcn/central-network/{central_network_id}/gdgw-attachments/{id}"
+		getAttachmentProduct = "cc"
+	)
+	getAttachmentClient, err := cfg.NewServiceClient(getAttachmentProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CC client: %s", err)
+	}
+
+	getAttachmentPath := getAttachmentClient.Endpoint + getAttachmentHttpUrl
+	getAttachmentPath = strings.ReplaceAll(getAttachmentPath, "{domain_id}", cfg.DomainID)
+	getAttachmentPath = strings.ReplaceAll(getAttachmentPath, "{central_network_id}",
+		state.Primary.Attributes["central_network_id"])
+	getAttachmentPath = strings.ReplaceAll(getAttachmentPath, "{id}", state.Primary.ID)
+
+	getAttachmentOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	getAttachmentResp, err := getAttachmentClient.Request("GET", getAttachmentPath, &getAttachmentOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving central network attachment: %s", err)
+	}
+
+	getAttachmentRespBody, err := utils.FlattenResponse(getAttachmentResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving central network attachment: %s", err)
+	}
+
+	return getAttachmentRespBody, nil
+}
+
+func TestAccCentralNetworkAttachment_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cc_central_network_attachment.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAttachmentResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckProjectID(t)
+			acceptance.TestAccPreCheckCCGlobalGateway(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCentralNetworkAttachment_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "central_network_id",
+						"huaweicloud_cc_central_network.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "This is a demo"),
+					resource.TestCheckResourceAttrPair(rName, "enterprise_router_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "enterprise_router_project_id", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(rName, "enterprise_router_region_id", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(rName, "global_dc_gateway_id", acceptance.HW_CC_GLOBAL_GATEWAY_ID),
+					resource.TestCheckResourceAttr(rName, "global_dc_gateway_project_id", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(rName, "global_dc_gateway_region_id", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttr(rName, "state", "AVAILABLE"),
+				),
+			},
+			{
+				Config: testCentralNetworkAttachment_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "central_network_id",
+						"huaweicloud_cc_central_network.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "description", "This is a demo update"),
+					resource.TestCheckResourceAttrPair(rName, "enterprise_router_id",
+						"huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttr(rName, "enterprise_router_project_id", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(rName, "enterprise_router_region_id", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(rName, "global_dc_gateway_id", acceptance.HW_CC_GLOBAL_GATEWAY_ID),
+					resource.TestCheckResourceAttr(rName, "global_dc_gateway_project_id", acceptance.HW_PROJECT_ID),
+					resource.TestCheckResourceAttr(rName, "global_dc_gateway_region_id", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttr(rName, "state", "AVAILABLE"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testCentralNetworkAttachmentImportState(rName),
+			},
+		},
+	})
+}
+
+func testCentralNetworkAttachment_basic(name string) string {
+	policy := testCentralNetworkPolicy_basic(name)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cc_central_network_attachment" "test" {
+  name                         = "%[2]s"
+  description                  = "This is a demo"
+  central_network_id           = huaweicloud_cc_central_network.test.id
+  enterprise_router_id         = huaweicloud_er_instance.test.id
+  enterprise_router_project_id = "%[3]s"
+  enterprise_router_region_id  = "%[4]s"
+  global_dc_gateway_id         = "%[5]s"
+  global_dc_gateway_project_id = "%[3]s"
+  global_dc_gateway_region_id  = "%[4]s"
+}
+`, policy, name, acceptance.HW_PROJECT_ID, acceptance.HW_REGION_NAME, acceptance.HW_CC_GLOBAL_GATEWAY_ID)
+}
+
+func testCentralNetworkAttachment_basic_update(name string) string {
+	policy := testCentralNetworkPolicy_basic(name)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cc_central_network_attachment" "test" {
+  name                         = "%[2]s_update"
+  description                  = "This is a demo update"
+  enterprise_router_id         = huaweicloud_er_instance.test.id
+  enterprise_router_project_id = "%[3]s"
+  enterprise_router_region_id  = "%[4]s"
+  global_dc_gateway_id         = "%[5]s"
+  global_dc_gateway_project_id = "%[3]s"
+  global_dc_gateway_region_id  = "%[4]s"
+}
+`, policy, name, acceptance.HW_PROJECT_ID, acceptance.HW_REGION_NAME, acceptance.HW_CC_GLOBAL_GATEWAY_ID)
+}
+
+func testCentralNetworkAttachmentImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.Attributes["central_network_id"] == "" {
+			return "", fmt.Errorf("attribute (central_network_id) of resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("attribute (ID) of resource (%s) not found: %s", name, rs)
+		}
+
+		return rs.Primary.Attributes["central_network_id"] + "/" +
+			rs.Primary.ID, nil
+	}
+}

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_attachment.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_attachment.go
@@ -1,0 +1,507 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CC
+// ---------------------------------------------------------------
+
+package cc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceCentralNetworkAttachment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCentralNetworkAttachmentCreate,
+		UpdateContext: resourceCentralNetworkAttachmentUpdate,
+		ReadContext:   resourceCentralNetworkAttachmentRead,
+		DeleteContext: resourceCentralNetworkAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceCentralNetworkAttachmentImportState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"central_network_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the attachment.`,
+			},
+			"enterprise_router_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The enterprise router ID.`,
+			},
+			"enterprise_router_project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The project ID to which the enterprise router belongs.`,
+			},
+			"enterprise_router_region_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The region ID to which the enterprise router belongs.`,
+			},
+			"global_dc_gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The global DC gateway ID.`,
+			},
+			"global_dc_gateway_project_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The project ID to which the global DC gateway belongs.`,
+			},
+			"global_dc_gateway_region_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The region ID to which the global DC gateway belongs.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The description of the attachment.`,
+			},
+			"central_network_plane_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The central network plane ID.`,
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Central network attachment status.`,
+			},
+		},
+	}
+}
+
+func resourceCentralNetworkAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		createCentralNetworkAttachmentHttpUrl = "v3/{domain_id}/gcn/central-network/{central_network_id}/gdgw-attachments"
+		createCentralNetworkAttachmentProduct = "cc"
+	)
+	createCentralNetworkAttachmentClient, err := cfg.NewServiceClient(createCentralNetworkAttachmentProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	createCentralNetworkAttachmentPath := createCentralNetworkAttachmentClient.Endpoint + createCentralNetworkAttachmentHttpUrl
+	createCentralNetworkAttachmentPath = strings.ReplaceAll(createCentralNetworkAttachmentPath, "{domain_id}", cfg.DomainID)
+	createCentralNetworkAttachmentPath = strings.ReplaceAll(createCentralNetworkAttachmentPath, "{central_network_id}",
+		d.Get("central_network_id").(string))
+
+	createCentralNetworkAttachmentOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			202,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	createCentralNetworkAttachmentOpt.JSONBody = utils.RemoveNil(buildCreateCentralNetworkAttachmentBodyParams(d))
+	createCentralNetworkAttachmentResp, err := createCentralNetworkAttachmentClient.Request("POST",
+		createCentralNetworkAttachmentPath, &createCentralNetworkAttachmentOpt)
+	if err != nil {
+		return diag.Errorf("error creating central network attachment: %s", err)
+	}
+
+	createCentralNetworkAttachmentRespBody, err := utils.FlattenResponse(createCentralNetworkAttachmentResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("central_network_gdgw_attachment.id", createCentralNetworkAttachmentRespBody)
+	if err != nil {
+		return diag.Errorf("error creating central network attachment: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	err = centralNetworkAttachmentWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for the central network attachment (%s) creation to complete: %s", d.Id(), err)
+	}
+
+	return resourceCentralNetworkAttachmentRead(ctx, d, meta)
+}
+
+func buildCreateCentralNetworkAttachmentBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"central_network_gdgw_attachment": map[string]interface{}{
+			"name":                         d.Get("name"),
+			"enterprise_router_id":         d.Get("enterprise_router_id"),
+			"enterprise_router_project_id": d.Get("enterprise_router_project_id"),
+			"enterprise_router_region_id":  d.Get("enterprise_router_region_id"),
+			"global_dc_gateway_id":         d.Get("global_dc_gateway_id"),
+			"global_dc_gateway_project_id": d.Get("global_dc_gateway_project_id"),
+			"global_dc_gateway_region_id":  d.Get("global_dc_gateway_region_id"),
+			"description":                  utils.ValueIngoreEmpty(d.Get("description")),
+			"central_network_plane_id":     utils.ValueIngoreEmpty(d.Get("central_network_plane_id")),
+		},
+	}
+	return bodyParams
+}
+
+func centralNetworkAttachmentWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			cfg := meta.(*config.Config)
+			region := cfg.GetRegion(d)
+			var (
+				centralNetworkAttachmentWaitingHttpUrl = "v3/{domain_id}/gcn/central-network/{central_network_id}/gdgw-attachments/{id}"
+				centralNetworkAttachmentWaitingProduct = "cc"
+			)
+			centralNetworkAttachmentWaitingClient, err := cfg.NewServiceClient(centralNetworkAttachmentWaitingProduct, region)
+			if err != nil {
+				return nil, "ERROR", fmt.Errorf("error creating CC client: %s", err)
+			}
+
+			centralNetworkAttachmentWaitingPath := centralNetworkAttachmentWaitingClient.Endpoint + centralNetworkAttachmentWaitingHttpUrl
+			centralNetworkAttachmentWaitingPath = strings.ReplaceAll(centralNetworkAttachmentWaitingPath, "{domain_id}", cfg.DomainID)
+			centralNetworkAttachmentWaitingPath = strings.ReplaceAll(centralNetworkAttachmentWaitingPath, "{central_network_id}",
+				d.Get("central_network_id").(string))
+			centralNetworkAttachmentWaitingPath = strings.ReplaceAll(centralNetworkAttachmentWaitingPath, "{id}", d.Id())
+
+			centralNetworkAttachmentWaitingOpt := golangsdk.RequestOpts{
+				KeepResponseBody: true,
+				OkCodes: []int{
+					200,
+				},
+				MoreHeaders: map[string]string{"Content-Type": "application/json"},
+			}
+
+			centralNetworkAttachmentWaitingResp, err := centralNetworkAttachmentWaitingClient.Request("GET",
+				centralNetworkAttachmentWaitingPath, &centralNetworkAttachmentWaitingOpt)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			centralNetworkAttachmentWaitingRespBody, err := utils.FlattenResponse(centralNetworkAttachmentWaitingResp)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+			statusRaw, err := jmespath.Search(`central_network_gdgw_attachment.state`, centralNetworkAttachmentWaitingRespBody)
+			if err != nil {
+				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `central_network_gdgw_attachment.state`)
+			}
+
+			status := fmt.Sprintf("%v", statusRaw)
+
+			targetStatus := []string{
+				"AVAILABLE",
+			}
+			if utils.StrSliceContains(targetStatus, status) {
+				return centralNetworkAttachmentWaitingRespBody, "COMPLETED", nil
+			}
+
+			pendingStatus := []string{
+				"CREATING",
+				"UPDATING",
+				"DELETING",
+			}
+			if utils.StrSliceContains(pendingStatus, status) {
+				return centralNetworkAttachmentWaitingRespBody, "PENDING", nil
+			}
+
+			return centralNetworkAttachmentWaitingRespBody, status, nil
+		},
+		Timeout:      t,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceCentralNetworkAttachmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		getCentralNetworkAttachmentHttpUrl = "v3/{domain_id}/gcn/central-network/{central_network_id}/gdgw-attachments/{id}"
+		getCentralNetworkAttachmentProduct = "cc"
+	)
+	getCentralNetworkAttachmentClient, err := cfg.NewServiceClient(getCentralNetworkAttachmentProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	getCentralNetworkAttachmentPath := getCentralNetworkAttachmentClient.Endpoint + getCentralNetworkAttachmentHttpUrl
+	getCentralNetworkAttachmentPath = strings.ReplaceAll(getCentralNetworkAttachmentPath, "{domain_id}", cfg.DomainID)
+	getCentralNetworkAttachmentPath = strings.ReplaceAll(getCentralNetworkAttachmentPath, "{central_network_id}",
+		d.Get("central_network_id").(string))
+	getCentralNetworkAttachmentPath = strings.ReplaceAll(getCentralNetworkAttachmentPath, "{id}", d.Id())
+
+	getCentralNetworkAttachmentOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	getCentralNetworkAttachmentResp, err := getCentralNetworkAttachmentClient.Request("GET",
+		getCentralNetworkAttachmentPath, &getCentralNetworkAttachmentOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving central network attachment")
+	}
+
+	respBody, err := utils.FlattenResponse(getCentralNetworkAttachmentResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("central_network_gdgw_attachment.name", respBody, nil)),
+		d.Set("enterprise_router_id", utils.PathSearch("central_network_gdgw_attachment.enterprise_router_id", respBody, nil)),
+		d.Set("enterprise_router_project_id", utils.PathSearch("central_network_gdgw_attachment.enterprise_router_project_id", respBody, nil)),
+		d.Set("enterprise_router_region_id", utils.PathSearch("central_network_gdgw_attachment.enterprise_router_region_id", respBody, nil)),
+		d.Set("global_dc_gateway_id", utils.PathSearch("central_network_gdgw_attachment.global_dc_gateway_id", respBody, nil)),
+		d.Set("global_dc_gateway_project_id", utils.PathSearch("central_network_gdgw_attachment.global_dc_gateway_project_id", respBody, nil)),
+		d.Set("global_dc_gateway_region_id", utils.PathSearch("central_network_gdgw_attachment.global_dc_gateway_region_id", respBody, nil)),
+		d.Set("central_network_plane_id", utils.PathSearch("central_network_gdgw_attachment.central_network_plane_id", respBody, nil)),
+		d.Set("state", utils.PathSearch("central_network_gdgw_attachment.state", respBody, nil)),
+		d.Set("central_network_id", utils.PathSearch("central_network_gdgw_attachment.central_network_id", respBody, nil)),
+		d.Set("description", utils.PathSearch("central_network_gdgw_attachment.description", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCentralNetworkAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateCentralNetworkAttachmentChanges := []string{
+		"name",
+		"description",
+	}
+
+	if d.HasChanges(updateCentralNetworkAttachmentChanges...) {
+		var (
+			updateCentralNetworkAttachmentHttpUrl = "v3/{domain_id}/gcn/central-network/{central_network_id}/gdgw-attachments/{id}"
+			updateCentralNetworkAttachmentProduct = "cc"
+		)
+		updateCentralNetworkAttachmentClient, err := cfg.NewServiceClient(updateCentralNetworkAttachmentProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating CC client: %s", err)
+		}
+
+		updateCentralNetworkAttachmentPath := updateCentralNetworkAttachmentClient.Endpoint + updateCentralNetworkAttachmentHttpUrl
+		updateCentralNetworkAttachmentPath = strings.ReplaceAll(updateCentralNetworkAttachmentPath, "{domain_id}", cfg.DomainID)
+		updateCentralNetworkAttachmentPath = strings.ReplaceAll(updateCentralNetworkAttachmentPath, "{central_network_id}",
+			d.Get("central_network_id").(string))
+		updateCentralNetworkAttachmentPath = strings.ReplaceAll(updateCentralNetworkAttachmentPath, "{id}", d.Id())
+
+		updateCentralNetworkAttachmentOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+			MoreHeaders: map[string]string{"Content-Type": "application/json"},
+		}
+
+		updateCentralNetworkAttachmentOpt.JSONBody = utils.RemoveNil(buildUpdateCentralNetworkAttachmentBodyParams(d))
+		_, err = updateCentralNetworkAttachmentClient.Request("PUT", updateCentralNetworkAttachmentPath,
+			&updateCentralNetworkAttachmentOpt)
+		if err != nil {
+			return diag.Errorf("error updating central network attachment: %s", err)
+		}
+
+		err = centralNetworkAttachmentWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return diag.Errorf("error waiting for the central network attachment (%s) update to complete: %s", d.Id(), err)
+		}
+	}
+
+	return resourceCentralNetworkAttachmentRead(ctx, d, meta)
+}
+
+func buildUpdateCentralNetworkAttachmentBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"central_network_gdgw_attachment": map[string]interface{}{
+			"name":        utils.ValueIngoreEmpty(d.Get("name")),
+			"description": utils.ValueIngoreEmpty(d.Get("description")),
+		},
+	}
+	return bodyParams
+}
+
+func resourceCentralNetworkAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		deleteCentralNetworkAttachmentHttpUrl = "v3/{domain_id}/gcn/central-network/{central_network_id}/attachments/{id}"
+		deleteCentralNetworkAttachmentProduct = "cc"
+	)
+	deleteCentralNetworkAttachmentClient, err := cfg.NewServiceClient(deleteCentralNetworkAttachmentProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	deleteCentralNetworkAttachmentPath := deleteCentralNetworkAttachmentClient.Endpoint + deleteCentralNetworkAttachmentHttpUrl
+	deleteCentralNetworkAttachmentPath = strings.ReplaceAll(deleteCentralNetworkAttachmentPath, "{domain_id}", cfg.DomainID)
+	deleteCentralNetworkAttachmentPath = strings.ReplaceAll(deleteCentralNetworkAttachmentPath, "{central_network_id}",
+		d.Get("central_network_id").(string))
+	deleteCentralNetworkAttachmentPath = strings.ReplaceAll(deleteCentralNetworkAttachmentPath, "{id}", d.Id())
+
+	deleteCentralNetworkAttachmentOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			202,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = deleteCentralNetworkAttachmentClient.Request("DELETE", deleteCentralNetworkAttachmentPath,
+		&deleteCentralNetworkAttachmentOpt)
+	if err != nil {
+		return diag.Errorf("error deleting central network attachment: %s", err)
+	}
+
+	err = centralNetworkAttachmentDeleteWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return diag.Errorf("error waiting for the central network attachment (%s) deletion to complete: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func centralNetworkAttachmentDeleteWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			cfg := meta.(*config.Config)
+			region := cfg.GetRegion(d)
+			// centralNetworkAttachmentDeleteWaiting: missing operation notes
+			var (
+				deleteWaitingHttpUrl = "v3/{domain_id}/gcn/central-network/{central_network_id}/gdgw-attachments/{id}"
+				deleteWaitingProduct = "cc"
+			)
+			centralNetworkAttachmentDeleteWaitingClient, err := cfg.NewServiceClient(deleteWaitingProduct, region)
+			if err != nil {
+				return nil, "ERROR", fmt.Errorf("error creating CC client: %s", err)
+			}
+
+			deleteWaitingPath := centralNetworkAttachmentDeleteWaitingClient.Endpoint + deleteWaitingHttpUrl
+			deleteWaitingPath = strings.ReplaceAll(deleteWaitingPath, "{domain_id}", cfg.DomainID)
+			deleteWaitingPath = strings.ReplaceAll(deleteWaitingPath, "{central_network_id}",
+				d.Get("central_network_id").(string))
+			deleteWaitingPath = strings.ReplaceAll(deleteWaitingPath, "{id}", d.Id())
+
+			deleteWaitingOpt := golangsdk.RequestOpts{
+				KeepResponseBody: true,
+				OkCodes: []int{
+					200,
+				},
+				MoreHeaders: map[string]string{"Content-Type": "application/json"},
+			}
+
+			deleteWaitingResp, err := centralNetworkAttachmentDeleteWaitingClient.Request("GET", deleteWaitingPath, &deleteWaitingOpt)
+			if err != nil {
+				if _, ok := err.(golangsdk.ErrDefault404); ok {
+					return deleteWaitingResp, "COMPLETED", nil
+				}
+
+				return nil, "ERROR", err
+			}
+
+			centralNetworkAttachmentDeleteWaitingRespBody, err := utils.FlattenResponse(deleteWaitingResp)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+			statusRaw, err := jmespath.Search(`central_network_gdgw_attachment.state`, centralNetworkAttachmentDeleteWaitingRespBody)
+			if err != nil {
+				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `central_network_gdgw_attachment.state`)
+			}
+
+			status := fmt.Sprintf("%v", statusRaw)
+
+			targetStatus := []string{
+				"DELETED",
+			}
+			if utils.StrSliceContains(targetStatus, status) {
+				return centralNetworkAttachmentDeleteWaitingRespBody, "COMPLETED", nil
+			}
+
+			pendingStatus := []string{
+				"DELETING",
+				"FREEZING",
+				"UNFREEZING",
+				"RECOVERING",
+			}
+			if utils.StrSliceContains(pendingStatus, status) {
+				return centralNetworkAttachmentDeleteWaitingRespBody, "PENDING", nil
+			}
+
+			return centralNetworkAttachmentDeleteWaitingRespBody, status, nil
+		},
+		Timeout:      t,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceCentralNetworkAttachmentImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import id, must be <central_network_id>/<id>")
+	}
+
+	d.Set("central_network_id", parts[0])
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:



😞 😞 😞 **The DC needs to deploy a carrier's physical network to connect to the user's local data center, So skip the acceptance test.**

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^TestAccCentralNetworkAttachment_basic$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc -v

=== RUN   TestAccCentralNetworkAttachment_basic
=== PAUSE TestAccCentralNetworkAttachment_basic
=== CONT  TestAccCentralNetworkAttachment_basic
    /home/huawei/git/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc/acceptance.go:1052: HW_CC_GLOBAL_GATEWAY_ID must be set for the acceptance test
--- SKIP: TestAccCentralNetworkAttachment_basic (0.01s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc	0.047s

```
