### PR TITLE
fix(iotda/dataforwardingrule): fix targets parameter does not support DMS_KAFKA_FORWARDING type

### DIFF
--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
@@ -591,7 +591,7 @@ func buildChannelDetail(target map[string]interface{}, channel, projectId string
 		}
 		return &d, nil
 
-	case "kafka_forwarding":
+	case "DMS_KAFKA_FORWARDING":
 		forward := target["kafka_forwarding"].([]interface{})
 		if len(forward) == 0 {
 			return nil, fmt.Errorf("kafka_forwarding is Required when the target type is DMS_KAFKA_FORWARDING")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 fix targets parameter does not support DMS_KAFKA_FORWARDING type
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
When reading the parameter targets, writing the case in the switch statement as "kafka'forwarding" resulted in a failure to match the "DMS_KAFKA-FORWARDING" type.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataForwardingRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataForwardingRule_basic -timeout 360m -parallel 4
=== RUN   TestAccDataForwardingRule_basic
=== PAUSE TestAccDataForwardingRule_basic
=== CONT  TestAccDataForwardingRule_basic
--- PASS: TestAccDataForwardingRule_basic (15.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     15.112s

```
