### PR TITLE
feat(DWS): support DWS cluster bind ELB

### DIFF
--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -116,6 +116,8 @@ The following arguments are supported:
 * `logical_cluster_enable` - (Optional, Bool) Specified whether to enable logical cluster. The switch needs to be turned
   on before creating a logical cluster.
 
+* `elb_id` - (Optional, String) Specifies the ID of the ELB load balancer.
+
 <a name="DwsCluster_PublicIp"></a>
 The `PublicIp` block supports:
 
@@ -197,6 +199,9 @@ In addition to all arguments above, the following attributes are exported:
 * `maintain_window` - Cluster maintenance window.
   The [MaintainWindow](#DwsCluster_MaintainWindow) structure is documented below.
 
+* `elb` - The ELB information bound to the cluster.
+  The [elb](#DwsCluster_elb) structure is documented below.
+
 <a name="DwsCluster_Endpoint"></a>
 The `Endpoint` block supports:
 
@@ -218,9 +223,26 @@ The `MaintainWindow` block supports:
   The valid values are **Mon**, **Tue**, **Wed**, **Thu**, **Fri**,
   **Sat**, and **Sun**.
 
-* `start_time` - Maintenance start time in HH:mm format. The time zone is GMT+0.  
+* `start_time` - Maintenance start time in HH:mm format. The time zone is GMT+0.
 
-* `end_time` - Maintenance end time in HH:mm format. The time zone is GMT+0.  
+* `end_time` - Maintenance end time in HH:mm format. The time zone is GMT+0.
+
+<a name="DwsCluster_elb"></a>
+The `elb` block supports:
+
+* `name` - The name of the ELB load balancer.
+
+* `id` - The ID of the ELB load balancer.
+
+* `public_ip` - The public IP address of the ELB load balancer.
+
+* `private_ip` - The private IP address of the ELB load balancer.
+
+* `private_endpoint` - The private endpoint of the ELB load balancer.
+
+* `vpc_id` - The ID of VPC to which the ELB load balancer belongs.
+
+* `private_ip_v6` - The IPv6 address of the ELB load balancer.
 
 ## Timeouts
 


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Support DWS cluster bind ELB load balancer.
2. Optimize `resourceDwsClusterUpdate`(DWS cluster resource update method) duplicate code, because cyclomatic complexity 23 of func `resourceDwsClusterUpdate` is high (> 20)

Which issue this PR fixes:
(optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged)
fixes #xxx

Special notes for your reviewer:

Release note:
```
 support DWS cluster bind ELB load balancer.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dws" TESTARGS="-run TestAccResourceCluster_basicV2"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_basicV2 -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== CONT  TestAccResourceCluster_basicV2
--- PASS: TestAccResourceCluster_basicV2 (2596.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       2596.879s
```
```
make testacc TEST="./huaweicloud/services/acceptance/dws" TESTARGS="-run TestAccResourceClusterBasicBindingElb"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_V1BindingElb -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_V1BindingElb
=== PAUSE TestAccResourceCluster_V1BindingElb
=== CONT  TestAccResourceCluster_V1BindingElb
--- PASS: TestAccResourceCluster_V1BindingElb(1993.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1993.684s
```
```
make testacc TEST="./huaweicloud/services/acceptance/dws" TESTARGS="-run TestAccResourceCluster_V2BindingElb"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_V2BindingElb -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_V2BindingElb
=== PAUSE TestAccResourceCluster_V2BindingElb
=== CONT  TestAccResourceCluster_V2BindingElb
--- PASS: TestAccResourceCluster_V2BindingElb (1826.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1826.253s
```
