### PR TITLE
fix: feat(OBS): upgrade OBS version to 3.23.12 and fix lifecycle configuration

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -124,7 +124,6 @@ resource "huaweicloud_obs_bucket" "bucket" {
 
   lifecycle_rule {
     name    = "tmp"
-    prefix  = "tmp/"
     enabled = true
 
     noncurrent_version_expiration {
@@ -305,6 +304,8 @@ The `lifecycle_rule` object supports the following:
 * `prefix` - (Optional, String) Object key prefix identifying one or more objects to which the rule applies. If omitted,
   all objects in the bucket will be managed by the lifecycle rule. The prefix cannot start or end with a slash (/),
   cannot have consecutive slashes (/), and cannot contain the following special characters: \:*?"<>|.
+  When configuring multiple `lifecycle_rule`, field `prefix` in multiple `lifecycle_rule` cannot have an inclusive
+  relationship.
 
 * `expiration` - (Optional, List) Specifies a period when objects that have been last updated are automatically
   deleted. (documented below).
@@ -318,7 +319,8 @@ The `lifecycle_rule` object supports the following:
   incomplete upload are automatically deleted. (documented below).
 
 At least one of `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition`,
-`abort_incomplete_multipart_upload` must be specified.
+`abort_incomplete_multipart_upload` must be specified. The parameter `versioning` must be set to **true** before using
+`noncurrent_version_expiration` or `noncurrent_version_transition`.
 
 The `expiration` object supports the following
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240112095931-5c9801e156b2
+	github.com/chnsz/golangsdk v0.0.0-20240118080137-e40d4741dbae
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240112095931-5c9801e156b2 h1:zW+pOnD1f9T/n6HtqeY2HxCJ/ubgAz3j3q4QhY/vi98=
-github.com/chnsz/golangsdk v0.0.0-20240112095931-5c9801e156b2/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240118080137-e40d4741dbae h1:6IYx7Qx7LPDwSUZtyTfPk7kr4aXtHVxK8qY/henS4Uk=
+github.com/chnsz/golangsdk v0.0.0-20240118080137-e40d4741dbae/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
+++ b/huaweicloud/services/acceptance/obs/resource_huaweicloud_obs_bucket_test.go
@@ -345,7 +345,7 @@ func TestAccObsBucket_lifecycle(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "lifecycle_rule.2.name", "rule3"),
 					resource.TestCheckResourceAttr(
-						resourceName, "lifecycle_rule.2.prefix", "path3/"),
+						resourceName, "lifecycle_rule.2.prefix", ""),
 					resource.TestCheckResourceAttr(
 						resourceName, "lifecycle_rule.1.transition.0.days", "30"),
 					resource.TestCheckResourceAttr(
@@ -788,7 +788,6 @@ resource "huaweicloud_obs_bucket" "bucket" {
   }
   lifecycle_rule {
     name    = "rule3"
-    prefix  = "path3/"
     enabled = true
 
     noncurrent_version_expiration {

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/CHANGELOG
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/CHANGELOG
@@ -1,3 +1,16 @@
+Version 3.23.12
+
+New Features:
+1. Added obs.WithDisableKeepAlive method to implement short connection function.
+2. Added deep archive storage-class.
+
+Documentation & Demo:
+
+Resolved Issues:
+1. Fixed the issue where bucket life cycle configuration failed in some scenarios.
+
+-----------------------------------------------------------------------------------
+
 Version 3.23.9
 
 New Features:

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/README.MD
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/README.MD
@@ -2,7 +2,7 @@
 
 ## Version
 
-3.23.9
+3.23.12
 
 ## How to change local obs sdk
 - Try to submit pull request to the official repository：

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/const.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/const.go
@@ -13,7 +13,7 @@
 package obs
 
 const (
-	OBS_SDK_VERSION        = "3.23.4"
+	OBS_SDK_VERSION        = "3.23.12"
 	USER_AGENT             = "obs-sdk-go/" + OBS_SDK_VERSION
 	HEADER_PREFIX          = "x-amz-"
 	HEADER_PREFIX_META     = "x-amz-meta-"
@@ -288,5 +288,14 @@ var (
 		"ignore-sign-in-query":         true,
 		"name":                         true,
 		"rename":                       true,
+		"customdomain":                 true,
+		"mirrorbacktosource":           true,
+	}
+
+	obsStorageClasses = []string{
+		string(StorageClassStandard),
+		string(StorageClassWarm),
+		string(StorageClassCold),
+		string(StorageClassDeepArchive),
 	}
 )

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/extension.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/extension.go
@@ -20,12 +20,14 @@ import (
 
 type extensionOptions interface{}
 type extensionHeaders func(headers map[string][]string, isObs bool) error
+type extensionProgressListener func() ProgressListener
 
-func WithProgress(progressListener ProgressListener) configurer {
-	return func(conf *config) {
-		conf.progressListener = progressListener
+func WithProgress(progressListener ProgressListener) extensionProgressListener {
+	return func() ProgressListener {
+		return progressListener
 	}
 }
+
 func setHeaderPrefix(key string, value string) extensionHeaders {
 	return func(headers map[string][]string, isObs bool) error {
 		if strings.TrimSpace(value) == "" {

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/mime.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/mime.go
@@ -391,6 +391,7 @@ var mimeTypes = map[string]string{
 	"zip":     "application/zip",
 	"dotx":    "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
 	"wps":     "application/vnd.ms-works",
+	"wpt":     "x-lml/x-gps",
 	"pptm":    "application/vnd.ms-powerpoint.presentation.macroenabled.12",
 	"heic":    "image/heic",
 	"mkv":     "video/x-matroska",

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/model_bucket.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/model_bucket.go
@@ -222,34 +222,6 @@ type GetBucketMetadataInput struct {
 	RequestHeader string
 }
 
-// SetObjectMetadataInput is the input parameter of SetObjectMetadata function
-type SetObjectMetadataInput struct {
-	Bucket                  string
-	Key                     string
-	VersionId               string
-	MetadataDirective       MetadataDirectiveType
-	Expires                 string
-	WebsiteRedirectLocation string
-	StorageClass            StorageClassType
-	Metadata                map[string]string
-	HttpHeader
-}
-
-// SetObjectMetadataOutput is the result of SetObjectMetadata function
-type SetObjectMetadataOutput struct {
-	BaseModel
-	MetadataDirective       MetadataDirectiveType
-	CacheControl            string
-	ContentDisposition      string
-	ContentEncoding         string
-	ContentLanguage         string
-	ContentType             string
-	Expires                 string
-	WebsiteRedirectLocation string
-	StorageClass            StorageClassType
-	Metadata                map[string]string
-}
-
 // GetBucketMetadataOutput is the result of GetBucketMetadata function
 type GetBucketMetadataOutput struct {
 	BaseModel
@@ -279,8 +251,8 @@ type GetBucketLoggingConfigurationOutput struct {
 	BucketLoggingStatus
 }
 
-// BucketLifecyleConfiguration defines the bucket lifecycle configuration
-type BucketLifecyleConfiguration struct {
+// BucketLifecycleConfiguration defines the bucket lifecycle configuration
+type BucketLifecycleConfiguration struct {
 	XMLName        xml.Name        `xml:"LifecycleConfiguration"`
 	LifecycleRules []LifecycleRule `xml:"Rule"`
 }
@@ -288,13 +260,13 @@ type BucketLifecyleConfiguration struct {
 // SetBucketLifecycleConfigurationInput is the input parameter of SetBucketLifecycleConfiguration function
 type SetBucketLifecycleConfigurationInput struct {
 	Bucket string `xml:"-"`
-	BucketLifecyleConfiguration
+	BucketLifecycleConfiguration
 }
 
 // GetBucketLifecycleConfigurationOutput is the result of GetBucketLifecycleConfiguration function
 type GetBucketLifecycleConfigurationOutput struct {
 	BaseModel
-	BucketLifecyleConfiguration
+	BucketLifecycleConfiguration
 }
 
 // SetBucketEncryptionInput is the input parameter of SetBucketEncryption function

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/model_object.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/model_object.go
@@ -389,3 +389,31 @@ type RenameFolderInput struct {
 type RenameFolderOutput struct {
 	BaseModel
 }
+
+// SetObjectMetadataInput is the input parameter of SetObjectMetadata function
+type SetObjectMetadataInput struct {
+	Bucket                  string
+	Key                     string
+	VersionId               string
+	MetadataDirective       MetadataDirectiveType
+	Expires                 string
+	WebsiteRedirectLocation string
+	StorageClass            StorageClassType
+	Metadata                map[string]string
+	HttpHeader
+}
+
+// SetObjectMetadataOutput is the result of SetObjectMetadata function
+type SetObjectMetadataOutput struct {
+	BaseModel
+	MetadataDirective       MetadataDirectiveType
+	CacheControl            string
+	ContentDisposition      string
+	ContentEncoding         string
+	ContentLanguage         string
+	ContentType             string
+	Expires                 string
+	WebsiteRedirectLocation string
+	StorageClass            StorageClassType
+	Metadata                map[string]string
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/progress.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/progress.go
@@ -81,11 +81,6 @@ func (t *teeReader) Read(p []byte) (n int, err error) {
 		}
 	}
 
-	if err == io.EOF {
-		event := newProgressEvent(TransferCompletedEvent, t.consumedBytes, t.totalBytes)
-		publishProgress(t.listener, event)
-	}
-
 	return
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/trait_bucket.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/trait_bucket.go
@@ -118,16 +118,18 @@ func (input CreateBucketInput) trans(isObs bool) (params map[string]string, head
 func (input SetBucketStoragePolicyInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	xml := make([]string, 0, 1)
 	if !isObs {
-		storageClass := "STANDARD"
-		if input.StorageClass == StorageClassWarm {
-			storageClass = string(storageClassStandardIA)
+		storageClass := input.StorageClass
+		if storageClass == "" {
+			storageClass = StorageClassStandard
+		} else if input.StorageClass == StorageClassWarm {
+			storageClass = storageClassStandardIA
 		} else if input.StorageClass == StorageClassCold {
-			storageClass = string(storageClassGlacier)
+			storageClass = storageClassGlacier
 		}
 		params = map[string]string{string(SubResourceStoragePolicy): ""}
 		xml = append(xml, fmt.Sprintf("<StoragePolicy><DefaultStorageClass>%s</DefaultStorageClass></StoragePolicy>", storageClass))
 	} else {
-		if input.StorageClass != StorageClassWarm && input.StorageClass != StorageClassCold {
+		if !IsContain(obsStorageClasses, string(input.StorageClass)) {
 			input.StorageClass = StorageClassStandard
 		}
 		params = map[string]string{string(SubResourceStorageClass): ""}
@@ -198,7 +200,7 @@ func (input SetBucketLoggingConfigurationInput) trans(isObs bool) (params map[st
 
 func (input SetBucketLifecycleConfigurationInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{string(SubResourceLifecycle): ""}
-	data, md5 := ConvertLifecyleConfigurationToXml(input.BucketLifecyleConfiguration, true, isObs)
+	data, md5 := ConvertLifecycleConfigurationToXml(input.BucketLifecycleConfiguration, true, isObs)
 	headers = map[string][]string{HEADER_MD5_CAMEL: {md5}}
 	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/type.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/type.go
@@ -161,6 +161,9 @@ const (
 	//StorageClassCold storage class: COLD
 	StorageClassCold StorageClassType = "COLD"
 
+	//StorageClassDeepArchive storage class: DEEP_ARCHIVE
+	StorageClassDeepArchive StorageClassType = "DEEP_ARCHIVE"
+
 	storageClassStandardIA StorageClassType = "STANDARD_IA"
 	storageClassGlacier    StorageClassType = "GLACIER"
 )

--- a/vendor/github.com/chnsz/golangsdk/openstack/obs/util.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/obs/util.go
@@ -122,6 +122,11 @@ func FormatUtcNow(format string) string {
 	return time.Now().UTC().Format(format)
 }
 
+// FormatNow gets a textual representation of the format time value
+func FormatNow(format string) string {
+	return time.Now().Format(format)
+}
+
 // FormatUtcToRfc1123 gets a textual representation of the RFC1123 format time value
 func FormatUtcToRfc1123(t time.Time) string {
 	ret := t.UTC().Format(time.RFC1123)
@@ -612,6 +617,8 @@ func GetReaderLen(reader io.Reader) (int64, error) {
 	case *io.LimitedReader:
 		contentLength = int64(v.N)
 	case *fileReaderWrapper:
+		contentLength = int64(v.totalCount)
+	case *readerWrapper:
 		contentLength = int64(v.totalCount)
 	default:
 		err = fmt.Errorf("can't get reader content length,unkown reader type")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240112095931-5c9801e156b2
+# github.com/chnsz/golangsdk v0.0.0-20240118080137-e40d4741dbae
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Upgrade OBS version to 3.23.9 and fix lifecycle configuration.
- The purpose of upgrading the version is to fix the configuration of the OBS lifecycle.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
This PR submitted three commits：
- Supplementary description to OBS lifecycle configuration.
- OBS lifecycle test case support empty prefix.
- Upgrade OBS version to 3.23.12.

Before upgrading the version, test case `TestAccObsBucket_lifecycle` will report the following error:
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/bf86a71e-6978-451a-91e3-da2e26448008)

After upgrading the version, test case `TestAccObsBucket_lifecycle` will be executed successfully as follows:
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/2e76c759-fbb7-4f1e-a7fc-ff4b14cb6edc)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAcc'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAcc -timeout 360m -parallel 4
=== RUN   TestAccObsBucketObjectDataSource_content
=== PAUSE TestAccObsBucketObjectDataSource_content
=== RUN   TestAccObsBucketObjectDataSource_source
=== PAUSE TestAccObsBucketObjectDataSource_source
=== RUN   TestAccObsBucketObjectDataSource_allParams
=== PAUSE TestAccObsBucketObjectDataSource_allParams
=== RUN   TestAccDataSourceObsBuckets_basic
=== PAUSE TestAccDataSourceObsBuckets_basic
=== RUN   TestAccOBSBucketAcl_basic
=== PAUSE TestAccOBSBucketAcl_basic
=== RUN   TestAccOBSBucketObjectAcl_basic
=== PAUSE TestAccOBSBucketObjectAcl_basic
=== RUN   TestAccOBSBucketObjectAcl_checkError
=== PAUSE TestAccOBSBucketObjectAcl_checkError
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== RUN   TestAccObsBucketPolicy_basic
=== PAUSE TestAccObsBucketPolicy_basic
=== RUN   TestAccObsBucketPolicy_update
=== PAUSE TestAccObsBucketPolicy_update
=== RUN   TestAccObsBucketPolicy_s3
=== PAUSE TestAccObsBucketPolicy_s3
=== RUN   TestAccObsBucketReplication_basic
=== PAUSE TestAccObsBucketReplication_basic
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== RUN   TestAccObsBucket_multiAZ
=== PAUSE TestAccObsBucket_multiAZ
=== RUN   TestAccObsBucket_parallelFS
=== PAUSE TestAccObsBucket_parallelFS
=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== RUN   TestAccObsBucket_quota
=== PAUSE TestAccObsBucket_quota
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== RUN   TestAccObsBucket_userDomainNames
=== PAUSE TestAccObsBucket_userDomainNames
=== CONT  TestAccObsBucketObjectDataSource_content
=== CONT  TestAccObsBucket_basic
=== CONT  TestAccObsBucket_logging
=== CONT  TestAccObsBucket_userDomainNames
--- PASS: TestAccObsBucket_logging (18.26s)
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_basic (21.22s)
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucketObjectDataSource_content (28.60s)
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_userDomainNames (29.01s)
=== CONT  TestAccObsBucket_quota
--- PASS: TestAccObsBucket_cors (11.44s)
=== CONT  TestAccObsBucket_multiAZ
--- PASS: TestAccObsBucket_website (11.24s)
=== CONT  TestAccObsBucketObject_source
--- PASS: TestAccObsBucket_lifecycle (12.06s)
=== CONT  TestAccObsBucket_parallelFS
--- PASS: TestAccObsBucket_quota (11.88s)
=== CONT  TestAccObsBucketReplication_basic
--- PASS: TestAccObsBucket_multiAZ (12.63s)
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_parallelFS (12.55s)
=== CONT  TestAccObsBucketPolicy_s3
--- PASS: TestAccObsBucketObject_source (29.83s)
=== CONT  TestAccObsBucketPolicy_update
--- PASS: TestAccObsBucket_versioning (20.38s)
=== CONT  TestAccObsBucketPolicy_basic
--- PASS: TestAccObsBucketPolicy_s3 (17.39s)
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucketPolicy_basic (17.06s)
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucketObject_content (16.98s)
=== CONT  TestAccObsBucket_withEpsId
--- PASS: TestAccObsBucketPolicy_update (30.09s)
=== CONT  TestAccOBSBucketObjectAcl_checkError
--- PASS: TestAccOBSBucketObjectAcl_checkError (12.16s)
=== CONT  TestAccOBSBucketObjectAcl_basic
--- PASS: TestAccObsBucketReplication_basic (94.79s)
=== CONT  TestAccOBSBucketAcl_basic
--- PASS: TestAccObsBucket_withEpsId (54.69s)
=== CONT  TestAccObsBucketObjectDataSource_allParams
--- PASS: TestAccOBSBucketObjectAcl_basic (44.39s)
=== CONT  TestAccObsBucketObjectDataSource_source
--- PASS: TestAccObsBucket_encryption (72.29s)
=== CONT  TestAccDataSourceObsBuckets_basic
--- PASS: TestAccOBSBucketAcl_basic (32.64s)
--- PASS: TestAccObsBucketObjectDataSource_allParams (30.67s)
--- PASS: TestAccDataSourceObsBuckets_basic (25.44s)
--- PASS: TestAccObsBucketObjectDataSource_source (29.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       178.513s
```
