### PR TITLE
feat(DC): DC virtual_gateway and virtual_interface support tags

### DIFF
--- a/docs/resources/dc_virtual_gateway.md
+++ b/docs/resources/dc_virtual_gateway.md
@@ -53,6 +53,8 @@ The following arguments are supported:
   gateway belongs.  
   Changing this will create a new resource.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the virtual gateway.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/dc_virtual_interface.md
+++ b/docs/resources/dc_virtual_interface.md
@@ -130,6 +130,8 @@ The following arguments are supported:
   interface belongs.  
   Changing this will create a new resource.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the virtual interface.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_gateway_test.go
+++ b/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_gateway_test.go
@@ -56,6 +56,8 @@ func TestAccVirtualGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "asn"),
 					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 				),
 			},
 			{
@@ -65,6 +67,8 @@ func TestAccVirtualGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "local_ep_group.0", updateCidr),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
 					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "tags.foo1", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value_update"),
 				),
 			},
 			{
@@ -91,6 +95,11 @@ resource "huaweicloud_dc_virtual_gateway" "test" {
   local_ep_group = [
     huaweicloud_vpc.test.cidr,
   ]
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `, name, cidr)
 }
@@ -109,6 +118,11 @@ resource "huaweicloud_dc_virtual_gateway" "test" {
   local_ep_group = [
     huaweicloud_vpc.test.cidr,
   ]
+
+  tags = {
+    foo1 = "bar"
+    key  = "value_update"
+  }
 }
 `, name, cidr)
 }

--- a/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go
+++ b/huaweicloud/services/acceptance/dc/resource_huaweicloud_dc_virtual_interface_test.go
@@ -68,6 +68,8 @@ func TestAccVirtualInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "device_id"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 				),
 			},
 			{
@@ -92,6 +94,8 @@ func TestAccVirtualInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "device_id"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttr(rName, "tags.foo1", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value_update"),
 				),
 			},
 			{
@@ -145,6 +149,11 @@ resource "huaweicloud_dc_virtual_interface" "test" {
   address_family       = "ipv4"
   local_gateway_v4_ip  = "1.1.1.1/30"
   remote_gateway_v4_ip = "1.1.1.2/30"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `, testAccVirtualInterface_base(name), acceptance.HW_DC_DIRECT_CONNECT_ID, name, vlan)
 }
@@ -172,6 +181,11 @@ resource "huaweicloud_dc_virtual_interface" "test" {
   address_family       = "ipv4"
   local_gateway_v4_ip  = "1.1.1.1/30"
   remote_gateway_v4_ip = "1.1.1.2/30"
+
+  tags = {
+    foo1 = "bar"
+    key  = "value_update"
+  }
 }
 `, testAccVirtualInterface_base(name), acceptance.HW_DC_DIRECT_CONNECT_ID, name, vlan)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
DC virtual_gateway and virtual_interface support tags

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.X
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dc/' TESTARGS='-run TestAccVirtualGateway_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccVirtualGateway_basic -timeout 360m -parallel 4 
=== RUN   TestAccVirtualGateway_basic 
=== PAUSE TestAccVirtualGateway_basic 
=== CONT  TestAccVirtualGateway_basic
--- PASS: TestAccVirtualGateway_basic (60.03s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        60.067s
```
```
make testacc TEST='./huaweicloud/services/acceptance/dc/' TESTARGS='-run TestAccVirtualInterface_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccVirtualInterface_basic -timeout 360m -parallel 4 
=== RUN   TestAccVirtualInterface_basic 
=== PAUSE TestAccVirtualInterface_basic
=== CONT  TestAccVirtualInterface_basic
--- PASS: TestAccVirtualInterface_basic (73.54s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        73.578s
```
