### PR TITLE
feat(BMS): bms instance support edit nics

### DIFF
--- a/docs/resources/bms_instance.md
+++ b/docs/resources/bms_instance.md
@@ -99,8 +99,8 @@ The following arguments are supported:
 * `vpc_id` - (Required, String, ForceNew) Specifies id of vpc in which to create the instance. Changing this creates a
   new instance.
 
-* `nics` - (Required, List, ForceNew) Specifies an array of one or more networks to attach to the instance. The network
-  object structure is documented below. Changing this creates a new instance.
+* `nics` - (Required, List) Specifies an array of one or more networks to attach to the instance. The network
+  object structure is documented below.
 
 * `admin_pass` - (Optional, String, ForceNew) Specifies the login password of the administrator for logging in to the
   BMS using password authentication. Changing this creates a new instance. The password must meet the following
@@ -194,11 +194,9 @@ The following arguments are supported:
 
 The `nics` block supports:
 
-* `subnet_id` - (Required, String, ForceNew) Specifies the ID of subnet to attach to the instance. Changing this creates
-  a new instance.
+* `subnet_id` - (Required, String) Specifies the ID of subnet to attach to the instance.
 
-* `ip_address` - (Optional, String, ForceNew) Specifies a fixed IPv4 address to be used on this network. Changing this
-  creates a new instance.
+* `ip_address` - (Optional, String) Specifies a fixed IPv4 address to be used on this network.
 
 The `data_disks` block supports:
 

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -68,7 +68,6 @@ func ResourceBmsInstance() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				MaxItems: 2,
-				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"subnet_id": {

--- a/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
+++ b/huaweicloud/services/bms/resource_huaweicloud_bms_instance.go
@@ -2,6 +2,7 @@ package bms
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -66,19 +67,17 @@ func ResourceBmsInstance() *schema.Resource {
 			"nics": {
 				Type:     schema.TypeList,
 				Required: true,
-				ForceNew: true,
 				MaxItems: 2,
+				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"subnet_id": {
 							Type:     schema.TypeString,
 							Required: true,
-							ForceNew: true,
 						},
 						"ip_address": {
 							Type:     schema.TypeString,
 							Optional: true,
-							ForceNew: true,
 							Computed: true,
 						},
 						"mac_address": {
@@ -457,7 +456,149 @@ func resourceBmsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
+	// Security group parammeters are missing in the network card, this is a legacy feature.
+	// The first network card can not be deleted, api error message:{"error": {"message": "primary port can not be deleted.", "code":"BMS.0222"}}
+	if d.HasChange("nics") {
+		addNics, deleteNics := getDiffNics(d)
+		if len(deleteNics) > 0 {
+			deleteNicsOps := baremetalservers.DeleteNicsOpts{
+				Nics: buildDeleteNicsParam(deleteNics),
+			}
+
+			job, err := baremetalservers.DeleteNics(bmsClient, d.Id(), deleteNicsOps).ExtractJobStatus()
+			if err != nil {
+				return diag.Errorf("error deleting BMS nics: %s", err)
+			}
+			jobId := job.JobID
+			if err = waitBMSJobSuccess(ctx, bmsClient, jobId, d); err != nil {
+				return diag.Errorf("the job (%s) is not SUCCESS while deleting BMS (%s) nics: %s", jobId,
+					d.Id(), err)
+			}
+		}
+
+		if len(addNics) > 0 {
+			addNicsOps := baremetalservers.AddNicsOpts{
+				Nics: buildAddNicsParam(addNics),
+			}
+
+			job, err := baremetalservers.AddNics(bmsClient, d.Id(), addNicsOps).ExtractJobStatus()
+			if err != nil {
+				return diag.Errorf("error adding BMS nics: %s", err)
+			}
+
+			jobId := job.JobID
+			if err = waitBMSJobSuccess(ctx, bmsClient, jobId, d); err != nil {
+				return diag.Errorf("the job (%s) is not SUCCESS while adding BMS (%s) nics: %s", jobId,
+					d.Id(), err)
+			}
+		}
+	}
+
 	return resourceBmsInstanceRead(ctx, d, meta)
+}
+
+// Get the list of new and to-be-deleted network cards.
+func getDiffNics(d *schema.ResourceData) (addList []interface{}, removeList []interface{}) {
+	oldNics, newNics := d.GetChange("nics")
+	oldList := oldNics.([]interface{})
+	newList := newNics.([]interface{})
+	for _, ov := range oldList {
+		om := ov.(map[string]interface{})
+		oSubnetId := om["subnet_id"].(string)
+		oIpAddress := om["ip_address"].(string)
+		needRemove := true
+		for _, nv := range newList {
+			nm := nv.(map[string]interface{})
+			nSubnetId := nm["subnet_id"].(string)
+			nIpAddress := nm["ip_address"].(string)
+
+			if oSubnetId == nSubnetId && oIpAddress == nIpAddress {
+				needRemove = false
+				break
+			}
+		}
+		if needRemove {
+			removeList = append(removeList, ov)
+		}
+	}
+
+	for _, nv := range newList {
+		nm := nv.(map[string]interface{})
+		nSubnetId := nm["subnet_id"].(string)
+		nIpAddress := nm["ip_address"].(string)
+		needAdd := true
+		for _, ov := range oldList {
+			om := ov.(map[string]interface{})
+			oSubnetId := om["subnet_id"].(string)
+			oIpAddress := om["ip_address"].(string)
+			if nSubnetId == oSubnetId && nIpAddress == oIpAddress {
+				needAdd = false
+				break
+			}
+		}
+		if needAdd {
+			addList = append(addList, nv)
+		}
+	}
+	return
+}
+
+func waitBMSJobSuccess(ctx context.Context, client *golangsdk.ServiceClient, jobId string, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"RUNNING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      JobRefreshFunc(client, jobId),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return nil
+	}
+
+	return err
+}
+
+func JobRefreshFunc(c *golangsdk.ServiceClient, jobId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		job, err := baremetalservers.GetJobDetail(c, jobId).ExtractJobStatus()
+		if err != nil {
+			return job, "ERROR", err
+		}
+		status := job.Status
+		if status == "SUCCESS" {
+			return job, status, nil
+		}
+		if status == "FAIL" {
+			return job, status, fmt.Errorf("the BMS job (%s) status is FAIL, the fail reason is: %s",
+				jobId, job.FailReason)
+		}
+		return job, "RUNNING", nil
+	}
+}
+
+func buildDeleteNicsParam(nics []interface{}) []baremetalservers.DeleteNic {
+	rst := make([]baremetalservers.DeleteNic, len(nics))
+	for i, nic := range nics {
+		variable := nic.(map[string]interface{})
+		rst[i] = baremetalservers.DeleteNic{
+			ID: variable["port_id"].(string),
+		}
+	}
+	return rst
+}
+
+func buildAddNicsParam(nics []interface{}) []baremetalservers.Nic {
+	rst := make([]baremetalservers.Nic, len(nics))
+	for i, nic := range nics {
+		variable := nic.(map[string]interface{})
+		rst[i] = baremetalservers.Nic{
+			SubnetId:  variable["subnet_id"].(string),
+			IpAddress: variable["ip_address"].(string),
+		}
+	}
+	return rst
 }
 
 func resourceBmsInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers/requests.go
@@ -194,50 +194,6 @@ type AddNicsOptsBuilder interface {
 	ToServerAddNicsMap() (map[string]interface{}, error)
 }
 
-func (opts StopServerOps) ToServerStopServerMap() (map[string]interface{}, error) {
-	return golangsdk.BuildRequestBody(opts, "os-stop")
-}
-
-func (opts StartServerOps) ToServerStartServerMap() (map[string]interface{}, error) {
-	return golangsdk.BuildRequestBody(opts, "os-start")
-}
-
-func (opts RebootServerOps) ToServerRebootServerMap() (map[string]interface{}, error) {
-	return golangsdk.BuildRequestBody(opts, "reboot")
-}
-
-type StartServerOps struct {
-	Servers []Servers `json:"servers" required:"true"`
-}
-
-type StopServerOps struct {
-	// The value can be: HARD and SOFT. Only HARD takes effect.
-	Type    string    `json:"type" required:"true"`
-	Servers []Servers `json:"servers" required:"true"`
-}
-
-type RebootServerOps struct {
-	// The value can be: HARD and SOFT. Only HARD takes effect.
-	Type    string    `json:"type" required:"true"`
-	Servers []Servers `json:"servers" required:"true"`
-}
-
-type Servers struct {
-	ID string `json:"id" required:"true"`
-}
-
-type RebootServerOpsBuilder interface {
-	ToServerRebootServerMap() (map[string]interface{}, error)
-}
-
-type StartServerOpsBuilder interface {
-	ToServerStartServerMap() (map[string]interface{}, error)
-}
-
-type StopServerOpsBuilder interface {
-	ToServerStopServerMap() (map[string]interface{}, error)
-}
-
 func (opts UpdateOpts) ToServerUpdateMap() (map[string]interface{}, error) {
 	b, err := golangsdk.BuildRequestBody(opts, "")
 	if err != nil {
@@ -292,38 +248,5 @@ func AddNics(client *golangsdk.ServiceClient, id string, ops AddNicsOptsBuilder)
 
 func GetJobDetail(client *golangsdk.ServiceClient, jobID string) (r JobResult) {
 	_, r.Err = client.Get(jobURL(client, jobID), &r.Body, nil)
-	return
-}
-
-func RebootServer(client *golangsdk.ServiceClient, ops RebootServerOpsBuilder) (r JobResult) {
-	reqBody, err := ops.ToServerRebootServerMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-
-	_, r.Err = client.Post(serverStatusPostURL(client), reqBody, &r.Body, nil)
-	return
-}
-
-func StartServer(client *golangsdk.ServiceClient, ops StartServerOpsBuilder) (r JobResult) {
-	reqBody, err := ops.ToServerStartServerMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-
-	_, r.Err = client.Post(serverStatusPostURL(client), reqBody, &r.Body, nil)
-	return
-}
-
-func StopServer(client *golangsdk.ServiceClient, ops StopServerOpsBuilder) (r JobResult) {
-	reqBody, err := ops.ToServerStopServerMap()
-	if err != nil {
-		r.Err = err
-		return
-	}
-
-	_, r.Err = client.Post(serverStatusPostURL(client), reqBody, &r.Body, nil)
 	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers/urls.go
@@ -7,6 +7,7 @@ const resourcePath = "baremetalservers"
 
 func createURL(sc *golangsdk.ServiceClient) string {
 	return sc.ServiceURL(resourcePath)
+	return sc.ServiceURL(resourcePath)
 }
 
 func getURL(sc *golangsdk.ServiceClient, serverID string) string {
@@ -27,8 +28,4 @@ func deleteNicsURL(sc *golangsdk.ServiceClient, serverID string) string {
 
 func addNicsURL(sc *golangsdk.ServiceClient, serverID string) string {
 	return sc.ServiceURL(resourcePath, serverID, "nics")
-}
-
-func serverStatusPostURL(sc *golangsdk.ServiceClient) string {
-	return sc.ServiceURL(resourcePath, "action")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
bms instance support edit nics

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
1.Security group parammeters are missing in the network card, this is a legacy feature.
2.The main network card is a network card configured with routing rules on the BMS server and cannot be unbound.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Support edit nics attribute information when updating a BMS instance
2. Remove the relevant forceNew attribute in nics.
3. Modify the forceNew attribute in nics in the document.
4. Add test cases related to editing nics.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/bms TESTARGS='-run TestAccBmsInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms -v -run TestAccBmsInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccBmsInstance_basic
=== PAUSE TestAccBmsInstance_basic
=== CONT  TestAccBmsInstance_basic
--- PASS: TestAccBmsInstance_basic (607.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       607.314s
```
