### PR TITLE
feat(as/policy): action structure support new parameter

### DIFF
--- a/docs/resources/as_policy.md
+++ b/docs/resources/as_policy.md
@@ -153,7 +153,12 @@ The `scaling_policy_action` block supports:
 * `operation` - (Optional, String) Specifies the operation to be performed. The options include `ADD` (default), `REMOVE`,
   and `SET`.
 
-* `instance_number` - (Optional, Int) Specifies the number of instances to be operated. The default number is 1.
+* `instance_number` - (Optional, Int) Specifies the number of instances to be operated.
+
+* `instance_percentage` - (Optional, Int) Specifies the percentage of instances to be operated.
+
+-> At most one of `instance_number` and `instance_percentage` can be set. When neither `instance_number` nor
+  `instance_percentage` is specified, the number of operation instances is **1**.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20231229075012-3457589ab494
+	github.com/chnsz/golangsdk v0.0.0-20240103070615-98052f465833
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20231229075012-3457589ab494 h1:qnZbqMSDpjZhxrpro9USTns0xggX+dLQCt3kULLsTQI=
-github.com/chnsz/golangsdk v0.0.0-20231229075012-3457589ab494/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240103070615-98052f465833 h1:gjtkCVBRDCPEMdy9b3R+xQf+x+9Aa98LT8F1OrTZG2g=
+github.com/chnsz/golangsdk v0.0.0-20240103070615-98052f465833/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
@@ -86,7 +86,7 @@ func TestAccASPolicy_Alarm(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "600"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "ALARM"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.operation", "ADD"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.instance_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.instance_percentage", "10"),
 					resource.TestCheckResourceAttrPair(resourceName, "scaling_group_id", "huaweicloud_as_group.acc_as_group", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "alarm_id", "huaweicloud_ces_alarmrule.alarm_rule", "id"),
 				),
