### PR TITLE
feat(fgs/function): add new resource to manage event

### DIFF
--- a/docs/resources/fgs_function_event.md
+++ b/docs/resources/fgs_function_event.md
@@ -1,0 +1,56 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# huaweicloud_fgs_function_event
+
+Manages an event for testing specified function within HuaweiCloud.
+
+## Example Usage
+
+### Create a simple event
+
+```hcl
+variable "function_urn" {}
+variable "event_name" {}
+variable "event_content" {}
+
+resource "huaweicloud_fgs_function_event" "test" {
+  function_urn = var.function_urn
+  name         = var.event_name
+  content      = base64encode(var.event_content)
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the function event is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `function_urn` - (Required, String, ForceNew) Specifies the URN of the function to which the event blongs.  
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the function event name.  
+  The name can contain a maximum of `25` characters and must start with a letter and end with a letter or digit.
+  Only letters, digits, underscores (_) and hyphens (-) are allowed.
+
+* `content` - (Required, String) Specifies the function event content.  
+  The value is the base64 encoding of the JSON string.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `updated_at` - The latest update (UTC) time of the function event, in RFC3339 format.
+
+  -> Only events that have changed will return this attribute.
+
+## Import
+
+Function event can be imported using the `function_urn` and `name`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_fgs_function_event.test <function_urn>/<name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1005,6 +1005,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_dependency":                 fgs.ResourceFgsDependency(),
 			"huaweicloud_fgs_dependency_version":         fgs.ResourceDependencyVersion(),
 			"huaweicloud_fgs_function":                   fgs.ResourceFgsFunctionV2(),
+			"huaweicloud_fgs_function_event":             fgs.ResourceFunctionEvent(),
 			"huaweicloud_fgs_trigger":                    fgs.ResourceFunctionGraphTrigger(),
 
 			"huaweicloud_ga_accelerator":    ga.ResourceAccelerator(),

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_event_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_event_test.go
@@ -1,0 +1,151 @@
+package fgs
+
+import (
+	"encoding/base64"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getFunctionEventResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/fgs/functions/{function_urn}/events/{event_id}"
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{function_urn}", state.Primary.Attributes["function_urn"])
+	getPath = strings.ReplaceAll(getPath, "{event_id}", state.Primary.ID)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error getting FunctionGraph function event: %s", err)
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func TestAccFunctionEvent_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName    = "huaweicloud_fgs_function_event.test"
+		name            = acceptance.RandomAccResourceName()
+		eventContent    = base64.StdEncoding.EncodeToString([]byte("{\"foo\": \"bar\"}"))
+		newEventContent = base64.StdEncoding.EncodeToString([]byte("{\"key\": \"value\"}"))
+
+		rc = acceptance.InitResourceCheck(resourceName, &obj, getFunctionEventResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// There is no special requirements for the permissions of the delegate. It only needs a agency name.
+			acceptance.TestAccPreCheckFgsAgency(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionEvent_basic(name, eventContent),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn", "huaweicloud_fgs_function.test", "urn"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "content", eventContent),
+					resource.TestCheckResourceAttr(resourceName, "updated_at", ""),
+				),
+			},
+			{
+				Config: testAccFunctionEvent_basic(name, newEventContent),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn", "huaweicloud_fgs_function.test", "urn"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "content", newEventContent),
+					resource.TestMatchResourceAttr(resourceName, "updated_at", regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccFunctionEventImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccFunctionEventImportStateFunc(rsName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var functionUrn, eventName string
+		rs, ok := s.RootModule().Resources[rsName]
+		if !ok {
+			return "", fmt.Errorf("the resource (%s) of function event is not found in the tfstate", rsName)
+		}
+		functionUrn = rs.Primary.Attributes["function_urn"]
+		eventName = rs.Primary.Attributes["name"]
+		if functionUrn == "" || eventName == "" {
+			return "", fmt.Errorf("the value of function URN or event name is empty")
+		}
+		return fmt.Sprintf("%s/%s", functionUrn, eventName), nil
+	}
+}
+
+func testAccFunctionEvent_basic(name, funcCode string) string {
+	return fmt.Sprintf(`
+variable "js_script_content" {
+  default = <<EOT
+exports.handler = async (event, context) => {
+    const result =
+    {
+        'repsonse_code': 200,
+        'headers':
+        {
+            'Content-Type': 'application/json'
+        },
+        'isBase64Encoded': false,
+        'body': JSON.stringify(event)
+    }
+    return result
+}
+EOT
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  agency      = "%[2]s"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  code_type   = "inline"
+  runtime     = "Node.js12.13"
+  func_code   = base64encode(jsonencode(var.js_script_content))
+}
+
+resource "huaweicloud_fgs_function_event" "test" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  name         = "%[1]s"
+  content      = "%[3]s"
+}
+`, name, acceptance.HW_FGS_AGENCY_NAME, funcCode)
+}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_event.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_event.go
@@ -1,0 +1,280 @@
+package fgs
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph POST /v2/{project_id}/fgs/functions/{function_urn}/events
+// @API FunctionGraph GET /v2/{project_id}/fgs/functions/{function_urn}/events/{event_id}
+// @API FunctionGraph PUT /v2/{project_id}/fgs/functions/{function_urn}/events/{event_id}
+// @API FunctionGraph DELETE /v2/{project_id}/fgs/functions/{function_urn}/events/{event_id}
+// @API FunctionGraph GET /v2/{project_id}/fgs/functions/{function_urn}/events
+
+func ResourceFunctionEvent() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFunctionEventCreate,
+		ReadContext:   resourceFunctionEventRead,
+		UpdateContext: resourceFunctionEventUpdate,
+		DeleteContext: resourceFunctionEventDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceFunctionEventImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the function event is located.`,
+			},
+			"function_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The URN of the function to which the event blongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The function event name.`,
+			},
+			"content": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The function event content.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update (UTC) time of the function event, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func resourceFunctionEventCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/functions/{function_urn}/events"
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{function_urn}", d.Get("function_urn").(string))
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildFunctionEventRequestBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph function event: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceId := utils.PathSearch("id", respBody, "")
+	d.SetId(resourceId.(string))
+
+	return resourceFunctionEventRead(ctx, d, meta)
+}
+
+func buildFunctionEventRequestBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":    d.Get("name"),
+		"content": d.Get("content"),
+	}
+}
+
+func parseFunctionEventLastModified(timeNum interface{}) interface{} {
+	var result string
+	if timeNum == nil {
+		return result
+	}
+
+	switch num := timeNum.(type) {
+	case int:
+		log.Printf("[DEBUG] The type of attribute 'last_modified' response value is 'int'")
+		result = utils.FormatTimeStampRFC3339(int64(num), true)
+	case float64:
+		log.Printf("[DEBUG] The type of attribute 'last_modified' response value is 'float64'")
+		// Ignore loss of precision.
+		result = utils.FormatTimeStampRFC3339(int64(num), true)
+	}
+
+	return result
+}
+
+func resourceFunctionEventRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		resourceId = d.Id()
+		httpUrl    = "v2/{project_id}/fgs/functions/{function_urn}/events/{event_id}"
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{function_urn}", d.Get("function_urn").(string))
+	getPath = strings.ReplaceAll(getPath, "{event_id}", resourceId)
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "FunctionGraph function event")
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.Errorf("error extrieving function event (%s): %s", resourceId, err)
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("content", utils.PathSearch("content", respBody, nil)),
+		d.Set("updated_at", parseFunctionEventLastModified(utils.PathSearch("last_modified", respBody, nil))),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving function event fields: %s", err)
+	}
+	return nil
+}
+
+func resourceFunctionEventUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		httpUrl    = "v2/{project_id}/fgs/functions/{function_urn}/events/{event_id}"
+		resourceId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{function_urn}", d.Get("function_urn").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{event_id}", resourceId)
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildFunctionEventRequestBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpts)
+	if err != nil {
+		return diag.Errorf("error updating FunctionGraph function event (%s): %s", resourceId, err)
+	}
+	return resourceFunctionEventRead(ctx, d, meta)
+}
+
+func resourceFunctionEventDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/functions/{function_urn}/events/{event_id}"
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{function_urn}", d.Get("function_urn").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{event_id}", d.Id())
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting FunctionGraph function event: %s", err)
+	}
+	return nil
+}
+
+func resourceFunctionEventImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format for import ID, want '<function_urn>/<name>', but got '%s'", d.Id())
+	}
+
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/fgs/functions/{function_urn}/events"
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	queryPath := client.Endpoint + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+	queryPath = strings.ReplaceAll(queryPath, "{function_urn}", parts[0])
+
+	queryOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	queryResp, err := client.Request("GET", queryPath, &queryOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving function event: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(queryResp)
+	if err != nil {
+		return nil, err
+	}
+
+	eventId := utils.PathSearch(fmt.Sprintf("events[?name=='%s']|[0].id", parts[1]), respBody, "").(string)
+	if eventId == "" {
+		return nil, fmt.Errorf("unable to find the resource ID of the function event")
+	}
+
+	d.SetId(eventId)
+	return []*schema.ResourceData{d}, d.Set("function_urn", parts[0])
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource to manage function test event.

-> The API response statuses of the function not found and the event not found are both `404`.

![797b49b6178efb88bf88e3896fdbaca](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/b5eb934c-077b-4bba-ad46-9074656b343c)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new resource to manage function test event.
2. support the related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFunctionEvent_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFunctionEvent_basic -timeout 360m -parallel 4
=== RUN   TestAccFunctionEvent_basic
=== PAUSE TestAccFunctionEvent_basic
=== CONT  TestAccFunctionEvent_basic
--- PASS: TestAccFunctionEvent_basic (167.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       167.492s
```
