### PR TITLE
fix(ecs): compute_instance support update user_data

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -289,8 +289,8 @@ The following arguments are supported:
 * `eip_id` - (Optional, String, ForceNew) Specifies the ID of an *existing* EIP assigned to the instance.
   This parameter and `eip_type`, `bandwidth` are alternative. Changing this creates a new instance.
 
-* `user_data` - (Optional, String, ForceNew) Specifies the user data to be injected during the instance creation. Text
-  and text files can be injected. Changing this creates a new instance.
+* `user_data` - (Optional, String) Specifies the user data to be injected during the instance creation. Text
+  and text files can be injected. This value support unencrypted, also support base64 encrypted.
 
   -> **NOTE:** If the `user_data` field is specified for a Linux ECS that is created using an image with Cloud-Init
   installed, the `admin_pass` field becomes invalid.

--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -289,8 +289,8 @@ The following arguments are supported:
 * `eip_id` - (Optional, String, ForceNew) Specifies the ID of an *existing* EIP assigned to the instance.
   This parameter and `eip_type`, `bandwidth` are alternative. Changing this creates a new instance.
 
-* `user_data` - (Optional, String) Specifies the user data to be injected during the instance creation. Text
-  and text files can be injected. This value support unencrypted, also support base64 encrypted.
+* `user_data` - (Optional, String) Specifies the user data to be injected to the instance during the creation. Text
+  and text files can be injected. The content of `user_data` can be plaint text or encoded with base64.
 
   -> **NOTE:** If the `user_data` field is specified for a Linux ECS that is created using an image with Cloud-Init
   installed, the `admin_pass` field becomes invalid.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240122120732-a2e21dec9d4e
+	github.com/chnsz/golangsdk v0.0.0-20240126070045-7740a1edfc43
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240122120732-a2e21dec9d4e h1:hQSrU87SaJkNBqwKIvgIYqBOKBF2ZTeJNAomQ6MTrKo=
-github.com/chnsz/golangsdk v0.0.0-20240122120732-a2e21dec9d4e/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240126070045-7740a1edfc43 h1:pnpH99fXzWR1WAjP6Dno+XhhKgE9ii5L+Ri5AmkTMFc=
+github.com/chnsz/golangsdk v0.0.0-20240126070045-7740a1edfc43/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -76,7 +76,7 @@ func TestAccComputeInstance_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"stop_before_destroy", "delete_eip_on_termination", "data_disks", "metadata",
+					"stop_before_destroy", "delete_eip_on_termination", "data_disks", "metadata", "user_data",
 				},
 			},
 		},
@@ -420,6 +420,11 @@ resource "huaweicloud_compute_instance" "test" {
   agent_list          = "hss"
   auto_terminate_time = "2025-10-10T11:11:00Z"
 
+  user_data = <<EOF
+#! /bin/bash
+echo user_test > /home/user.txt
+EOF
+
   network {
     uuid              = data.huaweicloud_vpc_subnet.test.id
     source_dest_check = false
@@ -461,6 +466,7 @@ resource "huaweicloud_compute_instance" "test" {
   agency_name         = "test222"
   agent_list          = "ces"
   auto_terminate_time = ""
+  user_data           = ""
 
   network {
     uuid              = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_instance_test.go
@@ -466,7 +466,6 @@ resource "huaweicloud_compute_instance" "test" {
   agency_name         = "test222"
   agent_list          = "ces"
   auto_terminate_time = ""
-  user_data           = ""
 
   network {
     uuid              = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -313,9 +313,10 @@ func ResourceComputeInstance() *schema.Resource {
 			"user_data": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				// just stash the hash for state & diff comparisons
 				StateFunc: utils.HashAndHexEncode,
+				// Suppress changes if we get a base64 format or plaint text user_data
+				DiffSuppressFunc: utils.SuppressUserData,
 			},
 			"metadata": {
 				Type:     schema.TypeMap,
@@ -971,9 +972,10 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	serverID := d.Id()
-	if d.HasChanges("name", "description") {
+	if d.HasChanges("name", "description", "user_data") {
 		var updateOpts cloudservers.UpdateOpts
 		updateOpts.Name = d.Get("name").(string)
+		updateOpts.UserData = []byte(d.Get("user_data").(string))
 		description := d.Get("description").(string)
 		updateOpts.Description = &description
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
@@ -422,13 +422,27 @@ type UpdateOptsBuilder interface {
 // server.
 type UpdateOpts struct {
 	Name        string  `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
 	Hostname    string  `json:"hostname,omitempty"`
+	UserData    []byte  `json:"-"`
+	Description *string `json:"description,omitempty"`
 }
 
 // ToServerUpdateMap formats an UpdateOpts structure into a request body.
 func (opts UpdateOpts) ToServerUpdateMap() (map[string]interface{}, error) {
-	return golangsdk.BuildRequestBody(opts, "server")
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var userData string
+	if _, err := base64.StdEncoding.DecodeString(string(opts.UserData)); err != nil {
+		userData = base64.StdEncoding.EncodeToString(opts.UserData)
+	} else {
+		userData = string(opts.UserData)
+	}
+	b["user_data"] = &userData
+
+	return map[string]interface{}{"server": b}, nil
 }
 
 // Update requests that various attributes of the indicated server be changed.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240122120732-a2e21dec9d4e
+# github.com/chnsz/golangsdk v0.0.0-20240126070045-7740a1edfc43
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -83,7 +83,6 @@ github.com/chnsz/golangsdk/openstack/cloudeyeservice/v2/alarmrule
 github.com/chnsz/golangsdk/openstack/cloudtable/v2/clusters
 github.com/chnsz/golangsdk/openstack/common/structs
 github.com/chnsz/golangsdk/openstack/common/tags
-github.com/chnsz/golangsdk/openstack/compute/v2/extensions/attachinterfaces
 github.com/chnsz/golangsdk/openstack/compute/v2/extensions/availabilityzones
 github.com/chnsz/golangsdk/openstack/compute/v2/extensions/floatingips
 github.com/chnsz/golangsdk/openstack/compute/v2/extensions/keypairs


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: compute_instance support update user_data

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.compute_instance support update user_data.
2.user_data support unencrypted value.
3.user_data support base64 encrypted value.
4.user_data, the value will be overwritten during creation, so this value will not be saved.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstance_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_basic
=== PAUSE TestAccComputeInstance_basic
=== CONT  TestAccComputeInstance_basic
--- PASS: TestAccComputeInstance_basic (376.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       376.447s
```
