### PR TITLE
feat(vpc): add a new resource sub network interface

### DIFF
--- a/docs/resources/vpc_sub_network_interface.md
+++ b/docs/resources/vpc_sub_network_interface.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# huaweicloud_vpc_sub_network_interface
+
+Manages a supplementary network interface resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "subnet_id" {}
+variable "parent_id" {}
+variable "vlan_id" {}
+
+resource "huaweicloud_vpc_sub_network_interface" "test" {
+  subnet_id   = var.subnet_id
+  parent_id   = var.parent_id
+  vlan_id     = var.vlan_id
+  description = "create a supplementary network interface"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the subnet to which the supplementary network
+  interface belongs.
+  Changing this creates a new resource.
+
+* `parent_id` - (Required, String, ForceNew) Specifies the ID of the elastic network interface to which the
+  supplementary network interface belongs.  
+  Changing this creates a new resource.
+
+* `security_group_ids` - (Optional, List) Specifies the list of the security groups IDs to which the supplementary
+  network interface belongs.
+
+* `description` - (Optional, String) Specifies the description of the supplementary network interface.
+
+* `vlan_id` - (Optional, String) Specifies the vlan ID of the supplementary network interface.
+  The valid value is range from `1` t0 `4094`.
+
+* `ip_address` - (Optional, String) Specifies the private IPv4 address of the supplementary network interface.
+
+* `ipv6_enable` - (Optional, Bool) Specifies the IPv6 address is it enabled of the supplementary network interface.
+
+* `ipv6_ip_address` - (Optional, String) Specifies the IPv6 address of the supplementary network interface.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `mac_address` - The MAC address of the supplementary network interface.
+
+* `parent_device_id` - The ID of the ECS to which the supplementary network interface belongs.
+
+* `vpc_id` - The ID of the VPC to which the supplementary network interface belongs.
+
+* `status` - The status of the supplementary network interface.
+
+* `created_at` - The create time of the supplementary network interface.
+
+## Import
+
+The supplementary network interface can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_vpc_sub_network_interface.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1279,6 +1279,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_address_group":               vpc.ResourceVpcAddressGroup(),
 			"huaweicloud_vpc_flow_log":                    vpc.ResourceVpcFlowLog(),
 			"huaweicloud_vpc_network_interface":           vpc.ResourceNetworkInterface(),
+			"huaweicloud_vpc_sub_network_interface":       vpc.ResourceSubNetworkInterface(),
 			"huaweicloud_vpc_traffic_mirror_filter":       vpc.ResourceTrafficMirrorFilter(),
 			"huaweicloud_vpc_traffic_mirror_filter_rule":  vpc.ResourceTrafficMirrorFilterRule(),
 

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_sub_network_interface_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_sub_network_interface_test.go
@@ -1,0 +1,157 @@
+package vpc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSubNetworkInterfaceResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	getSubNetworkInterfaceHttpUrl := "vpc/sub-network-interfaces/{sub_network_interface_id}"
+	getSubNetworkInterfacePath := client.ResourceBaseURL() + getSubNetworkInterfaceHttpUrl
+	getSubNetworkInterfacePath = strings.ReplaceAll(getSubNetworkInterfacePath, "{sub_network_interface_id}", state.Primary.ID)
+
+	getSubNetworkInterfaceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getSubNetworkInterfaceResp, err := client.Request("GET", getSubNetworkInterfacePath, &getSubNetworkInterfaceOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving sub network interface: %s", err)
+	}
+
+	return utils.FlattenResponse(getSubNetworkInterfaceResp)
+}
+
+func TestAccSubNetworkInterface_basic(t *testing.T) {
+	var (
+		sub_network_interface interface{}
+		name                  = acceptance.RandomAccResourceName()
+		rName                 = "huaweicloud_vpc_sub_network_interface.test"
+		rc                    = acceptance.InitResourceCheck(
+			rName,
+			&sub_network_interface,
+			getSubNetworkInterfaceResourceFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSubNetworkInterface_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "parent_id", "huaweicloud_compute_instance.test", "network.0.port"),
+					resource.TestCheckResourceAttr(rName, "description", "created by test acc"),
+					resource.TestCheckResourceAttr(rName, "vlan_id", "3002"),
+					resource.TestCheckResourceAttr(rName, "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "ip_address"),
+					resource.TestCheckResourceAttrSet(rName, "mac_address"),
+					resource.TestCheckResourceAttrSet(rName, "parent_device_id"),
+					resource.TestCheckResourceAttrSet(rName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+			{
+				Config: testSubNetworkInterface_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "parent_id", "huaweicloud_compute_instance.test", "network.0.port"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "vlan_id", "3002"),
+					resource.TestCheckResourceAttr(rName, "security_group_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testaccSubNetworkInterface_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_images_images" "test" {
+  architecture = "x86"
+  visibility   = "public"
+}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "computingv3"
+  generation        = "c7"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_images.test.images[0].id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testSubNetworkInterface_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_sub_network_interface" "test" {
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+  parent_id   = huaweicloud_compute_instance.test.network[0].port
+  vlan_id     = "3002"
+  description = "created by test acc"
+}
+`, testaccSubNetworkInterface_base(name))
+}
+
+func testSubNetworkInterface_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_sub_network_interface" "test" {
+  subnet_id   = huaweicloud_vpc_subnet.test.id
+  parent_id   = huaweicloud_compute_instance.test.network[0].port
+  vlan_id     = "3002"
+  description = ""
+}
+`, testaccSubNetworkInterface_base(name))
+}

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_sub_network_interface.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_sub_network_interface.go
@@ -1,0 +1,280 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: VPC POST /v3/{project_id}/vpc/sub-network-interfaces
+// API: VPC GET /v3/{project_id}/vpc/sub-network-interfaces/{sub_network_interface_id}
+// API: VPC PUT /v3/{project_id}/vpc/sub-network-interfaces/{sub_network_interface_id}
+// API: VPC DELETE /v3/{project_id}/vpc/sub-network-interfaces/{sub_network_interface_id}
+func ResourceSubNetworkInterface() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSubNetworkInterfaceCreate,
+		ReadContext:   resourceSubNetworkInterfaceRead,
+		UpdateContext: resourceSubNetworkInterfaceUpdate,
+		DeleteContext: resourceSubNetworkInterfaceDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"parent_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vlan_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"ipv6_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"ipv6_ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"mac_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"parent_device_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildCreateSubNetworkInterfaceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"sub_network_interface": map[string]interface{}{
+			"virsubnet_id":       d.Get("subnet_id"),
+			"parent_id":          d.Get("parent_id"),
+			"security_groups":    utils.ValueIngoreEmpty(d.Get("security_group_ids")),
+			"description":        utils.ValueIngoreEmpty(d.Get("description")),
+			"vlan_id":            utils.ValueIngoreEmpty(d.Get("vlan_id")),
+			"private_ip_address": utils.ValueIngoreEmpty(d.Get("ip_address")),
+			"ipv6_enable":        utils.ValueIngoreEmpty(d.Get("ipv6_enable")),
+			"ipv6_ip_address":    utils.ValueIngoreEmpty(d.Get("ipv6_ip_address")),
+		},
+	}
+	return bodyParams
+}
+
+func resourceSubNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	createSubNetworkInterfaceHttpUrl := "vpc/sub-network-interfaces"
+	createSubNetworkInterfacePath := client.ResourceBaseURL() + createSubNetworkInterfaceHttpUrl
+
+	createSubNetworkInterfaceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			201,
+		},
+	}
+
+	createSubNetworkInterfaceOpt.JSONBody = utils.RemoveNil(buildCreateSubNetworkInterfaceBodyParams(d))
+	createSubNetworkInterfaceResp, err := client.Request("POST", createSubNetworkInterfacePath, &createSubNetworkInterfaceOpt)
+	if err != nil {
+		return diag.Errorf("error creating supplementary network interface: %s", err)
+	}
+
+	createcreateSubNetworkInterfaceRespBody, err := utils.FlattenResponse(createSubNetworkInterfaceResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("sub_network_interface.id", createcreateSubNetworkInterfaceRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating supplementary network interface: %s is not found in API response", id)
+	}
+
+	d.SetId(id.(string))
+
+	return resourceSubNetworkInterfaceRead(ctx, d, meta)
+}
+
+func getSubNetworkInterfaceInfo(d *schema.ResourceData, meta interface{}) (*http.Response, error) {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPC v3 client: %s", err)
+	}
+
+	getSubNetworkInterfaceHttpUrl := "vpc/sub-network-interfaces/" + d.Id()
+	getSubNetworkInterfacePath := client.ResourceBaseURL() + getSubNetworkInterfaceHttpUrl
+
+	getSubNetworkInterfaceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	resp, err := client.Request("GET", getSubNetworkInterfacePath, &getSubNetworkInterfaceOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func resourceSubNetworkInterfaceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	getSubNetworkInterfaceResp, err := getSubNetworkInterfaceInfo(d, meta)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "VPC supplementary network interface")
+	}
+
+	getSubNetworkInterfaceRespBody, err := utils.FlattenResponse(getSubNetworkInterfaceResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("subnet_id", utils.PathSearch("sub_network_interface.virsubnet_id", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("parent_id", utils.PathSearch("sub_network_interface.parent_id", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("security_group_ids", utils.PathSearch("sub_network_interface.security_groups", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("description", utils.PathSearch("sub_network_interface.description", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("vlan_id", fmt.Sprintf("%v", utils.PathSearch("sub_network_interface.vlan_id", getSubNetworkInterfaceRespBody, nil))),
+		d.Set("ip_address", utils.PathSearch("sub_network_interface.private_ip_address", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("ipv6_enable", utils.PathSearch("sub_network_interface.ipv6_enable", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("ipv6_ip_address", utils.PathSearch("sub_network_interface.ipv6_ip_address", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("mac_address", utils.PathSearch("sub_network_interface.mac_address", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("parent_device_id", utils.PathSearch("sub_network_interface.parent_device_id", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("vpc_id", utils.PathSearch("sub_network_interface.vpc_id", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("status", utils.PathSearch("sub_network_interface.state", getSubNetworkInterfaceRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("sub_network_interface.created_at", getSubNetworkInterfaceRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateSubNetworkInterfaceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"sub_network_interface": map[string]interface{}{
+			"description":     d.Get("description"),
+			"security_groups": utils.ValueIngoreEmpty(d.Get("security_group_ids")),
+		},
+	}
+	return bodyParams
+}
+
+func resourceSubNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 Client: %s", err)
+	}
+
+	if d.HasChanges("security_group_ids", "description") {
+		updateSubNetworkInterfaceHttpUrl := "vpc/sub-network-interfaces/" + d.Id()
+		updateSubNetworkInterfacePath := client.ResourceBaseURL() + updateSubNetworkInterfaceHttpUrl
+
+		updateSubNetworkInterfaceOpts := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		updateSubNetworkInterfaceOpts.JSONBody = utils.RemoveNil(buildUpdateSubNetworkInterfaceBodyParams(d))
+		_, err = client.Request("PUT", updateSubNetworkInterfacePath, &updateSubNetworkInterfaceOpts)
+		if err != nil {
+			return diag.Errorf("error updating VPC supplementary network interface: %s", err)
+		}
+	}
+	return resourceSubNetworkInterfaceRead(ctx, d, meta)
+}
+
+func resourceSubNetworkInterfaceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("vpcv3", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC v3 Client: %s", err)
+	}
+
+	deleteSubNetworkInterfaceHttpUrl := "vpc/sub-network-interfaces/" + d.Id()
+	deleteSubNetworkInterfacePath := client.ResourceBaseURL() + deleteSubNetworkInterfaceHttpUrl
+
+	deleteSubNetworkInterfaceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+	_, err = client.Request("DELETE", deleteSubNetworkInterfacePath, &deleteSubNetworkInterfaceOpt)
+	if err != nil {
+		return diag.Errorf("error deleting supplementary network interface: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new resource to manages a sub network interface resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add a new resource
1.Manages a supplementary network interface resource
2.Add the resource documentation (docs/resource/vpc_sub_network_interface)
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_vpc)$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccSubNetworkInterface_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccSubNetworkInterface_basic -timeout 360m -parallel 4
=== RUN   TestAccSubNetworkInterface_basic
=== PAUSE TestAccSubNetworkInterface_basic
=== CONT  TestAccSubNetworkInterface_basic
--- PASS: TestAccSubNetworkInterface_basic (27.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       27.276s
```
