### PR TITLE
chore(nat): private nat gateway resource support vpc_id attribute

### DIFF
--- a/docs/resources/nat_private_gateway.md
+++ b/docs/resources/nat_private_gateway.md
@@ -70,6 +70,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The current status of the private NAT gateway.
 
+* `vpc_id` - The ID of the VPC to which the private NAT gateway belongs.
+
 ## Import
 
 The private NAT gateways can be imported using their `id`, e.g.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240105014415-f85b80e34b0e
+	github.com/chnsz/golangsdk v0.0.0-20240109025837-8aa22d6dae58
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240105014415-f85b80e34b0e h1:qiwCYGX4+f4z6z+UEuN/gNYzhviDX0gSU+oSe1oR+u8=
-github.com/chnsz/golangsdk v0.0.0-20240105014415-f85b80e34b0e/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240109025837-8aa22d6dae58 h1:BcWqT5aGMDkha8UGF//1EiNpT7lOLTermVm+SMQJBFk=
+github.com/chnsz/golangsdk v0.0.0-20240109025837-8aa22d6dae58/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_gateway_test.go
@@ -58,6 +58,7 @@ func TestAccPrivateGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName, "vpc_id"),
 				),
 			},
 			{
@@ -70,6 +71,7 @@ func TestAccPrivateGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "baaar"),
 					resource.TestCheckResourceAttr(rName, "tags.newKey", "value"),
+					resource.TestCheckResourceAttrSet(rName, "vpc_id"),
 				),
 			},
 			{

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_gateway.go
@@ -104,6 +104,11 @@ func ResourcePrivateGateway() *schema.Resource {
 				Computed:    true,
 				Description: "The current status of the private NAT gateway.",
 			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the VPC to which the private NAT gateway belongs.",
+			},
 		},
 	}
 }
@@ -165,6 +170,7 @@ func resourcePrivateGatewayRead(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("created_at", resp.CreatedAt),
 		d.Set("updated_at", resp.UpdatedAt),
 		d.Set("status", resp.Status),
+		d.Set("vpc_id", utils.PathSearch("[0].VpcId", resp.DownLinkVpcs, nil)),
 	)
 	if err = mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error saving private NAT gateway fields: %s", err)

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/gateways/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v3/gateways/results.go
@@ -31,12 +31,20 @@ type Gateway struct {
 	CreatedAt string `json:"created_at"`
 	// The latest update time of the private NAT gateway.
 	UpdatedAt string `json:"updated_at"`
-	// The subnet configuration of the private NAT gateway.
-	DownLinkVpcs []DownLinkVpc `json:"downlink_vpcs"`
+	// The VPC configuration of the private NAT gateway.
+	DownLinkVpcs []DownLinkVpcResp `json:"downlink_vpcs"`
 	// The key/value pairs to associate with the NAT geteway.
 	Tags []tags.ResourceTag `json:"tags"`
 	// The enterprise project ID to which the private NAT gateway belongs.
 	EnterpriseProjectId string `json:"enterprise_project_id"`
+}
+
+// DownLinkVpcResp is an object that represents the VPC configuration to which private NAT gateway belongs.
+type DownLinkVpcResp struct {
+	// The subnet ID to which the private NAT gateway belongs.
+	SubnetId string `json:"virsubnet_id"`
+	// The VPC ID to which the private NAT gateway belongs.
+	VpcId string `json:"vpc_id"`
 }
 
 type createResp struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240105014415-f85b80e34b0e
+# github.com/chnsz/golangsdk v0.0.0-20240109025837-8aa22d6dae58
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
private nat gateway resource support vpc_id attribute
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix private nat gateway resource 
1. support vpc_id attribute
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_private_nat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateGateway_basic
=== PAUSE TestAccPrivateGateway_basic
=== CONT  TestAccPrivateGateway_basic
--- PASS: TestAccPrivateGateway_basic (94.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       94.179s
```
