### PR TITLE
fix(dns/recordset): build client by zone id

### DIFF
--- a/docs/resources/dns_recordset.md
+++ b/docs/resources/dns_recordset.md
@@ -124,6 +124,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `zone_name` - The zone name of the record set.
 
+* `zone_type` - The type of zone. The value can be **public** or **private**.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
@@ -20,8 +20,13 @@ import (
 
 func getDNSRecordsetResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	region := acceptance.HW_REGION_NAME
+	dnsProduct := "dns"
+	if state.Primary.Attributes["zone_type"] != "public" {
+		dnsProduct = "dns_region"
+	}
+
 	// getDNSRecordset: Query DNS recordset
-	getDNSRecordsetClient, err := cfg.NewServiceClient("dns_region", region)
+	getDNSRecordsetClient, err := cfg.NewServiceClient(dnsProduct, region)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DNS Client: %s", err)
 	}
@@ -92,6 +97,7 @@ func TestAccDNSRecordset_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "weight", "3"),
 					resource.TestCheckResourceAttr(rName, "tags.key1", "value1"),
 					resource.TestCheckResourceAttr(rName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(rName, "zone_type", "public"),
 					resource.TestCheckResourceAttrSet(rName, "zone_name"),
 				),
 			},
@@ -148,6 +154,7 @@ func TestAccDNSRecordset_publicZone(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "records.0", "10.1.0.0"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "zone_type", "public"),
 					resource.TestCheckResourceAttrSet(rName, "zone_name"),
 				),
 			},
@@ -198,6 +205,7 @@ func TestAccDNSRecordset_privateZone(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "records.0", "10.1.0.3"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar_private"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value_private"),
+					resource.TestCheckResourceAttr(rName, "zone_type", "private"),
 					resource.TestCheckResourceAttrSet(rName, "zone_name"),
 				),
 			},

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
@@ -16,7 +16,12 @@ import (
 )
 
 func getDNSZoneResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	dnsClient, err := c.DnsV2Client(acceptance.HW_REGION_NAME)
+	dnsProduct := "dns"
+	if state.Primary.Attributes["zone_type"] != "public" {
+		dnsProduct = "dns_region"
+	}
+
+	dnsClient, err := c.NewServiceClient(dnsProduct, acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating DNS client: %s", err)
 	}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_recordsets.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_recordsets.go
@@ -152,20 +152,17 @@ func recordsetSchema() *schema.Resource {
 
 func resourceRecordsetsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
-		cfg        = meta.(*config.Config)
-		region     = cfg.GetRegion(d)
-		mErr       *multierror.Error
-		dnsProduct = "dns_region"
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		mErr   *multierror.Error
 	)
-	client, err := cfg.NewServiceClient(dnsProduct, region)
-	if err != nil {
-		return diag.Errorf("error creating DNS client: %s", err)
-	}
 
-	zoneType, err := getDNSZoneType(client, d.Get("zone_id").(string))
+	zoneID := d.Get("zone_id").(string)
+	client, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
 	// The private zone can only use v2 version API. The public zone use v2.1 version API
 	version := getApiVersionByZoneType(zoneType)
 	listHttpUrl := fmt.Sprintf("%s/zones/{zone_id}/recordsets", version)

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
@@ -343,6 +343,10 @@ func parseDNSV2RecordSetID(id string) (zoneID string, recordsetID string, err er
 	return
 }
 
