### PR TITLE
add datasource cts key event notifications

### DIFF
--- a/docs/data-sources/cts_notifications.md
+++ b/docs/data-sources/cts_notifications.md
@@ -1,0 +1,92 @@
+---
+subcategory: "Cloud Trace Service (CTS)"
+---
+
+# huaweicloud_cts_notifications
+
+Use this data source to get the list of CTS key event notifications.
+
+## Example Usage
+
+```hcl
+variable "notification_type" {}
+
+data "huaweicloud_cts_notifications" "test" {
+  type = var.notification_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the CTS key event notifications.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Required, String) Specifies the type of CTS key event notifications to query. The value can be **smn** or **fun**.
+
+* `name` - (Optional, String) Specifies the name of CTS key event notification to query.
+
+* `status` - (Optional, String) Specifies the status of CTS key event notifications to query.
+  The value can be **enabled** or **disabled**.
+
+* `operation_type` - (Optional, String) Specifies the type of operation that will send notifications.
+  The value cand be **customized** or **complete**.
+
+* `topic_id` - (Optional, String) Specifies the URN of the topic which CTS key event notification uses.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `notifications` - All CTS key event notifications that match the filter parameters.
+  The [notifications](#Notifications) structure is documented below.
+
+<a name="Notifications"></a>
+The `notifications` block supports:
+
+* `id` - The ID of the CTS key event notification.
+
+* `name` - The CTS key event notification name.
+
+* `operation_type` - The type of operation.
+
+* `operations` - An array of operations that will trigger notifications.
+  The [operations](#Notifications_Operations) structure is documented below.
+
+* `operation_users` - The list of users.
+  The [operation_users](#Notifications_OperationUsers) structure is documented below.
+
+* `status` - The status of CTS key event notification.
+
+* `topic_id` - The URN of the topic which CTS key event notification uses.
+
+* `filter` - Advanced filtering conditions for the CTS key event notification.
+  The [filter](#Notifications_Filter) structure is documented below.
+
+* `created_at` - The creation time of the CTS key event notification.
+
+<a name="Notifications_Operations"></a>
+The `operations` block supports:
+
+* `service` - The type of cloud serive.
+
+* `resource` - The type of resource.
+
+* `trace_names` - An array of trace names.
+
+<a name="Notifications_OperationUsers"></a>
+The `operation_users` block supports:
+
+* `group` - The IAM user group.
+
+* `users` - The list of IAM users.
+
+<a name="Notifications_Filter"></a>
+The `filter` block supports:
+
+* `condition` - The relation between the rules.
+
+* `rule` - The list of filter rules.

--- a/docs/resources/dataarts_architecture_code_table_values.md
+++ b/docs/resources/dataarts_architecture_code_table_values.md
@@ -1,0 +1,85 @@
+---
+subcategory: "DataArts Studio"
+---
+
+# huaweicloud_dataarts_architecture_code_table_values
+
+Manages a DataArts Architecture code table values resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "table_id" {}
+variable "field_id" {}
+variable "field_ordinal" {}
+variable "field_name" {}
+variable "field_code" {}
+variable "field_type" {}
+
+resource "huaweicloud_dataarts_architecture_code_table_values" "test" {
+  workspace_id  = var.workspace_id
+  table_id      = var.table_id
+  field_id      = var.field_id
+  field_ordinal = var.field_ordinal
+  field_name    = var.field_name
+  field_code    = var.field_code
+  field_type    = var.field_type
+
+  values {
+    value = "1"  
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the ID of DataArts Studio workspace.
+  Changing this parameter will create a new resource.
+
+* `table_id` - (Required, String, ForceNew) Specifies the ID of the code table.
+  Changing this parameter will create a new resource.
+
+* `field_id` - (Required, String, ForceNew) Specifies the ID of the code table field.
+  Changing this parameter will create a new resource.
+
+* `field_ordinal` - (Required, Int, ForceNew) Specifies the ordinal of the code table field.
+  Changing this parameter will create a new resource.
+
+* `field_name` - (Required, String, ForceNew) Specifies the name of the code table field.
+  Changing this parameter will create a new resource.
+
+* `field_code` - (Required, String, ForceNew) Specifies the code of the code table field.
+  Changing this parameter will create a new resource.
+
+* `field_type` - (Required, String, ForceNew) Specifies the type of the code table field.
+  Changing this parameter will create a new resource.
+
+* `values` - (Required, List) Specifies the values list of the code table field.
+  The [values](#Values) structure is documented below.
+
+<a name="Values"></a>
+The `values` block supports:
+
+* `value` - (Required, String) Specifies the value of a field.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `values` - The values list of the code table field.
+  The [values](#Values_Attr) structure is documented below.
+
+<a name="Values_Attr"></a>
+The `values` block supports:
+
+* `id` - The ID of a value.
+
+* `ordinal` - The ordinal of a value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1124,6 +1124,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_business_metric":        dataarts.ResourceBusinessMetric(),
 			"huaweicloud_dataarts_architecture_process":                dataarts.ResourceArchitectureProcess(),
 			"huaweicloud_dataarts_architecture_code_table":             dataarts.ResourceArchitectureCodeTable(),
+			"huaweicloud_dataarts_architecture_code_table_values":      dataarts.ResourceArchitectureCodeTableValues(),
 			"huaweicloud_dataarts_architecture_data_standard":          dataarts.ResourceDataStandard(),
 			"huaweicloud_dataarts_architecture_data_standard_template": dataarts.ResourceDataStandardTemplate(),
 			"huaweicloud_dataarts_architecture_reviewer":               dataarts.ResourceDataArtsArchitectureReviewer(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -436,6 +436,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_compute_instances":    ecs.DataSourceComputeInstances(),
 			"huaweicloud_compute_servergroups": ecs.DataSourceComputeServerGroups(),
 
+			"huaweicloud_cts_notifications": cts.DataSourceNotifications(),
+
 			"huaweicloud_cdm_clusters": cdm.DataSourceCdmClusters(),
 
 			"huaweicloud_cph_server_flavors": cph.DataSourceServerFlavors(),

--- a/huaweicloud/services/acceptance/cts/data_source_huaweicloud_cts_notifications_test.go
+++ b/huaweicloud/services/acceptance/cts/data_source_huaweicloud_cts_notifications_test.go
@@ -1,0 +1,240 @@
+package cts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCTSNotifications_basic(t *testing.T) {
+
+	defaultDataSourceName := "data.huaweicloud_cts_notifications.test"
+	nameFilterDataSourceName := "data.huaweicloud_cts_notifications.name_filter"
+	operationTypeFilterDataSourceName := "data.huaweicloud_cts_notifications.operation_type_filter"
+	statusFilterDataSourceName := "data.huaweicloud_cts_notifications.status_filter"
+	topicIDFilterDataSourceName := "data.huaweicloud_cts_notifications.topic_id_filter"
+
+	dc := acceptance.InitDataSourceCheck(defaultDataSourceName)
+	dcNameFilter := acceptance.InitDataSourceCheck(nameFilterDataSourceName)
+	dcOperationTypeFilter := acceptance.InitDataSourceCheck(operationTypeFilterDataSourceName)
+	dcStatusFilter := acceptance.InitDataSourceCheck(statusFilterDataSourceName)
+	dcTopicIDFilter := acceptance.InitDataSourceCheck(topicIDFilterDataSourceName)
+
+	name := acceptance.RandomAccResourceName()
+	name2 := acceptance.RandomAccResourceName()
+	ctsNotificationBaseConfig := testAccCTSNotification_basic(name)
+	baseConfig := testAccDatasourceCTSNotifications_base(ctsNotificationBaseConfig, name2)
+	disabledConfig := testAccDatasourceCTSNotifications_disabled_base(ctsNotificationBaseConfig, name2)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCTSNotifications_basic(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(defaultDataSourceName, "notifications.0.name"),
+					resource.TestCheckResourceAttrSet(defaultDataSourceName, "notifications.0.operation_type"),
+					resource.TestCheckResourceAttrSet(defaultDataSourceName, "notifications.0.status"),
+					resource.TestCheckResourceAttrSet(defaultDataSourceName, "notifications.0.id"),
+					resource.TestCheckResourceAttrSet(defaultDataSourceName, "notifications.0.topic_id"),
+					resource.TestCheckOutput("default_is_useful", "true"),
+				),
+			},
+			{
+				Config: testAccDatasourceCTSNotifications_nameFilter(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dcNameFilter.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(nameFilterDataSourceName, "notifications.0.id"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+				),
+			},
+			{
+				Config: testAccDatasourceCTSNotifications_operationTypeFilter(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dcOperationTypeFilter.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(operationTypeFilterDataSourceName, "notifications.0.id"),
+					resource.TestCheckOutput("operation_type_filter_is_useful", "true"),
+				),
+			},
+			{
+				Config: testAccDatasourceCTSNotifications_statusFilter(disabledConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dcStatusFilter.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(statusFilterDataSourceName, "notifications.0.id"),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+				),
+			},
+			{
+				Config: testAccDatasourceCTSNotifications_topicIDFilter(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dcTopicIDFilter.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(topicIDFilterDataSourceName, "notifications.0.id"),
+					resource.TestCheckOutput("topic_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCTSNotifications_base(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_smn_topic" "topic_2" {
+  name  = "%[2]s"
+}
+  
+resource "huaweicloud_cts_notification" "test" {
+  name           = "%[2]s"
+  operation_type = "customized"
+  smn_topic      = huaweicloud_smn_topic.topic_2.id
+  
+  filter {
+    condition = "OR"
+    rule      = ["code = 400","resource_name = name","api_version = 1.0"]
+  }
+
+  operations {
+    service     = "ECS"
+    resource    = "ecs"
+    trace_names = ["createServer", "deleteServer"]
+  }
+}
+`, baseConfig, name)
+}
+
+func testAccDatasourceCTSNotifications_disabled_base(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_smn_topic" "topic_2" {
+  name  = "%[2]s"
+}
+  
+resource "huaweicloud_cts_notification" "test" {
+  name           = "%[2]s"
+  operation_type = "customized"
+  smn_topic      = huaweicloud_smn_topic.topic_2.id
+  enabled        = false
+  
+  filter {
+    condition = "OR"
+    rule      = ["code = 400","resource_name = name","api_version = 1.0"]
+ }
+
+  operations {
+    service     = "ECS"
+    resource    = "ecs"
+    trace_names = ["createServer", "deleteServer"]
+  }
+}
+`, baseConfig, name)
+}
+
+func testAccDatasourceCTSNotifications_basic(config string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_cts_notifications" "test" {
+  type = "smn"
+  
+  depends_on = [
+    huaweicloud_cts_notification.test,
+    huaweicloud_cts_notification.notify
+  ]
+}
+
+output "default_is_useful" {
+  value = length(data.huaweicloud_cts_notifications.test.notifications) >= 2
+}
+`, config)
+}
+
+func testAccDatasourceCTSNotifications_nameFilter(config string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  name = huaweicloud_cts_notification.test.name
+}
+
+data "huaweicloud_cts_notifications" "name_filter" {
+  type = "smn"
+  name = local.name
+}
+  
+output "name_filter_is_useful" {
+  value = length(
+    data.huaweicloud_cts_notifications.name_filter.notifications
+  ) == 1 && data.huaweicloud_cts_notifications.name_filter.notifications[0].name == local.name
+}
+`, config)
+}
+
+func testAccDatasourceCTSNotifications_operationTypeFilter(config string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  operation_type = huaweicloud_cts_notification.notify.operation_type
+}
+
+data "huaweicloud_cts_notifications" "operation_type_filter" {
+  type = "smn"
+  operation_type = local.operation_type
+}
+  
+output "operation_type_filter_is_useful" {
+  value = length(data.huaweicloud_cts_notifications.operation_type_filter.notifications) > 0 && alltrue(
+    [for v in data.huaweicloud_cts_notifications.operation_type_filter.notifications[*].operation_type : v == local.operation_type]
+  )  
+}
+`, config)
+}
+
+func testAccDatasourceCTSNotifications_statusFilter(config string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  status = huaweicloud_cts_notification.test.status
+}
+
+data "huaweicloud_cts_notifications" "status_filter" {
+  type = "smn"
+  status = local.status
+}
+  
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_cts_notifications.status_filter.notifications) > 0 && alltrue(
+    [for v in data.huaweicloud_cts_notifications.status_filter.notifications[*].status : v == local.status]
+  )  
+}
+`, config)
+}
+
+func testAccDatasourceCTSNotifications_topicIDFilter(config string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  topic_id = huaweicloud_cts_notification.notify.smn_topic
+}
+
+data "huaweicloud_cts_notifications" "topic_id_filter" {
+  type = "smn"
+  topic_id = local.topic_id
+}
+  
+output "topic_id_filter_is_useful" {
+  value = length(data.huaweicloud_cts_notifications.topic_id_filter.notifications) > 0 && alltrue(
+	[for v in data.huaweicloud_cts_notifications.topic_id_filter.notifications[*].topic_id : v == local.topic_id]
+  )
+}
+`, config)
+}

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_code_table_values_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_architecture_code_table_values_test.go
@@ -1,0 +1,188 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getArchitectureCodeTableValuesFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/design/code-tables/{id}/values"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", state.Primary.Attributes["table_id"])
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": state.Primary.Attributes["workspace_id"]},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving DataArts Architecture code table values: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, err
+	}
+
+	fieldName := state.Primary.Attributes["field_name"]
+	findFieldValuesExpr := fmt.Sprintf("data.value.records[?name_ch=='%s'] | [0].code_table_field_values", fieldName)
+	curJson := utils.PathSearch(findFieldValuesExpr, getRespBody, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+
+	// After the test case is executed, the values of the all fields are cleared.
+	// There is no need to check if id of the value is nil.
+	if len(curArray) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return getRespBody, nil
+}
+
+func TestAccArchitectureCodeTableValues_basic(t *testing.T) {
+	var obj interface{}
+
+	baseConfig := testArchitectureCodeTableValuesConfig_base()
+	rName := "huaweicloud_dataarts_architecture_code_table_values.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getArchitectureCodeTableValuesFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testArchitectureCodeTableValues_basic(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "values.0.value", "1"),
+					resource.TestCheckResourceAttrSet(rName, "table_id"),
+					resource.TestCheckResourceAttrSet(rName, "field_id"),
+					resource.TestCheckResourceAttrSet(rName, "field_ordinal"),
+					resource.TestCheckResourceAttrSet(rName, "field_name"),
+					resource.TestCheckResourceAttrSet(rName, "field_code"),
+					resource.TestCheckResourceAttrSet(rName, "field_type"),
+				),
+			},
+			{
+				Config: testArchitectureCodeTableValues_basic_update(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "values.0.value", "one"),
+					resource.TestCheckResourceAttr(rName, "values.1.value", "two"),
+					resource.TestCheckResourceAttrSet(rName, "table_id"),
+					resource.TestCheckResourceAttrSet(rName, "field_id"),
+					resource.TestCheckResourceAttrSet(rName, "field_ordinal"),
+					resource.TestCheckResourceAttrSet(rName, "field_name"),
+					resource.TestCheckResourceAttrSet(rName, "field_code"),
+					resource.TestCheckResourceAttrSet(rName, "field_type"),
+				),
+			},
+		},
+	})
+}
+
+func testArchitectureCodeTableValuesConfig_base() string {
+	name := acceptance.RandomAccResourceName()
+	dirName := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_architecture_directory" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  type         = "CODE"
+}
+
+resource "huaweicloud_dataarts_architecture_code_table" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[3]s"
+  code         = "%[3]s_code"
+  directory_id = huaweicloud_dataarts_architecture_directory.test.id
+  description  = "test description"
+  
+  fields {
+    name        = "field"
+    code        = "field_code"
+    type        = "BIGINT"
+    description = "test field description"
+  }
+  
+  fields {
+    name        = "field1"
+    code        = "field_code1"
+    type        = "STRING"
+    description = "test field1 description"
+  }
+  
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, dirName, name)
+}
+
+func testArchitectureCodeTableValues_basic(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "huaweicloud_dataarts_architecture_code_table_values" "test" {
+  workspace_id  = "%[2]s"
+  table_id      = huaweicloud_dataarts_architecture_code_table.test.id
+  field_id      = huaweicloud_dataarts_architecture_code_table.test.fields[1].id
+  field_ordinal = huaweicloud_dataarts_architecture_code_table.test.fields[1].ordinal
+  field_name    = huaweicloud_dataarts_architecture_code_table.test.fields[1].name
+  field_code    = huaweicloud_dataarts_architecture_code_table.test.fields[1].code
+  field_type    = huaweicloud_dataarts_architecture_code_table.test.fields[1].type
+  
+  values {
+    value = "1"
+  }
+}
+`, baseConfig, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testArchitectureCodeTableValues_basic_update(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+resource "huaweicloud_dataarts_architecture_code_table_values" "test" {
+  workspace_id  = "%[2]s"
+  table_id      = huaweicloud_dataarts_architecture_code_table.test.id
+  field_id      = huaweicloud_dataarts_architecture_code_table.test.fields[1].id
+  field_ordinal = huaweicloud_dataarts_architecture_code_table.test.fields[1].ordinal
+  field_name    = huaweicloud_dataarts_architecture_code_table.test.fields[1].name
+  field_code    = huaweicloud_dataarts_architecture_code_table.test.fields[1].code
+  field_type    = huaweicloud_dataarts_architecture_code_table.test.fields[1].type
+  
+  values {
+    value = "one"
+  }
+  values {
+    value = "two"
+  }
+}
+`, baseConfig, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/cts/data_source_huaweicloud_cts_notifications.go
+++ b/huaweicloud/services/cts/data_source_huaweicloud_cts_notifications.go
@@ -1,0 +1,284 @@
+package cts
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: CTS GET /v3/{project_id}/notifications/{notification_type}
+func DataSourceNotifications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNotificationsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The region in which to query the CTS key event notification.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The type of CTS key event notification to query.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of CTS key event notification to query.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The status of CTS key event notifications to query.",
+			},
+			"operation_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type of operation that will send notifications.",
+			},
+			"topic_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The URN of the topic which CTS key event notification uses.",
+			},
+			"notifications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the CTS key event notification.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The CTS key event notification name.",
+						},
+						"operation_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of operation.",
+						},
+						"operations": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"service": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The type of cloud serive.",
+									},
+									"resource": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The type of resource.",
+									},
+									"trace_names": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Description: "An array of trace names.",
+									},
+								},
+							},
+							Description: "An array of operations that will trigger notifications.",
+						},
+						"operation_users": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"group": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The IAM user group.",
+									},
+									"users": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+										Description: "The list of IAM users.",
+									},
+								},
+							},
+							Description: "The list of users.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status of CTS key event notification.",
+						},
+						"topic_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URN of the topic which CTS key event notification uses.",
+						},
+						"filter": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"condition": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The relation between the rules.",
+									},
+									"rule": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+										Description: "The list of filter rules.",
+									},
+								},
+							},
+							Description: "Advanced filtering conditions for the CTS key event notification.",
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the CTS key event notification.",
+						},
+					},
+				},
+				Description: "All CTS key event notifications that match the filter parameters.",
+			},
+		},
+	}
+}
+
+func dataSourceNotificationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	ctsClient, err := cfg.HcCtsV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CTS client: %s", err)
+	}
+
+	var notificationType cts.ListNotificationsRequestNotificationType
+	if d.Get("type").(string) == "smn" {
+		notificationType = cts.GetListNotificationsRequestNotificationTypeEnum().SMN
+	}
+	if d.Get("type").(string) == "fun" {
+		notificationType = cts.GetListNotificationsRequestNotificationTypeEnum().FUN
+	}
+
+	listOpts := &cts.ListNotificationsRequest{
+		NotificationType: notificationType,
+	}
+	if rawName, nameExist := d.GetOk("name"); nameExist {
+		listOpts.NotificationName = utils.String(rawName.(string))
+	}
+
+	response, err := ctsClient.ListNotifications(listOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CTS key event notification")
+	}
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	result := flattenAllNotifications(d, response)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("notifications", result),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving CTS key event notification data source fields: %s", mErr)
+	}
+
+	return nil
+
+}
+
+func flattenAllNotifications(d *schema.ResourceData, response *cts.ListNotificationsResponse) []map[string]interface{} {
+	if response.Notifications == nil || len(*response.Notifications) == 0 {
+		return nil
+	}
+
+	allNotifications := *response.Notifications
+
+	var status cts.NotificationsResponseBodyStatus
+	rawStatus, statusExist := d.GetOk("status")
+	if statusExist {
+		v := rawStatus.(string)
+		if v == "enabled" {
+			status = cts.GetNotificationsResponseBodyStatusEnum().ENABLED
+		} else {
+			status = cts.GetNotificationsResponseBodyStatusEnum().DISABLED
+		}
+	}
+
+	var operationType cts.NotificationsResponseBodyOperationType
+	rawOperationType, operationTypeExist := d.GetOk("operation_type")
+	if operationTypeExist {
+		v := rawOperationType.(string)
+		if v == "complete" {
+			operationType = cts.GetNotificationsResponseBodyOperationTypeEnum().COMPLETE
+		} else {
+			operationType = cts.GetNotificationsResponseBodyOperationTypeEnum().CUSTOMIZED
+		}
+	}
+
+	rawTopicID, topicIDExist := d.GetOk("topic_id")
+
+	result := make([]map[string]interface{}, 0)
+	for _, notification := range allNotifications {
+		if statusExist && status != *notification.Status {
+			continue
+		}
+		if operationTypeExist && operationType != *notification.OperationType {
+			continue
+		}
+		if topicIDExist && rawTopicID.(string) != *notification.TopicId {
+			continue
+		}
+
+		notificationMap := map[string]interface{}{
+			"id":         notification.NotificationId,
+			"name":       notification.NotificationName,
+			"topic_id":   notification.TopicId,
+			"filter":     flattenNotificationFilter(notification.Filter),
+			"created_at": utils.FormatTimeStampRFC3339(*notification.CreateTime/1000, false),
+		}
+
+		if notification.Operations != nil {
+			notificationMap["operations"] = flattenNotificationOperations(*notification.Operations)
+		}
+
+		if notification.NotifyUserList != nil {
+			notificationMap["operation_users"] = flattenNotificationUsers(*notification.NotifyUserList)
+		}
+
+		if notification.OperationType != nil {
+			notificationMap["operation_type"] = formatValue(notification.OperationType)
+		}
+
+		if notification.Status != nil {
+			notificationMap["status"] = formatValue(notification.Status)
+		}
+
+		result = append(result, notificationMap)
+	}
+
+	return result
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_code_table_values.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_code_table_values.go
@@ -1,0 +1,360 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: DataArtsStudio PUT /v2/{project_id}/design/code-tables/{id}/values
+// API: DataArtsStudio GET /v2/{project_id}/design/code-tables/{id}/values
+func ResourceArchitectureCodeTableValues() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceArchitectureCodeTableValuesCreate,
+		ReadContext:   resourceArchitectureCodeTableValuesRead,
+		UpdateContext: resourceArchitectureCodeTableValuesUpdate,
+		DeleteContext: resourceArchitectureCodeTableValuesDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The region in which to create the resource.",
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of DataArts Studio workspace.",
+			},
+			"table_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the code table.",
+			},
+			"field_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ID of the code table field.",
+			},
+			"field_ordinal": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The ordinal of the code table field.",
+			},
+			"field_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the code table field.",
+			},
+			"field_code": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The code of the code table field.",
+			},
+			"field_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The type of the code table field.",
+			},
+			"values": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The value of a field.",
+						},
+						"ordinal": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The ordinal of a value.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of a value.",
+						},
+					},
+				},
+				Description: "The values list of the code table field.",
+			},
+		},
+	}
+}
+
+func resourceArchitectureCodeTableValuesCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	product := "dataarts"
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	createPath, createOpt := buildCodeTableValuesPathAndOpt(client, d)
+	createOpt.JSONBody = utils.RemoveNil(buildCreateCodeTableValuesParams(d))
+	createResp, err := client.Request("PUT", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Architecture code table values: %s", err)
+	}
+
+	_, err = utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("field_name").(string))
+
+	return resourceArchitectureCodeTableValuesRead(ctx, d, meta)
+}
+
+func buildCreateCodeTableValuesParams(d *schema.ResourceData) map[string]interface{} {
+	params := make([]map[string]interface{}, 1)
+	params[0] = map[string]interface{}{
+		"id":                      d.Get("field_id"),
+		"ordinal":                 d.Get("field_ordinal"),
+		"name_ch":                 d.Get("field_name"),
+		"name_en":                 d.Get("field_code"),
+		"data_type":               d.Get("field_type"),
+		"code_table_field_values": buildCreateCodeTableFieldValuesParams(d),
+	}
+	return map[string]interface{}{
+		"to_add": params,
+	}
+}
+
+func buildCreateCodeTableFieldValuesParams(d *schema.ResourceData) []map[string]interface{} {
+	rawValues := d.Get("values").([]interface{})
+	values := make([]map[string]interface{}, len(rawValues))
+	fieldID := d.Get("field_id").(string)
+	for i, rawValue := range rawValues {
+		valueMap := rawValue.(map[string]interface{})
+		value := map[string]interface{}{
+			"fd_id":    fieldID,
+			"fd_value": valueMap["value"].(string),
+			"ordinal":  i + 1,
+		}
+		values[i] = value
+	}
+	return values
+}
+
+func resourceArchitectureCodeTableValuesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	workspaceID := d.Get("workspace_id").(string)
+
+	var mErr *multierror.Error
+	product := "dataarts"
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath, getOpt := buildCodeTableValuesPathAndOpt(client, d)
+	fieldName := d.Get("field_name").(string)
+	values, fieldJson, err := flattenCodeTableFieldValues(client, getOpt,
+		getPath, fieldName)
+	if err != nil {
+		return diag.Errorf("error retrieving DataArts Architecture code table field values: %s", err)
+	}
+
+	if len(values) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving DataArts Architecture code table field values")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("workspace_id", workspaceID),
+		d.Set("table_id", utils.PathSearch("code_table_id", fieldJson, nil)),
+		d.Set("field_id", utils.PathSearch("id", fieldJson, nil)),
+		d.Set("field_ordinal", utils.PathSearch("ordinal", fieldJson, nil)),
+		d.Set("field_name", utils.PathSearch("name_ch", fieldJson, nil)),
+		d.Set("field_code", utils.PathSearch("name_en", fieldJson, nil)),
+		d.Set("field_type", utils.PathSearch("data_type", fieldJson, nil)),
+		d.Set("values", values),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCodeTableFieldValues(client *golangsdk.ServiceClient, getCodeTableFieldValuesOpt golangsdk.RequestOpts,
+	getCodeTableFieldValuesPath, fieldName string) ([]interface{}, interface{}, error) {
+	var fieldJson interface{}
+	offset := 0
+	values := make([]interface{}, 0)
+
+	for {
+		path := fmt.Sprintf("%s?limit=50&offset=%d", getCodeTableFieldValuesPath, offset)
+		getCodeTableFieldValuesResp, err := client.Request("GET", path, &getCodeTableFieldValuesOpt)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		getCodeTableFieldValuesRespBody, err := utils.FlattenResponse(getCodeTableFieldValuesResp)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		findFieldExpr := fmt.Sprintf("data.value.records[?name_ch=='%s'] | [0]", fieldName)
+		fieldJson = utils.PathSearch(findFieldExpr, getCodeTableFieldValuesRespBody, nil)
+		valuesJson := utils.PathSearch("code_table_field_values", fieldJson, make([]interface{}, 0))
+		valueArray := valuesJson.([]interface{})
+
+		hasValues := false
+		for _, rawValue := range valueArray {
+			id := utils.PathSearch("id", rawValue, nil)
+
+			// Filter out the deleted values.
+			// If a code table has a field, the deleted values will be cleared.
+			// If a code table has multiple fields, the structure of the deleted value will be retained, with the id set to nil.
+			if id != nil {
+				value := map[string]interface{}{
+					"id":      id,
+					"ordinal": utils.PathSearch("ordinal", rawValue, nil),
+					"value":   utils.PathSearch("fd_value", rawValue, nil),
+				}
+
+				values = append(values, value)
+				hasValues = true
+			}
+		}
+
+		if !hasValues {
+			log.Print("[INFO] The process of retrieving values has ended.")
+			break
+		}
+		offset += 50
+	}
+	return values, fieldJson, nil
+}
+
+func resourceArchitectureCodeTableValuesUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	product := "dataarts"
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	updatePath, updateOpt := buildCodeTableValuesPathAndOpt(client, d)
+	updateOpt.JSONBody = utils.RemoveNil(buildRemoveCodeTableValuesParams(d))
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+
+	if err != nil {
+		return diag.Errorf("error updating DataArts Architecture code table values: %s", err)
+	}
+
+	updateOpt.JSONBody = utils.RemoveNil(buildCreateCodeTableValuesParams(d))
+	_, err = client.Request("PUT", updatePath, &updateOpt)
+
+	if err != nil {
+		return diag.Errorf("error updating DataArts Architecture code table values: %s", err)
+	}
+
+	return resourceArchitectureCodeTableValuesRead(ctx, d, meta)
+}
+
+func buildRemoveCodeTableValuesParams(d *schema.ResourceData) map[string]interface{} {
+	params := make([]map[string]interface{}, 1)
+	params[0] = map[string]interface{}{
+		"id":                      d.Get("field_id"),
+		"ordinal":                 d.Get("field_ordinal"),
+		"name_ch":                 d.Get("field_name"),
+		"name_en":                 d.Get("field_code"),
+		"data_type":               d.Get("field_type"),
+		"code_table_field_values": buildRemoveCodeTableFieldValuesParams(d),
+	}
+	return map[string]interface{}{
+		"to_remove": params,
+	}
+}
+
+func buildRemoveCodeTableFieldValuesParams(d *schema.ResourceData) []map[string]interface{} {
+	rawValues, _ := d.GetChange("values")
+	oldValues := rawValues.([]interface{})
+	values := make([]map[string]interface{}, len(oldValues))
+	for i, oldValue := range oldValues {
+		valueMap := oldValue.(map[string]interface{})
+		value := map[string]interface{}{
+			"id":      valueMap["id"],
+			"ordinal": valueMap["ordinal"],
+		}
+		values[i] = value
+	}
+	return values
+}
+
+func resourceArchitectureCodeTableValuesDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	product := "dataarts"
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	path, opt := buildCodeTableValuesPathAndOpt(client, d)
+	opt.JSONBody = utils.RemoveNil(buildRemoveCodeTableValuesParams(d))
+	_, err = client.Request("PUT", path, &opt)
+
+	if err != nil {
+		return diag.Errorf("error deleting DataArts Architecture code table values: %s", err)
+	}
+
+	// Successful deletion API call does not guarantee that the resource is successfully deleted.
+	// Call the details API to confirm that the resource has been successfully deleted.
+	opt.JSONBody = nil
+	fieldName := d.Get("field_name").(string)
+	values, _, err := flattenCodeTableFieldValues(client, opt, path, fieldName)
+	if err != nil {
+		return diag.Errorf("error retrieving DataArts Architecture code table field values: %s", err)
+	}
+
+	if len(values) > 0 {
+		return diag.Errorf("error deleting DataArts Architecture code table values")
+	}
+	return nil
+}
+
+func buildCodeTableValuesPathAndOpt(client *golangsdk.ServiceClient, d *schema.ResourceData) (string, golangsdk.RequestOpts) {
+	httpUrl := "v2/{project_id}/design/code-tables/{id}/values"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{id}", d.Get("table_id").(string))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+	return path, opt
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add datasource cts key event notifications

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccDatasourceCTSNotifications_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccDatasourceCTSNotifications_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCTSNotifications_basic
=== PAUSE TestAccDatasourceCTSNotifications_basic
=== CONT  TestAccDatasourceCTSNotifications_basic
--- PASS: TestAccDatasourceCTSNotifications_basic (140.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       140.332s
```
