### PR TITLE
chore(cdm): add acc test and fix bug

### DIFF
--- a/docs/resources/cdm_link.md
+++ b/docs/resources/cdm_link.md
@@ -143,7 +143,7 @@ terraform import huaweicloud_cdm_link.test b11b407c-e604-4e8d-8bc4-92398320b847/
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `password` and `secret_key`.
+API response, security or some other reason. The missing attributes include: `password`, `secret_key` and `config`.
 It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated to
 align with the instance. Also you can ignore changes as below.
@@ -154,7 +154,7 @@ resource "huaweicloud_cdm_link" "test" {
 
   lifecycle {
     ignore_changes = [
-      password, secret_key,
+      password, secret_key, config,
     ]
   }
 }

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,7 @@ github.com/chnsz/golangsdk v0.0.0-20240105014415-f85b80e34b0e h1:qiwCYGX4+f4z6z+
 github.com/chnsz/golangsdk v0.0.0-20240105014415-f85b80e34b0e/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=z
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -1135,3 +1135,10 @@ func TestAccPreCheckDataArtsArchitectureReviewer(t *testing.T) {
 		t.Skip("HW_DATAARTS_ARCHITECTURE_USER_ID and HW_DATAARTS_ARCHITECTURE_USER_NAME must be set for the acceptance test")
 	}
 }
+
+// lintignore:AT003
+func TestAccPreCheckAKAndSK(t *testing.T) {
+	if HW_ACCESS_KEY == "" || HW_SECRET_KEY == "" {
+		t.Skip("HW_ACCESS_KEY and HW_SECRET_KEY must be set for acceptance tests")
+	}
+}

--- a/huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_job_test.go
+++ b/huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_job_test.go
@@ -48,8 +48,7 @@ func TestAccResourceCdmJob_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCdmJob_basic(name, bucketName, acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY),
-
+				Config: testAccCdmJob_basic(name, bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -57,7 +56,22 @@ func TestAccResourceCdmJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source_connector", "obs-connector"),
 					resource.TestCheckResourceAttr(resourceName, "destination_connector", "obs-connector"),
 					resource.TestCheckResourceAttr(resourceName, "config.0.retry_type", "NONE"),
-					resource.TestCheckResourceAttr(resourceName, "config.0.scheduler_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "config.0.scheduler_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "source_job_config.fromFileOpType", "DO_NOTHING"),
+					resource.TestCheckResourceAttr(resourceName, "destination_job_config.outputFormat", "BINARY_FILE"),
+					resource.TestCheckResourceAttr(resourceName, "destination_job_config.duplicateFileOpType", "REPLACE"),
+				),
+			},
+			{
+				Config: testAccCdmJob_update(name, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "job_type", "NORMAL_JOB"),
+					resource.TestCheckResourceAttr(resourceName, "source_connector", "obs-connector"),
+					resource.TestCheckResourceAttr(resourceName, "destination_connector", "obs-connector"),
+					resource.TestCheckResourceAttr(resourceName, "config.0.retry_type", "RETRY_TRIPLE"),
+					resource.TestCheckResourceAttr(resourceName, "config.0.scheduler_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "source_job_config.fromFileOpType", "DO_NOTHING"),
 					resource.TestCheckResourceAttr(resourceName, "destination_job_config.outputFormat", "BINARY_FILE"),
 					resource.TestCheckResourceAttr(resourceName, "destination_job_config.duplicateFileOpType", "REPLACE"),
@@ -73,26 +87,28 @@ func TestAccResourceCdmJob_basic(t *testing.T) {
 	})
 }
 
