### PR TITLE
fix(nat): remove unsupported characters when ECS instance reset password

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -474,11 +474,17 @@ func RandomCidrAndGatewayIp() (string, string) {
 	return fmt.Sprintf("172.16.%d.0/24", seed), fmt.Sprintf("172.16.%d.1", seed)
 }
 
-func RandomPassword() string {
+func RandomPassword(customChars ...string) string {
+	var specialChars string
+	if len(customChars) < 1 {
+		specialChars = "~!@#%^*-_=+?"
+	} else {
+		specialChars = customChars[0]
+	}
 	return fmt.Sprintf("%s%s%s%d",
 		acctest.RandStringFromCharSet(2, "ABCDEFGHIJKLMNOPQRSTUVWXZY"),
 		acctest.RandStringFromCharSet(3, acctest.CharSetAlpha),
-		acctest.RandStringFromCharSet(2, "~!@#%^*-_=+?"),
+		acctest.RandStringFromCharSet(2, specialChars),
 		acctest.RandIntRange(1000, 9999))
 }
 

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_dnat_rule_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_dnat_rule_test.go
@@ -149,7 +149,7 @@ resource "huaweicloud_nat_private_gateway" "test" {
   name                  = "%[2]s"
   enterprise_project_id = "0"
 }
-`, common.TestBaseComputeResources(name), name, acceptance.RandomPassword())
+`, common.TestBaseComputeResources(name), name, acceptance.RandomPassword("!@%-_=+[]:./?"))
 }
 
 func testAccPrivateDnatRule_basic_step_1(name string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Resolve the issue of test case failure caused by the ECS instance password contains forbided chars.
1.The common function  RandomPassword  contains special characters are following:
~!@#%^\*-\_=+?
2. Support special characters when ECS instance reset password are the following:
!@%-_=+[]:./?
3. Remove unsupported special characters in password characters when ECS instance reset password,the forbided
chars are the following: 
~#^\*

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Modify the logic of common function RandomPassword.
2. Modify the test case of the private dnat rule.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_Psnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_basic
=== PAUSE TestAccPrivateDnatRule_basic
=== CONT  TestAccPrivateDnatRule_basic
--- PASS: TestAccPrivateDnatRule_basic (392.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       392.871s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_Psnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_elbBackend"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_elbBackend -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_elbBackend
=== PAUSE TestAccPrivateDnatRule_elbBackend
=== CONT  TestAccPrivateDnatRule_elbBackend
--- PASS: TestAccPrivateDnatRule_elbBackend (490.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       490.918s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_Psnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_vipBackend"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_vipBackend -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_vipBackend
=== PAUSE TestAccPrivateDnatRule_vipBackend
=== CONT  TestAccPrivateDnatRule_vipBackend
--- PASS: TestAccPrivateDnatRule_vipBackend (211.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       211.608s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_Psnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule_customIpAddress"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule_customIpAddress -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_customIpAddress
=== PAUSE TestAccPrivateDnatRule_customIpAddress
=== CONT  TestAccPrivateDnatRule_customIpAddress
--- PASS: TestAccPrivateDnatRule_customIpAddress (236.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       236.071s
```