### PR TITLE
refactor(ecs): rewrite resource computer interface attach

### DIFF
--- a/docs/resources/compute_interface_attach.md
+++ b/docs/resources/compute_interface_attach.md
@@ -23,8 +23,8 @@ resource "huaweicloud_compute_interface_attach" "test" {
 ### Attach a port (under the specified network) to the ECS instance and use the custom security groups
 
 ```hcl
-variable "instance_id" {
-variable "network_id" {
+variable "instance_id" {}
+variable "network_id" {}
 variable "security_group_ids" {
   type = list(string)
 }
@@ -32,7 +32,6 @@ variable "security_group_ids" {
 resource "huaweicloud_compute_interface_attach" "test" {
   instance_id        = var.instance_id
   network_id         = var.network_id
-  fixed_ip           = "192.168.10.199"
   security_group_ids = var.security_group_ids
 }
 ```
@@ -98,18 +97,26 @@ The following arguments are supported:
 * `security_group_ids` - (Optional, List) Specifies the list of security group IDs bound to the specified port.  
   Defaults to the default security group.
 
+* `ipv6_enable` - (Optional, Bool, ForceNew) Specifies if the NIC supporting IPv6 or not.
+
+* `ipv6_bandwidth_id` - (Optional, String, ForceNew) Specifies the shared bandwidth ID to which the IPv6 NIC attaches.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in format of ECS instance ID and port ID separated by a slash.
+
 * `mac` - The MAC address of the NIC.
+
+* `fixed_ipv6` - The IPv6 address.
 
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 10 minutes.
+
 * `delete` - Default is 10 minutes.
 
 ## Import

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_interface_attach.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_interface_attach.go
@@ -3,7 +3,6 @@ package ecs
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -11,16 +10,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/compute/v2/extensions/attachinterfaces"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+// API: ECS POST /v1/{project_id}/cloudservers/{server_id}/nics
+// API: ECS POST /v1/{project_id}/cloudservers/{server_id}/nics/delete
+// API: ECS GET /v1/{project_id}/cloudservers/{server_id}/os-interface
+// API: VPC GET /v1/{project_id}/ports/{port_id}
+// API: VPC PUT /v1/{project_id}/ports/{port_id}
+// API: ECS GET /v1/{project_id}/jobs/{job_id}
 func ResourceComputeInterfaceAttach() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceComputeInterfaceAttachCreate,
@@ -28,7 +32,7 @@ func ResourceComputeInterfaceAttach() *schema.Resource {
 		UpdateContext: resourceComputeInterfaceAttachUpdate,
 		DeleteContext: resourceComputeInterfaceAttachDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceComputeInterfaceAttachImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -43,13 +47,11 @@ func ResourceComputeInterfaceAttach() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"instance_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-
 			"network_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -80,6 +82,21 @@ func ResourceComputeInterfaceAttach() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"ipv6_bandwidth_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"ipv6_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"fixed_ipv6": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"mac": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -88,165 +105,273 @@ func ResourceComputeInterfaceAttach() *schema.Resource {
 	}
 }
 
-func updateInterfacePort(client *golangsdk.ServiceClient, portId string, securityGroupIds []string,
-	sourceDestCheckEnabled bool) error {
-	opts := ports.UpdateOpts{
-		AllowedAddressPairs: nil,
-		SecurityGroups:      &securityGroupIds,
-	}
-	if !sourceDestCheckEnabled {
-		// Update the allowed-address-pairs of the port to 1.1.1.1/0
-		// to disable the source/destination check
-		portpairs := []ports.AddressPair{
-			{
-				IPAddress: "1.1.1.1/0",
-			},
-		}
-		opts.AllowedAddressPairs = &portpairs
-	}
-
-	_, err := ports.Update(client, portId, opts).Extract()
-	return err
-}
-
 func resourceComputeInterfaceAttachCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	computeClient, err := cfg.ComputeV2Client(region)
+	computeClient, err := cfg.NewServiceClient("ecs", region)
 	if err != nil {
 		return diag.Errorf("error creating compute client: %s", err)
 	}
