### PR TITLE
fix(DMS): wait for smart connect task to be done

### DIFF
--- a/docs/resources/dms_kafka_smart_connect_task.md
+++ b/docs/resources/dms_kafka_smart_connect_task.md
@@ -100,6 +100,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `created_at` - Indicates the creation time of the smart connect task.
 
+## Timeouts
+
+This resource provides the following timeout configuration options:
+
+* `create` - Default is 50 minutes.
+
 ## Import
 
 The kafka smart connect task can be imported using the kafka instance `connector_id` and `id` separated by a slash, e.g.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes # smart connect task test acceptance failed

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
wait for smart connect task to be done when creating the task.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccDmsKafkaSmartConnectTask_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsKafkaSmartConnectTask_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaSmartConnectTask_basic
=== PAUSE TestAccDmsKafkaSmartConnectTask_basic
=== CONT  TestAccDmsKafkaSmartConnectTask_basic
--- PASS: TestAccDmsKafkaSmartConnectTask_basic (1284.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1284.971s
```
