### PR TITLE
feat(VPCEP): add datasource to query VPC endpoint service permissions

### DIFF
--- a/docs/data-sources/vpcep_service_permissions.md
+++ b/docs/data-sources/vpcep_service_permissions.md
@@ -1,0 +1,47 @@
+---
+subcategory: "VPC Endpoint (VPCEP)"
+---
+
+# huaweicloud_vpcep_service_permissions
+
+Use this data source to get VPC endpoint service permissions.
+
+## Example Usage
+
+```hcl
+variable service_id {}
+variable permission {}
+
+data "huaweicloud_vpcep_service_permissions" "permissions" {
+  service_id = var.service_id
+  permission = var.permission
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the VPC endpoint service. If omitted, the
+  provider-level region will be used.
+
+* `service_id` - (Required, String) Specifies the ID of VPC endpoint service.
+
+* `permission` - (Optional, String) Specifies the account or organization to access the VPC endpoint service.
+  The permission format is **iam:domain::domain_id** or **organizations:orgPath::org_path**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `permissions` - The list of VPC endpoint service permissions.
+
+The `permissions` block supports:
+
+* `permission_id` - The ID of permission.
+
+* `permission` - The account or organization to access the VPC endpoint service.
+
+* `permission_type` - The permission type of the VPC endpoint service. The value can be **domainId** or **orgPath**.
+
+* `created_at` - The creation time of VPC endpoint permission.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -640,6 +640,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpcep_public_services":     vpcep.DataSourceVPCEPPublicServices(),
 			"huaweicloud_vpcep_services":            vpcep.DataSourceVPCEPServices(),
 			"huaweicloud_vpcep_service_connections": vpcep.DataSourceVPCEPServiceConnections(),
+			"huaweicloud_vpcep_service_permissions": vpcep.DataSourceVPCEPServicePermissions(),
 
 			"huaweicloud_vpn_gateway_availability_zones": vpn.DataSourceVpnGatewayAZs(),
 			"huaweicloud_vpn_gateways":                   vpn.DataSourceGateways(),

--- a/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_service_permissions_test.go
+++ b/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_service_permissions_test.go
@@ -1,0 +1,62 @@
+package vpcep
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceVPCEPServicePermissions_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_vpcep_service_permissions.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceVpcepServicePermissions_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "permissions.0.permission_id"),
+					resource.TestCheckResourceAttrSet(rName, "permissions.0.permission"),
+					resource.TestCheckResourceAttrSet(rName, "permissions.0.permission_type"),
+					resource.TestCheckResourceAttrSet(rName, "permissions.0.created_at"),
+
+					resource.TestCheckOutput("permission_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceVpcepServicePermissions_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpcep_service_permissions" "test" {
+  service_id = huaweicloud_vpcep_service.test.id
+}
+
+data "huaweicloud_vpcep_service_permissions" "permission_filter" {
+  service_id = huaweicloud_vpcep_service.test.id
+  permission = data.huaweicloud_vpcep_service_permissions.test.permissions.0.permission
+}
+
+locals {
+  permission = data.huaweicloud_vpcep_service_permissions.test.permissions.0.permission
+}
+
+output "permission_filter_is_useful" {
+  value = length(data.huaweicloud_vpcep_service_permissions.permission_filter.permissions) > 0 && alltrue(
+    [for v in data.huaweicloud_vpcep_service_permissions.permission_filter.permissions[*].permission : v == local.permission]
+  )  
+}
+`, testAccVPCEPService_Basic(name))
+}

--- a/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_service_permissions.go
+++ b/huaweicloud/services/vpcep/data_source_huaweicloud_vpcep_service_permissions.go
@@ -1,0 +1,114 @@
+package vpcep
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/services"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// API: VPCEP GET /v1/{project_id}/vpc-endpoint-services/{vpc_endpoint_service_id}/permissions
+func DataSourceVPCEPServicePermissions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVpcepServicePermissionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"service_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"permission": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"permissions": {
+				Type:     schema.TypeList,
+				Elem:     permissionsSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func permissionsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"permission_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"permission": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"permission_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceVpcepServicePermissionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcepClient, err := cfg.VPCEPClient(region)
+	if err != nil {
+		return diag.Errorf("error creating VPC endpoint client: %s", err)
+	}
+
+	serviceId := d.Get("service_id").(string)
+	listPermOpts := services.ListPermOpts{
+		Permission: d.Get("permission").(string),
+	}
+
+	allPermissions, err := services.ListAllPermissions(vpcepClient, serviceId, listPermOpts)
+	if err != nil {
+		return diag.Errorf("unable to retrieve VPC endpoint service permissions: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("permissions", flattenListVPCEPServicePermissions(allPermissions)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListVPCEPServicePermissions(allPermissions []services.Permission) []map[string]interface{} {
+	if allPermissions == nil {
+		return nil
+	}
+	permissions := make([]map[string]interface{}, len(allPermissions))
+	for i, v := range allPermissions {
+		permissions[i] = map[string]interface{}{
+			"permission_id":   v.ID,
+			"permission":      v.Permission,
+			"permission_type": v.PermissionType,
+			"created_at":      v.Created,
+		}
+	}
+	return permissions
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add datasource to query VPC endpoint service permissions
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccDatasourceVPCEPServicePermissions_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccDatasourceVPCEPServicePermissions_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceVPCEPServicePermissions_basic
=== PAUSE TestAccDatasourceVPCEPServicePermissions_basic
=== CONT  TestAccDatasourceVPCEPServicePermissions_basic
--- PASS: TestAccDatasourceVPCEPServicePermissions_basic (212.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     212.652s
