### PR TITLE
feat(VPC): add a new resource traffic mirror filter

### DIFF
--- a/docs/resources/vpc_traffic_mirror_filter.md
+++ b/docs/resources/vpc_traffic_mirror_filter.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# huaweicloud_vpc_traffic_mirror_filter
+
+ Manages a VPC traffic mirror filter resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "traffic_mirror_filter_name" {}
+
+resource "huaweicloud_vpc_traffic_mirror_filter" "test" {
+  name        = var.traffic_mirror_filter_name
+  description = "Traffic mirror filter created by terraform"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of the traffic mirror filter.
+
+* `description` - (Optional, String) Specifies the description of the traffic mirror filter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -  The resource ID.
+
+* `created_at` - The creation time of the traffic mirror filter.
+
+* `updated_at` - The latest update time of the traffic mirror filter.
+
+## Import
+
+The traffic mirror filter can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_vpc_traffic_mirror_filter.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1267,6 +1267,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_subnet":                      vpc.ResourceVpcSubnetV1(),
 			"huaweicloud_vpc_address_group":               vpc.ResourceVpcAddressGroup(),
 			"huaweicloud_vpc_flow_log":                    vpc.ResourceVpcFlowLog(),
+			"huaweicloud_vpc_traffic_mirror_filter":       vpc.ResourceTrafficMirrorFilter(),
 
 			"huaweicloud_vpcep_approval": vpcep.ResourceVPCEndpointApproval(),
 			"huaweicloud_vpcep_endpoint": vpcep.ResourceVPCEndpoint(),

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_traffic_mirror_filter_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_traffic_mirror_filter_test.go
@@ -1,0 +1,93 @@
+package vpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getTrafficMirrorFilterResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return "", fmt.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	getTrafficMirrorFilterHttpUrl := "vpc/traffic-mirror-filters/" + state.Primary.ID
+	getTrafficMirrorFilterPath := client.ResourceBaseURL() + getTrafficMirrorFilterHttpUrl
+	getTrafficMirrorFilterOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getTrafficMirrorFilterResp, err := client.Request("GET", getTrafficMirrorFilterPath, &getTrafficMirrorFilterOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving traffic mirror filter: %s", err)
+	}
+
+	return utils.FlattenResponse(getTrafficMirrorFilterResp)
+}
+
+func TestAccTrafficMirrorFilter_basic(t *testing.T) {
+	var (
+		trafficMirrorFilter interface{}
+		name                = acceptance.RandomAccResourceNameWithDash()
+		updatedName         = acceptance.RandomAccResourceNameWithDash()
+		resourceName        = "huaweicloud_vpc_traffic_mirror_filter.test"
+		desc                = "create VPC traffic mirror filter"
+
+		rc = acceptance.InitResourceCheck(
+			resourceName,
+			&trafficMirrorFilter,
+			getTrafficMirrorFilterResourceFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTrafficMirrorFilter_base(name, desc),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", desc),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccTrafficMirrorFilter_base(updatedName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", updatedName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccTrafficMirrorFilter_base(name string, description string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_traffic_mirror_filter" "test" {
+  name        = "%[1]s"
+  description = "%[2]s"
+}
+`, name, description)
+}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_traffic_mirror_filter.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_traffic_mirror_filter.go
@@ -1,0 +1,196 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: VPC POST /v3/{project_id}/vpc/traffic-mirror-filters
+// API: VPC GET /v3/{project_id}/vpc/traffic-mirror-filters/{traffic_mirror_filter_id}
+// API: VPC PUT /v3/{project_id}/vpc/traffic-mirror-filters/{traffic_mirror_filter_id}
+// API: VPC DELETE /v3/{project_id}/vpc/traffic-mirror-filters/{traffic_mirror_filter_id}
+func ResourceTrafficMirrorFilter() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTrafficMirrorFilterCreate,
+		ReadContext:   resourceTrafficMirrorFilterRead,
+		UpdateContext: resourceTrafficMirrorFilterUpdate,
+		DeleteContext: resourceTrafficMirrorFilterDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func getTrafficMirrorFilterHttpUrl(d *schema.ResourceData, client *golangsdk.ServiceClient) string {
+	trafficMirrorFilterPath := client.ResourceBaseURL() + "vpc/traffic-mirror-filters"
+	if d.Id() != "" {
+		trafficMirrorFilterPath += "/" + d.Id()
+	}
+	return trafficMirrorFilterPath
+}
+
+func buildTrafficMirrorFilterBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"traffic_mirror_filter": map[string]interface{}{
+			"name":        d.Get("name"),
+			"description": d.Get("description"),
+		},
+	}
+	return bodyParams
+}
+
+func resourceTrafficMirrorFilterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	ctreateTrafficMirrorFilterPath := getTrafficMirrorFilterHttpUrl(d, client)
+	createTrafficMirrorFilterOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			201,
+		},
+	}
+	createTrafficMirrorFilterOpt.JSONBody = utils.RemoveNil(buildTrafficMirrorFilterBodyParams(d))
+	createTrafficMirrorFilterResp, err := client.Request("POST", ctreateTrafficMirrorFilterPath, &createTrafficMirrorFilterOpt)
+	if err != nil {
+		return diag.Errorf("error creating traffic mirror filter: %s", err)
+	}
+
+	createTrafficMirrorFilterRespBody, err := utils.FlattenResponse(createTrafficMirrorFilterResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("traffic_mirror_filter.id", createTrafficMirrorFilterRespBody)
+	if err != nil {
+		return diag.Errorf("error creating traffic mirror filter: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceTrafficMirrorFilterRead(ctx, d, meta)
+}
+
+func resourceTrafficMirrorFilterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	getTrafficMirrorFilterPath := getTrafficMirrorFilterHttpUrl(d, client)
+	getTrafficMirrorFilterOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getTrafficMirrorFilterResp, err := client.Request("GET", getTrafficMirrorFilterPath, &getTrafficMirrorFilterOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "VPC traffic mirror filter")
+	}
+
+	getTrafficMirrorFilterRespBody, err := utils.FlattenResponse(getTrafficMirrorFilterResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("traffic_mirror_filter.name", getTrafficMirrorFilterRespBody, nil)),
+		d.Set("description", utils.PathSearch("traffic_mirror_filter.description", getTrafficMirrorFilterRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("traffic_mirror_filter.created_at", getTrafficMirrorFilterRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("traffic_mirror_filter.updated_at", getTrafficMirrorFilterRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceTrafficMirrorFilterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	if d.HasChanges("name", "description") {
+		updateTrafficMirrorFilterOpts := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		updateTrafficMirrorFilterOpts.JSONBody = utils.RemoveNil(buildTrafficMirrorFilterBodyParams(d))
+		updateTrafficMirrorFilterPath := getTrafficMirrorFilterHttpUrl(d, client)
+		_, err = client.Request("PUT", updateTrafficMirrorFilterPath, &updateTrafficMirrorFilterOpts)
+		if err != nil {
+			return diag.Errorf("error updating traffic mirror filter: %s", err)
+		}
+	}
+
+	return resourceTrafficMirrorFilterRead(ctx, d, meta)
+}
+
+func resourceTrafficMirrorFilterDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	deleteTrafficMirrorFilterPath := getTrafficMirrorFilterHttpUrl(d, client)
+	deleteTrafficMirrorFilterOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+	_, err = client.Request("DELETE", deleteTrafficMirrorFilterPath, &deleteTrafficMirrorFilterOpt)
+	if err != nil {
+		return diag.Errorf("error deleting traffic mirror filter: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource traffic mirror filter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST=./huaweicloud/services/acceptance/vpc TESTARGS='-run TestAccTrafficMirrorFilter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccTrafficMirrorFilter_basic -timeout 360m -parallel 4
=== RUN   TestAccTrafficMirrorFilter_basic
=== PAUSE TestAccTrafficMirrorFilter_basic
=== CONT  TestAccTrafficMirrorFilter_basic
--- PASS: TestAccTrafficMirrorFilter_basic (18.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       18.213s
```
