### PR TITLE
fix(drs): set the resource ID before querying task satus API

### DIFF
--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -328,13 +328,12 @@ func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	jobId := rst.Results[0].Id
+	d.SetId(jobId)
 
 	err = waitingforJobStatus(ctx, client, jobId, "create", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	d.SetId(jobId)
 
 	valid := testConnections(client, jobId, opts.Jobs[0])
 	if !valid {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Set the resource ID before querying task satus API.

After creating the resource API, while waiting for the task to be completed, if the task status query API reports an error, the resource will remain and will not be deleted. Therefore, set the resource ID before querying the task status API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Set the resource ID before querying task satus API.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
make testacc TEST=./huaweicloud/services/acceptance/drs TESTARGS='-run TestAccResourceDrsJob_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccResourceDrsJob_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_basic
=== PAUSE TestAccResourceDrsJob_basic
=== CONT  TestAccResourceDrsJob_basic
--- PASS: TestAccResourceDrsJob_basic (1275.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       1275.853s
```