-func testAccCdmJob_basic(name, bucketName, ak, sk string) string {
-	clusterConfig := testAccCdmCluster_basic(name)
-
+func testAccCdmLinkAndOBS(name, bucketName string) string {
 	return fmt.Sprintf(`
-%s
-
 resource "huaweicloud_obs_bucket" "input" {
-  bucket        = "%s-input"
+  bucket        = "%[1]s-input"
   acl           = "private"
   force_destroy = true
 }
 
 resource "huaweicloud_obs_bucket" "output" {
-  bucket        = "%s-output"
+  bucket        = "%[1]s-output"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_obs_bucket" "dirty" {
+  bucket        = "%[1]s-dirty"
   acl           = "private"
   force_destroy = true
 }
 
 resource "huaweicloud_cdm_link" "test" {
-  name       = "%s"
+  name       = "%[2]s"
   connector  = "obs-connector"
   cluster_id = huaweicloud_cdm_cluster.test.id
   enabled    = true
@@ -103,9 +119,20 @@ resource "huaweicloud_cdm_link" "test" {
     "port"        = "443"
   }
 
-  access_key = "%s"
-  secret_key = "%s"
+  access_key = "%[3]s"
+  secret_key = "%[4]s"
 }
+`, bucketName, name, acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY)
+}
+
+func testAccCdmJob_basic(name, bucketName string) string {
+	clusterConfig := testAccCdmCluster_basic(name)
+	linkAndOBSConfig := testAccCdmLinkAndOBS(name, bucketName)
+
+	return fmt.Sprintf(`
+%s
+
+%s
 
 resource "huaweicloud_cdm_job" "test" {
   name       = "%s"
@@ -146,12 +173,20 @@ resource "huaweicloud_cdm_job" "test" {
   }
 
   config {
-    retry_type                   = "NONE"
-    scheduler_enabled            = false
-    throttling_extractors_number = 4
-    throttling_record_dirty_data = false
-    throttling_max_error_records = 10
-    throttling_loader_number     = 1
+    retry_type                          = "NONE"
+    scheduler_enabled                   = true
+    scheduler_cycle_type                = "month"
+    scheduler_cycle                     = 1
+    scheduler_run_at                    = 1
+    scheduler_start_date                = "2024-01-04 12:00:00"
+    scheduler_disposable_type           = "NONE"
+    throttling_extractors_number        = 4
+    throttling_record_dirty_data        = true
+    throttling_dirty_write_to_link      = huaweicloud_cdm_link.test.name
+    throttling_dirty_write_to_bucket    = huaweicloud_obs_bucket.dirty.bucket
+    throttling_dirty_write_to_directory = "/"
+    throttling_max_error_records        = 10
+    throttling_loader_number            = 1
   }
 
   lifecycle {
@@ -160,5 +195,78 @@ resource "huaweicloud_cdm_job" "test" {
     ]
   }
 }
-`, clusterConfig, bucketName, bucketName, name, ak, sk, name)
+`, clusterConfig, linkAndOBSConfig, name)
+}
+
+func testAccCdmJob_update(name, bucketName string) string {
+	clusterConfig := testAccCdmCluster_basic(name)
+	linkAndOBSConfig := testAccCdmLinkAndOBS(name, bucketName)
+
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "huaweicloud_cdm_job" "test" {
+  name       = "%s"
+  job_type   = "NORMAL_JOB"
+  cluster_id = huaweicloud_cdm_cluster.test.id
+
+  source_connector = "obs-connector"
+  source_link_name = huaweicloud_cdm_link.test.name
+  source_job_config = {
+    "bucketName"               = huaweicloud_obs_bucket.input.bucket
+    "inputDirectory"           = "/"
+    "listTextFile"             = "false"
+    "inputFormat"              = "BINARY_FILE"
+    "fromCompression"          = "NONE"
+    "fromFileOpType"           = "DO_NOTHING"
+    "useMarkerFile"            = "false"
+    "useTimeFilter"            = "false"
+    "fileSeparator"            = "|"
+    "filterType"               = "NONE"
+    "useWildCard"              = "false"
+    "decryption"               = "NONE"
+    "nonexistentPathDisregard" = "false"
+  }
+
+  destination_connector = "obs-connector"
+  destination_link_name = huaweicloud_cdm_link.test.name
+  destination_job_config = {
+    "bucketName"          = huaweicloud_obs_bucket.output.bucket
+    "outputDirectory"     = "/"
+    "outputFormat"        = "BINARY_FILE"
+    "validateMD5"         = "true"
+    "recordMD5Result"     = "false"
+    "duplicateFileOpType" = "REPLACE"
+    "useCustomDirectory"  = "false"
+    "encryption"          = "NONE"
+    "copyContentType"     = "false"
+    "shouldClearTable"    = "false"
+  }
+
+  config {
+    retry_type                          = "RETRY_TRIPLE"
+    scheduler_enabled                   = true
+    scheduler_cycle_type                = "month"
+    scheduler_cycle                     = 1
+    scheduler_run_at                    = 1
+    scheduler_start_date                = "2024-01-04 12:00:00"
+    scheduler_disposable_type           = "NONE"
+    throttling_extractors_number        = 4
+    throttling_record_dirty_data        = true
+    throttling_dirty_write_to_link      = huaweicloud_cdm_link.test.name
+    throttling_dirty_write_to_bucket    = huaweicloud_obs_bucket.dirty.bucket
+    throttling_dirty_write_to_directory = "/"
+    throttling_max_error_records        = 10
+    throttling_loader_number            = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      source_job_config, destination_job_config,
+    ]
+  }
+}
+`, clusterConfig, linkAndOBSConfig, name)
 }

