### PR TITLE
fix(iotda/device): fix read function duplicate setting name field

### DIFF
--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
@@ -214,7 +214,6 @@ func ResourceDeviceRead(_ context.Context, d *schema.ResourceData, meta interfac
 		d.Set("name", response.DeviceName),
 		d.Set("device_id", response.DeviceId),
 		d.Set("node_id", response.NodeId),
-		d.Set("name", response.DeviceName),
 		d.Set("product_id", response.ProductId),
 		d.Set("gateway_id", response.GatewayId),
 		d.Set("description", response.Description),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix read function duplicate setting name field
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
delete rows with duplicate name field settings in the read function.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.fix device resource read function duplicate setting name field
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDevice_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDevice_basic -timeout 360m -parallel 4
=== RUN   TestAccDevice_basic
--- PASS: TestAccDevice_basic (14.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     14.088s
```
