### PR TITLE
chore(er/routetable): resource supports updating tags

### DIFF
--- a/docs/resources/er_route_table.md
+++ b/docs/resources/er_route_table.md
@@ -41,8 +41,7 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies the description of the route table.  
   The description contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
 
-* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the route table.  
-  Changing this parameter will create a new resource.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the route table.  
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_route_table_test.go
@@ -65,6 +65,7 @@ func TestAccRouteTable_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
 					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
 				),
 			},
 			{
@@ -131,7 +132,7 @@ resource "huaweicloud_er_route_table" "test" {
   name        = "%[2]s"
 
   tags = {
-    foo = "bar"
+    owner = "terraform"
   }
 }
 `, testRouteTable_base(name, bgpAsNum), name)

--- a/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
@@ -75,7 +75,7 @@ func ResourceRouteTable() *schema.Resource {
 						"The angle brackets (< and >) are not allowed."),
 				),
 			},
-			"tags": common.TagsForceNewSchema(),
+			"tags": common.TagsSchema(),
 			// Attributes
 			"is_default_association": {
 				Type:        schema.TypeBool,
@@ -240,6 +240,13 @@ func resourceRouteTableUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	if d.HasChanges("name", "description") {
 		if err = updateRouteTableBasicInfo(ctx, client, d); err != nil {
 			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		err = utils.UpdateResourceTags(client, d, "route-table", d.Id())
+		if err != nil {
+			return diag.Errorf("error updating route table tags: %s", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

ER route table resource supports updating tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add update tags parameter logic in the code.
2. modify related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST=./huaweicloud/services/acceptance/er TESTARGS='-run TestAccRouteTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccRouteTable_basic -timeout 360m -parallel 4
=== RUN   TestAccRouteTable_basic
=== PAUSE TestAccRouteTable_basic
=== CONT  TestAccRouteTable_basic
--- PASS: TestAccRouteTable_basic (113.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        113.120s
```
