### PR TITLE
chore(er/attachment): resource supports updating tags

### DIFF
--- a/docs/resources/er_vpc_attachment.md
+++ b/docs/resources/er_vpc_attachment.md
@@ -64,8 +64,7 @@ The following arguments are supported:
 
   The default value is false. Changing this parameter will create a new resource.
 
-* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the VPC attachment.  
-  Changing this parameter will create a new resource.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the VPC attachment.  
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_vpc_attachment_test.go
@@ -65,6 +65,7 @@ func TestAccVpcAttachment_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
 					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
 				),
 			},
 			{
@@ -166,7 +167,7 @@ resource "huaweicloud_er_vpc_attachment" "test" {
   auto_create_vpc_routes = true
 
   tags = {
-    foo = "bar"
+    owner = "terraform"
   }
 }
 `, testVpcAttachment_base(name, bgpAsNum), name)

--- a/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
@@ -92,7 +92,7 @@ func ResourceVpcAttachment() *schema.Resource {
 				ForceNew:    true,
 				Description: `Whether to automatically configure routes for the VPC which pointing to the ER instance.`,
 			},
-			"tags": common.TagsForceNewSchema(),
+			"tags": common.TagsSchema(),
 			// Attributes
 			"status": {
 				Type:        schema.TypeString,
@@ -248,6 +248,13 @@ func resourceVpcAttachmentUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChanges("name", "description") {
 		if err = updateVpcAttachmentBasicInfo(ctx, client, d); err != nil {
 			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = utils.UpdateResourceTags(client, d, "vpc-attachment", d.Id())
+		if err != nil {
+			return diag.Errorf("error updating VPC attachment tags: %s", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

ER VPC attachment resource supports updating tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add update tags parameter logic in the code.
2. modify related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/er TESTARGS='-run TestAccVpcAttachment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccVpcAttachment_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcAttachment_basic
=== PAUSE TestAccVpcAttachment_basic
=== CONT  TestAccVpcAttachment_basic
--- PASS: TestAccVpcAttachment_basic (172.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        173.006s
```
