### PR TITLE
docs(cce): add examples of manage PVC with k8s provider

### DIFF
--- a/examples/cce/cce-with-kubernetes/manage-storage/README.md
+++ b/examples/cce/cce-with-kubernetes/manage-storage/README.md
@@ -1,0 +1,11 @@
+# cce-with-kubernetes
+
+In this example, we will create a CCE cluster with EIP,
+then we will use the Kubernetes provider to connect and manage the cluster.
+We authenticate to the cluster with certificate.
+And we will manage the storage of the cluster with Kubernetes provider.
+
+For more information about the storage,
+[please see document](https://support.huaweicloud.com/intl/en-us/usermanual-cce/cce_10_0307.html).
+For more information about the Kubernetes provider,
+[please see document](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs).

--- a/examples/cce/cce-with-kubernetes/manage-storage/pvc-with-existing-OBS-bucket/README.md
+++ b/examples/cce/cce-with-kubernetes/manage-storage/pvc-with-existing-OBS-bucket/README.md
@@ -1,0 +1,13 @@
+# cce-with-kubernetes
+
+In this example, we will create a CCE cluster with EIP,
+then we will use the Kubernetes provider to connect and manage the cluster.
+We authenticate to the cluster with certificate.
+We create an OBS bucket, and use this bucket to create a PVC.
+
+For more information about using an existing OBS bucket through a static PV,
+[please see document](https://support.huaweicloud.com/intl/en-us/usermanual-cce/cce_10_0379.html).
+For more information about the Kubernetes PVC resource,
+[please see document](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/persistent_volume_claim).
+For more information about the Kubernetes PV resource,
+[please see document](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/persistent_volume).

--- a/examples/cce/cce-with-kubernetes/manage-storage/pvc-with-existing-OBS-bucket/main.tf
+++ b/examples/cce/cce-with-kubernetes/manage-storage/pvc-with-existing-OBS-bucket/main.tf
@@ -1,0 +1,209 @@
+data "huaweicloud_availability_zones" "myaz" {}
+
+data "huaweicloud_vpc" "myvpc" {
+  id = var.vpc_id
+}
+
+data "huaweicloud_vpc_subnet" "mysubnet" {
+  id = var.subnet_id
+}
+
+resource "huaweicloud_vpc_eip" "cce" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "cce-apiserver"
+    size        = 20
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_cce_cluster" "cluster" {
+  name                   = var.cce_name
+  cluster_type           = "VirtualMachine"
+  cluster_version        = "v1.19"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = data.huaweicloud_vpc.myvpc.id
+  subnet_id              = data.huaweicloud_vpc_subnet.mysubnet.id
+  container_network_type = "overlay_l2"
+  authentication_mode    = "rbac"
+  eip                    = huaweicloud_vpc_eip.cce.address
+  delete_all             = "true"
+}
+
+resource "huaweicloud_cce_node" "cce-node1" {
+  cluster_id        = huaweicloud_cce_cluster.cluster.id
+  name              = "node1"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
+  key_pair          = var.key_pair_name
+
+  root_volume {
+    size       = 80
+    volumetype = "SAS"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SAS"
+  }
+}
+
+resource "huaweicloud_cce_node" "cce-node2" {
+  cluster_id        = huaweicloud_cce_cluster.cluster.id
+  name              = "node2"
+  flavor_id         = "s6.large.2"
+  availability_zone = data.huaweicloud_availability_zones.myaz.names[0]
+  key_pair          = var.key_pair_name
+
+  root_volume {
+    size       = 80
+    volumetype = "SAS"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SAS"
+  }
+}
+
+provider "kubernetes" {
+  host                   = "https://${huaweicloud_vpc_eip.cce.address}:5443"
+  cluster_ca_certificate = base64decode(huaweicloud_cce_cluster.cluster.certificate_clusters[0].certificate_authority_data)
+  client_certificate     = base64decode(huaweicloud_cce_cluster.cluster.certificate_users[0].client_certificate_data)
+  client_key             = base64decode(huaweicloud_cce_cluster.cluster.certificate_users[0].client_key_data)
+}
+
+resource "huaweicloud_obs_bucket" "my-bucket" {
+  bucket   = "my-bucket"
+  multi_az = true
+}
+
+resource "kubernetes_secret" "my-secret" {
+  metadata {
+    name      = "my-secret"
+    namespace = "default"
+
+    labels = {
+      "secret.kubernetes.io/used-by" = "csi"
+    }
+  }
+
+  data = {
+    "access.key" = "my_access_key"
+    "secret.key" = "my_secret_key"
+  }
+
+  type = "cfe/secure-opaque"
+}
+
+resource "kubernetes_persistent_volume" "my-pv" {
+  metadata {
+    name = "my-pv-obs"
+
+    annotations = {
+      "pv.kubernetes.io/provisioned-by" = "everest-csi-provisioner"
+      "everest.io/reclaim-policy"       = "retain-volume-only"
+    }
+  }
+  spec {
+    access_modes = ["ReadWriteMany"]
+
+    capacity = {
+      storage = "1Gi"
+    }
+    persistent_volume_source {
+      csi {
+        driver        = "obs.csi.everest.io"
+        fs_type       = "s3fs"
+        volume_handle = huaweicloud_obs_bucket.my-bucket.bucket
+
+        volume_attributes = {
+          "storage.kubernetes.io/csiProvisionerIdentity" = "everest-csi-provisioner"
+          "everest.io/obs-volume-type"                   = "STANDARD"
+          "everest.io/region"                            = "my_region"
+          "everest.io/enterprise-project-id"             = "0"
+        }
+
+        node_publish_secret_ref {
+          name      = kubernetes_secret.my-secret.metadata[0].name
+          namespace = kubernetes_secret.my-secret.metadata[0].namespace
+        }
+      }
+    }
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = "csi-obs"
+  }
+}
+
+resource "kubernetes_persistent_volume_claim" "my-pvc" {
+  metadata {
+    name      = "my-pvc-obs"
+    namespace = "default"
+
+    annotations = {
+      "volume.beta.kubernetes.io/storage-provisioner"    = "everest-csi-provisioner"
+      "everest.io/obs-volume-type"                       = "STANDARD"
+      "csi.storage.k8s.io/fstype"                        = "s3fs"
+      "csi.storage.k8s.io/node-publish-secret-name"      = kubernetes_secret.my-secret.metadata[0].name
+      "csi.storage.k8s.io/node-publish-secret-namespace" = kubernetes_secret.my-secret.metadata[0].namespace
+      "everest.io/enterprise-project-id"                 = "0"
+    }
+  }
+  spec {
+    access_modes = ["ReadWriteMany"]
+    resources {
+      requests = {
+        storage = "1Gi"
+      }
+    }
+    storage_class_name = "csi-obs"
+    volume_name        = kubernetes_persistent_volume.my-pv.metadata.0.name
+  }
+}
+
+resource "kubernetes_deployment" "my-deployment" {
+  metadata {
+    name      = "web-demo"
+    namespace = "default"
+  }
+
+  spec {
+    replicas = 2
+
+    selector {
+      match_labels = {
+        app = "web-demo"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "web-demo"
+        }
+      }
+
+      spec {
+        container {
+          name  = "container-1"
+          image = "nginx:latest"
+
+          volume_mount {
+            name       = "pvc-obs-volume"
+            mount_path = "/data"
+          }
+        }
+        image_pull_secrets {
+          name = "default-secret"
+        }
+        volume {
+          name = "pvc-obs-volume"
+          persistent_volume_claim {
+            claim_name = kubernetes_persistent_volume_claim.my-pvc.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/cce/cce-with-kubernetes/manage-storage/pvc-with-new-OBS-bucket/README.md
+++ b/examples/cce/cce-with-kubernetes/manage-storage/pvc-with-new-OBS-bucket/README.md
@@ -1,0 +1,13 @@
+# cce-with-kubernetes
+
+In this example, we will create a CCE cluster with EIP,
+then we will use the Kubernetes provider to connect and manage the cluster.
+We authenticate to the cluster with certificate.
+We create a PVC, which will create a new OBS automatically.
+
+For more information about using an OBS bucket through a dynamic PV,
+[please see document](https://support.huaweicloud.com/intl/en-us/usermanual-cce/cce_10_0630.html).
+For more information about the Kubernetes PVC resource,
+[please see document](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/persistent_volume_claim).
+For more information about the Kubernetes PV resource,
+[please see document](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/persistent_volume).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The APIs used in resource huaweicloud_cce_pvc are deprecated.
So we won't do anymore work in this resource.

As an alternative, we recommend customers to use the kubernetes provider to mange PVC in a CCE cluster.
In this PR, I add some examples of using OBS as PVC with the kubernetes provider.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
