### PR TITLE
feat(fgs): support new dependency version resource

### DIFF
--- a/docs/resources/fgs_dependency.md
+++ b/docs/resources/fgs_dependency.md
@@ -6,6 +6,9 @@ subcategory: "FunctionGraph"
 
 Manages a custom dependency package within HuaweiCloud FunctionGraph.
 
+~> This resource will be deprecated in a future version. Please use `huaweicloud_fgs_dependency_version` resource to
+replace it. For specific usage instructions, please refer to the corresponding document.
+
 ## Example Usage
 
 ### Create a custom dependency package using a OBS bucket path where the zip file is located

--- a/docs/resources/fgs_dependency_version.md
+++ b/docs/resources/fgs_dependency_version.md
@@ -1,0 +1,99 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# huaweicloud_fgs_dependency_version
+
+Manages a custom dependency version within HuaweiCloud.
+
+-> We recommend using this resource to replace the `huaweicloud_fgs_dependency` resource for managing dependency
+packages. You can migrate smoothly because the parameter behavior of the two resources is consistent.
+
+## Example Usage
+
+### Create a custom dependency version using a OBS bucket path where the ZIP file is located
+
+```hcl
+variable "dependency_name"
+variable "custom_dependency_location"
+
+resource "huaweicloud_fgs_dependency_version" "test" {
+  name    = var.dependency_name
+  runtime = "Python3.6"
+  link    = var.custom_dependency_location
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the custom dependency version is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `runtime` - (Required, String, ForceNew) Specifies the runtime of the custom dependency version.
+  The valid values are as follows:
+  + **Java8**
+  + **Java11**
+  + **Node.js6.10**
+  + **Node.js8.10**
+  + **Node.js10.16**
+  + **Node.js12.13**
+  + **Node.js14.18**
+  + **Python2.7**
+  + **Python3.6**
+  + **Python3.9**
+  + **Go1.8**
+  + **Go1.x**
+  + **C#(.NET Core 2.0)**
+  + **C#(.NET Core 2.1)**
+  + **C#(.NET Core 3.1)**
+  + **Custom**
+  + **PHP 7.3**
+  + **http**
+
+  Changing this will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the custom dependency package to which the version belongs.
+  The name can contain a maximum of `96` characters and must start with a letter and end with a letter or digit.
+  Only letters, digits, underscores (_), periods (.), and hyphens (-) are allowed.  
+  Changing this will create a new resource.
+
+* `link` - (Required, String, ForceNew) Specifies the OBS bucket path where the dependency package is located.
+  The OBS object URL must be in ZIP format, such as
+  `https://obs-terraform.obs.cn-north-4.myhuaweicloud.com/huaweicloudsdkcore.zip`.
+  Changing this will create a new resource.
+
+  -> A link can only be used to create at most one dependency package.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of the custom dependency version.
+  The description can contain a maximum of `512` characters.  
+  Changing this will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, consists of dependency ID and version number, separated by a slash.
+
+* `version` - The dependency package version.
+
+* `version_id` - The ID of the dependency package version.
+
+* `owner` - The dependency owner, public indicates a public dependency.
+
+* `etag` - The unique ID of the dependency.
+
+* `size` - The dependency size, in bytes.
+
+## Import
+
+Dependency version can be imported using the resource `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_fgs_dependency_version.test <id>
+```
+
+Or using related dependency package `name` and the `version` number, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_fgs_dependency_version.test <name>/<version>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -982,6 +982,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_fgs_async_invoke_configuration": fgs.ResourceAsyncInvokeConfiguration(),
 			"huaweicloud_fgs_dependency":                 fgs.ResourceFgsDependency(),
