### PR TITLE
feat(DCS): fix dcs instance param validation

### DIFF
--- a/docs/resources/dcs_instance.md
+++ b/docs/resources/dcs_instance.md
@@ -163,25 +163,22 @@ The following arguments are supported:
 * `whitelist_enable` - (Optional, Bool) Enable or disable the IP address whitelists. Defaults to true.
   If the whitelist is disabled, all IP addresses connected to the VPC can access the instance.
 
-* `maintain_begin` - (Optional, String) Time at which the maintenance time window starts.
-  The valid values are `22:00:00`, `02:00:00`, `06:00:00`, `10:00:00`, `14:00:00` and `18:00:00`.
-  Default value is `02:00:00`.
+* `maintain_begin` - (Optional, String) Time at which the maintenance time window starts. Defaults to **02:00:00**.
   + The start time and end time of a maintenance time window must indicate the time segment of a supported maintenance
     time window.
-  + Parameters `maintain_begin` and `maintain_end` must be set in pairs.
-  + If parameter maintain_begin is left blank, parameter maintain_end is also blank.
-    In this case, the system automatically allocates the default start time 02:00:00.
+  + The start time must be on the hour, such as **18:00:00**.
+  + If parameter `maintain_begin` is left blank, parameter `maintain_end` is also blank.
+    In this case, the system automatically allocates the default start time **02:00:00**.
 
-* `maintain_end` - (Optional, String) Time at which the maintenance time window ends.
-  The valid values are `22:00:00`, `02:00:00`, `06:00:00`, `10:00:00`, `14:00:00` and `18:00:00`.
-  Default value is `06:00:00`.
+* `maintain_end` - (Optional, String) Time at which the maintenance time window ends. Defaults to **06:00:00**.
   + The start time and end time of a maintenance time window must indicate the time segment of a supported maintenance
     time window.
-  + The end time is four hours later than the start time.
-    For example, if the start time is 22:00:00, the end time is 02:00:00.
-  + Parameters `maintain_begin` and `maintain_end` must be set in pairs.
-  + If parameter maintain_end is left blank, parameter maintain_begin is also blank.
-    In this case, the system automatically allocates the default end time 06:00:00.
+  + The end time is one hour later than the start time. For example, if the start time is **18:00:00**, the end time is
+    **19:00:00**.
+  + If parameter `maintain_end` is left blank, parameter `maintain_begin` is also blank.
+    In this case, the system automatically allocates the default end time **06:00:00**.
+
+-> **NOTE:** Parameters `maintain_begin` and `maintain_end` must be set in pairs.
 
 * `backup_policy` - (Optional, List) Specifies the backup configuration to be used with the instance.
   The structure is described below.