@@ -288,8 +288,8 @@ resource "huaweicloud_as_policy" "acc_as_policy"{
   cool_down_time      = 600
 
   scaling_policy_action {
-    operation       = "ADD"
-    instance_number = 1
+    operation           = "ADD"
+    instance_percentage = 10
   }
 }
 `, testASPolicy_base(rName), rName)

--- a/huaweicloud/services/as/resource_huaweicloud_as_policy.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_policy.go
@@ -115,7 +115,12 @@ func ResourceASPolicy() *schema.Resource {
 						"instance_number": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  1,
+							Computed: true,
+						},
+						"instance_percentage": {
+							Type:          schema.TypeInt,
+							Optional:      true,
+							ConflictsWith: []string{"scaling_policy_action.0.instance_number"},
 						},
 					},
 				},
@@ -190,8 +195,9 @@ func buildScheduledPolicy(rawScheduledPolicy map[string]interface{}) policies.Sc
 
 func buildPolicyAction(rawPolicyAction map[string]interface{}) policies.ActionOpts {
 	policyAction := policies.ActionOpts{
-		Operation:   rawPolicyAction["operation"].(string),
-		InstanceNum: rawPolicyAction["instance_number"].(int),
+		Operation:          rawPolicyAction["operation"].(string),
+		InstanceNum:        rawPolicyAction["instance_number"].(int),
+		InstancePercentage: rawPolicyAction["instance_percentage"].(int),
 	}
 	return policyAction
 }
@@ -270,8 +276,9 @@ func resourceASPolicyRead(_ context.Context, d *schema.ResourceData, meta interf
 func flattenPolicyAction(action policies.Action) []map[string]interface{} {
 	return []map[string]interface{}{
 		{
-			"operation":       action.Operation,
-			"instance_number": action.InstanceNum,
+			"operation":           action.Operation,
+			"instance_number":     action.InstanceNum,
+			"instance_percentage": action.InstancePercentage,
 		},
 	}
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies/requests.go
@@ -4,12 +4,12 @@ import (
 	"github.com/chnsz/golangsdk"
 )
 
-//CreateOptsBuilder is an interface by which can serialize the create parameters
+// CreateOptsBuilder is an interface by which can serialize the create parameters
 type CreateOptsBuilder interface {
 	ToPolicyCreateMap() (map[string]interface{}, error)
 }
 
-//CreateOpts is a struct which will be used to create a policy
+// CreateOpts is a struct which will be used to create a policy
 type CreateOpts struct {
 	Name           string             `json:"scaling_policy_name" required:"true"`
 	ID             string             `json:"scaling_group_id" required:"true"`
@@ -29,16 +29,17 @@ type SchedulePolicyOpts struct {
 }
 
 type ActionOpts struct {
-	Operation   string `json:"operation,omitempty"`
-	InstanceNum int    `json:"instance_number,omitempty"`
+	Operation          string `json:"operation,omitempty"`
+	InstanceNum        int    `json:"instance_number,omitempty"`
+	InstancePercentage int    `json:"instance_percentage,omitempty"`
 }
 
 func (opts CreateOpts) ToPolicyCreateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-//Create is a method which can be able to access to create the policy of autoscaling
-//service.
+// Create is a method which can be able to access to create the policy of autoscaling
+// service.
 func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	b, err := opts.ToPolicyCreateMap()
 	if err != nil {
@@ -52,12 +53,12 @@ func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateRe
 	return
 }
 
-//UpdateOptsBuilder is an interface which can build the map paramter of update function
+// UpdateOptsBuilder is an interface which can build the map paramter of update function
 type UpdateOptsBuilder interface {
 	ToPolicyUpdateMap() (map[string]interface{}, error)
 }
 
-//UpdateOpts is a struct which represents the parameters of update function
+// UpdateOpts is a struct which represents the parameters of update function
 type UpdateOpts struct {
 	Name           string             `json:"scaling_policy_name,omitempty"`
 	Type           string             `json:"scaling_policy_type,omitempty"`
@@ -71,8 +72,8 @@ func (opts UpdateOpts) ToPolicyUpdateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-//Update is a method which can be able to update the policy via accessing to the
-//autoscaling service with Put method and parameters
+// Update is a method which can be able to update the policy via accessing to the
+// autoscaling service with Put method and parameters
 func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	body, err := opts.ToPolicyUpdateMap()
 	if err != nil {
@@ -86,14 +87,46 @@ func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) 
 	return
 }
 
-//Delete is a method which can be able to access to delete a policy of autoscaling
+// Delete is a method which can be able to access to delete a policy of autoscaling
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(deleteURL(client, id), nil)
 	return
 }
 
-//Get is a method which can be able to access to get a policy detailed information
+// Get is a method which can be able to access to get a policy detailed information
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// ListOpts is the structure that used to query the policies of scaling group.
+type ListOpts struct {
+	// The scaling group ID.
+	GroupID string `json:"scaling_group_id" required:"true"`
+	// The scaling policy name.
+	Name string `q:"scaling_policy_name"`
+	// The scaling policy type.
+	Type string `q:"scaling_policy_type"`
+	// The scaling policy ID.
+	PolicyID string `q:"scaling_policy_id"`
+	// Start number value. The value must be a positive integer.
+	StartNumber int `q:"start_number"`
+	// Number of records displayed per page.
+	// The value must be a positive integer.
+	Limit int `q:"limit"`
+}
+
+// List is a method used to query the policies of scaling group with given parameters.
+// Due to API limitations, there can be a maximum of 10 policies, so pagination is not considered here,
+// simply call the API instead.
+func List(client *golangsdk.ServiceClient, opts ListOpts) (r ListResult) {
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	url := listURL(client, opts.GroupID) + query.String()
+	_, r.Err = client.Get(url, &r.Body, nil)
 	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies/results.go
@@ -4,12 +4,12 @@ import (
 	"github.com/chnsz/golangsdk"
 )
 
-//Create Result is a struct which represents the create result of policy
+// CreateResult is a struct which represents the create result of policy
 type CreateResult struct {
 	golangsdk.Result
 }
 
-//Extract of CreateResult will deserialize the result of Creation
+// Extract of CreateResult will deserialize the result of Creation
 func (r CreateResult) Extract() (string, error) {
 	var a struct {
 		ID string `json:"scaling_policy_id"`
@@ -18,15 +18,16 @@ func (r CreateResult) Extract() (string, error) {
 	return a.ID, err
 }
 
-//DeleteResult is a struct which represents the delete result.
+// DeleteResult is a struct which represents the delete result.
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
 
-//Policy is a struct that represents the result of get policy
+// Policy is a struct that represents the result of get policy
 type Policy struct {
 	ID             string         `json:"scaling_group_id"`
 	Name           string         `json:"scaling_policy_name"`
+	PolicyID       string         `json:"scaling_policy_id"`
 	Status         string         `json:"policy_status"`
 	Type           string         `json:"scaling_policy_type"`
 	AlarmID        string         `json:"alarm_id"`
@@ -45,11 +46,12 @@ type SchedulePolicy struct {
 }
 
 type Action struct {
-	Operation   string `json:"operation"`
-	InstanceNum int    `json:"instance_number"`
+	Operation          string `json:"operation"`
+	InstanceNum        int    `json:"instance_number"`
+	InstancePercentage int    `json:"instance_percentage"`
 }
 
-//GetResult is a struct which represents the get result
+// GetResult is a struct which represents the get result
 type GetResult struct {
 	golangsdk.Result
 }
@@ -60,16 +62,34 @@ func (r GetResult) Extract() (Policy, error) {
 	return p, err
 }
 
-//UpdateResult is a struct from which can get the result of udpate method
+// UpdateResult is a struct from which can get the result of update method
 type UpdateResult struct {
 	golangsdk.Result
 }
 
-//Extract will deserialize the result to group id with string
+// Extract will deserialize the result to group id with string
 func (r UpdateResult) Extract() (string, error) {
 	var a struct {
 		ID string `json:"scaling_policy_id"`
 	}
 	err := r.Result.ExtractInto(&a)
 	return a.ID, err
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// ListResult represents a result of the List method.
+type ListResult struct {
+	commonResult
+}
+
+// Extract is a method to extract the list of policies for specified scaling group.
+func (r ListResult) Extract() ([]Policy, error) {
+	var s struct {
+		Policies []Policy `json:"scaling_policies"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Policies, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies/urls.go
@@ -6,23 +6,27 @@ import (
 
 const resourcePath = "scaling_policy"
 
-//createURL will build the rest query url of creation
-//the create url is endpoint/scaling_policy
+// createURL will build the rest query url of creation
+// the create url is endpoint/scaling_policy
 func createURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(resourcePath)
 }
 
