### PR TITLE
feat(workspace/service): resource support unlock action

### DIFF
--- a/docs/resources/workspace_service.md
+++ b/docs/resources/workspace_service.md
@@ -127,6 +127,9 @@ The following arguments are supported:
 
 * `management_subnet_cidr` - (Optional, String, ForceNew) The subnet segment of the management component.
 
+* `lock_enabled` - (Optional, Bool) Specifies whether to allow the provider to automatically unlock locked service
+  when it is running. The default value is **false**.
+
 * `otp_config_info` - (Optional, List) Specifies the configuration of auxiliary authentication.
   The [object](#config_info) structure is documented below.
 
@@ -201,6 +204,14 @@ In addition to all arguments above, the following attributes are exported:
   is registered. The [object](#service_security_group) structure is documented below.
 
 * `status` - The current status of the Workspace service.
+
+* `is_locked` - Whether the Workspace service is locked. The valid values are as follows:
+  + **0**: Indicates not locked.
+  + **1**: Indicates locked.
+
+* `lock_time` - The time of the Workspace service is locked.
+
+* `lock_reason` - The reason of the Workspace service is locked.
 
 <a name="service_security_group"></a>
 The `infrastructure_security_group` and `desktop_security_group` block supports:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240126095129-b85640b7f982
+	github.com/chnsz/golangsdk v0.0.0-20240126095247-f7504c8f85cd
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240126095129-b85640b7f982 h1:cM8SMxDbREyWJwpuFG2fbOnaTF1zhEL0u02NP8I/ZW4=
-github.com/chnsz/golangsdk v0.0.0-20240126095129-b85640b7f982/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240126095247-f7504c8f85cd h1:qsZyXIqgyVPcQIlg7dEioHHuRtZbw4RVn2uTvKcpasM=
+github.com/chnsz/golangsdk v0.0.0-20240126095247-f7504c8f85cd/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_service_test.go
@@ -62,6 +62,7 @@ func TestAccService_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "desktop_security_group.0.id"),
 					resource.TestCheckResourceAttrSet(resourceName, "internet_access_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttr(resourceName, "is_locked", "0"),
 				),
 			},
 			{

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_service.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_service.go
@@ -224,6 +224,10 @@ func ResourceService() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"lock_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"internet_access_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -247,6 +251,18 @@ func ResourceService() *schema.Resource {
 				Optional: true,
 				MaxItems: 1,
 				Elem:     assistAuthSchemaResource(),
+			},
+			"is_locked": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"lock_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"lock_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -451,6 +467,15 @@ func getAssistAuthConfig(client *golangsdk.ServiceClient) ([]map[string]interfac
 	return result, err
 }
 
+func getLockStatus(client *golangsdk.ServiceClient) (*services.LockStatusResp, error) {
+	resp, err := services.GetLockStatus(client)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving the lock status of Workspace service: %s", err)
+	}
+
+	return resp, nil
+}
+
 func resourceServiceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
@@ -499,6 +524,17 @@ func resourceServiceRead(_ context.Context, d *schema.ResourceData, meta interfa
 	} else {
 		mErr = multierror.Append(mErr, d.Set("otp_config_info", configInfo))
 	}
+
+	lockResp, err := getLockStatus(client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(mErr,
+		d.Set("is_locked", lockResp.IsLocked),
+		d.Set("lock_time", lockResp.LockTime),
+		d.Set("lock_reason", lockResp.LockReason),
+	)
 
 	if err = mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error setting service fields: %s", err)
@@ -592,6 +628,24 @@ func updateAssistAuthConfig(client *golangsdk.ServiceClient, d *schema.ResourceD
 	return services.UpdateAssistAuthConfig(client, opts)
 }
 
+func unlockService(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	opts := services.UnlockOpts{
+		OperateType: "unlock",
+	}
+	resp, err := services.UnlockService(client, opts)
+	if err != nil {
+		return fmt.Errorf("error unLocking of the Workspace service: %s", err)
+	}
+
+	_, err = waitForWorkspaceJobCompleted(ctx, client, resp.JobId, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return fmt.Errorf("error waiting for the job (%s) completed: %s", resp.JobId, err)
+	}
+	log.Printf("[DEBUG] The job (%s) has been completed", resp.JobId)
+
+	return err
+}
+
 func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	conf := meta.(*config.Config)
 	client, err := conf.WorkspaceV2Client(conf.GetRegion(d))
@@ -623,6 +677,18 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	if d.HasChanges("otp_config_info") {
 		if err = updateAssistAuthConfig(client, d); err != nil {
 			return diag.Errorf("error updating authentication config parameters of service: %s", err)
+		}
+	}
+
+	if d.HasChanges("lock_enabled") {
+		lockEnabled := d.Get("lock_enabled").(bool)
+		// If the current service is not locked, this action is not required.
+		if !lockEnabled {
+			return nil
+		}
+
+		if err = unlockService(ctx, client, d); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 	return resourceServiceRead(ctx, d, meta)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240126095129-b85640b7f982
+# github.com/chnsz/golangsdk v0.0.0-20240126095247-f7504c8f85cd
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Provide the capability of activating Workspace services that have not been used for 14 days.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 1. the Workspace service support unlock action.
 2. support related document and test case.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccService_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccService_basic -timeout 360m -parallel 4
=== RUN   TestAccService_basic
--- PASS: TestAccService_basic (628.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 628.692s
```
