### PR TITLE
feat(VPCEP): add a new datasource to query VPC endpoint list

### DIFF
--- a/docs/data-sources/vpcep_endpoints.md
+++ b/docs/data-sources/vpcep_endpoints.md
@@ -1,0 +1,90 @@
+---
+subcategory: "VPC Endpoint (VPCEP)"
+---
+
+# huaweicloud_vpcep_endpoints
+
+Use this data source to get a list of VPC endpoints.
+
+## Example Usage
+
+```hcl
+variable "service_name" {}
+variable "endpoint_id" {}
+
+data "huaweicloud_vpcep_endpoints" "endpoints" {
+  service_name = var.service_name
+  endpoint_id  = var.endpoint_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to query the VPC endpoints.
+  If omitted, the provider-level region will be used.
+
+* `service_name` - (Optional, String) The name of the VPC endpoint service.
+
+* `vpc_id` - (Optional, String) The ID of the VPC where the endpoint is created.
+
+* `endpoint_id` - (Optional, String) The ID of the VPC endpoint.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `endpoints` - A list of VPC endpoints.
+
+The `endpoints` block supports:
+
+* `id` - The ID of the VPC endpoint.
+
+* `service_type` - The type of the VPC endpoint service. The valid value can be:
+  + **gateway**: Configured by operation and maintenance personnel.
+  Users do not need to create it and can use it directly.
+  + **interface**: Including cloud services configured by operation and maintenance personnel
+  and private services created by users themselves. Among them, the cloud services configured
+  by operation and maintenance personnel do not need to be created, and users can use them directly.
+  You can query the public endpoint service list to view all user-visible and connectable
+  endpoint services configured by operation and maintenance personnel, and create an **interface**
+  type endpoint service by creating an endpoint service.
+
+* `status` - The status of the VPC endpoint. The value can be **accepted**, **pendingAcceptance**, **creating**,
+  **failed**, **deleting**, or **rejected**.
+
+* `service_name` - The name of the VPC endpoint service.
+
+* `service_id` - The ID of the VPC endpoint service.
+
+* `packet_id` - The packet ID of the VPC endpoint.
+  OBS uses this field to implement double-ended fixed features, and distinguish what endpoint instance it is.
+
+* `enable_dns` - Whether to create a private domain name. The value can be **true** or **false**.
+  When the type of endpoint service is **gateway**, the field is not valid.
+
+* `ip_address` - The IP address for accessing the associated VPC endpoint service.
+
+* `description` - The description of VPC endpoint.
+
+* `vpc_id` - The ID of the VPC where the endpoint is created.
+
+* `subnet_id` - The network ID of the subnet in the VPC specified by `vpc_id`, in UUID format.
+
+* `created_at` - The creation time of the VPC endpoint. Use UTC time format, the format is: YYYY-MM-DDTHH:MM:SSZ.
+
+* `updated_at` - The update time of the VPC endpoint. Use UTC time format, the format is: YYYY-MM-DDTHH:MM:SSZ.
+
+* `tags` - The key/value pairs associating with the VPC endpoint.
+
+* `whitelist` - The list of IP address or CIDR block which can be accessed to the
+  VPC endpoint.
+  If not created, an empty list is returned.
+  This field is displayed when creating an endpoint connected to an **interface** type endpoint service.
+  Array length: **1** - **1000**.
+
+* `enable_whitelist` - Whether to enable access control.
+  This field is displayed when creating an endpoint connected to an **interface** type endpoint service.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -637,6 +637,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_subnets":            vpc.DataSourceVpcSubnets(),
 			"huaweicloud_vpc_subnet_ids":         vpc.DataSourceVpcSubnetIdsV1(),
 
+			"huaweicloud_vpcep_endpoints":           vpcep.DataSourceVPCEPEndpoints(),
 			"huaweicloud_vpcep_public_services":     vpcep.DataSourceVPCEPPublicServices(),
 			"huaweicloud_vpcep_services":            vpcep.DataSourceVPCEPServices(),
 			"huaweicloud_vpcep_service_connections": vpcep.DataSourceVPCEPServiceConnections(),

--- a/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_endpoints_test.go
+++ b/huaweicloud/services/acceptance/vpcep/data_source_huaweicloud_vpcep_endpoints_test.go
@@ -1,0 +1,97 @@
+package vpcep
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceVPCEPEndpoints_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_vpcep_endpoints.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceVpcepEndpoints_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "endpoints.0.service_id"),
+					resource.TestCheckResourceAttrSet(rName, "endpoints.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(rName, "endpoints.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(rName, "endpoints.0.enable_dns"),
+					resource.TestCheckResourceAttrSet(rName, "endpoints.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "endpoints.0.enable_whitelist"),
+					resource.TestCheckResourceAttr(rName, "endpoints.0.tags.owner", "tf-acc"),
+					resource.TestCheckResourceAttr(rName, "endpoints.0.whitelist.0", "192.168.0.0/24"),
+
+					resource.TestCheckOutput("service_name_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("vpc_id_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("endpoint_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceVpcepEndpoints_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpcep_endpoints" "test" {
+  depends_on = [huaweicloud_vpcep_endpoint.test]
+}
+
+data "huaweicloud_vpcep_endpoints" "service_name_filter" {
+  service_name = data.huaweicloud_vpcep_endpoints.test.endpoints.0.service_name
+}
+
+locals {
+  service_name = data.huaweicloud_vpcep_endpoints.test.endpoints.0.service_name
+}
+
+output "service_name_filter_is_useful" {
+  value = length(data.huaweicloud_vpcep_endpoints.service_name_filter.endpoints) > 0 && alltrue(
+    [for v in data.huaweicloud_vpcep_endpoints.service_name_filter.endpoints[*].service_name : v == local.service_name]
+  )  
+}
+
+data "huaweicloud_vpcep_endpoints" "vpc_id_filter" {
+  vpc_id = data.huaweicloud_vpcep_endpoints.test.endpoints.0.vpc_id
+}
+  
+locals {
+  vpc_id = data.huaweicloud_vpc.myvpc.id
+}
+  
+output "vpc_id_filter_is_useful" {
+  value = length(data.huaweicloud_vpcep_endpoints.vpc_id_filter.endpoints) > 0 && alltrue(
+	[for v in data.huaweicloud_vpcep_endpoints.vpc_id_filter.endpoints[*].vpc_id : v == local.vpc_id]
+  )  
+}
+
+data "huaweicloud_vpcep_endpoints" "endpoint_id_filter" {
+  endpoint_id = data.huaweicloud_vpcep_endpoints.test.endpoints.0.id
+}
+  
+locals {
+  endpoint_id = huaweicloud_vpcep_endpoint.test.id
+}
+  
+output "endpoint_id_filter_is_useful" {
+  value = length(data.huaweicloud_vpcep_endpoints.endpoint_id_filter.endpoints) > 0 && alltrue(
+    [for v in data.huaweicloud_vpcep_endpoints.endpoint_id_filter.endpoints[*].id : v == local.endpoint_id]
+  )  
+}
+`, testAccVPCEndpoint_Basic(name))
+}

