### PR TITLE
chore(ecs): move ecs resource to deprecated

### DIFF
--- a/docs/resources/compute_keypair.md
+++ b/docs/resources/compute_keypair.md
@@ -1,10 +1,10 @@
 ---
-subcategory: "Elastic Cloud Server (ECS)"
+subcategory: "Deprecated"
 ---
 
 # huaweicloud_compute_keypair
 
--> **DEPRECATED:**  This resource  has been deprecated. Please use [huaweicloud_kps_keypair](https://www.terraform.io/docs/providers/huaweicloud/r/kps_keypair).
+!> **WARNING:** It has been deprecated, use `huaweicloud_kps_keypair` instead.
 
 Manages a keypair resource within HuaweiCloud.
 

--- a/huaweicloud/resource_huaweicloud_bcs_instance.go
+++ b/huaweicloud/resource_huaweicloud_bcs_instance.go
@@ -593,7 +593,7 @@ func blockchainStateRefreshFunc(client *golangsdk.ServiceClient, instanceID stri
 	return func() (interface{}, string, error) {
 		instance, err := blockchains.Get(client, instanceID).Extract()
 		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault400); ok {
+			if _, ok := err.(golangsdk.ErrDefault401); ok {
 				return instance, "IsDeleted", nil
 			}
 			return nil, "FOUND ERROR", err

--- a/huaweicloud/resource_huaweicloud_bcs_instance_test.go
+++ b/huaweicloud/resource_huaweicloud_bcs_instance_test.go
@@ -109,7 +109,7 @@ func testAccCheckBCSInstanceV2Destroy() resource.TestCheckFunc {
 			id := rs.Primary.ID
 			instance, err := blockchains.Get(client, id).Extract()
 			if err != nil {
-				if _, ok := err.(golangsdk.ErrDefault400); ok {
+				if _, ok := err.(golangsdk.ErrDefault401); ok {
 					return nil
 				}
 				return err
@@ -178,11 +178,11 @@ resource "huaweicloud_cce_cluster" "test" {
   subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "overlay_l2"
   service_network_cidr   = "10.248.0.0/16"
-  cluster_version        = "v1.15.11-r1"
+  cluster_version        = "v1.19.16-r1"
   delete_sfs             = true
 }
 
-resource "huaweicloud_compute_keypair" "test" {
+resource "huaweicloud_kps_keypair" "test" {
   name = "%s"
 
   lifecycle {
@@ -197,14 +197,10 @@ resource "huaweicloud_cce_node" "test" {
   cluster_id            = huaweicloud_cce_cluster.test.id
   flavor_id             = "s6.xlarge.2"
   availability_zone     = data.huaweicloud_availability_zones.test.names[0]
-  key_pair              = huaweicloud_compute_keypair.test.name
+  key_pair              = huaweicloud_kps_keypair.test.name
   max_pods              = 30
   ecs_performance_type  = "normal"
   os                    = "CentOS 7.6"
-  iptype                = "5_bgp"
-  bandwidth_charge_mode = "traffic"
-  sharetype             = "PER"
-  bandwidth_size        = 5
 
   root_volume {
     size       = 40

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
@@ -153,7 +153,7 @@ data "huaweicloud_networking_secgroup" "test" {
   name = "default"
 }
 
-resource "huaweicloud_compute_keypair" "acc_key" {
+resource "huaweicloud_kps_keypair" "acc_key" {
   name       = "%s"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
@@ -169,7 +169,7 @@ resource "huaweicloud_as_configuration" "acc_as_config"{
   instance_config {
     image              = data.huaweicloud_images_image.test.id
     flavor             = data.huaweicloud_compute_flavors.test.ids[0]
-    key_name           = huaweicloud_compute_keypair.acc_key.id
+    key_name           = huaweicloud_kps_keypair.acc_key.id
     security_group_ids = [data.huaweicloud_networking_secgroup.test.id]
 
     metadata = {
@@ -220,7 +220,7 @@ resource "huaweicloud_as_configuration" "acc_as_config"{
   scaling_configuration_name = "%s"
   instance_config {
     instance_id = huaweicloud_compute_instance.test.id
-    key_name    = huaweicloud_compute_keypair.acc_key.id
+    key_name    = huaweicloud_kps_keypair.acc_key.id
     user_data   = "IyEvYmluL3NoCmVjaG8gIkhlbGxvIFdvcmxkISBUaGUgdGltZSBpcyBub3cgJChkYXRlIC1SKSEiIHwgdGVlIC9yb290L291dHB1dC50eHQK"
   }
 }

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
@@ -214,7 +214,7 @@ func testASGroup_Base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_compute_keypair" "acc_key" {
+resource "huaweicloud_kps_keypair" "acc_key" {
   name       = "%[2]s"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
@@ -243,7 +243,7 @@ resource "huaweicloud_as_configuration" "acc_as_config"{
   instance_config {
 	image    = data.huaweicloud_images_image.test.id
 	flavor   = data.huaweicloud_compute_flavors.test.ids[0]
-    key_name = huaweicloud_compute_keypair.acc_key.id
+    key_name = huaweicloud_kps_keypair.acc_key.id
     disk {
       size        = 40
       volume_type = "SSD"

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
@@ -153,7 +153,7 @@ func testASPolicy_base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_compute_keypair" "acc_key" {
+resource "huaweicloud_kps_keypair" "acc_key" {
   name       = "%[2]s"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
@@ -163,7 +163,7 @@ resource "huaweicloud_as_configuration" "acc_as_config"{
   instance_config {
     image    = data.huaweicloud_images_image.test.id
     flavor   = data.huaweicloud_compute_flavors.test.ids[0]
-    key_name = huaweicloud_compute_keypair.acc_key.id
+    key_name = huaweicloud_kps_keypair.acc_key.id
     disk {
       size        = 40
       volume_type = "SATA"

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_pvc_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_pvc_test.go
@@ -160,7 +160,7 @@ func testAccCceCluster_config(rName string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
-resource "huaweicloud_compute_keypair" "test" {
+resource "huaweicloud_kps_keypair" "test" {
   name = "%[2]s"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
@@ -178,7 +178,7 @@ resource "huaweicloud_cce_node" "test" {
   name              = "%[2]s"
   flavor_id         = "s6.large.2"
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  key_pair          = huaweicloud_compute_keypair.test.name
+  key_pair          = huaweicloud_kps_keypair.test.name
 
   root_volume {
     size       = 40

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
@@ -163,7 +163,7 @@ func TestAccResourceNotebook_all(t *testing.T) {
 
 func testAccNotebook_All(rName string, ip string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_compute_keypair" "test" {
+resource "huaweicloud_kps_keypair" "test" {
   name       = "%s"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
@@ -175,7 +175,7 @@ resource "huaweicloud_modelarts_notebook" "test" {
   description = "%s"
 
   allowed_access_ips = ["%s"]
-  key_pair           = huaweicloud_compute_keypair.test.name
+  key_pair           = huaweicloud_kps_keypair.test.name
 
   volume {
     type = "EFS"

--- a/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_test.go
+++ b/huaweicloud/services/acceptance/mrs/resource_huaweicloud_mapreduce_cluster_test.go
@@ -638,7 +638,7 @@ func testAccMrsMapReduceClusterConfig_keypair(rName, pwd string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_compute_keypair" "test" {
+resource "huaweicloud_kps_keypair" "test" {
   name = "%s"
 
   lifecycle {
@@ -654,7 +654,7 @@ resource "huaweicloud_mapreduce_cluster" "test" {
   type               = "STREAMING"
   version            = "MRS 1.9.2"
   manager_admin_pass = "%s"
-  node_key_pair      = huaweicloud_compute_keypair.test.name
+  node_key_pair      = huaweicloud_kps_keypair.test.name
   subnet_id          = huaweicloud_vpc_subnet.test.id
   vpc_id             = huaweicloud_vpc.test.id
   component_list     = ["Storm"]

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_application_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_application_test.go
@@ -97,7 +97,7 @@ data "huaweicloud_images_image" "test" {
   most_recent = true
 }
 
-resource "huaweicloud_compute_keypair" "test" {
+resource "huaweicloud_kps_keypair" "test" {
   name = "%[1]s"
 }
 
@@ -126,7 +126,7 @@ resource "huaweicloud_compute_instance" "test" {
   image_id           = data.huaweicloud_images_image.test.id
   flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
-  key_pair           = huaweicloud_compute_keypair.test.name
+  key_pair           = huaweicloud_kps_keypair.test.name
   security_group_ids = [huaweicloud_networking_secgroup.test.id]
 
   enterprise_project_id = "%[2]s"

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_environment_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestage_environment_test.go
@@ -137,7 +137,7 @@ variable "rds_config" {
 
   default = [
     {fixed_ip = "192.168.0.58", port = "8636"},
-    {fixed_ip = "192.168.0.158", port = "8637"},
+    {fixed_ip = "192.168.0.160", port = "8637"},
   ]
 }
 
@@ -166,7 +166,7 @@ data "huaweicloud_images_image" "test" {
   most_recent = true
 }
 
-resource "huaweicloud_compute_keypair" "test" {
+resource "huaweicloud_kps_keypair" "test" {
   name = "%[1]s"
 }
 
@@ -240,7 +240,7 @@ resource "huaweicloud_cce_node" "test" {
   name              = "%[1]s-${count.index}"
   flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  key_pair          = huaweicloud_compute_keypair.test.name
+  key_pair          = huaweicloud_kps_keypair.test.name
 
   root_volume {
     volumetype = "SSD"
@@ -293,7 +293,7 @@ resource "huaweicloud_compute_instance" "test" {
   image_id           = data.huaweicloud_images_image.test.id
   flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
-  key_pair           = huaweicloud_compute_keypair.test.name
+  key_pair           = huaweicloud_kps_keypair.test.name
   security_group_ids = [huaweicloud_networking_secgroup.test.id]
 
   network {
@@ -307,7 +307,7 @@ resource "huaweicloud_as_configuration" "test" {
   instance_config {
     flavor   = data.huaweicloud_compute_flavors.test.ids[0]
     image    = data.huaweicloud_images_image.test.id
-    key_name = huaweicloud_compute_keypair.test.name
+    key_name = huaweicloud_kps_keypair.test.name
 
     disk {
       disk_type   = "SYS"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
`huaweicloud_compute_keypair` has been deprecated, use `huaweicloud_kps_keypair` instead.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
1.huaweicloud_bcs_instance
make testacc TEST='./huaweicloud/' TESTARGS='-run TestAccBCSV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/ -v -run TestAccBCSV2Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccBCSV2Instance_basic
=== PAUSE TestAccBCSV2Instance_basic
=== CONT  TestAccBCSV2Instance_basic
--- PASS: TestAccBCSV2Instance_basic (1273.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       1273.216s

2.huaweicloud_as_configuration
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_basic
=== PAUSE TestAccASConfiguration_basic
=== CONT  TestAccASConfiguration_basic
--- PASS: TestAccASConfiguration_basic (54.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        54.682s

make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_instance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_instance -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_instance
=== PAUSE TestAccASConfiguration_instance
=== CONT  TestAccASConfiguration_instance
--- PASS: TestAccASConfiguration_instance (191.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        191.955s

3.huaweicloud_as_group
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== CONT  TestAccASGroup_basic
--- PASS: TestAccASGroup_basic (388.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        388.464s

make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_forceDelete'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_forceDelete -timeout 360m -parallel 4
=== RUN   TestAccASGroup_forceDelete
=== PAUSE TestAccASGroup_forceDelete
=== CONT  TestAccASGroup_forceDelete
--- PASS: TestAccASGroup_forceDelete (260.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        260.607s

make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_sourceDestCheck'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_sourceDestCheck -timeout 360m -parallel 4
=== RUN   TestAccASGroup_sourceDestCheck
=== PAUSE TestAccASGroup_sourceDestCheck
=== CONT  TestAccASGroup_sourceDestCheck
--- PASS: TestAccASGroup_sourceDestCheck (163.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        163.612s

4.huaweicloud_as_policy
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_basic
=== PAUSE TestAccASPolicy_basic
=== CONT  TestAccASPolicy_basic
--- PASS: TestAccASPolicy_basic (210.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        210.407s

make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASPolicy_Alarm'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_Alarm -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_Alarm
=== PAUSE TestAccASPolicy_Alarm
=== CONT  TestAccASPolicy_Alarm
--- PASS: TestAccASPolicy_Alarm (125.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        125.577s

5.huaweicloud_cce_pvc
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCcePersistentVolumeClaimsV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCcePersistentVolumeClaimsV1_basic -timeout 360m -parallel 4
=== RUN   TestAccCcePersistentVolumeClaimsV1_basic
=== PAUSE TestAccCcePersistentVolumeClaimsV1_basic
=== CONT  TestAccCcePersistentVolumeClaimsV1_basic
--- PASS: TestAccCcePersistentVolumeClaimsV1_basic (947.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       947.448s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCcePersistentVolumeClaimsV1_obs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCcePersistentVolumeClaimsV1_obs -timeout 360m -parallel 4
=== RUN   TestAccCcePersistentVolumeClaimsV1_obs
=== PAUSE TestAccCcePersistentVolumeClaimsV1_obs
=== CONT  TestAccCcePersistentVolumeClaimsV1_obs
--- PASS: TestAccCcePersistentVolumeClaimsV1_obs (862.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       862.911s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCcePersistentVolumeClaimsV1_sfs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCcePersistentVolumeClaimsV1_sfs -timeout 360m -parallel 4
=== RUN   TestAccCcePersistentVolumeClaimsV1_sfs
=== PAUSE TestAccCcePersistentVolumeClaimsV1_sfs
=== CONT  TestAccCcePersistentVolumeClaimsV1_sfs
--- PASS: TestAccCcePersistentVolumeClaimsV1_sfs (862.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       862.720s

6.huaweicloud_modelarts_notebook
//cn-north-4
make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run TestAccResourceNotebook_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run TestAccResourceNotebook_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceNotebook_basic
=== PAUSE TestAccResourceNotebook_basic
=== CONT  TestAccResourceNotebook_basic
--- PASS: TestAccResourceNotebook_basic (95.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 95.481s

make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run TestAccResourceNotebook_all'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run TestAccResourceNotebook_all -timeout 360m -parallel 4
=== RUN   TestAccResourceNotebook_all
=== PAUSE TestAccResourceNotebook_all
=== CONT  TestAccResourceNotebook_all
--- PASS: TestAccResourceNotebook_all (163.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 163.996s

7.huaweicloud_mapreduce_cluster
//cn-north-4
make testacc TEST='./huaweicloud/services/acceptance/mrs' TESTARGS='-run TestAccMrsMapReduceCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run TestAccMrsMapReduceCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceCluster_basic
=== PAUSE TestAccMrsMapReduceCluster_basic
=== CONT  TestAccMrsMapReduceCluster_basic
--- PASS: TestAccMrsMapReduceCluster_basic (750.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       750.089s

make testacc TEST='./huaweicloud/services/acceptance/mrs' TESTARGS='-run TestAccMrsMapReduceCluster_keypair'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run TestAccMrsMapReduceCluster_keypair -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceCluster_keypair
=== PAUSE TestAccMrsMapReduceCluster_keypair
=== CONT  TestAccMrsMapReduceCluster_keypair
--- PASS: TestAccMrsMapReduceCluster_keypair (740.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       740.792s

make testacc TEST='./huaweicloud/services/acceptance/mrs' TESTARGS='-run TestAccMrsMapReduceCluster_analysis'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run TestAccMrsMapReduceCluster_analysis -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceCluster_analysis
=== PAUSE TestAccMrsMapReduceCluster_analysis
=== CONT  TestAccMrsMapReduceCluster_analysis
--- PASS: TestAccMrsMapReduceCluster_analysis (2254.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       2254.617s

make testacc TEST='./huaweicloud/services/acceptance/mrs' TESTARGS='-run TestAccMrsMapReduceCluster_stream'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mrs -v -run TestAccMrsMapReduceCluster_stream -timeout 360m -parallel 4
=== RUN   TestAccMrsMapReduceCluster_stream
=== PAUSE TestAccMrsMapReduceCluster_stream
=== CONT  TestAccMrsMapReduceCluster_stream
--- PASS: TestAccMrsMapReduceCluster_stream (2110.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mrs       2110.164s

8.huaweicloud_servicestage_application
//cn-north-4
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run TestAccApplication_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run TestAccApplication_basic -timeout 360m -parallel 4
=== RUN   TestAccApplication_basic
=== PAUSE TestAccApplication_basic
=== CONT  TestAccApplication_basic
--- PASS: TestAccApplication_basic (328.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      328.786

9.huaweicloud_servicestage_environment
//cn-north-4
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run TestAccEnvironment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run TestAccEnvironment_basic -timeout 360m -parallel 4
=== RUN   TestAccEnvironment_basic
=== PAUSE TestAccEnvironment_basic
=== CONT  TestAccEnvironment_basic
--- PASS: TestAccEnvironment_basic (1369.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      1369.625s
```
