### PR TITLE
feat(DMS): add wait logic to kafka permissions

### DIFF
--- a/docs/resources/dms_kafka_permissions.md
+++ b/docs/resources/dms_kafka_permissions.md
@@ -61,6 +61,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID which is formatted `<instance_id>/<topic_name>`.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.
+
 ## Import
 
 DMS kafka permissions can be imported using the kafka instance ID and topic name separated by a slash, e.g.:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240103070615-98052f465833
+	github.com/chnsz/golangsdk v0.0.0-20240104014600-4287f9738784
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240103070615-98052f465833 h1:gjtkCVBRDCPEMdy9b3R+xQf+x+9Aa98LT8F1OrTZG2g=
-github.com/chnsz/golangsdk v0.0.0-20240103070615-98052f465833/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240104014600-4287f9738784 h1:WsD5sSpzoa24jkujsPlTyPDwU37q9lfIer288aO+3rk=
+github.com/chnsz/golangsdk v0.0.0-20240104014600-4287f9738784/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_permissions.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_permissions.go
@@ -5,10 +5,15 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances"
 
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model"
 
@@ -25,6 +30,10 @@ func ResourceDmsKafkaPermissions() *schema.Resource {
 		ReadContext:   resourceDmsKafkaPermissionsRead,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -122,6 +131,17 @@ func resourceDmsKafkaPermissionsCreateOrUpdate(ctx context.Context, d *schema.Re
 
 	id := instanceId + "/" + topicName
 	d.SetId(id)
+
+	cli, err := c.DmsV2Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS Kafka(v2) client: %s", err)
+	}
+
+	err = waitForKafkaTopicAccessPolicyComplete(ctx, cli, d, instanceId, schema.TimeoutCreate)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	return resourceDmsKafkaPermissionsRead(ctx, d, meta)
 }
 
@@ -192,6 +212,16 @@ func resourceDmsKafkaPermissionsDelete(ctx context.Context, d *schema.ResourceDa
 		return diag.Errorf("error deleting DMS kafka permissions: %s", err)
 	}
 
+	cli, err := c.DmsV2Client(c.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DMS Kafka(v2) client: %s", err)
+	}
+
+	err = waitForKafkaTopicAccessPolicyComplete(ctx, cli, d, instanceId, schema.TimeoutDelete)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
 
@@ -205,4 +235,35 @@ func flattenPolicies(policies []model.PolicyEntity) []map[string]interface{} {
 	}
 
 	return policiesToSet
+}
+
+func waitForKafkaTopicAccessPolicyComplete(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	instanceID string, timeout string) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"CREATED"},
+		Refresh:      kafkaInstancePolicyRefreshFunc(client, instanceID),
+		Timeout:      d.Timeout(timeout),
+		Delay:        1 * time.Second,
+		PollInterval: 2 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for DMS Kafka instance (%s) task to be completed: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func kafkaInstancePolicyRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := instances.Get(client, instanceID).Extract()
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		if resp.Task.Name == "updateTopicPolicies" {
+			return resp, "PENDING", nil
+		}
+		return resp, "CREATED", nil
+	}
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
@@ -96,6 +96,7 @@ type Instance struct {
 	MessageQueryInstEnable     bool               `json:"message_query_inst_enable"`
 	VpcClientPlain             bool               `json:"vpc_client_plain"`
 	SupportFeatures            string             `json:"support_features"`
+	Task                       Task               `json:"task"`
 	TraceEnable                bool               `json:"trace_enable"`
 	PodConnectAddress          string             `json:"pod_connect_address"`
 	DiskEncrypted              bool               `json:"disk_encrypted"`
@@ -103,6 +104,12 @@ type Instance struct {
 	CesVersion                 string             `json:"ces_version"`
 	AccessUser                 string             `json:"access_user"`
 	Tags                       []tags.ResourceTag `json:"tags"`
+}
+
+type Task struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	CreatedAt string `json:"created_at"`
 }
 
 // UpdateResult is a struct from which can get the result of update method

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240103070615-98052f465833
+# github.com/chnsz/golangsdk v0.0.0-20240104014600-4287f9738784
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add wait logic to kafka permissions
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add wait logic to kafka permissions
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccDmsKafkaPermissions_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsKafkaPermissions_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaPermissions_basic
=== PAUSE TestAccDmsKafkaPermissions_basic
=== CONT  TestAccDmsKafkaPermissions_basic
--- PASS: TestAccDmsKafkaPermissions_basic (917.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       917.788s
```