-	nicClient, err := cfg.NetworkingV2Client(region)
+
+	// Create NIC and get `job_id`
+	nic := make([]map[string]interface{}, 1)
+	nic[0] = utils.RemoveNil(buildCreateNicBodyParams(d))
+
+	createNicHttpUrl := "v1/{project_id}/cloudservers/{server_id}/nics"
+	createNicPath := computeClient.Endpoint + createNicHttpUrl
+	createNicPath = strings.ReplaceAll(createNicPath, "{project_id}", computeClient.ProjectID)
+	createNicPath = strings.ReplaceAll(createNicPath, "{server_id}", d.Get("instance_id").(string))
+	createNicOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"nics": nic,
+		},
+	}
+	createNicResp, err := computeClient.Request("POST", createNicPath, &createNicOpt)
 	if err != nil {
-		return diag.Errorf("error creating VPC v2.0 client: %s", err)
+		return diag.Errorf("error creating ECS NIC: %s", err)
 	}
-
-	var portId string
-	if v, ok := d.GetOk("port_id"); ok {
-		portId = v.(string)
-	}
-
-	var networkId string
-	if v, ok := d.GetOk("network_id"); ok {
-		networkId = v.(string)
-	}
-
-	// For some odd reason the API takes an array of IPs, but you can only have one element in the array.
-	var fixedIPs []attachinterfaces.FixedIP
-	if v, ok := d.GetOk("fixed_ip"); ok {
-		fixedIPs = append(fixedIPs, attachinterfaces.FixedIP{IPAddress: v.(string)})
-	}
-
-	attachOpts := attachinterfaces.CreateOpts{
-		PortID:    portId,
-		NetworkID: networkId,
-		FixedIPs:  fixedIPs,
-	}
-
-	log.Printf("[DEBUG] compute interface attach options: %#v", attachOpts)
-	instanceId := d.Get("instance_id").(string)
-	attachment, err := attachinterfaces.Create(computeClient, instanceId, attachOpts).Extract()
+	createNicRespBody, err := utils.FlattenResponse(createNicResp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	portID := attachment.PortID
-	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"ATTACHING"},
-		Target:     []string{"ATTACHED"},
-		Refresh:    computeInterfaceAttachAttachFunc(computeClient, instanceId, portID),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
-	}
-
-	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return diag.Errorf("error creating attaching interface to compute instance %s: %s", instanceId, err)
-	}
-
-	// Use the instance ID and port ID as the resource ID.
-	id := fmt.Sprintf("%s/%s", instanceId, portID)
-	d.SetId(id)
-
-	var (
-		securityGroupIds       = d.Get("security_group_ids").([]interface{})
-		sourceDestCheckEnabled = d.Get("source_dest_check").(bool)
-	)
-	err = updateInterfacePort(nicClient, portID, utils.ExpandToStringList(securityGroupIds), sourceDestCheckEnabled)
+	jobID, err := jmespath.Search("job_id", createNicRespBody)
 	if err != nil {
-		return diag.Errorf("error updating VPC port (%s): %s", portID, err)
+		return diag.Errorf("error creating ECS NIC: `job_id` not found in API response")
+	}
+
+	// Wait for job status become `SUCCESS`.
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      getJobRefreshFunc(computeClient, jobID.(string)),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	result, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("Error waiting for ECS NIC created: %s", err)
+	}
+
+	// Get `nic_id`
+	id, err := jmespath.Search("entities.sub_jobs|[0].entities.nic_id", result)
+	if err != nil {
+		return diag.Errorf("error creating ECS NIC: `nic_id` not found in API response")
+	}
+	d.SetId(id.(string))
+
+	// Update port if `source_dest_check` is false, else skip update,
+	// because `security_group_ids` is set when NIC is created.
+	vpcClient, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+	if !d.Get("source_dest_check").(bool) {
+		err = updatePort(vpcClient, d.Id(), d.Get("security_group_ids"), d.Get("source_dest_check").(bool))
+		if err != nil {
+			return diag.Errorf("error creating ECS NIC: %s", err)
+		}
 	}
 
 	return resourceComputeInterfaceAttachRead(ctx, d, meta)
 }
 
