### PR TITLE
chore(eip): add attributes and params for eip

### DIFF
--- a/docs/data-sources/vpc_bandwidths.md
+++ b/docs/data-sources/vpc_bandwidths.md
@@ -73,6 +73,10 @@ The `bandwidths` block supports:
 
 * `status` - Indicates the status of the bandwidth.
 
+* `created_at` - Indicates the create time of the bandwidth.
+
+* `updated_at` - Indicates the update time of the bandwidth.
+
 <a name="attrblock--bandwidths--publicips"></a>
 The `publicips` block supports:
 

--- a/docs/data-sources/vpc_eip.md
+++ b/docs/data-sources/vpc_eip.md
@@ -29,6 +29,8 @@ data "huaweicloud_vpc_eip" "by_address" {
 
 In addition to all arguments above, the following attributes are exported:
 
+* `name` - The name of the EIP.
+
 * `status` - The status of the EIP.
 
 * `type` - The type of the EIP.
@@ -41,6 +43,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `bandwidth_id` - The bandwidth id of the EIP.
 
+* `bandwidth_name` - The bandwidth name of the EIP.
+
 * `bandwidth_size` - The bandwidth size of the EIP.
 
 * `bandwidth_share_type` - The bandwidth share type of the EIP.
+
+* `created_at` - The create time of the EIP.

--- a/docs/data-sources/vpc_eips.md
+++ b/docs/data-sources/vpc_eips.md
@@ -38,6 +38,8 @@ The arguments of this data source act as filters for querying the available EIPs
 
 * `public_ips` - (Optional, List) Specifies an array of one or more public ip addresses of the desired EIP.
 
+* `private_ips` - (Optional, List) Specifies an array of one or more private ip addresses of the desired EIP.
+
 * `port_ids` - (Optional, List) Specifies an array of one or more port ids which bound to the desired EIP.
 
 * `ip_version` - (Optional, Int) Specifies ip version of the desired EIP. The options are:
@@ -80,3 +82,4 @@ The `eips` block supports:
 * `bandwidth_size` - The bandwidth size of the EIP.
 * `bandwidth_share_type` - The bandwidth share type of the EIP.
 * `tags` - The key/value pairs which associated with the EIP.
+* `created_at` - The create time of the EIP.

--- a/docs/resources/vpc_bandwidth.md
+++ b/docs/resources/vpc_bandwidth.md
@@ -67,6 +67,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - Indicates the bandwidth status.
 
+* `created_at` - Indicates the bandwidth create time.
+
+* `updated_at` - Indicates the bandwidth update time.
+
 * `publicips` - An array of EIPs that use the bandwidth. The object includes the following:
   + `id` - The ID of the EIP or IPv6 port that uses the bandwidth.
   + `type` - The EIP type. Possible values are *5_bgp* (dynamic BGP) and *5_sbgp* (static BGP).

--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -116,7 +116,7 @@ The `bandwidth` block supports:
 * `id` - (Optional, String, ForceNew) The shared bandwidth ID.  
   This parameter is mandatory when `share_type` is set to **WHOLE**. Changing this will create a new resource.
 
-* `charge_mode` - (Optional, String, ForceNew) Specifies whether the bandwidth is billed by traffic or by bandwidth
+* `charge_mode` - (Optional, String) Specifies whether the bandwidth is billed by traffic or by bandwidth
   size. The value can be **traffic** or **bandwidth**. Changing this will create a new resource.
 
 ## Attribute Reference
@@ -129,6 +129,7 @@ In addition to all arguments above, the following attributes are exported:
 * `private_ip` - The private IP address bound to the EIP.
 * `port_id` - The port ID which the EIP associated with.
 * `status` - The status of EIP.
+* `created_at` - The create time of EIP.
 
 ## Timeouts
 

--- a/docs/resources/vpc_eip_associate.md
+++ b/docs/resources/vpc_eip_associate.md
@@ -74,6 +74,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The resource ID in UUID format.
 * `mac_address` - The MAC address of the private IP.
 * `status` - The status of EIP, should be **BOUND**.
+* `public_ipv6` - The IPv6 address of the private IP.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
@@ -69,6 +69,7 @@ func TestAccVpcEip_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.size", "8"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.charge_mode", "bandwidth"),
 				),
 			},
 			{
@@ -312,7 +313,7 @@ resource "huaweicloud_vpc_eip" "test" {
     share_type  = "PER"
     name        = "%[1]s"
     size        = 8
-    charge_mode = "traffic"
+    charge_mode = "bandwidth"
   }
 
   tags = {

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_bandwidths.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_bandwidths.go
@@ -82,6 +82,14 @@ func DataSourceBandWidths() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"publicips": publicIPListComputedSchema(),
 					},
 				},
