### PR TITLE
feat(DMS): create rocketmq instance with new api and add api description

### DIFF
--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
@@ -29,6 +29,17 @@ type dmsError struct {
 	ErrorMsg  string `json:"error_msg"`
 }
 
+// API: RocketMQ POST /v2/{engine}/{project_id}/instances
+// API: RocketMQ PUT /v2/{project_id}/instances/{instance_id}
+// API: RocketMQ GET /v2/{project_id}/instances/{instance_id}
+// API: RocketMQ DELETE /v2/{project_id}/instances/{instance_id}
+// API: RocketMQ POST /v2/{project_id}/rocketmq/{instance_id}/tags/action
+// API: RocketMQ GET /v2/{project_id}/kafka/{instance_id}/tags
+// API: RocketMQ POST /v2/{project_id}/instances/{instance_id}/crossvpc/modify
+// API: BSS GET /v2/orders/customer-orders/details/{order_id}
+// API: BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
+// API: BSS DELETE /v2/orders/subscriptions/resources/autorenew/{instance_id}
+// API: BSS POST /v2/orders/subscriptions/resources/unsubscribe
 func ResourceDmsRocketMQInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDmsRocketMQInstanceCreate,
@@ -287,7 +298,7 @@ func resourceDmsRocketMQInstanceCreate(ctx context.Context, d *schema.ResourceDa
 
 	// createRocketmqInstance: create DMS rocketmq instance
 	var (
-		createRocketmqInstanceHttpUrl = "v2/{project_id}/instances"
+		createRocketmqInstanceHttpUrl = "v2/reliability/{project_id}/instances"
 		createRocketmqInstanceProduct = "dmsv2"
 	)
 	createRocketmqInstanceClient, err := cfg.NewServiceClient(createRocketmqInstanceProduct, region)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
   create rocketmq instance with new api and add api description

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
create rocketmq instance with new api and add api description
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccDmsRocketMQInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQInstance_basic
=== PAUSE TestAccDmsRocketMQInstance_basic
=== CONT  TestAccDmsRocketMQInstance_basic
--- PASS: TestAccDmsRocketMQInstance_basic (762.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       762.823s

make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccDmsRocketMQInstance_prepaid_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQInstance_prepaid_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQInstance_prepaid_basic
=== PAUSE TestAccDmsRocketMQInstance_prepaid_basic
=== CONT  TestAccDmsRocketMQInstance_prepaid_basic
--- PASS: TestAccDmsRocketMQInstance_prepaid_basic (877.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       877.301s

```
