### PR TITLE
feat(cbh): add a new data source to query the list of CBH specification

### DIFF
--- a/docs/data-sources/cbh_flavors.md
+++ b/docs/data-sources/cbh_flavors.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Cloud Bastion Host (CBH)"
+---
+
+# huaweicloud_cbh_flavors
+
+Use this data source to get the list of CBH specifications.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cbh_flavors" "test" {
+  type = "basic"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `asset` - (Optional, Int) Specifies the number of CBH assets.
+
+* `type` - (Optional, String) Specifies the type of CBH specification. The value can be:
+  + **basic**: Standard version.
+  + **enhance**: Professional version.
+
+* `vcpus` - (Optional, Int) Specifies the number of CPU cores of the CBH.
+
+* `memory` - (Optional, Int) Specifies the memory size of the CBH, in GB.
+
+* `max_connection` - (Optional, Int) Specifies the maximum number of connections to the CBH.
+
+* `flavor_id` - (Optional, String) Specifies the ID of the specification of CBH.
+  At present, CBH provides two functional versions: standard version and professional version.
+  The standard version is equipped with asset specifications of 10(for example the `flavor_id` is: **cbh.basic.10**),
+  20, 50, 100, 200, 500, 1000, 2000, 5000, and 10000.
+  The professional version is equipped with 10(for example the `flavor_id` is: **cbh.enhance.10**),
+  20, 50, 100, 200, 500, 1000, 2000, 5000, 10000 asset specifications.
+  The specification 'enhance' is more advanced than the specification 'basic'.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `flavors` - Indicates the list of CBH specification.
+  The [flavor](#CbhFlavors_flavor) structure is documented below.
+
+<a name="CbhFlavors_flavor"></a>
+The `flavor` block supports:
+
+* `id` - Indicates the ID of the specification.
+
+* `ecs_system_data_size` - The disk size of the CBH system disk, in GB.
+
+* `vcpus` - The number of CPU cores of the CBH.
+
+* `memory` - The memory size of the CBH, in GB.
+
+* `asset` - The number of CBH assets.
+
+* `max_connection` - The maximum number of connections to the CBH.
+
+* `type` - The type of CBH specification. The value can be:
+  + **basic**: Standard version.
+  + **enhance**: Professional version.
+
+* `data_disk_size` - The size of the CBH data disk, in TB.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -412,6 +412,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_policies": cbr.DataSourcePolicies(),
 
 			"huaweicloud_cbh_instances": cbh.DataSourceCbhInstances(),
+			"huaweicloud_cbh_flavors":   cbh.DataSourceCbhFlavors(),
 
 			"huaweicloud_cce_addon_template":      cce.DataSourceAddonTemplate(),
 			"huaweicloud_cce_cluster":             cce.DataSourceCCEClusterV3(),

--- a/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_flavors_test.go
+++ b/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_flavors_test.go
@@ -1,0 +1,120 @@
+package cbh
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCbhFlavors_basic(t *testing.T) {
+	rName := "data.huaweicloud_cbh_flavors.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCbhFlavors_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.ecs_system_data_size"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.vcpus"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.memory"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.asset"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.max_connection"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "flavors.0.data_disk_size"),
+
+					resource.TestCheckOutput("flavor_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckOutput("asset_filter_is_useful", "true"),
+					resource.TestCheckOutput("memory_filter_is_useful", "true"),
+					resource.TestCheckOutput("vcpus_filter_is_useful", "true"),
+					resource.TestCheckOutput("max_connection_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCbhFlavors_basic() string {
+	return `
+data "huaweicloud_cbh_flavors" "test" {}
+
+locals {
+  flavor_id = data.huaweicloud_cbh_flavors.test.flavors[0].id
+}
+data "huaweicloud_cbh_flavors" "flavor_id_filter" {
+  flavor_id = local.flavor_id
+}
+output "flavor_id_filter_is_useful" {
+  value = length(data.huaweicloud_cbh_flavors.flavor_id_filter.flavors) > 0 && alltrue(
+    [for v in data.huaweicloud_cbh_flavors.flavor_id_filter.flavors[*].id : v == local.flavor_id]
+  )  
+}
+
+locals {
+  type = data.huaweicloud_cbh_flavors.test.flavors[0].type
+}
+data "huaweicloud_cbh_flavors" "type_filter" {
+  type = local.type
+}
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_cbh_flavors.type_filter.flavors) > 0 && alltrue(
+    [for v in data.huaweicloud_cbh_flavors.type_filter.flavors[*].type : v == local.type]
+  )  
+}
+
+locals {
+  asset = data.huaweicloud_cbh_flavors.test.flavors[0].asset
+}
+data "huaweicloud_cbh_flavors" "asset_filter" {
+  asset = local.asset
+}
+output "asset_filter_is_useful" {
+  value = length(data.huaweicloud_cbh_flavors.asset_filter.flavors) > 0 && alltrue(
+    [for v in data.huaweicloud_cbh_flavors.asset_filter.flavors[*].asset : v == local.asset]
+  )  
+}
+
+locals {
+  memory = data.huaweicloud_cbh_flavors.test.flavors[0].memory
+}
+data "huaweicloud_cbh_flavors" "memory_filter" {
+  memory = local.memory
+}
+output "memory_filter_is_useful" {
+  value = length(data.huaweicloud_cbh_flavors.memory_filter.flavors) > 0 && alltrue(
+    [for v in data.huaweicloud_cbh_flavors.memory_filter.flavors[*].memory : v == local.memory]
+  )  
+}
+
+locals {
+  vcpus = data.huaweicloud_cbh_flavors.test.flavors[0].vcpus
+}
+data "huaweicloud_cbh_flavors" "vcpus_filter" {
+  vcpus = local.vcpus
+}
+output "vcpus_filter_is_useful" {
+  value = length(data.huaweicloud_cbh_flavors.vcpus_filter.flavors) > 0 && alltrue(
+    [for v in data.huaweicloud_cbh_flavors.vcpus_filter.flavors[*].vcpus : v == local.vcpus]
+  )  
+}
+
+locals {
+  max_connection = data.huaweicloud_cbh_flavors.test.flavors[0].max_connection
+}
+data "huaweicloud_cbh_flavors" "max_connection_filter" {
+  max_connection = local.max_connection
+}
+output "max_connection_filter_is_useful" {
+  value = length(data.huaweicloud_cbh_flavors.max_connection_filter.flavors) > 0 && alltrue(
+    [for v in data.huaweicloud_cbh_flavors.max_connection_filter.flavors[*].max_connection : v == local.max_connection]
+  )  
+}
+`
+}

--- a/huaweicloud/services/cbh/data_source_huaweicloud_cbh_flavors.go
+++ b/huaweicloud/services/cbh/data_source_huaweicloud_cbh_flavors.go
@@ -1,0 +1,208 @@
+package cbh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// API: GET CBH /v2/{project_id}/instance/specification
+func DataSourceCbhFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"asset": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"vcpus": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"max_connection": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"flavors": {
+				Type:     schema.TypeList,
+				Elem:     flavorSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func flavorSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ecs_system_data_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"vcpus": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"asset": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"max_connection": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_disk_size": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// get CBH Flavors: Query CBH Flavors
+	var (
+		getCBHFlavorsHttpUrl = "v2/{project_id}/cbs/instance/specification"
+		getCBHFlavorsProduct = "cbh"
+	)
+	getCBHFlavorsClient, err := cfg.NewServiceClient(getCBHFlavorsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	getCBHFlavorsPath := getCBHFlavorsClient.Endpoint + getCBHFlavorsHttpUrl
+	getCBHFlavorsPath = strings.ReplaceAll(getCBHFlavorsPath, "{project_id}",
+		getCBHFlavorsClient.ProjectID)
+	getCBHFlavorsPath += "?action=create"
+
+	getCBHFlavorsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	getCBHFlavorsResp, err := getCBHFlavorsClient.Request("GET", getCBHFlavorsPath, &getCBHFlavorsOpt)
+
+	if err != nil {
+		return diag.Errorf("error retrieving CBH flavors, %s", err)
+	}
+
+	getCBHFlavorsRespBody, err := utils.FlattenResponse(getCBHFlavorsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("flavors", filterGetFlavorsResponseBodyFlavor(
+			flattenListFlavorsBody(getCBHFlavorsRespBody), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterGetFlavorsResponseBodyFlavor(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("flavor_id"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("id", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("type"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("type", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("asset"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("asset", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("memory"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("memory", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("vcpus"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("vcpus", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("max_connection"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("max_connection", v, nil)) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func flattenListFlavorsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	// The responseBody is in the form of an array
+	curArray := resp.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                   utils.PathSearch("resource_spec_code", v, nil),
+			"ecs_system_data_size": utils.PathSearch("ecs_system_data_size", v, nil),
+			"vcpus":                utils.PathSearch("cpu", v, nil),
+			"memory":               utils.PathSearch("ram", v, nil),
+			"asset":                utils.PathSearch("asset", v, nil),
+			"max_connection":       utils.PathSearch("connection", v, nil),
+			"type":                 utils.PathSearch("type", v, nil),
+			"data_disk_size":       utils.PathSearch("data_disk_size", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
+ Data source design idea: first query all supported specifications through action=create, and then filter through the parameters of the specifications.
+ Supported filterable parameters：flavor_id,type,asset,memory,vcpus,max_connection.
+ The responseBody of the API is in the form of an array.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccDatasourceCbhFlavors_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccDatasourceCbhFlavors_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCbhFlavors_basic
=== PAUSE TestAccDatasourceCbhFlavors_basic
=== CONT  TestAccDatasourceCbhFlavors_basic
--- PASS: TestAccDatasourceCbhFlavors_basic (39.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       39.778s
```