@@ -139,6 +147,8 @@ func dataSourceBandWidthsRead(_ context.Context, d *schema.ResourceData, meta in
 			"bandwidth_type":        item.BandwidthType,
 			"charge_mode":           item.ChargeMode,
 			"status":                item.Status,
+			"created_at":            item.CreatedAt,
+			"updated_at":            item.UpdatedAt,
 			"publicips":             flattenPublicIPs(item),
 		}
 		rst[i] = bandwidth

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eip.go
@@ -38,7 +38,10 @@ func DataSourceVpcEip() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -63,11 +66,19 @@ func DataSourceVpcEip() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"bandwidth_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"bandwidth_size": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 			"bandwidth_share_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -120,6 +131,7 @@ func dataSourceVpcEipRead(_ context.Context, d *schema.ResourceData, meta interf
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
+		d.Set("name", eipInfo.Alias),
 		d.Set("status", NormalizeEipStatus(eipInfo.Status)),
 		d.Set("public_ip", eipInfo.PublicAddress),
 		d.Set("ipv6_address", eipInfo.PublicIpv6Address),
@@ -128,9 +140,11 @@ func dataSourceVpcEipRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("type", eipInfo.Type),
 		d.Set("private_ip", eipInfo.PrivateAddress),
 		d.Set("bandwidth_id", eipInfo.BandwidthID),
+		d.Set("bandwidth_name", eipInfo.BandwidthName),
 		d.Set("bandwidth_size", eipInfo.BandwidthSize),
 		d.Set("bandwidth_share_type", eipInfo.BandwidthShareType),
 		d.Set("enterprise_project_id", eipInfo.EnterpriseProjectID),
+		d.Set("created_at", eipInfo.CreateTime),
 	)
 
 	if err = mErr.ErrorOrNil(); err != nil {

--- a/huaweicloud/services/eip/data_source_huaweicloud_vpc_eips.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_vpc_eips.go
@@ -40,6 +40,11 @@ func DataSourceVpcEips() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"private_ips": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"port_ids": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -126,6 +131,10 @@ func DataSourceVpcEips() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -149,6 +158,7 @@ func dataSourceVpcEipsRead(_ context.Context, d *schema.ResourceData, meta inter
 	listOpts := &eips.ListOpts{
 		Id:                  utils.ExpandToStringList(d.Get("ids").([]interface{})),
 		PublicIp:            utils.ExpandToStringList(d.Get("public_ips").([]interface{})),
+		PrivateIp:           utils.ExpandToStringList(d.Get("private_ips").([]interface{})),
 		PortId:              utils.ExpandToStringList(d.Get("port_ids").([]interface{})),
 		IPVersion:           d.Get("ip_version").(int),
 		EnterpriseProjectId: cfg.DataGetEnterpriseProjectID(d),
@@ -204,6 +214,7 @@ func dataSourceVpcEipsRead(_ context.Context, d *schema.ResourceData, meta inter
 			"bandwidth_name":        item.BandwidthName,
 			"bandwidth_share_type":  item.BandwidthShareType,
 			"tags":                  tagRst,
+			"created_at":            item.CreateTime,
 		}
 
 		eipList = append(eipList, eip)

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_bandwidth.go
@@ -91,6 +91,14 @@ func ResourceVpcBandWidthV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"publicips": publicIPListComputedSchema(),
 		},
 	}
@@ -280,6 +288,8 @@ func resourceVpcBandWidthV2Read(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("bandwidth_type", b.BandwidthType),
 		d.Set("public_border_group", b.PublicBorderGroup),
 		d.Set("status", b.Status),
+		d.Set("created_at", b.CreatedAt),
+		d.Set("updated_at", b.UpdatedAt),
 		d.Set("charging_mode", normalizeChargingMode(b.BillingInfo)),
 		d.Set("publicips", flattenPublicIPs(b)),
 	)

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip.go
@@ -166,7 +166,6 @@ func ResourceVpcEIPV1() *schema.Resource {
 						"charge_mode": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							ForceNew:    true,
 							Computed:    true,
 							Description: `Whether the bandwidth is billed by traffic or by bandwidth size.`,
 						},
@@ -218,6 +217,10 @@ func ResourceVpcEIPV1() *schema.Resource {
 				Computed: true,
 			},
 			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -466,6 +469,7 @@ func resourceVpcEipRead(_ context.Context, d *schema.ResourceData, meta interfac
 		d.Set("private_ip", publicIp.PrivateAddress),
 		d.Set("port_id", publicIp.PortID),
 		d.Set("enterprise_project_id", publicIp.EnterpriseProjectID),
+		d.Set("created_at", publicIp.CreateTime),
 		d.Set("status", NormalizeEipStatus(publicIp.Status)),
 		d.Set("publicip", flattenEipPublicIpDetails(publicIp)),
 		d.Set("bandwidth", flattenEipBandwidthDetails(publicIp, bandWidth)),
@@ -581,8 +585,9 @@ func updateEipBandwidth(vpcV1Client *golangsdk.ServiceClient, cfg *config.Config
 	}
 
 	updateOpts := bandwidths.UpdateOpts{
-		Size: newMap["size"].(int),
-		Name: newMap["name"].(string),
+		Size:       newMap["size"].(int),
+		Name:       newMap["name"].(string),
+		ChargeMode: newMap["charge_mode"].(string),
 	}
 	log.Printf("[DEBUG] Bandwidth Update Options: %#v", updateOpts)
 	_, err := bandwidths.Update(vpcV1Client, bandwidthId, updateOpts).Extract()

--- a/huaweicloud/services/eip/resource_huaweicloud_vpc_eip_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_vpc_eip_associate.go
@@ -74,7 +74,10 @@ func ResourceEIPAssociate() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"port_id"},
 			},
