### PR TITLE
refactor(workspace/service): add a constraint description and refactor test case

### DIFF
--- a/docs/resources/workspace_service.md
+++ b/docs/resources/workspace_service.md
@@ -120,7 +120,9 @@ The following arguments are supported:
 
 * `internet_access_port` - (Optional, Int) Specifies the internet access port.
   The valid value is range from `1,025` to `65,535`.
-
+  
+  -> If you want to modify the internet access port, please open a service ticket to enable this function.  
+  
 * `dedicated_subnets` - (Optional, List) The subnet segments of the dedicated access.
 
 * `management_subnet_cidr` - (Optional, String, ForceNew) The subnet segment of the management component.

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -119,6 +119,8 @@ var (
 	HW_WORKSPACE_AD_DOMAIN_IP   = os.Getenv("HW_WORKSPACE_AD_DOMAIN_IP")   // Active domain IP, e.g. "192.168.196.3".
 	HW_WORKSPACE_AD_VPC_ID      = os.Getenv("HW_WORKSPACE_AD_VPC_ID")      // The VPC ID to which the AD server and desktops belongs.
 	HW_WORKSPACE_AD_NETWORK_ID  = os.Getenv("HW_WORKSPACE_AD_NETWORK_ID")  // The network ID to which the AD server belongs.
+	// The internet access port to which the Workspace service.
+	HW_WORKSPACE_INTERNET_ACCESS_PORT = os.Getenv("HW_WORKSPACE_INTERNET_ACCESS_PORT")
 
 	HW_FGS_TRIGGER_LTS_AGENCY = os.Getenv("HW_FGS_TRIGGER_LTS_AGENCY")
 
@@ -766,6 +768,13 @@ func TestAccPreCheckWorkspaceAD(t *testing.T) {
 	if HW_WORKSPACE_AD_DOMAIN_NAME == "" || HW_WORKSPACE_AD_SERVER_PWD == "" || HW_WORKSPACE_AD_DOMAIN_IP == "" ||
 		HW_WORKSPACE_AD_VPC_ID == "" || HW_WORKSPACE_AD_NETWORK_ID == "" {
 		t.Skip("The configuration of AD server is not completed for Workspace service acceptance test.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckWorkspaceInternetAccessPort(t *testing.T) {
+	if HW_WORKSPACE_INTERNET_ACCESS_PORT == "" {
+		t.Skip("HW_WORKSPACE_INTERNET_ACCESS_PORT must be set for Workspace service acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
@@ -60,7 +60,6 @@ func TestAccService_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "infrastructure_security_group.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "desktop_security_group.0.name"),
 					resource.TestCheckResourceAttrSet(resourceName, "desktop_security_group.0.id"),
-					resource.TestCheckResourceAttrSet(resourceName, "internet_access_port"),
 					resource.TestCheckResourceAttrSet(resourceName, "internet_access_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 				),
@@ -73,7 +72,6 @@ func TestAccService_basic(t *testing.T) {
 						"huaweicloud_vpc_subnet.master", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "network_ids.1",
 						"huaweicloud_vpc_subnet.standby", "id"),
-					resource.TestCheckResourceAttr(resourceName, "internet_access_port", "9001"),
 					resource.TestCheckResourceAttrSet(resourceName, "internet_access_address"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_id", rName),
@@ -93,6 +91,45 @@ func TestAccService_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccService_internetAccessPort(t *testing.T) {
+	var (
+		service      services.Service
+		resourceName = "huaweicloud_workspace_service.test"
+		rName        = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&service,
+		getServiceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceInternetAccessPort(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccService_basic_step1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "internet_access_port"),
+				),
+			},
+			{
+				Config: testAccService_internetAccessPort_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "internet_access_port", acceptance.HW_WORKSPACE_INTERNET_ACCESS_PORT),
+				),
 			},
 		},
 	})
@@ -138,7 +175,6 @@ func TestAccService_localAD(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "infrastructure_security_group.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "desktop_security_group.0.name"),
 					resource.TestCheckResourceAttrSet(resourceName, "desktop_security_group.0.id"),
-					resource.TestCheckResourceAttrSet(resourceName, "internet_access_port"),
 					resource.TestCheckResourceAttrSet(resourceName, "internet_access_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
 				),
@@ -152,7 +188,6 @@ func TestAccService_localAD(t *testing.T) {
 						"huaweicloud_vpc_subnet.master", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "network_ids.2",
 						"huaweicloud_vpc_subnet.standby", "id"),
-					resource.TestCheckResourceAttr(resourceName, "internet_access_port", "9001"),
 					resource.TestCheckResourceAttrSet(resourceName, "internet_access_address"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "otp_config_info.0.enable", "true"),
@@ -174,6 +209,45 @@ func TestAccService_localAD(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"ad_domain.0.password",
 				},
+			},
+		},
+	})
+}
+
+func TestAccService_internetAccessPort_localAD(t *testing.T) {
+	var (
+		service      services.Service
+		resourceName = "huaweicloud_workspace_service.test"
+		rName        = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&service,
+		getServiceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceInternetAccessPort(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccService_localAD_step1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "internet_access_port"),
+				),
+			},
+			{
+				Config: testAccService_localAD_internetAccessPort_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "internet_access_port", acceptance.HW_WORKSPACE_INTERNET_ACCESS_PORT),
+				),
 			},
 		},
 	})
