### PR TITLE
fix(cnad/organization/ucs): region format adjust

### DIFF
--- a/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_black_white_list_test.go
+++ b/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_black_white_list_test.go
@@ -17,10 +17,11 @@ import (
 
 func getBlackWhiteListResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	var (
+		region               = acceptance.HW_REGION_NAME
 		getBlackWhiteHttpUrl = "v1/cnad/policies/{policy_id}"
 		getBlackWhiteProduct = "aad"
 	)
-	getBlackWhiteClient, err := cfg.NewServiceClient(getBlackWhiteProduct, "")
+	getBlackWhiteClient, err := cfg.NewServiceClient(getBlackWhiteProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_policy_associate_test.go
+++ b/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_policy_associate_test.go
@@ -17,10 +17,11 @@ import (
 
 func getPolicyAssociateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	var (
+		region                    = acceptance.HW_REGION_NAME
 		getProtectedObjectHttpUrl = "v1/cnad/protected-ips"
 		getProtectedObjectProduct = "aad"
 	)
-	getProtectedObjectClient, err := cfg.NewServiceClient(getProtectedObjectProduct, "")
+	getProtectedObjectClient, err := cfg.NewServiceClient(getProtectedObjectProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_policy_test.go
+++ b/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_policy_test.go
@@ -17,10 +17,11 @@ import (
 
 func getPolicyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	var (
+		region                 = acceptance.HW_REGION_NAME
 		getPolicyDetailHttpUrl = "v1/cnad/policies/{policy_id}"
 		getPolicyDetailProduct = "aad"
 	)
-	getPolicyDetailClient, err := cfg.NewServiceClient(getPolicyDetailProduct, "")
+	getPolicyDetailClient, err := cfg.NewServiceClient(getPolicyDetailProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_protected_object_test.go
+++ b/huaweicloud/services/acceptance/cnad/resource_huaweicloud_cnad_advanced_protected_object_test.go
@@ -17,10 +17,11 @@ import (
 
 func getProtectedObjectResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	var (
+		region                    = acceptance.HW_REGION_NAME
 		getProtectedObjectHttpUrl = "v1/cnad/protected-ips"
 		getProtectedObjectProduct = "aad"
 	)
-	getProtectedObjectClient, err := cfg.NewServiceClient(getProtectedObjectProduct, "")
+	getProtectedObjectClient, err := cfg.NewServiceClient(getProtectedObjectProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_accepter_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_accepter_test.go
@@ -18,10 +18,11 @@ import (
 func getAccountInviteAccepterResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	// getAccountInviteAccepter: Query Organizations account invite accepter
 	var (
+		region                          = acceptance.HW_REGION_NAME
 		getAccountInviteAccepterHttpUrl = "v1/organizations/handshakes/{handshake_id}"
 		getAccountInviteAccepterProduct = "organizations"
 	)
-	getAccountInviteAccepterClient, err := cfg.NewServiceClient(getAccountInviteAccepterProduct, "")
+	getAccountInviteAccepterClient, err := cfg.NewServiceClient(getAccountInviteAccepterProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_test.go
@@ -18,11 +18,12 @@ import (
 func getAccountInviteResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	// getAccountInvite: Query Organizations account invite
 	var (
+		region                  = acceptance.HW_REGION_NAME
 		getAccountHttpUrl       = "v1/organizations/accounts/{account_id}"
 		getAccountInviteHttpUrl = "v1/organizations/handshakes/{handshake_id}"
 		getAccountInviteProduct = "organizations"
 	)
-	getAccountInviteClient, err := cfg.NewServiceClient(getAccountInviteProduct, "")
+	getAccountInviteClient, err := cfg.NewServiceClient(getAccountInviteProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_test.go
@@ -18,10 +18,11 @@ import (
 func getAccountResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	// getAccount: Query Organizations account
 	var (
+		region            = acceptance.HW_REGION_NAME
 		getAccountHttpUrl = "v1/organizations/accounts/{account_id}"
 		getAccountProduct = "organizations"
 	)
-	getAccountClient, err := cfg.NewServiceClient(getAccountProduct, acceptance.HW_REGION_NAME)
+	getAccountClient, err := cfg.NewServiceClient(getAccountProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Organizations client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organization_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organization_test.go
@@ -17,10 +17,11 @@ import (
 func resourceOrganizationRead(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
 	// getOrganization: Query Organizations organization
 	var (
+		region                 = acceptance.HW_REGION_NAME
 		getOrganizationHttpUrl = "v1/organizations"
 		getOrganizationProduct = "organizations"
 	)
-	getOrganizationClient, err := cfg.NewServiceClient(getOrganizationProduct, "")
+	getOrganizationClient, err := cfg.NewServiceClient(getOrganizationProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organizational_unit_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_organizational_unit_test.go
@@ -18,10 +18,11 @@ import (
 func getOrganizationalUnitResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	// getOrganizationalUnit: Query Organizations organizational unit
 	var (
+		region                       = acceptance.HW_REGION_NAME
 		getOrganizationalUnitHttpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
 		getOrganizationalUnitProduct = "organizations"
 	)
-	getOrganizationalUnitClient, err := cfg.NewServiceClient(getOrganizationalUnitProduct, "")
+	getOrganizationalUnitClient, err := cfg.NewServiceClient(getOrganizationalUnitProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_trusted_service_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_trusted_service_test.go
@@ -17,10 +17,11 @@ import (
 func getTrustedServiceResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	// getTrustedService: Query Organizations trusted service
 	var (
+		region                   = acceptance.HW_REGION_NAME
 		getTrustedServiceHttpUrl = "v1/organizations/trusted-services"
 		getTrustedServiceProduct = "organizations"
 	)
-	getTrustedServiceClient, err := cfg.NewServiceClient(getTrustedServiceProduct, "")
+	getTrustedServiceClient, err := cfg.NewServiceClient(getTrustedServiceProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/ucs/resource_huaweicloud_ucs_cluster_test.go
+++ b/huaweicloud/services/acceptance/ucs/resource_huaweicloud_ucs_cluster_test.go
@@ -19,10 +19,11 @@ import (
 func getClusterResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	// getCluster: Query the UCS Cluster detail
 	var (
+		region            = acceptance.HW_REGION_NAME
 		getClusterHttpUrl = "v1/clusters/{id}"
 		getClusterProduct = "ucs"
 	)
-	getClusterClient, err := cfg.NewServiceClient(getClusterProduct, "")
+	getClusterClient, err := cfg.NewServiceClient(getClusterProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating UCS Client: %s", err)
 	}
@@ -172,6 +173,7 @@ resource "huaweicloud_cce_cluster" "test" {
   subnet_id              = huaweicloud_vpc_subnet.test.id
   container_network_type = "overlay_l2"
   service_network_cidr   = "10.248.0.0/16"
+  cluster_version        = "v1.19.16-r1"
 
   tags = {
     foo = "bar"

--- a/huaweicloud/services/acceptance/ucs/resource_huaweicloud_ucs_fleet_test.go
+++ b/huaweicloud/services/acceptance/ucs/resource_huaweicloud_ucs_fleet_test.go
@@ -18,10 +18,11 @@ import (
 func getFleetResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	// getFleet: Query the UCS Fleet detail
 	var (
+		region          = acceptance.HW_REGION_NAME
 		getFleetHttpUrl = "v1/clustergroups/{id}"
 		getFleetProduct = "ucs"
 	)
-	getFleetClient, err := cfg.NewServiceClient(getFleetProduct, "")
+	getFleetClient, err := cfg.NewServiceClient(getFleetProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating UCS Client: %s", err)
 	}

--- a/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_available_objects.go
+++ b/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_available_objects.go
@@ -83,6 +83,7 @@ func availableProtectedObjectsSchema() *schema.Resource {
 func resourceAvailableProtectedObjectsRead(_ context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -90,7 +91,7 @@ func resourceAvailableProtectedObjectsRead(_ context.Context, d *schema.Resource
 		getProtectedObjectsHttpUrl = "v1/cnad/packages/{package_id}/unbound-protected-ips"
 		getProtectedObjectsProduct = "aad"
 	)
-	getProtectedObjectsClient, err := cfg.NewServiceClient(getProtectedObjectsProduct, "")
+	getProtectedObjectsClient, err := cfg.NewServiceClient(getProtectedObjectsProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_instances.go
+++ b/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_instances.go
@@ -114,13 +114,14 @@ func instanceSchema() *schema.Resource {
 
 func resourceInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 	var (
 		getAdvancedInstancesHttpUrl = "v1/cnad/packages"
 		getAdvancedInstancesProduct = "aad"
 	)
-	getAdvancedInstancesClient, err := cfg.NewServiceClient(getAdvancedInstancesProduct, "")
+	getAdvancedInstancesClient, err := cfg.NewServiceClient(getAdvancedInstancesProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_protected_objects.go
+++ b/huaweicloud/services/cnad/data_source_huaweicloud_cnad_advanced_protected_objects.go
@@ -137,11 +137,12 @@ func dataSourceProtectedObjectsSchema() *schema.Resource {
 func resourceProtectedObjectsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg                        = meta.(*config.Config)
+		region                     = cfg.GetRegion(d)
 		mErr                       *multierror.Error
 		getProtectedObjectsHttpUrl = "v1/cnad/protected-ips"
 		getProtectedObjectsProduct = "aad"
 	)
-	getProtectedObjectsClient, err := cfg.NewServiceClient(getProtectedObjectsProduct, "")
+	getProtectedObjectsClient, err := cfg.NewServiceClient(getProtectedObjectsProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_black_white_list.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_black_white_list.go
@@ -59,7 +59,8 @@ func ResourceBlackWhiteList() *schema.Resource {
 
 func resourceBlackWhiteListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.NewServiceClient("aad", "")
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aad", region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -81,13 +82,14 @@ func resourceBlackWhiteListCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceBlackWhiteListRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 	var mErr *multierror.Error
 
 	var (
 		getBlackWhiteListHttpUrl = "v1/cnad/policies/{policy_id}"
 		getBlackWhiteListProduct = "aad"
 	)
-	getBlackWhiteListClient, err := cfg.NewServiceClient(getBlackWhiteListProduct, "")
+	getBlackWhiteListClient, err := cfg.NewServiceClient(getBlackWhiteListProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -126,7 +128,8 @@ func resourceBlackWhiteListRead(_ context.Context, d *schema.ResourceData, meta 
 
 func resourceBlackWhiteListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.NewServiceClient("aad", "")
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aad", region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -165,7 +168,8 @@ func resourceBlackWhiteListUpdate(ctx context.Context, d *schema.ResourceData, m
 func resourceBlackWhiteListDelete(_ context.Context, d *schema.ResourceData,
 	meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.NewServiceClient("aad", "")
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aad", region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy.go
@@ -99,12 +99,13 @@ func ResourceCNADAdvancedPolicy() *schema.Resource {
 
 func resourceCNADAdvancedPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var (
 		createPolicyHttpUrl = "v1/cnad/policies"
 		createPolicyProduct = "aad"
 	)
-	createPolicyClient, err := cfg.NewServiceClient(createPolicyProduct, "")
+	createPolicyClient, err := cfg.NewServiceClient(createPolicyProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -155,8 +156,9 @@ func buildCreatePolicyBodyParams(d *schema.ResourceData) map[string]interface{} 
 
 func resourceCNADAdvancedPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
-	getPolicyClient, err := cfg.NewServiceClient("aad", "")
+	getPolicyClient, err := cfg.NewServiceClient("aad", region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -200,8 +202,9 @@ func resourceCNADAdvancedPolicyRead(_ context.Context, d *schema.ResourceData, m
 
 func resourceCNADAdvancedPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
-	updatePolicyClient, err := cfg.NewServiceClient("aad", "")
+	updatePolicyClient, err := cfg.NewServiceClient("aad", region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -242,12 +245,13 @@ func buildUpdatePolicyBodyParams(d *schema.ResourceData) map[string]interface{} 
 
 func resourceCNADAdvancedPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var (
 		deletePolicyHttpUrl = "v1/cnad/policies/{policy_id}"
 		deletePolicyProduct = "aad"
 	)
-	deletePolicyClient, err := cfg.NewServiceClient(deletePolicyProduct, "")
+	deletePolicyClient, err := cfg.NewServiceClient(deletePolicyProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy_associate.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy_associate.go
@@ -133,7 +133,8 @@ func associateProtectedObjectSchema() *schema.Resource {
 
 func resourcePolicyAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.NewServiceClient("aad", "")
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aad", region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -150,11 +151,12 @@ func resourcePolicyAssociateCreate(ctx context.Context, d *schema.ResourceData, 
 func resourcePolicyAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg                       = meta.(*config.Config)
+		region                    = cfg.GetRegion(d)
 		mErr                      *multierror.Error
 		getProtectedObjectHttpUrl = "v1/cnad/protected-ips"
 		getProtectedObjectProduct = "aad"
 	)
-	getProtectedObjectClient, err := cfg.NewServiceClient(getProtectedObjectProduct, "")
+	getProtectedObjectClient, err := cfg.NewServiceClient(getProtectedObjectProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -233,7 +235,8 @@ func buildGetObjectsPolicyQueryParams(d *schema.ResourceData) string {
 
 func resourcePolicyAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.NewServiceClient("aad", "")
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aad", region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -257,7 +260,8 @@ func resourcePolicyAssociateUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourcePolicyAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	client, err := cfg.NewServiceClient("aad", "")
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aad", region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_protected_object.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_protected_object.go
@@ -123,11 +123,12 @@ func resourceProtectedObjectCreateOrUpdate(ctx context.Context, d *schema.Resour
 	meta interface{}) diag.Diagnostics {
 	var (
 		cfg                    = meta.(*config.Config)
+		region                 = cfg.GetRegion(d)
 		protectedObjectHttpUrl = "v1/cnad/packages/{package_id}/protected-ips"
 		protectedObjectProduct = "aad"
 		instanceID             = d.Get("instance_id").(string)
 	)
-	protectedObjectClient, err := cfg.NewServiceClient(protectedObjectProduct, "")
+	protectedObjectClient, err := cfg.NewServiceClient(protectedObjectProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -174,11 +175,12 @@ func buildProtectedObjectBodyParams(d *schema.ResourceData) map[string]interface
 func resourceProtectedObjectRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg                       = meta.(*config.Config)
+		region                    = cfg.GetRegion(d)
 		mErr                      *multierror.Error
 		getProtectedObjectHttpUrl = "v1/cnad/protected-ips"
 		getProtectedObjectProduct = "aad"
 	)
-	getProtectedObjectClient, err := cfg.NewServiceClient(getProtectedObjectProduct, "")
+	getProtectedObjectClient, err := cfg.NewServiceClient(getProtectedObjectProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}
@@ -252,10 +254,11 @@ func buildGetProtectedObjectQueryParams(d *schema.ResourceData) string {
 func resourceProtectedObjectDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg                    = meta.(*config.Config)
+		region                 = cfg.GetRegion(d)
 		protectedObjectHttpUrl = "v1/cnad/packages/{package_id}/protected-ips"
 		protectedObjectProduct = "aad"
 	)
-	protectedObjectClient, err := cfg.NewServiceClient(protectedObjectProduct, "")
+	protectedObjectClient, err := cfg.NewServiceClient(protectedObjectProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating CNAD Client: %s", err)
 	}

--- a/huaweicloud/services/organizations/data_source_huaweicloud_organizations_organization.go
+++ b/huaweicloud/services/organizations/data_source_huaweicloud_organizations_organization.go
@@ -74,6 +74,7 @@ func DataSourceOrganization() *schema.Resource {
 
 func dataSourceOrganizationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -81,7 +82,7 @@ func dataSourceOrganizationRead(_ context.Context, d *schema.ResourceData, meta 
 	var (
 		getOrganizationProduct = "organizations"
 	)
-	getOrganizationClient, err := cfg.NewServiceClient(getOrganizationProduct, "")
+	getOrganizationClient, err := cfg.NewServiceClient(getOrganizationProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_associate.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_associate.go
@@ -68,12 +68,13 @@ func ResourceAccountAssociate() *schema.Resource {
 
 func resourceAccountAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createAccountAssociate: create Organizations account associate
 	var (
 		createAccountAssociateProduct = "organizations"
 	)
-	createAccountAssociateClient, err := cfg.NewServiceClient(createAccountAssociateProduct, "")
+	createAccountAssociateClient, err := cfg.NewServiceClient(createAccountAssociateProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -98,6 +99,7 @@ func resourceAccountAssociateCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceAccountAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -106,7 +108,7 @@ func resourceAccountAssociateRead(_ context.Context, d *schema.ResourceData, met
 		getAccountAssociateHttpUrl = "v1/organizations/accounts/{account_id}"
 		getAccountAssociateProduct = "organizations"
 	)
-	getAccountAssociateClient, err := cfg.NewServiceClient(getAccountAssociateProduct, "")
+	getAccountAssociateClient, err := cfg.NewServiceClient(getAccountAssociateProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -152,12 +154,13 @@ func resourceAccountAssociateRead(_ context.Context, d *schema.ResourceData, met
 
 func resourceAccountAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// updateAccountAssociate: update Organizations account associate
 	var (
 		updateAccountAssociateProduct = "organizations"
 	)
-	updateAccountAssociateClient, err := cfg.NewServiceClient(updateAccountAssociateProduct, "")
+	updateAccountAssociateClient, err := cfg.NewServiceClient(updateAccountAssociateProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -178,12 +181,13 @@ func resourceAccountAssociateUpdate(ctx context.Context, d *schema.ResourceData,
 
 func resourceAccountAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteAccountAssociate: Delete Organizations account associate
 	var (
 		deleteAccountAssociateProduct = "organizations"
 	)
-	deleteAccountAssociateClient, err := cfg.NewServiceClient(deleteAccountAssociateProduct, "")
+	deleteAccountAssociateClient, err := cfg.NewServiceClient(deleteAccountAssociateProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
@@ -86,13 +86,14 @@ canceled, declined, or expired.`,
 
 func resourceAccountInviteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createAccountInvite: create Organizations account invite
 	var (
 		createAccountInviteHttpUrl = "v1/organizations/accounts/invite"
 		createAccountInviteProduct = "organizations"
 	)
-	createAccountInviteClient, err := cfg.NewServiceClient(createAccountInviteProduct, "")
+	createAccountInviteClient, err := cfg.NewServiceClient(createAccountInviteProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -141,12 +142,13 @@ func buildCreateAccountInviteTargetChildBody(d *schema.ResourceData) map[string]
 
 func resourceAccountInviteRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
 	// getAccountInvite: Query Organizations account invite
 	getAccountInviteProduct := "organizations"
-	getAccountInviteClient, err := cfg.NewServiceClient(getAccountInviteProduct, "")
+	getAccountInviteClient, err := cfg.NewServiceClient(getAccountInviteProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -227,12 +229,13 @@ func resourceAccountInviteUpdate(_ context.Context, _ *schema.ResourceData, _ in
 
 func resourceAccountInviteDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteAccountInvite: Delete Organizations account invite
 	var (
 		deleteAccountInviteProduct = "organizations"
 	)
-	deleteAccountInviteClient, err := cfg.NewServiceClient(deleteAccountInviteProduct, "")
+	deleteAccountInviteClient, err := cfg.NewServiceClient(deleteAccountInviteProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_accepter.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_accepter.go
@@ -91,13 +91,14 @@ cancelled, declined, or expired.`,
 
 func resourceAccountInviteAccepterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createAccountInviteAccepter: create Organizations account invite accepter
 	var (
 		createAccountInviteAccepterHttpUrl = "v1/received-handshakes/{handshake_id}/accept"
 		createAccountInviteAccepterProduct = "organizations"
 	)
-	createAccountInviteAccepterClient, err := cfg.NewServiceClient(createAccountInviteAccepterProduct, "")
+	createAccountInviteAccepterClient, err := cfg.NewServiceClient(createAccountInviteAccepterProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -132,6 +133,7 @@ func resourceAccountInviteAccepterCreate(ctx context.Context, d *schema.Resource
 
 func resourceAccountInviteAccepterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -139,7 +141,7 @@ func resourceAccountInviteAccepterRead(_ context.Context, d *schema.ResourceData
 	var (
 		getAccountInviteAccepterProduct = "organizations"
 	)
-	getAccountInviteAccepterClient, err := cfg.NewServiceClient(getAccountInviteAccepterProduct, "")
+	getAccountInviteAccepterClient, err := cfg.NewServiceClient(getAccountInviteAccepterProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -176,6 +178,7 @@ func resourceAccountInviteAccepterUpdate(_ context.Context, _ *schema.ResourceDa
 
 func resourceAccountInviteAccepterDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	if !d.Get("leave_organization_on_destroy").(bool) {
 		return nil
@@ -186,7 +189,7 @@ func resourceAccountInviteAccepterDelete(_ context.Context, d *schema.ResourceDa
 		deleteAccountInviteAccepterHttpUrl = "v1/organizations/leave"
 		deleteAccountInviteAccepterProduct = "organizations"
 	)
-	deleteAccountInviteAccepterClient, err := cfg.NewServiceClient(deleteAccountInviteAccepterProduct, "")
+	deleteAccountInviteAccepterClient, err := cfg.NewServiceClient(deleteAccountInviteAccepterProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_organization.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_organization.go
@@ -97,13 +97,14 @@ func ResourceOrganization() *schema.Resource {
 
 func resourceOrganizationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createOrganization: create Organizations organization
 	var (
 		createOrganizationHttpUrl = "v1/organizations"
 		createOrganizationProduct = "organizations"
 	)
-	createOrganizationClient, err := cfg.NewServiceClient(createOrganizationProduct, "")
+	createOrganizationClient, err := cfg.NewServiceClient(createOrganizationProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -162,6 +163,7 @@ func resourceOrganizationCreate(ctx context.Context, d *schema.ResourceData, met
 
 func resourceOrganizationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -169,7 +171,7 @@ func resourceOrganizationRead(_ context.Context, d *schema.ResourceData, meta in
 	var (
 		getOrganizationProduct = "organizations"
 	)
-	getOrganizationClient, err := cfg.NewServiceClient(getOrganizationProduct, "")
+	getOrganizationClient, err := cfg.NewServiceClient(getOrganizationProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -356,12 +358,13 @@ func policyStateRefreshFunc(client *golangsdk.ServiceClient, policyType string) 
 
 func resourceOrganizationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// updateOrganization: update Organizations organization
 	var (
 		updateOrganizationProduct = "organizations"
 	)
-	updateOrganizationClient, err := cfg.NewServiceClient(updateOrganizationProduct, "")
+	updateOrganizationClient, err := cfg.NewServiceClient(updateOrganizationProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -401,15 +404,16 @@ func resourceOrganizationUpdate(ctx context.Context, d *schema.ResourceData, met
 	return resourceOrganizationRead(ctx, d, meta)
 }
 
-func resourceOrganizationDelete(_ context.Context, _ *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOrganizationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteOrganization: Delete Organizations organization
 	var (
 		deleteOrganizationHttpUrl = "v1/organizations"
 		deleteOrganizationProduct = "organizations"
 	)
-	deleteOrganizationClient, err := cfg.NewServiceClient(deleteOrganizationProduct, "")
+	deleteOrganizationClient, err := cfg.NewServiceClient(deleteOrganizationProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_organizational_unit.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_organizational_unit.go
@@ -62,13 +62,14 @@ want to create a new organizational unit.`,
 
 func resourceOrganizationalUnitCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createOrganizationalUnit: create Organizations organizational unit
 	var (
 		createOrganizationalUnitHttpUrl = "v1/organizations/organizational-units"
 		createOrganizationalUnitProduct = "organizations"
 	)
-	createOrganizationalUnitClient, err := cfg.NewServiceClient(createOrganizationalUnitProduct, "")
+	createOrganizationalUnitClient, err := cfg.NewServiceClient(createOrganizationalUnitProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -114,6 +115,7 @@ func buildCreateOrganizationalUnitBodyParams(d *schema.ResourceData) map[string]
 
 func resourceOrganizationalUnitRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -122,7 +124,7 @@ func resourceOrganizationalUnitRead(_ context.Context, d *schema.ResourceData, m
 		getOrganizationalUnitHttpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
 		getOrganizationalUnitProduct = "organizations"
 	)
-	getOrganizationalUnitClient, err := cfg.NewServiceClient(getOrganizationalUnitProduct, "")
+	getOrganizationalUnitClient, err := cfg.NewServiceClient(getOrganizationalUnitProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -174,13 +176,14 @@ func resourceOrganizationalUnitRead(_ context.Context, d *schema.ResourceData, m
 
 func resourceOrganizationalUnitUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// updateOrganizationalUnit: update Organizations organizational unit
 	var (
 		updateOrganizationalUnitHttpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
 		updateOrganizationalUnitProduct = "organizations"
 	)
-	updateOrganizationalUnitClient, err := cfg.NewServiceClient(updateOrganizationalUnitProduct, "")
+	updateOrganizationalUnitClient, err := cfg.NewServiceClient(updateOrganizationalUnitProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -222,13 +225,14 @@ func buildUpdateOrganizationalUnitBodyParams(d *schema.ResourceData) map[string]
 
 func resourceOrganizationalUnitDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteOrganizationalUnit: Delete Organizations organizational unit
 	var (
 		deleteOrganizationalUnitHttpUrl = "v1/organizations/organizational-units/{organizational_unit_id}"
 		deleteOrganizationalUnitProduct = "organizations"
 	)
-	deleteOrganizationalUnitClient, err := cfg.NewServiceClient(deleteOrganizationalUnitProduct, "")
+	deleteOrganizationalUnitClient, err := cfg.NewServiceClient(deleteOrganizationalUnitProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_trusted_service.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_trusted_service.go
@@ -47,13 +47,14 @@ func ResourceTrustedService() *schema.Resource {
 
 func resourceTrustedServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createTrustedService: create Organizations trusted service
 	var (
 		createTrustedServiceHttpUrl = "v1/organizations/trusted-services/enable"
 		createTrustedServiceProduct = "organizations"
 	)
-	createTrustedServiceClient, err := cfg.NewServiceClient(createTrustedServiceProduct, "")
+	createTrustedServiceClient, err := cfg.NewServiceClient(createTrustedServiceProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -84,6 +85,7 @@ func buildTrustedServiceBodyParams(d *schema.ResourceData) map[string]interface{
 
 func resourceTrustedServiceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -92,7 +94,7 @@ func resourceTrustedServiceRead(_ context.Context, d *schema.ResourceData, meta 
 		getTrustedServiceHttpUrl = "v1/organizations/trusted-services"
 		getTrustedServiceProduct = "organizations"
 	)
-	getTrustedServiceClient, err := cfg.NewServiceClient(getTrustedServiceProduct, "")
+	getTrustedServiceClient, err := cfg.NewServiceClient(getTrustedServiceProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}
@@ -162,13 +164,14 @@ func buildGetTrustedServiceQueryParams(marker string) string {
 
 func resourceTrustedServiceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteTrustedService: Delete Organizations trusted service
 	var (
 		deleteTrustedServiceHttpUrl = "v1/organizations/trusted-services/disable"
 		deleteTrustedServiceProduct = "organizations"
 	)
-	deleteTrustedServiceClient, err := cfg.NewServiceClient(deleteTrustedServiceProduct, "")
+	deleteTrustedServiceClient, err := cfg.NewServiceClient(deleteTrustedServiceProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating Organizations Client: %s", err)
 	}

--- a/huaweicloud/services/ucs/resource_huaweicloud_ucs_cluster.go
+++ b/huaweicloud/services/ucs/resource_huaweicloud_ucs_cluster.go
@@ -128,13 +128,14 @@ func ResourceCluster() *schema.Resource {
 
 func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createCluster: Create a UCS Cluster.
 	var (
 		createClusterHttpUrl = "v1/clusters"
 		createClusterProduct = "ucs"
 	)
-	createClusterClient, err := cfg.NewServiceClient(createClusterProduct, "")
+	createClusterClient, err := cfg.NewServiceClient(createClusterProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}
@@ -210,6 +211,7 @@ func buildCreateClusterSpecBodyParams(d *schema.ResourceData) map[string]interfa
 
 func resourceClusterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -218,7 +220,7 @@ func resourceClusterRead(_ context.Context, d *schema.ResourceData, meta interfa
 		getClusterHttpUrl = "v1/clusters/{id}"
 		getClusterProduct = "ucs"
 	)
-	getClusterClient, err := cfg.NewServiceClient(getClusterProduct, "")
+	getClusterClient, err := cfg.NewServiceClient(getClusterProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}
@@ -266,11 +268,12 @@ func resourceClusterRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var (
 		updateClusterProduct = "ucs"
 	)
-	updateClusterClient, err := cfg.NewServiceClient(updateClusterProduct, "")
+	updateClusterClient, err := cfg.NewServiceClient(updateClusterProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}
@@ -372,13 +375,14 @@ func buildUpdateClusterSpecBodyParams(d *schema.ResourceData) map[string]interfa
 
 func resourceClusterDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteCluster: Delete an existing UCS Cluster
 	var (
 		deleteClusterHttpUrl = "v1/clusters/{id}"
 		deleteClusterProduct = "ucs"
 	)
-	deleteClusterClient, err := cfg.NewServiceClient(deleteClusterProduct, "")
+	deleteClusterClient, err := cfg.NewServiceClient(deleteClusterProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}

--- a/huaweicloud/services/ucs/resource_huaweicloud_ucs_fleet.go
+++ b/huaweicloud/services/ucs/resource_huaweicloud_ucs_fleet.go
@@ -82,13 +82,14 @@ func FleetPermissionSchema() *schema.Resource {
 
 func resourceFleetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createFleet: Create a UCS Fleet.
 	var (
 		createFleetHttpUrl = "v1/clustergroups"
 		createFleetProduct = "ucs"
 	)
-	createFleetClient, err := cfg.NewServiceClient(createFleetProduct, "")
+	createFleetClient, err := cfg.NewServiceClient(createFleetProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}
@@ -149,6 +150,7 @@ func buildCreateFleetSpecOpts(d *schema.ResourceData) map[string]interface{} {
 
 func resourceFleetRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -157,7 +159,7 @@ func resourceFleetRead(_ context.Context, d *schema.ResourceData, meta interface
 		getFleetHttpUrl = "v1/clustergroups/{id}"
 		getFleetProduct = "ucs"
 	)
-	getFleetClient, err := cfg.NewServiceClient(getFleetProduct, "")
+	getFleetClient, err := cfg.NewServiceClient(getFleetProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}
@@ -213,8 +215,9 @@ func flattenPermissions(permissionsRaw interface{}) []map[string]interface{} {
 
 func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 	updateFleetProduct := "ucs"
-	updateFleetClient, err := cfg.NewServiceClient(updateFleetProduct, "")
+	updateFleetClient, err := cfg.NewServiceClient(updateFleetProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}
@@ -223,7 +226,7 @@ func resourceFleetUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		// updateFleet: Update the UCS Fleet
 		updateFleetHttpUrl := "v1/clustergroups/{id}/description"
 
-		updateFleetClient, err := cfg.NewServiceClient(updateFleetProduct, "")
+		updateFleetClient, err := cfg.NewServiceClient(updateFleetProduct, region)
 		if err != nil {
 			return diag.Errorf("error creating UCS Client: %s", err)
 		}
@@ -312,13 +315,14 @@ func buildUpdateFleetPermissionsRequestBodyPolicy(rawParams interface{}) []map[s
 
 func resourceFleetDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deleteFleet: Delete an existing UCS Fleet
 	var (
 		deleteFleetHttpUrl = "v1/clustergroups/{id}"
 		deleteFleetProduct = "ucs"
 	)
-	deleteFleetClient, err := cfg.NewServiceClient(deleteFleetProduct, "")
+	deleteFleetClient, err := cfg.NewServiceClient(deleteFleetProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}

--- a/huaweicloud/services/ucs/resource_huaweicloud_ucs_policy.go
+++ b/huaweicloud/services/ucs/resource_huaweicloud_ucs_policy.go
@@ -102,13 +102,14 @@ func PolicyContentSchema() *schema.Resource {
 
 func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// createPolicy: Create a UCS Policy.
 	var (
 		createPolicyHttpUrl = "v1/permissions/rules"
 		createPolicyProduct = "ucs"
 	)
-	createPolicyClient, err := cfg.NewServiceClient(createPolicyProduct, "")
+	createPolicyClient, err := cfg.NewServiceClient(createPolicyProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}
@@ -192,6 +193,7 @@ func buildPolicyRequestBodyContent(rawParams interface{}) []map[string]interface
 
 func resourcePolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	var mErr *multierror.Error
 
@@ -200,7 +202,7 @@ func resourcePolicyRead(_ context.Context, d *schema.ResourceData, meta interfac
 		getPolicyHttpUrl = "v1/permissions/rules"
 		getPolicyProduct = "ucs"
 	)
-	getPolicyClient, err := cfg.NewServiceClient(getPolicyProduct, "")
+	getPolicyClient, err := cfg.NewServiceClient(getPolicyProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}
@@ -265,6 +267,7 @@ func flattenGetPolicyResponseBodyContent(resp interface{}) []interface{} {
 
 func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	updatePolicyChanges := []string{
 		"description",
@@ -279,7 +282,7 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			updatePolicyHttpUrl = "v1/permissions/rules/{id}"
 			updatePolicyProduct = "ucs"
 		)
-		updatePolicyClient, err := cfg.NewServiceClient(updatePolicyProduct, "")
+		updatePolicyClient, err := cfg.NewServiceClient(updatePolicyProduct, region)
 		if err != nil {
 			return diag.Errorf("error creating UCS Client: %s", err)
 		}
@@ -312,13 +315,14 @@ func buildUpdatePolicyBodyParams(d *schema.ResourceData) map[string]interface{} 
 
 func resourcePolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
 
 	// deletePolicy: Delete an existing UCS Policy
 	var (
 		deletePolicyHttpUrl = "v1/permissions/rules/{id}"
 		deletePolicyProduct = "ucs"
 	)
-	deletePolicyClient, err := cfg.NewServiceClient(deletePolicyProduct, "")
+	deletePolicyClient, err := cfg.NewServiceClient(deletePolicyProduct, region)
 	if err != nil {
 		return diag.Errorf("error creating UCS Client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: region format adjust

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes # "reason":"validate register cce cluster request error:cce cluster version not support in UCS service"

concrete measure：Add specific version information of CCE.
example： cluster_version = "v1.19.16-r1"

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

root@ecs-wangyuancheng:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (endpoint)$ make testacc TEST="./huaweicloud/services/acceptance/ucs" TESTARGS="-run TestAccCluster_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ucs -v -run TestAccCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCluster_basic
=== PAUSE TestAccCluster_basic
=== CONT  TestAccCluster_basic
--- PASS: TestAccCluster_basic (606.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ucs       606.304s

root@ecs-wangyuancheng:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (endpoint)$ make testacc TEST="./huaweicloud/services/acceptance/ucs" TESTARGS="-run TestAccCluster_cce"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ucs -v -run TestAccCluster_cce -timeout 360m -parallel 4
=== RUN   TestAccCluster_cce
=== PAUSE TestAccCluster_cce
=== CONT  TestAccCluster_cce
--- PASS: TestAccCluster_cce (576.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ucs       576.107s

root@ecs-wangyuancheng:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (endpoint)$ make testacc TEST="./huaweicloud/services/acceptance/ucs" TESTARGS="-run TestAccFleet_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ucs -v -run TestAccFleet_basic -timeout 360m -parallel 4
=== RUN   TestAccFleet_basic
=== PAUSE TestAccFleet_basic
=== CONT  TestAccFleet_basic
--- PASS: TestAccFleet_basic (61.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ucs       61.757s

root@ecs-wangyuancheng:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (endpoint)$ make testacc TEST="./huaweicloud/services/acceptance/ucs" TESTARGS="-run TestAccPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ucs -v -run TestAccPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccPolicy_basic
=== PAUSE TestAccPolicy_basic
=== CONT  TestAccPolicy_basic
--- PASS: TestAccPolicy_basic (39.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ucs       39.390s