-
+			"public_ipv6": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"mac_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -200,6 +203,7 @@ func resourceEIPAssociateRead(_ context.Context, d *schema.ResourceData, meta in
 		d.Set("region", region),
 		d.Set("port_id", eIP.PortID),
 		d.Set("public_ip", eIP.PublicAddress),
+		d.Set("public_ipv6", eIP.PublicIpv6Address),
 		d.Set("fixed_ip", eIP.PrivateAddress),
 		d.Set("network_id", associatedPort.NetworkId),
 		d.Set("mac_address", associatedPort.MacAddress),

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/requests.go
@@ -6,13 +6,13 @@ import (
 	"github.com/chnsz/golangsdk/pagination"
 )
 
-//ApplyOptsBuilder is an interface by which can build the request body of public ip
-//application
+// ApplyOptsBuilder is an interface by which can build the request body of public ip
+// application
 type ApplyOptsBuilder interface {
 	ToPublicIpApplyMap() (map[string]interface{}, error)
 }
 
-//ApplyOpts is a struct which is used to create public ip
+// ApplyOpts is a struct which is used to create public ip
 type ApplyOpts struct {
 	IP                  PublicIpOpts  `json:"publicip" required:"true"`
 	Bandwidth           BandwidthOpts `json:"bandwidth" required:"true"`
@@ -41,7 +41,7 @@ func (opts ApplyOpts) ToPublicIpApplyMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "")
 }
 
-//Apply is a method by which can access to apply the public ip
+// Apply is a method by which can access to apply the public ip
 func Apply(client *golangsdk.ServiceClient, opts ApplyOptsBuilder) (r ApplyResult) {
 	b, err := opts.ToPublicIpApplyMap()
 	if err != nil {
@@ -54,20 +54,20 @@ func Apply(client *golangsdk.ServiceClient, opts ApplyOptsBuilder) (r ApplyResul
 	return
 }
 
-//Get is a method by which can get the detailed information of public ip
+// Get is a method by which can get the detailed information of public ip
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
 	return
 }
 
-//Delete is a method by which can be able to delete a private ip
+// Delete is a method by which can be able to delete a private ip
 func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = client.Delete(resourceURL(client, id), nil)
 	return
 }
 
-//UpdateOptsBuilder is an interface by which can be able to build the request
-//body
+// UpdateOptsBuilder is an interface by which can be able to build the request
+// body
 type UpdateOptsBuilder interface {
 	ToPublicIpUpdateMap() (map[string]interface{}, error)
 }