@@ -230,7 +304,6 @@ resource "huaweicloud_workspace_service" "test" {
     huaweicloud_vpc_subnet.standby.id,
   ]
 
-  internet_access_port = 9001
   enterprise_id        = "%[2]s"
 
   otp_config_info {
@@ -253,7 +326,6 @@ resource "huaweicloud_workspace_service" "test" {
     huaweicloud_vpc_subnet.standby.id,
   ]
 
-  internet_access_port = 9001
   enterprise_id        = "%[2]s"
 
   otp_config_info {
@@ -341,7 +413,6 @@ resource "huaweicloud_workspace_service" "test" {
     huaweicloud_vpc_subnet.standby.id,
   ]
 
-  internet_access_port = 9001
   enterprise_id        = "%[7]s"
 
   otp_config_info {
@@ -382,7 +453,6 @@ resource "huaweicloud_workspace_service" "test" {
     huaweicloud_vpc_subnet.standby.id,
   ]
 
-  internet_access_port = 9001
   enterprise_id        = "%[7]s"
 
   otp_config_info {
@@ -395,4 +465,58 @@ resource "huaweicloud_workspace_service" "test" {
 `, testAccService_localAD_base(rName), acceptance.HW_WORKSPACE_AD_DOMAIN_NAME, acceptance.HW_WORKSPACE_AD_SERVER_PWD,
 		acceptance.HW_WORKSPACE_AD_DOMAIN_IP, acceptance.HW_WORKSPACE_AD_VPC_ID, acceptance.HW_WORKSPACE_AD_NETWORK_ID,
 		rName)
+}
+
+func testAccService_internetAccessPort_update(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_service" "test" {
+  access_mode = "INTERNET"
+  vpc_id      = huaweicloud_vpc.test.id
+  network_ids = [
+    huaweicloud_vpc_subnet.master.id,
+    huaweicloud_vpc_subnet.standby.id,
+  ]
+  
+  internet_access_port = "%[2]s"
+  enterprise_id        = "%[3]s"
+}
+`, testAccService_base(rName), acceptance.HW_WORKSPACE_INTERNET_ACCESS_PORT, rName)
+}
+
+func testAccService_localAD_internetAccessPort_update(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_service" "test" {
+  depends_on = [
+    huaweicloud_vpc_subnet.master,
+	huaweicloud_vpc_subnet.standby,
+  ]
+
+  ad_domain {
+    name               = "%[2]s"
+    admin_account      = "Administrator"
+    password           = "%[3]s"
+    active_domain_ip   = "%[4]s"
+    active_domain_name = "server.%[2]s"
+    active_dns_ip      = "%[4]s"
+  }
+
+  auth_type   = "LOCAL_AD"
+  access_mode = "INTERNET"
+  vpc_id      = "%[5]s"
+  network_ids = [
+    "%[6]s",
+    huaweicloud_vpc_subnet.master.id,
+    huaweicloud_vpc_subnet.standby.id,
+  ]
+
+  internet_access_port = "%[7]s"
+  enterprise_id        = "%[8]s"
+}
+`, testAccService_localAD_base(rName), acceptance.HW_WORKSPACE_AD_DOMAIN_NAME, acceptance.HW_WORKSPACE_AD_SERVER_PWD,
+		acceptance.HW_WORKSPACE_AD_DOMAIN_IP, acceptance.HW_WORKSPACE_AD_VPC_ID, acceptance.HW_WORKSPACE_AD_NETWORK_ID,
+		acceptance.HW_WORKSPACE_INTERNET_ACCESS_PORT, rName)
 }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 Add a constraint description and refactor test case
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
// region="cn-north-4"
 make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccService_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccService_basic -timeout 360m -parallel 4
=== RUN   TestAccService_basic
=== PAUSE TestAccService_basic
=== CONT  TestAccService_basic
--- PASS: TestAccService_basic (177.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 177.390s

// region="cn-south-1"
make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccService_internetAccessPort'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccService_internetAccessPort -timeout 360m -parallel 4
=== RUN   TestAccService_internetAccessPort
=== PAUSE TestAccService_internetAccessPort
=== CONT  TestAccService_internetAccessPort
--- PASS: TestAccService_internetAccessPort (598.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 598.172s



make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccService_localAD'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccService_localAD -timeout 360m -parallel 4
=== RUN   TestAccService_localAD
=== PAUSE TestAccService_localAD
=== CONT  TestAccService_localAD
--- PASS: TestAccService_localAD (614.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 614.706s


make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccService_internetAccessPort_localAD'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccService_internetAccessPort_localAD -timeout 360m -parallel 4
=== RUN   TestAccService_internetAccessPort_localAD
=== PAUSE TestAccService_internetAccessPort_localAD
=== CONT  TestAccService_internetAccessPort_localAD
--- PASS: TestAccService_internetAccessPort_localAD (580.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 580.193s
```
