### PR TITLE
feat(CC): add a resource to manage auth

### DIFF
--- a/docs/resources/cc_authorization.md
+++ b/docs/resources/cc_authorization.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Cloud Connect (CC)"
+---
+
+# huaweicloud_cc_authorization
+
+Manages a cross-account authorization resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable instance_id {}
+variable cloud_connection_domain_id {}
+variable cloud_connection_id {}
+
+resource "huaweicloud_cc_authorization" "test" {
+   name                       = "demo"
+   instance_type              = "vpc"
+   instance_id                = var.instance_id
+   cloud_connection_domain_id = var.cloud_connection_domain_id
+   cloud_connection_id        = var.cloud_connection_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Optional, String) The name of the cross-account authorization.
+
+* `instance_type` - (Required, String, ForceNew) The instance type.
+  The options are as follows:
+    + **vpc**: VPC
+
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) The instance ID.
+
+  Changing this parameter will create a new resource.
+
+* `cloud_connection_domain_id` - (Required, String, ForceNew) The peer account ID that you want to authorize.
+
+  Changing this parameter will create a new resource.
+
+* `cloud_connection_id` - (Required, String, ForceNew) Peer cloud connection ID.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) The description of the cross-account authorization.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Import
+
+The cross-account authorization can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_cc_authorization.test 0ce123456a00f2591fabc00385ff1234
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -795,6 +795,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cc_connection":                   cc.ResourceCloudConnection(),
 			"huaweicloud_cc_network_instance":             cc.ResourceNetworkInstance(),
