### PR TITLE
feat(DWS): DWS datasource flavors support datastore_version attribute

### DIFF
--- a/docs/data-sources/dws_flavors.md
+++ b/docs/data-sources/dws_flavors.md
@@ -56,6 +56,8 @@ The `Flavors` block supports:
        in single-node or cluster mode.
     - **stream**: built-in time series operators; up to 40:1 compression ratio; applicable to IoT services.
 
+* `datastore_version` - The version of datastore.
+
 * `vcpus` - The vcpus of the dws node flavor.
 
 * `memory` - The ram of the dws node flavor in GB.

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_flavors_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_flavors_test.go
@@ -24,6 +24,7 @@ func TestAccDwsFlavorsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.flavor_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.volumetype"),
 					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.size"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.datastore_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.availability_zones.#"),
 					resource.TestCheckResourceAttr(resourceName, "flavors.0.vcpus", "8"),
 				),

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_flavors.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_flavors.go
@@ -25,6 +25,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+// API: DWS GET /v2/{project_id}/node-types
 func DataSourceDwsFlavors() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: resourceDwsFlavorsRead,
@@ -79,6 +80,11 @@ func dwsFlavorsFlavorsSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The type of datastore.`,
+			},
+			"datastore_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The version of datastore.`,
 			},
 			"vcpus": {
 				Type:        schema.TypeInt,
@@ -204,6 +210,7 @@ func flattenListNodeTypesFlavors(resp interface{}) []interface{} {
 		rst = append(rst, map[string]interface{}{
 			"flavor_id":            utils.PathSearch("spec_name", v, nil),
 			"datastore_type":       utils.PathSearch("datastore_type", v, nil),
+			"datastore_version":    flattenFlavorsDatastoreVersion(v),
 			"vcpus":                utils.PathSearch("vcpus", v, nil),
 			"memory":               utils.PathSearch("ram", v, nil),
 			"volumetype":           utils.PathSearch("detail[?type=='LOCAL_DISK' || type=='SSD' ].type|[0]", v, nil),
@@ -213,6 +220,16 @@ func flattenListNodeTypesFlavors(resp interface{}) []interface{} {
 		})
 	}
 	return rst
+}
+
+func flattenFlavorsDatastoreVersion(resp interface{}) string {
+	version, err := jmespath.Search("datastores[0].version", resp)
+	if err != nil {
+		log.Printf("[WARN] error parsing version from response: %s", err)
+		return ""
+	}
+
+	return version.(string)
 }
 
 func flattenFlavorsElasticVolumeSpecs(resp interface{}) []interface{} {


### PR DESCRIPTION
**What this PR does / why we need it**:
DWS datasource flavors support datastore_version attribute
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
DWS datasource flavors support datastore_version attribute
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dws" TESTARGS="-run TestAccDwsFlavorsData
Source_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDwsFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccDwsFlavorsDataSource_basic
=== PAUSE TestAccDwsFlavorsDataSource_basic
=== CONT  TestAccDwsFlavorsDataSource_basic
--- PASS: TestAccDwsFlavorsDataSource_basic (35.99s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       36.042s
```
