### PR TITLE
feat(cce): update cce GetCert method and set parameter "duration" as -1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231227110234-16eb63256210
+	github.com/chnsz/golangsdk v0.0.0-20231229075012-3457589ab494
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231227110234-16eb63256210 h1:INlAkEDZdSBe7Ob+1RzNNgzMKx6vaezbVjImZMaMIoM=
-github.com/chnsz/golangsdk v0.0.0-20231227110234-16eb63256210/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20231229075012-3457589ab494 h1:qnZbqMSDpjZhxrpro9USTns0xggX+dLQCt3kULLsTQI=
+github.com/chnsz/golangsdk v0.0.0-20231229075012-3457589ab494/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_v3.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_cluster_v3.go
@@ -252,8 +252,10 @@ func dataSourceCCEClusterV3Read(_ context.Context, d *schema.ResourceData, meta 
 	}
 	mErr = multierror.Append(mErr, d.Set("endpoints", v))
 
-	// set kube_config_raw
-	r := clusters.GetCert(cceClient, d.Id())
+	// set kube_config_raw, duration -1 is equal to the maximum value 1827 days
+	opts := clusters.GetCertOpts{Duration: -1}
+	r := clusters.GetCert(cceClient, d.Id(), opts)
+
 	kubeConfigRaw, err := utils.JsonMarshal(r.Body)
 	if err != nil {
 		logp.Printf("Error marshaling r.Body: %s", err)
@@ -262,7 +264,7 @@ func dataSourceCCEClusterV3Read(_ context.Context, d *schema.ResourceData, meta 
 
 	cert, err := r.Extract()
 	if err != nil {
-		logp.Printf("Error retrieving HuaweiCloud CCE cluster cert: %s", err)
+		logp.Printf("Error retrieving CCE cluster cert: %s", err)
 	}
 
 	//Set Certificate Clusters

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_clusters.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_clusters.go
@@ -272,7 +272,9 @@ func dataSourceCCEClustersV3Read(_ context.Context, d *schema.ResourceData, meta
 		}
 		cluster["endpoints"] = endpoints
 
-		r := clusters.GetCert(cceClient, v.Metadata.Id)
+		// duration -1 is equal to the maximum value 1827 days
+		opts := clusters.GetCertOpts{Duration: -1}
+		r := clusters.GetCert(cceClient, d.Id(), opts)
 
 		kubeConfigRaw, err := utils.JsonMarshal(r.Body)
 
@@ -285,7 +287,7 @@ func dataSourceCCEClustersV3Read(_ context.Context, d *schema.ResourceData, meta
 		cert, err := r.Extract()
 
 		if err != nil {
-			logp.Printf("Error retrieving HuaweiCloud CCE cluster cert: %s", err)
+			logp.Printf("Error retrieving CCE cluster cert: %s", err)
 		}
 
 		//Set Certificate Clusters

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster.go
@@ -826,7 +826,9 @@ func resourceClusterRead(_ context.Context, d *schema.ResourceData, meta interfa
 		mErr = multierror.Append(mErr, d.Set("charging_mode", "prePaid"))
 	}
 
-	r := clusters.GetCert(cceClient, d.Id())
+	// duration -1 is equal to the maximum value 1827 days
+	opts := clusters.GetCertOpts{Duration: -1}
+	r := clusters.GetCert(cceClient, d.Id(), opts)
 
 	kubeConfigRaw, err := utils.JsonMarshal(r.Body)
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
@@ -168,12 +168,18 @@ func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
 }
 
 // GetCert retrieves a particular cluster certificate based on its unique ID.
-func GetCert(c *golangsdk.ServiceClient, id string) (r GetCertResult) {
-	_, r.Err = c.Get(certificateURL(c, id), &r.Body, &golangsdk.RequestOpts{
-		OkCodes:     []int{200},
-		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
-	})
+func GetCert(c *golangsdk.ServiceClient, id string, opts GetCertOpts) (r GetCertResult) {
+	body, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(certificateURL(c, id), body, &r.Body, nil)
 	return
+}
+
+type GetCertOpts struct {
+	Duration int `json:"duration" required:"true"`
 }
 
 // UpdateOpts contains all the values needed to update a new cluster

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/results.go
@@ -211,6 +211,8 @@ type CertCluster struct {
 	Server string `json:"server"`
 	//Certificate data
 	CertAuthorityData string `json:"certificate-authority-data"`
+	//whether skip tls verify
+	InsecureSkipTLSVerify bool `json:"insecure-skip-tls-verify"`
 }
 
 type CertUsers struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231227110234-16eb63256210
+# github.com/chnsz/golangsdk v0.0.0-20231229075012-3457589ab494
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The cce getCert method is modified, need input parameter "duration" to get cce cert.
use the duration value as -1 means default use the maximum validity certificate.

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated. **User not aware**
* [ ] Schema updated. **No changed.**

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cce" TESTARGS="-run TestAccCluster_basic"                         
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCluster_basic -timeout 360m -parallel 4 
=== RUN   TestAccCluster_basic 
=== PAUSE TestAccCluster_basic
=== CONT  TestAccCluster_basic
--- PASS: TestAccCluster_basic (578.88s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       578.923s

```

```
make testacc TEST="./huaweicloud/services/acceptance/cce" TESTARGS="-run TestAccCCEClusterV3DataSource_basic"                          
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCEClusterV3DataSource_basic -timeout 360m -parallel 4 
=== RUN   TestAccCCEClusterV3DataSource_basic 
=== PAUSE TestAccCCEClusterV3DataSource_basic
=== CONT  TestAccCCEClusterV3DataSource_basic
--- PASS: TestAccCCEClusterV3DataSource_basic (577.80s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       577.832s

```

```
make testacc TEST="./huaweicloud/services/acceptance/cce" TESTARGS="-run TestAccCCEClustersDataSource_basic"             
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCCEClustersDataSource_basic -timeout 360m -parallel 4 
=== RUN   TestAccCCEClustersDataSource_basic 
=== PAUSE TestAccCCEClustersDataSource_basic
=== CONT  TestAccCCEClustersDataSource_basic
--- PASS: TestAccCCEClustersDataSource_basic (876.15s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       876.189s
```
