### PR TITLE
feat(eip): add resource global internet bandwidth

### DIFF
--- a/docs/resources/global_internet_bandwidth.md
+++ b/docs/resources/global_internet_bandwidth.md
@@ -1,0 +1,84 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# huaweicloud_global_internet_bandwidth
+
+Manages a global internet bandwidth resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "bandwidth_name" {}
+
+data "huaweicloud_global_eip_pools" "all" {}
+
+resource "huaweicloud_global_internet_bandwidth" "test" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  charge_mode           = "95peak_guar"
+  enterprise_project_id = var.enterprise_project_id
+  size                  = 300
+  isp                   = data.huaweicloud_global_eip_pools.all.geip_pools[0].isp
+  name                  = var.bandwidth_name
+  type                  = data.huaweicloud_global_eip_pools.all.geip_pools[0].allowed_bandwidth_types[0].type
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `access_site` - (Required, String, ForceNew) Specifies the access site name.
+  Changing this creates a new resource.
+
+* `charge_mode` - (Required, String) Specifies the charge mode, for example, **95peak_guar**.
+
+* `isp` - (Required, String, ForceNew) Specifies the internet service provider of the global internet bandwidth.
+  Changing this creates a new resource.
+
+* `size` - (Required, Int) Specifies the size of the global internet bandwidth.
+  The value ranges from **300 Mbit/s** to **5000 Mbit/s** in normal.
+
+* `ingress_size` - (Optional, Int) Specifies the ingress size of the global internet bandwidth.
+  It's **not** used for charge mode **95peak_guar**.
+
+* `type` - (Optional, String) Specifies the type of the global internet bandwidth.
+
+* `tags` - (Optional, Map) Specifies the tags of the global internet bandwidth.
+
+* `name` - (Optional, String) Specifies the name of the global internet bandwidth.
+
+* `description` - (Optional, String) Specifies the description of the global internet bandwidth.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id to which the global
+  internet bandwidth belongs. Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `frozen_info` - The frozen info of the global internet bandwidth.
+
+* `ratio_95peak` - The enhanced 95% guaranteed rate of the global internet bandwidth.
+
+* `status` - The status of the global internet bandwidth.
+
+* `created_at` - The create time of the global internet bandwidth.
+
+* `updated_at` - The update time of the global internet bandwidth.
+
+## Import
+
+The global internet bandwidth can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_global_internet_bandwidth.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1293,6 +1293,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_eip":                 eip.ResourceVpcEIPV1(),
 			"huaweicloud_vpc_eip_associate":       eip.ResourceEIPAssociate(),
 
