### PR TITLE
feat(fgs/application): add new resource support

### DIFF
--- a/docs/resources/fgs_application.md
+++ b/docs/resources/fgs_application.md
@@ -1,0 +1,136 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# huaweicloud_fgs_application
+
+Manages an application within HuaweiCloud.
+
+-> Currently, only available in `cn-north-4` and `cn-east-3` regions.
+
+## Example Usage
+
+### Create a simple application
+
+```hcl
+variable "application_name"
+variable "application_template_id"
+variable "agency_name"
+
+resource "huaweicloud_fgs_application" "test" {
+  name        = var.application_name
+  template_id = var.application_template_id
+  agency_name = var.agency_name
+  description = "Created by terraform script"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create an application.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the application name.  
+  The name can contain a maximum of 60 characters and must start with a letter and end with a letter or digit.
+  Only letters, digits, underscores (_) and hyphens (-) are allowed.  
+  Changing this parameter will create a new resource.
+
+* `template_id` - (Required, String, ForceNew) Specifies the ID of the template used by the application.  
+  Changing this parameter will create a new resource.
+
+* `agency_name` - (Optional, String, ForceNew) Specifies the agency name used by the application.  
+  Changing this parameter will create a new resource.
+
+  -> If omitted, the service will automatically create an agency, please ensure that the tenant has IAM related
+     permissions. The agency will be deleted when the application is deleted.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of the application.  
+  The description can contain a maximum of `1,024` characters.  
+  Changing this parameter will create a new resource.
+
+* `params` - (Optional, String, ForceNew) Specifies the template parameters, in JSON format.  
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The application ID in UUID format.
+
+* `stack_id` - The ID of the stack where the application is deployed.
+
+* `stack_resources` - The list of the stack resources information.  
+  The [stack_resources](#fgs_app_stack_resources) structure is documented below.
+
+* `repository` - The repository information.  
+  The [repository](#fgs_app_repository) structure is documented below.
+
+* `status` - The status of the application.
+
+* `updated_at` - The latest update time of the application.
+
+* `apig_url` - The dependency package size in bytes.
+
+<a name="fgs_app_stack_resources"></a>
+The `stack_resources` block supports:
+
+* `physical_resource_id` - The physical resource ID.
+
+* `physical_resource_name` - The physical resource name.
+
+* `logical_resource_name` - The logical resource name.
+
+* `logical_resource_type` - The logical resource type.
+
+* `resource_status` - The status of resource.
+
+* `status_message` - The status information.
+
+* `href` - The hyperlink.
+
+* `display_name` - The cloud service name.
+
+<a name="fgs_app_repository"></a>
+The `repository` block supports:
+
+* `https_url` - The HTTP address of the repository.
+
+* `web_url` - The repository link.
+
+* `status` - The repository status.
+
+* `project_id` - The project ID of the repository.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+Application can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_fgs_application.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response.
+The missing attributes include: `template_id`, `agency_name`, `params`.
+It is generally recommended running `terraform plan` after importing the application.
+You can then decide if changes should be applied to the application, or the resource definition should be updated to
+align with the application. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_fgs_application" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      template_id, agency_name,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -995,6 +995,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_snapshot": evs.ResourceEvsSnapshotV2(),
 			"huaweicloud_evs_volume":   evs.ResourceEvsVolume(),
 
+			"huaweicloud_fgs_application":                fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration": fgs.ResourceAsyncInvokeConfiguration(),
 			"huaweicloud_fgs_dependency":                 fgs.ResourceFgsDependency(),
 			"huaweicloud_fgs_dependency_version":         fgs.ResourceDependencyVersion(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -123,6 +123,7 @@ var (
 	HW_WORKSPACE_INTERNET_ACCESS_PORT = os.Getenv("HW_WORKSPACE_INTERNET_ACCESS_PORT")
 
 	HW_FGS_TRIGGER_LTS_AGENCY = os.Getenv("HW_FGS_TRIGGER_LTS_AGENCY")
+	HW_FGS_TEMPLATE_ID        = os.Getenv("HW_FGS_TEMPLATE_ID")
 
 	HW_KMS_ENVIRONMENT    = os.Getenv("HW_KMS_ENVIRONMENT")
 	HW_KMS_HSM_CLUSTER_ID = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
@@ -446,6 +447,13 @@ func TestAccPreCheckMrsBootstrapScript(t *testing.T) {
 func TestAccPreCheckFgsTrigger(t *testing.T) {
 	if HW_FGS_TRIGGER_LTS_AGENCY == "" {
 		t.Skip("HW_FGS_TRIGGER_LTS_AGENCY must be set for FGS trigger acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckFgsTemplateId(t *testing.T) {
+	if HW_FGS_TEMPLATE_ID == "" {
+		t.Skip("HW_FGS_TEMPLATE_ID must be set for FGS acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -122,8 +122,8 @@ var (
 	// The internet access port to which the Workspace service.
 	HW_WORKSPACE_INTERNET_ACCESS_PORT = os.Getenv("HW_WORKSPACE_INTERNET_ACCESS_PORT")
 
-	HW_FGS_TRIGGER_LTS_AGENCY = os.Getenv("HW_FGS_TRIGGER_LTS_AGENCY")
-	HW_FGS_TEMPLATE_ID        = os.Getenv("HW_FGS_TEMPLATE_ID")
+	HW_FGS_AGENCY_NAME = os.Getenv("HW_FGS_AGENCY_NAME")
+	HW_FGS_TEMPLATE_ID = os.Getenv("HW_FGS_TEMPLATE_ID")
 
 	HW_KMS_ENVIRONMENT    = os.Getenv("HW_KMS_ENVIRONMENT")
 	HW_KMS_HSM_CLUSTER_ID = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
@@ -444,9 +444,17 @@ func TestAccPreCheckMrsBootstrapScript(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckFgsTrigger(t *testing.T) {
-	if HW_FGS_TRIGGER_LTS_AGENCY == "" {
-		t.Skip("HW_FGS_TRIGGER_LTS_AGENCY must be set for FGS trigger acceptance tests")
+func TestAccPreCheckFgsAgency(t *testing.T) {
+	// The agency should be FunctionGraph and authorize these roles:
+	// For the acceptance tests of the async invoke configuration:
+	// + FunctionGraph FullAccess
+	// + DIS Operator
+	// + OBS Administrator
+	// + SMN Administrator
+	// For the acceptance tests of the function trigger and the application:
+	// + LTS Administrator
+	if HW_FGS_AGENCY_NAME == "" {
+		t.Skip("HW_FGS_AGENCY_NAME must be set for FGS acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_application_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_application_test.go
@@ -1,0 +1,100 @@
+package fgs
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getWorkloadQueueResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/fgs/applications/{id}"
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error getting FunctionGraph application: %s", err)
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func TestAccApplication_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_fgs_application.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getWorkloadQueueResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsTrigger(t)
+			acceptance.TestAccPreCheckFgsTemplateId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplication_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestMatchResourceAttr(resourceName, "stack_resources.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckResourceAttr(resourceName, "repository.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"template_id",
+					"agency_name",
+					"params",
+				},
+			},
+		},
+	})
+}
+
+func testAccApplication_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_fgs_application" "test" {
+  name        = "%[1]s"
+  agency_name = "%[2]s"
+  template_id = "%[3]s"
+  description = "Created by terraform script"
+}
+`, name, acceptance.HW_FGS_TRIGGER_LTS_AGENCY, acceptance.HW_FGS_TEMPLATE_ID)
+}

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_application_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_application_test.go
@@ -57,7 +57,8 @@ func TestAccApplication_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckFgsTrigger(t)
+			// Please read the instructions carefully before use to ensure sufficient permissions.
+			acceptance.TestAccPreCheckFgsAgency(t)
 			acceptance.TestAccPreCheckFgsTemplateId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -96,5 +97,5 @@ resource "huaweicloud_fgs_application" "test" {
   template_id = "%[3]s"
   description = "Created by terraform script"
 }
