### PR TITLE
chore(nat): private snat rule resource support eps and transit_ip_address attribute

### DIFF
--- a/docs/resources/nat_private_snat_rule.md
+++ b/docs/resources/nat_private_snat_rule.md
@@ -71,6 +71,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - The latest update time of the SNAT rule.
 
+* `transit_ip_address` - The address of the transit IP.
+
+* `enterprise_project_id` - The ID of the enterprise project to which the private SNAT rule belongs.
+
 ## Import
 
 SNAT rules can be imported using their `id`, e.g.

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_snat_rule_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_snat_rule_test.go
@@ -55,6 +55,8 @@ func TestAccPrivateSnatRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
 					resource.TestCheckResourceAttrPair(rName, "subnet_id",
 						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "transit_ip_address"),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
 			},
 			{
@@ -172,6 +174,8 @@ func TestAccPrivateSnatRule_cidr(t *testing.T) {
 						"huaweicloud_nat_private_transit_ip.test", "id"),
 					resource.TestCheckResourceAttrPair(rName, "cidr",
 						"huaweicloud_vpc_subnet.test", "cidr"),
+					resource.TestCheckResourceAttrSet(rName, "transit_ip_address"),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
 			},
 			{

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_snat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_snat_rule.go
@@ -82,6 +82,16 @@ func ResourcePrivateSnatRule() *schema.Resource {
 				Computed:    true,
 				Description: "The latest update time of the SNAT rule.",
 			},
+			"transit_ip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The address of the transit IP",
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the enterprise project to which the private SNAT rule belongs.",
+			},
 		},
 	}
 }
@@ -132,6 +142,8 @@ func resourcePrivateSnatRuleRead(_ context.Context, d *schema.ResourceData, meta
 		d.Set("cidr", resp.Cidr),
 		d.Set("created_at", resp.CreatedAt),
 		d.Set("updated_at", resp.UpdatedAt),
+		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
+		d.Set("transit_ip_address", utils.PathSearch("[0].Address", resp.TransitIpAssociations, nil)),
 	)
 
 	if err = mErr.ErrorOrNil(); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Private snat rule resource support enterprise_project_id and transit_ip_address attribute

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Support enterprise_project_id and transit_ip_address attribute
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_privatesnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateSnatRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateSnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateSnatRule_basic
=== PAUSE TestAccPrivateSnatRule_basic
=== CONT  TestAccPrivateSnatRule_basic
--- PASS: TestAccPrivateSnatRule_basic (140.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       140.796s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_privatesnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateSnatRule_cidr"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateSnatRule_cidr -timeout 360m -parallel 4
=== RUN   TestAccPrivateSnatRule_cidr
=== PAUSE TestAccPrivateSnatRule_cidr
=== CONT  TestAccPrivateSnatRule_cidr
--- PASS: TestAccPrivateSnatRule_cidr (143.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       143.214s
```