--- a/huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_link_test.go
+++ b/huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_link_test.go
@@ -54,6 +54,19 @@ func TestAccResourceCdmLink_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "connector", "obs-connector"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "config.port", "443"),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_id", "huaweicloud_cdm_cluster.test", "id"),
+				),
+			},
+			{
+				Config: testAccCdmLinkResource_update(name, bucketName, acceptance.HW_ACCESS_KEY,
+					acceptance.HW_SECRET_KEY),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "connector", "obs-connector"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "config.port", "80"),
 					resource.TestCheckResourceAttrPair(resourceName, "cluster_id", "huaweicloud_cdm_cluster.test", "id"),
 				),
 			},
@@ -91,8 +104,203 @@ resource "huaweicloud_cdm_link" "test" {
     "port"        = "443"
   }
 
-  access_key   = "%s"
-  secret_key   = "%s"
+  access_key = "%s"
+  secret_key = "%s"
 }
 `, clusterConfig, bucketName, name, ak, sk)
+}
+
+func testAccCdmLinkResource_update(name, bucketName, ak, sk string) string {
+	clusterConfig := testAccCdmCluster_basic(name)
+
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%s"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_cdm_link" "test" {
+  name       = "%s"
+  connector  = "obs-connector"
+  cluster_id = huaweicloud_cdm_cluster.test.id
+  enabled    = true
+
+  config = {
+    "storageType" = "OBS"
+    "server"      = trimprefix(huaweicloud_obs_bucket.test.bucket_domain_name, "${huaweicloud_obs_bucket.test.bucket}.")
+    "port"        = "80"
+  }
+
+  access_key = "%s"
+  secret_key = "%s"
+}
+`, clusterConfig, bucketName, name, ak, sk)
+}
+
+// Link to DLI
+func TestAccResourceCdmLink_DLI(t *testing.T) {
+	var obj link.LinkCreateOpts
+	resourceName := "huaweicloud_cdm_link.testDLI"
+	name := acceptance.RandomAccResourceName()
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCdmLinkResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAKAndSK(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCdmLinkResource_DLI(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "connector", "dli-connector"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_id", "huaweicloud_cdm_cluster.test", "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret_key"},
+			},
+		},
+	})
+}
+
+func testAccCdmLinkResource_DLI(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cdm_link" "testDLI" {
+  name       = "%[2]s"
+  connector  = "dli-connector"
+  cluster_id = huaweicloud_cdm_cluster.test.id
+  enabled    = true
+
+  config = {
+    "region"    = "%[3]s"
+    "projectId" = "%[4]s"
+  }
+
+  access_key = "%[5]s"
+  secret_key = "%[6]s"
+}
+`, testAccCdmCluster_basic(name), name, acceptance.HW_REGION_NAME, acceptance.HW_PROJECT_ID,
+		acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY)
+}
+
+// Link to CSS
+func TestAccResourceCdmLink_CSS(t *testing.T) {
+	var obj link.LinkCreateOpts
+	resourceName := "huaweicloud_cdm_link.testCSS"
+	name := acceptance.RandomAccResourceName()
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCdmLinkResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCdmLinkResource_CSS(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "connector", "elasticsearch-connector"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster_id", "huaweicloud_cdm_cluster.test", "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testAccCdmLinkResource_CSS(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_networking_secgroup_rule" "rule" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  ethertype         = "IPv4"
+  direction         = "ingress"
+  protocol          = "tcp"
+  ports             = "9200"
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "huaweicloud_networking_secgroup_rule" "out_v4_all" {
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  ethertype         = "IPv4"
+  direction         = "egress"
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "huaweicloud_css_cluster" "test" {
+  name           = "%[2]s"
+  engine_version = "7.10.2"
+  security_mode  = true
+  https_enabled  = true
+  password       = "Test@passw0rd"
+
+  ess_node_config {
+    flavor          = "ess.spec-4u8g"
+    instance_number = 1
+    volume {
+      volume_type = "HIGH"
+      size        = 40
+    }
+  }
+
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  vpc_id            = huaweicloud_vpc.test.id
+}
+
+resource "huaweicloud_cdm_link" "testCSS" {
+  name       = "%[2]s"
+  connector  = "elasticsearch-connector"
+  cluster_id = huaweicloud_cdm_cluster.test.id
+  enabled    = true
+
+  config = {
+    "linkType" = "CSS"
+    "safemode" = "true"
+    "host"     = huaweicloud_css_cluster.test.endpoint
+    "user"     = "admin"
+  }
+
+  password = "Test@passw0rd"
+
+  lifecycle {
+    ignore_changes = [
+      config,
+    ]
+  }
+}
+`, testAccCdmCluster_basic(name), name)
 }

