### PR TITLE
feat(DWS): Add new resource to manage DWS logical cluster

### DIFF
--- a/docs/resources/dws_logical_cluster.md
+++ b/docs/resources/dws_logical_cluster.md
@@ -1,0 +1,114 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# huaweicloud_dws_logical_cluster
+
+Manages a DWS logical cluster resource within HuaweiCloud.
+
+-> **NOTE:** The first DWS logical cluster can't be deleted. When performing a delete operation, the resource will only
+be removed from the state, but it remains in the cloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "ring_hosts" {
+  type = list(object({
+    host_name = string
+    back_ip   = string
+    cpu_cores = number
+    memory    = number
+    disk_size = number
+  }))
+}
+
+resource "huaweicloud_dws_logical_cluster" "test" {
+  logical_cluster_name = "test_name"
+  cluster_id           = var.cluster_id
+
+  cluster_rings {
+    dynamic "ring_hosts" {
+      for_each = var.ring_hosts
+      content {
+        host_name = ring_hosts.value.host_name
+        back_ip   = ring_hosts.value.back_ip
+        cpu_cores = ring_hosts.value.cpu_cores
+        memory    = ring_hosts.value.memory
+        disk_size = ring_hosts.value.disk_size
+      }
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the DWS cluster ID.
+
+  Changing this parameter will create a new resource.
+
+* `logical_cluster_name` - (Required, String, ForceNew) Specifies the logical cluster name. Changing this parameter will
+  create a new resource. Only letters, digits, and underscores (_) are allowed. The maximum length is 63 characters.
+  The name must be unique and cannot be the keywords `group_version1`, `group_version2`, `group_version3`,
+  `installation`, `elastic_group`, `optimal`, and `query`.
+
+* `cluster_rings` - (Required, List, ForceNew) Specifies the DWS logical cluster ring list information.
+  Changing this parameter will create a new resource.
+The [cluster_rings](#LogicalCluster_ClusterRings) structure is documented below.
+
+<a name="LogicalCluster_ClusterRings"></a>
+The `cluster_rings` block supports:
+
+* `ring_hosts` - (Required, List, ForceNew) Specifies the cluster host ring information. All host information of a ring
+  must be specified. Changing this parameter will create a new resource.
+The [ring_hosts](#LogicalCluster_RingHosts) structure is documented below.
+
+<a name="LogicalCluster_RingHosts"></a>
+The `ring_hosts` block supports:
+
+* `host_name` - (Required, String, ForceNew) Specifies the host name. Changing this parameter will create a new resource.
+
+* `back_ip` - (Required, String, ForceNew) Specifies the backend IP address. Changing this parameter will create a new resource.
+
+* `cpu_cores` - (Required, Int, ForceNew) Specifies the number of CPU cores. Changing this parameter will create a new resource.
+
+* `memory` - (Required, Float, ForceNew) Specifies the host memory. Changing this parameter will create a new resource.
+
+* `disk_size` - (Required, Float, ForceNew) Specifies the host disk size. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The DWS logical cluster status.
+
+* `first_logical_cluster` - Whether it is the first logical cluster. The first logical cluster cannot be deleted.
+
+* `edit_enable` - Whether editing is allowed.
+
+* `restart_enable` - Whether to allow restart.
+
+* `delete_enable` - Whether deletion is allowed.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The DWS logical cluster resource can be imported using the `cluster_id` and `id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dws_logical_cluster.test <cluster_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -951,6 +951,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_job": drs.ResourceDrsJob(),
 
 			"huaweicloud_dws_cluster":            dws.ResourceDwsCluster(),
+			"huaweicloud_dws_logical_cluster":    dws.ResourceLogicalCluster(),
 			"huaweicloud_dws_event_subscription": dws.ResourceDwsEventSubs(),
 			"huaweicloud_dws_alarm_subscription": dws.ResourceDwsAlarmSubs(),
 			"huaweicloud_dws_snapshot":           dws.ResourceDwsSnapshot(),

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_logical_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_logical_cluster_test.go
@@ -1,0 +1,210 @@
+package dws
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getLogicalClusterResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/clusters/{cluster_id}/logical-clusters"
+		product = "dws"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", state.Primary.Attributes["cluster_id"])
+	getResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		getPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return nil, err
+	}
+
+	getRespJson, err := json.Marshal(getResp)
+	if err != nil {
+		return nil, err
+	}
+	var getRespBody interface{}
+	err = json.Unmarshal(getRespJson, &getRespBody)
+	if err != nil {
+		return nil, err
+	}
+	expression := fmt.Sprintf("logical_clusters[?logical_cluster_id=='%s']|[0]", state.Primary.ID)
+	cluster := utils.PathSearch(expression, getRespBody, nil)
+	if cluster == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return cluster, nil
+}
+
+// Two logical clusters are created to cover the deletion logic.
+// At the current stage, multiple logical clusters cannot be created simultaneously under the same cluster.
+// This is a legacy feature and will be added later.
+func TestAccLogicalCluster_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dws_logical_cluster.test"
+	rName2 := "huaweicloud_dws_logical_cluster.test2"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getLogicalClusterResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testLogicalCluster_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "cluster_id",
+						"huaweicloud_dws_cluster.test", "id"),
+					resource.TestCheckResourceAttr(rName, "logical_cluster_name", name),
+					resource.TestCheckResourceAttr(rName, "cluster_rings.#", "2"),
+					resource.TestCheckResourceAttr(rName2, "cluster_rings.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.host_name"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.back_ip"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.cpu_cores"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.memory"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.0.disk_size"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.1.host_name"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.1.back_ip"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.1.cpu_cores"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.1.memory"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.1.disk_size"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.2.host_name"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.2.back_ip"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.2.cpu_cores"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.2.memory"),
+					resource.TestCheckResourceAttrSet(rName, "cluster_rings.0.ring_hosts.2.disk_size"),
+
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "first_logical_cluster"),
+					resource.TestCheckResourceAttrSet(rName, "edit_enable"),
+					resource.TestCheckResourceAttrSet(rName, "restart_enable"),
+					resource.TestCheckResourceAttrSet(rName, "delete_enable"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testLogicalClusterImportState(rName),
+			},
+		},
+	})
+}
+
+func testLogicalCluster_base(name string) string {
+	clusterBasic := testAccDwsCluster_basic(name, 10, dws.PublicBindTypeAuto, "cluster123@!", "bar")
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_dws_logical_cluster_rings" "test" {
+  cluster_id = huaweicloud_dws_cluster.test.id
+}
+`, clusterBasic)
+}
+
+func testLogicalCluster_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dws_logical_cluster" "test" {
+  cluster_id           = huaweicloud_dws_cluster.test.id
+  logical_cluster_name = "%s"
+
+  cluster_rings {
+    dynamic "ring_hosts" {
+      for_each = data.huaweicloud_dws_logical_cluster_rings.test.cluster_rings.0.ring_hosts[*]
+      content {
+        host_name = ring_hosts.value.host_name
+        back_ip   = ring_hosts.value.back_ip
+        cpu_cores = ring_hosts.value.cpu_cores
+        memory    = ring_hosts.value.memory
+        disk_size = ring_hosts.value.disk_size
+      }
+    }
+  }
+
+  cluster_rings {
+    dynamic "ring_hosts" {
+      for_each = data.huaweicloud_dws_logical_cluster_rings.test.cluster_rings.1.ring_hosts[*]
+      content {
+        host_name = ring_hosts.value.host_name
+        back_ip   = ring_hosts.value.back_ip
+        cpu_cores = ring_hosts.value.cpu_cores
+        memory    = ring_hosts.value.memory
+        disk_size = ring_hosts.value.disk_size
+      }
+    }
+  }
+}
+
+resource "huaweicloud_dws_logical_cluster" "test2" {
+  cluster_id           = huaweicloud_dws_cluster.test.id
+  logical_cluster_name = "%s_test2"
+
+  cluster_rings {
+    dynamic "ring_hosts" {
+      for_each = data.huaweicloud_dws_logical_cluster_rings.test.cluster_rings.2.ring_hosts[*]
+      content {
+        host_name = ring_hosts.value.host_name
+        back_ip   = ring_hosts.value.back_ip
+        cpu_cores = ring_hosts.value.cpu_cores
+        memory    = ring_hosts.value.memory
+        disk_size = ring_hosts.value.disk_size
+      }
+    }
+  }
+
+  depends_on = [
+    huaweicloud_dws_logical_cluster.test
+  ]
+}
+`, testLogicalCluster_base(name), name, name)
+}
+
+// testLogicalClusterImportState use to return an ID with format <cluster_id>/<id>
+func testLogicalClusterImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", name)
+		}
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		if clusterID == "" {
+			return "", fmt.Errorf("attribute (cluster_id) of resource (%s) not found", name)
+		}
+
+		return clusterID + "/" + rs.Primary.ID, nil
+	}
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
@@ -1,0 +1,497 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product DWS
+// ---------------------------------------------------------------
+
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	deleteNotExistMsg            = "logical cluster is not existed"
+	deleteFirstLogicalClusterMsg = "the first logical cluster can't be deleted"
+)
+
+// API: DWS POST /v2/{project_id}/clusters/{cluster_id}/logical-clusters
+// API: DWS GET /v2/{project_id}/clusters/{cluster_id}/logical-clusters
+// API: DWS DELETE /v2/{project_id}/clusters/{cluster_id}/logical-clusters/{logical_cluster_id}
+func ResourceLogicalCluster() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceLogicalClusterCreate,
+		ReadContext:   resourceLogicalClusterRead,
+		DeleteContext: resourceLogicalClusterDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceLogicalClusterImportState,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the DWS cluster ID.`,
+			},
+			"logical_cluster_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the logical cluster name.`,
+			},
+			"cluster_rings": {
+				Type:        schema.TypeSet,
+				Elem:        logicalClusterRingsSchema(),
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the DWS cluster ring list information.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The DWS logical cluster status.`,
+			},
+			"first_logical_cluster": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether it is the first logical cluster. The first logical cluster cannot be deleted.`,
+			},
+			"edit_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether editing is allowed.`,
+			},
+			"restart_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to allow restart.`,
+			},
+			"delete_enable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether deletion is allowed.`,
+			},
+		},
+	}
+}
+
+func logicalClusterRingsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"ring_hosts": {
+				Type:        schema.TypeSet,
+				Elem:        logicalRingHostsSchema(),
+				Required:    true,
+				ForceNew:    true,
+				Description: `Indicates the cluster host ring information.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func logicalRingHostsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"host_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the host name.`,
+			},
+			"back_ip": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the backend IP address.`,
+			},
+			"cpu_cores": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the number of CPU cores.`,
+			},
+			"memory": {
+				Type:        schema.TypeFloat,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the host memory.`,
+			},
+			"disk_size": {
+				Type:        schema.TypeFloat,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the host disk size.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceLogicalClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/clusters/{cluster_id}/logical-clusters"
+		product     = "dws"
+		clusterName = d.Get("logical_cluster_name").(string)
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{cluster_id}", d.Get("cluster_id").(string))
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildCreateLogicalClusterBodyParams(d),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating DWS logical cluster: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	errCode := utils.PathSearch("error_code", createRespBody, "").(string)
+	if errCode != "DWS.0000" {
+		errMsg := utils.PathSearch("error_msg", createRespBody, "").(string)
+		return diag.Errorf("error creating DWS logical cluster: error code: %s, error message: %s", errCode, errMsg)
+	}
+
+	clusterRespBody, err := waitingForStateCompleted(ctx, client, d, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for DWS logical cluster (%s) creation to complete: %s", clusterName, err)
+	}
+
+	id, err := jmespath.Search("logical_cluster_id", clusterRespBody)
+	if err != nil || id == nil {
+		return diag.Errorf("error creating DWS logical cluster: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return resourceLogicalClusterRead(ctx, d, meta)
+}
+
+func buildCreateLogicalClusterBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"logical_cluster": map[string]interface{}{
+			"logical_cluster_name": d.Get("logical_cluster_name"),
+			"cluster_rings":        buildLogicalClusterRingsRequestBody(d.Get("cluster_rings")),
+		},
+	}
+}
+
+func buildLogicalClusterRingsRequestBody(rawParams interface{}) []map[string]interface{} {
+	if rawSet, ok := rawParams.(*schema.Set); ok && rawSet.Len() > 0 {
+		rst := make([]map[string]interface{}, 0, rawSet.Len())
+		for _, v := range rawSet.List() {
+			raw, isMap := v.(map[string]interface{})
+			if !isMap {
+				continue
+			}
+
+			rst = append(rst, map[string]interface{}{
+				"ring_hosts": buildLogicalRingHostsRequestBody(raw["ring_hosts"]),
+			})
+		}
+		return rst
+	}
+	return nil
+}
+
+func buildLogicalRingHostsRequestBody(rawParams interface{}) []map[string]interface{} {
+	if rawSet, ok := rawParams.(*schema.Set); ok && rawSet.Len() > 0 {
+		rst := make([]map[string]interface{}, 0, rawSet.Len())
+		for _, v := range rawSet.List() {
+			raw, isMap := v.(map[string]interface{})
+			if !isMap {
+				continue
+			}
+
+			rst = append(rst, map[string]interface{}{
+				"host_name": raw["host_name"],
+				"back_ip":   raw["back_ip"],
+				"cpu_cores": raw["cpu_cores"],
+				"memory":    raw["memory"],
+				"disk_size": raw["disk_size"],
+			})
+		}
+		return rst
+	}
+	return nil
+}
+
+func waitingForStateCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) (interface{}, error) {
+	clusterName := d.Get("logical_cluster_name").(string)
+	expression := fmt.Sprintf("logical_clusters[?logical_cluster_name=='%s']|[0]", clusterName)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			clusterRespBody, err := readLogicalClusters(client, d)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			cluster := utils.PathSearch(expression, clusterRespBody, nil)
+			if cluster == nil {
+				return nil, "ERROR", golangsdk.ErrDefault404{}
+			}
+
+			completed := utils.PathSearch("action_info.completed", cluster, false).(bool)
+			result := utils.PathSearch("action_info.result", cluster, "").(string)
+			if completed && result == "success" {
+				return cluster, "COMPLETED", nil
+			}
+
+			if completed && result == "failed" {
+				return cluster, "ERROR", fmt.Errorf("the DWS logical cluster (%s) is failed", clusterName)
+			}
+			return cluster, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	return stateConf.WaitForStateContext(ctx)
+}
+
+func resourceLogicalClusterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr                     *multierror.Error
+		cfg                      = meta.(*config.Config)
+		region                   = cfg.GetRegion(d)
+		getLogicalClusterProduct = "dws"
+	)
+	client, err := cfg.NewServiceClient(getLogicalClusterProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	clusterRespBody, err := readLogicalClusters(client, d)
+	// The list API response status code is `404` when the cluster does not exist.
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DWS logical cluster")
+	}
+
+	expression := fmt.Sprintf("logical_clusters[?logical_cluster_id=='%s']|[0]", d.Id())
+	cluster := utils.PathSearch(expression, clusterRespBody, nil)
+	if cluster == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("logical_cluster_name", utils.PathSearch("logical_cluster_name", cluster, nil)),
+		d.Set("cluster_rings", flattenResponseBodyClusterRings(cluster)),
+		d.Set("status", utils.PathSearch("status", cluster, nil)),
+		d.Set("first_logical_cluster", utils.PathSearch("first_logical_cluster", cluster, nil)),
+		d.Set("edit_enable", utils.PathSearch("edit_enable", cluster, nil)),
+		d.Set("restart_enable", utils.PathSearch("restart_enable", cluster, nil)),
+		d.Set("delete_enable", utils.PathSearch("delete_enable", cluster, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenResponseBodyClusterRings(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("cluster_rings", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, len(curArray))
+	for i, v := range curArray {
+		rst[i] = map[string]interface{}{
+			"ring_hosts": flattenRingHosts(v),
+		}
+	}
+	return rst
+}
+
+// waitingForDeleteStateEnable This method is used to wait for operable status before deleting.
+// Deleting operations can only be performed when `delete_enable` is true.
+func waitingForDeleteStateEnable(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	expression := fmt.Sprintf("logical_clusters[?logical_cluster_id=='%s']|[0]", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED", "FIRST_LOGICAL_CLUSTER"},
+		Refresh: func() (interface{}, string, error) {
+			clusterRespBody, err := readLogicalClusters(client, d)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			cluster := utils.PathSearch(expression, clusterRespBody, nil)
+			if cluster == nil {
+				return nil, "ERROR", golangsdk.ErrDefault404{}
+			}
+
+			enable := utils.PathSearch("delete_enable", cluster, false).(bool)
+			if enable {
+				return enable, "COMPLETED", nil
+			}
+
+			// When `first_logical_cluster` is true, field `delete_enable` will always be false.
+			isFirstCluster := utils.PathSearch("first_logical_cluster", cluster, false).(bool)
+			if isFirstCluster {
+				return enable, "FIRST_LOGICAL_CLUSTER", nil
+			}
+
+			return enable, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceLogicalClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/clusters/{cluster_id}/logical-clusters/{logical_cluster_id}"
+		product = "dws"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	if err := waitingForDeleteStateEnable(ctx, client, d, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.Errorf("error waiting for DWS logical cluster (%s) to become delete enable: %s", d.Id(), err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", d.Get("cluster_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{logical_cluster_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	deleteResp, err := client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DWS logical cluster: %s", err)
+	}
+
+	deleteRespBody, err := utils.FlattenResponse(deleteResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// The successful API call does not mean that the deletion is successful. Also need to judge and parse the response body.
+	if diagResponse := checkLogicalClusterDeleteResponse(d, deleteRespBody); diagResponse != nil {
+		return diagResponse
+	}
+
+	err = waitingForStateDeleted(ctx, client, d, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return diag.Errorf("error waiting for DWS logical cluster (%s) deletion to complete: %s", d.Id(), err)
+	}
+	return nil
+}
+
+// waitingForStateDeleted This method is used to wait for delete to complete.
+func waitingForStateDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	expression := fmt.Sprintf("logical_clusters[?logical_cluster_id=='%s']|[0]", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			clusterRespBody, err := readLogicalClusters(client, d)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+
+			cluster := utils.PathSearch(expression, clusterRespBody, nil)
+			if cluster == nil {
+				obj := map[string]string{"code": "COMPLETED"}
+				return obj, "COMPLETED", nil
+			}
+			return cluster, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+// checkLogicalClusterDeleteResponse Check whether the DWS logical cluster delete API response body contains error msg.
+// Not exist response body:     `{"error_code": "DWS.9999","error_msg": "logical cluster is not existed"}`
+// First cluster response body: `{"error_code": "DWS.9999","error_msg": "the first logical cluster can't be deleted"}`
+// Success delete response body:`{"error_code": "DWS.0000","error_msg": null}`
+func checkLogicalClusterDeleteResponse(d *schema.ResourceData, respBody interface{}) diag.Diagnostics {
+	errCode := utils.PathSearch("error_code", respBody, "").(string)
+	if errCode == "DWS.0000" {
+		return nil
+	}
+
+	errMsg := utils.PathSearch("error_msg", respBody, "").(string)
+	if errMsg == deleteNotExistMsg {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	if errMsg == deleteFirstLogicalClusterMsg {
+		errMsg = "The first logical cluster can't be deleted. The project is only removed from the state," +
+			" but it remains in the cloud."
+		return diag.Diagnostics{
+			diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  errMsg,
+			},
+		}
+	}
+	return diag.Errorf("error deleting DWS logical cluster: error code: %s, error message: %s", errCode, errMsg)
+}
+
+func resourceLogicalClusterImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	partLength := len(parts)
+
+	if partLength == 2 {
+		d.SetId(parts[1])
+		return []*schema.ResourceData{d}, d.Set("cluster_id", parts[0])
+	}
+	return nil, fmt.Errorf("invalid format specified for import ID, must be <cluster_id>/<id>")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Add new resource to manage DWS logical cluster

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The operations of creating, and deleting are all asynchronous operations and require monitoring of task status.
- Wait for the cluster to reach an operational state before deleting.
- Editing is not supported due to a problem with the editing API.
- The indicator of whether the deletion operation is successful is the message information in the response body.
- The first logical cluster does not support deleting.
- When the logical cluster does not exist, execute `terraform plan` and the program will exit safely.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/66650cce-7e4d-497a-95bf-38959022c8c2)
- When the logical cluster is the first cluster, execute `terraform destroy` and  the program will exist safely.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/e0b01f44-baaa-4a19-8f0c-23be6200c643)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dws' TESTARGS='-run TestAccLogicalCluster_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccLogicalCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccLogicalCluster_basic
=== PAUSE TestAccLogicalCluster_basic
=== CONT  TestAccLogicalCluster_basic
--- PASS: TestAccLogicalCluster_basic (1788.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1788.516s
```
