### PR TITLE
feat(ECS): ECS compute instance support auto terminate time

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -369,6 +369,15 @@ The following arguments are supported:
 
   -> **NOTE:** The `power_action` is a one-time action.
 
+* `auto_terminate_time` - (Optional, String) Specifies the auto terminate time.
+  The value is in the format of "yyyy-MM-ddTHH:mm:ssZ" in UTC+0 and complies with ISO8601.
+  If the value of second (ss) is not "00", the system automatically sets to the current value of minute (mm).
+  The auto terminate time must be at least half an hour later than the current time.
+  The auto terminate time cannot be three years later than the current time.
+  For example, set the value to "2024-09-25T12:05:00Z".
+
+  -> **NOTE:** The `auto_terminate_time` is only support in **postpaid** charging mode.
+
 The `network` block supports:
 
 * `uuid` - (Required, String, ForceNew) Specifies the network UUID to attach to the instance.

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -50,6 +50,7 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metadata.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "auto_terminate_time", "2025-10-10T11:11:00Z"),
 				),
 			},
 			{
@@ -67,6 +68,7 @@ func TestAccComputeInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
 					resource.TestCheckResourceAttr(resourceName, "network.0.source_dest_check", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_terminate_time", ""),
 				),
 			},
 			{
@@ -416,6 +418,7 @@ resource "huaweicloud_compute_instance" "test" {
   stop_before_destroy = true
   agency_name         = "test111"
   agent_list          = "hss"
+  auto_terminate_time = "2025-10-10T11:11:00Z"
 
   network {
     uuid              = data.huaweicloud_vpc_subnet.test.id
@@ -457,6 +460,7 @@ resource "huaweicloud_compute_instance" "test" {
   stop_before_destroy = true
   agency_name         = "test222"
   agent_list          = "ces"
+  auto_terminate_time = ""
 
   network {
     uuid              = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -458,7 +458,10 @@ func ResourceComputeInstance() *schema.Resource {
 					"ON", "OFF", "REBOOT", "FORCE-OFF", "FORCE-REBOOT",
 				}, false),
 			},
-
+			"auto_terminate_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			// computed attributes
 			"volume_attached": {
 				Type:     schema.TypeList,
@@ -586,19 +589,20 @@ func resourceComputeInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	createOpts := &cloudservers.CreateOpts{
-		Name:             d.Get("name").(string),
-		Description:      d.Get("description").(string),
-		ImageRef:         imageId,
-		FlavorRef:        flavorId,
-		KeyName:          d.Get("key_pair").(string),
-		VpcId:            vpcId,
-		SecurityGroups:   secGroupIDs,
-		AvailabilityZone: d.Get("availability_zone").(string),
-		RootVolume:       buildInstanceRootVolume(d),
-		DataVolumes:      buildInstanceDataVolumes(d),
-		Nics:             buildInstanceNicsRequest(d),
-		PublicIp:         buildInstancePublicIPRequest(d),
-		UserData:         []byte(d.Get("user_data").(string)),
+		Name:              d.Get("name").(string),
+		Description:       d.Get("description").(string),
+		ImageRef:          imageId,
+		FlavorRef:         flavorId,
+		KeyName:           d.Get("key_pair").(string),
+		VpcId:             vpcId,
+		SecurityGroups:    secGroupIDs,
+		AvailabilityZone:  d.Get("availability_zone").(string),
+		RootVolume:        buildInstanceRootVolume(d),
+		DataVolumes:       buildInstanceDataVolumes(d),
+		Nics:              buildInstanceNicsRequest(d),
+		PublicIp:          buildInstancePublicIPRequest(d),
+		UserData:          []byte(d.Get("user_data").(string)),
+		AutoTerminateTime: d.Get("auto_terminate_time").(string),
 	}
 
 	if tags, ok := d.GetOk("tags"); ok {
@@ -811,7 +815,7 @@ func resourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, meta
 	d.Set("charging_mode", normalizeChargingMode(server.Metadata.ChargingMode))
 	d.Set("created_at", server.Created.Format(time.RFC3339))
 	d.Set("updated_at", server.Updated.Format(time.RFC3339))
-
+	d.Set("auto_terminate_time", server.AutoTerminateTime)
 	flavorInfo := server.Flavor
 	d.Set("flavor_id", flavorInfo.ID)
 	d.Set("flavor_name", flavorInfo.Name)
@@ -1194,6 +1198,13 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
+	if d.HasChange("auto_terminate_time") {
+		terminateTime := d.Get("auto_terminate_time").(string)
+		err := cloudservers.UpdateAutoTerminateTime(ecsClient, serverID, terminateTime).ExtractErr()
+		if err != nil {
+			return diag.Errorf("error updating auto-terminate-time of server (%s): %s", serverID, err)
+		}
+	}
 	var diags diag.Diagnostics
 	if d.HasChanges("hostname") {
 		hostname := d.Get("hostname").(string)

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -816,6 +816,7 @@ func resourceComputeInstanceRead(_ context.Context, d *schema.ResourceData, meta
 	d.Set("created_at", server.Created.Format(time.RFC3339))
 	d.Set("updated_at", server.Updated.Format(time.RFC3339))
 	d.Set("auto_terminate_time", server.AutoTerminateTime)
+
 	flavorInfo := server.Flavor
 	d.Set("flavor_id", flavorInfo.ID)
 	d.Set("flavor_name", flavorInfo.Name)

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
@@ -52,6 +52,8 @@ type CreateOpts struct {
 	ServerTags []tags.ResourceTag `json:"server_tags,omitempty"`
 
 	Description string `json:"description,omitempty"`
+
+	AutoTerminateTime string `json:"auto_terminate_time,omitempty"`
 }
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
@@ -454,5 +456,14 @@ func UpdateMetadata(client *golangsdk.ServiceClient, id string, opts map[string]
 // DeleteMetadatItem will delete the key-value pair with the given key for the given server ID.
 func DeleteMetadatItem(client *golangsdk.ServiceClient, id, key string) (r DeleteMetadatItemResult) {
 	_, r.Err = client.Delete(metadatItemURL(client, id, key), nil)
+	return
+}
+
+// update auto terminate time for the given server ID.
+func UpdateAutoTerminateTime(client *golangsdk.ServiceClient, id, terminateTime string) (r UpdateResult) {
+	body := map[string]interface{}{
+		"auto_terminate_time": terminateTime,
+	}
+	_, r.Err = client.Post(updateAutoTerminateTimeURL(client, id), body, nil, &golangsdk.RequestOpts{OkCodes: []int{204}})
 	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/results.go
@@ -133,6 +133,7 @@ type CloudServer struct {
 	VolumeAttached      []VolumeAttached     `json:"os-extended-volumes:volumes_attached"`
 	OsSchedulerHints    OsSchedulerHints     `json:"os:scheduler_hints"`
 	Fault               Fault                `json:"fault"`
+	AutoTerminateTime   string               `json:"auto_terminate_time"`
 }
 
 // ECS fault causes

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/urls.go
@@ -49,3 +49,7 @@ func metadataURL(client *golangsdk.ServiceClient, serverID string) string {
 func metadatItemURL(client *golangsdk.ServiceClient, serverID, key string) string {
 	return client.ServiceURL("cloudservers", serverID, "metadata", key)
 }
+
+func updateAutoTerminateTimeURL(client *golangsdk.ServiceClient, serverID string) string {
+	return client.ServiceURL("cloudservers", serverID, "actions/update-auto-terminate-time")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
1.ECS compute instance support auto terminate time



## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/ecs TESTARGS='-run TestAccComputeInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (345.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       345.457s

