### PR TITLE
feat(RDS): rds instance support modify replication mode

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -195,15 +195,14 @@ The following arguments are supported:
 
 * `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
 
-* `ha_replication_mode` - (Optional, String, ForceNew) Specifies the replication mode for the standby DB instance.
-  Changing this parameter will create a new resource.
+* `ha_replication_mode` - (Optional, String) Specifies the replication mode for the standby DB instance.
   + For MySQL, the value is **async** or **semisync**.
   + For PostgreSQL, the value is **async** or **sync**.
   + For Microsoft SQL Server, the value is **sync**.
   + For MariaDB, the value is **async** or **semisync**.
 
-  -> **NOTE:** async indicates the asynchronous replication mode. semisync indicates the semi-synchronous replication
-  mode. sync indicates the synchronous replication mode.
+  -> **NOTE:** **async** indicates the asynchronous replication mode. **semisync** indicates the semi-synchronous
+  replication mode. **sync** indicates the synchronous replication mode.
 
 * `lower_case_table_names` - (Optional, String, ForceNew) Specifies the case-sensitive state of the database table name,
   the default value is "1". Changing this parameter will create a new resource.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240104014600-4287f9738784
+	github.com/chnsz/golangsdk v0.0.0-20240104090724-adb48912a13e
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240104014600-4287f9738784 h1:WsD5sSpzoa24jkujsPlTyPDwU37q9lfIer288aO+3rk=
-github.com/chnsz/golangsdk v0.0.0-20240104014600-4287f9738784/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240104090724-adb48912a13e h1:BJaI64RQKIFt8AJASfMiShyvaQSygSCaVutw4F1MGoc=
+github.com/chnsz/golangsdk v0.0.0-20240104090724-adb48912a13e/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/requests.go
@@ -295,3 +295,34 @@ func Resize(client *golangsdk.ServiceClient, id string, opts ResizeInstanceOpts)
 	}
 	return "", err
 }
+
+// ResetPasswordOpts is a struct which represents the parameter of ResetPassword function
+type ResetPasswordOpts struct {
+	// Indicates the new password of an instance.
+	NewPassword string `json:"new_password" required:"true"`
+}
+
+// ConvertToResetPasswordMap is used for type convert
+func (opts ResetPasswordOpts) ConvertToResetPasswordMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// ResetPasswordOptsBuilder is an interface which can build the map parameter of ResetPassword function
+type ResetPasswordOptsBuilder interface {
+	ConvertToResetPasswordMap() (map[string]interface{}, error)
+}
+
+// ResetPassword is used to reset password for the instance
+// via accessing to the service with POST method and parameters
+func ResetPassword(client *golangsdk.ServiceClient, id string, opts ResetPasswordOptsBuilder) (r ResetPasswordResult) {
+	body, err := opts.ConvertToResetPasswordMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(resetPasswordURL(client, id), body, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/results.go
@@ -136,3 +136,8 @@ func ExtractInstances(r pagination.Page) (ListResponse, error) {
 	err := (r.(Page)).ExtractInto(&s)
 	return s, err
 }
+
+// ResetPasswordResult is a struct that contains all the return parameters of ResetPassword function
+type ResetPasswordResult struct {
+	golangsdk.Result
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/rabbitmq/instances/urls.go
@@ -39,3 +39,8 @@ func listURL(client *golangsdk.ServiceClient) string {
 func extend(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, id, "extend")
 }
+
+// resetPasswordURL will build the url of resetting password
+func resetPasswordURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, resourcePath, id, "password")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -642,3 +642,22 @@ func ModifyMaintainWindow(c *golangsdk.ServiceClient, opts ActionInstanceBuilder
 	_, r.Err = c.Put(updateURL(c, instanceId, "ops-window"), b, nil, &golangsdk.RequestOpts{})
 	return
 }
+
+type ModifyReplicationModeOpts struct {
+	Mode string `json:"mode" required:"true"`
+}
+
+func (opts ModifyReplicationModeOpts) ToActionInstanceMap() (map[string]interface{}, error) {
+	return toActionInstanceMap(opts)
+}
+
+// ModifyReplicationMode is a method used to modify replication mode.
+func ModifyReplicationMode(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r ModifyReplicationModeResult) {
+	b, err := opts.ToActionInstanceMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, instanceId, "failover/mode"), b, &r.Body, &golangsdk.RequestOpts{})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -34,6 +34,10 @@ type ModifyMaintainWindowResult struct {
 	commonResult
 }
 
+type ModifyReplicationModeResult struct {
+	commonResult
+}
+
 type SingleToHaResult struct {
 	commonResult
 }
@@ -185,6 +189,18 @@ type GetConfigurationResp struct {
 
 func (r GetConfigurationResult) Extract() (*GetConfigurationResp, error) {
 	var response GetConfigurationResp
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type ReplicationMode struct {
+	WorkflowId      string `json:"workflowId"`
+	InstanceId      string `json:"instanceId"`
+	ReplicationMode string `json:"replicationMode"`
+}
+
+func (r ModifyReplicationModeResult) Extract() (*ReplicationMode, error) {
+	var response ReplicationMode
 	err := r.ExtractInto(&response)
 	return &response, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/domains/requests.go
@@ -149,7 +149,7 @@ func Update(c *golangsdk.ServiceClient, domainID string, opts UpdateOptsBuilder)
 	}
 
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
-	_, r.Err = c.Put(resourceURL(c, domainID)+query.String(), b, nil, reqOpt)
+	_, r.Err = c.Patch(resourceURL(c, domainID)+query.String(), b, nil, reqOpt)
 	return
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240104014600-4287f9738784
+# github.com/chnsz/golangsdk v0.0.0-20240104090724-adb48912a13e
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support modify replication mode
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support modify replication mode
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=12
==> Checking that code complies with gofmt requirements...

TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 12
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_without_password
=== PAUSE TestAccRdsInstance_without_password
=== RUN   TestAccRdsInstance_withEpsId
=== PAUSE TestAccRdsInstance_withEpsId
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_withParameters
=== PAUSE TestAccRdsInstance_withParameters
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_withEpsId
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_without_password
=== CONT  TestAccRdsInstance_withParameters
--- PASS: TestAccRdsInstance_mariadb (428.91s)
--- PASS: TestAccRdsInstance_withEpsId (480.15s)
--- PASS: TestAccRdsInstance_without_password (496.29s)
--- PASS: TestAccRdsInstance_ha (510.91s)
--- PASS: TestAccRdsInstance_basic (604.90s)
--- PASS: TestAccRdsInstance_withParameters (629.17s)
--- PASS: TestAccRdsInstance_sqlserver (755.33s)
--- PASS: TestAccRdsInstance_prePaid (1031.92s)
--- PASS: TestAccRdsInstance_mysql (1452.17s)
--- PASS: TestAccRdsInstance_restore_pg (2277.53s)
--- PASS: TestAccRdsInstance_restore_mysql (2573.75s)
--- PASS: TestAccRdsInstance_restore_sqlserver (3237.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3237.329s
```
