### PR TITLE
feat(eip): add data source global eip pools

### DIFF
--- a/docs/data-sources/global_eip_pools.md
+++ b/docs/data-sources/global_eip_pools.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# huaweicloud_global_eip_pools
+
+Use this data source to get a list of global EIP pools available to your account.
+
+## Example Usage
+
+### Get all available global EIP pools
+
+```hcl
+data "huaweicloud_global_eip_pools" "all" {}
+```
+
+### Get specific available global EIP pools information
+
+```hcl
+data "huaweicloud_global_eip_pools" "test" {
+  access_site = "cn-south-guangzhou"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `access_site` - (Optional, String) Specifies the access site to which the global EIP pool belongs.
+
+* `ip_version` - (Optional, Int) Specifies the ip version. Valid values are **4** and **6**.
+
+* `isp` - (Optional, String) Specifies the internet service provider of the global EIP pool.
+
+* `name` - (Optional, String) Specifies the name of the global EIP pool.
+
+* `type` - (Optional, String) Specifies the type of the global EIP pool.
+
+  Valid values are:
+  + **GEIP**: global EIP.
+  + **GEIP_SEGMENT**: global EIP range.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `geip_pools` - The available global EIP pools list.
+  The [geip_pools](#attrblock--geip_pools) structure is documented below.
+
+<a name="attrblock--geip_pools"></a>
+The `geip_pools` block supports:
+
+* `id` - The id of the global EIP pool.
+
+* `access_site` - The access site to which the global EIP pool belongs.
+
+* `cn_name` - The Chinese name of the global EIP pool.
+
+* `en_name` - The English name of the global EIP pool.
+
+* `ip_version` - The ip version of the global EIP pool.
+
+* `isp` - The internet service provider of the global EIP pool.
+
+* `name` - The name of the global EIP pool.
+
+* `type` - The type of the global EIP pool.
+
+* `allowed_bandwidth_types` - The allowed bandwidth type of the global EIP pool
+  The [allowed_bandwidth_type](#attrblock--geip_pools--allowed_bandwidth_type) structure is documented below.
+
+* `created_at` - The create time of the global EIP pool.
+
+* `updated_at` - The update time of the global EIP pool.
+
+<a name="attrblock--geip_pools--allowed_bandwidth_type"></a>
+The `allowed_bandwidth_type` block supports:
+
+* `cn_name` - The Chinese name of the allowed bandwidth type.
+
+* `en_name` - The English name of the allowed bandwidth type.
+
+* `type` - The type of the allowed bandwidth.

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -312,6 +312,13 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version: "v3",
 		Product: "VPC",
 	},
+	"geip": {
+		Name:             "eip",
+		Version:          "v3",
+		Scope:            "global",
+		WithOutProjectID: true,
+		Product:          "EIP",
+	},
 	"nat": {
 		Name:    "nat",
 		Version: "v2",

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -634,10 +634,11 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_tms_resource_types": tms.DataSourceResourceTypes(),
 
-			"huaweicloud_vpc_bandwidth":  eip.DataSourceBandWidth(),
-			"huaweicloud_vpc_bandwidths": eip.DataSourceBandWidths(),
-			"huaweicloud_vpc_eip":        eip.DataSourceVpcEip(),
-			"huaweicloud_vpc_eips":       eip.DataSourceVpcEips(),
+			"huaweicloud_vpc_bandwidth":    eip.DataSourceBandWidth(),
+			"huaweicloud_vpc_bandwidths":   eip.DataSourceBandWidths(),
+			"huaweicloud_vpc_eip":          eip.DataSourceVpcEip(),
+			"huaweicloud_vpc_eips":         eip.DataSourceVpcEips(),
+			"huaweicloud_global_eip_pools": eip.DataSourceGlobalEIPPools(),
 
 			"huaweicloud_vpc":                    vpc.DataSourceVpcV1(),
 			"huaweicloud_vpcs":                   vpc.DataSourceVpcs(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_pools_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_pools_test.go
@@ -1,0 +1,213 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGlobalEIPPools_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_global_eip_pools.all"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalEIPPoolsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "geip_pools.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccGlobalEIPPoolsDataSource_basic string = `data "huaweicloud_global_eip_pools" "all" {}`
+
+func TestAccGlobalEIPPools_filter(t *testing.T) {
+	byName := "data.huaweicloud_global_eip_pools.filter_by_name"
+	byNameNotFound := "data.huaweicloud_global_eip_pools.filter_by_name_not_found"
+	dcbyName := acceptance.InitDataSourceCheck(byName)
+	dcbyNameNotFound := acceptance.InitDataSourceCheck(byNameNotFound)
+
+	byAccessSite := "data.huaweicloud_global_eip_pools.filter_by_access_site"
+	byAccessSiteNotFound := "data.huaweicloud_global_eip_pools.filter_by_access_site_not_found"
+	dcbyAccessSite := acceptance.InitDataSourceCheck(byAccessSite)
+	dcbyAccessSiteNotFound := acceptance.InitDataSourceCheck(byAccessSiteNotFound)
+
+	byISP := "data.huaweicloud_global_eip_pools.filter_by_isp"
+	byISPNotFound := "data.huaweicloud_global_eip_pools.filter_by_isp_not_found"
+	dcbyISP := acceptance.InitDataSourceCheck(byISP)
+	dcbyISPNotFound := acceptance.InitDataSourceCheck(byISPNotFound)
+
+	byIPVersion := "data.huaweicloud_global_eip_pools.filter_by_ip_version"
+	byIPVersionNotFound := "data.huaweicloud_global_eip_pools.filter_by_ip_version_not_found"
+	dcbyIPVersion := acceptance.InitDataSourceCheck(byIPVersion)
+	dcbyIPVersionNotFound := acceptance.InitDataSourceCheck(byIPVersionNotFound)
+
+	byType := "data.huaweicloud_global_eip_pools.filter_by_type"
+	byTypeNotFound := "data.huaweicloud_global_eip_pools.filter_by_type_not_found"
+	dcbyType := acceptance.InitDataSourceCheck(byType)
+	dcbyTypeNotFound := acceptance.InitDataSourceCheck(byTypeNotFound)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalEIPPools_filter(),
+				Check: resource.ComposeTestCheckFunc(
+
+					dcbyName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcbyNameNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful_not_found", "true"),
+
+					dcbyAccessSite.CheckResourceExists(),
+					resource.TestCheckOutput("is_access_site_filter_useful", "true"),
+					dcbyAccessSiteNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_access_site_filter_useful_not_found", "true"),
+
+					dcbyISP.CheckResourceExists(),
+					resource.TestCheckOutput("is_isp_filter_useful", "true"),
+					dcbyISPNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_isp_filter_useful_not_found", "true"),
+
+					dcbyIPVersion.CheckResourceExists(),
+					resource.TestCheckOutput("is_ip_version_filter_useful", "true"),
+					dcbyIPVersionNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_ip_version_filter_useful_not_found", "true"),
+
+					dcbyType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcbyTypeNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful_not_found", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGlobalEIPPools_filter() string {
+	rName := acceptance.RandomAccResourceName()
+	rNameWithDash := acceptance.RandomAccResourceNameWithDash()
+	return fmt.Sprintf(`
+// filter by name
+data "huaweicloud_global_eip_pools" "filter_by_name" {
+  name = "bgp_default"
+}
+
+data "huaweicloud_global_eip_pools" "filter_by_name_not_found" {
+  name = "%[1]s"
+}
+
+locals {
+  filter_result_by_name = [for v in data.huaweicloud_global_eip_pools.filter_by_name.geip_pools[*].name : 
+    v == "bgp_default"]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.filter_result_by_name) > 0 && alltrue(local.filter_result_by_name) 
+}
+
+output "is_name_filter_useful_not_found" {
+  value = length(data.huaweicloud_global_eip_pools.filter_by_name_not_found.geip_pools) == 0
+}
+
+// filter by access site
+data "huaweicloud_global_eip_pools" "filter_by_access_site" {
+  access_site = "cn-south-guangzhou"
+}
+
+data "huaweicloud_global_eip_pools" "filter_by_access_site_not_found" {
+  access_site = "%[2]s"
+}
+
+locals {
+  filter_result_by_access_site = [for v in data.huaweicloud_global_eip_pools.filter_by_access_site.geip_pools[*].access_site : 
+    v == "cn-south-guangzhou"]
+}
+
+output "is_access_site_filter_useful" {
+  value = length(local.filter_result_by_access_site) > 0 && alltrue(local.filter_result_by_access_site) 
+}
+
+output "is_access_site_filter_useful_not_found" {
+  value = length(data.huaweicloud_global_eip_pools.filter_by_access_site_not_found.geip_pools) == 0
+}
+
+// filter by isp
+data "huaweicloud_global_eip_pools" "filter_by_isp" {
+  isp = "Dyn_BGP"
+}
+
+data "huaweicloud_global_eip_pools" "filter_by_isp_not_found" {
+  isp = "%[1]s"
+}
+
+locals {
+  filter_result_by_isp = [for v in data.huaweicloud_global_eip_pools.filter_by_isp.geip_pools[*].isp : 
+    v == "Dyn_BGP"]
+}
+
+output "is_isp_filter_useful" {
+  value = length(local.filter_result_by_isp) > 0 && alltrue(local.filter_result_by_isp) 
+}
+
+output "is_isp_filter_useful_not_found" {
+  value = length(data.huaweicloud_global_eip_pools.filter_by_isp_not_found.geip_pools) == 0
+}
+
+// filter by ip version
+data "huaweicloud_global_eip_pools" "filter_by_ip_version" {
+  ip_version = 4
+}
+
+data "huaweicloud_global_eip_pools" "filter_by_ip_version_not_found" {
+  ip_version = 6
+}
+
+locals {
+  filter_result_by_ip_version = [for v in data.huaweicloud_global_eip_pools.filter_by_ip_version.geip_pools[*].ip_version : 
+    v == 4]
+}
+
+output "is_ip_version_filter_useful" {
+  value = length(local.filter_result_by_ip_version) > 0 && alltrue(local.filter_result_by_ip_version) 
+}
+
+output "is_ip_version_filter_useful_not_found" {
+  value = length(data.huaweicloud_global_eip_pools.filter_by_ip_version_not_found.geip_pools) == 0
+}
+
+// filter by type
+data "huaweicloud_global_eip_pools" "filter_by_type" {
+  type = "GEIP"
+}
+
+data "huaweicloud_global_eip_pools" "filter_by_type_not_found" {
+  type = "GEIP_SEGMENT"
+}
+
+locals {
+  filter_result_by_type = [for v in data.huaweicloud_global_eip_pools.filter_by_type.geip_pools[*].type : 
+    v == "GEIP"]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.filter_result_by_type) > 0 && alltrue(local.filter_result_by_type) 
+}
+
+output "is_type_filter_useful_not_found" {
+  value = length(data.huaweicloud_global_eip_pools.filter_by_type_not_found.geip_pools) == 0
+}
+`, rName, rNameWithDash)
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eip_pools.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eip_pools.go
@@ -1,0 +1,221 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/{domain_id}/geip/geip-pools
+func DataSourceGlobalEIPPools() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalEIPPoolsRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"access_site": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"isp": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_version": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"geip_pools": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"en_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cn_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"isp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_version": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"access_site": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"allowed_bandwidth_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"cn_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"en_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGlobalEIPPoolsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	getGlobalEIPPoolsHttpUrl := "v3/{domain_id}/geip/geip-pools"
+	getGlobalEIPPoolsPath := client.Endpoint + getGlobalEIPPoolsHttpUrl
+	getGlobalEIPPoolsPath = strings.ReplaceAll(getGlobalEIPPoolsPath, "{domain_id}", cfg.DomainID)
+	getGlobalEIPPoolsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getGlobalEIPPoolsPath += "?limit=10"
+	if name, ok := d.GetOk("name"); ok {
+		getGlobalEIPPoolsPath += fmt.Sprintf("&name=%s", name)
+	}
+	if accessSite, ok := d.GetOk("access_site"); ok {
+		getGlobalEIPPoolsPath += fmt.Sprintf("&access_site=%s", accessSite)
+	}
+	if isp, ok := d.GetOk("isp"); ok {
+		getGlobalEIPPoolsPath += fmt.Sprintf("&isp=%s", isp)
+	}
+	if ipVersion, ok := d.GetOk("ip_version"); ok {
+		getGlobalEIPPoolsPath += fmt.Sprintf("&ip_version=%v", ipVersion)
+	}
+	if poolType, ok := d.GetOk("type"); ok {
+		getGlobalEIPPoolsPath += fmt.Sprintf("&type=%s", poolType)
+	}
+
+	currentTotal := 0
+	getGlobalEIPPoolsPath += fmt.Sprintf("&offset=%v", currentTotal)
+
+	results := make([]map[string]interface{}, 0)
+
+	for {
+		getGlobalEIPPoolsResp, err := client.Request("GET", getGlobalEIPPoolsPath, &getGlobalEIPPoolsOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		getGlobalEIPPoolsRespBody, err := utils.FlattenResponse(getGlobalEIPPoolsResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		geipPools := utils.PathSearch("geip_pools", getGlobalEIPPoolsRespBody, make([]interface{}, 0)).([]interface{})
+		for _, pool := range geipPools {
+			results = append(results, map[string]interface{}{
+				"name":        utils.PathSearch("name", pool, nil),
+				"id":          utils.PathSearch("id", pool, nil),
+				"en_name":     utils.PathSearch("en_name", pool, nil),
+				"cn_name":     utils.PathSearch("cn_name", pool, nil),
+				"isp":         utils.PathSearch("isp", pool, nil),
+				"ip_version":  utils.PathSearch("ip_version", pool, float64(0)),
+				"access_site": utils.PathSearch("access_site", pool, nil),
+				"type":        utils.PathSearch("type", pool, nil),
+				"created_at":  utils.PathSearch("created_at", pool, nil),
+				"updated_at":  utils.PathSearch("updated_at", pool, nil),
+				"allowed_bandwidth_types": flattenAllowedBandwidthTypes(
+					utils.PathSearch("allowed_bandwidth_types", pool, make([]interface{}, 0))),
+			})
+		}
+
+		// `current_count` means the number of pools in this page, and the limit of page is `10`.
+		currentCount := utils.PathSearch("page_info.current_count", getGlobalEIPPoolsRespBody, 0)
+		if currentCount.(float64) < 10 {
+			break
+		}
+
+		currentTotal += len(geipPools)
+		index := strings.Index(getGlobalEIPPoolsPath, "offset")
+		getGlobalEIPPoolsPath = fmt.Sprintf("%soffset=%v", getGlobalEIPPoolsPath[:index], currentTotal)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("geip_pools", results),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAllowedBandwidthTypes(rawParams interface{}) interface{} {
+	rawArray, _ := rawParams.([]interface{})
+	if len(rawArray) == 0 {
+		return nil
+	}
+	rst := make([]map[string]interface{}, len(rawArray))
+	for i, val := range rawArray {
+		params := map[string]interface{}{
+			"type":    utils.PathSearch("type", val, nil),
+			"cn_name": utils.PathSearch("cn_name", val, nil),
+			"en_name": utils.PathSearch("en_name", val, nil),
+		}
+		rst[i] = params
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add data source `huaweicloud_global_eip_pools`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGlobalEIPPools_filter"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGlobalEIPPools_filter -timeout 360m -parallel 4
=== RUN   TestAccGlobalEIPPools_filter
=== PAUSE TestAccGlobalEIPPools_filter
=== CONT  TestAccGlobalEIPPools_filter
--- PASS: TestAccGlobalEIPPools_filter (38.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       38.537s

make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGlobalEIPPools_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGlobalEIPPools_basic -timeout 360m -parallel 4
=== RUN   TestAccGlobalEIPPools_basic
=== PAUSE TestAccGlobalEIPPools_basic
=== CONT  TestAccGlobalEIPPools_basic
--- PASS: TestAccGlobalEIPPools_basic (11.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       11.617s
```