@@ -84,7 +84,7 @@ func (opts UpdateOpts) ToPublicIpUpdateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "publicip")
 }
 
-//Update is a method which can be able to update the port of public ip
+// Update is a method which can be able to update the port of public ip
 func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
 	b, err := opts.ToPublicIpUpdateMap()
 	if err != nil {
@@ -150,4 +150,21 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return PublicIPPage{pagination.LinkedPageBase{PageResult: r}}
 	})
+}
+
+type ChangeToPeriodOpts struct {
+	PublicIPIDs []string           `json:"publicip_ids" required:"true"`
+	ExtendParam structs.ChargeInfo `json:"extendParam" required:"true"`
+}
+
+// ChangeToPeriod is is used to change the EIP to prePaid billing mode
+func ChangeToPeriod(c *golangsdk.ServiceClient, opts ChangeToPeriodOpts) (r ChangeResult) {
+	body, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Post(changeToPeriodURL(c), body, &r.Body, nil)
+	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/results.go
@@ -5,7 +5,7 @@ import (
 	"github.com/chnsz/golangsdk/pagination"
 )
 
-//ApplyResult is a struct which represents the result of apply public ip
+// ApplyResult is a struct which represents the result of apply public ip
 type ApplyResult struct {
 	golangsdk.Result
 }
@@ -27,7 +27,7 @@ func (r ApplyResult) Extract() (PublicIp, error) {
 	return ipResp.IP, err
 }
 
-//PublicIp is a struct that represents a public ip
+// PublicIp is a struct that represents a public ip
 type PublicIp struct {
 	ID                       string   `json:"id"`
 	Status                   string   `json:"status"`
@@ -49,7 +49,7 @@ type PublicIp struct {
 	AllowShareBandwidthTypes []string `json:"allow_share_bandwidth_types"`
 }
 
-//GetResult is a return struct of get method
+// GetResult is a return struct of get method
 type GetResult struct {
 	golangsdk.Result
 }
@@ -62,12 +62,12 @@ func (r GetResult) Extract() (PublicIp, error) {
 	return getResp.IP, err
 }
 
-//DeleteResult is a struct of delete result
+// DeleteResult is a struct of delete result
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
 
-//UpdateResult is a struct which contains the result of update method
+// UpdateResult is a struct which contains the result of update method
 type UpdateResult struct {
 	golangsdk.Result
 }
@@ -102,4 +102,18 @@ func ExtractPublicIPs(r pagination.Page) ([]PublicIp, error) {
 func (r PublicIPPage) IsEmpty() (bool, error) {
 	s, err := ExtractPublicIPs(r)
 	return len(s) == 0, err
+}
+
+type ChangeResult struct {
+	golangsdk.Result
+}
+
+func (r ChangeResult) Extract() (string, error) {
+	var s struct {
+		PublicIPIDs []string `json:"publicip_ids"`
+		OrderID     string   `json:"order_id"`
+		RequestID   string   `json:"request_id"`
+	}
+	err := r.ExtractInto(&s)
+	return s.OrderID, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/urls.go
@@ -15,3 +15,7 @@ func resourceURL(client *golangsdk.ServiceClient, id string) string {
 func listURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(client.ProjectID, resourcePath)
 }
+
+func changeToPeriodURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, resourcePath, "change-to-period")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add attributes and params for EIP:
Add attributes `name`, `bandwidth_name` and `created_at` for `data.huaweicloud_vpc_eip`.
Add params `private_ips` to search for data and add attribute `created_at` for `data.hauweicloud_vpc_eips`.
Add attributes `created_at` and `updated_at` for `data.huaweicloud_vpc_bandwidth`.
Add attributes `created_at` and `updated_at` for `data.huaweicloud_vpc_bandwidths`.

Add attribute `created_at` for `resource.huaweicloud_vpc_eip`, and update the updateOpts with the param `charge_mode`.
Add attribute `public_ipv6` for `resource.huaweicloud_vpc_eip_associate`.

Add acctest for updataOpts param `charge_mode` in `resource.huaweicloud_vpc_eip`.


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcEip_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcEip_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcEip_basic
=== PAUSE TestAccVpcEip_basic
=== CONT  TestAccVpcEip_basic
--- PASS: TestAccVpcEip_basic (57.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       57.256s
```
