### PR TITLE
feat(cc): cc_bandwidth_package support update enterprise_project_id

### DIFF
--- a/docs/resources/cc_bandwidth_package.md
+++ b/docs/resources/cc_bandwidth_package.md
@@ -70,11 +70,8 @@ The following arguments are supported:
 * `description` - (Optional, String) The description about the bandwidth package.  
   The description can contain a maximum of 85 characters.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) ID of the enterprise project that the bandwidth package
-  belongs to.
-  Value 0 indicates the default enterprise project.
-
-  Changing this parameter will create a new resource.
+* `enterprise_project_id` - (Optional, String) ID of the enterprise project that the bandwidth package
+  belongs to. Value 0 indicates the default enterprise project.
 
 * `resource_id` - (Optional, String) ID of the resource that the bandwidth package is bound to.  
 

--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_bandwidth_package_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_bandwidth_package_test.go
@@ -173,3 +173,90 @@ resource "huaweicloud_cc_bandwidth_package" "test" {
 }
 `, name)
 }
+
+func TestAccBandwidthPackage_withEpsId(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cc_bandwidth_package.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBandwidthPackageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBandwidthPackage_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "local_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "remote_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
+					resource.TestCheckResourceAttr(rName, "billing_mode", "3"),
+					resource.TestCheckResourceAttr(rName, "bandwidth", "5"),
+					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttr(rName, "description", "This is an accaptance test"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+				),
+			},
+			{
+				Config: testBandwidthPackage_updateWithEpsId(name + "update"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"update"),
+					resource.TestCheckResourceAttr(rName, "local_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "remote_area_id", "Chinese-Mainland"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
+					resource.TestCheckResourceAttr(rName, "billing_mode", "3"),
+					resource.TestCheckResourceAttr(rName, "bandwidth", "6"),
+					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttr(rName, "description", "This is an accaptance test update"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform_test"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test", "id")),
+			},
+		},
+	})
+}
+
+func testBandwidthPackage_updateWithEpsId(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_connection" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_cc_bandwidth_package" "test" {
+  name                  = "%[1]s"
+  local_area_id         = "Chinese-Mainland"
+  remote_area_id        = "Chinese-Mainland"
+  charge_mode           = "bandwidth"
+  billing_mode          = 3
+  bandwidth             = 6
+  description           = "This is an accaptance test update"
+  enterprise_project_id = "%[2]s"
+  resource_id           = huaweicloud_cc_connection.test.id
+  resource_type         = "cloud_connection"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform_test"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: cc_bandwidth_package support update enterprise_project_id 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccBandwidthPackage_withEpsId"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccBandwidthPackage_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccBandwidthPackage_withEpsId
=== PAUSE TestAccBandwidthPackage_withEpsId
=== CONT  TestAccBandwidthPackage_withEpsId
--- PASS: TestAccBandwidthPackage_withEpsId (39.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        39.270s
```
