### PR TITLE
feat(CDN): the resource supports updating private buckets access

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -130,6 +130,10 @@ The following arguments are supported:
 * `sources` - (Required, List, ForceNew) An array of one or more objects specifies the domain name of the origin server.
   The sources object structure is documented below.
 
+* `private_bucket_access` - (Optional, Bool) Specifies whether private bucket retrieval is enabled.
+  This field is valid only when `origin_type` of origin sources incloud **obs_bucket**.
+  This field must be set to **true** when using a private bucket domain name. Defaults to **false**.
+
 * `service_area` - (Optional, String, ForceNew) The area covered by the acceleration service. Valid values are
   `mainland_china`, `outside_mainland_china`, and `global`. Changing this parameter will create a new resource.
 
@@ -149,12 +153,18 @@ The `sources` block supports:
 * `origin` - (Required, String) The domain name or IP address of the origin server.
 
 * `origin_type` - (Required, String) The origin server type. The valid values are 'ipaddr', 'domain', and 'obs_bucket'.
+  When a CDN domain is configured with multiple origin servers of **obs_bucket**,
+  the OBS buckets should be all private bucket or all public bucket.
+  When configure an origin server with private bucket, the delegation
+  authorization should be enabled on the OBS service side.
 
 * `active` - (Optional, Int) Whether an origin server is active or standby (1: active; 0: standby). The default value is
   1.
 
 * `obs_web_hosting_enabled` - (Optional, Bool) Whether to enable static website hosting for the OBS bucket.
   This parameter is mandatory when the `origin_type` is **obs_bucket**.
+  If the value of the field is **true**, please confirm that static website hosting has been enabled
+  on the OBS side, otherwise business abnormalities will occur.
 
 * `http_port` - (Optional, Int) Specifies the HTTP port. Default value: **80**.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240131083918-b47be709aa48
