### PR TITLE
feat(DWS): DWS cluster support editing logical cluster switch

### DIFF
--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -113,6 +113,9 @@ The following arguments are supported:
 * `keep_last_manual_snapshot` - (Optional, Int) The number of latest manual snapshots that need to be
   retained when deleting the cluster.
 
+* `logical_cluster_enable` - (Optional, Bool) Specified whether to enable logical cluster. The switch needs to be turned
+  on before creating a logical cluster.
+
 <a name="DwsCluster_PublicIp"></a>
 The `PublicIp` block supports:
 
@@ -237,7 +240,7 @@ $ terraform import huaweicloud_dws_cluster.test 47ad727e-9dcc-4833-bde0-bb298607
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `user_pwd`, `number_of_cn`, `kms_key_id`,
-`volume`, `dss_pool_id`.
+`volume`, `dss_pool_id`, `logical_cluster_enable`.
 It is generally recommended running `terraform plan` after importing a cluster.
 You can then decide if changes should be applied to the cluster, or the resource definition
 should be updated to align with the cluster. Also you can ignore changes as below.
@@ -248,7 +251,7 @@ resource "huaweicloud_dws_cluster" "test" {
 
   lifecycle {
     ignore_changes = [
-      user_pwd, number_of_cn, kms_key_id, volume, dss_pool_id
+      user_pwd, number_of_cn, kms_key_id, volume, dss_pool_id, logical_cluster_enable
     ]
   }
 }

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
@@ -56,7 +56,7 @@ func getClusterResourceFunc(cfg *config.Config, state *terraform.ResourceState) 
 	return getDwsClusterRespBody, nil
 }
 
-func TestAccResourceDWS_basic(t *testing.T) {
+func TestAccResourceDWS_basicV1(t *testing.T) {
 	var obj interface{}
 
 	resourceName := "huaweicloud_dws_cluster.test"
@@ -79,25 +79,27 @@ func TestAccResourceDWS_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "number_of_node", "3"),
+					resource.TestCheckResourceAttr(resourceName, "logical_cluster_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "val"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 			{
-				Config: testAccDwsCluster_basic(name, 6, dws.PublicBindTypeAuto, "cluster123@!u", "cat"),
+				Config: testAccDwsCluster_basic(name, 6, dws.PublicBindTypeAuto, "cluster123@!u", "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "number_of_node", "6"),
+					resource.TestCheckResourceAttr(resourceName, "logical_cluster_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "val"),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo", "cat"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"user_pwd", "number_of_cn", "volume", "endpoints"},
+				ImportStateVerifyIgnore: []string{"user_pwd", "number_of_cn", "volume", "endpoints", "logical_cluster_enable"},
 			},
 		},
 	})
@@ -112,15 +114,16 @@ func testAccDwsCluster_basic(rName string, numberOfNode int, publicIpBindType, p
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_dws_cluster" "test" {
-  name              = "%s"
-  node_type         = "dwsk2.xlarge"
-  number_of_node    = %d
-  vpc_id            = huaweicloud_vpc.test.id
-  network_id        = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  user_name         = "test_cluster_admin"
-  user_pwd          = "%s"
+  name                   = "%s"
+  node_type              = "dwsk2.xlarge"
+  number_of_node         = %d
+  vpc_id                 = huaweicloud_vpc.test.id
+  network_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id      = huaweicloud_networking_secgroup.test.id
+  availability_zone      = data.huaweicloud_availability_zones.test.names[0]
+  user_name              = "test_cluster_admin"
+  user_pwd               = "%s"
+  logical_cluster_enable = true
 
   public_ip {
     public_bind_type = "%s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

DWS cluster support editing logical cluster switch

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dws' TESTARGS='-run TestAccResourceDWS_basicV1'
...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceDWS_basicV1 -timeout 360m -parallel 4
=== RUN   TestAccResourceDWS_basicV1
=== PAUSE TestAccResourceDWS_basicV1
=== CONT  TestAccResourceDWS_basicV1
--- PASS: TestAccResourceDWS_basicV1 (2118.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       2118.984s
```
