### PR TITLE
test(workspace): the acceptance test method is changed to serial

### DIFF
--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_access_policy_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_access_policy_test.go
@@ -32,7 +32,7 @@ func TestAccAccessPolicy_basic(t *testing.T) {
 		rc           = acceptance.InitResourceCheck(resourceName, &accessPolicy, getAccessPolicyFunc)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_desktop_test.go
@@ -35,7 +35,7 @@ func TestAccDesktop_basic(t *testing.T) {
 		getDesktopFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -118,7 +118,7 @@ func TestAccDesktop_UpdateWithEpsId(t *testing.T) {
 		getDesktopFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMigrateEpsID(t)
@@ -168,7 +168,7 @@ func TestAccDesktop_powerAction(t *testing.T) {
 		getDesktopFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_eip_associate_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_eip_associate_test.go
@@ -35,7 +35,7 @@ func TestAccEipAssociate_basic(t *testing.T) {
 		rc           = acceptance.InitResourceCheck(resourceName, &eips, getEipAssociateFunc)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_policy_group_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_policy_group_test.go
@@ -36,7 +36,7 @@ func TestAccPolicyGroup_basic(t *testing.T) {
 		getPolicyGroupFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
@@ -39,7 +39,7 @@ func TestAccService_basic(t *testing.T) {
 		getServiceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},
@@ -109,7 +109,7 @@ func TestAccService_internetAccessPort(t *testing.T) {
 		getServiceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckWorkspaceInternetAccessPort(t)
@@ -148,7 +148,7 @@ func TestAccService_localAD(t *testing.T) {
 		getServiceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckWorkspaceAD(t)
@@ -227,9 +227,10 @@ func TestAccService_internetAccessPort_localAD(t *testing.T) {
 		getServiceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAD(t)
 			acceptance.TestAccPreCheckWorkspaceInternetAccessPort(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_terminal_bindings_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_terminal_bindings_test.go
@@ -40,7 +40,7 @@ func TestAccTerminalBindings_basic(t *testing.T) {
 		rc           = acceptance.InitResourceCheck(resourceName, &bindings, getTerminalBindingsFunc)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_user_group_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_user_group_test.go
@@ -41,7 +41,7 @@ func TestAccUserGroup_basic(t *testing.T) {
 		getUserGroupFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_user_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_user_test.go
@@ -36,7 +36,7 @@ func TestAccUser_basic(t *testing.T) {
 		getUserFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Change acceptance testing from parallel testing to serial testing.

Only one service resource can be created in a region.  The number of concurrent Workspace service test cases cannot be controlled during full testing, so multiple services will be created, causing the test cases to fail.

![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/3ef62081-7936-4254-a8ca-dd58e4cac9b8)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Change acceptance testing from parallel testing to serial testing.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...

make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccService'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccService -timeout 360m -parallel 4
=== RUN   TestAccService_basic
--- PASS: TestAccService_basic (736.21s)
=== RUN   TestAccService_internetAccessPort
--- PASS: TestAccService_internetAccessPort (778.39s)
=== RUN   TestAccService_localAD
    acceptance.go:797: The configuration of AD server is not completed for Workspace service acceptance test.
--- SKIP: TestAccService_localAD (0.01s)
=== RUN   TestAccService_internetAccessPort_localAD
    acceptance.go:797: The configuration of AD server is not completed for Workspace service acceptance test.
--- SKIP: TestAccService_internetAccessPort_localAD (0.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1514.715s

make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccDesktop'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccDesktop -timeout 360m -parallel 4
=== RUN   TestAccDesktop_basic
--- PASS: TestAccDesktop_basic (1460.81s)
=== RUN   TestAccDesktop_UpdateWithEpsId
--- PASS: TestAccDesktop_UpdateWithEpsId (531.98s)
=== RUN   TestAccDesktop_powerAction
--- PASS: TestAccDesktop_powerAction (788.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 2780.996s

make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccUser'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccUser -timeout 360m -parallel 4
=== RUN   TestAccUserGroup_basic
--- PASS: TestAccUserGroup_basic (682.43s)
=== RUN   TestAccUser_basic
--- PASS: TestAccUser_basic (571.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1253.913s

make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccEipAssociate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccEipAssociate -timeout 360m -parallel 4
=== RUN   TestAccEipAssociate_basic
--- PASS: TestAccEipAssociate_basic (467.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 467.575s

make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccPolicyGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccPolicyGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccPolicyGroup_basic
--- PASS: TestAccPolicyGroup_basic (126.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 126.233s

make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccTerminalBindings_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccTerminalBindings_basic -timeout 360m -parallel 4
=== RUN   TestAccTerminalBindings_basic
--- PASS: TestAccTerminalBindings_basic (1032.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1032.448s

make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccAccessPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccAccessPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccAccessPolicy_basic
--- PASS: TestAccAccessPolicy_basic (464.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 464.303s```
