### PR TITLE
feat(eip): add resource global eip

### DIFF
--- a/docs/resources/global_eip.md
+++ b/docs/resources/global_eip.md
@@ -1,0 +1,103 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# huaweicloud_global_eip
+
+Manages a global EIP resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "enterprise_project_id" {}
+variable "bandwidth_name" {}
+variable "eip_name" {}
+
+data "huaweicloud_global_eip_pools" "all" {}
+
+resource "huaweicloud_global_internet_bandwidth" "test" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  charge_mode           = "95peak_guar"
+  enterprise_project_id = var.enterprise_project_id
+  size                  = 300
+  isp                   = data.huaweicloud_global_eip_pools.all.geip_pools[0].isp
+  name                  = var.bandwidth_name
+  type                  = data.huaweicloud_global_eip_pools.all.geip_pools[0].allowed_bandwidth_types[0].type
+}
+
+resource "huaweicloud_global_eip" "test" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  enterprise_project_id = var.enterprise_project_id
+  geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
+  internet_bandwidth_id = huaweicloud_global_internet_bandwidth.test.id
+  name                  = var.eip_name
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `access_site` - (Required, String, ForceNew) Specifies the access site name.
+  Changing this creates a new resource.
+
+* `geip_pool_name` - (Required, String, ForceNew) Specifies the global EIP pool name.
+  Changing this creates a new resource.
+
+* `internet_bandwidth_id` - (Required, String, ForceNew) Specifies the internet bandwidth id which the global EIP use.
+  Changing this creates a new resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id to which the global EIP
+  belongs. Changing this creates a new resource.
+
+* `description` - (Optional, String) Specifies the description of the global EIP.
+
+* `name` - (Optional, String) Specifies the name of the global EIP.
+
+* `tags` - (Optional, Map) Specifies the tags of the global EIP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `ip_address` - The ip address of the global EIP.
+
+* `ip_version` - The ip version of the global EIP.
+
+* `isp` - The the internet service provider of the global EIP.
+
+* `global_connection_bandwidth_id` - The ID of the global connection bandwidth.
+
+* `global_connection_bandwidth_type` - The type of the global connection bandwidth.
+
+* `associate_instance_region` - The region of the associate instance.
+
+* `associate_instance_id` - The ID of the associate instance.
+
+* `associate_instance_type` - The type of the associate instance.
+
+* `frozen` - The global EIP is frozen or not.
+
+* `frozen_info` - The frozen info of the global EIP.
+
+* `polluted` - The global EIP is polluted or not.
+
+* `status` - The status of the global EIP.
+
+* `created_at` - The create time of the global EIP.
+
+* `updated_at` - The update time of the global EIP.
+
+## Import
+
+The global EIP can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_global_eip.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1297,6 +1297,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_eip_associate":       eip.ResourceEIPAssociate(),
 
 			"huaweicloud_global_internet_bandwidth": eip.ResourceGlobalInternetBandwidth(),
