### PR TITLE
feat(AOM): add a resource to manage AOM prometheus instance

### DIFF
--- a/docs/resources/aom_prom_instance.md
+++ b/docs/resources/aom_prom_instance.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Application Operations Management (AOM)"
+---
+
+# huaweicloud_aom_prom_instance
+
+Manages an AOM prometheus instance resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+
+resource "huaweicloud_aom_prom_instance" "instance" {
+  prom_name             = "test_demo"
+  prom_type             = "ECS"
+  enterprise_project_id = var.enterprise_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the AOM prometheus instance.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `prom_name` - (Required, String, ForceNew) Specifies the name of the AOM prometheus instance.
+  The value can contain `1` to `100` characters. Only Chinese and English letters, digits, underscores (_)
+  and hyphens (-) are allowed, and it must start with letters, digits or Chinese characters.
+  Changing this parameter will create a new resource.
+
+* `prom_type` - (Required, String, ForceNew) Specifies the type of the AOM prometheus instance.
+  The value can be: **DEFAULT**, **ECS**, **VPC**, **CCE**, **REMOTE_WRITE**, **KUBERNETES**,
+  **CLOUD_SERVICE** or **ACROSS_ACCOUNT**.
+  Changing this parameter will create a new resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of the
+  AOM prometheus instance. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `created_at` - The creation time of AOM prometheus instance.
+
+* `prom_http_api_endpoint` - The url for calling the AOM Prometheus instance.
+
+* `prom_version` - The version of AOM prometheus instance.
+
+* `remote_read_url` - The remote read address of AOM Prometheus instance.
+
+* `remote_write_url` - The remote write address of AOM Prometheus instance.
+
+## Import
+
+The AOM prometheus instance can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_aom_prom_instance.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -739,10 +739,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_aom_service_discovery_rule": aom.ResourceServiceDiscoveryRule(),
 			"huaweicloud_aom_alarm_action_rule":      aom.ResourceAlarmActionRule(),
 			"huaweicloud_aom_alarm_silence_rule":     aom.ResourceAlarmSilenceRule(),
-
-			"huaweicloud_aom_cmdb_application": aom.ResourceCmdbApplication(),
-			"huaweicloud_aom_cmdb_component":   aom.ResourceCmdbComponent(),
-			"huaweicloud_aom_cmdb_environment": aom.ResourceCmdbEnvironment(),
+			"huaweicloud_aom_cmdb_application":       aom.ResourceCmdbApplication(),
+			"huaweicloud_aom_cmdb_component":         aom.ResourceCmdbComponent(),
+			"huaweicloud_aom_cmdb_environment":       aom.ResourceCmdbEnvironment(),
+			"huaweicloud_aom_prom_instance":          aom.ResourcePromInstance(),
 
 			"huaweicloud_rfs_stack": rfs.ResourceStack(),
 

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
@@ -1,0 +1,100 @@
+package aom
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getPromInstanceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("aom", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AOM client: %s", err)
+	}
+
+	getPrometheusInstanceHttpUrl := "v1/{project_id}/aom/prometheus"
+	getPrometheusInstanceHttpUrl = strings.ReplaceAll(getPrometheusInstanceHttpUrl, "{project_id}", client.ProjectID)
+	getPrometheusInstanceHttpUrl += fmt.Sprintf("?prom_id=%s", state.Primary.ID)
+	getPrometheusInstancePath := client.Endpoint + getPrometheusInstanceHttpUrl
+
+	getPrometheusInstanceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	getPrometheusInstanceResp, err := client.Request("GET", getPrometheusInstancePath, &getPrometheusInstanceOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
+	}
+
+	getPrometheusInstanceRespBody, err := utils.FlattenResponse(getPrometheusInstanceResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
+	}
+
+	curJson, err := jmespath.Search("prometheus[0]", getPrometheusInstanceRespBody)
+	if err != nil || curJson == nil {
+		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
+	}
+
+	return curJson, nil
+}
+
+func TestAccPromInstance_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_aom_prom_instance.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getPromInstanceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: tesAOMPromInstance_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "prom_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "prom_type", "DEFAULT"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "remote_write_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "remote_read_url"),
+					resource.TestCheckResourceAttrSet(resourceName, "prom_http_api_endpoint"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func tesAOMPromInstance_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_aom_prom_instance" "test" {
+  prom_name             = "%s"
+  prom_type             = "DEFAULT"
+  enterprise_project_id = "0"
+}
+`, name)
+}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
@@ -1,0 +1,214 @@
+package aom
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: AOM POST /v1/{project_id}/aom/prometheus
+// API: AOM DELETE /v1/{project_id}/aom/prometheus
+// API: AOM GET /v1/{project_id}/aom/prometheus
+
+const (
+	prometheusInstanceNotExistsCode = "AOM.11017014"
+)
+
+func ResourcePromInstance() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePromInstanceCreate,
+		ReadContext:   resourcePromInstanceRead,
+		DeleteContext: resourcePromInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"prom_name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"prom_type": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+
+			// attributes
+			"remote_write_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"remote_read_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"prom_http_api_endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"prom_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePromInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	product := "aom"
+
+	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	createPrometheusInstanceHttpUrl := "v1/{project_id}/aom/prometheus"
+	createPrometheusInstanceHttpUrl = strings.ReplaceAll(createPrometheusInstanceHttpUrl, "{project_id}", client.ProjectID)
+	createPrometheusInstancePath := client.Endpoint + createPrometheusInstanceHttpUrl
+
+	createPrometheusInstanceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	createPrometheusInstanceOpt.JSONBody = utils.RemoveNil(buildCreatePrometheusInstanceBodyParams(d, cfg))
+	createPrometheusInstanceResp, err := client.Request("POST", createPrometheusInstancePath, &createPrometheusInstanceOpt)
+	if err != nil {
+		return diag.Errorf("error creating AOM prometheus instance: %s", err)
+	}
+	createPrometheusInstanceRespBody, err := utils.FlattenResponse(createPrometheusInstanceResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("prometheus[0].prom_id", createPrometheusInstanceRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating AOM prometheus instance: ID is not found in API response")
+	}
+
+	d.SetId(id.(string))
+
+	return resourcePromInstanceRead(ctx, d, meta)
+}
+
+func buildCreatePrometheusInstanceBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"prom_name":             d.Get("prom_name"),
+		"prom_type":             d.Get("prom_type"),
+		"enterprise_project_id": utils.ValueIngoreEmpty(cfg.GetEnterpriseProjectID(d)),
+	}
+	return bodyParams
+}
+
+func resourcePromInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	product := "aom"
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	getPrometheusInstanceHttpUrl := "v1/{project_id}/aom/prometheus"
+	getPrometheusInstanceHttpUrl = strings.ReplaceAll(getPrometheusInstanceHttpUrl, "{project_id}", client.ProjectID)
+	getPrometheusInstanceHttpUrl += fmt.Sprintf("?prom_id=%s", d.Id())
+	getPrometheusInstancePath := client.Endpoint + getPrometheusInstanceHttpUrl
+
+	getPrometheusInstanceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	getPrometheusInstanceResp, err := client.Request("GET", getPrometheusInstancePath, &getPrometheusInstanceOpt)
+	if err != nil {
+		diag.Errorf("error retrieving AOM prometheus instance: %s", err)
+	}
+
+	getPrometheusInstanceRespBody, err := utils.FlattenResponse(getPrometheusInstanceResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	curJson, err := jmespath.Search("prometheus[0]", getPrometheusInstanceRespBody)
+	if err != nil {
+		return diag.Errorf("error parsing AOM prometheus instance: %s", err)
+	}
+
+	if curJson == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving AOM prometheus instance")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("prom_name", utils.PathSearch("prom_name", curJson, nil)),
+		d.Set("prom_type", utils.PathSearch("prom_type", curJson, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", curJson, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("prom_create_timestamp", curJson, float64(0)).(float64))/1000, false)),
+		d.Set("prom_version", utils.PathSearch("prom_version", curJson, nil)),
+		d.Set("remote_write_url", utils.PathSearch("prom_spec_config.remote_write_url", curJson, nil)),
+		d.Set("remote_read_url", utils.PathSearch("prom_spec_config.remote_read_url", curJson, nil)),
+		d.Set("prom_http_api_endpoint", utils.PathSearch("prom_spec_config.prom_http_api_endpoint", curJson, nil)),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting AOM prometheus instance fields: %s", err)
+	}
+
+	return nil
+}
+
+func resourcePromInstanceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	product := "aom"
+
+	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	deletePrometheusInstanceHttpUrl := "v1/{project_id}/aom/prometheus"
+	deletePrometheusInstanceHttpUrl += fmt.Sprintf("?prom_id=%s", d.Id())
+	deletePrometheusInstancePath := client.Endpoint + deletePrometheusInstanceHttpUrl
+	deletePrometheusInstancePath = strings.ReplaceAll(deletePrometheusInstancePath, "{project_id}", client.ProjectID)
+
+	deletePrometheusInstanceOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("DELETE", deletePrometheusInstancePath, &deletePrometheusInstanceOpt)
+	if err != nil && !hasErrorCode(err, prometheusInstanceNotExistsCode) {
+		return diag.Errorf("error deleting AOM prometheus instance: %s", err)
+	}
+
+	return nil
+}

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
@@ -17,14 +17,13 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// API: AOM POST /v1/{project_id}/aom/prometheus
-// API: AOM DELETE /v1/{project_id}/aom/prometheus
-// API: AOM GET /v1/{project_id}/aom/prometheus
-
 const (
 	prometheusInstanceNotExistsCode = "AOM.11017014"
 )
 
+// API: AOM POST /v1/{project_id}/aom/prometheus
+// API: AOM DELETE /v1/{project_id}/aom/prometheus
+// API: AOM GET /v1/{project_id}/aom/prometheus
 func ResourcePromInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourcePromInstanceCreate,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
When the AOM prometheus instance  is not exist, the detail API response body is:  {"error_code": "AOM.11017014","error_msg": "prom instance not found","trace_id": ""}
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/49688229/38f7acf7-1b5d-42d7-b795-56a4d3aefb10)

**Release note**:


```release-note
add a resource to manage AOM prometheus instance
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccPromInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccPromInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccPromInstance_basic
=== PAUSE TestAccPromInstance_basic
=== CONT  TestAccPromInstance_basic
--- PASS: TestAccPromInstance_basic (45.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       45.706s