--- a/huaweicloud/services/vpcep/data_source_huaweicloud_vpc_endpoints.go
+++ b/huaweicloud/services/vpcep/data_source_huaweicloud_vpc_endpoints.go
@@ -1,0 +1,224 @@
+package vpcep
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: VPCEP GET /v1/{project_id}/vpc-endpoints
+func DataSourceVPCEPEndpoints() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceVpcepEndpointsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"endpoint_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"endpoints": {
+				Type:     schema.TypeList,
+				Elem:     endpointSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func endpointSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"packet_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"enable_dns": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": common.TagsComputedSchema(),
+			"whitelist": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enable_whitelist": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceVpcepEndpointsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// get VPC endpoints: Query VPC endpoints
+	var (
+		getVPCEPEndpointsHttpUrl = "v1/{project_id}/vpc-endpoints"
+		getVPCEPEndpointsProduct = "vpcep"
+	)
+	getVPCEPEndpointsClient, err := conf.NewServiceClient(getVPCEPEndpointsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating VPCEP client: %s", err)
+	}
+
+	getVPCEPEndpointsPath := getVPCEPEndpointsClient.Endpoint + getVPCEPEndpointsHttpUrl
+	getVPCEPEndpointsPath = strings.ReplaceAll(getVPCEPEndpointsPath, "{project_id}",
+		getVPCEPEndpointsClient.ProjectID)
+	getVPCEPEndpointsPath += buildVPCEPEndpointsQueryParams(d, conf)
+
+	getVPCEPEndpointsResp, err := pagination.ListAllItems(
+		getVPCEPEndpointsClient,
+		"offset",
+		getVPCEPEndpointsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving endpoints, %s", err)
+	}
+
+	listVPCEPEndpointsRespJson, err := json.Marshal(getVPCEPEndpointsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listVPCEPEndpointsRespBody interface{}
+	err = json.Unmarshal(listVPCEPEndpointsRespJson, &listVPCEPEndpointsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("endpoints", flattenListEndpointsBody(listVPCEPEndpointsRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildVPCEPEndpointsQueryParams(d *schema.ResourceData, _ *config.Config) string {
+	res := ""
+	if v, ok := d.GetOk("service_name"); ok {
+		res = fmt.Sprintf("%s&endpoint_service_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("vpc_id"); ok {
+		res = fmt.Sprintf("%s&vpc_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("endpoint_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func flattenListEndpointsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("endpoints", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":               utils.PathSearch("id", v, nil),
+			"service_type":     utils.PathSearch("service_type", v, nil),
+			"status":           utils.PathSearch("status", v, nil),
+			"service_name":     utils.PathSearch("endpoint_service_name", v, nil),
+			"service_id":       utils.PathSearch("endpoint_service_id", v, nil),
+			"packet_id":        utils.PathSearch("marker_id", v, nil),
+			"ip_address":       utils.PathSearch("ip", v, nil),
+			"vpc_id":           utils.PathSearch("vpc_id", v, nil),
+			"subnet_id":        utils.PathSearch("subnet_id", v, nil),
+			"created_at":       utils.PathSearch("created_at", v, nil),
+			"updated_at":       utils.PathSearch("updated_at", v, nil),
+			"description":      utils.PathSearch("description", v, nil),
+			"enable_dns":       utils.StringToBool(utils.PathSearch("enable_dns", v, "")),
+			"enable_whitelist": utils.StringToBool(utils.PathSearch("enable_whitelist", v, "")),
+			"tags":             utils.FlattenTagsToMap(utils.PathSearch("tags", v, make([]interface{}, 0))),
+			"whitelist":        utils.ExpandToStringList(utils.PathSearch("whitelist", v, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccDatasourceVPCEPEndpoints_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccDatasourceVPCEPEndpoints_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceVPCEPEndpoints_basic
=== PAUSE TestAccDatasourceVPCEPEndpoints_basic
=== CONT  TestAccDatasourceVPCEPEndpoints_basic
--- PASS: TestAccDatasourceVPCEPEndpoints_basic (235.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     235.754s
```
