### PR TITLE
feat(workspace): add datasource to get the list of desktops

### DIFF
--- a/docs/data-sources/workspace_desktops.md
+++ b/docs/data-sources/workspace_desktops.md
@@ -1,0 +1,146 @@
+---
+subcategory: "Workspace"
+---
+
+# huaweicloud_workspace_desktops
+
+Use this data source to get the list of Workspace desktops within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "desktop_id" {}
+
+data "huaweicloud_workspace_desktops" "test" {
+  desktop_id = var.desktop_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `desktop_id` - (Optional, String) Specifies ID of the desktop.
+
+* `name` - (Optional, String) Specifies the name of the desktop.
+
+* `user_name` - (Optional, String) Specifies the user name to which the desktops belongs.
+
+* `fixed_ip` - (Optional, String) Specifies the fixed IP address of the desktop.
+
+* `desktop_type` - (Optional, String) Specifies the type of the desktops.
+  The valid values are as follows:
+  + **DEDICATED**: Normal desktop.
+  + **POOLED**: Desktop in the Workspace desktop pool.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs used to query the desktops.
+
+* `user_attached` - (Optional, String) Specify whether to query desktops by assigned users.
+  The value can be **true** and **false**.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the desktops.
+
+* `image_id` - (Optional, String) Specifies the image ID of the desktops.
+
+* `in_maintenance_mode` - (Optional, String) Specify whether to query desktops by maintenance mode.
+  The value can be **true** and **false**.
+
+* `status` - (Optional, String) Specifies the status of the desktops.
+  The valid values are as follows: **ACTIVE**, **SHUTOFF**, **ERROR**.
+
+* `subnet_id` - (Optional, String) Specifies the subnet ID of desktops.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `desktops` - The list of the desktops.  
+  The [desktops](#workspace_desktops) structure is documented below.
+
+<a name="workspace_desktops"></a>
+The `desktops` block supports:
+
+* `id` - The desktop ID.
+
+* `name` - The desktop name.
+
+* `type` - The desktop type.
+
+* `enterprise_project_id` - The enterprise project ID to which the desktop belongs.
+
+* `image_id` - The image ID of the desktop.
+
+* `status` - The status of the desktop.
+
+* `in_maintenance_mode` - Whether the desktop is in maintenance mode.
+
+* `subnet_id` - The subnet ID to which the desktop belongs.
+
+* `tags` - The key/value pairs to associate with the desktop.
+
+* `internet_mode` - The access mode of desktop.
+  The valid values are as follows: **NAT**, **EIP**, **BOTH**.
+
+* `ip_addresses` - The list of fixed IP addresses.
+
+* `root_volume` - The root volume to which the desktop belongs.
+  The [root_volume](#desktop_volume) structure is documented below.
+
+* `data_volume` - The data volumes to which the desktop belongs.
+  The [data_volume](#desktop_volume) structure is documented below.
+
+* `availability_zone` - The availability zone to which the desktop belongs.
+
+* `attach_user_infos` - The list of user information assigned to the desktop.
+  The [attach_user_infos](#desktop_attach_user_infos) structure is documented below.
+
+* `created_at` - The creation time of the desktop.
+
+* `site_name` - The site name of desktop.
+
+* `site_type` - The site type of desktop.
+
+* `attach_state` - The assignment status of the desktop.
+
+* `product_id` - The product ID used by the desktop.
+
+* `flavor_id` - The flavor ID used by the desktop.
+
+* `ou_name` - The ou name used by the desktop.
+
+* `ou_version` - The ou version used by the desktop.
+
+* `join_domain` - Whether Connect to AD domain when the desktop was created. The valid values are as follows:
+  + **0**: Indicates AD domain enabled.
+  + **1**: Indicates AD domain not enabled.
+
+* `is_support_internet` - Whether the desktop is associated with an EIP.
+
+<a name="desktop_attach_user_infos"></a>
+The `attach_user_infos` block supports:
+
+* `user_group` - The user group to which the desktop belongs.
+
+* `user_name` - The user name to which the desktop belongs.
+
+<a name="desktop_volume"></a>
+The `root_volume` and `data_volume` block supports:
+
+* `type` - The volume type.
+
+* `size` - The volume size.
+
+* `device` - The device of the volume.
+
+* `id` - The unique identification ID of the disk.
+
+* `name` - The volume name.
+
+* `volume_id` - The volume ID.
+
+* `created_at` - The creation time of the volume.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -658,7 +658,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_address_groups":      waf.DataSourceWafAddressGroups(),
 			"huaweicloud_dws_flavors":             dws.DataSourceDwsFlavors(),
 
-			"huaweicloud_workspace_flavors": workspace.DataSourceWorkspaceFlavors(),
+			"huaweicloud_workspace_desktops": workspace.DataSourceDesktops(),
+			"huaweicloud_workspace_flavors":  workspace.DataSourceWorkspaceFlavors(),
 
 			// Legacy
 			"huaweicloud_images_image_v2":        ims.DataSourceImagesImageV2(),

--- a/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktops_test.go
+++ b/huaweicloud/services/acceptance/workspace/data_source_huaweicloud_workspace_desktops_test.go
@@ -1,0 +1,253 @@
+package workspace
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDesktops_basic(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceNameWithDash()
+		dataSourceName = "data.huaweicloud_workspace_desktops.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byDesktopId   = "data.huaweicloud_workspace_desktops.filter_by_desktop_id"
+		dcByDesktopId = acceptance.InitDataSourceCheck(byDesktopId)
+
+		byName   = "data.huaweicloud_workspace_desktops.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byUserName = "data.huaweicloud_workspace_desktops.filter_by_user_name"
+		dcUserName = acceptance.InitDataSourceCheck(byUserName)
+
+		byTags = "data.huaweicloud_workspace_desktops.filter_by_tags"
+		dcTags = acceptance.InitDataSourceCheck(byTags)
+
+		byImageId = "data.huaweicloud_workspace_desktops.filter_by_image_id"
+		dcImageId = acceptance.InitDataSourceCheck(byImageId)
+
+		byEnterpriseProjectId = "data.huaweicloud_workspace_desktops.filter_by_eps_id"
+		dcEnterpriseProjectId = acceptance.InitDataSourceCheck(byEnterpriseProjectId)
+
+		bySubnetId = "data.huaweicloud_workspace_desktops.filter_by_subnet_id"
+		dcSubnetId = acceptance.InitDataSourceCheck(bySubnetId)
+
+		byStatus = "data.huaweicloud_workspace_desktops.filter_by_status"
+		dcStatus = acceptance.InitDataSourceCheck(byStatus)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDesktops_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "desktops.#"),
+					resource.TestCheckResourceAttr(dataSourceName, "desktops.0.is_support_internet", "false"),
+					dcByDesktopId.CheckResourceExists(),
+					resource.TestCheckOutput("is_desktop_id_filter_useful", "true"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+
+					dcUserName.CheckResourceExists(),
+					resource.TestCheckOutput("is_user_name_filter_useful", "true"),
+
+					dcTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+
+					dcImageId.CheckResourceExists(),
+					resource.TestCheckOutput("is_image_id_filter_useful", "true"),
+
+					dcEnterpriseProjectId.CheckResourceExists(),
+					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
+
+					dcSubnetId.CheckResourceExists(),
+					resource.TestCheckOutput("is_subnet_id_filter_useful", "true"),
+
+					dcStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDesktops_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+		
+data "huaweicloud_workspace_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  os_type           = "Windows"
+}
+
+resource "huaweicloud_workspace_desktop" "test" {
+  flavor_id         = try(data.huaweicloud_workspace_flavors.test.flavors[0].id)
+  image_type        = "market"
+  image_id          = try(data.huaweicloud_images_images.test.images[0].id)
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  security_groups   = [
+    huaweicloud_workspace_service.test.desktop_security_group.0.id,
+    huaweicloud_networking_secgroup.test.id,
+  ]
+
+  nic {
+    network_id = huaweicloud_vpc_subnet.test.id
+  }
+
+  name        = "%[2]s"
+  user_name   = "user-%[2]s"
+  user_email  = "terraform@example.com"
+  user_group  = "administrators"
+  delete_user = true
+
+  root_volume {
+    type = "SAS"
+    size = 80
+  }
+
+  data_volume {
+    type = "SAS"
+    size = 50
+  }
+}
+
+data "huaweicloud_workspace_desktops" "test" {
+  depends_on = [
+    huaweicloud_workspace_desktop.test
+  ] 
+}
+
+// By desktop ID filter
+locals {
+  desktop_id = data.huaweicloud_workspace_desktops.test.desktops[0].id
+}
+
+data "huaweicloud_workspace_desktops" "filter_by_desktop_id" {
+  desktop_id = local.desktop_id
+}
+
+output "is_desktop_id_filter_useful" {
+  value = length(data.huaweicloud_workspace_desktops.filter_by_desktop_id.desktops) == 1 && alltrue(
+    [for v in data.huaweicloud_workspace_desktops.filter_by_desktop_id.desktops[*].id : v == local.desktop_id]
+  )
+}
+
+// By desktop name filter
+locals {
+  name = data.huaweicloud_workspace_desktops.test.desktops[0].name
+}
+
+data "huaweicloud_workspace_desktops" "filter_by_name" {
+  name = local.name
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_workspace_desktops.filter_by_name.desktops) > 0 && alltrue(
+    [for v in data.huaweicloud_workspace_desktops.filter_by_name.desktops[*].name : v == local.name]
+  )
+}
+
+// By user name filter
+locals {
+  user_name = data.huaweicloud_workspace_desktops.test.desktops[0].attach_user_infos[0].user_name
+}
+
+data "huaweicloud_workspace_desktops" "filter_by_user_name" {
+  user_name = local.user_name
+}
+
+output "is_user_name_filter_useful" {
+  value = length(data.huaweicloud_workspace_desktops.filter_by_user_name.desktops) > 0 && alltrue(
+    [for v in data.huaweicloud_workspace_desktops.filter_by_user_name.desktops[*].attach_user_infos[0].user_name : v == local.user_name]
+  )
+}
+
+// By tags filter
+locals {
+  tags = data.huaweicloud_workspace_desktops.test.desktops[0].tags
+}
+
+data "huaweicloud_workspace_desktops" "filter_by_tags" {
+  tags = local.tags
+}
+
+locals {
+  tags_filter_result = [
+    for v in data.huaweicloud_workspace_desktops.filter_by_tags.desktops[*].tags : v == local.tags
+  ]
+}
+
+output "is_tags_filter_useful" {
+  value = alltrue(local.tags_filter_result) && length(local.tags_filter_result) > 0
+}
+
+// By image ID filter
+locals {
+  image_id = data.huaweicloud_workspace_desktops.test.desktops[0].image_id
+}
+
+data "huaweicloud_workspace_desktops" "filter_by_image_id" {
+  image_id = local.image_id
+}
+
+output "is_image_id_filter_useful" {
+  value = length(data.huaweicloud_workspace_desktops.filter_by_image_id.desktops) > 0 && alltrue(
+    [for v in data.huaweicloud_workspace_desktops.filter_by_image_id.desktops[*].image_id : v == local.image_id]
+  )
+}
+
+// By enperprise project ID filter
+locals {
+  eps_id = data.huaweicloud_workspace_desktops.test.desktops[0].enterprise_project_id
+}
+
+data "huaweicloud_workspace_desktops" "filter_by_eps_id" {
+  enterprise_project_id = local.eps_id
+}
+
+output "is_enterprise_project_id_filter_useful" {
+  value = length(data.huaweicloud_workspace_desktops.filter_by_eps_id.desktops) > 0 && alltrue(
+    [for v in data.huaweicloud_workspace_desktops.filter_by_eps_id.desktops[*].enterprise_project_id : v == local.eps_id]
+  )
+}
+
+// By subnet ID filter
+locals {
+  subnet_id = data.huaweicloud_workspace_desktops.test.desktops[0].subnet_id
+}
+
+data "huaweicloud_workspace_desktops" "filter_by_subnet_id" {
+  subnet_id = local.subnet_id
+}
+
+output "is_subnet_id_filter_useful" {
+  value = length(data.huaweicloud_workspace_desktops.filter_by_subnet_id.desktops) > 0 && alltrue(
+    [for v in data.huaweicloud_workspace_desktops.filter_by_subnet_id.desktops[*].subnet_id : v == local.subnet_id]
+  )
+}
+
+// By desktop status filter
+locals {
+  status = data.huaweicloud_workspace_desktops.test.desktops[0].status
+}
+
+data "huaweicloud_workspace_desktops" "filter_by_status" {
+  status = local.status
+}
+
+output "is_status_filter_useful" {
+  value = length(data.huaweicloud_workspace_desktops.filter_by_status.desktops) > 0 && alltrue(
+    [for v in data.huaweicloud_workspace_desktops.filter_by_status.desktops[*].status : v == local.status]
+  )
+}
+`, testAccDesktop_base(rName), rName)
+}

--- a/huaweicloud/services/workspace/data_source_huaweicloud_workspace_desktops.go
+++ b/huaweicloud/services/workspace/data_source_huaweicloud_workspace_desktops.go
@@ -1,0 +1,453 @@
+package workspace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: GET /v2/{project_id}/desktops/detail
+func DataSourceDesktops() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDesktopsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"desktop_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"fixed_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"desktop_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": common.TagsSchema(),
+			"user_attached": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"in_maintenance_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"desktops": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     desktopSchema(),
+			},
+		},
+	}
+}
+
+func desktopSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"in_maintenance_mode": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"internet_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_addresses": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"root_volume": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     volumeSchema(),
+			},
+			"data_volume": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     volumeSchema(),
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attach_user_infos": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_group": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"site_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"site_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ou_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ou_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attach_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"join_domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_support_internet": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func volumeSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"device": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildListDesktopsQueryParams(cfg *config.Config, d *schema.ResourceData) string {
+	queryParam := ""
+	if v, ok := d.GetOk("desktop_id"); ok {
+		queryParam += fmt.Sprintf("&desktop_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		queryParam += fmt.Sprintf("&computer_name=%v", v)
+	}
+
+	if v, ok := d.GetOk("user_name"); ok {
+		queryParam += fmt.Sprintf("&user_name=%v", v)
+	}
+
+	if v, ok := d.GetOk("fixed_ip"); ok {
+		queryParam += fmt.Sprintf("&desktop_ip=%v", v)
+	}
+
+	if v, ok := d.GetOk("desktop_type"); ok {
+		queryParam += fmt.Sprintf("&desktop_type=%v", v)
+	}
+
+	if v, ok := d.GetOk("user_attached"); ok {
+		queryParam += fmt.Sprintf("&user_attached=%v", v)
+	}
+
+	if v, ok := d.GetOk("image_id"); ok {
+		queryParam += fmt.Sprintf("&image_id=%v", v)
+	}
+
+	if v, ok := d.GetOk("in_maintenance_mode"); ok {
+		queryParam += fmt.Sprintf("&in_maintenance_mode=%v", v)
+	}
+
+	if v, ok := d.GetOk("status"); ok {
+		queryParam += fmt.Sprintf("&status=%v", v)
+	}
+
+	if v, ok := d.GetOk("subnet_id"); ok {
+		queryParam += fmt.Sprintf("&subnet_id=%v", v)
+	}
+
+	epsID := cfg.GetEnterpriseProjectID(d)
+	if epsID != "" {
+		queryParam = fmt.Sprintf("%s&enterprise_project_id=%v", queryParam, epsID)
+	}
+
+	if queryParam != "" {
+		queryParam = "?" + queryParam[1:]
+	}
+
+	return queryParam
+}
+
+func dataSourceDesktopsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.WorkspaceV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace v2 client: %s", err)
+	}
+
+	listDesktopsPath := client.ResourceBaseURL() + "desktops/detail"
+	listDesktopsQueryParams := buildListDesktopsQueryParams(cfg, d)
+	listDesktopsPath += listDesktopsQueryParams
+
+	resp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		listDesktopsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving Workspace desktops")
+	}
+
+	listRespJson, err := json.Marshal(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listRespBody interface{}
+	err = json.Unmarshal(listRespJson, &listRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	curJson := utils.PathSearch("desktops", listRespBody, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("desktops", flattenListDesktops(filterListDesktopByTags(curArray, d))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterListDesktopByTags(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	tagFilter := d.Get("tags").(map[string]interface{})
+	if len(tagFilter) == 0 {
+		return all
+	}
+
+	for _, v := range all {
+		tags := utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil))
+		tagmap := utils.ExpandToStringMap(tags)
+		if !utils.HasMapContains(tagmap, tagFilter) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func flattenListDesktops(resp []interface{}) []interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(resp))
+	for i, v := range resp {
+		rst[i] = map[string]interface{}{
+			"id":                    utils.PathSearch("desktop_id", v, nil),
+			"name":                  utils.PathSearch("computer_name", v, nil),
+			"type":                  utils.PathSearch("desktop_type", v, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+			"image_id":              utils.PathSearch("metadata.\"metering.image_id\"", v, nil),
+			"status":                utils.PathSearch("status", v, nil),
+			"in_maintenance_mode":   utils.PathSearch("in_maintenance_mode", v, false).(bool),
+			"subnet_id":             utils.PathSearch("subnet_id", v, nil),
+			"tags":                  utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
+			"internet_mode":         utils.PathSearch("internet_mode", v, nil),
+			"ip_addresses":          utils.PathSearch("ip_addresses", v, nil),
+			"root_volume":           flattenRootVolume(utils.PathSearch("root_volume", v, nil)),
+			"data_volume":           flattenDataVolumes(utils.PathSearch("data_volumes", v, make([]interface{}, 0))),
+			"availability_zone":     utils.PathSearch("availability_zone", v, nil),
+			"attach_user_infos":     flattenAttachUserInfos(utils.PathSearch("attach_user_infos", v, make([]interface{}, 0))),
+			"created_at":            utils.PathSearch("created", v, nil),
+			"site_type":             utils.PathSearch("site_type", v, nil),
+			"site_name":             utils.PathSearch("site_name", v, nil),
+			"product_id":            utils.PathSearch("product_id", v, nil),
+			"flavor_id":             utils.PathSearch("product.flavor_id", v, nil),
+			"ou_name":               utils.PathSearch("ou_name", v, nil),
+			"ou_version":            utils.PathSearch("ou_version", v, nil),
+			"attach_state":          utils.PathSearch("attach_state", v, nil),
+			"join_domain":           utils.PathSearch("join_domain", v, nil),
+			"is_support_internet":   utils.PathSearch("is_support_internet", v, nil),
+		}
+	}
+	return rst
+}
+
+func getVolume(volume interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type":       utils.PathSearch("type", volume, nil),
+		"size":       utils.PathSearch("size", volume, nil),
+		"device":     utils.PathSearch("device", volume, nil),
+		"id":         utils.PathSearch("id", volume, nil),
+		"volume_id":  utils.PathSearch("volume_id", volume, nil),
+		"created_at": utils.PathSearch("create_time", volume, nil),
+		"name":       utils.PathSearch("display_name", volume, nil),
+	}
+}
+
+func flattenRootVolume(volume interface{}) []map[string]interface{} {
+	if volume == nil {
+		return nil
+	}
+
+	rootVolume := []map[string]interface{}{getVolume(volume)}
+	return rootVolume
+}
+
+func flattenDataVolumes(curRaw interface{}) []map[string]interface{} {
+	curArray := curRaw.([]interface{})
+	if len(curArray) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(curArray))
+	for i, volume := range curArray {
+		result[i] = getVolume(volume)
+	}
+	return result
+}
+
+func flattenAttachUserInfos(raw interface{}) []map[string]interface{} {
+	curArray := raw.([]interface{})
+	if len(curArray) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(curArray))
+	for i, volume := range curArray {
+		result[i] = map[string]interface{}{
+			"user_name":  utils.PathSearch("user_name", volume, nil),
+			"user_group": utils.PathSearch("user_group", volume, nil),
+		}
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add workspace desktops datasource.

New dataSource:
+ huaweicloud_workspace_desktops

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. using this data source to get the list of Workspace desktops.
2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccDataSourceDesktops_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccDataSourceDesktops_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDesktops_basic
--- PASS: TestAccDataSourceDesktops_basic (524.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 524.813s
```