+	github.com/chnsz/golangsdk v0.0.0-20240201110032-08ec05884b51
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,10 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240131083918-b47be709aa48 h1:VbIL6E5vLln1mNMCzIbig/bNApXwcS6Jjg6V64WL6C4=
-github.com/chnsz/golangsdk v0.0.0-20240131083918-b47be709aa48/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240130075455-507447321a6a h1:oBXKi8ie0wt3B1MbVcXZDJKX9VqSK0YsDUvy0TgIgpM=
+github.com/chnsz/golangsdk v0.0.0-20240130075455-507447321a6a/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240201110032-08ec05884b51 h1:u8gUlJlyJbWGRKwAxBITNBIZaOgHlsKCecJkoJkdKoc=
+github.com/chnsz/golangsdk v0.0.0-20240201110032-08ec05884b51/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -330,6 +332,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -66,6 +66,7 @@ var (
 	HW_RAM_SHARE_UPDATE_ACCOUNT_ID   = os.Getenv("HW_RAM_SHARE_UPDATE_ACCOUNT_ID")
 	HW_RAM_SHARE_UPDATE_RESOURCE_URN = os.Getenv("HW_RAM_SHARE_UPDATE_RESOURCE_URN")
 
+	HW_CDN_SOURCE_ORIGIN            = os.Getenv("HW_CDN_SOURCE_ORIGIN")
 	HW_CDN_DOMAIN_NAME              = os.Getenv("HW_CDN_DOMAIN_NAME")
 	HW_CDN_CERT_PATH                = os.Getenv("HW_CDN_CERT_PATH")
 	HW_CDN_PRIVATE_KEY_PATH         = os.Getenv("HW_CDN_PRIVATE_KEY_PATH")
@@ -1110,6 +1111,13 @@ func TestAccPreCheckLtsEnableFlag(t *testing.T) {
 func TestAccPreCheckCCINamespace(t *testing.T) {
 	if HW_CCI_NAMESPACE == "" {
 		t.Skip("This environment does not support CCI Namespace tests")
+	}
+}
+
+// lintignore:AT003
+func TstAccPrecheckCDNSourceOrigin(t *testing.T) {
+	if HW_CDN_SOURCE_ORIGIN == "" {
+		t.Skip("HW_CDN_SOURCE_ORIGIN must be set for the acceptance test")
 	}
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/requests.go
@@ -11,6 +11,10 @@ type ExtensionOpts struct {
 	EnterpriseProjectId string `q:"enterprise_project_id"`
 }
 
+type PrivateBucketAccessOpts struct {
+	Status *bool `json:"status,omitempty"`
+}
+
 // ToExtensionQuery formats a ExtensionOpts into a query string.
 func (opts ExtensionOpts) ToExtensionQuery() (string, error) {
 	q, err := golangsdk.BuildQueryString(opts)
@@ -44,10 +48,18 @@ type CreateOptsBuilder interface {
 	ToCdnDomainCreateMap() (map[string]interface{}, error)
 }
 
+type PrivateBucketAccessBuilder interface {
+	ToCdnUpdatePrivateBucketAccessMap() (map[string]interface{}, error)
+}
+
 // ToCdnDomainCreateMap assembles a request body based on the contents of a
 // CreateOpts.
 func (opts CreateOpts) ToCdnDomainCreateMap() (map[string]interface{}, error) {
 	return golangsdk.BuildRequestBody(opts, "domain")
+}
+
+func (opts PrivateBucketAccessOpts) ToCdnUpdatePrivateBucketAccessMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
 }
 
 // OriginOpts specifies the attributes used to modify the orogin server.
@@ -77,6 +89,16 @@ func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateRe
 	}
 
 	_, r.Err = client.Post(createURL(client), reqBody, &r.Body, &golangsdk.RequestOpts{OkCodes: []int{200}})
+	return
+}
+
+func UpdatePrivateBucketAccess(client *golangsdk.ServiceClient, domainId string, opts PrivateBucketAccessBuilder) (r PrivateBucketAccessResult) {
+	reqBody, err := opts.ToCdnUpdatePrivateBucketAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(updatePrivateBucketAccessURL(client, domainId), reqBody, &r.Body, nil)
 	return
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/results.go
@@ -59,6 +59,16 @@ type CdnDomain struct {
 	ModifyTime time.Time `json:"-"`
 }
 
+type PrivateBucketAccessStatus struct {
+	Status    bool      `json:"status"`
+	ErrorResp ErrorResp `json:"error"`
+}
+
+type ErrorResp struct {
+	ErrorCode string `json:"error_code"`
+	ErrorMsg  string `json:"error_msg"`
+}
+
 type OriginSources struct {
 	// the domain name or the IP address of the origin server
 	Sources []DomainSources `json:"sources"`
@@ -72,6 +82,16 @@ type commonResult struct {
 // method to interpret it as a CDN domain.
 type GetResult struct {
 	commonResult
+}
+
+type PrivateBucketAccessResult struct {
+	commonResult
+}
+
+func (r PrivateBucketAccessResult) Extract() (*PrivateBucketAccessStatus, error) {
+	var response PrivateBucketAccessStatus
+	err := r.ExtractInto(&response)
+	return &response, err
 }
 
 func (r GetResult) Extract() (*CdnDomain, error) {

--- a/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/urls.go
@@ -10,6 +10,10 @@ func createURL(sc *golangsdk.ServiceClient) string {
 	return sc.ServiceURL(rootPath)
 }
 
+func updatePrivateBucketAccessURL(sc *golangsdk.ServiceClient, domainId string) string {
+	return sc.ServiceURL(rootPath, domainId, "private-bucket-access")
+}
+
 func deleteURL(sc *golangsdk.ServiceClient, domainId string) string {
 	return sc.ServiceURL(rootPath, domainId)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240131083918-b47be709aa48
+# github.com/chnsz/golangsdk v0.0.0-20240201110032-08ec05884b51
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
+ There are many restrictions on the use of the field ‘obs_web_hosting_enabled’ when updating resources, which have been written into the md document in sequence.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
+ This interface can only be changed from a public bucket to a private bucket, that is, when `private_bucket_access` is **true**. The operation of changing from a private bucket to a public bucket does not exist and is meaningless in actual business.
+ the updatePrivateBucketAccess API will response OK, even if errors occurrred, so we judge private bucket access whether is updated.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccCdnDomain_obs_bucket"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_obs_bucket -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_obs_bucket
=== PAUSE TestAccCdnDomain_obs_bucket
=== CONT  TestAccCdnDomain_obs_bucket
--- PASS: TestAccCdnDomain_obs_bucket (322.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       323.022s
```
