### PR TITLE
feat(CSS): add resource CSS cluster scan task

### DIFF
--- a/docs/resources/css_scan_task.md
+++ b/docs/resources/css_scan_task.md
@@ -1,0 +1,121 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+---
+
+# huaweicloud_css_scan_task
+
+Manages a CSS cluster scan task resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+variable "scan_task_name" {}
+
+resource "huaweicloud_css_scan_task" "test" {
+  cluster_id = var.cluster_id
+  name       = var.scan_task_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies ID of the CSS cluster.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the cluster scan task.
+  Changing this creates a new resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of the cluster scan task.
+  Changing this creates a new resource.
+
+* `alarm` - (Optional, List, ForceNew) Specifies sending SMN alarm message configuration
+  after the cluster scan task is completed.
+  Changing this creates a new resource.
+  The [alarm](#css_scan_task_alarm) structure is documented below.
+
+<a name="css_scan_task_alarm"></a>
+The `alarm` block supports:
+
+* `level` - (Required, String) Specifies the level of alarm messages found by the cluster scan task.
+  The valid values are **high**, **medium**, **suggestion** and **noRisk**.
+
+* `smn_topic` - (Required, String) Specifies the name of the SMN topic.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The execution status of the cluster scan task.
+
+* `created_at` - The creation time of the cluster scan task.
+
+* `smn_status` - The SMN alarm sending status after the cluster scan task is completed.
+
+* `smn_fail_reason` - The reason for failure in sending SMN alarm.
+
+* `summary` - The risk summary after the cluster scan task is completed.
+  The [summary](#css_scan_task_summary_attr) structure is documented below.
+
+* `task_risks` - The risk found by the cluster scan task.
+  The [task_risks](#css_scan_task_risks_attr) structure is documented below.
+
+<a name="css_scan_task_summary_attr"></a>
+The `summary` block supports:
+
+* `high_num` - The number of high-risk items found by the cluster scan task.
+
+* `medium_num` - The number of medium-risk items found by the cluster scan task.
+
+* `suggestion_num` - The number of suggestions found by the cluster scan task.
+
+<a name="css_scan_task_risks_attr"></a>
+The `task_risks` block supports:
+
+* `risk` - The risk item.
+
+* `level` - The level of the risk item.
+
+* `description` - The description of the risk item.
+
+* `suggestion` - The suggestion on how to resolve this risk item.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+
+## Import
+
+The CSS cluster scan task can be imported using `cluster_id` and `name` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_css_scan_task.test <cluster_id>/<name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
+API response. The missing attribute is: `alarm`.
+It is generally recommended running `terraform plan` after importing a scan task.
+You can then decide if changes should be applied to the scan task, or the resource definition should be updated to align
+with the scan task. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_css_scan_task" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      alarm,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -887,6 +887,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_snapshot":      css.ResourceCssSnapshot(),
 			"huaweicloud_css_thesaurus":     css.ResourceCssthesaurus(),
 			"huaweicloud_css_configuration": css.ResourceCssConfiguration(),
+			"huaweicloud_css_scan_task":     css.ResourceScanTask(),
 
 			"huaweicloud_dbss_instance": dbss.ResourceInstance(),
 

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_scan_task_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_scan_task_test.go
@@ -1,0 +1,145 @@
+package css
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getScanTaskFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		getScanTaskHttpUrl = "v1.0/{project_id}/clusters/{cluster_id}/ai-ops"
+		getScanTaskProduct = "css"
+	)
+
+	getScanTaskClient, err := conf.NewServiceClient(getScanTaskProduct, acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CSS client: %s", err)
+	}
+
+	getScanTaskPath := getScanTaskClient.Endpoint + getScanTaskHttpUrl
+	getScanTaskPath = strings.ReplaceAll(getScanTaskPath, "{project_id}", getScanTaskClient.ProjectID)
+	getScanTaskPath = strings.ReplaceAll(getScanTaskPath, "{cluster_id}", state.Primary.Attributes["cluster_id"])
+
+	getScanTaskPathOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	currentTotal := 0
+	for {
+		currentPath := fmt.Sprintf("%s?limit=10&start=%d", getScanTaskPath, currentTotal)
+		getScanTaskResp, err := getScanTaskClient.Request("GET", currentPath, &getScanTaskPathOpt)
+		if err != nil {
+			return nil, err
+		}
+		getScanTaskRespBody, err := utils.FlattenResponse(getScanTaskResp)
+		if err != nil {
+			return nil, err
+		}
+		scanTasks := utils.PathSearch("aiops_list", getScanTaskRespBody, make([]interface{}, 0)).([]interface{})
+		findAiopsList := fmt.Sprintf("aiops_list | [?name=='%s'] | [0]", state.Primary.Attributes["name"])
+		scanTask, err := jmespath.Search(findAiopsList, getScanTaskRespBody)
+		if err != nil {
+			return nil, err
+		}
+		if scanTask != nil {
+			return scanTask, nil
+		}
+		total := utils.PathSearch("total_size", getScanTaskRespBody, 0).(float64)
+		currentTotal += len(scanTasks)
+		if float64(currentTotal) == total {
+			break
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func TestAccScanTask_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_css_scan_task.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getScanTaskFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScanTask_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "scan task test"),
+					resource.TestCheckResourceAttr(resourceName, "alarm.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "alarm.0.level", "suggestion"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "summary.#"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"alarm"},
+				ImportStateIdFunc:       testAccResourceScanTaskImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccResourceScanTaskImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		clusterID := rs.Primary.Attributes["cluster_id"]
+		scanTaskName := rs.Primary.Attributes["name"]
+		if clusterID == "" || scanTaskName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, " +
+				"must be '<cluster_id>/<name>'")
+		}
+		return fmt.Sprintf("%s/%s", clusterID, scanTaskName), nil
+	}
+}
+
+func testAccScanTask_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_smn_topic" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_css_scan_task" "test" {
+  cluster_id  = huaweicloud_css_cluster.test.id
+  name        = "%[2]s"
+  description = "scan task test"
+  
+  alarm {
+    level     = "suggestion"
+    smn_topic = huaweicloud_smn_topic.test.name
+  }
+}
+`, testAccCssCluster_basic(rName, 1, 7, "bar"), rName)
+}

--- a/huaweicloud/services/css/resource_huaweicloud_css_scan_task.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_scan_task.go
@@ -1,0 +1,417 @@
+package css
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	ClusterScanTaskRunning   = "RUNNING"
+	ClusterScanTaskCompleted = "COMPLETED"
+	ClusterScanTaskFailed    = "FAILED"
+)
+
+// @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/ai-ops
+// @API CSS GET /v1.0/{project_id}/clusters/{cluster_id}/ai-ops
+// @API CSS DELETE /v1.0/{project_id}/clusters/{cluster_id}/ai-ops/{aiops_id}
+func ResourceScanTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceScanTaskCreate,
+		ReadContext:   resourceScanTaskRead,
+		DeleteContext: resourceScanTaskDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceScanTaskImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"alarm": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"level": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"smn_topic": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"smn_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"smn_fail_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"summary": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"high_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"medium_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"suggestion_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"task_risks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"risk": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"level": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"suggestion": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceScanTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	clusterID := d.Get("cluster_id").(string)
+
+	// createScanTask: create a scan task.
+	var (
+		createScanTaskUrl     = "v1.0/{project_id}/clusters/{cluster_id}/ai-ops"
+		createScanTaskProduct = "css"
+	)
+
+	createScanTaskClient, err := conf.NewServiceClient(createScanTaskProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CSS client: %s", err)
+	}
+	createScanTaskPath := createScanTaskClient.Endpoint + createScanTaskUrl
+	createScanTaskPath = strings.ReplaceAll(createScanTaskPath, "{project_id}", createScanTaskClient.ProjectID)
+	createScanTaskPath = strings.ReplaceAll(createScanTaskPath, "{cluster_id}", clusterID)
+
+	createScanTaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	createScanTaskOpt.JSONBody = utils.RemoveNil(buildcreateScanTaskBodyParams(d))
+	_, err = createScanTaskClient.Request("POST", createScanTaskPath, &createScanTaskOpt)
+	if err != nil {
+		return diag.Errorf("error creating CSS cluster scan task: %s", err)
+	}
+
+	id, err := refreshScanTaskID(d, region, conf)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{ClusterScanTaskRunning},
+		Target:       []string{ClusterScanTaskCompleted, ClusterScanTaskFailed},
+		Refresh:      scanTaskStateRefreshFunc(d, region, conf),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        60 * time.Second,
+		PollInterval: 60 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the cluster scan task to become available: %s", err)
+	}
+
+	return resourceScanTaskRead(ctx, d, meta)
+}
+
+func resourceScanTaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	var mErr *multierror.Error
+
+	scanTask, err := getScanTaskByName(d, region, conf)
+	if err != nil {
+		common.CheckDeletedDiag(d, err, "CSS cluster scan task")
+	}
+
+	createdAt := utils.PathSearch("create_time", scanTask, 0).(float64) / 1000
+	status := int(utils.PathSearch("status", scanTask, 0).(float64))
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", scanTask, nil)),
+		d.Set("description", utils.PathSearch("desc", scanTask, nil)),
+		d.Set("status", convertClusterScanTaskStatus(status)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(createdAt), false)),
+		d.Set("smn_status", utils.PathSearch("smn_status", scanTask, nil)),
+		d.Set("smn_fail_reason", utils.PathSearch("smn_fail_reason", scanTask, nil)),
+		d.Set("summary", flattenScanTaskSummaryResponse(scanTask)),
+		d.Set("task_risks", flattenScanTaskRisksResponse(scanTask)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceScanTaskDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	clusterID := d.Get("cluster_id").(string)
+
+	// deleteScanTask: delete a scan task.
+	var (
+		deleteScanTaskUrl     = "v1.0/{project_id}/clusters/{cluster_id}/ai-ops/{aiops_id}"
+		deleteScanTaskProduct = "css"
+	)
+
+	deleteScanTaskClient, err := conf.NewServiceClient(deleteScanTaskProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CSS client: %s", err)
+	}
+	deleteScanTaskPath := deleteScanTaskClient.Endpoint + deleteScanTaskUrl
+	deleteScanTaskPath = strings.ReplaceAll(deleteScanTaskPath, "{project_id}", deleteScanTaskClient.ProjectID)
+	deleteScanTaskPath = strings.ReplaceAll(deleteScanTaskPath, "{cluster_id}", clusterID)
+	deleteScanTaskPath = strings.ReplaceAll(deleteScanTaskPath, "{aiops_id}", d.Id())
+
+	deleteScanTaskOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = deleteScanTaskClient.Request("DELETE", deleteScanTaskPath, &deleteScanTaskOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CSS cluster scan task: %s", err)
+	}
+
+	return nil
+}
+
+func buildcreateScanTaskBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"alarm":       buildcreateScanTaskAlarmBodyParams(d.Get("alarm")),
+	}
+	return bodyParams
+}
+
+func buildcreateScanTaskAlarmBodyParams(rawParams interface{}) map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok && len(rawArray) == 1 {
+		raw := rawArray[0].(map[string]interface{})
+		params := map[string]interface{}{
+			"level":     raw["level"],
+			"smn_topic": raw["smn_topic"],
+		}
+		return params
+	}
+	return nil
+}
+
+func refreshScanTaskID(d *schema.ResourceData, region string, conf *config.Config) (string, error) {
+	scanTask, err := getScanTaskByName(d, region, conf)
+	if err != nil {
+		return "", err
+	}
+	id := utils.PathSearch("id", scanTask, "").(string)
+
+	return id, nil
+}
+
+func scanTaskStateRefreshFunc(d *schema.ResourceData, region string, conf *config.Config) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		scanTask, err := getScanTaskByName(d, region, conf)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault400); ok {
+				return nil, ClusterScanTaskCompleted, nil
+			}
+			return scanTask, "ERROR", err
+		}
+		status := utils.PathSearch("status", scanTask, 0).(float64)
+		return scanTask, convertClusterScanTaskStatus(int(status)), nil
+	}
+}
+
+func getScanTaskByName(d *schema.ResourceData, region string, conf *config.Config) (interface{}, error) {
+	getScanTaskHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/ai-ops"
+	getScanTaskProduct := "css"
+	getScanTaskClient, err := conf.NewServiceClient(getScanTaskProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CSS client: %s", err)
+	}
+
+	getScanTaskPath := getScanTaskClient.Endpoint + getScanTaskHttpUrl
+	getScanTaskPath = strings.ReplaceAll(getScanTaskPath, "{project_id}", getScanTaskClient.ProjectID)
+	getScanTaskPath = strings.ReplaceAll(getScanTaskPath, "{cluster_id}", d.Get("cluster_id").(string))
+
+	getScanTaskPathOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	currentTotal := 0
+	for {
+		currentPath := fmt.Sprintf("%s?limit=10&start=%d", getScanTaskPath, currentTotal)
+		getScanTaskResp, err := getScanTaskClient.Request("GET", currentPath, &getScanTaskPathOpt)
+		if err != nil {
+			return getScanTaskResp, err
+		}
+		getScanTaskRespBody, err := utils.FlattenResponse(getScanTaskResp)
+		if err != nil {
+			return nil, err
+		}
+		scanTasks := utils.PathSearch("aiops_list", getScanTaskRespBody, make([]interface{}, 0)).([]interface{})
+		findAiopsList := fmt.Sprintf("aiops_list | [?name=='%s'] | [0]", d.Get("name"))
+		scanTask, err := jmespath.Search(findAiopsList, getScanTaskRespBody)
+		if err != nil {
+			return nil, err
+		}
+		if scanTask != nil {
+			return scanTask, nil
+		}
+		total := utils.PathSearch("total_size", getScanTaskRespBody, 0).(float64)
+		currentTotal += len(scanTasks)
+		if float64(currentTotal) == total {
+			break
+		}
+	}
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func flattenScanTaskSummaryResponse(resp interface{}) []interface{} {
+	var rst []interface{}
+	curJson, err := jmespath.Search("summary", resp)
+	if err != nil {
+		log.Printf("[WARN] error parsing summary object from response: %#v", err)
+		return rst
+	}
+
+	rst = []interface{}{
+		map[string]interface{}{
+			"high_num":       int(utils.PathSearch("high", curJson, 0).(float64)),
+			"medium_num":     int(utils.PathSearch("medium", curJson, 0).(float64)),
+			"suggestion_num": int(utils.PathSearch("suggestion", curJson, 0).(float64)),
+		},
+	}
+
+	return rst
+}
+
+func flattenScanTaskRisksResponse(resp interface{}) []interface{} {
+	curJson := utils.PathSearch("task_risks", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"risk":        utils.PathSearch("riskType", v, nil),
+			"level":       utils.PathSearch("level", v, nil),
+			"description": utils.PathSearch("desc", v, nil),
+			"suggestion":  utils.PathSearch("suggestion", v, nil),
+		})
+	}
+	return rst
+}
+
+func convertClusterScanTaskStatus(status int) string {
+	state := ClusterScanTaskRunning
+	if status == 200 {
+		state = ClusterScanTaskCompleted
+	}
+	if status == 300 {
+		state = ClusterScanTaskFailed
+	}
+
+	return state
+}
+
+func resourceScanTaskImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format of import ID, must be <cluster_id>/<name>")
+	}
+
+	d.Set("cluster_id", parts[0])
+	d.Set("name", parts[1])
+
+	scanTask, err := getScanTaskByName(d, region, conf)
+	if err != nil {
+		return []*schema.ResourceData{d}, err
+	}
+
+	id := utils.PathSearch("id", scanTask, "")
+	d.SetId(id.(string))
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Add resource CSS cluster scan task. Currently, all Elasticsearch clusters support intelligent operation and maintenance functions.
2. Intelligent operation and maintenance supports the following functions: Start the scan task, Query cluster risk items, Delete scan task.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
add resource CSS cluster scan task
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccScanTask_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccScanTask_basic -timeout 360m -parallel 4
=== RUN   TestAccScanTask_basic
=== PAUSE TestAccScanTask_basic
=== CONT  TestAccScanTask_basic
--- PASS: TestAccScanTask_basic (998.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       998.743s
```