-`, name, acceptance.HW_FGS_TRIGGER_LTS_AGENCY, acceptance.HW_FGS_TEMPLATE_ID)
+`, name, acceptance.HW_FGS_AGENCY_NAME, acceptance.HW_FGS_TEMPLATE_ID)
 }

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_invoke_configuration_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_invoke_configuration_test.go
@@ -36,15 +36,14 @@ func TestAccAsyncInvokeConfig_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			// The agency should be FunctionGraph and authorize with "FunctionGraph FullAccess" and "DIS Operator"
-			// and "OBS Administrator" and "SMN Administrator"
-			acceptance.TestAccPreCheckFgsTrigger(t)
+			// Please read the instructions carefully before use to ensure sufficient permissions.
+			acceptance.TestAccPreCheckFgsAgency(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAsyncInvokeConfig_basic_step1(name, acceptance.HW_FGS_TRIGGER_LTS_AGENCY),
+				Config: testAccAsyncInvokeConfig_basic_step1(name, acceptance.HW_FGS_AGENCY_NAME),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "function_urn",
@@ -59,7 +58,7 @@ func TestAccAsyncInvokeConfig_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAsyncInvokeConfig_basic_step2(name, acceptance.HW_FGS_TRIGGER_LTS_AGENCY),
+				Config: testAccAsyncInvokeConfig_basic_step2(name, acceptance.HW_FGS_AGENCY_NAME),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "function_urn",

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_trigger_test.go
@@ -164,7 +164,11 @@ func TestAccFunctionGraphTrigger_lts(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheckFgsTrigger(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please read the instructions carefully before use to ensure sufficient permissions.
+			acceptance.TestAccPreCheckFgsAgency(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
@@ -297,16 +301,6 @@ resource "huaweicloud_lts_stream" "test" {
   stream_name = "%[1]s"
 }
 
-resource "huaweicloud_identity_agency" "test" {
-  name = "%[1]s"
-  delegated_service_name = "%[3]s"
-
-  project_role {
-    project = "%[2]s"
-    roles = ["LTS FullAccess"]
-  }
-}
-
 resource "huaweicloud_fgs_function" "test" {
   name        = "%[1]s"
   app         = "default"
@@ -315,7 +309,7 @@ resource "huaweicloud_fgs_function" "test" {
   timeout     = 10
   runtime     = "Python2.7"
   code_type   = "inline"
-  agency      = huaweicloud_identity_agency.test.name
+  agency      = "%[2]s"
   func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
 }
 
@@ -327,5 +321,5 @@ resource "huaweicloud_fgs_trigger" "test" {
     log_group_id = huaweicloud_lts_group.test.id
     log_topic_id = huaweicloud_lts_stream.test.id
   }
-}`, rName, acceptance.HW_REGION_NAME, acceptance.HW_FGS_TRIGGER_LTS_AGENCY)
+}`, rName, acceptance.HW_FGS_AGENCY_NAME)
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_application.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_application.go
@@ -1,0 +1,415 @@
+package fgs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: FunctionGraph POST /v2/{project_id}/fgs/applications
+// API: FunctionGraph GET /v2/{project_id}/fgs/applications/{id}
+// API: FunctionGraph DELETE /v2/{project_id}/fgs/applications/{id}
+func ResourceApplication() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApplicationCreate,
+		ReadContext:   resourceApplicationRead,
+		DeleteContext: resourceApplicationDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the application is located.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The application name`,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The ID of the template used by the application.`,
+					utils.SchemaDescInput{
+						Required: true,
+					}),
+			},
+			"agency_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The agency name used by the application.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The description of the application.`,
+			},
+			"params": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  `The template parameters.`,
+			},
+			"stack_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the stack where the application is deployed.`,
+			},
+			"stack_resources": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        stackResourceSchema(),
+				Description: `The list of the stack resources information.`,
+			},
+			"repository": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        repositorySchema(),
+				Description: `The repository information.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The application status.`,
+			},
+		},
+	}
+}
+
+func stackResourceSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"physical_resource_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The physical resource ID.`,
+			},
+			"physical_resource_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The physical resource name.`,
+			},
+			"logical_resource_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The logical resource name.`,
+			},
+			"logical_resource_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The logical resource type.`,
+			},
+			"resource_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of resource.`,
+			},
+			"status_message": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status information.`,
+			},
+			"href": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The hyperlink.`,
+			},
+			"display_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cloud service name.`,
+			},
+		},
+	}
+}
+
+func repositorySchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"https_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The HTTP address of the repository.`,
+			},
+			"web_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The repository link.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The repository status.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: `The project ID of the repository.`,
+			},
+		},
+	}
+}
+
+func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/applications"
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateApplicationBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph application: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceId := utils.PathSearch("application_id", respBody, "")
+	d.SetId(resourceId.(string))
+
+	err = waitForApplicationStatusCompleted(ctx, client, d)
+	if err != nil {
+		diag.Errorf("error waiting for the application (%s) status to become success: %s", resourceId, err)
+	}
+
+	return resourceApplicationRead(ctx, d, meta)
+}
+
+func buildCreateApplicationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := d.Get("params").(string)
+	parseResult := make(map[string]interface{})
+	err := json.Unmarshal([]byte(params), &parseResult)
+	if err != nil {
+		log.Printf("[ERROR] Invalid type of the params, not json format")
+	}
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"template_id": d.Get("template_id"),
+		"description": d.Get("description"),
+		"agency_name": d.Get("agency_name"),
+		"params":      parseResult,
+	}
+}
+
+func waitForApplicationStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      applicationStatusRefreshFunc(client, d, []string{"success"}),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func applicationStatusRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		applicationId := d.Id()
+		respBody, err := getApplicationById(client, applicationId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				log.Printf("[DEBUG] The FunctionGraph application (%s) has been deleted", applicationId)
+				return respBody, "COMPLETED", nil
+			}
+			return respBody, "ERROR", err
+		}
+
+		status := utils.PathSearch("name", respBody, "").(string)
+		unexpectedStatuses := []string{
+			"CreateFail", "InitingFailed", "RegisterFailed", "InstallFailed",
+			"UpdateFailed", "RollbackFailed", "UnRegisterFailed", "DeleteFailed",
+		}
+		if utils.StrSliceContains(unexpectedStatuses, status) {
+			return respBody, "ERROR", fmt.Errorf("unexpect status (%s)", status)
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return respBody, "COMPLETED", nil
+		}
+		return respBody, "PENDING", nil
+	}
+}
+
+func getApplicationById(client *golangsdk.ServiceClient, resourceId string) (interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/fgs/applications/{id}"
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", resourceId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceApplicationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	respBody, err := getApplicationById(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "FunctionGraph application")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("stack_id", utils.PathSearch("stack_id", respBody, nil)),
+		d.Set("stack_resources", flattenStackResource(respBody)),
+		d.Set("repository", flattenRepository(respBody)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenStackResource(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("stack_resources", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"physical_resource_id":   utils.PathSearch("physical_resource_id", v, nil),
+			"physical_resource_name": utils.PathSearch("physical_resource_name", v, nil),
+			"logical_resource_name":  utils.PathSearch("logical_resource_name", v, nil),
+			"logical_resource_type":  utils.PathSearch("logical_resource_type", v, nil),
+			"resource_status":        utils.PathSearch("resource_status", v, nil),
+			"status_message":         utils.PathSearch("status_message", v, nil),
+			"href":                   utils.PathSearch("href", v, nil),
+			"display_name":           utils.PathSearch("display_name", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenRepository(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("repo", resp, make(map[string]interface{}))
+	repoElem := map[string]interface{}{
+		"https_url":  utils.PathSearch("https_url", curJson, nil),
+		"web_url":    utils.PathSearch("web_url", curJson, nil),
+		"status":     utils.PathSearch("repo_status", curJson, nil),
+		"project_id": utils.PathSearch("project_id", curJson, nil),
+	}
+	return []interface{}{repoElem}
+}
+
+func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/applications/{id}"
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{id}", d.Id())
+	// Due to API restrictions, the request body must pass in an empty JSON.
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting FunctionGraph application: %s", err)
+	}
+
+	err = waitForApplicationDeleted(ctx, client, d)
+	if err != nil {
+		diag.Errorf("error waiting for the application (%s) status to become deleted: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func waitForApplicationDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      applicationStatusRefreshFunc(client, d, nil),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Due to console free requirements, it is currently necessary to complete the missing resources under the FunctionGraph service.
The role of the application center is to use resource orchestration services to deploy peripheral resources (including functions, delegates, triggers, etc.) required by the application, so that these resources can cooperate with each other and perform tasks together.

New resource：
- huaweicloud_fgs_application

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new resource used to create the application.
2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccApplication_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccApplication_basic -timeout 360m -parallel 4
=== RUN   TestAccApplication_basic
=== PAUSE TestAccApplication_basic
=== CONT  TestAccApplication_basic
--- PASS: TestAccApplication_basic (1435.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       1435.416s
```
