### PR TITLE
feat(dli/datasource): upgrade authentication APIs' version

### DIFF
--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_auth_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_auth_test.go
@@ -19,7 +19,7 @@ func getDatasourceAuthResourceFunc(cfg *config.Config, state *terraform.Resource
 	region := acceptance.HW_REGION_NAME
 	// getDatasourceAuth: Query the DLI datasource authentication.
 	var (
-		getDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos"
+		getDatasourceAuthHttpUrl = "v3/{project_id}/datasource/auth-infos"
 		getDatasourceAuthProduct = "dli"
 	)
 	getDatasourceAuthClient, err := cfg.NewServiceClient(getDatasourceAuthProduct, region)

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
@@ -1,8 +1,3 @@
-// ---------------------------------------------------------------
-// *** AUTO GENERATED CODE ***
-// @Product DLI
-// ---------------------------------------------------------------
-
 package dli
 
 import (
@@ -23,6 +18,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+// @API DLI POST /v3/{project_id}/datasource/auth-infos
+// @API DLI GET /v3/{project_id}/datasource/auth-infos
+// @API DLI PUT /v3/{project_id}/datasource/auth-infos
+// @API DLI DELETE /v3/{project_id}/datasource/auth-infos/{auth_info_name}
 func ResourceDatasourceAuth() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDatasourceAuthCreate,
@@ -152,7 +151,7 @@ func resourceDatasourceAuthCreate(ctx context.Context, d *schema.ResourceData, m
 
 	// createDatasourceAuth: create a DLI datasource authentication.
 	var (
-		createDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos"
+		createDatasourceAuthHttpUrl = "v3/{project_id}/datasource/auth-infos"
 		createDatasourceAuthProduct = "dli"
 	)
 	createDatasourceAuthClient, err := cfg.NewServiceClient(createDatasourceAuthProduct, region)
@@ -206,7 +205,7 @@ func resourceDatasourceAuthRead(_ context.Context, d *schema.ResourceData, meta 
 
 	// getDatasourceAuth: Query the DLI datasource authentication.
 	var (
-		getDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos"
+		getDatasourceAuthHttpUrl = "v3/{project_id}/datasource/auth-infos"
 		getDatasourceAuthProduct = "dli"
 	)
 	getDatasourceAuthClient, err := cfg.NewServiceClient(getDatasourceAuthProduct, region)
@@ -247,7 +246,7 @@ func resourceDatasourceAuthRead(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("region", region),
 		d.Set("name", utils.PathSearch("auth_infos[0].auth_info_name", getDatasourceAuthRespBody, nil)),
 		d.Set("type", utils.PathSearch("auth_infos[0].datasource_type", getDatasourceAuthRespBody, nil)),
-		d.Set("username", utils.PathSearch("auth_infos[0].username", getDatasourceAuthRespBody, nil)),
+		d.Set("username", utils.PathSearch("auth_infos[0].user_name", getDatasourceAuthRespBody, nil)),
 		d.Set("certificate_location", utils.PathSearch("auth_infos[0].certificate_location", getDatasourceAuthRespBody, nil)),
 		d.Set("truststore_location", utils.PathSearch("auth_infos[0].truststore_location", getDatasourceAuthRespBody, nil)),
 		d.Set("keystore_location", utils.PathSearch("auth_infos[0].keystore_location", getDatasourceAuthRespBody, nil)),
@@ -287,7 +286,7 @@ func resourceDatasourceAuthUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	if d.HasChanges(updateDatasourceAuthChanges...) {
 		var (
-			updateDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos"
+			updateDatasourceAuthHttpUrl = "v3/{project_id}/datasource/auth-infos"
 			updateDatasourceAuthProduct = "dli"
 		)
 		updateDatasourceAuthClient, err := cfg.NewServiceClient(updateDatasourceAuthProduct, region)
@@ -334,7 +333,7 @@ func resourceDatasourceAuthDelete(_ context.Context, d *schema.ResourceData, met
 
 	// deleteDatasourceAuth: missing operation notes
 	var (
-		deleteDatasourceAuthHttpUrl = "v2.0/{project_id}/datasource/auth-infos/{id}"
+		deleteDatasourceAuthHttpUrl = "v3/{project_id}/datasource/auth-infos/{id}"
 		deleteDatasourceAuthProduct = "dli"
 	)
 	deleteDatasourceAuthClient, err := cfg.NewServiceClient(deleteDatasourceAuthProduct, region)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Now, the ver.3 APIs are supported, replace all OpenStack APIs (ver.2) and they are not recommend.
During the APIs' upgrade, some attributes are difference as follows:
- The old one, user name is names 'username' in the API response.
- The new one,  user name is names 'user_name' in the API response.

The API publishment status of the two versions is as follows:
| published region | Ver.2 | Ver.3 |
| --- | --- | --- |
| ap-southeast-2 | Y | Y |
| la-south-2 | Y | Y |
| cn-southwest-2 | Y | Y |
| ap-southeast-1 | Y | Y |
| af-south-1 | Y | Y |
| cn-south-1 | Y | Y |
| cn-north-4 | Y | Y |
| cn-east-3 | Y | Y |

The online status of the ver.3 API is now consistent with the live network.

![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/cd1df6e5-03fe-4d80-9943-4e8de5df11f7)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. upgrade all authentication APIs' version.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

Basic
```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDatasourceAuth_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDatasourceAuth_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAuth_basic
=== PAUSE TestAccDatasourceAuth_basic
=== CONT  TestAccDatasourceAuth_basic
--- PASS: TestAccDatasourceAuth_basic (13.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       13.690s
```
CSS certificate
```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDatasourceAuth_css'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDatasourceAuth_css -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAuth_css
=== PAUSE TestAccDatasourceAuth_css
=== CONT  TestAccDatasourceAuth_css
--- PASS: TestAccDatasourceAuth_css (16.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       16.493s
```
Kafka SSL certificate
```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDatasourceAuth_Kafka_SSL'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDatasourceAuth_Kafka_SSL -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAuth_Kafka_SSL
=== PAUSE TestAccDatasourceAuth_Kafka_SSL
=== CONT  TestAccDatasourceAuth_Kafka_SSL
--- PASS: TestAccDatasourceAuth_Kafka_SSL (17.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       17.314s
```
KRB
```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDatasourceAuth_KRB'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDatasourceAuth_KRB -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAuth_KRB
=== PAUSE TestAccDatasourceAuth_KRB
=== CONT  TestAccDatasourceAuth_KRB
--- PASS: TestAccDatasourceAuth_KRB (9.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       9.450s
```
