### PR TITLE
feat(eip): support changing bandwidth to pre-paid mode

### DIFF
--- a/docs/resources/vpc_bandwidth.md
+++ b/docs/resources/vpc_bandwidth.md
@@ -35,18 +35,19 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the Shared Bandwidth.
   Changing this creates a new bandwidth.
 
-* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the Shared Bandwidth.
-  The valid values are **prePaid** and **postPaid**, defaults to **postPaid**. Changing this will create a new bandwidth.
+* `charging_mode` - (Optional, String) Specifies the charging mode of the Shared Bandwidth.
+  The valid values are **prePaid** and **postPaid**, defaults to **postPaid**.
 
-* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the Shared Bandwidth.
+* `period_unit` - (Optional, String) Specifies the charging period unit of the Shared Bandwidth.
   Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
-  Changing this will create a new bandwidth.
 
-* `period` - (Optional, Int, ForceNew) Specifies the charging period of the Shared Bandwidth.
+* `period` - (Optional, Int) Specifies the charging period of the Shared Bandwidth.
   + If `period_unit` is set to **month**, the value ranges from `1` to `9`.
   + If `period_unit` is set to **year**, the value ranges from `1` to `3`.
 
-  This parameter is mandatory if `charging_mode` is set to **prePaid**. Changing this will create a new bandwidth.
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.
+
+-> **NOTE:** `period_unit`, `period` can only be updated when changing from **postPaid** to **prePaid** billing mode.
 
 * `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
   Valid values are **true** and **false**. Defaults to **false**.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Change param in bandwidth, remove `ForceNew` for `charging_mode` and add acctest.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcBandWidth_changeToPeriod"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcBandWidth_changeToPeriod -timeout 360m -parallel 4
=== RUN   TestAccVpcBandWidth_changeToPeriod
=== PAUSE TestAccVpcBandWidth_changeToPeriod
=== CONT  TestAccVpcBandWidth_changeToPeriod
--- PASS: TestAccVpcBandWidth_changeToPeriod (107.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       107.112s
```