+func buildCreateNicBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"subnet_id":       utils.ValueIngoreEmpty(d.Get("network_id")),
+		"security_groups": buildNicsRequestBodySecurityGroups(d.Get("security_group_ids")),
+		"ip_address":      utils.ValueIngoreEmpty(d.Get("fixed_ip")),
+		"port_id":         utils.ValueIngoreEmpty(d.Get("port_id")),
+		"ipv6_enable":     utils.ValueIngoreEmpty(d.Get("ipv6_enable")),
+		"ipv6_bandwidth": map[string]interface{}{
+			"id": utils.ValueIngoreEmpty(d.Get("ipv6_bandwidth_id")),
+		},
+	}
+	return bodyParams
+}
+
+func buildNicsRequestBodySecurityGroups(rawParams interface{}) []map[string]interface{} {
+	rawArray, _ := rawParams.([]interface{})
+	if len(rawArray) == 0 {
+		return nil
+	}
+	ids := make([]map[string]interface{}, len(rawArray))
+	for i, val := range rawArray {
+		id := val.(string)
+		params := map[string]interface{}{
+			"id": id,
+		}
+		ids[i] = params
+	}
+	return ids
+}
+
+func getJob(computeClient *golangsdk.ServiceClient, id string) (interface{}, error) {
+	getJobHttpUrl := "v1/{project_id}/jobs/{job_id}"
+	getJobPath := computeClient.Endpoint + getJobHttpUrl
+	getJobPath = strings.ReplaceAll(getJobPath, "{project_id}", computeClient.ProjectID)
+	getJobPath = strings.ReplaceAll(getJobPath, "{job_id}", id)
+	getJobOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getJobResp, err := computeClient.Request("GET", getJobPath, &getJobOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getJobResp)
+}
+
+func getJobRefreshFunc(computeClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		result, err := getJob(computeClient, id)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		status, err := jmespath.Search("status", result)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		if status.(string) == "FAIL" {
+			err = fmt.Errorf("job failed with code %s: %s",
+				utils.PathSearch("error_code", result, ""), utils.PathSearch("fail_reason", result, ""))
+			return nil, "FAIL", err
+		}
+		if status.(string) == "SUCCESS" {
+			return result, "SUCCESS", nil
+		}
+		return result, "PENDING", nil
+	}
+}
+
+func updatePort(vpcClient *golangsdk.ServiceClient, portID string, securityGroupIds interface{}, sourceDestCheck bool) error {
+	updatePortHttpUrl := "v1/{project_id}/ports/{port_id}"
+	updatePortPath := vpcClient.Endpoint + updatePortHttpUrl
+	updatePortPath = strings.ReplaceAll(updatePortPath, "{project_id}", vpcClient.ProjectID)
+	updatePortPath = strings.ReplaceAll(updatePortPath, "{port_id}", portID)
+
+	// Update `allowedAddressPairs` of the port to `1.1.1.1/0` to disable the source/destination check.
+	allowedAddressPairs := make([]map[string]interface{}, 0)
+	if !sourceDestCheck {
+		allowedAddressPairs = append(allowedAddressPairs, map[string]interface{}{
+			"ip_address": "1.1.1.1/0",
+		})
+	}
+
+	port := make(map[string]interface{})
+	port["allowed_address_pairs"] = allowedAddressPairs
+	if len(securityGroupIds.([]interface{})) > 0 {
+		port["security_groups"] = securityGroupIds
+	}
+
+	updatePortOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"port": port,
+		},
+	}
+
+	_, err := vpcClient.Request("PUT", updatePortPath, &updatePortOpt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func resourceComputeInterfaceAttachRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	computeClient, err := cfg.ComputeV2Client(region)
+	computeClient, err := cfg.NewServiceClient("ecs", region)
 	if err != nil {
 		return diag.Errorf("error creating compute client: %s", err)
 	}
-	networkingClient, err := cfg.NetworkingV2Client(region)
-	if err != nil {
-		return diag.Errorf("error creating networking client: %s", err)
-	}
 
-	instanceId, portId, err := computeInterfaceAttachParseID(d.Id())
+	id := d.Id()
+
+	// Get NIC.
+	listNicsHttpUrl := "v1/{project_id}/cloudservers/{server_id}/os-interface"
+	listNicsPath := computeClient.Endpoint + listNicsHttpUrl
+	listNicsPath = strings.ReplaceAll(listNicsPath, "{project_id}", computeClient.ProjectID)
+	listNicsPath = strings.ReplaceAll(listNicsPath, "{server_id}", d.Get("instance_id").(string))
+	listNicsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	listNicsResp, err := computeClient.Request("GET", listNicsPath, &listNicsOpt)
+	if err != nil {
+		return diag.Errorf("error getting NIC list: %s", err)
+	}
+	listNicsRespBody, err := utils.FlattenResponse(listNicsResp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	attachment, err := attachinterfaces.Get(computeClient, instanceId, portId).Extract()
+	jsonPaths := fmt.Sprintf("interfaceAttachments[?port_id=='%s']|[0]", id)
+	nic, err := jmespath.Search(jsonPaths, listNicsRespBody)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving compute interface attach")
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
-	var (
-		securitygroups []string
-		ipAddress      string
-		macAddress     string
-		sdCheck        bool
-	)
-
-	if len(attachment.FixedIPs) > 0 {
-		ipAddress = attachment.FixedIPs[0].IPAddress
+	// Getting VPC port.
+	vpcClient, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
 	}
-	if port, err := ports.Get(networkingClient, attachment.PortID).Extract(); err == nil {
-		macAddress = port.MACAddress
-		securitygroups = port.SecurityGroups
-		sdCheck = len(port.AllowedAddressPairs) == 0
+	port, err := readVPCPort(vpcClient, id)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("instance_id", instanceId),
-		d.Set("port_id", attachment.PortID),
-		d.Set("network_id", attachment.NetID),
-		d.Set("fixed_ip", ipAddress),
-		d.Set("mac", macAddress),
-		d.Set("security_group_ids", securitygroups),
-		d.Set("source_dest_check", sdCheck),
+		d.Set("port_id", id),
+		d.Set("network_id", utils.PathSearch("net_id", nic, nil)),
+		d.Set("fixed_ip", utils.PathSearch("fixed_ips|[0].ip_address", nic, nil)),
+		d.Set("fixed_ipv6", utils.PathSearch("fixed_ips|[1].ip_address", nic, nil)),
+		d.Set("ipv6_enable", len(utils.PathSearch("fixed_ips", nic, make([]interface{}, 0)).([]interface{})) == 2),
+		d.Set("mac", utils.PathSearch("mac_addr", nic, nil)),
+		d.Set("security_group_ids", utils.PathSearch("port.security_groups", port, make([]interface{}, 0))),
+		d.Set("source_dest_check", flattenSourceDestCheck(utils.PathSearch("port.allowed_address_pairs", port, make([]interface{}, 0)))),
+		d.Set("ipv6_bandwidth_id", utils.PathSearch("port.ipv6_bandwidth_id", port, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
-func resourceComputeInterfaceAttachUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	nicClient, err := cfg.NetworkingV2Client(cfg.GetRegion(d))
-	if err != nil {
-		return diag.Errorf("error creating networking client: %s", err)
+func readVPCPort(vpcClient *golangsdk.ServiceClient, portID string) (interface{}, error) {
+	getPortHttpUrl := "v1/{project_id}/ports/{port_id}"
+	getPortPath := vpcClient.Endpoint + getPortHttpUrl
+	getPortPath = strings.ReplaceAll(getPortPath, "{project_id}", vpcClient.ProjectID)
+	getPortPath = strings.ReplaceAll(getPortPath, "{port_id}", portID)
+	getPortOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
 	}
 
-	var (
-		portId                 = d.Get("port_id").(string)
-		securityGroupIds       = d.Get("security_group_ids").([]interface{})
-		sourceDestCheckEnabled = d.Get("source_dest_check").(bool)
-	)
-	err = updateInterfacePort(nicClient, portId, utils.ExpandToStringList(securityGroupIds), sourceDestCheckEnabled)
+	getPortResp, err := vpcClient.Request("GET", getPortPath, &getPortOpt)
 	if err != nil {
-		return diag.Errorf("error updating VPC port (%s): %s", portId, err)
+		return nil, fmt.Errorf("error retrieving VPC port: %s", err)
+	}
+	return utils.FlattenResponse(getPortResp)
+}
+
+func flattenSourceDestCheck(allowedAddressPairs interface{}) bool {
+	pairs := allowedAddressPairs.([]interface{})
+	return len(pairs) == 0
+}
+
+func resourceComputeInterfaceAttachUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	vpcClient, err := cfg.NewServiceClient("vpc", region)
+	if err != nil {
+		return diag.Errorf("error creating VPC client: %s", err)
+	}
+
+	err = updatePort(vpcClient, d.Id(), d.Get("security_group_ids"), d.Get("source_dest_check").(bool))
+	if err != nil {
+		return diag.Errorf("error updating ECS NIC port (%s): %s", d.Id(), err)
 	}
 
 	return resourceComputeInterfaceAttachRead(ctx, d, meta)
@@ -254,87 +379,67 @@ func resourceComputeInterfaceAttachUpdate(ctx context.Context, d *schema.Resourc
 
 func resourceComputeInterfaceAttachDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	computeClient, err := cfg.ComputeV2Client(cfg.GetRegion(d))
+	region := cfg.GetRegion(d)
+	computeClient, err := cfg.NewServiceClient("ecs", region)
 	if err != nil {
 		return diag.Errorf("error creating compute client: %s", err)
 	}
 
-	instanceId, portId, err := computeInterfaceAttachParseID(d.Id())
+	serverID := d.Get("instance_id").(string)
+
+	deleteNicsHttpUrl := "v1/{project_id}/cloudservers/{server_id}/nics/delete"
+	deleteNicsPath := computeClient.Endpoint + deleteNicsHttpUrl
+	deleteNicsPath = strings.ReplaceAll(deleteNicsPath, "{project_id}", computeClient.ProjectID)
+	deleteNicsPath = strings.ReplaceAll(deleteNicsPath, "{server_id}", serverID)
+
+	nic := make([]map[string]interface{}, 0)
+	nic = append(nic, map[string]interface{}{
+		"id": d.Get("port_id"),
+	})
+	deleteNicOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"nics": nic,
+		},
+	}
+	// The `DELETE` API use `POST` method actually.
+	deleteNicResp, err := computeClient.Request("POST", deleteNicsPath, &deleteNicOpt)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	deleteNicRespBody, err := utils.FlattenResponse(deleteNicResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	jobID, err := jmespath.Search("job_id", deleteNicRespBody)
+	if err != nil {
+		return diag.Errorf("error deleting ECS NIC: `job_id` not found in API response")
+	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{""},
-		Target:     []string{"DETACHED"},
-		Refresh:    computeInterfaceAttachDetachFunc(computeClient, instanceId, portId),
-		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Pending:      []string{"PENDING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      getJobRefreshFunc(computeClient, jobID.(string)),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
-		return diag.Errorf("error detaching interface from compute instance %s: %s", instanceId, err)
+		return diag.Errorf("error waiting for the ECS NIC to be deleted: %s", err)
 	}
 
 	return nil
 }
 
-func computeInterfaceAttachAttachFunc(
-	computeClient *golangsdk.ServiceClient, instanceId, attachmentId string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		va, err := attachinterfaces.Get(computeClient, instanceId, attachmentId).Extract()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return va, "ATTACHING", nil
-			}
-			return va, "", err
-		}
+func resourceComputeInterfaceAttachImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	partLength := len(parts)
 
-		return va, "ATTACHED", nil
+	if partLength == 2 {
+		d.SetId(parts[1])
+		return []*schema.ResourceData{d}, d.Set("instance_id", parts[0])
 	}
-}
-
-func computeInterfaceAttachDetachFunc(
-	computeClient *golangsdk.ServiceClient, instanceId, attachmentId string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] Attempting to detach interface attachment %s from instance %s",
-			attachmentId, instanceId)
-
-		va, err := attachinterfaces.Get(computeClient, instanceId, attachmentId).Extract()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return va, "DETACHED", nil
-			}
-			return va, "", err
-		}
-
-		err = attachinterfaces.Delete(computeClient, instanceId, attachmentId).ExtractErr()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return va, "DETACHED", nil
-			}
-
-			if _, ok := err.(golangsdk.ErrDefault400); ok {
-				return nil, "", nil
-			}
-
-			return nil, "", err
-		}
-
-		log.Printf("[DEBUG] compute interface attachment %s is still active.", attachmentId)
-		return nil, "", nil
-	}
-}
-
-func computeInterfaceAttachParseID(id string) (instanceID, portID string, err error) {
-	idParts := strings.Split(id, "/")
-	if len(idParts) < 2 {
-		err = fmt.Errorf("unable to parse the resource ID, must be <instance_id>/<port_id> format")
-		return
-	}
-
-	instanceID = idParts[0]
-	portID = idParts[1]
-	return
+	return nil, fmt.Errorf("invalid format specified for import ID, must be <instance_id>/<port_id>")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Rewrite resource computer interface attach.
Add two params `ipv6_enable` and `ipv6_bandwidth_id` to support IPv6.


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInterfaceAttach_Basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInterfaceAttach_Basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInterfaceAttach_Basic
=== PAUSE TestAccComputeInterfaceAttach_Basic
=== CONT  TestAccComputeInterfaceAttach_Basic
--- PASS: TestAccComputeInterfaceAttach_Basic (566.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       566.805s
```
