### PR TITLE
feat(eip): add data source vpc bandwidths

### DIFF
--- a/docs/data-sources/vpc_bandwidths.md
+++ b/docs/data-sources/vpc_bandwidths.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# huaweicloud_vpc_bandwidths
+
+Use this data source to get a list of shared bandwidths.
+
+## Example Usage
+
+### Example Usage of getting all bandwidths
+
+```hcl
+data "huaweicloud_vpc_bandwidth" "all" {}
+```
+
+### Example Usage to filter specific bandwidths
+
+```hcl
+variable "bandwidth_name" {}
+
+data "huaweicloud_vpc_bandwidth" "filter_by_name" {
+  name = var.bandwidth_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the bandwidths.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the bandwidth.
+
+* `size` - (Optional, Int) Specifies the size of the bandwidth.
+
+* `bandwidth_id` - (Optional, String) Specifies the ID of the bandwidth.
+
+* `charge_mode` - (Optional, String) Specifies the charge mode of the bandwidth.
+  Possible values can be **bandwidth** and **95peak_plus**.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `bandwidths` - The filtered bandwidths.
+  The [bandwidths](#attrblock--bandwidths) structure is documented below.
+
+<a name="attrblock--bandwidths"></a>
+The `bandwidths` block supports:
+
+* `id` - Indicates the ID of the bandwidth.
+
+* `bandwidth_type` - Indicates the bandwidth type.
+
+* `charge_mode` - Indicates the charge mode of the bandwidth.
+
+* `enterprise_project_id` - Indicates the enterprise project id the bandwidth belongs to.
+
+* `name` - Indicates the name of the bandwidth.
+
+* `publicips` - An array of EIPs that use the bandwidth. The object includes the following:
+  The [publicips](#attrblock--bandwidths--publicips) structure is documented below.
+
+* `share_type` - Indicates whether the bandwidth is shared or dedicated.
+
+* `size` - Indicates the size of the bandwidth.
+
+* `status` - Indicates the status of the bandwidth.
+
+<a name="attrblock--bandwidths--publicips"></a>
+The `publicips` block supports:
+
+* `id` - The ID of the EIP or IPv6 port that uses the bandwidth.
+
+* `ip_address` - The IPv4 or IPv6 address.
+
+* `ip_version` - The IP version.
+
+* `type` - The EIP type.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -629,9 +629,10 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_tms_resource_types": tms.DataSourceResourceTypes(),
 
-			"huaweicloud_vpc_bandwidth": eip.DataSourceBandWidth(),
-			"huaweicloud_vpc_eip":       eip.DataSourceVpcEip(),
-			"huaweicloud_vpc_eips":      eip.DataSourceVpcEips(),
+			"huaweicloud_vpc_bandwidth":  eip.DataSourceBandWidth(),
+			"huaweicloud_vpc_bandwidths": eip.DataSourceBandWidths(),
+			"huaweicloud_vpc_eip":        eip.DataSourceVpcEip(),
+			"huaweicloud_vpc_eips":       eip.DataSourceVpcEips(),
 
 			"huaweicloud_vpc":                    vpc.DataSourceVpcV1(),
 			"huaweicloud_vpcs":                   vpc.DataSourceVpcs(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_bandwidths_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_vpc_bandwidths_test.go
@@ -1,0 +1,271 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBandWidthsDataSource_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.huaweicloud_vpc_bandwidths.all"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBandWidthsDataSource_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "bandwidths.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBandWidthsDataSourceBase(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name                  = "%s"
+  size                  = 5
+  enterprise_project_id = "%s"
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    share_type = "WHOLE"
+    id         = huaweicloud_vpc_bandwidth.test.id
+  }
+}
+`, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccBandWidthsDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_vpc_bandwidths" "all" {
+  depends_on = [huaweicloud_vpc_eip.test]
+}
+`, testAccBandWidthsDataSourceBase(rName))
+}
+
+func TestAccBandWidthsDataSource_filter(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSourceName := "huaweicloud_vpc_bandwidth.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	eipResourceName := "huaweicloud_vpc_eip.test"
+
+	byEpsId := "data.huaweicloud_vpc_bandwidths.filter_by_eps_id"
+	byEpsIdNotFound := "data.huaweicloud_vpc_bandwidths.filter_by_eps_id_not_found"
+	dcbyEpsId := acceptance.InitDataSourceCheck(byEpsId)
+	dcbyEpsIdNotFound := acceptance.InitDataSourceCheck(byEpsIdNotFound)
+
+	byName := "data.huaweicloud_vpc_bandwidths.filter_by_name"
+	byNameNotFound := "data.huaweicloud_vpc_bandwidths.filter_by_name_not_found"
+	dcbyName := acceptance.InitDataSourceCheck(byName)
+	dcbyNameNotFound := acceptance.InitDataSourceCheck(byNameNotFound)
+
+	bySize := "data.huaweicloud_vpc_bandwidths.filter_by_size"
+	bySizeNotFound := "data.huaweicloud_vpc_bandwidths.filter_by_size_not_found"
+	dcbySize := acceptance.InitDataSourceCheck(bySize)
+	dcbySizeNotFound := acceptance.InitDataSourceCheck(bySizeNotFound)
+
+	byChargeMode := "data.huaweicloud_vpc_bandwidths.filter_by_charge_mode"
+	byChargeModeNotFound := "data.huaweicloud_vpc_bandwidths.filter_by_charge_mode_not_found"
+	dcbyChargeMode := acceptance.InitDataSourceCheck(byChargeMode)
+	dcbyChargeModeNotFound := acceptance.InitDataSourceCheck(byChargeModeNotFound)
+
+	byID := "data.huaweicloud_vpc_bandwidths.filter_by_id"
+	byIDNotFound := "data.huaweicloud_vpc_bandwidths.filter_by_id_not_found"
+	dcbyID := acceptance.InitDataSourceCheck(byID)
+	dcbyIDNotFound := acceptance.InitDataSourceCheck(byIDNotFound)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataArtsStudioWorkspaces_filter(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+
+					dcbyEpsId.CheckResourceExists(),
+					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
+					dcbyEpsIdNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_eps_id_filter_useful_not_found", "true"),
+
+					dcbyName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcbyNameNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful_not_found", "true"),
+
+					dcbySize.CheckResourceExists(),
+					resource.TestCheckOutput("is_size_filter_useful", "true"),
+					dcbySizeNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_size_filter_useful_not_found", "true"),
+
+					dcbyChargeMode.CheckResourceExists(),
+					resource.TestCheckOutput("is_charge_mode_filter_useful", "true"),
+					dcbyChargeModeNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_charge_mode_filter_useful_not_found", "true"),
+
+					dcbyID.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					dcbyIDNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful_not_found", "true"),
+					resource.TestCheckResourceAttrPair(byID, "bandwidths.0.publicips.0.id",
+						eipResourceName, "id"),
+					resource.TestCheckResourceAttrPair(byID, "bandwidths.0.publicips.0.ip_address",
+						eipResourceName, "address"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataArtsStudioWorkspaces_filter(rName string) string {
+	randUUID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+%[1]s
+
+// filter_by_eps_id
+data "huaweicloud_vpc_bandwidths" "filter_by_eps_id" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  enterprise_project_id = "%[2]s"
+}
+
+data "huaweicloud_vpc_bandwidths" "filter_by_eps_id_not_found" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  enterprise_project_id = "%[3]s"
+}
+
+locals {
+  filter_result_by_eps_id = [for v in data.huaweicloud_vpc_bandwidths.filter_by_eps_id.bandwidths[*].enterprise_project_id : 
+    v == huaweicloud_vpc_bandwidth.test.enterprise_project_id]
+}
+
+output "is_eps_id_filter_useful" {
+  value = length(local.filter_result_by_eps_id) > 0 && alltrue(local.filter_result_by_eps_id) 
+}
+
+output "is_eps_id_filter_useful_not_found" {
+  value = length(data.huaweicloud_vpc_bandwidths.filter_by_eps_id_not_found.bandwidths) == 0
+}
+
+// filter_by_name
+data "huaweicloud_vpc_bandwidths" "filter_by_name" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  name = "%[4]s"
+}
+
+data "huaweicloud_vpc_bandwidths" "filter_by_name_not_found" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  name = "test-not-found-%[4]s"
+}
+
+locals {
+  filter_result_by_name = [for v in data.huaweicloud_vpc_bandwidths.filter_by_name.bandwidths[*].name :
+    v == huaweicloud_vpc_bandwidth.test.name]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.filter_result_by_name) > 0 && alltrue(local.filter_result_by_name)
+}
+
+output "is_name_filter_useful_not_found" {
+  value = length(data.huaweicloud_vpc_bandwidths.filter_by_name_not_found.bandwidths) == 0
+}
+
+// filter_by_size
+data "huaweicloud_vpc_bandwidths" "filter_by_size" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  size = huaweicloud_vpc_bandwidth.test.size
+}
+
+data "huaweicloud_vpc_bandwidths" "filter_by_size_not_found" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  size = -1
+}
+
+locals {
+  filter_result_by_size = [for v in data.huaweicloud_vpc_bandwidths.filter_by_size.bandwidths[*].size :
+    v == huaweicloud_vpc_bandwidth.test.size]
+}
+
+output "is_size_filter_useful" {
+  value = length(local.filter_result_by_size) > 0 && alltrue(local.filter_result_by_size)
+}
+
+output "is_size_filter_useful_not_found" {
+  value = length(data.huaweicloud_vpc_bandwidths.filter_by_size_not_found.bandwidths) == 0
+}
+
+// filter_by_charge_mode
+data "huaweicloud_vpc_bandwidths" "filter_by_charge_mode" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  charge_mode = huaweicloud_vpc_bandwidth.test.charge_mode
+}
+
+data "huaweicloud_vpc_bandwidths" "filter_by_charge_mode_not_found" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  charge_mode = "95peak_plus"
+}
+
+locals {
+  filter_result_by_charge_mode = [for v in data.huaweicloud_vpc_bandwidths.filter_by_charge_mode.bandwidths[*].charge_mode :
+    v == huaweicloud_vpc_bandwidth.test.charge_mode]
+}
+
+output "is_charge_mode_filter_useful" {
+  value = length(local.filter_result_by_charge_mode) > 0 && alltrue(local.filter_result_by_charge_mode)
+}
+
+output "is_charge_mode_filter_useful_not_found" {
+  value = length(data.huaweicloud_vpc_bandwidths.filter_by_charge_mode_not_found.bandwidths) == 0
+}
+
+// filter_by_id
+data "huaweicloud_vpc_bandwidths" "filter_by_id" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  bandwidth_id = huaweicloud_vpc_bandwidth.test.id
+}
+
+data "huaweicloud_vpc_bandwidths" "filter_by_id_not_found" {
+  depends_on = [huaweicloud_vpc_eip.test]
+
+  bandwidth_id = "%[3]s"
+}
+
+output "is_id_filter_useful" {
+  value = length(data.huaweicloud_vpc_bandwidths.filter_by_id.bandwidths) == 1
+}
+
+output "is_id_filter_useful_not_found" {
+  value = length(data.huaweicloud_vpc_bandwidths.filter_by_id_not_found.bandwidths) == 0
+}
+`, testAccBandWidthsDataSourceBase(rName), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, randUUID, rName)
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_bandwidths.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_bandwidths.go
@@ -1,0 +1,162 @@
+package eip
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: EIP GET /v1/{project_id}/bandwidths
+func DataSourceBandWidths() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBandWidthsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"bandwidth_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"charge_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"bandwidths": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"share_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bandwidth_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"charge_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"publicips": publicIPListComputedSchema(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceBandWidthsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	bwClient, err := cfg.NetworkingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating bandwidth v1 client: %s", err)
+	}
+
+	listOpts := bandwidths.ListOpts{
+		ShareType:           "WHOLE",
+		EnterpriseProjectID: cfg.DataGetEnterpriseProjectID(d),
+	}
+
+	allBWs, err := bandwidths.List(bwClient, listOpts).Extract()
+	if err != nil {
+		return diag.Errorf("unable to list bandwidths: %s", err)
+	}
+
+	filter := map[string]interface{}{}
+	if v, ok := d.GetOk("name"); ok {
+		filter["Name"] = v
+	}
+	if v, ok := d.GetOk("bandwidth_id"); ok {
+		filter["ID"] = v
+	}
+	if v, ok := d.GetOk("size"); ok {
+		filter["Size"] = v
+	}
+	if v, ok := d.GetOk("charge_mode"); ok {
+		filter["ChargeMode"] = v
+	}
+
+	filterBWs, err := utils.FilterSliceWithField(allBWs, filter)
+	if err != nil {
+		return diag.Errorf("filter bandwidths failed: %s", err)
+	}
+
+	rst := make([]map[string]interface{}, len(filterBWs))
+	for i, v := range filterBWs {
+		item := v.(bandwidths.BandWidth)
+		bandwidth := map[string]interface{}{
+			"id":                    item.ID,
+			"name":                  item.Name,
+			"size":                  item.Size,
+			"enterprise_project_id": item.EnterpriseProjectID,
+			"share_type":            item.ShareType,
+			"bandwidth_type":        item.BandwidthType,
+			"charge_mode":           item.ChargeMode,
+			"status":                item.Status,
+			"publicips":             flattenPublicIPs(item),
+		}
+		rst[i] = bandwidth
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("bandwidths", rst),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting bandwidth fields: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add data source vpc bandwidths.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccBandWidthsDataSource_filter"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccBandWidthsDataSource_filter -timeout 360m -parallel 4
=== RUN   TestAccBandWidthsDataSource_filter
=== PAUSE TestAccBandWidthsDataSource_filter
=== CONT  TestAccBandWidthsDataSource_filter
--- PASS: TestAccBandWidthsDataSource_filter (82.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       82.780s
```
