### PR TITLE
feat(DMS): rocketmq supports specification modification

### DIFF
--- a/docs/resources/dms_rocketmq_instance.md
+++ b/docs/resources/dms_rocketmq_instance.md
@@ -44,9 +44,7 @@ The following arguments are supported:
 * `engine_version` - (Required, String, ForceNew) Specifies the version of the RocketMQ engine. Value: 4.8.0.
   Changing this parameter will create a new resource.
 
-* `storage_space` - (Required, Int, ForceNew) Specifies the message storage capacity, Unit: GB.
-  Value range: 300-3000.
-  Changing this parameter will create a new resource.
+* `storage_space` - (Required, Int) Specifies the message storage capacity, Unit: GB. Value range: 300-3000.
 
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC.
   Changing this parameter will create a new resource.
@@ -61,7 +59,7 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `flavor_id` - (Required, String, ForceNew) Specifies a product ID. The options are as follows:
+* `flavor_id` - (Required, String) Specifies a product ID. The options are as follows:
   + **c6.4u8g.cluster**: maximum number of topics on each broker: 4000; maximum number of consumer groups
     on each broker: 4000
   + **c6.8u16g.cluster**: maximum number of topics on each broker: 8000; maximum number of consumer groups
@@ -70,7 +68,6 @@ The following arguments are supported:
     on each broker: 12,000
   + **c6.16u32g.cluster**: maximum number of topics on each broker: 16,000; maximum number of consumer groups
     on each broker: 16,000
-  Changing this parameter will create a new resource.
 
 * `storage_spec_code` - (Required, String, ForceNew) Specifies the storage I/O specification.
   The options are as follows:
@@ -93,8 +90,7 @@ The following arguments are supported:
   multiple EIP IDs. This parameter is mandatory if public access is enabled (that is, enable_publicip is set to true).
   This parameter can not be updated if public access is disabled.
 
-* `broker_num` - (Optional, Int, ForceNew) Specifies the broker numbers. Defaults to 1.
-  Changing this parameter will create a new resource.
+* `broker_num` - (Optional, Int) Specifies the broker numbers. Defaults to **1**.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the instance.
   Changing this parameter will create a new resource.

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -319,3 +319,21 @@ func RetryContextWithWaitForState(param *RetryContextWithWaitForStateParam) (int
 
 	return stateConf.WaitForStateContext(param.Ctx)
 }
