### PR TITLE
feat(as): add policy execute logs datasource support

### DIFF
--- a/docs/data-sources/as_policy_execute_logs.md
+++ b/docs/data-sources/as_policy_execute_logs.md
@@ -1,0 +1,118 @@
+---
+subcategory: "Auto Scaling"
+---
+
+# huaweicloud_as_policy_execute_logs
+
+Use this data source to get a list of AS policy execution logs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "scaling_policy_id" {}
+
+data "huaweicloud_as_policy_execute_logs" "test" {
+  scaling_policy_id = var.scaling_policy_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the policy execution logs.
+  If omitted, the provider-level region will be used.
+
+* `scaling_policy_id` - (Required, String) Specifies the scaling policy ID.
+
+* `log_id` - (Optional, String) Specifies the policy execution log ID.
+
+* `scaling_resource_id` - (Optional, String) Specifies the scaling resource ID.
+
+* `scaling_resource_type` - (Optional, String) Specifies the scaling resource type.
+  The value can be **SCALING_GROUP** or **BANDWIDTH**.
+
+* `execute_type` - (Optional, String) Specifies the policy execution type.  
+  The valid values are as follows:
+  + **SCHEDULED**: automatically triggered scheduled policy.
+  + **RECURRENCE**: automatically triggered recurrence policy.
+  + **ALARM**: automatically triggered alarm policy.
+  + **MANUAL**: manually triggered policy.
+
+* `start_time` - (Optional, String) Specifies the start time of the policy execution used for query. The time format is
+  **yyyy-MM-ddThh:mm:ssZ**.  
+  The query result is all data with a policy execution time greater than or equal to this value.
+
+* `end_time` - (Optional, String) Specifies the end time of the policy execution used for query. The time format is
+  **yyyy-MM-ddThh:mm:ssZ**.  
+  The query result shows all data with policy execution time less than this value.
+
+* `status` - (Optional, String) Specifies the policy execution status. The value can be **SUCCESS**, **FAIL**
+  or **EXECUTING**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `execute_logs` - All policy execution logs that match the filter parameters.  
+  The [execute_logs](#as_execute_logs_attr) structure is documented below.
+
+<a name="as_execute_logs_attr"></a>
+The `execute_logs` block supports:
+
+* `id` - The policy execution log ID.
+
+* `status` - The policy execution status.
+
+* `failed_reason` - The reason of policy execution failure.
+
+* `execute_type` - The policy execution type.
+
+* `execute_time` - The policy execution time, the time format is **yyyy-MM-ddThh:mm:ssZ**.
+
+* `scaling_policy_id` - The scaling policy ID.
+
+* `scaling_resource_id` - The scaling resource ID.
+
+* `scaling_resource_type` - The scaling resource type.
+
+* `type` - The policy execution task type. The value can be **REMOVE**, **ADD** or **SET**.
+
+* `old_value` - The scaling original value.
+  + When `scaling_resource_type` is **SCALING_GROUP**, this field represents the number of instances.
+  + When `scaling_resource_type` is **BANDWIDTH**, this field represents the bandwidth size, in Mbit/s.
+
+* `desire_value` - The scaling target value.
+  + When `scaling_resource_type` is **SCALING_GROUP**, this field represents the number of instances.
+  + When `scaling_resource_type` is **BANDWIDTH**, this field represents the bandwidth size, in Mbit/s.
+
+* `limit_value` - The operational limitations. When `scaling_resource_type` is **BANDWIDTH** and `type` is not **SET**,
+  this field takes effect in Mbit/s.
+  + When `type` is **ADD**, this field represents the maximum bandwidth limit.
+  + When `type` is **REMOVE**, this field represents the minimum bandwidth limit.
+
+* `job_records` - The concrete tasks included in executing actions.  
+  The [job_records](#as_job_records_attr) structure is documented below.
+
+* `metadata` - The additional information.
+
+<a name="as_job_records_attr"></a>
+The `job_records` block supports:
+
+* `job_name` - The job name.
+
+* `job_status` - The job execution status. The value can be **SUCCESS** or **FAIL**.
+
+* `record_type` - The record type. The value can be **API** or **MEG**.
+
+* `record_time` - The record time, the time format is **YYYY-MM-DDThh:mmZ**.
+
+* `request` - The request information, the field is valid while `record_type` is **API**.
+
+* `response` - The response information, the field is valid while `record_type` is **API**.
+
+* `code` - The response code, the field is valid while `record_type` is **API**.
+
+* `message` - The message content, the field is valid while `record_type` is **MEG**.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240126095247-f7504c8f85cd
+	github.com/chnsz/golangsdk v0.0.0-20240130075455-507447321a6a
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240126095247-f7504c8f85cd h1:qsZyXIqgyVPcQIlg7dEioHHuRtZbw4RVn2uTvKcpasM=
-github.com/chnsz/golangsdk v0.0.0-20240126095247-f7504c8f85cd/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240130075455-507447321a6a h1:oBXKi8ie0wt3B1MbVcXZDJKX9VqSK0YsDUvy0TgIgpM=
+github.com/chnsz/golangsdk v0.0.0-20240130075455-507447321a6a/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -395,11 +395,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_environments": apig.DataSourceEnvironments(),
 			"huaweicloud_apig_groups":       apig.DataSourceGroups(),
 
-			"huaweicloud_as_configurations":  as.DataSourceASConfigurations(),
-			"huaweicloud_as_groups":          as.DataSourceASGroups(),
-			"huaweicloud_as_activity_logs":   as.DataSourceActivityLogs(),
-			"huaweicloud_as_policies":        as.DataSourceASPolicies(),
-			"huaweicloud_as_lifecycle_hooks": as.DataSourceLifeCycleHooks(),
+			"huaweicloud_as_configurations":      as.DataSourceASConfigurations(),
+			"huaweicloud_as_groups":              as.DataSourceASGroups(),
+			"huaweicloud_as_activity_logs":       as.DataSourceActivityLogs(),
+			"huaweicloud_as_policies":            as.DataSourceASPolicies(),
+			"huaweicloud_as_lifecycle_hooks":     as.DataSourceLifeCycleHooks(),
+			"huaweicloud_as_policy_execute_logs": as.DataSourcePolicyExecuteLogs(),
 
 			"huaweicloud_account":            DataSourceAccount(),
 			"huaweicloud_availability_zones": DataSourceAvailabilityZones(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -244,7 +244,8 @@ var (
 
 	HW_CERT_BATCH_PUSH_ID = os.Getenv("HW_CERT_BATCH_PUSH_ID")
 
-	HW_AS_SCALING_GROUP_ID = os.Getenv("HW_AS_SCALING_GROUP_ID")
+	HW_AS_SCALING_GROUP_ID  = os.Getenv("HW_AS_SCALING_GROUP_ID")
+	HW_AS_SCALING_POLICY_ID = os.Getenv("HW_AS_SCALING_POLICY_ID")
 
 	HW_DATAARTS_WORKSPACE_ID            = os.Getenv("HW_DATAARTS_WORKSPACE_ID")
 	HW_DATAARTS_CDM_NAME                = os.Getenv("HW_DATAARTS_CDM_NAME")
@@ -1144,6 +1145,13 @@ func TestAccPreCheckCCAuth(t *testing.T) {
 func TestAccPreCheckASScalingGroupID(t *testing.T) {
 	if HW_AS_SCALING_GROUP_ID == "" {
 		t.Skip("HW_AS_SCALING_GROUP_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckASScalingPolicyID(t *testing.T) {
+	if HW_AS_SCALING_POLICY_ID == "" {
+		t.Skip("HW_AS_SCALING_POLICY_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_policy_execute_logs_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_policy_execute_logs_test.go
@@ -1,0 +1,110 @@
+package as
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccPolicyExecuteLogsDataSource_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_as_policy_execute_logs.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckASScalingPolicyID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyExecuteLogsDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "scaling_policy_id", acceptance.HW_AS_SCALING_POLICY_ID),
+					resource.TestCheckOutput("is_log_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_resource_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_execute_type_filter_useful", "true"),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccPolicyExecuteLogsDataSource_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_as_policy_execute_logs" "test" {
+  scaling_policy_id = "%[1]s"
+}
+
+// Filter using log ID.
+locals {
+  log_id = data.huaweicloud_as_policy_execute_logs.test.execute_logs[0].id
+}
+
+data "huaweicloud_as_policy_execute_logs" "log_id_filter" {
+  scaling_policy_id = "%[1]s"
+  log_id            = local.log_id
+}
+
+output "is_log_id_filter_useful" {
+  value = length(data.huaweicloud_as_policy_execute_logs.log_id_filter.execute_logs) > 0 && alltrue(
+    [for v in data.huaweicloud_as_policy_execute_logs.log_id_filter.execute_logs[*].id : v == local.log_id]
+  )
+}
+
+// Filter using scaling resource ID.
+locals {
+  scaling_resource_id = data.huaweicloud_as_policy_execute_logs.test.execute_logs[0].scaling_resource_id
+}
+
+data "huaweicloud_as_policy_execute_logs" "resource_id_filter" {
+  scaling_policy_id   = "%[1]s"
+  scaling_resource_id = local.scaling_resource_id
+}
+
+output "is_resource_id_filter_useful" {
+  value = length(data.huaweicloud_as_policy_execute_logs.resource_id_filter.execute_logs) > 0 && alltrue(
+    [for v in data.huaweicloud_as_policy_execute_logs.resource_id_filter.execute_logs[*].scaling_resource_id : v == local.scaling_resource_id]
+  )
+}
+
+// Filter using execute type.
+locals {
+  execute_type = data.huaweicloud_as_policy_execute_logs.test.execute_logs[0].execute_type
+}
+
+data "huaweicloud_as_policy_execute_logs" "execute_type_filter" {
+  scaling_policy_id = "%[1]s"
+  execute_type      = local.execute_type
+}
+
+output "is_execute_type_filter_useful" {
+  value = length(data.huaweicloud_as_policy_execute_logs.execute_type_filter.execute_logs) > 0 && alltrue(
+    [for v in data.huaweicloud_as_policy_execute_logs.execute_type_filter.execute_logs[*].execute_type : v == local.execute_type]
+  )
+}
+
+// Filter using status.
+locals {
+  status = data.huaweicloud_as_policy_execute_logs.test.execute_logs[0].status
+}
+
+data "huaweicloud_as_policy_execute_logs" "status_filter" {
+  scaling_policy_id = "%[1]s"
+  status            = local.status
+}
+
+output "is_status_filter_useful" {
+  value = length(data.huaweicloud_as_policy_execute_logs.status_filter.execute_logs) > 0 && alltrue(
+    [for v in data.huaweicloud_as_policy_execute_logs.status_filter.execute_logs[*].status : v == local.status]
+  )
+}
+`, acceptance.HW_AS_SCALING_POLICY_ID)
+}

--- a/huaweicloud/services/as/data_source_huaweicloud_as_policy_execute_logs.go
+++ b/huaweicloud/services/as/data_source_huaweicloud_as_policy_execute_logs.go
@@ -1,0 +1,249 @@
+package as
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/policyexecutelogs"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API AS GET /autoscaling-api/v1/{project_id}/scaling_policy_execute_log/{scaling_policy_id}
+func DataSourcePolicyExecuteLogs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePolicyExecuteLogsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"scaling_policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"log_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scaling_resource_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scaling_resource_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"execute_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"execute_logs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"failed_reason": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"execute_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"execute_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"scaling_policy_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"scaling_resource_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"scaling_resource_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"old_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"desire_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"limit_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"job_records": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"job_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"job_status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"record_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"record_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"request": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"response": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"message": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"metadata": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourcePolicyExecuteLogsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.AutoscalingV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating AS v1 client: %s", err)
+	}
+
+	opts := policyexecutelogs.ListOpts{
+		PolicyID:     d.Get("scaling_policy_id").(string),
+		LogID:        d.Get("log_id").(string),
+		ResourceID:   d.Get("scaling_resource_id").(string),
+		ResourceType: d.Get("scaling_resource_type").(string),
+		ExecuteType:  d.Get("execute_type").(string),
+		StartTime:    d.Get("start_time").(string),
+		EndTime:      d.Get("end_time").(string),
+	}
+
+	executeLogList, err := policyexecutelogs.List(client, opts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "AS policy execute logs")
+	}
+
+	executeLogs := make([]map[string]interface{}, 0, len(executeLogList))
+	for _, executeLog := range executeLogList {
+		if val, ok := d.GetOk("status"); ok && val.(string) != executeLog.Status {
+			continue
+		}
+		executeLogMap := map[string]interface{}{
+			"id":                    executeLog.ID,
+			"status":                executeLog.Status,
+			"failed_reason":         executeLog.FailedReason,
+			"execute_type":          executeLog.ExecuteType,
+			"execute_time":          executeLog.ExecuteTime,
+			"scaling_policy_id":     executeLog.PolicyID,
+			"scaling_resource_id":   executeLog.ResourceID,
+			"scaling_resource_type": executeLog.ResourceType,
+			"type":                  executeLog.Type,
+			"old_value":             executeLog.OldValue,
+			"desire_value":          executeLog.DesireValue,
+			"limit_value":           executeLog.LimitValue,
+			"job_records":           flattenJobRecords(executeLog.JobRecords),
+			"metadata":              executeLog.MetaData,
+		}
+		executeLogs = append(executeLogs, executeLogMap)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("execute_logs", executeLogs),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving AS policy execute logs data source fields: %s", mErr)
+	}
+	return nil
+}
+
+func flattenJobRecords(jobRecords []policyexecutelogs.JobRecord) []map[string]interface{} {
+	if len(jobRecords) == 0 {
+		return nil
+	}
+
+	jobRecordList := make([]map[string]interface{}, 0, len(jobRecords))
+	for _, jobRecord := range jobRecords {
+		job := map[string]interface{}{
+			"job_name":    jobRecord.JobName,
+			"job_status":  jobRecord.JobStatus,
+			"record_type": jobRecord.RecordType,
+			"record_time": jobRecord.RecordTime,
+			"request":     jobRecord.Request,
+			"response":    jobRecord.Response,
+			"code":        jobRecord.Code,
+			"message":     jobRecord.Message,
+		}
+		jobRecordList = append(jobRecordList, job)
+	}
+
+	return jobRecordList
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policyexecutelogs/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policyexecutelogs/requests.go
@@ -1,0 +1,49 @@
+package policyexecutelogs
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListOpts is the structure that used to query the execution logs of scaling policy.
+type ListOpts struct {
+	// The scaling policy ID.
+	PolicyID string `json:"scaling_policy_id" required:"true"`
+	// The policy execution log ID.
+	LogID string `q:"log_id"`
+	// The scaling resource type. The value can be SCALING_GROUP or BANDWIDTH.
+	ResourceType string `q:"scaling_resource_type"`
+	// The scaling resource ID.
+	ResourceID string `q:"scaling_resource_id"`
+	// The policy execution type. The value can be SCHEDULED, RECURRENCE, ALARM or MANUAL.
+	ExecuteType string `q:"execute_type"`
+	// The starting time of query.
+	StartTime string `q:"start_time"`
+	// The ending time of query.
+	EndTime string `q:"end_time"`
+	// Start number value. The value must be a positive integer.
+	StartNumber int `q:"start_number"`
+	// Number of records displayed per page.
+	// The value must be a positive integer.
+	Limit int `q:"limit"`
+}
+
+// List is a method used to query the execution logs of scaling policy with given parameters.
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]ExecuteLog, error) {
+	url := listURL(client, opts.PolicyID)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := ExecuteLogPage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractExecuteLogs(pages)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policyexecutelogs/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policyexecutelogs/results.go
@@ -1,0 +1,108 @@
+package policyexecutelogs
+
+import (
+	"strconv"
+
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ExecuteLog is the structure that represents the execution log detail.
+type ExecuteLog struct {
+	// The policy execution log ID.
+	ID string `json:"id"`
+	// The policy execution status. The value can be SUCCESS, FAIL or EXECUTING.
+	Status string `json:"status"`
+	// The reason of policy execution failure.
+	FailedReason string `json:"failed_reason"`
+	// The policy execution type. The value can be SCHEDULED, RECURRENCE, ALARM or MANUAL.
+	ExecuteType string `json:"execute_type"`
+	// The policy execution time.
+	ExecuteTime string `json:"execute_time"`
+	// The scaling policy ID.
+	PolicyID string `json:"scaling_policy_id"`
+	// The scaling resource type. The value can be SCALING_GROUP or BANDWIDTH.
+	ResourceType string `json:"scaling_resource_type"`
+	// The scaling resource ID.
+	ResourceID string `json:"scaling_resource_id"`
+	// The scaling original value, indicates the number of instances or bandwidth size.
+	OldValue string `json:"old_value"`
+	// The scaling target value, indicates the number of instances or bandwidth size.
+	DesireValue string `json:"desire_value"`
+	// The operational limitations.
+	LimitValue string `json:"limit_value"`
+	// The policy execution task type. The value can be REMOVE, ADD or SET.
+	Type string `json:"type"`
+	// The concrete tasks included in executing actions.
+	JobRecords []JobRecord `json:"job_records"`
+	// The additional information.
+	MetaData map[string]interface{} `json:"meta_data"`
+	// The project ID.
+	TenantID string `json:"tenant_id"`
+}
+
+// JobRecord is the structure that represents the concrete tasks included in executing actions.
+type JobRecord struct {
+	// The job name.
+	JobName string `json:"job_name"`
+	// The record type. The value can be API or MEG.
+	RecordType string `json:"record_type"`
+	// The record time.
+	RecordTime string `json:"record_time"`
+	// The request information.
+	Request string `json:"request"`
+	// The response information.
+	Response string `json:"response"`
+	// The response code.
+	Code string `json:"code"`
+	// The message content.
+	Message string `json:"message"`
+	// The job execution status. The value can be SUCCESS or FAIL.
+	JobStatus string `json:"job_status"`
+}
+
+// ExecuteLogPage is a single page maximum result representing a query by start_number page.
+type ExecuteLogPage struct {
+	pagination.OffsetPageBase
+}
+
+// NextStartNumber returns startNumber of the next element of the page.
+func (current ExecuteLogPage) NextStartNumber() int {
+	q := current.URL.Query()
+	// get `start_number` and `limit` from query path.
+	// If the limit is not set, it will be set to `20` by default for querying.
+	startNumber, _ := strconv.Atoi(q.Get("start_number"))
+	limit, _ := strconv.Atoi(q.Get("limit"))
+	if limit == 0 {
+		limit = 20
+	}
+
+	return startNumber + limit
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (current ExecuteLogPage) NextPageURL() (string, error) {
+	next := current.NextStartNumber()
+	if next == 0 {
+		return "", nil
+	}
+
+	currentURL := current.URL
+	q := currentURL.Query()
+	q.Set("start_number", strconv.Itoa(next))
+	currentURL.RawQuery = q.Encode()
+
+	return currentURL.String(), nil
+}
+
+// IsEmpty checks whether a ExecuteLogPage struct is empty.
+func (b ExecuteLogPage) IsEmpty() (bool, error) {
+	logs, err := extractExecuteLogs(b)
+	return len(logs) == 0, err
+}
+
+// extractExecuteLogs is a method to extract the list of execution logs for specified scaling policy.
+func extractExecuteLogs(r pagination.Page) ([]ExecuteLog, error) {
+	var s []ExecuteLog
+	err := r.(ExecuteLogPage).Result.ExtractIntoSlicePtr(&s, "scaling_policy_execute_log")
+	return s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policyexecutelogs/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/policyexecutelogs/urls.go
@@ -1,0 +1,9 @@
+package policyexecutelogs
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+func listURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL("scaling_policy_execute_log", policyID)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240126095247-f7504c8f85cd
+# github.com/chnsz/golangsdk v0.0.0-20240130075455-507447321a6a
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -49,6 +49,7 @@ github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups
 github.com/chnsz/golangsdk/openstack/autoscaling/v1/instances
 github.com/chnsz/golangsdk/openstack/autoscaling/v1/lifecyclehooks
 github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies
+github.com/chnsz/golangsdk/openstack/autoscaling/v1/policyexecutelogs
 github.com/chnsz/golangsdk/openstack/autoscaling/v1/scheduledtasks
 github.com/chnsz/golangsdk/openstack/autoscaling/v1/tags
 github.com/chnsz/golangsdk/openstack/bcs/v2/blockchains


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1.Add policy execute logs datasource support
2.The policy resource in the current provider cannot generate logs through scripts, so environment variables are used to inject the policy ID
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add policy execute logs datasource support
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccPolicyExecuteLogsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccPolicyExecuteLogsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccPolicyExecuteLogsDataSource_basic
=== PAUSE TestAccPolicyExecuteLogsDataSource_basic
=== CONT  TestAccPolicyExecuteLogsDataSource_basic
--- PASS: TestAccPolicyExecuteLogsDataSource_basic (25.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        25.959s
```
