### PR TITLE
fix(DWS): fix DWS cluster unit test fail and lint error

### DIFF
--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -84,6 +84,7 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
 
 * `version` - (Required, String, ForceNew) The cluster version.
+  [For details](https://support.huaweicloud.com/intl/en-us/versioning-dws/dws_12_0000.html).
   Changing this parameter will create a new resource.
 
 * `volume` - (Required, List, ForceNew) The information about the volume.

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
@@ -56,7 +56,7 @@ func getClusterResourceFunc(cfg *config.Config, state *terraform.ResourceState) 
 	return getDwsClusterRespBody, nil
 }
 
-func TestAccResourceDWS_basicV1(t *testing.T) {
+func TestAccResourceCluster_basicV1(t *testing.T) {
 	var obj interface{}
 
 	resourceName := "huaweicloud_dws_cluster.test"
@@ -137,7 +137,7 @@ resource "huaweicloud_dws_cluster" "test" {
 `, baseNetwork, rName, numberOfNode, password, publicIpBindType, tag)
 }
 
-func TestAccResourceDWS_basicV2(t *testing.T) {
+func TestAccResourceCluster_basicV2(t *testing.T) {
 	var obj interface{}
 
 	resourceName := "huaweicloud_dws_cluster.test"
@@ -162,8 +162,8 @@ func TestAccResourceDWS_basicV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "number_of_node", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "val"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "version", "8.2.0.103"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.capacity", "100"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
 			},
 			{
@@ -174,8 +174,8 @@ func TestAccResourceDWS_basicV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "number_of_node", "6"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "val"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "cat"),
-					resource.TestCheckResourceAttr(resourceName, "version", "8.2.0.103"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.capacity", "150"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
 				),
 			},
 			{
@@ -196,6 +196,12 @@ func testAccDwsCluster_basicV2(rName string, numberOfNode int, publicIpBindType,
 
 data "huaweicloud_availability_zones" "test" {}
 
+data "huaweicloud_dws_flavors" "test" {
+  vcpus = 4
+  memory = 32
+  datastore_type = "dws"
+}
+
 resource "huaweicloud_dws_cluster" "test" {
   name              = "%s"
   node_type         = "dwsk2.xlarge"
@@ -206,7 +212,7 @@ resource "huaweicloud_dws_cluster" "test" {
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   user_name         = "test_cluster_admin"
   user_pwd          = "%s"
-  version           = "8.2.0.103"
+  version           = data.huaweicloud_dws_flavors.test.flavors[0].datastore_version
   number_of_cn      = 3
 
   public_ip {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
fix DWS cluster v2 basic unit test datastore version parameter illegal error.

**Special notes for your reviewer**:

**Release note**:

```
fix DWS cluster unit test fail and lint error
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dws" TESTARGS="-run TestAccResourceCluster_basicV2"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_basicV2 -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== CONT  TestAccResourceCluster_basicV2
--- PASS: TestAccResourceCluster_basicV2 (2374.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       2374.917s
```