+// Use this function to build the client by DNS zone ID
+// For a public zone, the endpoint of client should be https://dns.myhuaweicloud.com
+// For a private zone, the endpoint of client should be https://dns.{region}.myhuaweicloud.com
+// In most regions, the both endpoints can work well, but it's very useful for regions like `la-north-2`
 func chooseDNSClientbyZoneID(d *schema.ResourceData, zoneID string, meta interface{}) (*golangsdk.ServiceClient, string, error) {
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For a **public** zone and recordset, the endpoint of client should be https://dns.myhuaweicloud.com
For a **private** zone and recordset, the endpoint of client should be https://dns.{region}.myhuaweicloud.com
In most regions, the both endpoints can work well, but it's very useful for regions like **la-north-2**

Add `zone_type` attribute to indicate the zone type is **public** or **private**.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #3396

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

###  HW_REGION_NAME=cn-north-4

```
make testacc TEST="./huaweicloud/services/acceptance/dns" TESTARGS="-run TestAccDNSRecordset"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSRecordset -timeout 360m -parallel 4
=== RUN   TestAccDNSRecordset_basic
=== PAUSE TestAccDNSRecordset_basic
=== RUN   TestAccDNSRecordset_publicZone
=== PAUSE TestAccDNSRecordset_publicZone
=== RUN   TestAccDNSRecordset_privateZone
=== PAUSE TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_basic
=== CONT  TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_publicZone
--- PASS: TestAccDNSRecordset_publicZone (53.09s)
--- PASS: TestAccDNSRecordset_basic (54.70s)
--- PASS: TestAccDNSRecordset_privateZone (77.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       77.398s
```

###  HW_REGION_NAME=la-north-2

```
$ make testacc TEST="./huaweicloud/services/acceptance/dns" TESTARGS="-run TestAccDNSRecordset"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSRecordset -timeout 360m -parallel 4
=== RUN   TestAccDNSRecordset_basic
=== PAUSE TestAccDNSRecordset_basic
=== RUN   TestAccDNSRecordset_publicZone
=== PAUSE TestAccDNSRecordset_publicZone
=== RUN   TestAccDNSRecordset_privateZone
=== PAUSE TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_basic
=== CONT  TestAccDNSRecordset_privateZone
=== CONT  TestAccDNSRecordset_publicZone
--- PASS: TestAccDNSRecordset_publicZone (91.27s)
--- PASS: TestAccDNSRecordset_basic (93.36s)
=== NAME  TestAccDNSRecordset_privateZone
    resource_huaweicloud_dns_recordset_test.go:191: Step 2/4 error: Error running apply: exit status 1

        Error: error updating DNS recordset: Bad request with: [PUT https://dns.la-north-2.myhuaweicloud.com/v2/zones/8a9c8b0f8d2f1e*******e585724e/recordsets/8a9c8b0f8d2f1e*******7255], request_id: 163bb134c1ed*******41d6b5d1, error message: {"code":"DNS.0308","message":"Attribute 'records' is invalid. When type is 'A', records should be ipv4 address list."}

          with huaweicloud_dns_recordset.test,
          on terraform_plugin_test.tf line 23, in resource "huaweicloud_dns_recordset" "test":
          23: resource "huaweicloud_dns_recordset" "test" {

--- FAIL: TestAccDNSRecordset_privateZone (144.73s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       144.768s
FAIL
make: *** [GNUmakefile:21: testacc] Error 1

$ make testacc TEST="./huaweicloud/services/acceptance/dns" TESTARGS="-run TestAccDNSZone"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSZone -timeout 360m -parallel 4
=== RUN   TestAccDNSZone_basic
=== PAUSE TestAccDNSZone_basic
=== RUN   TestAccDNSZone_private
=== PAUSE TestAccDNSZone_private
=== RUN   TestAccDNSZone_readTTL
=== PAUSE TestAccDNSZone_readTTL
=== RUN   TestAccDNSZone_withEpsId
=== PAUSE TestAccDNSZone_withEpsId
=== CONT  TestAccDNSZone_basic
=== CONT  TestAccDNSZone_readTTL
=== CONT  TestAccDNSZone_withEpsId
=== CONT  TestAccDNSZone_private
=== NAME  TestAccDNSZone_withEpsId
    acceptance.go:409: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccDNSZone_withEpsId (0.00s)
--- PASS: TestAccDNSZone_readTTL (45.65s)
--- PASS: TestAccDNSZone_basic (73.48s)
--- PASS: TestAccDNSZone_private (95.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       95.531s

$ make testacc TEST="./huaweicloud/services/acceptance/dns" TESTARGS="-run TestAccDatasourceDNSRecordsets_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDatasourceDNSRecordsets_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDNSRecordsets_basic
=== PAUSE TestAccDatasourceDNSRecordsets_basic
=== CONT  TestAccDatasourceDNSRecordsets_basic
--- PASS: TestAccDatasourceDNSRecordsets_basic (84.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       84.645s
```
