### PR TITLE
test(er): modify concurrent test to serial test

### DIFF
--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_attachments_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_attachments_test.go
@@ -20,10 +20,9 @@ func TestAccAttachmentsDataSource_basic(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -116,10 +115,9 @@ func TestAccAttachmentsDataSource_filterById(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -179,10 +177,9 @@ func TestAccAttachmentsDataSource_filterByType(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -248,10 +245,9 @@ func TestAccAttachmentsDataSource_filterByStatus(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -309,10 +305,9 @@ func TestAccAttachmentsDataSource_filterByTags(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -382,10 +377,9 @@ func TestAccAttachmentsDataSource_filterByResourceId(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_flow_logs_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_flow_logs_test.go
@@ -43,7 +43,7 @@ func TestAccDatasourceFlowLogs_basic(t *testing.T) {
 		dcByLogStreamId = acceptance.InitDataSourceCheck(byLogStreamId)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_instances_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_instances_test.go
@@ -19,10 +19,9 @@ func TestAccInstancesDataSource_basic(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -84,10 +83,9 @@ func TestAccInstancesDataSource_filterById(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -125,10 +123,9 @@ func TestAccInstancesDataSource_filterByStatus(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -166,10 +163,9 @@ func TestAccInstancesDataSource_filterByEpsId(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -212,10 +208,9 @@ func TestAccInstancesDataSource_filterByTags(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
@@ -19,10 +19,9 @@ func TestAccRouteTablesDataSource_basic(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -46,10 +45,9 @@ func TestAccRouteTablesDataSource_byName(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -73,10 +71,9 @@ func TestAccRouteTablesDataSource_byId(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -100,10 +97,9 @@ func TestAccRouteTablesDataSource_byTags(t *testing.T) {
 		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
@@ -40,7 +40,7 @@ func TestAccAssociation_basic(t *testing.T) {
 		getAssociationResourceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_flow_log_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_flow_log_test.go
@@ -56,7 +56,7 @@ func TestAccFlowLog_basic(t *testing.T) {
 		)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_instance_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_instance_test.go
@@ -58,7 +58,7 @@ func TestAccInstance_basic(t *testing.T) {
 		getInstanceResourceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_propagation_test.go
@@ -40,7 +40,7 @@ func TestAccPropagation_basic(t *testing.T) {
 		getPropagationResourceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
@@ -39,10 +39,9 @@ func TestAccRouteTable_basic(t *testing.T) {
 		getRouteTableResourceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_static_route_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_static_route_test.go
@@ -38,10 +38,9 @@ func TestAccStaticRoute_basic(t *testing.T) {
 		crossVpcRes   = acceptance.InitResourceCheck(crossVpcResName, &obj, getStaticRouteFunc)
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckER(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      sourceSelfRes.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
@@ -38,7 +38,7 @@ func TestAccVpcAttachment_basic(t *testing.T) {
 		getVpcAttachmentResourceFunc,
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Since the server limits the user's ER instance quota (maximum value: 1), test cases containing ER instances can only be tested in a serial manner. If concurrent testing is used, an error will be reported.
```
Error: error creating Instance: Bad request with: [POST https://er.cn-north-4.myhuaweicloud.com/v3/0970dd7a1300f5672ff2c003c60ae115/enterprise-router/instances], request_id: 16bb60ce9bb67790bd8d843bccbde956, error message: {"error_code":"ER.04009008","error_msg":"Quota Insufficient.","request_id":"16bb60ce9bb67790bd8d843bccbde956"}
        
          with huaweicloud_er_instance.test,
          on terraform_plugin_test.tf line 19, in resource "huaweicloud_er_instance" "test":
          19: resource "huaweicloud_er_instance" "test" {
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. modify concurrent test to serial test
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAcc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAcc -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_basic
--- PASS: TestAccAttachmentsDataSource_basic (111.51s)
=== RUN   TestAccAttachmentsDataSource_filterById
--- PASS: TestAccAttachmentsDataSource_filterById (105.67s)
=== RUN   TestAccAttachmentsDataSource_filterByType
--- PASS: TestAccAttachmentsDataSource_filterByType (110.29s)
=== RUN   TestAccAttachmentsDataSource_filterByStatus
--- PASS: TestAccAttachmentsDataSource_filterByStatus (110.30s)
=== RUN   TestAccAttachmentsDataSource_filterByTags
--- PASS: TestAccAttachmentsDataSource_filterByTags (104.21s)
=== RUN   TestAccAttachmentsDataSource_filterByResourceId
--- PASS: TestAccAttachmentsDataSource_filterByResourceId (111.25s)
=== RUN   TestAccDataSourceAZs_basic
=== PAUSE TestAccDataSourceAZs_basic
=== RUN   TestAccDatasourceFlowLogs_basic
--- PASS: TestAccDatasourceFlowLogs_basic (161.54s)
=== RUN   TestAccInstancesDataSource_basic
--- PASS: TestAccInstancesDataSource_basic (49.85s)
=== RUN   TestAccInstancesDataSource_filterById
--- PASS: TestAccInstancesDataSource_filterById (48.61s)
=== RUN   TestAccInstancesDataSource_filterByStatus
--- PASS: TestAccInstancesDataSource_filterByStatus (53.38s)
=== RUN   TestAccInstancesDataSource_filterByEpsId
--- PASS: TestAccInstancesDataSource_filterByEpsId (58.93s)
=== RUN   TestAccInstancesDataSource_filterByTags
--- PASS: TestAccInstancesDataSource_filterByTags (58.03s)
=== RUN   TestAccRouteTablesDataSource_basic
--- PASS: TestAccRouteTablesDataSource_basic (68.94s)
=== RUN   TestAccRouteTablesDataSource_byName
--- PASS: TestAccRouteTablesDataSource_byName (68.76s)
=== RUN   TestAccRouteTablesDataSource_byId
--- PASS: TestAccRouteTablesDataSource_byId (66.17s)
=== RUN   TestAccRouteTablesDataSource_byTags
--- PASS: TestAccRouteTablesDataSource_byTags (65.75s)
=== RUN   TestAccAssociation_basic
    resource_huaweicloud_er_association_test.go:43: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # huaweicloud_er_instance.test will be updated in-place
          ~ resource "huaweicloud_er_instance" "test" {
              ~ availability_zones             = [
                  - "cn-north-4a",
                  + "cn-north-4g",
                ]
                id                             = "5e2e1191-2931-4fd7-89a3-009de0fd0962"
                name                           = "tf_test_x0zgm"
                # (9 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAssociation_basic (118.38s)
=== RUN   TestAccFlowLog_basic
--- PASS: TestAccFlowLog_basic (184.17s)
=== RUN   TestAccInstance_basic
--- PASS: TestAccInstance_basic (57.10s)
=== RUN   TestAccPropagation_basic
--- PASS: TestAccPropagation_basic (121.66s)
=== RUN   TestAccRouteTable_basic
--- PASS: TestAccRouteTable_basic (83.13s)
=== RUN   TestAccStaticRoute_basic
--- PASS: TestAccStaticRoute_basic (165.75s)
=== RUN   TestAccVpcAttachment_basic
--- PASS: TestAccVpcAttachment_basic (142.89s)
=== CONT  TestAccDataSourceAZs_basic
--- PASS: TestAccDataSourceAZs_basic (6.36s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        2232.645s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```
