### PR TITLE
feat(WAF): add a new datasource to query waf domain list

### DIFF
--- a/docs/data-sources/waf_domains.md
+++ b/docs/data-sources/waf_domains.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# huaweicloud_waf_domains
+
+Use this data source to get a list of WAF domains.
+
+## Example Usage
+
+```hcl
+variable "domain" {}
+variable "enterprise_project_id" {}
+
+data "huaweicloud_waf_domains" "domains" {
+  domain                = var.domain
+  enterprise_project_id = var.enterprise_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to query the WAF domains.
+  If omitted, the provider-level region will be used.
+
+* `domain` - (Optional, String) The protected domain name or IP address (port allowed).
+
+* `policy_name` - (Optional, String) The policy name associated with the domain.
+
+* `enterprise_project_id` - (Optional, String) The enterprise project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `domains` - A list of WAF domains.
+
+The `domains` block supports:
+
+* `id` - The ID of WAF domain.
+
+* `description` - The description of WAF domain.
+
+* `proxy` - Whether the protected domain name uses a proxy.
+  Valid values are **true** and **false**.
+
+* `domain` - The protected domain name or IP address (port allowed).
+
+* `policy_id` - The policy ID associated with the domain.
+
+* `pci_3ds` - The status of the PCI 3DS compliance certification check.
+
+* `pci_dss` - The status of the PCI DSS compliance certification check.
+
+* `ipv6_enable` - Whether to support IPv6.
+
+* `protect_status` - The protection status of domain, **0**: suspended, **1**: enabled.
+
+* `access_status` - Whether a domain name is connected to WAF. Valid values are:
+  + **0** - The domain name is not connected to WAF.
+  + **1** - The domain name is connected to WAF.
+
+* `charging_mode` - The charging mode of the domain.
+  Valid values are **prePaid** and **postPaid**.
+
+* `website_name` - The website name.
+
+* `proxy_layer` - Type of front-end proxy. Valid values are:
+  **0**: No proxy. No proxy products are deployed in front of WAF.
+  **4**: Layer-4 proxy. Web proxy products, such as layer-4 anti-DDoS,
+  that will not change the source or destination IP addresses are deployed in front of WAF.
+  **7**: Layer-7 proxy. Web proxy products, such as layer-7 anti-DDoS, CDN,
+  and other cloud acceleration services, that will change the source and
+  destination IP addresses are deployed in front of WAF.
+  If a layer-7 proxy is configured, WAF reads the real client IP address
+  from the related fields in the header.
+
+* `created_at` - The creation time of domain.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -652,6 +652,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_reference_tables":    waf.DataSourceWafReferenceTablesV1(),
 			"huaweicloud_waf_instance_groups":     waf.DataSourceWafInstanceGroups(),
 			"huaweicloud_waf_dedicated_domains":   waf.DataSourceWafDedicatedDomains(),
+			"huaweicloud_waf_domains":             waf.DataSourceWafDomains(),
 			"huaweicloud_waf_address_groups":      waf.DataSourceWafAddressGroups(),
 			"huaweicloud_dws_flavors":             dws.DataSourceDwsFlavors(),
 

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_domains_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_domains_test.go
@@ -1,0 +1,90 @@
+package waf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceWAFDomains_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_waf_domains.test"
+	policyNameTestName := "data.huaweicloud_waf_domains.policy_name_filter"
+	domainName := fmt.Sprintf("%s.huawei.com", name)
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDomains_basic(name, domainName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.proxy"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.domain"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.policy_id"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.protect_status"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.pci_3ds"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.pci_dss"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.access_status"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(policyNameTestName, "domains.#"),
+
+					resource.TestCheckOutput("domain_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("enterprise_project_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDomains_basic(name string, domainName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_waf_domains" "test" {
+  depends_on = [huaweicloud_waf_domain.domain_1]
+}
+
+data "huaweicloud_waf_domains" "domain_filter" {
+  domain = data.huaweicloud_waf_domains.test.domains.0.domain
+}
+
+locals {
+  domain = data.huaweicloud_waf_domains.test.domains.0.domain
+}
+
+output "domain_filter_is_useful" {
+  value = length(data.huaweicloud_waf_domains.domain_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_domains.domain_filter.domains[*].domain : v == local.domain]
+  )  
+}
+
+data "huaweicloud_waf_domains" "policy_name_filter" {
+  policy_name = huaweicloud_waf_policy.policy_1.name
+}
+
+data "huaweicloud_waf_domains" "enterprise_project_id_filter" {
+  enterprise_project_id = data.huaweicloud_waf_domains.test.domains.0.enterprise_project_id
+}
+	
+locals {
+  enterprise_project_id = data.huaweicloud_waf_domains.test.domains.0.enterprise_project_id
+}
+
+output "enterprise_project_id_filter_is_useful" {
+  value = length(data.huaweicloud_waf_domains.enterprise_project_id_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_waf_domains.enterprise_project_id_filter.domains[*].enterprise_project_id : v == local.enterprise_project_id]
+  )  
+}
+`, testAccWafDomainV1_update2(name, domainName))
+}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_domains.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_domains.go
@@ -1,0 +1,221 @@
+package waf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: WAF GET /v1/{project_id}/waf/instance
+func DataSourceWafDomains() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceDomainsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domains": {
+				Type:     schema.TypeList,
+				Elem:     wafDomainSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func wafDomainSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"proxy": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protect_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"pci_3ds": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"pci_dss": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ipv6_enable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"access_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"charging_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"website_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"proxy_layer": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceDomainsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		getWAFDomainsHttpUrl = "v1/{project_id}/waf/instance"
+		getWAFDomainsProduct = "waf"
+	)
+	getWAFDomainsClient, err := cfg.NewServiceClient(getWAFDomainsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating WAF client: %s", err)
+	}
+
+	getWAFDomainsPath := getWAFDomainsClient.Endpoint + getWAFDomainsHttpUrl
+	getWAFDomainsPath = strings.ReplaceAll(getWAFDomainsPath, "{project_id}",
+		getWAFDomainsClient.ProjectID)
+	getWAFDomainsPath += buildWAFDomainsQueryParams(d, cfg)
+
+	getWAFDomainsResp, err := pagination.ListAllItems(
+		getWAFDomainsClient,
+		"page",
+		getWAFDomainsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving WAF domains, %s", err)
+	}
+
+	listWAFDomainsRespJson, err := json.Marshal(getWAFDomainsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listWAFDomainsRespBody interface{}
+	err = json.Unmarshal(listWAFDomainsRespJson, &listWAFDomainsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("domains", flattenListDomainsBody(listWAFDomainsRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListDomainsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("items", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		createTime := utils.PathSearch("create_time", v, 0)
+		rst = append(rst, map[string]interface{}{
+			"id":                    utils.PathSearch("id", v, nil),
+			"description":           utils.PathSearch("description", v, nil),
+			"proxy":                 utils.StringToBool(utils.PathSearch("proxcy", v, "")),
+			"domain":                utils.PathSearch("hostname", v, nil),
+			"policy_id":             utils.PathSearch("policyid", v, nil),
+			"protect_status":        utils.PathSearch("protect_status", v, nil),
+			"pci_3ds":               utils.StringToBool(utils.PathSearch("flag.pci_3ds", v, "")),
+			"pci_dss":               utils.StringToBool(utils.PathSearch("flag.pci_dss", v, "")),
+			"ipv6_enable":           utils.StringToBool(utils.PathSearch("flag.ipv6", v, "")),
+			"access_status":         utils.PathSearch("access_status", v, nil),
+			"charging_mode":         utils.PathSearch("paid_type", v, nil),
+			"website_name":          utils.PathSearch("web_tag", v, nil),
+			"proxy_layer":           utils.PathSearch("proxy_layer", v, nil),
+			"created_at":            utils.FormatTimeStampRFC3339(int64(createTime.(float64))/1000, false),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+		})
+	}
+	return rst
+}
+
+func buildWAFDomainsQueryParams(d *schema.ResourceData, conf *config.Config) string {
+	res := ""
+	epsId := conf.GetEnterpriseProjectID(d)
+	if epsId != "" {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsId)
+	}
+	if v, ok := d.GetOk("domain"); ok {
+		res = fmt.Sprintf("%s&hostname=%v", res, v)
+	}
+	if v, ok := d.GetOk("policy_name"); ok {
+		res = fmt.Sprintf("%s&policyname=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->


**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
+ The field `policy_name` cannot be obtained in the resource, so only verify the quantity.
+ `TestAccWafDomainV1_update2` is referenced because there is a resource `policy` in the resource configuration and the `name` of the policy needs to be used.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccDatasourceWAFDomains_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDatasourceWAFDomains_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceWAFDomains_basic
=== PAUSE TestAccDatasourceWAFDomains_basic
=== CONT  TestAccDatasourceWAFDomains_basic
--- PASS: TestAccDatasourceWAFDomains_basic (126.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       126.503s
```