+			"huaweicloud_cc_authorization":                cc.ResourceAuthorization(),
 			"huaweicloud_cc_bandwidth_package":            cc.ResourceBandwidthPackage(),
 			"huaweicloud_cc_inter_region_bandwidth":       cc.ResourceInterRegionBandwidth(),
 			"huaweicloud_cc_central_network":              cc.ResourceCentralNetwork(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -231,7 +231,9 @@ var (
 
 	HW_CCI_NAMESPACE = os.Getenv("HW_CCI_NAMESPACE")
 
-	HW_CC_GLOBAL_GATEWAY_ID = os.Getenv("HW_CC_GLOBAL_GATEWAY_ID")
+	HW_CC_GLOBAL_GATEWAY_ID  = os.Getenv("HW_CC_GLOBAL_GATEWAY_ID")
+	HW_CC_PEER_DOMAIN_ID     = os.Getenv("HW_CC_PEER_DOMAIN_ID")
+	HW_CC_PEER_CONNECTION_ID = os.Getenv("HW_CC_PEER_CONNECTION_ID")
 
 	HW_CERT_BATCH_PUSH_ID = os.Getenv("HW_CERT_BATCH_PUSH_ID")
 
@@ -1059,6 +1061,13 @@ func TestAccPreCheckCERT(t *testing.T) {
 func TestAccPreCheckCCGlobalGateway(t *testing.T) {
 	if HW_CC_GLOBAL_GATEWAY_ID == "" {
 		t.Skip("HW_CC_GLOBAL_GATEWAY_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCCAuth(t *testing.T) {
+	if HW_CC_PEER_DOMAIN_ID == "" || HW_CC_PEER_CONNECTION_ID == "" {
+		t.Skip("HW_CC_PEER_DOMAIN_ID, HW_CC_PEER_CONNECTION_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_authorization_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_authorization_test.go
@@ -1,0 +1,146 @@
+package cc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAuthorizationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	var (
+		getAuthorizationHttpUrl = "v3/{domain_id}/ccaas/authorisations?id={id}"
+		getAuthorizationProduct = "cc"
+	)
+	getAuthorizationClient, err := cfg.NewServiceClient(getAuthorizationProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CC client: %s", err)
+	}
+
+	getAuthorizationPath := getAuthorizationClient.Endpoint + getAuthorizationHttpUrl
+	getAuthorizationPath = strings.ReplaceAll(getAuthorizationPath, "{domain_id}", cfg.DomainID)
+	getAuthorizationPath = strings.ReplaceAll(getAuthorizationPath, "{id}", state.Primary.ID)
+
+	getAuthorizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	getAuthorizationResp, err := getAuthorizationClient.Request("GET", getAuthorizationPath, &getAuthorizationOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving authorization: %s", err)
+	}
+
+	getAuthorizationRespBody, err := utils.FlattenResponse(getAuthorizationResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving authorization: %s", err)
+	}
+
+	jsonPath := fmt.Sprintf("authorisations[?id =='%s']|[0]", state.Primary.ID)
+	getAuthorizationRespBody = utils.PathSearch(jsonPath, getAuthorizationRespBody, nil)
+	if getAuthorizationRespBody == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return getAuthorizationRespBody, nil
+}
+
+func TestAccAuthorization_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cc_authorization.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAuthorizationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCCAuth(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAuthorization_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "instance_type", "vpc"),
+					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttr(rName, "cloud_connection_domain_id", acceptance.HW_CC_PEER_DOMAIN_ID),
+					resource.TestCheckResourceAttr(rName, "cloud_connection_id", acceptance.HW_CC_PEER_CONNECTION_ID),
+					resource.TestCheckResourceAttr(rName, "description", "This is a test"),
+				),
+			},
+			{
+				Config: testAuthorization_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "instance_type", "vpc"),
+					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttr(rName, "cloud_connection_domain_id", acceptance.HW_CC_PEER_DOMAIN_ID),
+					resource.TestCheckResourceAttr(rName, "cloud_connection_id", acceptance.HW_CC_PEER_CONNECTION_ID),
+					resource.TestCheckResourceAttr(rName, "description", "This is a test update"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAuthorization_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name        = "%s"
+  cidr        = "192.168.0.0/16"
+}
+
+resource "huaweicloud_cc_authorization" "test" {
+   name                       = "%[1]s"
+   instance_type              = "vpc"
+   instance_id                = huaweicloud_vpc.test.id
+   cloud_connection_domain_id = "%[2]s"
+   cloud_connection_id        = "%[3]s"
+   description                = "This is a test"
+}
+`, name, acceptance.HW_CC_PEER_DOMAIN_ID, acceptance.HW_CC_PEER_CONNECTION_ID)
+}
+
+func testAuthorization_basic_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name        = "%s"
+  cidr        = "192.168.0.0/16"
+}
+
+resource "huaweicloud_cc_authorization" "test" {
+   name                       = "%[1]s_update"
+   instance_type              = "vpc"
+   instance_id                = huaweicloud_vpc.test.id
+   cloud_connection_domain_id = "%[2]s"
+   cloud_connection_id        = "%[3]s"
+   description                = "This is a test update"
+}
+`, name, acceptance.HW_CC_PEER_DOMAIN_ID, acceptance.HW_CC_PEER_CONNECTION_ID)
+}

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_authorization.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_authorization.go
@@ -1,0 +1,283 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CC
+// ---------------------------------------------------------------
+
+package cc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceAuthorization() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAuthorizationCreate,
+		UpdateContext: resourceAuthorizationUpdate,
+		ReadContext:   resourceAuthorizationRead,
+		DeleteContext: resourceAuthorizationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The name of the cross-account authorization.`,
+			},
+			"instance_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The instance type.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The instance ID.`,
+			},
+			"cloud_connection_domain_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The peer account ID that you want to authorize.`,
+			},
+			"cloud_connection_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Peer cloud connection ID.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The description of the cross-account authorization.`,
+			},
+		},
+	}
+}
+
+func resourceAuthorizationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		createAuthorizationHttpUrl = "v3/{domain_id}/ccaas/authorisations"
+		createAuthorizationProduct = "cc"
+	)
+	createAuthorizationClient, err := cfg.NewServiceClient(createAuthorizationProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	createAuthorizationPath := createAuthorizationClient.Endpoint + createAuthorizationHttpUrl
+	createAuthorizationPath = strings.ReplaceAll(createAuthorizationPath, "{domain_id}", cfg.DomainID)
+
+	createAuthorizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			201,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	createAuthorizationOpt.JSONBody = utils.RemoveNil(buildCreateAuthorizationBodyParams(d, cfg))
+	createAuthorizationResp, err := createAuthorizationClient.Request("POST", createAuthorizationPath, &createAuthorizationOpt)
+	if err != nil {
+		return diag.Errorf("error creating authorization: %s", err)
+	}
+
+	createAuthorizationRespBody, err := utils.FlattenResponse(createAuthorizationResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("authorisation.id", createAuthorizationRespBody)
+	if err != nil {
+		return diag.Errorf("error creating authorization: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceAuthorizationRead(ctx, d, meta)
+}
+
+func buildCreateAuthorizationBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
+	region := cfg.GetRegion(d)
+	bodyParams := map[string]interface{}{
+		"authorisation": map[string]interface{}{
+			"name":                       utils.ValueIngoreEmpty(d.Get("name")),
+			"description":                utils.ValueIngoreEmpty(d.Get("description")),
+			"instance_type":              d.Get("instance_type"),
+			"instance_id":                d.Get("instance_id"),
+			"project_id":                 cfg.GetProjectID(region),
+			"region_id":                  region,
+			"cloud_connection_domain_id": d.Get("cloud_connection_domain_id"),
+			"cloud_connection_id":        d.Get("cloud_connection_id"),
+		},
+	}
+	return bodyParams
+}
+
+func resourceAuthorizationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// getAuthorization: Query the cross-account authorization
+	var (
+		getAuthorizationHttpUrl = "v3/{domain_id}/ccaas/authorisations?id={id}"
+		getAuthorizationProduct = "cc"
+	)
+	getAuthorizationClient, err := cfg.NewServiceClient(getAuthorizationProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	getAuthorizationPath := getAuthorizationClient.Endpoint + getAuthorizationHttpUrl
+	getAuthorizationPath = strings.ReplaceAll(getAuthorizationPath, "{domain_id}", cfg.DomainID)
+	getAuthorizationPath = strings.ReplaceAll(getAuthorizationPath, "{id}", d.Id())
+
+	getAuthorizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	getAuthorizationResp, err := getAuthorizationClient.Request("GET", getAuthorizationPath, &getAuthorizationOpt)
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving authorization")
+	}
+
+	getAuthorizationRespBody, err := utils.FlattenResponse(getAuthorizationResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jsonPath := fmt.Sprintf("authorisations[?id =='%s']|[0]", d.Id())
+	getAuthorizationRespBody = utils.PathSearch(jsonPath, getAuthorizationRespBody, nil)
+	if getAuthorizationRespBody == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "no data found")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", getAuthorizationRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getAuthorizationRespBody, nil)),
+		d.Set("instance_type", utils.PathSearch("instance_type", getAuthorizationRespBody, nil)),
+		d.Set("instance_id", utils.PathSearch("instance_id", getAuthorizationRespBody, nil)),
+		d.Set("cloud_connection_domain_id", utils.PathSearch("cloud_connection_domain_id", getAuthorizationRespBody, nil)),
+		d.Set("cloud_connection_id", utils.PathSearch("cloud_connection_id", getAuthorizationRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAuthorizationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateAuthorizationChanges := []string{
+		"name",
+		"description",
+	}
+
+	if d.HasChanges(updateAuthorizationChanges...) {
+		var (
+			updateAuthorizationHttpUrl = "v3/{domain_id}/ccaas/authorisations/{id}"
+			updateAuthorizationProduct = "cc"
+		)
+		updateAuthorizationClient, err := cfg.NewServiceClient(updateAuthorizationProduct, region)
+		if err != nil {
+			return diag.Errorf("error creating CC client: %s", err)
+		}
+
+		updateAuthorizationPath := updateAuthorizationClient.Endpoint + updateAuthorizationHttpUrl
+		updateAuthorizationPath = strings.ReplaceAll(updateAuthorizationPath, "{domain_id}", cfg.DomainID)
+		updateAuthorizationPath = strings.ReplaceAll(updateAuthorizationPath, "{id}", d.Id())
+
+		updateAuthorizationOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+			MoreHeaders: map[string]string{"Content-Type": "application/json"},
+		}
+
+		updateAuthorizationOpt.JSONBody = utils.RemoveNil(buildUpdateAuthorizationBodyParams(d))
+		_, err = updateAuthorizationClient.Request("PUT", updateAuthorizationPath, &updateAuthorizationOpt)
+		if err != nil {
+			return diag.Errorf("error updating authorization: %s", err)
+		}
+	}
+	return resourceAuthorizationRead(ctx, d, meta)
+}
+
+func buildUpdateAuthorizationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"authorisation": map[string]interface{}{
+			"name":        utils.ValueIngoreEmpty(d.Get("name")),
+			"description": utils.ValueIngoreEmpty(d.Get("description")),
+		},
+	}
+	return bodyParams
+}
+
+func resourceAuthorizationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		deleteAuthorizationHttpUrl = "v3/{domain_id}/ccaas/authorisations/{id}"
+		deleteAuthorizationProduct = "cc"
+	)
+	deleteAuthorizationClient, err := cfg.NewServiceClient(deleteAuthorizationProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	deleteAuthorizationPath := deleteAuthorizationClient.Endpoint + deleteAuthorizationHttpUrl
+	deleteAuthorizationPath = strings.ReplaceAll(deleteAuthorizationPath, "{domain_id}", cfg.DomainID)
+	deleteAuthorizationPath = strings.ReplaceAll(deleteAuthorizationPath, "{id}", d.Id())
+
+	deleteAuthorizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = deleteAuthorizationClient.Request("DELETE", deleteAuthorizationPath, &deleteAuthorizationOpt)
+	if err != nil {
+		return diag.Errorf("error deleting authorization: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

😞 😞 😞 The resource needs other domain and connection_id to auth, So skip the acceptance test.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
Running tool: /usr/local/go/bin/go test -timeout 9000000000s -run ^TestAccAuthorization_basic$ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc -v

=== RUN   TestAccAuthorization_basic
=== PAUSE TestAccAuthorization_basic
=== CONT  TestAccAuthorization_basic
    /home/huawei/git/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc/acceptance.go:1070: HW_CC_PEER_DOMAIN_ID, HW_CC_PEER_CONNECTION_ID must be set for the acceptance test
--- SKIP: TestAccAuthorization_basic (0.00s)
PASS
ok  	github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc	0.039s

```
