### PR TITLE
feat(dataarts): add resource dataarts architecture code table values

### DIFF
--- a/docs/resources/dataarts_architecture_code_table_values.md
+++ b/docs/resources/dataarts_architecture_code_table_values.md
@@ -1,0 +1,85 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_architecture_code_table_values
+
+Manages a DataArts Architecture code table values resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "table_id" {}
+variable "field_id" {}
+variable "field_ordinal" {}
+variable "field_name" {}
+variable "field_code" {}
+variable "field_type" {}
+
+resource "huaweicloud_dataarts_architecture_code_table_values" "test" {
+  workspace_id  = var.workspace_id
+  table_id      = var.table_id
+  field_id      = var.field_id
+  field_ordinal = var.field_ordinal
+  field_name    = var.field_name
+  field_code    = var.field_code
+  field_type    = var.field_type
+
+  values {
+    value = "1"  
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the ID of DataArts Studio workspace.
+  Changing this parameter will create a new resource.
+
+* `table_id` - (Required, String, ForceNew) Specifies the ID of the code table.
+  Changing this parameter will create a new resource.
+
+* `field_id` - (Required, String, ForceNew) Specifies the ID of the code table field.
+  Changing this parameter will create a new resource.
+
+* `field_ordinal` - (Required, Int, ForceNew) Specifies the ordinal of the code table field.
+  Changing this parameter will create a new resource.
+
+* `field_name` - (Required, String, ForceNew) Specifies the name of the code table field.
+  Changing this parameter will create a new resource.
+
+* `field_code` - (Required, String, ForceNew) Specifies the code of the code table field.
+  Changing this parameter will create a new resource.
+
+* `field_type` - (Required, String, ForceNew) Specifies the type of the code table field.
+  Changing this parameter will create a new resource.
+
+* `values` - (Required, List) Specifies the values list of the code table field.
+  The [values](#Values) structure is documented below.
+
+<a name="Values"></a>
+The `values` block supports:
+
+* `value` - (Required, String) Specifies the value of a field.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `values` - The values list of the code table field.
+  The [values](#Values_Attr) structure is documented below.
+
+<a name="Values_Attr"></a>
+The `values` block supports:
+
+* `id` - The ID of a value.
+
+* `ordinal` - The ordinal of a value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1124,6 +1124,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_business_metric":        dataarts.ResourceBusinessMetric(),
 			"huaweicloud_dataarts_architecture_process":                dataarts.ResourceArchitectureProcess(),
 			"huaweicloud_dataarts_architecture_code_table":             dataarts.ResourceArchitectureCodeTable(),
+			"huaweicloud_dataarts_architecture_code_table_values":      dataarts.ResourceArchitectureCodeTableValues(),
 			"huaweicloud_dataarts_architecture_data_standard":          dataarts.ResourceDataStandard(),
 			"huaweicloud_dataarts_architecture_data_standard_template": dataarts.ResourceDataStandardTemplate(),
 			"huaweicloud_dataarts_architecture_reviewer":               dataarts.ResourceDataArtsArchitectureReviewer(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_code_table_values_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_code_table_values_test.go
@@ -1,0 +1,188 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getArchitectureCodeTableValuesFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/design/code-tables/{id}/values"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", state.Primary.Attributes["table_id"])
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": state.Primary.Attributes["workspace_id"]},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DataArts Architecture code table values: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	fieldName := state.Primary.Attributes["field_name"]
+	findFieldValuesExpr := fmt.Sprintf("data.value.records[?name_ch=='%s'] | [0].code_table_field_values", fieldName)
+	curJson := utils.PathSearch(findFieldValuesExpr, getRespBody, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+
+	// After the test case is executed, the values of the all fields are cleared.
+	// There is no need to check if id of the value is nil.
+	if len(curArray) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccArchitectureCodeTableValues_basic(t *testing.T) {
+	var obj interface{}
+
+	baseConfig := testArchitectureCodeTableValuesConfig_base()
+	rName := "huaweicloud_dataarts_architecture_code_table_values.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getArchitectureCodeTableValuesFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testArchitectureCodeTableValues_basic(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "values.0.value", "1"),
+					resource.TestCheckResourceAttrSet(rName, "table_id"),
+					resource.TestCheckResourceAttrSet(rName, "field_id"),
+					resource.TestCheckResourceAttrSet(rName, "field_ordinal"),
+					resource.TestCheckResourceAttrSet(rName, "field_name"),
+					resource.TestCheckResourceAttrSet(rName, "field_code"),
+					resource.TestCheckResourceAttrSet(rName, "field_type"),
+				),
+			},
+			{
+				Config: testArchitectureCodeTableValues_basic_update(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "values.0.value", "one"),
+					resource.TestCheckResourceAttr(rName, "values.1.value", "two"),
+					resource.TestCheckResourceAttrSet(rName, "table_id"),
+					resource.TestCheckResourceAttrSet(rName, "field_id"),
+					resource.TestCheckResourceAttrSet(rName, "field_ordinal"),
+					resource.TestCheckResourceAttrSet(rName, "field_name"),
+					resource.TestCheckResourceAttrSet(rName, "field_code"),
+					resource.TestCheckResourceAttrSet(rName, "field_type"),
+				),
+			},
+		},
+	})
+}
+
+func testArchitectureCodeTableValuesConfig_base() string {
+	name := acceptance.RandomAccResourceName()
+	dirName := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_directory" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  type         = "CODE"
+}
+
+resource "huaweicloud_dataarts_architecture_code_table" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[3]s"
+  code         = "%[3]s_code"
+  directory_id = huaweicloud_dataarts_architecture_directory.test.id
+  description  = "test description"
+  
+  fields {
+    name        = "field"
+    code        = "field_code"
+    type        = "BIGINT"
+    description = "test field description"
+  }
+  
+  fields {
+    name        = "field1"
+    code        = "field_code1"
+    type        = "STRING"
+    description = "test field1 description"
+  }
+  
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, dirName, name)
+}
+
+func testArchitectureCodeTableValues_basic(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "huaweicloud_dataarts_architecture_code_table_values" "test" {
+  workspace_id  = "%[2]s"
+  table_id      = huaweicloud_dataarts_architecture_code_table.test.id
+  field_id      = huaweicloud_dataarts_architecture_code_table.test.fields[1].id
+  field_ordinal = huaweicloud_dataarts_architecture_code_table.test.fields[1].ordinal
+  field_name    = huaweicloud_dataarts_architecture_code_table.test.fields[1].name
+  field_code    = huaweicloud_dataarts_architecture_code_table.test.fields[1].code
+  field_type    = huaweicloud_dataarts_architecture_code_table.test.fields[1].type
+  
+  values {
+    value = "1"
+  }
+}
+`, baseConfig, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testArchitectureCodeTableValues_basic_update(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "huaweicloud_dataarts_architecture_code_table_values" "test" {
+  workspace_id  = "%[2]s"
+  table_id      = huaweicloud_dataarts_architecture_code_table.test.id
+  field_id      = huaweicloud_dataarts_architecture_code_table.test.fields[1].id
+  field_ordinal = huaweicloud_dataarts_architecture_code_table.test.fields[1].ordinal
+  field_name    = huaweicloud_dataarts_architecture_code_table.test.fields[1].name
+  field_code    = huaweicloud_dataarts_architecture_code_table.test.fields[1].code
+  field_type    = huaweicloud_dataarts_architecture_code_table.test.fields[1].type
+  
+  values {
+    value = "one"
+  }
+  values {
+    value = "two"
+  }
+}
+`, baseConfig, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_code_table_values.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_code_table_values.go
@@ -1,0 +1,360 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio PUT /v2/{project_id}/design/code-tables/{id}/values
+// API: DataArtsStudio GET /v2/{project_id}/design/code-tables/{id}/values
+func ResourceArchitectureCodeTableValues() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceArchitectureCodeTableValuesCreate,
+		ReadContext:   resourceArchitectureCodeTableValuesRead,
+		UpdateContext: resourceArchitectureCodeTableValuesUpdate,
+		DeleteContext: resourceArchitectureCodeTableValuesDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region in which to create the resource.",
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of DataArts Studio workspace.",
+			},
+			"table_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the code table.",
+			},
+			"field_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the code table field.",
+			},
+			"field_ordinal": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ordinal of the code table field.",
+			},
+			"field_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the code table field.",
+			},
+			"field_code": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The code of the code table field.",
+			},
+			"field_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The type of the code table field.",
+			},
+			"values": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The value of a field.",
+						},
+						"ordinal": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The ordinal of a value.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of a value.",
+						},
+					},
+				},
+				Description: "The values list of the code table field.",
+			},
+		},
+	}
+}
+
+func resourceArchitectureCodeTableValuesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	product := "dataarts"
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	createPath, createOpt := buildCodeTableValuesPathAndOpt(client, d)
+	createOpt.JSONBody = utils.RemoveNil(buildCreateCodeTableValuesParams(d))
+	createResp, err := client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Architecture code table values: %s", err)
+	}
+
+	_, err = utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("field_name").(string))
+
+	return resourceArchitectureCodeTableValuesRead(ctx, d, meta)
+}
+
+func buildCreateCodeTableValuesParams(d *schema.ResourceData) map[string]interface{} {
+	params := make([]map[string]interface{}, 1)
+	params[0] = map[string]interface{}{
+		"id":                      d.Get("field_id"),
+		"ordinal":                 d.Get("field_ordinal"),
+		"name_ch":                 d.Get("field_name"),
+		"name_en":                 d.Get("field_code"),
+		"data_type":               d.Get("field_type"),
+		"code_table_field_values": buildCreateCodeTableFieldValuesParams(d),
+	}
+	return map[string]interface{}{
+		"to_add": params,
+	}
+}
+
+func buildCreateCodeTableFieldValuesParams(d *schema.ResourceData) []map[string]interface{} {
+	rawValues := d.Get("values").([]interface{})
+	values := make([]map[string]interface{}, len(rawValues))
+	fieldID := d.Get("field_id").(string)
+	for i, rawValue := range rawValues {
+		valueMap := rawValue.(map[string]interface{})
+		value := map[string]interface{}{
+			"fd_id":    fieldID,
+			"fd_value": valueMap["value"].(string),
+			"ordinal":  i + 1,
+		}
+		values[i] = value
+	}
+	return values
+}
+
+func resourceArchitectureCodeTableValuesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	workspaceID := d.Get("workspace_id").(string)
+
+	var mErr *multierror.Error
+	product := "dataarts"
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath, getOpt := buildCodeTableValuesPathAndOpt(client, d)
+	fieldName := d.Get("field_name").(string)
+	values, fieldJson, err := flattenCodeTableFieldValues(client, getOpt,
+		getPath, fieldName)
+	if err != nil {
+		return diag.Errorf("error retrieving DataArts Architecture code table field values: %s", err)
+	}
+
+	if len(values) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving DataArts Architecture code table field values")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("workspace_id", workspaceID),
+		d.Set("table_id", utils.PathSearch("code_table_id", fieldJson, nil)),
+		d.Set("field_id", utils.PathSearch("id", fieldJson, nil)),
+		d.Set("field_ordinal", utils.PathSearch("ordinal", fieldJson, nil)),
+		d.Set("field_name", utils.PathSearch("name_ch", fieldJson, nil)),
+		d.Set("field_code", utils.PathSearch("name_en", fieldJson, nil)),
+		d.Set("field_type", utils.PathSearch("data_type", fieldJson, nil)),
+		d.Set("values", values),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCodeTableFieldValues(client *golangsdk.ServiceClient, getCodeTableFieldValuesOpt golangsdk.RequestOpts,
+	getCodeTableFieldValuesPath, fieldName string) ([]interface{}, interface{}, error) {
+	var fieldJson interface{}
+	offset := 0
+	values := make([]interface{}, 0)
+
+	for {
+		path := fmt.Sprintf("%s?limit=50&offset=%d", getCodeTableFieldValuesPath, offset)
+		getCodeTableFieldValuesResp, err := client.Request("GET", path, &getCodeTableFieldValuesOpt)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		getCodeTableFieldValuesRespBody, err := utils.FlattenResponse(getCodeTableFieldValuesResp)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		findFieldExpr := fmt.Sprintf("data.value.records[?name_ch=='%s'] | [0]", fieldName)
+		fieldJson = utils.PathSearch(findFieldExpr, getCodeTableFieldValuesRespBody, nil)
+		valuesJson := utils.PathSearch("code_table_field_values", fieldJson, make([]interface{}, 0))
+		valueArray := valuesJson.([]interface{})
+
+		hasValues := false
+		for _, rawValue := range valueArray {
+			id := utils.PathSearch("id", rawValue, nil)
+
+			// Filter out the deleted values.
+			// If a code table has a field, the deleted values will be cleared.
+			// If a code table has multiple fields, the structure of the deleted value will be retained, with the id set to nil.
+			if id != nil {
+				value := map[string]interface{}{
+					"id":      id,
+					"ordinal": utils.PathSearch("ordinal", rawValue, nil),
+					"value":   utils.PathSearch("fd_value", rawValue, nil),
+				}
+
+				values = append(values, value)
+				hasValues = true
+			}
+		}
+
+		if !hasValues {
+			log.Print("[INFO] The process of retrieving values has ended.")
+			break
+		}
+		offset += 50
+	}
+	return values, fieldJson, nil
+}
+
+func resourceArchitectureCodeTableValuesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	product := "dataarts"
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	updatePath, updateOpt := buildCodeTableValuesPathAndOpt(client, d)
+	updateOpt.JSONBody = utils.RemoveNil(buildRemoveCodeTableValuesParams(d))
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+
+	if err != nil {
+		return diag.Errorf("error updating DataArts Architecture code table values: %s", err)
+	}
+
+	updateOpt.JSONBody = utils.RemoveNil(buildCreateCodeTableValuesParams(d))
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+
+	if err != nil {
+		return diag.Errorf("error updating DataArts Architecture code table values: %s", err)
+	}
+
+	return resourceArchitectureCodeTableValuesRead(ctx, d, meta)
+}
+
+func buildRemoveCodeTableValuesParams(d *schema.ResourceData) map[string]interface{} {
+	params := make([]map[string]interface{}, 1)
+	params[0] = map[string]interface{}{
+		"id":                      d.Get("field_id"),
+		"ordinal":                 d.Get("field_ordinal"),
+		"name_ch":                 d.Get("field_name"),
+		"name_en":                 d.Get("field_code"),
+		"data_type":               d.Get("field_type"),
+		"code_table_field_values": buildRemoveCodeTableFieldValuesParams(d),
+	}
+	return map[string]interface{}{
+		"to_remove": params,
+	}
+}
+
+func buildRemoveCodeTableFieldValuesParams(d *schema.ResourceData) []map[string]interface{} {
+	rawValues, _ := d.GetChange("values")
+	oldValues := rawValues.([]interface{})
+	values := make([]map[string]interface{}, len(oldValues))
+	for i, oldValue := range oldValues {
+		valueMap := oldValue.(map[string]interface{})
+		value := map[string]interface{}{
+			"id":      valueMap["id"],
+			"ordinal": valueMap["ordinal"],
+		}
+		values[i] = value
+	}
+	return values
+}
+
+func resourceArchitectureCodeTableValuesDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	product := "dataarts"
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	path, opt := buildCodeTableValuesPathAndOpt(client, d)
+	opt.JSONBody = utils.RemoveNil(buildRemoveCodeTableValuesParams(d))
+	_, err = client.Request("PUT", path, &opt)
+
+	if err != nil {
+		return diag.Errorf("error deleting DataArts Architecture code table values: %s", err)
+	}
+
+	// Successful deletion API call does not guarantee that the resource is successfully deleted.
+	// Call the details API to confirm that the resource has been successfully deleted.
+	opt.JSONBody = nil
+	fieldName := d.Get("field_name").(string)
+	values, _, err := flattenCodeTableFieldValues(client, opt, path, fieldName)
+	if err != nil {
+		return diag.Errorf("error retrieving DataArts Architecture code table field values: %s", err)
+	}
+
+	if len(values) > 0 {
+		return diag.Errorf("error deleting DataArts Architecture code table values")
+	}
+	return nil
+}
+
+func buildCodeTableValuesPathAndOpt(client *golangsdk.ServiceClient, d *schema.ResourceData) (string, golangsdk.RequestOpts) {
+	httpUrl := "v2/{project_id}/design/code-tables/{id}/values"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{id}", d.Get("table_id").(string))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+	return path, opt
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource dataarts architecture code table values

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccArchitectureCodeTableValues_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccArchitectureCodeTableValues_basic -timeout 360m -parallel 4
=== RUN   TestAccArchitectureCodeTableValues_basic
=== PAUSE TestAccArchitectureCodeTableValues_basic
=== CONT  TestAccArchitectureCodeTableValues_basic
--- PASS: TestAccArchitectureCodeTableValues_basic (59.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  59.187s
```