+
+// GetEipsbyAddresses returns the EIPs of addresses when success.
+func GetEipsbyAddresses(client *golangsdk.ServiceClient, addresses []string, epsID string) ([]eips.PublicIp, error) {
+	listOpts := &eips.ListOpts{
+		PublicIp:            addresses,
+		EnterpriseProjectId: epsID,
+	}
+	pages, err := eips.List(client, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	allEips, err := eips.ExtractPublicIPs(pages)
+	if err != nil {
+		return nil, fmtp.Errorf("Unable to retrieve eips: %s ", err)
+	}
+	return allEips, nil
+}

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_instance_test.go
@@ -32,12 +32,7 @@ func getDmsRocketMQInstanceResourceFunc(cfg *config.Config, state *terraform.Res
 	getRocketmqInstancePath = strings.ReplaceAll(getRocketmqInstancePath, "{project_id}", getRocketmqInstanceClient.ProjectID)
 	getRocketmqInstancePath = strings.ReplaceAll(getRocketmqInstancePath, "{instance_id}", fmt.Sprintf("%v", state.Primary.ID))
 
-	getRocketmqInstanceOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-	}
+	getRocketmqInstanceOpt := golangsdk.RequestOpts{KeepResponseBody: true}
 	getRocketmqInstanceResp, err := getRocketmqInstanceClient.Request("GET", getRocketmqInstancePath, &getRocketmqInstanceOpt)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving DmsRocketMQInstance: %s", err)
@@ -68,11 +63,14 @@ func TestAccDmsRocketMQInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "4.8.0"),
 					resource.TestCheckResourceAttr(resourceName, "enable_acl", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "broker_num", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_space", "500"),
+					resource.TestCheckResourceAttrPair(resourceName, "engine_version", "data.huaweicloud_dms_rocketmq_flavors.test", "versions.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor_id", "data.huaweicloud_dms_rocketmq_flavors.test", "flavors.0.id"),
 				),
 			},
 			{
@@ -80,12 +78,15 @@ func TestAccDmsRocketMQInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "4.8.0"),
 					resource.TestCheckResourceAttr(resourceName, "enable_acl", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key3", "value3_update"),
+					resource.TestCheckResourceAttr(resourceName, "broker_num", "2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_space", "1200"),
+					resource.TestCheckResourceAttrPair(resourceName, "engine_version", "data.huaweicloud_dms_rocketmq_flavors.test", "versions.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor_id", "data.huaweicloud_dms_rocketmq_flavors.test", "flavors.1.id"),
 				),
 			},
 			{
@@ -120,11 +121,11 @@ func TestAccDmsRocketMQInstance_prepaid_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "4.8.0"),
 					resource.TestCheckResourceAttr(resourceName, "enable_acl", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttrPair(resourceName, "engine_version", "data.huaweicloud_dms_rocketmq_flavors.test", "versions.0"),
 				),
 			},
 			{
@@ -132,12 +133,12 @@ func TestAccDmsRocketMQInstance_prepaid_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "engine_version", "4.8.0"),
 					resource.TestCheckResourceAttr(resourceName, "enable_acl", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key3", "value3_update"),
+					resource.TestCheckResourceAttrPair(resourceName, "engine_version", "data.huaweicloud_dms_rocketmq_flavors.test", "versions.0"),
 				),
 			},
 			{
@@ -145,6 +146,69 @@ func TestAccDmsRocketMQInstance_prepaid_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"auto_renew", "period", "period_unit"},
+			},
+		},
+	})
+}
+
+func TestAccDmsRocketMQInstance_broker_publicip(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	updateName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_rocketmq_instance.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDmsRocketMQInstanceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsRocketMQInstance_broker_publicip(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "enable_acl", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_publicip", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "broker_num", "1"),
+					resource.TestCheckResourceAttr(resourceName, "storage_space", "300"),
+					resource.TestCheckResourceAttrSet(resourceName, "publicip_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "publicip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_broker_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_namesrv_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "engine_version", "data.huaweicloud_dms_rocketmq_flavors.test", "versions.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor_id", "data.huaweicloud_dms_rocketmq_flavors.test", "flavors.0.id"),
+				),
+			},
+			{
+				Config: testDmsRocketMQInstance_broker_publicip_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "enable_acl", "false"),
+					resource.TestCheckResourceAttr(resourceName, "enable_publicip", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "broker_num", "2"),
+					resource.TestCheckResourceAttr(resourceName, "storage_space", "800"),
+					resource.TestCheckResourceAttrSet(resourceName, "publicip_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "publicip_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_broker_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_namesrv_address"),
+					resource.TestCheckResourceAttrPair(resourceName, "engine_version", "data.huaweicloud_dms_rocketmq_flavors.test", "versions.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor_id", "data.huaweicloud_dms_rocketmq_flavors.test", "flavors.0.id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -183,6 +247,7 @@ func TestAccDmsRocketMQInstance_publicip(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
 					resource.TestCheckResourceAttr(resourceName, "enable_publicip", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "publicip_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "publicip_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_broker_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_namesrv_address"),
 				),
@@ -202,10 +267,18 @@ func testDmsRocketMQInstance_basic(name string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
+data "huaweicloud_dms_rocketmq_flavors" "test" {
+  type = "cluster"
+}
+
+locals {
+  query_results = data.huaweicloud_dms_rocketmq_flavors.test
+  flavor        = data.huaweicloud_dms_rocketmq_flavors.test.flavors[0]
+}
+
 resource "huaweicloud_dms_rocketmq_instance" "test" {
   name              = "%s"
-  engine_version    = "4.8.0"
-  storage_space     = 300
+  engine_version    = local.query_results.versions[0]
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -216,10 +289,11 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
     data.huaweicloud_availability_zones.test.names[2],
   ]
 
-  flavor_id         = "c6.4u8g.cluster"
-  storage_spec_code = "dms.physical.storage.high.v2"
-  broker_num        = 1
+  storage_spec_code = local.flavor.ios[0].storage_spec_code
   enable_acl        = true
+  flavor_id         = local.flavor.id
+  storage_space     = 500  
+  broker_num        = 1
 
   tags = {
     key1 = "value1"
@@ -235,10 +309,20 @@ func testDmsRocketMQInstance_update(name string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
+data "huaweicloud_dms_rocketmq_flavors" "test" {
+  type = "cluster"
+}
+
+locals {
+  query_results = data.huaweicloud_dms_rocketmq_flavors.test
+  flavor        = data.huaweicloud_dms_rocketmq_flavors.test.flavors[0]
+  newFlavor     = data.huaweicloud_dms_rocketmq_flavors.test.flavors[1]
+}
+
 resource "huaweicloud_dms_rocketmq_instance" "test" {
   name              = "%s"
-  engine_version    = "4.8.0"
-  storage_space     = 300
+  engine_version    = local.query_results.versions[0]
+  
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -249,10 +333,11 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
     data.huaweicloud_availability_zones.test.names[1],
   ]
 
-  flavor_id         = "c6.4u8g.cluster"
-  storage_spec_code = "dms.physical.storage.high.v2"
-  broker_num        = 1
+  storage_spec_code = local.flavor.ios[0].storage_spec_code
   enable_acl        = false
+  flavor_id         = local.newFlavor.id
+  storage_space     = 1200 
+  broker_num        = 2
 
   tags = {
     key1 = "value1_update"
@@ -269,9 +354,18 @@ func testDmsRocketMQInstance_prepaid_basic(name string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
+data "huaweicloud_dms_rocketmq_flavors" "test" {
+  type = "cluster"
+}
+
+locals {
+  query_results = data.huaweicloud_dms_rocketmq_flavors.test
+  flavor        = data.huaweicloud_dms_rocketmq_flavors.test.flavors[0]
+}
+
 resource "huaweicloud_dms_rocketmq_instance" "test" {
   name              = "%s"
-  engine_version    = "4.8.0"
+  engine_version    = local.query_results.versions[0]
   storage_space     = 300
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
@@ -288,8 +382,8 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
   period        = 1
   auto_renew    = true
 
-  flavor_id         = "c6.4u8g.cluster"
-  storage_spec_code = "dms.physical.storage.high.v2"
+  flavor_id         = local.flavor.id
+  storage_spec_code = local.flavor.ios[0].storage_spec_code
   broker_num        = 1
   enable_acl        = true
 
@@ -307,9 +401,18 @@ func testDmsRocketMQInstance_prepaid_update(name string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
+data "huaweicloud_dms_rocketmq_flavors" "test" {
+  type = "cluster"
+}
+
+locals {
+  query_results = data.huaweicloud_dms_rocketmq_flavors.test
+  flavor        = data.huaweicloud_dms_rocketmq_flavors.test.flavors[0]
+}
+
 resource "huaweicloud_dms_rocketmq_instance" "test" {
   name              = "%s"
-  engine_version    = "4.8.0"
+  engine_version    = local.query_results.versions[0]
   storage_space     = 300
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
@@ -326,8 +429,8 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
   period        = 1
   auto_renew    = false
 
-  flavor_id         = "c6.4u8g.cluster"
-  storage_spec_code = "dms.physical.storage.high.v2"
+  flavor_id         = local.flavor.id
+  storage_spec_code = local.flavor.ios[0].storage_spec_code
   broker_num        = 1
   enable_acl        = false
 
@@ -336,6 +439,117 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
     key2 = "value2_update"
     key3 = "value3_update"
   }
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testDmsRocketMQInstance_broker_publicip(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_dms_rocketmq_flavors" "test" {
+  type = "cluster.small"
+}
+
+resource "huaweicloud_vpc_eip" "test_eip" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "test_eip_${count.index}"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+
+  count = 3
+}
+
+locals {
+  query_results = data.huaweicloud_dms_rocketmq_flavors.test
+  flavor        = data.huaweicloud_dms_rocketmq_flavors.test.flavors[0]
+  publicip_id   = "${huaweicloud_vpc_eip.test_eip[0].id},${huaweicloud_vpc_eip.test_eip[1].id},${huaweicloud_vpc_eip.test_eip[2].id}"
+}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%s"
+  engine_version    = local.query_results.versions[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0],
+    data.huaweicloud_availability_zones.test.names[1],
+    data.huaweicloud_availability_zones.test.names[2],
+  ]
+
+  storage_spec_code = local.flavor.ios[0].storage_spec_code
+  enable_acl        = true
+  flavor_id         = local.flavor.id
+  storage_space     = 300  
+  broker_num        = 1
+  enable_publicip   = true
+  publicip_id       = local.publicip_id
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testDmsRocketMQInstance_broker_publicip_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_dms_rocketmq_flavors" "test" {
+  type = "cluster.small"
+}
+
+resource "huaweicloud_vpc_eip" "test_eip" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "test_eip_${count.index}"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+
+  count = 6
+}
+
+locals {
+  query_results = data.huaweicloud_dms_rocketmq_flavors.test
+  flavor        = data.huaweicloud_dms_rocketmq_flavors.test.flavors[0]
+  publicip_id   = format("%%s,%%s,%%s,%%s,%%s,%%s", huaweicloud_vpc_eip.test_eip[0].id,huaweicloud_vpc_eip.test_eip[1].id,
+  huaweicloud_vpc_eip.test_eip[2].id,huaweicloud_vpc_eip.test_eip[3].id,huaweicloud_vpc_eip.test_eip[4].id,huaweicloud_vpc_eip.test_eip[5].id)
+}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%s"
+  engine_version    = local.query_results.versions[0]
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0],
+    data.huaweicloud_availability_zones.test.names[1],
+    data.huaweicloud_availability_zones.test.names[2],
+  ]
+
+  storage_spec_code = local.flavor.ios[0].storage_spec_code
+  enable_acl        = false
+  flavor_id         = local.flavor.id
+  storage_space     = 800
+  broker_num        = 2  
+  enable_publicip   = true
+  publicip_id       = local.publicip_id
 }
 `, common.TestBaseNetwork(name), name)
 }
@@ -357,7 +571,7 @@ locals {
 
 resource "huaweicloud_dms_rocketmq_instance" "test" {
   name              = "%[2]s"
-  engine_version    = element(local.query_results.versions, length(local.query_results.versions)-1)
+  engine_version    = local.query_results.versions[length(local.query_results.versions)-1]
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -404,7 +618,7 @@ locals {
 
 resource "huaweicloud_dms_rocketmq_instance" "test" {
   name              = "%[2]s"
-  engine_version    = element(local.query_results.versions, length(local.query_results.versions)-1)
+  engine_version    = local.query_results.versions[length(local.query_results.versions)-1]
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id

--- a/huaweicloud/utils/diff_suppress_funcs.go
+++ b/huaweicloud/utils/diff_suppress_funcs.go
@@ -141,3 +141,15 @@ func CompareJsonTemplateAreEquivalent(tem1, tem2 string) (bool, error) {
 	}
 	return equal, nil
 }
+
+func SuppressStringSepratedByCommaDiffs(_, old, new string, _ *schema.ResourceData) bool {
+	if len(old) != len(new) {
+		return false
+	}
+	oldArray := strings.Split(old, ",")
+	newArray := strings.Split(new, ",")
+	sort.Strings(oldArray)
+	sort.Strings(newArray)
+
+	return reflect.DeepEqual(oldArray, newArray)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rocketmq supports specification modification
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
rocketmq supports specification modification: flavor_id, storage_space, broker_num and publicip(for increased brokers)
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./loud/services/acceptance/dms/ TESTARGS='-run TestAccDmsRocketMQInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsRocketMQInstance -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQInstance_basic
=== PAUSE TestAccDmsRocketMQInstance_basic
=== RUN   TestAccDmsRocketMQInstance_prepaid_basic
=== PAUSE TestAccDmsRocketMQInstance_prepaid_basic
=== RUN   TestAccDmsRocketMQInstance_broker_publicip
=== PAUSE TestAccDmsRocketMQInstance_broker_publicip
=== RUN   TestAccDmsRocketMQInstance_publicip
=== PAUSE TestAccDmsRocketMQInstance_publicip
=== CONT  TestAccDmsRocketMQInstance_basic
=== CONT  TestAccDmsRocketMQInstance_broker_publicip
=== CONT  TestAccDmsRocketMQInstance_publicip
=== CONT  TestAccDmsRocketMQInstance_prepaid_basic
--- PASS: TestAccDmsRocketMQInstance_publicip (704.74s)
--- PASS: TestAccDmsRocketMQInstance_prepaid_basic (1152.70s)
--- PASS: TestAccDmsRocketMQInstance_broker_publicip (1683.47s)
--- PASS: TestAccDmsRocketMQInstance_basic (3228.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       3228.806s
```