-//deleteURL will build the url of deletion
-//its pattern is endpoint/scaling_policy/<policy-id>
+// deleteURL will build the url of deletion
+// its pattern is endpoint/scaling_policy/<policy-id>
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(resourcePath, id)
 }
 
-//getURL will build the get url of get function
+// getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(resourcePath, id)
 }
 
 func updateURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(resourcePath, id)
+}
+
+func listURL(client *golangsdk.ServiceClient, groupID string) string {
+	return client.ServiceURL(resourcePath, groupID, "list")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20231229075012-3457589ab494
+# github.com/chnsz/golangsdk v0.0.0-20240103070615-98052f465833
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
action structure support new parameter
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.action structure support new parameter
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_basic
=== PAUSE TestAccASPolicy_basic
=== CONT  TestAccASPolicy_basic
--- PASS: TestAccASPolicy_basic (102.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        102.378s
root@ecs-dev-jinyangyang:/mnt/d/project/huawei/terraform/src/github.com/huaweicloud/terraform-provider-huaweicloud# make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASPolicy_Alarm"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_Alarm -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_Alarm
=== PAUSE TestAccASPolicy_Alarm
=== CONT  TestAccASPolicy_Alarm
--- PASS: TestAccASPolicy_Alarm (78.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        78.445s
```
