### PR TITLE
refactor(cts): change  cts tracker resource id from name to UUID

### DIFF
--- a/docs/resources/cts_data_tracker.md
+++ b/docs/resources/cts_data_tracker.md
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID which equals the tracker name.
+* `id` - The resource ID in UUID format.
 * `type` - The tracker type, only **data** is available.
 * `transfer_enabled` - Whether traces will be transferred.
 * `status` - The tracker status, the value can be **enabled**, **disabled** or **error**.

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
@@ -19,7 +19,7 @@ func getCTSDataTrackerResourceObj(conf *config.Config, state *terraform.Resource
 		return nil, fmt.Errorf("error creating CTS client: %s", err)
 	}
 
-	name := state.Primary.ID
+	name := state.Primary.Attributes["name"]
 	trackerType := cts.GetListTrackersRequestTrackerTypeEnum().DATA
 	listOpts := &cts.ListTrackersRequest{
 		TrackerName: &name,
@@ -88,6 +88,7 @@ func TestAccCTSDataTracker_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: testCTSDataTrackerImportState(resourceName),
 			},
 		},
 	})
@@ -135,4 +136,15 @@ resource "huaweicloud_cts_data_tracker" "tracker" {
   lts_enabled          = false
 }
 `, rName)
+}
+
+func testCTSDataTrackerImportState(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		return rs.Primary.Attributes["name"], nil
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 When the resource need to add tags functionality, it require a resource id, but the current value of the resource id is the resource name.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update create method to store resource id
2. add a new import method to use resource id 
3. add a new import method in test case to use resource id
```

## PR Checklist

* [x] Tests passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSTracker_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSTracker_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSTracker_basic
=== PAUSE TestAccCTSTracker_basic
=== CONT  TestAccCTSTracker_basic
--- PASS: TestAccCTSTracker_basic (48.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       48.419s

 make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSDataTracker_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSDataTracker_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSDataTracker_basic
=== PAUSE TestAccCTSDataTracker_basic
=== CONT  TestAccCTSDataTracker_basic
--- PASS: TestAccCTSDataTracker_basic (65.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       65.682s

```
