### PR TITLE
feat(VPC): support VPC network interface parameter allowed_addresses update to nil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240111065248-fc4a6e18256c
+	github.com/chnsz/golangsdk v0.0.0-20240112032133-3e40257d5a71
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240111065248-fc4a6e18256c h1:s0vLD+VUw159mg8HEOn1Fd8IsKEx80vQtzWaj/bXbFc=
-github.com/chnsz/golangsdk v0.0.0-20240111065248-fc4a6e18256c/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240112032133-3e40257d5a71 h1:6t4DZxcSV7NqbsXTc9xcWXaF6xpU0U2l9kVJ+sp+o3I=
+github.com/chnsz/golangsdk v0.0.0-20240112032133-3e40257d5a71/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_network_interface_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_network_interface_test.go
@@ -44,14 +44,15 @@ func TestAccVpcNetworkInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "mac_address"),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_lease_time", "2h"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_addresses.0", "192.168.1.5"),
 				),
 			},
 			{
 				Config: testAccNetworkInterface_update(rName + "-update"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", ""),
-					resource.TestCheckResourceAttr(resourceName, "dhcp_lease_time", "2h"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_addresses.0", "192.168.1.5"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_addresses.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "1"),
 				),
 			},
@@ -86,6 +87,8 @@ func testAccNetworkInterface_basic(rName string) string {
 resource "huaweicloud_vpc_network_interface" "test" {
   name      = "%s"
   subnet_id = huaweicloud_vpc_subnet.test.id
+  allowed_addresses  = ["192.168.1.5"]
+  dhcp_lease_time    = "2h"
 }
 `, testAccNetwork_base(rName), rName)
 }
@@ -99,8 +102,6 @@ func testAccNetworkInterface_update(rName string) string {
 resource "huaweicloud_vpc_network_interface" "test" {
   subnet_id          = huaweicloud_vpc_subnet.test.id
   security_group_ids = [huaweicloud_networking_secgroup.secgroup_1.id]
-  allowed_addresses  = ["192.168.1.5"]
-  dhcp_lease_time    = "2h"
 }
 `, testAccNetwork_base(rName), testAccSecGroup_basic(rName))
 }

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_network_interface.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_network_interface.go
@@ -2,7 +2,6 @@ package vpc
 
 import (
 	"context"
-	"log"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -63,7 +62,6 @@ func ResourceNetworkInterface() *schema.Resource {
 			"allowed_addresses": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"dhcp_lease_time": {
@@ -285,8 +283,9 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 	if d.HasChange("allowed_addresses") {
 		allowedAddrPairs := buildAllowedAddrPairs(d)
-		if allowedAddrPairs != nil {
-			opts.AllowedAddressPairs = allowedAddrPairs
+		opts.AllowedAddressPairs = allowedAddrPairs
+		if allowedAddrPairs == nil {
+			opts.AllowedAddressPairs = make([]ports.AddressPair, 0)
 		}
 	}
 	if d.HasChange("dhcp_lease_time") {
@@ -295,7 +294,7 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 			opts.ExtraDhcpOpts = extraDhcpOpts
 		}
 	}
-	log.Printf("[DEBUG] update VPC network interface options: %#v", opts)
+
 	_, err = ports.Update(client, d.Id(), opts)
 	if err != nil {
 		return diag.Errorf("error updating VPC network interface: %s", err)

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/ports/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/ports/requests.go
@@ -104,11 +104,11 @@ type UpdateOpts struct {
 	// Specifies the name of the port.
 	Name string `json:"name"`
 	// Specifies an array of one or more security group IDs.
-	SecurityGroups []string `json:"security_groups,omitempty"`
+	SecurityGroups []string `json:"security_groups"`
 	// Specifies a set of zero or more allowed address pairs.
-	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
 	// Specifies the extended option (extended attribute) of DHCP.
-	ExtraDhcpOpts []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
+	ExtraDhcpOpts []ExtraDhcpOpt `json:"extra_dhcp_opts"`
 }
 
 // Update is a method to update the existing network port.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240111065248-fc4a6e18256c
+# github.com/chnsz/golangsdk v0.0.0-20240112032133-3e40257d5a71
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
…date

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
1.update VPC network interface allowed addresses set to be nil

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/vpc TESTARGS='-run TestAccVpcNetworkInterface_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcNetworkInterface_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcNetworkInterface_basic
=== PAUSE TestAccVpcNetworkInterface_basic
=== CONT  TestAccVpcNetworkInterface_basic
--- PASS: TestAccVpcNetworkInterface_basic (92.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       92.523s

