### PR TITLE
chore(nat): private dnat rule resource support enterprise_project_id attribute

### DIFF
--- a/docs/resources/nat_private_dnat_rule.md
+++ b/docs/resources/nat_private_dnat_rule.md
@@ -154,6 +154,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - The latest update time of the DNAT rule.
 
+* `enterprise_project_id` - The ID of the enterprise project to which the private DNAT rule belongs.
+
 ## Import
 
 DNAT rules can be imported using their `id`, e.g.

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_dnat_rule_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_dnat_rule_test.go
@@ -60,6 +60,7 @@ func TestAccPrivateDnatRule_basic(t *testing.T) {
 						"huaweicloud_compute_instance.test", "network.0.port"),
 					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
 					resource.TestCheckResourceAttrSet(rName, "backend_type"),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
 			},
 			{
@@ -237,6 +238,7 @@ func TestAccPrivateDnatRule_elbBackend(t *testing.T) {
 					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
 						"data.huaweicloud_networking_port.test", "id"),
 					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
 			},
 			{
@@ -490,6 +492,7 @@ func TestAccPrivateDnatRule_vipBackend(t *testing.T) {
 					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
 						"huaweicloud_networking_vip.test", "id"),
 					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
 			},
 			{
@@ -624,6 +627,7 @@ func TestAccPrivateDnatRule_customIpAddress(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "protocol", "any"),
 					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
 						"huaweicloud_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
 			},
 			{

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_dnat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_dnat_rule.go
@@ -96,6 +96,11 @@ func ResourcePrivateDnatRule() *schema.Resource {
 				Computed:    true,
 				Description: "The latest update time of the DNAT rule.",
 			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the enterprise project to which the private DNAT rule belongs.",
+			},
 		},
 	}
 }
@@ -151,6 +156,7 @@ func resourcePrivateDnatRuleRead(_ context.Context, d *schema.ResourceData, meta
 		d.Set("backend_type", resp.Type),
 		d.Set("created_at", resp.CreatedAt),
 		d.Set("updated_at", resp.UpdatedAt),
+		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
 	)
 
 	// Parse the internal service port


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Private dnat rule resource support enterprise_project_id attribute

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Support enterprise_project_id attribute
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_privatednat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_basic
=== PAUSE TestAccPrivateDnatRule_basic
=== CONT  TestAccPrivateDnatRule_basic
--- PASS: TestAccPrivateDnatRule_basic (406.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       406.210s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_privatednat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_elbBackend"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_elbBackend -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_elbBackend
=== PAUSE TestAccPrivateDnatRule_elbBackend
=== CONT  TestAccPrivateDnatRule_elbBackend
--- PASS: TestAccPrivateDnatRule_elbBackend (526.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       526.190s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_privatednat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_vipBackend"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_vipBackend -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_vipBackend
=== PAUSE TestAccPrivateDnatRule_vipBackend
=== CONT  TestAccPrivateDnatRule_vipBackend
--- PASS: TestAccPrivateDnatRule_vipBackend (189.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       189.510s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_privatednat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_customIpAddress"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_customIpAddress -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_customIpAddress
=== PAUSE TestAccPrivateDnatRule_customIpAddress
=== CONT  TestAccPrivateDnatRule_customIpAddress
--- PASS: TestAccPrivateDnatRule_customIpAddress (220.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       220.405s
```
