### PR TITLE
feat(eip): add data source global eip access sites

### DIFF
--- a/docs/data-sources/global_eip_access_sites.md
+++ b/docs/data-sources/global_eip_access_sites.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# huaweicloud_global_eip_access_sites
+
+Use this data source to get a list of global EIP access sites.
+
+## Example Usage
+
+### Get all global EIP access sites
+
+```hcl
+data "huaweicloud_global_eip_access_sites" "all" {}
+```
+
+### Get specific global EIP access sites through proxy region
+
+```hcl
+data "huaweicloud_global_eip_access_sites" "test" {
+  proxy_region = "cn-south-1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, String) Specifies the name of the access sites.
+
+* `proxy_region` - (Optional, String) Specifies the region ID where the pop site is hosted.
+
+* `iec_az_code` - (Optional, String) Specifies the availability zone code of the edge site.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `access_sites` - The access sites list.
+  The [access_sites](#attrblock--access_sites) structure is documented below.
+
+<a name="attrblock--access_sites"></a>
+The `access_sites` block supports:
+
+* `id` - The ID of the access site.
+
+* `proxy_region` - The region ID where the pop site is hosted.
+
+* `iec_az_code` - The availability zone code of the edge site
+
+* `name` - The name of the access site.
+
+* `cn_name` - The Chinese name of the access site.
+
+* `en_name` - The English name of the access site.
+
+* `created_at` - The create time of the access site.
+
+* `updated_at` - The update time of the access site.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -635,11 +635,12 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_tms_resource_types": tms.DataSourceResourceTypes(),
 
-			"huaweicloud_vpc_bandwidth":    eip.DataSourceBandWidth(),
-			"huaweicloud_vpc_bandwidths":   eip.DataSourceBandWidths(),
-			"huaweicloud_vpc_eip":          eip.DataSourceVpcEip(),
-			"huaweicloud_vpc_eips":         eip.DataSourceVpcEips(),
-			"huaweicloud_global_eip_pools": eip.DataSourceGlobalEIPPools(),
+			"huaweicloud_vpc_bandwidth":           eip.DataSourceBandWidth(),
+			"huaweicloud_vpc_bandwidths":          eip.DataSourceBandWidths(),
+			"huaweicloud_vpc_eip":                 eip.DataSourceVpcEip(),
+			"huaweicloud_vpc_eips":                eip.DataSourceVpcEips(),
+			"huaweicloud_global_eip_pools":        eip.DataSourceGlobalEIPPools(),
+			"huaweicloud_global_eip_access_sites": eip.DataSourceGlobalEIPAccessSites(),
 
 			"huaweicloud_vpc":                    vpc.DataSourceVpcV1(),
 			"huaweicloud_vpcs":                   vpc.DataSourceVpcs(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_access_sites_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eip_access_sites_test.go
@@ -1,0 +1,149 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGlobalEIPAccessSites_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_global_eip_access_sites.all"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalEIPAccessSitesDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "access_sites.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccGlobalEIPAccessSitesDataSource_basic string = `data "huaweicloud_global_eip_access_sites" "all" {}`
+
+func TestAccGlobalEIPAccessSites_filter(t *testing.T) {
+	byName := "data.huaweicloud_global_eip_access_sites.filter_by_name"
+	byNameNotFound := "data.huaweicloud_global_eip_access_sites.filter_by_name_not_found"
+	dcbyName := acceptance.InitDataSourceCheck(byName)
+	dcbyNameNotFound := acceptance.InitDataSourceCheck(byNameNotFound)
+
+	byProxyRegion := "data.huaweicloud_global_eip_access_sites.filter_by_proxy_region"
+	byProxyRegionNotFound := "data.huaweicloud_global_eip_access_sites.filter_by_proxy_region_not_found"
+	dcbyProxyRegion := acceptance.InitDataSourceCheck(byProxyRegion)
+	dcbyProxyRegionNotFound := acceptance.InitDataSourceCheck(byProxyRegionNotFound)
+
+	byIecAZCode := "data.huaweicloud_global_eip_access_sites.filter_by_iec_az_code"
+	byIecAZCodeNotFound := "data.huaweicloud_global_eip_access_sites.filter_by_iec_az_code_not_found"
+	dcbyIecAZCode := acceptance.InitDataSourceCheck(byIecAZCode)
+	dcbyIecAZCodeNotFound := acceptance.InitDataSourceCheck(byIecAZCodeNotFound)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalEIPAccessSites_filter(),
+				Check: resource.ComposeTestCheckFunc(
+
+					dcbyName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcbyNameNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful_not_found", "true"),
+
+					dcbyProxyRegion.CheckResourceExists(),
+					resource.TestCheckOutput("is_proxy_region_filter_useful", "true"),
+					dcbyProxyRegionNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_proxy_region_filter_useful_not_found", "true"),
+
+					dcbyIecAZCode.CheckResourceExists(),
+					resource.TestCheckOutput("is_iec_az_code_filter_useful", "true"),
+					dcbyIecAZCodeNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_iec_az_code_filter_useful_not_found", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGlobalEIPAccessSites_filter() string {
+	rNameWithDash := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+// filter by name
+data "huaweicloud_global_eip_access_sites" "filter_by_name" {
+  name = "cn-south-guangzhou"
+}
+
+data "huaweicloud_global_eip_access_sites" "filter_by_name_not_found" {
+  name = "%[1]s"
+}
+
+locals {
+  filter_result_by_name = [for v in data.huaweicloud_global_eip_access_sites.filter_by_name.access_sites[*].name : 
+    v == "cn-south-guangzhou"]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.filter_result_by_name) > 0 && alltrue(local.filter_result_by_name) 
+}
+
+output "is_name_filter_useful_not_found" {
+  value = length(data.huaweicloud_global_eip_access_sites.filter_by_name_not_found.access_sites) == 0
+}
+
+// filter by proxy_region
+data "huaweicloud_global_eip_access_sites" "filter_by_proxy_region" {
+  proxy_region = "cn-south-1"
+}
+
+data "huaweicloud_global_eip_access_sites" "filter_by_proxy_region_not_found" {
+  proxy_region = "%[1]s"
+}
+
+locals {
+  filter_result_by_proxy_region = [for v in data.huaweicloud_global_eip_access_sites.filter_by_proxy_region.access_sites[*].proxy_region : 
+    v == "cn-south-1"]
+}
+
+output "is_proxy_region_filter_useful" {
+  value = length(local.filter_result_by_proxy_region) > 0 && alltrue(local.filter_result_by_proxy_region) 
+}
+
+output "is_proxy_region_filter_useful_not_found" {
+  value = length(data.huaweicloud_global_eip_access_sites.filter_by_proxy_region_not_found.access_sites) == 0
+}
+
+// filter by iec_az_code
+data "huaweicloud_global_eip_access_sites" "filter_by_iec_az_code" {
+  iec_az_code = "cn-north-900d"
+}
+
+data "huaweicloud_global_eip_access_sites" "filter_by_iec_az_code_not_found" {
+  iec_az_code = "%[1]s"
+}
+
+locals {
+  filter_result_by_iec_az_code = [for v in data.huaweicloud_global_eip_access_sites.filter_by_iec_az_code.access_sites[*].iec_az_code : 
+    v == "cn-north-900d"]
+}
+
+output "is_iec_az_code_filter_useful" {
+  value = length(local.filter_result_by_iec_az_code) > 0 && alltrue(local.filter_result_by_iec_az_code) 
+}
+
+output "is_iec_az_code_filter_useful_not_found" {
+  value = length(data.huaweicloud_global_eip_access_sites.filter_by_iec_az_code_not_found.access_sites) == 0
+}
+`, rNameWithDash)
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eip_access_sites.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eip_access_sites.go
@@ -1,0 +1,156 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/{domain_id}/geip/access-sites
+func DataSourceGlobalEIPAccessSites() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalEIPAccessSiteRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"proxy_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"iec_az_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"access_sites": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"proxy_region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"iec_az_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"en_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cn_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGlobalEIPAccessSiteRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	getGlobalEIPAccessSiteHttpUrl := "v3/{domain_id}/geip/access-sites"
+	getGlobalEIPAccessSitePath := client.Endpoint + getGlobalEIPAccessSiteHttpUrl
+	getGlobalEIPAccessSitePath = strings.ReplaceAll(getGlobalEIPAccessSitePath, "{domain_id}", cfg.DomainID)
+	getGlobalEIPAccessSiteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getGlobalEIPAccessSitePath += "?limit=10"
+	if name, ok := d.GetOk("name"); ok {
+		getGlobalEIPAccessSitePath += fmt.Sprintf("&name=%s", name)
+	}
+	if proxyRegion, ok := d.GetOk("proxy_region"); ok {
+		getGlobalEIPAccessSitePath += fmt.Sprintf("&proxy_region=%s", proxyRegion)
+	}
+	if iecAZCode, ok := d.GetOk("iec_az_code"); ok {
+		getGlobalEIPAccessSitePath += fmt.Sprintf("&iec_az_code=%s", iecAZCode)
+	}
+	currentTotal := 0
+	getGlobalEIPAccessSitePath += fmt.Sprintf("&offset=%v", currentTotal)
+
+	results := make([]map[string]interface{}, 0)
+	for {
+		getGlobalEIPAccessSiteResp, err := client.Request("GET", getGlobalEIPAccessSitePath, &getGlobalEIPAccessSiteOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		getGlobalEIPAccessSiteRespBody, err := utils.FlattenResponse(getGlobalEIPAccessSiteResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		accessSites := utils.PathSearch("access_sites", getGlobalEIPAccessSiteRespBody, make([]interface{}, 0)).([]interface{})
+		for _, accessSite := range accessSites {
+			results = append(results, map[string]interface{}{
+				"id":           utils.PathSearch("id", accessSite, nil),
+				"name":         utils.PathSearch("name", accessSite, nil),
+				"en_name":      utils.PathSearch("en_name", accessSite, nil),
+				"cn_name":      utils.PathSearch("cn_name", accessSite, nil),
+				"proxy_region": utils.PathSearch("proxy_region", accessSite, nil),
+				"iec_az_code":  utils.PathSearch("iec_az_code", accessSite, nil),
+				"created_at":   utils.PathSearch("created_at", accessSite, nil),
+				"updated_at":   utils.PathSearch("updated_at", accessSite, nil),
+			})
+		}
+
+		// `current_count` means the number of `access_sites` in this page, and the limit of page is `10`.
+		currentCount := utils.PathSearch("page_info.current_count", getGlobalEIPAccessSiteRespBody, float64(0))
+		if currentCount.(float64) < 10 {
+			break
+		}
+
+		currentTotal += len(accessSites)
+		index := strings.Index(getGlobalEIPAccessSitePath, "offset")
+		getGlobalEIPAccessSitePath = fmt.Sprintf("%soffset=%v", getGlobalEIPAccessSitePath[:index], currentTotal)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("access_sites", results),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add data source `huaweicloud_global_eip_access_sites`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGlobalEIPAccessSites_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGlobalEIPAccessSites_basic -timeout 360m -parallel 4
=== RUN   TestAccGlobalEIPAccessSites_basic
=== PAUSE TestAccGlobalEIPAccessSites_basic
=== CONT  TestAccGlobalEIPAccessSites_basic
--- PASS: TestAccGlobalEIPAccessSites_basic (11.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       11.547s

make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGlobalEIPAccessSites_filter"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGlobalEIPAccessSites_filter -timeout 360m -parallel 4
=== RUN   TestAccGlobalEIPAccessSites_filter
=== PAUSE TestAccGlobalEIPAccessSites_filter
=== CONT  TestAccGlobalEIPAccessSites_filter
--- PASS: TestAccGlobalEIPAccessSites_filter (26.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       26.949s
```
