### PR TITLE
feat(rds): add rds MySQL binlog data source

### DIFF
--- a/docs/data-sources/rds_mysql_binlog.md
+++ b/docs/data-sources/rds_mysql_binlog.md
@@ -1,0 +1,34 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_mysql_binlog
+
+Use this data source to get the binlog retention hours of RDS MySQL.
+
+## Example Usage
+
+```hcl
+var "instance_id" {}
+
+data "huaweicloud_rds_mysql_binlog" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RDS MySQL instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `binlog_retention_hours` - The binlog retention period. Value range: 0 to 168 (7x24).

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -609,6 +609,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_pg_plugins":           rds.DataSourcePgPlugins(),
 			"huaweicloud_rds_mysql_databases":      rds.DataSourceRdsMysqlDatabases(),
 			"huaweicloud_rds_mysql_accounts":       rds.DataSourceRdsMysqlAccounts(),
+			"huaweicloud_rds_mysql_binlog":         rds.DataSourceRdsMysqlBinlog(),
 			"huaweicloud_rds_parametergroups":      rds.DataSourceParametergroups(),
 
 			"huaweicloud_rms_policy_definitions":           rms.DataSourcePolicyDefinitions(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_binlog_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_binlog_test.go
@@ -1,0 +1,47 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccMysqlBinlogDataSource_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_rds_mysql_binlog.test"
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
+		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMysqlBinlogDataSource_basic(name, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "binlog_retention_hours"),
+					resource.TestCheckResourceAttrPair(rName, "binlog_retention_hours",
+						"huaweicloud_rds_mysql_binlog.test", "binlog_retention_hours"),
+				),
+			},
+		},
+	})
+}
+
+func testAccMysqlBinlogDataSource_basic(name string, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rds_mysql_binlog" "test" {
+  depends_on  = [huaweicloud_rds_mysql_binlog.test]
+  instance_id = huaweicloud_rds_mysql_binlog.test.instance_id
+}
+
+`, testMysqlBinlog_basic(name, dbPwd))
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_mysql_binlog.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_mysql_binlog.go
@@ -1,0 +1,93 @@
+package rds
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RDS GET /v3/{project_id}/instances/{instance_id}/binlog/clear-policy
+func DataSourceRdsMysqlBinlog() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsmysqlBinlogRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"binlog_retention_hours": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRdsmysqlBinlogRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	var mErr *multierror.Error
+	var (
+		getMysqlBinlogHttpUrl = "v3/{project_id}/instances/{instance_id}/binlog/clear-policy"
+		getMysqlBinlogProduct = "rds"
+	)
+	getMysqlBinlogClient, err := cfg.NewServiceClient(getMysqlBinlogProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+	getMysqlBinlogPath := getMysqlBinlogClient.Endpoint + getMysqlBinlogHttpUrl
+	getMysqlBinlogPath = strings.ReplaceAll(getMysqlBinlogPath, "{project_id}", getMysqlBinlogClient.ProjectID)
+	getMysqlBinlogPath = strings.ReplaceAll(getMysqlBinlogPath, "{instance_id}", fmt.Sprintf("%v",
+		d.Get("instance_id")))
+	getMysqlBinlogOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	}
+
+	getMysqlBinlogResp, err := getMysqlBinlogClient.Request("GET", getMysqlBinlogPath, &getMysqlBinlogOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getMysqlBinlogRespBody, err := utils.FlattenResponse(getMysqlBinlogResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	retentionHours := utils.PathSearch("binlog_retention_hours", getMysqlBinlogRespBody, nil)
+
+	if retentionHours == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("binlog_retention_hours", retentionHours),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 add rds MySQL binlogs data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
 add rds MySQL binlogs data source
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-ru
n TestAccMysqlBinlogs_basic'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlBinlogs_basic -timeout 360m -parallel 4 
=== RUN   TestAccMysqlBinlogs_basic 
=== PAUSE TestAccMysqlBinlogs_basic
=== CONT  TestAccMysqlBinlogs_basic
--- PASS: TestAccMysqlBinlogs_basic (487.24s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       487.282s
```
