### PR TITLE
fix(CCM): update ccm private ca support crl configuration and pending days

### DIFF
--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go
@@ -47,7 +47,7 @@ func getPrivateCAResourceFunc(conf *config.Config, state *terraform.ResourceStat
 
 func TestAccCCMPrivateCA_basic(t *testing.T) {
 	var obj interface{}
-	rName := acceptance.RandomAccResourceName()
+	rName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_ccm_private_ca.test_subordinate"
 
 	rc := acceptance.InitResourceCheck(
@@ -81,6 +81,7 @@ func TestAccCCMPrivateCA_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "charging_mode"),
 					resource.TestCheckResourceAttrSet(resourceName, "free_quota"),
 					resource.TestCheckResourceAttrSet(resourceName, "expired_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "crl_configuration.0.crl_dis_point"),
 				),
 			},
 			{
@@ -137,10 +138,16 @@ func tesPrivateCA_basic(commonName string) string {
 	return fmt.Sprintf(`
 %s
 
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[2]s-crl-bucket"
+  acl           = "private"
+  force_destroy = true
+}
+
 resource "huaweicloud_ccm_private_ca" "test_subordinate" {
   type = "SUBORDINATE"
   distinguished_name {
-    common_name         = "%s-subordinate"
+    common_name         = "%[2]s-subordinate"
     country             = "CN"
     state               = "GD"
     locality            = "SZ"
@@ -159,6 +166,10 @@ resource "huaweicloud_ccm_private_ca" "test_subordinate" {
     foo = "bar"
     key = "value"
   }
+  crl_configuration {
+    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
+    valid_days      = "7"
+  }
 }`, tesPrivateCA_base(commonName), commonName)
 }
 
@@ -167,10 +178,16 @@ func testPrivateCA_updateTags(commonName string) string {
 	return fmt.Sprintf(`
 %s
 
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[2]s-crl-bucket"
+  acl           = "private"
+  force_destroy = true
+}
+  
 resource "huaweicloud_ccm_private_ca" "test_subordinate" {
   type = "SUBORDINATE"
   distinguished_name {
-    common_name         = "%s-subordinate"
+    common_name         = "%[2]s-subordinate"
     country             = "CN"
     state               = "GD"
     locality            = "SZ"
@@ -188,6 +205,10 @@ resource "huaweicloud_ccm_private_ca" "test_subordinate" {
   tags = {
     foo1 = "bar1"
     key1 = "value1"
+  }
+  crl_configuration {
+    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
+    valid_days      = "7"
   }
 }`, tesPrivateCA_base(commonName), commonName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Parameter crl_configuration and pending_days is invalid and used to fix the issue, so the changes are as follows:

1.Modify schema crl_name to computed,and if crl_name is empty, the service will set a value, so delete the assignment operation.
2.Modify the crl_configuration build method, add parameter enabled for request.
3.Modify the sending method of parameter pending_days , from request body to query parameters.
4.Modify the test cases, change RandomAccResourceName to RandomAccResourceNameWithDash to support the creation of obs resources, and add test check for crl_configuration.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
make testacc TEST=./huaweicloud/services/acceptance/ccm TESTARGS='-run TestAccCCMPrivateCA_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCCMPrivateCA_basic -timeout 360m -parallel 4
=== RUN   TestAccCCMPrivateCA_basic
=== PAUSE TestAccCCMPrivateCA_basic
=== CONT  TestAccCCMPrivateCA_basic
--- PASS: TestAccCCMPrivateCA_basic (35.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       35.859s


