### PR TITLE
feat(DMS): update automatic topic for kafka instance

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -192,11 +192,10 @@ The following arguments are supported:
 * `dumping` - (Optional, Bool, ForceNew) Specifies whether to enable message dumping.
   Changing this creates a new instance resource.
 
-* `enable_auto_topic` - (Optional, Bool, ForceNew) Specifies whether to enable automatic topic creation. If automatic
+* `enable_auto_topic` - (Optional, Bool) Specifies whether to enable automatic topic creation. If automatic
   topic creation is enabled, a topic will be automatically created with 3 partitions and 3 replicas when a message is
   produced to or consumed from a topic that does not exist.
   The default value is false.
-  Changing this creates a new instance resource.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the Kafka instance.
 

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
@@ -62,6 +62,7 @@ func TestAccKafkaInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "kafka test update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
+					resource.TestCheckResourceAttr(resourceName, "enable_auto_topic", "true"),
 				),
 			},
 			{
@@ -331,6 +332,7 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   manager_password   = "Kafkatest@123"
   security_protocol  = "SASL_PLAINTEXT"
   enabled_mechanisms = ["SCRAM-SHA-512"]
+  enable_auto_topic  = true
 
   tags = {
     key1  = "value"

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
@@ -345,3 +345,23 @@ func UpdateCrossVpc(c *golangsdk.ServiceClient, instanceId string, opts CrossVpc
 	})
 	return &r, err
 }
+
+// AutoTopicOpts is a struct which represents the parameter of UpdateAutoTopic function
+type AutoTopicOpts struct {
+	// Indicates whether to enable automatic topic creation.
+	EnableAutoTopic *bool `json:"enable_auto_topic" required:"true"`
+}
+
+// UpdateAutoTopic is used to enable or disable automatic topic creation.
+// via accessing to the service with POST method and parameters
+func UpdateAutoTopic(client *golangsdk.ServiceClient, id string,
+	opts AutoTopicOpts) (r AutoTopicResult) {
+	body, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(autoTopicURL(client, id), body, nil, &golangsdk.RequestOpts{})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
@@ -165,3 +165,8 @@ type Connection struct {
 	// Listeners IP.
 	ListenersIp string `json:"ip"`
 }
+
+// AutoTopicResult is a struct that contains all the return parameters of UpdateAutoTopic function
+type AutoTopicResult struct {
+	golangsdk.Result
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/urls.go
@@ -36,3 +36,8 @@ func extend(client *golangsdk.ServiceClient, id string) string {
 func crossVpcURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL(client.ProjectID, resourcePath, id, "crossvpc/modify")
 }
+
+// autoTopicURL will build the url of UpdateAutoTopic
+func autoTopicURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, resourcePath, id, "autotopic")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  enable or disable automatic topic
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccKafkaInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccKafkaInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstance_basic
=== PAUSE TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_basic
--- PASS: TestAccKafkaInstance_basic (1507.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1507.317s

```
