### PR TITLE
fix(DMS): update timeout for smart connect task

### DIFF
--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_smart_connect_task.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_smart_connect_task.go
@@ -193,7 +193,7 @@ func resourceDmsKafkaSmartConnectTaskCreate(ctx context.Context, d *schema.Resou
 		Pending:      []string{"CREATING"},
 		Target:       []string{"RUNNING"},
 		Refresh:      smartConnectTaskStateRefreshFunc(createKafkaSmartConnectTaskClient, connectorID, d.Id()),
-		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        1 * time.Second,
 		PollInterval: 5 * time.Second,
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes # update timeout when creating smart connect task

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
update timeout when creating smart connect task
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/ser       vices/acceptance/dms/ TESTARGS='-run TestAccDmsKafkaSmartConnectTask_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccDmsKafkaSmartConnectTask_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaSmartConnectTask_basic
=== PAUSE TestAccDmsKafkaSmartConnectTask_basic
=== CONT  TestAccDmsKafkaSmartConnectTask_basic
--- PASS: TestAccDmsKafkaSmartConnectTask_basic (1238.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1238.891s
```