+			"huaweicloud_fgs_dependency_version":         fgs.ResourceDependencyVersion(),
 			"huaweicloud_fgs_function":                   fgs.ResourceFgsFunctionV2(),
 			"huaweicloud_fgs_trigger":                    fgs.ResourceFunctionGraphTrigger(),
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
@@ -1,0 +1,128 @@
+package fgs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
+)
+
+func getDependencyVersionFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.FgsV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	dependId, version, err := fgs.ParseDependVersionResourceId(state.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+	return dependencies.GetVersion(client, dependId, version)
+}
+
+func TestAccDependencyVersion_basic(t *testing.T) {
+	var (
+		obj dependencies.Dependency
+
+		rName        = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_fgs_dependency_version.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDependencyVersionFunc)
+
+		pkgLocation = fmt.Sprintf("https://%s.obs.cn-north-4.myhuaweicloud.com/FunctionGraph/dependencies/huaweicloudsdkcore.zip",
+			acceptance.HW_OBS_BUCKET_NAME)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBSBucket(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDependencyVersion_basic(rName, pkgLocation),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "Python2.7"),
+					resource.TestCheckResourceAttr(resourceName, "link", pkgLocation),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Test the ID format: <depend_name>/<version>
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccDependencyVersionImportStateFunc_withDependName(resourceName),
+			},
+			// Test the ID format: <depend_name>/<version_id>
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccDependencyVersionImportStateFunc_withVersionId(resourceName),
+			},
+		},
+	})
+}
+
+func testAccDependencyVersionImportStateFunc_withDependName(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var dependName, version string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		dependName = rs.Primary.Attributes["name"]
+		version = rs.Primary.Attributes["version"]
+		if dependName == "" || version == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<depend_name>/<version>', but got '%s/%s'",
+				dependName, version)
+		}
+		return fmt.Sprintf("%s/%s", dependName, version), nil
+	}
+}
+
+func testAccDependencyVersionImportStateFunc_withVersionId(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var dependName, versionId string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		dependName = rs.Primary.Attributes["name"]
+		versionId = rs.Primary.Attributes["version_id"]
+		if dependName == "" || versionId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<depend_name>/<version_id>', but got '%s/%s'",
+				dependName, versionId)
+		}
+		return fmt.Sprintf("%s/%s", dependName, versionId), nil
+	}
+}
+
+func testAccDependencyVersion_basic(rName, pkgLocation string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_fgs_dependency_version" "test" {
+  name        = "%s"
+  description = "Created by terraform script"
+  runtime     = "Python2.7"
+  link        = "%s"
+}
+`, rName, pkgLocation)
+}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
@@ -1,0 +1,264 @@
+package fgs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: FunctionGraph POST /v2/{project_id}/fgs/dependencies/version
+// API: FunctionGraph GET /v2/{project_id}/fgs/dependencies
+// API: FunctionGraph GET /v2/{project_id}/fgs/dependencies/{depend_id}/version
+// API: FunctionGraph GET /v2/{project_id}/fgs/dependencies/{depend_id}/version/{version}
+// API: FunctionGraph DELETE /v2/{project_id}/fgs/dependencies/{depend_id}/version/{version}
+func ResourceDependencyVersion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDependencyVersionCreate,
+		ReadContext:   resourceDependencyVersionRead,
+		DeleteContext: resourceDependencyVersionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDependencyVersionImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region where the custom dependency version is located.",
+			},
+			"runtime": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The runtime of the custom dependency package version.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the custom dependency package to which the version belongs.",
+			},
+			"link": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The OBS bucket path where the dependency package is located.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The description of the custom dependency version.",
+			},
+			"version": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The dependency package version.",
+			},
+			"version_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the dependency package version.",
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The dependency owner, public indicates a public dependency.",
+			},
+			"etag": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique ID of the dependency.",
+			},
+			"size": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The dependency size, in bytes.",
+			},
+		},
+	}
+}
+
+func buildDependencyVersionOpts(d *schema.ResourceData) dependencies.DependVersionOpts {
+	// Since the ZIP file upload is limited in size and requires encoding, only the OBS type is supported.
+	// The ZIP file uploading can also be achieved by uploading OBS objects and is more secure.
+	return dependencies.DependVersionOpts{
+		Name:        d.Get("name").(string),
+		Runtime:     d.Get("runtime").(string),
+		Description: utils.String(d.Get("description").(string)),
+		Type:        "obs",
+		Link:        d.Get("link").(string),
+	}
+}
+
+func resourceDependencyVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	resp, err := dependencies.CreateVersion(client, buildDependencyVersionOpts(d))
+	if err != nil {
+		return diag.Errorf("error creating custom dependency version: %s", err)
+	}
+	// Using depend ID and version number as the resource ID.
+	d.SetId(fmt.Sprintf("%s/%d", resp.DepId, resp.Version))
+
+	return resourceDependencyVersionRead(ctx, d, meta)
+}
+
+func ParseDependVersionResourceId(resourceId string) (dependId, versionInfo string, err error) {
+	parts := strings.Split(resourceId, "/")
+	if len(parts) < 2 {
+		err = fmt.Errorf("invalid ID format for dependency version resource, it must contain two parts: "+
+			"dependency package information and version information, e.g. '<dependency name>/<version number>'. "+
+			"but the ID that you provided does not meet this requirement '%s'", resourceId)
+		return
+	}
+	dependId = parts[0]
+	versionInfo = parts[1]
+	return
+}
+
+func resourceDependencyVersionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	dependId, version, err := ParseDependVersionResourceId(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	resp, err := dependencies.GetVersion(client, dependId, version)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "FunctionGraph dependency version")
+	}
+
+	mErr := multierror.Append(
+		d.Set("runtime", resp.Runtime),
+		d.Set("name", resp.Name),
+		d.Set("description", resp.Description),
+		d.Set("link", resp.Link),
+		d.Set("etag", resp.Etag),
+		d.Set("size", resp.Size),
+		d.Set("owner", resp.Owner),
+		d.Set("version", resp.Version),
+		d.Set("version_id", resp.ID),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting resource fields of custom dependency version (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceDependencyVersionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	dependId, version, err := ParseDependVersionResourceId(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = dependencies.DeleteVersion(client, dependId, version)
+	if err != nil {
+		return diag.Errorf("error deleting custom dependency version: %s", err)
+	}
+	return nil
+}
+
+// getSpecifiedDependencyVersion is a method that queries the corresponding dependency version based on the entered ID.
+// The entered ID can be in the following formats:
+// + <depend_id>/<version> (Standard resource ID format)
+// + <depend_id>/<version_id>
+// + <depend_name>/<version> (All information that can be found through the console)
+// + <depend_name>/<version_id>
+func getSpecifiedDependencyVersion(client *golangsdk.ServiceClient, resourceId string) (*dependencies.DependencyVersion, error) {
+	dependInfo, versionInfo, err := ParseDependVersionResourceId(resourceId)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the input dependency package information part is not in UUID format, perform a query to obtain the
+	// corresponding ID.
+	if !utils.IsUUID(dependInfo) {
+		opts := dependencies.ListOpts{
+			Name: dependInfo,
+		}
+		allPages, err := dependencies.List(client, opts).AllPages()
+		if err != nil {
+			return nil, err
+		}
+		listResp, _ := dependencies.ExtractDependencies(allPages)
+		if len(listResp.Dependencies) < 1 {
+			return nil, golangsdk.ErrDefault404{
+				ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+					Body: []byte(fmt.Sprintf("unable to find the dependency package using its name: %s", dependInfo)),
+				},
+			}
+		}
+		// Make sure the dependInfo content is the dependency ID.
+		dependInfo = listResp.Dependencies[0].ID
+	}
+
+	// If the input dependency version information part is in UUID format, perform a query to obtain the specified
+	// version using its ID.
+	if utils.IsUUID(versionInfo) {
+		opts := dependencies.ListVersionsOpts{
+			DependId: dependInfo,
+		}
+		listResp, err := dependencies.ListVersions(client, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, dependVersion := range listResp {
+			if dependVersion.ID == versionInfo {
+				return &dependVersion, nil
+			}
+		}
+		return nil, golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("unable to find the dependency package using its ID: %s", versionInfo)),
+			},
+		}
+	}
+	return dependencies.GetVersion(client, dependInfo, versionInfo)
+}
+
+func resourceDependencyVersionImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	cfg := meta.(*config.Config)
+	client, err := cfg.FgsV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	// Query the corresponding dependency version based on the user's import ID.
+	resp, err := getSpecifiedDependencyVersion(client, d.Id())
+	if err != nil {
+		return []*schema.ResourceData{d}, err
+	}
+	d.SetId(fmt.Sprintf("%s/%d", resp.DepId, resp.Version))
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -571,3 +571,11 @@ func ConvertMemoryUnit(memory interface{}, diffLevel int) int {
 	}
 	return memoryInt * Power(1024, -diffLevel)
 }
+
+// IsUUID is a method used to determine whether a string is in UUID format.
+func IsUUID(uuid string) bool {
+	// Using regular expressions to match UUID formats, with or without underscores.
+	pattern := "[0-9a-fA-F]{8}(-?[0-9a-fA-F]{4}){3}-?[0-9a-fA-F]{12}"
+	match, _ := regexp.MatchString(pattern, uuid)
+	return match
+}

--- a/huaweicloud/utils/utils_test.go
+++ b/huaweicloud/utils/utils_test.go
@@ -116,3 +116,18 @@ func TestAccFunction_ConvertMemoryUnit(t *testing.T) {
 		t.Logf("The processing result of ConvertMemoryUnit method meets expectation: %s", green(expected[i]))
 	}
 }
+
+func TestAccFunction_IsUUID(t *testing.T) {
+	var (
+		ids      = []string{"550e8400-e29b-41d4-a716-446655440000", "550e8400e29b41d4a716446655440000", "abc123", ""}
+		expected = []bool{true, true, false, false}
+	)
+
+	for i, idInput := range ids {
+		if isValid := IsUUID(idInput); isValid != expected[i] {
+			t.Fatalf("The processing result of IsUUID method is not as expected, want %s, but %s, the ID is %s",
+				green(expected[i]), yellow(isValid), idInput)
+		}
+		t.Logf("The processing result of IsUUID method meets expectation: %s", green(expected[i]))
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New resource (`huaweicloud_fgs_dependency_version`) is support for FunctionGraph dependency version.
Compared with resource `huaweicloud_fgs_dependency`, this resource will return its version information, and the API used by the two is different. The API of the former has been marked as being deprecated.

NOTE：
1. Resource Logic

Since the console cannot query the ID of the dependent package and its version, the import logic only provides the name and version number through API query.
Four kinds are supported:
+ <depend_id>/<version> (Standard resource ID format)
+ <depend_id>/<version_id>
+ <depend_name>/<version> (All information that can be found through the console)
+ <depend_name>/<version_id>

2. Resource usage

This resource is a replacement for resource `huaweicloud_fgs_dependency`. When the API is offline in the future, the old resource will no longer be available, and subsequent capability improvements will also be carried out on the new resource.
Currently, resource `huaweicloud_fgs_dependency` is pre-deprecated.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Support a public method to check whether string input is UUID format.
2. Support a new resource to manage FunctionGraph dependency version.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccDependencyVersion_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccDependencyVersion_basic -timeout 360m -parallel 4
=== RUN   TestAccDependencyVersion_basic
=== PAUSE TestAccDependencyVersion_basic
=== CONT  TestAccDependencyVersion_basic
--- PASS: TestAccDependencyVersion_basic (8.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       8.787s
```
