### PR TITLE
feat(DWS): DWS support a datasource to get logical cluster rings

### DIFF
--- a/docs/data-sources/dws_logical_cluster_rings.md
+++ b/docs/data-sources/dws_logical_cluster_rings.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# huaweicloud_dws_logical_cluster_rings
+
+Use this data source to get the list of DWS logical cluster rings.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_dws_logical_cluster_rings" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the DWS cluster ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `cluster_rings` - Indicates the cluster ring list information.
+  The [cluster_rings](#LogicalClusterRings_ClusterRings) structure is documented below.
+
+<a name="LogicalClusterRings_ClusterRings"></a>
+The `cluster_rings` block supports:
+
+* `is_available` - Indicates whether the cluster host ring is available. Only host rings with this field set to **true**
+  can be used to create logical clusters.
+
+* `ring_hosts` - Indicates the cluster host ring list information.
+  The [ring_hosts](#LogicalClusterRings_ClusterRingsRingHosts) structure is documented below.
+
+<a name="LogicalClusterRings_ClusterRingsRingHosts"></a>
+The `ring_hosts` block supports:
+
+* `host_name` - Indicates the host name.
+
+* `back_ip` - Indicates the backend IP address.
+
+* `cpu_cores` - Indicates the number of CPU cores.
+
+* `memory` - Indicates the host memory.
+
+* `disk_size` - Indicates the host disk size. The unit is GB.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -655,7 +655,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_instance_groups":     waf.DataSourceWafInstanceGroups(),
 			"huaweicloud_waf_dedicated_domains":   waf.DataSourceWafDedicatedDomains(),
 			"huaweicloud_waf_address_groups":      waf.DataSourceWafAddressGroups(),
-			"huaweicloud_dws_flavors":             dws.DataSourceDwsFlavors(),
+
+			"huaweicloud_dws_flavors":               dws.DataSourceDwsFlavors(),
+			"huaweicloud_dws_logical_cluster_rings": dws.DataSourceLogicalClusterRings(),
 
 			"huaweicloud_workspace_flavors": workspace.DataSourceWorkspaceFlavors(),
 

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_logical_cluster_rings_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_logical_cluster_rings_test.go
@@ -1,0 +1,69 @@
+package dws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDatasourceLogicalClusterRings_basic(t *testing.T) {
+	rName := "data.huaweicloud_dws_logical_cluster_rings.test"
+
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceLogicalClusterRings_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_rings.#", "2"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.is_available"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.host_name"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.back_ip"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.cpu_cores"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.memory"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.disk_size"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceLogicalClusterRings_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_dws_cluster" "test" {
+  name              = "%[2]s"
+  node_type         = "dwsk2.xlarge"
+  number_of_node    = 7
+  vpc_id            = huaweicloud_vpc.test.id
+  network_id        = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  user_name         = "test_cluster_admin"
+  user_pwd          = "cluster123@!"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccDatasourceLogicalClusterRings_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_dws_logical_cluster_rings" "test" {
+  cluster_id = huaweicloud_dws_cluster.test.id
+}
+`, testAccDatasourceLogicalClusterRings_base())
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_logical_cluster_rings.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_logical_cluster_rings.go
@@ -1,0 +1,275 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DWS
+// ---------------------------------------------------------------
+
+package dws
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceLogicalClusterRings() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceLogicalClusterRingsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the DWS cluster ID.`,
+			},
+			"cluster_rings": {
+				Type:        schema.TypeList,
+				Elem:        clusterRingsSchema(),
+				Computed:    true,
+				Description: `Indicates the cluster ring list information.`,
+			},
+		},
+	}
+}
+
+func clusterRingsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"is_available": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Indicates whether the cluster host ring is available.`,
+			},
+			"ring_hosts": {
+				Type:        schema.TypeList,
+				Elem:        ringHostsSchema(),
+				Computed:    true,
+				Description: `Indicates the cluster host ring list information.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func ringHostsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"host_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the host name.`,
+			},
+			"back_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the backend IP address.`,
+			},
+			"cpu_cores": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Indicates the number of CPU cores.`,
+			},
+			"memory": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `Indicates the host memory.`,
+			},
+			"disk_size": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `Indicates the host disk size.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func readLogicalClusters(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getPath := client.Endpoint + "v2/{project_id}/clusters/{cluster_id}/logical-clusters"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
+	getResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return nil, err
+	}
+
+	getRespJson, err := json.Marshal(getResp)
+	if err != nil {
+		return nil, err
+	}
+	var getRespBody interface{}
+	err = json.Unmarshal(getRespJson, &getRespBody)
+	if err != nil {
+		return nil, err
+	}
+	return getRespBody, nil
+}
+
+func readLogicalClusterRings(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getPath := client.Endpoint + "v2/{project_id}/clusters/{cluster_id}/logical-clusters/rings"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
+	getResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return nil, err
+	}
+
+	getRespJson, err := json.Marshal(getResp)
+	if err != nil {
+		return nil, err
+	}
+	var getRespBody interface{}
+	err = json.Unmarshal(getRespJson, &getRespBody)
+	if err != nil {
+		return nil, err
+	}
+	return getRespBody, nil
+}
+
+func resourceLogicalClusterRingsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dws"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	clusterRespBody, err := readLogicalClusters(client, d)
+	if err != nil {
+		return diag.Errorf("error retrieving DWS logical clusters: %s", err)
+	}
+	logicalClusterRings := flattenLogicalClusterRings(clusterRespBody)
+	if len(logicalClusterRings) == 0 {
+		// When the logical cluster list API cannot query the data, try to obtain it from logical cluster ring list API.
+		clusterRingRespBody, err := readLogicalClusterRings(client, d)
+		if err != nil {
+			return diag.Errorf("error retrieving DWS logical cluster rings: %s", err)
+		}
+		logicalClusterRings = flattenClusterRings(clusterRingRespBody, true)
+	}
+	sort.Sort(RingsSlice(logicalClusterRings))
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("cluster_rings", logicalClusterRings),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenLogicalClusterRings(resp interface{}) []interface{} {
+	var rst []interface{}
+
+	availableExpression := "logical_clusters[?logical_cluster_name == 'elastic_group']"
+	availableCurJson := utils.PathSearch(availableExpression, resp, make([]interface{}, 0))
+	availableCurArray := availableCurJson.([]interface{})
+	for _, v := range availableCurArray {
+		rst = append(rst, flattenClusterRings(v, true)...)
+	}
+
+	unAvailableExpression := "logical_clusters[?logical_cluster_name != 'elastic_group']"
+	unAvailableCurJson := utils.PathSearch(unAvailableExpression, resp, make([]interface{}, 0))
+	unAvailableCurArray := unAvailableCurJson.([]interface{})
+	for _, v := range unAvailableCurArray {
+		rst = append(rst, flattenClusterRings(v, false)...)
+	}
+	return rst
+}
+
+func flattenClusterRings(resp interface{}, isAvailable bool) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("cluster_rings", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, len(curArray))
+	for i, v := range curArray {
+		rst[i] = map[string]interface{}{
+			"ring_hosts":   flattenRingHosts(v),
+			"is_available": isAvailable,
+		}
+	}
+	return rst
+}
+
+func flattenRingHosts(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("ring_hosts", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, len(curArray))
+	for i, v := range curArray {
+		rst[i] = map[string]interface{}{
+			"host_name": utils.PathSearch("host_name", v, nil),
+			"back_ip":   utils.PathSearch("back_ip", v, nil),
+			"cpu_cores": utils.PathSearch("cpu_cores", v, nil),
+			"memory":    utils.PathSearch("memory", v, nil),
+			"disk_size": utils.PathSearch("disk_size", v, nil),
+		}
+	}
+	return rst
+}
+
+type RingsSlice []interface{}
+
+func (x RingsSlice) Len() int {
+	return len(x)
+}
+
+// Less Sort by comparing the largest IP value in the array
+func (x RingsSlice) Less(i, j int) bool {
+	ringHostsI := utils.PathSearch("ring_hosts", x[i], make([]interface{}, 0)).([]interface{})
+	ringHostsJ := utils.PathSearch("ring_hosts", x[j], make([]interface{}, 0)).([]interface{})
+
+	return searchMaxBackIp(ringHostsI) > searchMaxBackIp(ringHostsJ)
+}
+
+func searchMaxBackIp(ringHosts []interface{}) string {
+	var maxBackIp string
+	for _, v := range ringHosts {
+		backIp := utils.PathSearch("back_ip", v, "").(string)
+		if backIp > maxBackIp {
+			maxBackIp = backIp
+		}
+	}
+	return maxBackIp
+}
+
+func (x RingsSlice) Swap(i, j int) { x[i], x[j] = x[j], x[i] }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

DWS support a datasource to get logical cluster rings

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- This datasource uses two list APIs, mainly based on logical cluster list API.
- The elements of the response body are sorted according to the largest IP value.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dws' TESTARGS='-run TestAccDatasourceLogicalClusterRings_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDatasourceLogicalClusterRings_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceLogicalClusterRings_basic
=== PAUSE TestAccDatasourceLogicalClusterRings_basic
=== CONT  TestAccDatasourceLogicalClusterRings_basic
--- PASS: TestAccDatasourceLogicalClusterRings_basic (1393.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1393.307s
```
