### PR TITLE
feat(cts): add exclude_service, compress_type, is_sort_by_service attribute to cts tracker

### DIFF
--- a/docs/resources/cts_tracker.md
+++ b/docs/resources/cts_tracker.md
@@ -41,6 +41,15 @@ The following arguments are supported:
 
 * `kms_id` - (Optional, String) Specifies the ID of KMS key used for trace file encryption.
 
+* `compress_type` - (Optional, String) Specifies the compression type of trace files. The value can be
+  **gzip** or **json**. The default value is **gzip**.
+
+* `is_sort_by_service` - (Optional, Bool) Specifies whether to divide the path of the trace file by cloud service.
+  The default value is **true**.
+
+* `exclude_service` - (Optional, List) Specifies the names of the cloud services for which traces don't need to be transferred.
+  Currently, only **KMS** is supported.
+
 * `enabled` - (Optional, Bool) Specifies whether tracker is enabled.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CTS tracker.

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_tracker_test.go
@@ -32,6 +32,8 @@ func TestAccCTSTracker_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "system"),
 					resource.TestCheckResourceAttr(resourceName, "type", "system"),
 					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "compress_type", "gzip"),
+					resource.TestCheckResourceAttr(resourceName, "is_sort_by_service", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
@@ -42,6 +44,9 @@ func TestAccCTSTracker_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "file_prefix", "cts-updated"),
 					resource.TestCheckResourceAttr(resourceName, "lts_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "status", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "compress_type", "json"),
+					resource.TestCheckResourceAttr(resourceName, "is_sort_by_service", "true"),
+					resource.TestCheckResourceAttr(resourceName, "exclude_service.0", "KMS"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.newkey", "value"),
 				),
@@ -152,9 +157,11 @@ resource "huaweicloud_obs_bucket" "bucket" {
 }
 
 resource "huaweicloud_cts_tracker" "tracker" {
-  bucket_name = huaweicloud_obs_bucket.bucket.bucket
-  file_prefix = "cts"
-  lts_enabled = true
+  bucket_name        = huaweicloud_obs_bucket.bucket.bucket
+  file_prefix        = "cts"
+  lts_enabled        = true
+  compress_type      = "gzip"
+  is_sort_by_service = false
 
   tags = {
     foo = "bar"
@@ -172,10 +179,13 @@ resource "huaweicloud_obs_bucket" "bucket" {
 }
 
 resource "huaweicloud_cts_tracker" "tracker" {
-  bucket_name = huaweicloud_obs_bucket.bucket.bucket
-  file_prefix = "cts-updated"
-  lts_enabled = false
-  enabled     = false
+  bucket_name        = huaweicloud_obs_bucket.bucket.bucket
+  file_prefix        = "cts-updated"
+  lts_enabled        = false
+  enabled            = false
+  compress_type      = "json"
+  is_sort_by_service = true
+  exclude_service    = ["KMS"]
 
   tags = {
     foo    = "bar1"

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go
@@ -71,6 +71,24 @@ func ResourceCTSTracker() *schema.Resource {
 				Optional:     true,
 				RequiredWith: []string{"bucket_name"},
 			},
+			"compress_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"bucket_name"},
+			},
+			"is_sort_by_service": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				RequiredWith: []string{"bucket_name"},
+				Default:      true,
+			},
+			"exclude_service": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			"lts_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -176,8 +194,16 @@ func resourceCTSTrackerUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	// update other configurations
 	if d.IsNewResource() || d.HasChangeExcept("enabled") {
 		obsInfo := cts.TrackerObsInfo{
-			BucketName:     utils.String(d.Get("bucket_name").(string)),
-			FilePrefixName: utils.String(d.Get("file_prefix").(string)),
+			BucketName:      utils.String(d.Get("bucket_name").(string)),
+			FilePrefixName:  utils.String(d.Get("file_prefix").(string)),
+			IsSortByService: utils.Bool(d.Get("is_sort_by_service").(bool)),
+		}
+		if v, ok := d.GetOk("compress_type"); ok {
+			compressType := cts.GetTrackerObsInfoCompressTypeEnum().GZIP
+			if v.(string) != "gzip" {
+				compressType = cts.GetTrackerObsInfoCompressTypeEnum().JSON
+			}
+			obsInfo.CompressType = &compressType
 		}
 
 		trackerType := cts.GetUpdateTrackerRequestBodyTrackerTypeEnum().SYSTEM
@@ -188,6 +214,10 @@ func resourceCTSTrackerUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			IsOrganizationTracker: utils.Bool(d.Get("organization_enabled").(bool)),
 			IsSupportValidate:     utils.Bool(d.Get("validate_file").(bool)),
 			ObsInfo:               &obsInfo,
+		}
+
+		if v, ok := d.GetOk("exclude_service"); ok {
+			updateBody.ManagementEventSelector = buildManagementEventSelector(v.(*schema.Set).List())
 		}
 
 		var encryption bool
@@ -253,7 +283,12 @@ func resourceCTSTrackerRead(_ context.Context, d *schema.ResourceData, meta inte
 			mErr,
 			d.Set("bucket_name", bucketName),
 			d.Set("file_prefix", ctsTracker.ObsInfo.FilePrefixName),
+			d.Set("is_sort_by_service", ctsTracker.ObsInfo.IsSortByService),
 		)
+
+		if ctsTracker.ObsInfo.CompressType != nil {
+			mErr = multierror.Append(mErr, d.Set("compress_type", formatValue(ctsTracker.ObsInfo.CompressType)))
+		}
 
 		if *bucketName != "" {
 			mErr = multierror.Append(mErr, d.Set("transfer_enabled", true))
@@ -262,6 +297,9 @@ func resourceCTSTrackerRead(_ context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
+	if ctsTracker.ManagementEventSelector != nil {
+		mErr = multierror.Append(mErr, d.Set("exclude_service", ctsTracker.ManagementEventSelector.ExcludeService))
+	}
 	if ctsTracker.TrackerType != nil {
 		mErr = multierror.Append(mErr, d.Set("type", formatValue(ctsTracker.TrackerType)))
 	}
@@ -288,9 +326,12 @@ func resourceCTSTrackerDelete(_ context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("failed to disable CTS system tracker: %s", err)
 	}
 
+	compressType := cts.GetTrackerObsInfoCompressTypeEnum().JSON
 	obsInfo := cts.TrackerObsInfo{
-		BucketName:     utils.String(""),
-		FilePrefixName: utils.String(""),
+		BucketName:      utils.String(""),
+		FilePrefixName:  utils.String(""),
+		IsSortByService: utils.Bool(false),
+		CompressType:    &compressType,
 	}
 
 	updateBody := cts.UpdateTrackerRequestBody{
@@ -343,8 +384,17 @@ func formatValue(i interface{}) string {
 
 func createSystemTracker(d *schema.ResourceData, ctsClient *client.CtsClient) (string, error) {
 	obsInfo := cts.TrackerObsInfo{
-		BucketName:     utils.String(d.Get("bucket_name").(string)),
-		FilePrefixName: utils.String(d.Get("file_prefix").(string)),
+		BucketName:      utils.String(d.Get("bucket_name").(string)),
+		FilePrefixName:  utils.String(d.Get("file_prefix").(string)),
+		IsSortByService: utils.Bool(d.Get("is_sort_by_service").(bool)),
+	}
+
+	if v, ok := d.GetOk("compress_type"); ok {
+		compressType := cts.GetTrackerObsInfoCompressTypeEnum().GZIP
+		if v.(string) != "gzip" {
+			compressType = cts.GetTrackerObsInfoCompressTypeEnum().JSON
+		}
+		obsInfo.CompressType = &compressType
 	}
 
 	trackerType := cts.GetCreateTrackerRequestBodyTrackerTypeEnum().SYSTEM
@@ -355,6 +405,10 @@ func createSystemTracker(d *schema.ResourceData, ctsClient *client.CtsClient) (s
 		IsOrganizationTracker: utils.Bool(d.Get("organization_enabled").(bool)),
 		IsSupportValidate:     utils.Bool(d.Get("validate_file").(bool)),
 		ObsInfo:               &obsInfo,
+	}
+
+	if v, ok := d.GetOk("exclude_service"); ok {
+		reqBody.ManagementEventSelector = buildManagementEventSelector(v.(*schema.Set).List())
 	}
 
 	if v, ok := d.GetOk("kms_id"); ok {
@@ -377,6 +431,19 @@ func createSystemTracker(d *schema.ResourceData, ctsClient *client.CtsClient) (s
 	}
 
 	return *resp.Id, nil
+}
+
+func buildManagementEventSelector(rawServices []interface{}) *cts.ManagementEventSelector {
+	if len(rawServices) == 0 {
+		return nil
+	}
+
+	services := utils.ExpandToStringList(rawServices)
+	selector := cts.ManagementEventSelector{
+		ExcludeService: &services,
+	}
+
+	return &selector
 }
 
 func getSystemTracker(ctsClient *client.CtsClient) (*cts.TrackerResponseBody, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add exclude_service, compress_type, is_sort_by_service attribute to cts tracker

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add exclude_service, compress_type, is_sort_by_service attribute to cts tracker
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSTracker_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSTracker_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSTracker_basic
=== PAUSE TestAccCTSTracker_basic
=== CONT  TestAccCTSTracker_basic
--- PASS: TestAccCTSTracker_basic (48.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       48.233s
```
