### PR TITLE
feat(cts): add compress_type, is_sort_by_service attribute to cts data tracker 

### DIFF
--- a/docs/resources/cts_data_tracker.md
+++ b/docs/resources/cts_data_tracker.md
@@ -46,6 +46,12 @@ The following arguments are supported:
 * `obs_retention_period` - (Optional, Int) Specifies the retention period that traces are stored in `bucket_name`,
   the value can be **0**(permanent), **30**, **60**, **90**, **180** or **1095**.
 
+* `compress_type` - (Optional, String) Specifies the compression type of trace files. The value can be **gzip**
+  or **json**. The default value is **gzip**.
+
+* `is_sort_by_service` - (Optional, Bool) Specifies whether to divide the path of the trace file by cloud service.
+  The default value is **true**.
+
 * `lts_enabled` - (Optional, Bool) Specifies whether trace analysis is enabled.
 
 * `validate_file` - (Optional, Bool) Specifies whether trace file verification is enabled during trace transfer.

--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_data_tracker_test.go
@@ -85,6 +85,8 @@ func TestAccCTSDataTracker_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.newkey", "value"),
+					resource.TestCheckResourceAttr(resourceName, "compress_type", "json"),
+					resource.TestCheckResourceAttr(resourceName, "is_sort_by_service", "false"),
 				),
 			},
 			{
@@ -142,6 +144,8 @@ resource "huaweicloud_cts_data_tracker" "tracker" {
   file_prefix          = "cts"
   validate_file        = false
   lts_enabled          = false
+  compress_type        = "json"
+  is_sort_by_service   = false
 
   tags = {
     foo    = "bar1"

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
@@ -89,6 +89,17 @@ func ResourceCTSDataTracker() *schema.Resource {
 				Optional:     true,
 				RequiredWith: []string{"bucket_name"},
 			},
+			"compress_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"bucket_name"},
+			},
+			"is_sort_by_service": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				RequiredWith: []string{"bucket_name"},
+				Default:      true,
+			},
 			"lts_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -199,8 +210,16 @@ func buildDataBucketOpts(d *schema.ResourceData) *cts.DataBucket {
 
 func buildTransferBucketOpts(d *schema.ResourceData) *cts.TrackerObsInfo {
 	transferCfg := cts.TrackerObsInfo{
-		BucketName:     utils.String(d.Get("bucket_name").(string)),
-		FilePrefixName: utils.String(d.Get("file_prefix").(string)),
+		BucketName:      utils.String(d.Get("bucket_name").(string)),
+		FilePrefixName:  utils.String(d.Get("file_prefix").(string)),
+		IsSortByService: utils.Bool(d.Get("is_sort_by_service").(bool)),
+	}
+	if v, ok := d.GetOk("compress_type"); ok {
+		compressType := cts.GetTrackerObsInfoCompressTypeEnum().GZIP
+		if v.(string) != "gzip" {
+			compressType = cts.GetTrackerObsInfoCompressTypeEnum().JSON
+		}
+		transferCfg.CompressType = &compressType
 	}
 	if v, ok := d.GetOk("obs_retention_period"); ok {
 		lifecycle := int32(v.(int))
@@ -306,7 +325,7 @@ func resourceCTSDataTrackerUpdate(ctx context.Context, d *schema.ResourceData, m
 			DataBucket:        buildDataBucketOpts(d),
 		}
 
-		if d.HasChanges("bucket_name", "file_prefix", "obs_retention_period") {
+		if d.HasChanges("bucket_name", "file_prefix", "obs_retention_period", "compress_type", "is_sort_by_service") {
 			updateReq.ObsInfo = buildTransferBucketOpts(d)
 		}
 
@@ -397,7 +416,12 @@ func resourceCTSDataTrackerRead(_ context.Context, d *schema.ResourceData, meta 
 			mErr,
 			d.Set("bucket_name", bucketName),
 			d.Set("file_prefix", ctsTracker.ObsInfo.FilePrefixName),
+			d.Set("is_sort_by_service", ctsTracker.ObsInfo.IsSortByService),
 		)
+
+		if ctsTracker.ObsInfo.CompressType != nil {
+			mErr = multierror.Append(mErr, d.Set("compress_type", formatValue(ctsTracker.ObsInfo.CompressType)))
+		}
 
 		if *bucketName != "" {
 			mErr = multierror.Append(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add compress_type, is_sort_by_service attribute to cts data tracker 

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add compress_type, is_sort_by_service attribute to cts data tracker
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSDataTracker_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSDataTracker_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSDataTracker_basic
=== PAUSE TestAccCTSDataTracker_basic
=== CONT  TestAccCTSDataTracker_basic
--- PASS: TestAccCTSDataTracker_basic (57.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       57.210s

```
