### PR TITLE
feat(VPCEP): add datasource to query VPC endpoint service connections

### DIFF
--- a/docs/data-sources/vpcep_service_connections.md
+++ b/docs/data-sources/vpcep_service_connections.md
@@ -1,0 +1,56 @@
+---
+subcategory: "VPC Endpoint (VPCEP)"
+---
+
+# huaweicloud_vpcep_service_connections
+
+Use this data source to get VPC endpoint service connections.
+
+## Example Usage
+
+```hcl
+variable service_id {}
+variable endpoint_id {}
+variable status {}
+
+data "huaweicloud_vpcep_service_connections" "connections" {
+  service_id  = var.service_id
+  endpoint_id = var.endpoint_id
+  status      = var.status
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the VPC endpoint service. If omitted, the
+  provider-level region will be used.
+
+* `service_id` - (Required, String) Specifies the ID of VPC endpoint service.
+
+* `endpoint_id` - (Optional, String) Specifies the ID of VPC endpoint which has connected to
+  VPC endpoint service.
+
+* `status` - (Optional, String) Specifies the connection status of the VPC endpoint.
+  The value can be **pendingAcceptance**, **accepted**, **rejected** and **failed**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `connections` - The list of VPC endpoint service connections.
+
+The `connections` block supports:
+
+* `endpoint_id` - The ID of VPC endpoint.
+
+* `status` - The connection status of the VPC endpoint.
+
+* `domain_id` - The Domain ID.
+
+* `created_at` - The creation time of VPC endpoint.
+
+* `updated_at` - The latest update time of VPC endpoint.
+
+* `description` - The description of the VPC endpoint connection.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -637,8 +637,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_subnets":            vpc.DataSourceVpcSubnets(),
 			"huaweicloud_vpc_subnet_ids":         vpc.DataSourceVpcSubnetIdsV1(),
 
-			"huaweicloud_vpcep_public_services": vpcep.DataSourceVPCEPPublicServices(),
-			"huaweicloud_vpcep_services":        vpcep.DataSourceVPCEPServices(),
+			"huaweicloud_vpcep_public_services":     vpcep.DataSourceVPCEPPublicServices(),
+			"huaweicloud_vpcep_services":            vpcep.DataSourceVPCEPServices(),
+			"huaweicloud_vpcep_service_connections": vpcep.DataSourceVPCEPServiceConnections(),
 
 			"huaweicloud_vpn_gateway_availability_zones": vpn.DataSourceVpnGatewayAZs(),
 			"huaweicloud_vpn_gateways":                   vpn.DataSourceGateways(),

--- a/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_service_connections_test.go
+++ b/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_service_connections_test.go
@@ -1,0 +1,80 @@
+package vpcep
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceVPCEPServiceConnections_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_vpcep_service_connections.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceVpcepServiceConnections_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.endpoint_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.domain_id"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "connections.0.updated_at"),
+
+					resource.TestCheckOutput("endpoint_id_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceVpcepServiceConnections_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpcep_service_connections" "test" {
+  service_id = huaweicloud_vpcep_endpoint.test.service_id
+}
+
+data "huaweicloud_vpcep_service_connections" "endpoint_id_filter" {
+  service_id  = huaweicloud_vpcep_endpoint.test.service_id
+  endpoint_id = data.huaweicloud_vpcep_service_connections.test.connections.0.endpoint_id
+}
+
+locals {
+  endpoint_id = data.huaweicloud_vpcep_service_connections.test.connections.0.endpoint_id
+}
+
+output "endpoint_id_filter_is_useful" {
+  value = length(data.huaweicloud_vpcep_service_connections.endpoint_id_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_vpcep_service_connections.endpoint_id_filter.connections[*].endpoint_id : v == local.endpoint_id]
+  )  
+}
+
+data "huaweicloud_vpcep_service_connections" "status_filter" {
+  service_id = huaweicloud_vpcep_endpoint.test.service_id
+  status     = data.huaweicloud_vpcep_service_connections.test.connections.0.status
+}
+  
+locals {
+  status = data.huaweicloud_vpcep_service_connections.test.connections.0.status
+}
+  
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_vpcep_service_connections.status_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_vpcep_service_connections.status_filter.connections[*].status : v == local.status]
+  )  
+}
+`, testAccVPCEndpoint_Basic(name))
+}

--- a/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_service_connections.go
+++ b/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_service_connections.go
@@ -1,0 +1,129 @@
+package vpcep
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/services"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// API: VPCEP GET /v1/{project_id}/vpc-endpoint-services/{vpc_endpoint_service_id}/connections
+func DataSourceVPCEPServiceConnections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVpcepServiceConnectionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"service_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"endpoint_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"connections": {
+				Type:     schema.TypeList,
+				Elem:     connectionsSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func connectionsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"endpoint_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceVpcepServiceConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC endpoint client: %s", err)
+	}
+
+	serviceId := d.Get("service_id").(string)
+	listConnOpts := services.ListConnOpts{
+		EndpointID: d.Get("endpoint_id").(string),
+		Status:     d.Get("status").(string),
+	}
+
+	allConnections, err := services.ListAllConnections(vpcepClient, serviceId, listConnOpts)
+	if err != nil {
+		return diag.Errorf("unable to retrieve VPC endpoint service connections: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("connections", flattenListVPCEPServiceConnections(allConnections)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListVPCEPServiceConnections(allConnections []services.Connection) []map[string]interface{} {
+	if allConnections == nil {
+		return nil
+	}
+	connections := make([]map[string]interface{}, len(allConnections))
+	for i, v := range allConnections {
+		connections[i] = map[string]interface{}{
+			"endpoint_id": v.EndpointID,
+			"domain_id":   v.DomainID,
+			"status":      v.Status,
+			"created_at":  v.Created,
+			"updated_at":  v.Updated,
+			"description": v.Description,
+		}
+	}
+	return connections
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccDatasourceVPCEPServiceConnections_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccDatasourceVPCEPServiceConnections_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceVPCEPServiceConnections_basic
=== PAUSE TestAccDatasourceVPCEPServiceConnections_basic
=== CONT  TestAccDatasourceVPCEPServiceConnections_basic
--- PASS: TestAccDatasourceVPCEPServiceConnections_basic (240.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     240.779s