--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
@@ -52,7 +52,7 @@ func TestAccDcsInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.id", "1"),
@@ -70,7 +70,7 @@ func TestAccDcsInstances_basic(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.begin_at", "01:00-02:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.save_days", "2"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.backup_at.#", "3"),
@@ -118,7 +118,7 @@ func TestAccDcsInstances_ha_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -133,7 +133,7 @@ func TestAccDcsInstances_ha_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -144,7 +144,7 @@ func TestAccDcsInstances_ha_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -186,7 +186,7 @@ func TestAccDcsInstances_ha_expand_replica(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -201,7 +201,7 @@ func TestAccDcsInstances_ha_expand_replica(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -243,7 +243,7 @@ func TestAccDcsInstances_ha_to_proxy(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -258,7 +258,7 @@ func TestAccDcsInstances_ha_to_proxy(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -300,7 +300,7 @@ func TestAccDcsInstances_rw_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -315,7 +315,7 @@ func TestAccDcsInstances_rw_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "16"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -326,7 +326,7 @@ func TestAccDcsInstances_rw_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -368,7 +368,7 @@ func TestAccDcsInstances_rw_expand_replica(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -383,7 +383,7 @@ func TestAccDcsInstances_rw_expand_replica(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -425,7 +425,7 @@ func TestAccDcsInstances_rw_to_proxy(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -440,7 +440,7 @@ func TestAccDcsInstances_rw_to_proxy(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -482,7 +482,7 @@ func TestAccDcsInstances_proxy_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -497,7 +497,7 @@ func TestAccDcsInstances_proxy_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "16"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -508,7 +508,7 @@ func TestAccDcsInstances_proxy_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -550,7 +550,7 @@ func TestAccDcsInstances_proxy_to_ha(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -565,7 +565,7 @@ func TestAccDcsInstances_proxy_to_ha(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -607,7 +607,7 @@ func TestAccDcsInstances_proxy_to_rw(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -622,7 +622,7 @@ func TestAccDcsInstances_proxy_to_rw(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -664,7 +664,7 @@ func TestAccDcsInstances_cluster_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -679,7 +679,7 @@ func TestAccDcsInstances_cluster_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -690,7 +690,7 @@ func TestAccDcsInstances_cluster_change_capacity(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -732,7 +732,7 @@ func TestAccDcsInstances_cluster_expand_replica(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "22:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "02:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "23:00:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "availability_zones.0",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
@@ -747,7 +747,7 @@ func TestAccDcsInstances_cluster_expand_replica(t *testing.T) {
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
-					resource.TestCheckResourceAttr(resourceName, "maintain_end", "10:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 				),
 			},
 			{
@@ -974,7 +974,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
-  maintain_end       = "02:00:00"
+  maintain_end       = "23:00:00"
 
   backup_policy {
     backup_type = "auto"
@@ -1035,7 +1035,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 
   backup_policy {
     backup_type = "auto"
@@ -1097,7 +1097,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
-  maintain_end       = "02:00:00"
+  maintain_end       = "23:00:00"
 }`, instanceName)
 }
 
@@ -1132,7 +1132,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1167,7 +1167,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1202,7 +1202,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1237,7 +1237,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1272,7 +1272,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
-  maintain_end       = "02:00:00"
+  maintain_end       = "23:00:00"
 }`, instanceName)
 }
 
@@ -1307,7 +1307,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1342,7 +1342,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1377,7 +1377,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1412,7 +1412,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1447,7 +1447,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
-  maintain_end       = "02:00:00"
+  maintain_end       = "23:00:00"
 }`, instanceName)
 }
 
@@ -1482,7 +1482,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1517,7 +1517,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1552,7 +1552,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1587,7 +1587,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1622,7 +1622,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
-  maintain_end       = "02:00:00"
+  maintain_end       = "23:00:00"
 }`, instanceName)
 }
 
@@ -1657,7 +1657,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1692,7 +1692,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 
@@ -1727,7 +1727,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
-  maintain_end       = "10:00:00"
+  maintain_end       = "07:00:00"
 }`, instanceName)
 }
 

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -201,19 +201,13 @@ func ResourceDcsInstance() *schema.Resource {
 			"maintain_begin": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				RequiredWith: []string{"maintain_end"},
-				Default:      "02:00:00",
-				ValidateFunc: validation.StringInSlice([]string{
-					"22:00:00", "02:00:00", "06:00:00", "10:00:00", "14:00:00", "18:00:00",
-				}, false),
 			},
 			"maintain_end": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "06:00:00",
-				ValidateFunc: validation.StringInSlice([]string{
-					"22:00:00", "02:00:00", "06:00:00", "10:00:00", "14:00:00", "18:00:00",
-				}, false),
+				Computed: true,
 			},
 			"backup_policy": {
 				Type:          schema.TypeList,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dcs instance param validation
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dcs instance param validation
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TERSTARGS='-run TestAccDcsInstances_' TEST_PARALLELISM=17       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v  -timeout 360m -parallel 17
=== RUN   TestAccDatasourceDcsBackups_basic
=== PAUSE TestAccDatasourceDcsBackups_basic
=== RUN   TestAccDataSourceDcsFlavorsV2_basic
=== PAUSE TestAccDataSourceDcsFlavorsV2_basic
=== RUN   TestAccDatasourceDcsInstance_basic
=== PAUSE TestAccDatasourceDcsInstance_basic
=== RUN   TestAccDcsMaintainWindowDataSource_basic
=== PAUSE TestAccDcsMaintainWindowDataSource_basic
=== RUN   TestAccDatasourceTemplateDetail_basic
=== PAUSE TestAccDatasourceTemplateDetail_basic
=== RUN   TestAccDatasourceTemplates_basic
=== PAUSE TestAccDatasourceTemplates_basic
=== RUN   TestAccDcsBackup_basic
=== PAUSE TestAccDcsBackup_basic
=== RUN   TestAccCustomTemplate_basic
=== PAUSE TestAccCustomTemplate_basic
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_ha_change_capacity
=== PAUSE TestAccDcsInstances_ha_change_capacity
=== RUN   TestAccDcsInstances_ha_expand_replica
=== PAUSE TestAccDcsInstances_ha_expand_replica
=== RUN   TestAccDcsInstances_ha_to_proxy
=== PAUSE TestAccDcsInstances_ha_to_proxy
=== RUN   TestAccDcsInstances_rw_change_capacity
=== PAUSE TestAccDcsInstances_rw_change_capacity
=== RUN   TestAccDcsInstances_rw_expand_replica
=== PAUSE TestAccDcsInstances_rw_expand_replica
=== RUN   TestAccDcsInstances_rw_to_proxy
=== PAUSE TestAccDcsInstances_rw_to_proxy
=== RUN   TestAccDcsInstances_proxy_change_capacity
=== PAUSE TestAccDcsInstances_proxy_change_capacity
=== RUN   TestAccDcsInstances_proxy_to_ha
=== PAUSE TestAccDcsInstances_proxy_to_ha
=== RUN   TestAccDcsInstances_proxy_to_rw
=== PAUSE TestAccDcsInstances_proxy_to_rw
=== RUN   TestAccDcsInstances_cluster_change_capacity
=== PAUSE TestAccDcsInstances_cluster_change_capacity
=== RUN   TestAccDcsInstances_cluster_expand_replica
=== PAUSE TestAccDcsInstances_cluster_expand_replica
=== RUN   TestAccDcsInstances_withEpsId
=== PAUSE TestAccDcsInstances_withEpsId
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== RUN   TestAccDcsInstances_prePaid
=== PAUSE TestAccDcsInstances_prePaid
=== CONT  TestAccDatasourceDcsBackups_basic
=== CONT  TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_ha_to_proxy
=== CONT  TestAccDcsInstances_ha_expand_replica
=== CONT  TestAccDcsInstances_withEpsId
=== CONT  TestAccDcsInstances_proxy_to_ha
=== CONT  TestAccDcsInstances_cluster_change_capacity
=== CONT  TestAccDatasourceTemplates_basic
=== CONT  TestAccDcsInstances_single
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_rw_to_proxy
=== CONT  TestAccDcsInstances_proxy_change_capacity
=== CONT  TestAccDcsInstances_rw_expand_replica
=== CONT  TestAccDcsInstances_tiny
=== CONT  TestAccDcsInstances_ha_change_capacity
=== CONT  TestAccCustomTemplate_basic
--- PASS: TestAccCustomTemplate_basic (113.26s)
=== CONT  TestAccDcsInstances_proxy_to_rw
--- PASS: TestAccDatasourceTemplates_basic (123.17s)
=== CONT  TestAccDcsMaintainWindowDataSource_basic
--- PASS: TestAccDcsMaintainWindowDataSource_basic (13.35s)
=== CONT  TestAccDatasourceTemplateDetail_basic
--- PASS: TestAccDcsInstances_tiny (392.29s)
=== CONT  TestAccDcsInstances_cluster_expand_replica
--- PASS: TestAccDcsInstances_whitelists (486.49s)
--- PASS: TestAccDcsInstances_prePaid (493.46s)
--- PASS: TestAccDcsInstances_ha_expand_replica (501.31s)
--- PASS: TestAccDcsInstances_rw_expand_replica (502.73s)
--- PASS: TestAccDatasourceDcsBackups_basic (506.05s)
--- PASS: TestAccDcsInstances_basic (507.40s)
--- PASS: TestAccDatasourceDcsInstance_basic (233.24s)
=== CONT  TestAccDcsInstances_cluster_expand_replica
--- PASS: TestAccDcsInstances_whitelists (486.49s)
--- PASS: TestAccDcsInstances_prePaid (493.46s)
--- PASS: TestAccDcsInstances_ha_expand_replica (501.31s)
--- PASS: TestAccDcsInstances_rw_expand_replica (502.73s)
--- PASS: TestAccDatasourceDcsBackups_basic (506.05s)
--- PASS: TestAccDcsInstances_basic (507.40s)
--- PASS: TestAccDatasourceDcsInstance_basic (233.24s)
--- PASS: TestAccDcsBackup_basic (266.16s)
--- PASS: TestAccDcsInstances_ha_change_capacity (595.79s)
--- PASS: TestAccDcsInstances_rw_change_capacity (351.31s)
--- PASS: TestAccDcsInstances_ha_to_proxy (725.03s)
--- PASS: TestAccDcsInstances_rw_to_proxy (747.67s)
--- PASS: TestAccDcsInstances_cluster_expand_replica (437.77s)
--- PASS: TestAccDcsInstances_proxy_to_rw (789.82s)
--- PASS: TestAccDcsInstances_proxy_to_ha (905.52s)
--- PASS: TestAccDcsInstances_cluster_change_capacity (1476.58s)
--- PASS: TestAccDcsInstances_proxy_change_capacity (2101.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       2101.302s
```