--- a/huaweicloud/services/cdm/resource_huaweicloud_cdm_job.go
+++ b/huaweicloud/services/cdm/resource_huaweicloud_cdm_job.go
@@ -615,6 +615,7 @@ func flattenFromOrToConfig(configName string, configs []job.Configs) map[string]
 			for _, v := range item.Inputs {
 				if v.Value != "" {
 					key := strings.Replace(v.Name, configPref, "", 1)
+					// Value in return is encoded, use `url.PathUnescape` to decode it.
 					result[key], _ = url.PathUnescape(v.Value)
 				}
 			}
@@ -646,6 +647,7 @@ func setJobConfigtoState(d *schema.ResourceData, configs []job.Configs) error {
 				case "throttlingConfig.obsBucket":
 					result["throttling_dirty_write_to_bucket"] = v.Value
 				case "throttlingConfig.dirtyDataDirectory":
+					// Value in return is encoded, use `url.PathUnescape` to decode it.
 					result["throttling_dirty_write_to_directory"], pErr = url.PathUnescape(v.Value)
 					err = multierror.Append(err, pErr)
 				case "throttlingConfig.maxErrorRecords":
@@ -662,9 +664,13 @@ func setJobConfigtoState(d *schema.ResourceData, configs []job.Configs) error {
 				case "schedulerConfig.runAt":
 					result["scheduler_run_at"] = v.Value
 				case "schedulerConfig.startDate":
-					result["scheduler_start_date"] = v.Value
+					// Value in return is encoded, use `url.PathUnescape` to decode it.
+					result["scheduler_start_date"], pErr = url.PathUnescape(v.Value)
+					err = multierror.Append(err, pErr)
 				case "schedulerConfig.stopDate":
-					result["scheduler_stop_date"] = v.Value
+					// Value in return is encoded, use `url.PathUnescape` to decode it.
+					result["scheduler_stop_date"], pErr = url.PathUnescape(v.Value)
+					err = multierror.Append(err, pErr)
 				case "schedulerConfig.disposableType":
 					result["scheduler_disposable_type"] = v.Value
 				case "retryJobConfig.retryJobType":

--- a/huaweicloud/services/cdm/resource_huaweicloud_cdm_link.go
+++ b/huaweicloud/services/cdm/resource_huaweicloud_cdm_link.go
@@ -3,6 +3,7 @@ package cdm
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -243,7 +244,12 @@ func setLinkConfigToState(d *schema.ResourceData, configs []link.Configs) error 
 					case "accessKey", "ak":
 						d.Set("access_key", v.Value)
 					default:
-						result[key] = v.Value
+						// Value in return is encoded, use `url.PathUnescape` to decode it.
+						rst, err := url.PathUnescape(v.Value)
+						if err != nil {
+							return err
+						}
+						result[key] = rst
 					}
 				}
 			}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add acc test and fix bug

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
./scripts/acc-test.sh 

[skipped] ./huaweicloud/services/acceptance/acceptance/acceptance_test.go does not exist

run acceptance tests of huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_job_test.go:
=== RUN   TestAccResourceCdmJob_basic
=== PAUSE TestAccResourceCdmJob_basic
=== CONT  TestAccResourceCdmJob_basic
--- PASS: TestAccResourceCdmJob_basic (1028.21s)
PASS
coverage: 68.8% of statements in ./huaweicloud/services/cdm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdm       1028.249s       coverage: 68.8% of statements in ./huaweicloud/services/cdm

run acceptance tests of huaweicloud/services/acceptance/cdm/resource_huaweicloud_cdm_link_test.go:
=== RUN   TestAccResourceCdmLink_basic
=== PAUSE TestAccResourceCdmLink_basic
=== RUN   TestAccResourceCdmLink_DLI
=== PAUSE TestAccResourceCdmLink_DLI
=== RUN   TestAccResourceCdmLink_CSS
=== PAUSE TestAccResourceCdmLink_CSS
=== CONT  TestAccResourceCdmLink_basic
=== CONT  TestAccResourceCdmLink_CSS
=== CONT  TestAccResourceCdmLink_DLI
--- PASS: TestAccResourceCdmLink_CSS (965.46s)
--- PASS: TestAccResourceCdmLink_basic (1000.91s)
--- PASS: TestAccResourceCdmLink_DLI (1037.26s)
PASS
coverage: 37.5% of statements in ./huaweicloud/services/cdm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdm       1037.301s       coverage: 37.5% of statements in ./huaweicloud/services/cdm

### coverage of files in huaweicloud/services:

- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cdm/resource_huaweicloud_cdm_job.go (80.1%)
- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cdm/resource_huaweicloud_cdm_link.go (82.9%)

### [summary] 0 failed in 2 resource acceptance tests
```
