### PR TITLE
feat(EVS): resource EVS supports updating QoS of cloudvolume

### DIFF
--- a/docs/resources/evs_volume.md
+++ b/docs/resources/evs_volume.md
@@ -97,7 +97,7 @@ The following arguments are supported:
   -> If the specified disk type is not available in the AZ, the disk will fail to create.
   The volume type **ESSD2** only support in postpaid charging mode.
 
-* `iops` - (Optional, Int, ForceNew) Specifies the IOPS(Input/Output Operations Per Second) for the volume.
+* `iops` - (Optional, Int) Specifies the IOPS(Input/Output Operations Per Second) for the volume.
   The field is valid and required when `volume_type` is set to **GPSSD2** or **ESSD2**.
 
   + If `volume_type` is set to **GPSSD2**. The field `iops` ranging from 3,000 to 128,000.
@@ -106,15 +106,11 @@ The following arguments are supported:
   + If `volume_type` is set to **ESSD2**. The field `iops` ranging from 100 to 256,000.
     This IOPS must also be less than or equal to 1000 multiplying the capacity.
 
-  Changing this creates a new disk.
-
-* `throughput` - (Optional, Int, ForceNew) Specifies the throughput for the volume. The Unit is MiB/s.
+* `throughput` - (Optional, Int) Specifies the throughput for the volume. The Unit is MiB/s.
   The field is valid and required when `volume_type` is set to **GPSSD2**.
 
   + If `volume_type` is set to **GPSSD2**. The field `throughput` ranging from 125 to 1,000.
     This throughput must also be less than or equal to the IOPS divided by 4.
-
-  Changing this creates a new disk.
 
 * `name` - (Optional, String) Specifies the disk name. The value can contain a maximum of 255 bytes.
 

--- a/go.sum
+++ b/go.sum
@@ -26,7 +26,8 @@ github.com/chnsz/golangsdk v0.0.0-20240109025837-8aa22d6dae58 h1:BcWqT5aGMDkha8U
 github.com/chnsz/golangsdk v0.0.0-20240109025837-8aa22d6dae58/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=z
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
@@ -329,6 +330,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -612,6 +612,10 @@ func (c *Config) BlockStorageV21Client(region string) (*golangsdk.ServiceClient,
 	return c.NewServiceClient("evsv21", region)
 }
 