+			"huaweicloud_global_internet_bandwidth": eip.ResourceGlobalInternetBandwidth(),
+
 			"huaweicloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),
 			"huaweicloud_vpc_route_table":                 vpc.ResourceVPCRouteTable(),

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_internet_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_internet_bandwidth_test.go
@@ -1,0 +1,132 @@
+package eip
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getInternetBandwidthResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("geip", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GEIP client: %s", err)
+	}
+	getInternetBandwidthHttpUrl := "v3/{domain_id}/geip/internet-bandwidths/{id}"
+	getInternetBandwidthPath := client.Endpoint + getInternetBandwidthHttpUrl
+	getInternetBandwidthPath = strings.ReplaceAll(getInternetBandwidthPath, "{domain_id}", cfg.DomainID)
+	getInternetBandwidthPath = strings.ReplaceAll(getInternetBandwidthPath, "{id}", state.Primary.ID)
+
+	getInternetBandwidthOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getInternetBandwidthResp, err := client.Request("GET", getInternetBandwidthPath, &getInternetBandwidthOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving global internet bandwidth: %s", err)
+	}
+	return utils.FlattenResponse(getInternetBandwidthResp)
+}
+
+func TestAccInternetBandwidth_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_global_internet_bandwidth.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getInternetBandwidthResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInternetBandwidth_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "95peak_guar"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "size", "300"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrSet(rName, "ratio_95peak"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+			{
+				Config: testAccInternetBandwidth_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "size", "400"),
+					resource.TestCheckResourceAttr(rName, "description", "test-update"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccInternetBandwidth_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_global_internet_bandwidth" "test" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  charge_mode           = "95peak_guar"
+  enterprise_project_id = "%s"
+  size                  = 300
+  isp                   = data.huaweicloud_global_eip_pools.all.geip_pools[0].isp
+  name                  = "%s"
+  type                  = data.huaweicloud_global_eip_pools.all.geip_pools[0].allowed_bandwidth_types[0].type
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testAccGlobalEIPPoolsDataSource_basic, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}
+
+func testAccInternetBandwidth_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_global_internet_bandwidth" "test" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  charge_mode           = "95peak_guar"
+  enterprise_project_id = "%s"
+  size                  = 400
+  isp                   = data.huaweicloud_global_eip_pools.all.geip_pools[0].isp
+  name                  = "%s-update"
+  description           = "test-update"
+  type                  = data.huaweicloud_global_eip_pools.all.geip_pools[0].allowed_bandwidth_types[0].type
+
+  tags = {
+    key = "value"
+  }
+}
+`, testAccGlobalEIPPoolsDataSource_basic, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_global_internet_bandwidth.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_internet_bandwidth.go
@@ -1,0 +1,344 @@
+package eip
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP POST /v3/{domain_id}/geip/internet-bandwidths
+// @API EIP DELETE /v3/{domain_id}/geip/internet-bandwidths/{id}
+// @API EIP GET /v3/{domain_id}/geip/internet-bandwidths/{id}
+// @API EIP PUT /v3/{domain_id}/geip/internet-bandwidths/{id}
+// @API EIP POST /v3/internet-bandwidth/{resource_id}/tags/delete
+// @API EIP POST /v3/internet-bandwidth/{resource_id}/tags/create
+func ResourceGlobalInternetBandwidth() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInternetBandwidthCreate,
+		ReadContext:   resourceInternetBandwidthRead,
+		UpdateContext: resourceInternetBandwidthUpdate,
+		DeleteContext: resourceInternetBandwidthDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"access_site": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"isp": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"charge_mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"ingress_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"ratio_95peak": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"frozen_info": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceInternetBandwidthCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	createInternetBandwidthHttpUrl := "v3/{domain_id}/geip/internet-bandwidths"
+	createInternetBandwidthPath := client.Endpoint + createInternetBandwidthHttpUrl
+	createInternetBandwidthPath = strings.ReplaceAll(createInternetBandwidthPath, "{domain_id}", cfg.DomainID)
+
+	createInternetBandwidthOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"internet_bandwidth": utils.RemoveNil(buildCreateInternetBandwidthBodyParams(d, cfg.GetEnterpriseProjectID(d))),
+		},
+	}
+
+	createInternetBandwidthResp, err := client.Request("POST", createInternetBandwidthPath, &createInternetBandwidthOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	createInternetBandwidthRespBody, err := utils.FlattenResponse(createInternetBandwidthResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("internet_bandwidth.id", createInternetBandwidthRespBody)
+	if err != nil {
+		return diag.Errorf("error creating global internet bandwidth: %s is not found in API response", "id")
+	}
+	d.SetId(id.(string))
+
+	return resourceInternetBandwidthRead(ctx, d, meta)
+}
+
+func buildCreateInternetBandwidthBodyParams(d *schema.ResourceData, epsID string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"isp":                   d.Get("isp"),
+		"access_site":           d.Get("access_site"),
+		"charge_mode":           d.Get("charge_mode"),
+		"size":                  d.Get("size"),
+		"ingress_size":          utils.ValueIngoreEmpty(d.Get("ingress_size")),
+		"description":           utils.ValueIngoreEmpty(d.Get("description")),
+		"name":                  utils.ValueIngoreEmpty(d.Get("name")),
+		"type":                  utils.ValueIngoreEmpty(d.Get("type")),
+		"enterprise_project_id": epsID,
+		"tags":                  utils.ValueIngoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
+	}
+	return bodyParams
+}
+
+func resourceInternetBandwidthRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	getInternetBandwidthHttpUrl := "v3/{domain_id}/geip/internet-bandwidths/{id}"
+	getInternetBandwidthPath := client.Endpoint + getInternetBandwidthHttpUrl
+	getInternetBandwidthPath = strings.ReplaceAll(getInternetBandwidthPath, "{domain_id}", cfg.DomainID)
+	getInternetBandwidthPath = strings.ReplaceAll(getInternetBandwidthPath, "{id}", d.Id())
+
+	getInternetBandwidthOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getInternetBandwidthResp, err := client.Request("GET", getInternetBandwidthPath, &getInternetBandwidthOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving global internet bandwidth")
+	}
+	getInternetBandwidthRespBody, err := utils.FlattenResponse(getInternetBandwidthResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	bandwidth, err := jmespath.Search("internet_bandwidth", getInternetBandwidthRespBody)
+	if err != nil {
+		return diag.Errorf("error getting global internet bandwidth: %s is not found in API response", "bandwidth")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("isp", utils.PathSearch("isp", bandwidth, nil)),
+		d.Set("access_site", utils.PathSearch("access_site", bandwidth, nil)),
+		d.Set("charge_mode", utils.PathSearch("charge_mode", bandwidth, nil)),
+		d.Set("size", utils.PathSearch("size", bandwidth, 0)),
+		d.Set("ingress_size", utils.PathSearch("ingress_size", bandwidth, 0)),
+		d.Set("description", utils.PathSearch("description", bandwidth, nil)),
+		d.Set("name", utils.PathSearch("name", bandwidth, nil)),
+		d.Set("type", utils.PathSearch("type", bandwidth, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", bandwidth, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("tags", bandwidth, nil))),
+		d.Set("ratio_95peak", utils.PathSearch("ratio_95peak", bandwidth, nil)),
+		d.Set("frozen_info", utils.PathSearch("freezen_info", bandwidth, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", bandwidth, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", bandwidth, nil)),
+		d.Set("status", utils.PathSearch("status", bandwidth, nil)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting global internet bandwidth fields: %s", err)
+	}
+	return nil
+}
+
+func resourceInternetBandwidthUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	updateChanges := []string{
+		"charge_mode",
+		"size",
+		"description",
+		"name",
+		"ingress_size",
+	}
+
+	if d.HasChanges(updateChanges...) {
+		updateInternetBandwidthHttpUrl := "v3/{domain_id}/geip/internet-bandwidths/{id}"
+		updateInternetBandwidthPath := client.Endpoint + updateInternetBandwidthHttpUrl
+		updateInternetBandwidthPath = strings.ReplaceAll(updateInternetBandwidthPath, "{domain_id}", cfg.DomainID)
+		updateInternetBandwidthPath = strings.ReplaceAll(updateInternetBandwidthPath, "{id}", d.Id())
+
+		updateInternetBandwidthOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody: map[string]interface{}{
+				"internet_bandwidth": utils.RemoveNil(buildUpdateInternetBandwidthBodyParams(d)),
+			},
+		}
+
+		_, err = client.Request("PUT", updateInternetBandwidthPath, &updateInternetBandwidthOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// update tags
+	if d.HasChange("tags") {
+		tagErr := updateTags(client, d, "internet-bandwidth", d.Id())
+		if tagErr != nil {
+			return diag.Errorf("error updating tags of global internet bandwidth (%s): %s", d.Id(), tagErr)
+		}
+	}
+
+	return resourceInternetBandwidthRead(ctx, d, meta)
+}
+
+func buildUpdateInternetBandwidthBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"charge_mode": d.Get("charge_mode"),
+		"size":        d.Get("size"),
+		"description": d.Get("description"),
+		"name":        utils.ValueIngoreEmpty(d.Get("name")),
+	}
+
+	if d.Get("charge_mode").(string) != "95peak_guar" {
+		bodyParams["ingress_size"] = utils.ValueIngoreEmpty(d.Get("ingress_size"))
+	}
+
+	return bodyParams
+}
+
+func updateTags(client *golangsdk.ServiceClient, d *schema.ResourceData, tagsType string, id string) error {
+	oRaw, nRaw := d.GetChange("tags")
+	oMap := oRaw.(map[string]interface{})
+	nMap := nRaw.(map[string]interface{})
+
+	manageTagsHttpUrl := "v3/{tags_type}/{resource_id}/tags/{action}"
+	manageTagsPath := client.Endpoint + manageTagsHttpUrl
+	manageTagsPath = strings.ReplaceAll(manageTagsPath, "{tags_type}", tagsType)
+	manageTagsPath = strings.ReplaceAll(manageTagsPath, "{resource_id}", id)
+	manageTagsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	// remove old tags
+	if len(oMap) > 0 {
+		manageTagsOpt.JSONBody = map[string]interface{}{
+			"tags": utils.ExpandResourceTags(oMap),
+		}
+		deleteTagsPath := strings.ReplaceAll(manageTagsPath, "{action}", "delete")
+		_, err := client.Request("POST", deleteTagsPath, &manageTagsOpt)
+		if err != nil {
+			return err
+		}
+	}
+
+	// set new tags
+	if len(nMap) > 0 {
+		manageTagsOpt.JSONBody = map[string]interface{}{
+			"tags": utils.ExpandResourceTags(nMap),
+		}
+		createTagsPath := strings.ReplaceAll(manageTagsPath, "{action}", "create")
+		_, err := client.Request("POST", createTagsPath, &manageTagsOpt)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceInternetBandwidthDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	deleteInternetBandwidthHttpUrl := "v3/{domain_id}/geip/internet-bandwidths/{id}"
+	deleteInternetBandwidthPath := client.Endpoint + deleteInternetBandwidthHttpUrl
+	deleteInternetBandwidthPath = strings.ReplaceAll(deleteInternetBandwidthPath, "{domain_id}", cfg.DomainID)
+	deleteInternetBandwidthPath = strings.ReplaceAll(deleteInternetBandwidthPath, "{id}", d.Id())
+
+	deleteInternetBandwidthOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deleteInternetBandwidthPath, &deleteInternetBandwidthOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add resource `huaweicloud_global_internet_bandwidth`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccInternetBandwidth_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccInternetBandwidth_basic -timeout 360m -parallel 4
=== RUN   TestAccInternetBandwidth_basic
=== PAUSE TestAccInternetBandwidth_basic
=== CONT  TestAccInternetBandwidth_basic
--- PASS: TestAccInternetBandwidth_basic (44.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       44.831s
```