+			"huaweicloud_global_eip":                eip.ResourceGlobalEIP(),
 
 			"huaweicloud_vpc_peering_connection":          vpc.ResourceVpcPeeringConnectionV2(),
 			"huaweicloud_vpc_peering_connection_accepter": vpc.ResourceVpcPeeringConnectionAccepterV2(),

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_test.go
@@ -1,0 +1,127 @@
+package eip
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getGEIPResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("geip", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GEIP client: %s", err)
+	}
+	getGEIPHttpUrl := "v3/{domain_id}/global-eips/{id}"
+	getGEIPPath := client.Endpoint + getGEIPHttpUrl
+	getGEIPPath = strings.ReplaceAll(getGEIPPath, "{domain_id}", cfg.DomainID)
+	getGEIPPath = strings.ReplaceAll(getGEIPPath, "{id}", state.Primary.ID)
+
+	getGEIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getGEIPResp, err := client.Request("GET", getGEIPPath, &getGEIPOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving global EIP: %s", err)
+	}
+	return utils.FlattenResponse(getGEIPResp)
+}
+
+func TestAccGEIP_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_global_eip.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getGEIPResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGEIP_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrSet(rName, "isp"),
+					resource.TestCheckResourceAttrSet(rName, "ip_version"),
+					resource.TestCheckResourceAttrSet(rName, "ip_address"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+				),
+			},
+			{
+				Config: testAccGEIP_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "description", "test-update"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccGEIP_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_global_eip" "test" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  enterprise_project_id = "%s"
+  geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
+  internet_bandwidth_id = huaweicloud_global_internet_bandwidth.test.id
+  name                  = "%s"
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testAccInternetBandwidth_basic(name), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}
+
+func testAccGEIP_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_global_eip" "test" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  enterprise_project_id = "%s"
+  geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
+  internet_bandwidth_id = huaweicloud_global_internet_bandwidth.test.id
+  name                  = "%s-update"
+  description           = "test-update"
+
+  tags = {
+    key = "value"
+  }
+}
+`, testAccInternetBandwidth_basic(name), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}

--- a/huaweicloud/services/eip/resource_huaweicloud_global_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_eip.go
@@ -1,0 +1,367 @@
+package eip
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP POST /v3/{domain_id}/global-eips
+// @API EIP DELETE /v3/{domain_id}/global-eips/{id}
+// @API EIP GET /v3/{domain_id}/global-eips/{id}
+// @API EIP PUT /v3/{domain_id}/global-eips/{id}
+// @API EIP POST /v3/global-eip/{resource_id}/tags/delete
+// @API EIP POST /v3/global-eip/{resource_id}/tags/create
+func ResourceGlobalEIP() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGlobalEIPCreate,
+		ReadContext:   resourceGlobalEIPRead,
+		UpdateContext: resourceGlobalEIPUpdate,
+		DeleteContext: resourceGlobalEIPDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"access_site": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"geip_pool_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"internet_bandwidth_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Computed: true,
+			},
+			"isp": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_version": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"frozen": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"frozen_info": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"polluted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"global_connection_bandwidth_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"global_connection_bandwidth_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"associate_instance_region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"associate_instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"associate_instance_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGlobalEIPCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	createGEIPHttpUrl := "v3/{domain_id}/global-eips"
+	createGEIPPath := client.Endpoint + createGEIPHttpUrl
+	createGEIPPath = strings.ReplaceAll(createGEIPPath, "{domain_id}", cfg.DomainID)
+
+	createGEIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"global_eip": utils.RemoveNil(buildCreateGEIPBodyParams(d, cfg.GetEnterpriseProjectID(d))),
+		},
+	}
+
+	createGEIPResp, err := client.Request("POST", createGEIPPath, &createGEIPOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	createGEIPRespBody, err := utils.FlattenResponse(createGEIPResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("global_eip.id", createGEIPRespBody)
+	if err != nil {
+		return diag.Errorf("error creating global EIP: %s is not found in API response", "id")
+	}
+	d.SetId(id.(string))
+
+	err = waitForGEIPComplete(ctx, d.Timeout(schema.TimeoutCreate), d.Id(), cfg.DomainID, client)
+	if err != nil {
+		return diag.Errorf("Error creating global EIP: %s", err)
+	}
+
+	return resourceGlobalEIPRead(ctx, d, meta)
+}
+
+func waitForGEIPComplete(ctx context.Context, timeout time.Duration, id string, domainID string,
+	client *golangsdk.ServiceClient) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      geipStatusRefreshFunc(id, domainID, client),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func buildCreateGEIPBodyParams(d *schema.ResourceData, epsID string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"access_site":           d.Get("access_site"),
+		"geip_pool_name":        d.Get("geip_pool_name"),
+		"internet_bandwidth_id": d.Get("internet_bandwidth_id"),
+		"description":           utils.ValueIngoreEmpty(d.Get("description")),
+		"name":                  utils.ValueIngoreEmpty(d.Get("name")),
+		"enterprise_project_id": epsID,
+		"tags":                  utils.ValueIngoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
+	}
+	return bodyParams
+}
+
+func geipStatusRefreshFunc(id string, domainID string, client *golangsdk.ServiceClient) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getGEIPHttpUrl := "v3/{domain_id}/global-eips/{id}"
+		getGEIPPath := client.Endpoint + getGEIPHttpUrl
+		getGEIPPath = strings.ReplaceAll(getGEIPPath, "{domain_id}", domainID)
+		getGEIPPath = strings.ReplaceAll(getGEIPPath, "{id}", id)
+		getGEIPOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		getGEIPResp, err := client.Request("GET", getGEIPPath, &getGEIPOpt)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		getGEIPRespBody, err := utils.FlattenResponse(getGEIPResp)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		status, err := jmespath.Search("global_eip.status", getGEIPRespBody)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+		if status.(string) == "inuse" || status.(string) == "idle" {
+			return getGEIPRespBody, "SUCCESS", nil
+		}
+		return getGEIPRespBody, "PENDING", nil
+	}
+}
+
+func resourceGlobalEIPRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	getGEIPHttpUrl := "v3/{domain_id}/global-eips/{id}"
+	getGEIPPath := client.Endpoint + getGEIPHttpUrl
+	getGEIPPath = strings.ReplaceAll(getGEIPPath, "{domain_id}", cfg.DomainID)
+	getGEIPPath = strings.ReplaceAll(getGEIPPath, "{id}", d.Id())
+
+	getGEIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getGEIPResp, err := client.Request("GET", getGEIPPath, &getGEIPOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving global EIP")
+	}
+	getGEIPRespBody, err := utils.FlattenResponse(getGEIPResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	geip, err := jmespath.Search("global_eip", getGEIPRespBody)
+	if err != nil {
+		return diag.Errorf("error getting global EIP: %s is not found in API response", "global_eip")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("access_site", utils.PathSearch("access_site", geip, nil)),
+		d.Set("geip_pool_name", utils.PathSearch("geip_pool_name", geip, nil)),
+		d.Set("internet_bandwidth_id", utils.PathSearch("internet_bandwidth_info.id", geip, nil)),
+		d.Set("description", utils.PathSearch("description", geip, nil)),
+		d.Set("name", utils.PathSearch("name", geip, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", geip, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("tags", geip, nil))),
+		d.Set("isp", utils.PathSearch("isp", geip, nil)),
+		d.Set("polluted", utils.PathSearch("polluted", geip, false)),
+		d.Set("ip_version", utils.PathSearch("ip_version", geip, float64(0))),
+		d.Set("ip_address", utils.PathSearch("ip_address", geip, nil)),
+		d.Set("frozen", utils.PathSearch("freezen", geip, false)),
+		d.Set("frozen_info", utils.PathSearch("freezen_info", geip, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", geip, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", geip, nil)),
+		d.Set("status", utils.PathSearch("status", geip, nil)),
+		d.Set("global_connection_bandwidth_id", utils.PathSearch("global_connection_bandwidth_info.gcb_id", geip, nil)),
+		d.Set("global_connection_bandwidth_type", utils.PathSearch("global_connection_bandwidth_info.gcb_type", geip, nil)),
+		d.Set("associate_instance_region", utils.PathSearch("associate_instance_info.region", geip, nil)),
+		d.Set("associate_instance_id", utils.PathSearch("associate_instance_info.instance_id", geip, nil)),
+		d.Set("associate_instance_type", utils.PathSearch("associate_instance_info.instance_type", geip, nil)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting global EIP fields: %s", err)
+	}
+	return nil
+}
+
+func resourceGlobalEIPUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	updateChanges := []string{
+		"description",
+		"name",
+	}
+
+	if d.HasChanges(updateChanges...) {
+		updateGEIPHttpUrl := "v3/{domain_id}/global-eips/{id}"
+		updateGEIPPath := client.Endpoint + updateGEIPHttpUrl
+		updateGEIPPath = strings.ReplaceAll(updateGEIPPath, "{domain_id}", cfg.DomainID)
+		updateGEIPPath = strings.ReplaceAll(updateGEIPPath, "{id}", d.Id())
+
+		updateGEIPOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody: map[string]interface{}{
+				"global_eip": utils.RemoveNil(map[string]interface{}{
+					"description": d.Get("description"),
+					"name":        utils.ValueIngoreEmpty(d.Get("name")),
+				}),
+			},
+		}
+
+		_, err = client.Request("PUT", updateGEIPPath, &updateGEIPOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// update tags
+	if d.HasChange("tags") {
+		tagErr := updateTags(client, d, "global-eip", d.Id())
+		if tagErr != nil {
+			return diag.Errorf("error updating tags of global EIP (%s): %s", d.Id(), tagErr)
+		}
+	}
+
+	err = waitForGEIPComplete(ctx, d.Timeout(schema.TimeoutCreate), d.Id(), cfg.DomainID, client)
+	if err != nil {
+		return diag.Errorf("Error updating global EIP: %s", err)
+	}
+
+	return resourceGlobalEIPRead(ctx, d, meta)
+}
+
+func resourceGlobalEIPDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	deleteGEIPHttpUrl := "v3/{domain_id}/global-eips/{id}"
+	deleteGEIPPath := client.Endpoint + deleteGEIPHttpUrl
+	deleteGEIPPath = strings.ReplaceAll(deleteGEIPPath, "{domain_id}", cfg.DomainID)
+	deleteGEIPPath = strings.ReplaceAll(deleteGEIPPath, "{id}", d.Id())
+
+	deleteGEIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deleteGEIPPath, &deleteGEIPOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add resource `huaweicloud_global_eip`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGEIP_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGEIP_basic -timeout 360m -parallel 4
=== RUN   TestAccGEIP_basic
=== PAUSE TestAccGEIP_basic
=== CONT  TestAccGEIP_basic
--- PASS: TestAccGEIP_basic (74.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       74.576s
```