+func (c *Config) BlockStorageV5Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("evsv5", region)
+}
+
 func (c *Config) BlockStorageV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("evs", region)
 }

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -23,7 +23,7 @@ var multiCatalogKeys = map[string][]string{
 	"iam":          {"identity", "iam_no_version"},
 	"bss":          {"bssv2"},
 	"ecs":          {"ecsv21", "ecsv11"},
-	"evs":          {"evsv21", "evsv1"},
+	"evs":          {"evsv21", "evsv1", "evsv5"},
 	"cce":          {"ccev1", "cce_addon"},
 	"cci":          {"cciv1_bata"},
 	"vpc":          {"networkv2", "vpcv3", "fwv2"},
@@ -244,6 +244,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"evsv21": {
 		Name:    "evs",
 		Version: "v2.1",
+		Product: "EVS",
+	},
+	"evsv5": {
+		Name:    "evs",
+		Version: "v5",
 		Product: "EVS",
 	},
 	"sfs": {

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -251,6 +251,9 @@ var (
 	HW_DATAARTS_CONNECTION_NAME         = os.Getenv("HW_DATAARTS_CONNECTION_NAME")
 	HW_DATAARTS_ARCHITECTURE_USER_ID    = os.Getenv("HW_DATAARTS_ARCHITECTURE_USER_ID")
 	HW_DATAARTS_ARCHITECTURE_USER_NAME  = os.Getenv("HW_DATAARTS_ARCHITECTURE_USER_NAME")
+
+	HW_EVS_AVAILABILITY_ZONE_GPSSD2 = os.Getenv("HW_EVS_AVAILABILITY_ZONE_GPSSD2")
+	HW_EVS_AVAILABILITY_ZONE_ESSD2  = os.Getenv("HW_EVS_AVAILABILITY_ZONE_ESSD2")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -566,6 +569,20 @@ func TestAccPreCheckOBSUserDomainNames(t *testing.T) {
 func TestAccPreCheckChargingMode(t *testing.T) {
 	if HW_CHARGING_MODE != "prePaid" {
 		t.Skip("This environment does not support prepaid tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckAvailabilityZoneGPSSD2(t *testing.T) {
+	if HW_EVS_AVAILABILITY_ZONE_GPSSD2 == "" {
+		t.Skip("If you want to change the QoS of a GPSSD2 type cloudvolume, you must specify an availability zone that supports GPSSD2 type under the current region")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckAvailabilityZoneESSD2(t *testing.T) {
+	if HW_EVS_AVAILABILITY_ZONE_ESSD2 == "" {
+		t.Skip("If you want to change the QoS of a ESSD2 type cloudvolume, you must specify an availability zone that supports ESSD2 type under the current region")
 	}
 }
 

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_test.go
@@ -250,6 +250,90 @@ func TestAccEvsVolume_withServerId(t *testing.T) {
 	})
 }
 
+func TestAccEvsVolume_GPSSD2(t *testing.T) {
+	var volume cloudvolumes.Volume
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_evs_volume.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&volume,
+		getVolumeResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Type GPSSD2 is only supported in part availability_zones under the certain region.
+			acceptance.TestAccPreCheckAvailabilityZoneGPSSD2(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEvsVolume_GPSSD2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone", acceptance.HW_EVS_AVAILABILITY_ZONE_GPSSD2),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "125"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_GPSSD2_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "4000"),
+					resource.TestCheckResourceAttr(resourceName, "throughput", "150"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEvsVolume_ESSD2(t *testing.T) {
+	var volume cloudvolumes.Volume
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_evs_volume.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&volume,
+		getVolumeResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Type ESSD2 is only supported in part availability_zones under the certain region.
+			acceptance.TestAccPreCheckAvailabilityZoneESSD2(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEvsVolume_ESSD2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone", acceptance.HW_EVS_AVAILABILITY_ZONE_ESSD2),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "ESSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "3000"),
+				),
+			},
+			{
+				Config: testAccEvsVolume_ESSD2_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "ESSD2"),
+					resource.TestCheckResourceAttr(resourceName, "iops", "4000"),
+				),
+			},
+		},
+	})
+}
+
 func testAccEvsVolume_base() string {
 	return `
 variable "volume_configuration" {
@@ -514,4 +598,58 @@ resource "huaweicloud_evs_volume" "test" {
   charging_mode     = "postPaid"
 }
 `, testAccComputeInstance_basic(rName), rName)
+}
+
+func testAccEvsVolume_GPSSD2(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%[1]s"
+  description       = "test volume for updating QoS when volume_type is GPSSD2"
+  availability_zone = "%[2]s"
+  size              = 100
+  volume_type       = "GPSSD2"
+  iops              = 3000
+  throughput        = 125
+}
+`, rName, acceptance.HW_EVS_AVAILABILITY_ZONE_GPSSD2)
+}
+
+func testAccEvsVolume_GPSSD2_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%[1]s"
+  description       = "test volume for updating QoS when volume_type is GPSSD2"
+  availability_zone = "%[2]s"
+  size              = 100
+  volume_type       = "GPSSD2"
+  iops              = 4000
+  throughput        = 150
+}
+`, rName, acceptance.HW_EVS_AVAILABILITY_ZONE_GPSSD2)
+}
+
+func testAccEvsVolume_ESSD2(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%[1]s"
+  description       = "test volume for updating QoS when volume_type is ESSD2"
+  availability_zone = "%[2]s"
+  size              = 100
+  volume_type       = "ESSD2"
+  iops              = 3000
+}
+`, rName, acceptance.HW_EVS_AVAILABILITY_ZONE_ESSD2)
+}
+
+func testAccEvsVolume_ESSD2_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%[1]s"
+  description       = "test volume for updating QoS when volume_type is ESSD2"
+  availability_zone = "%[2]s"
+  size              = 100
+  volume_type       = "ESSD2"
+  iops              = 4000
+}
+`, rName, acceptance.HW_EVS_AVAILABILITY_ZONE_ESSD2)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes/requests.go
@@ -1,0 +1,32 @@
+package cloudvolumes
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+type QoSModifyOpts struct {
+	IopsAndThroughputOpts IopsAndThroughputOpts `json:"qos_modify" required:"true"`
+}
+
+type IopsAndThroughputOpts struct {
+	Iops       int `json:"iops" required:"true"`
+	Throughput int `json:"throughput,omitempty"`
+}
+
+func (opts QoSModifyOpts) ToVolumeUpdateQoSMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+type UpdateQoSOptsBuilder interface {
+	ToVolumeUpdateQoSMap() (map[string]interface{}, error)
+}
+
+func ModifyQoS(client *golangsdk.ServiceClient, id string, opts UpdateQoSOptsBuilder) (r JobResult) {
+	b, err := opts.ToVolumeUpdateQoSMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(qoSURL(client, id), b, &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes/resullts.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes/resullts.go
@@ -1,0 +1,22 @@
+package cloudvolumes
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// JobResult contains the response body and error from UpdateQoS response
+type JobResult struct {
+	golangsdk.Result
+}
+
+// JobResponse contains all the information from UpdateQoS response
+type JobResponse struct {
+	JobID string `json:"job_id"`
+}
+
+// Extract will get the JobResponse object out of the JobResult
+func (r JobResult) Extract() (*JobResponse, error) {
+	job := new(JobResponse)
+	err := r.ExtractInto(job)
+	return job, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes/urls.go
@@ -1,0 +1,7 @@
+package cloudvolumes
+
+import "github.com/chnsz/golangsdk"
+
+func qoSURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("cloudvolumes", id, "qos")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,6 +184,7 @@ github.com/chnsz/golangsdk/openstack/er/v3/vpcattachments
 github.com/chnsz/golangsdk/openstack/evs/v1/jobs
 github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes
 github.com/chnsz/golangsdk/openstack/evs/v2/snapshots
+github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes
 github.com/chnsz/golangsdk/openstack/fgs/v2/aliases
 github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies
 github.com/chnsz/golangsdk/openstack/fgs/v2/function


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
+ The API interface for updating QoS is asynchronous
+ Interface constraints: QoS can be updated only when the cloudvolume `status` is **available** or **in-use**
+ Type **GPSSD2** and **ESSD2** are only supported in part `availability_zones` under the certain `region` 
+ **GPSSD2** type must input `iops` and `throughput`
+ **ESSD2** type must input `iops`  and not input `throughput`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccEvsVolume_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_basic
=== PAUSE TestAccEvsVolume_basic
=== CONT  TestAccEvsVolume_basic
--- PASS: TestAccEvsVolume_basic (118.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       118.517s
make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccEvsVolume_withEpsId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_withEpsId
=== PAUSE TestAccEvsVolume_withEpsId
=== CONT  TestAccEvsVolume_withEpsId
--- PASS: TestAccEvsVolume_withEpsId (58.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       59.023s
make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccEvsVolume_withServerId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_withServerId -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_withServerId
=== PAUSE TestAccEvsVolume_withServerId
=== CONT  TestAccEvsVolume_withServerId
--- PASS: TestAccEvsVolume_withServerId (331.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       331.333s
make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccEvsVolume_GPSSD2"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_GPSSD2 -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_GPSSD2
=== PAUSE TestAccEvsVolume_GPSSD2
=== CONT  TestAccEvsVolume_GPSSD2
--- PASS: TestAccEvsVolume_GPSSD2 (184.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       184.061s
make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccEvsVolume_ESSD2"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_ESSD2 -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_ESSD2
=== PAUSE TestAccEvsVolume_ESSD2
=== CONT  TestAccEvsVolume_ESSD2
--- PASS: TestAccEvsVolume_ESSD2 (79.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       79.219s
```
