### PR TITLE
feat(cc): add interflow_mode, spec_code attribute to cc bandwidth package

### DIFF
--- a/docs/resources/cc_bandwidth_package.md
+++ b/docs/resources/cc_bandwidth_package.md
@@ -67,6 +67,41 @@ The following arguments are supported:
   If omitted, the provider-level project ID will be used.
   Changing this parameter will create a new resource.
 
+* `interflow_mode` - (Optional, String, ForceNew) Interflow mode of the bandwidth package.
+  Valid values are **Area** and **Region**, defaults to **Area**. Changing this parameter will create a new resource.
+
+* `spec_code` - (Optional, String, ForceNew) Specification code of the bandwidth package.
+  Changing this parameter will create a new resource.
+  If the value of `interflow_mode` is **Area**, the values are as follows:
+  + **bandwidth.aftoela**: Southern Africa-Eastern Latin America on both the Chinese Mainland website and International website.
+  + **bandwidth.aftonla**: Southern Africa-Northern Latin America on both the Chinese Mainland website and International
+    website.
+  + **bandwidth.aftowla**: Southern Africa-Western Latin America on both the Chinese Mainland website and International website.
+  + **bandwidth.aptoaf**: Asia Pacific-Southern Africa on the International website.
+  + **bandwidth.aptoap**: Asia Pacific on the International website.
+  + **bandwidth.aptoela**: Asia Pacific-Eastern Latin America on both the Chinese Mainland website and International website.
+  + **bandwidth.aptonla**: Asia Pacific-Northern Latin America on both the Chinese Mainland website and International website.
+  + **bandwidth.aptowla**: Asia Pacific-Western Latin America on both the Chinese Mainland website and International website.
+  + **bandwidth.cmtoaf**: Chinese mainland-Southern Africa on the International website.
+  + **bandwidth.cmtoap**: Chinese mainland-Asia Pacific on the International website.
+  + **bandwidth.cmtocm**: Chinese mainland on the International website.
+  + **bandwidth.cmtoela**: Chinese mainland-Eastern Latin America on both the Chinese Mainland website and International
+    website.
+  + **bandwidth.cmtonla**: Chinese mainland-Northern Latin America on both the Chinese Mainland website and International
+    website.
+  + **bandwidth.cmtowla**: Chinese mainland-Western Latin America on both the Chinese Mainland website and International
+    website.
+  + **bandwidth.elatoela**: Eastern Latin America on both the Chinese Mainland website and International website.
+  + **bandwidth.elatonla**: Eastern Latin America–Northern Latin America on both the Chinese Mainland website and
+    International website.
+  + **bandwidth.wlatoela**: Western Latin America-Eastern Latin America on both the Chinese Mainland website and
+    International website.
+  + **bandwidth.wlatonla**: Western Latin America–Northern Latin America on both the Chinese Mainland website and
+    International website.
+  + **bandwidth.wlatowla**: Western Latin America on both the Chinese Mainland website and International website.
+
+  If the value of `interflow_mode` is **Region**, the value depends on the specified interflow regions, e.g. **Beijing4toGuangzhou**.
+
 * `description` - (Optional, String) The description about the bandwidth package.  
   The description can contain a maximum of 85 characters.
 

--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_bandwidth_package_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_bandwidth_package_test.go
@@ -260,3 +260,70 @@ resource "huaweicloud_cc_bandwidth_package" "test" {
 }
 `, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
+
+func TestAccBandwidthPackage_regionalInterflow(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cc_bandwidth_package.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBandwidthPackageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBandwidthPackage_regionalInterflow(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "local_area_id", "cn-north-4"),
+					resource.TestCheckResourceAttr(rName, "remote_area_id", "cn-south-1"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "bandwidth"),
+					resource.TestCheckResourceAttr(rName, "billing_mode", "5"),
+					resource.TestCheckResourceAttr(rName, "bandwidth", "4"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "value"),
+					resource.TestCheckResourceAttr(rName, "interflow_mode", "Region"),
+					resource.TestCheckResourceAttr(rName, "spec_code", "Beijing4toGuangzhou"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "resource_type", "cloud_connection"),
+					resource.TestCheckResourceAttrSet(rName, "project_id"),
+					resource.TestCheckResourceAttrPair(rName, "resource_id", "huaweicloud_cc_connection.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testBandwidthPackage_regionalInterflow(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_connection" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_cc_bandwidth_package" "test" {
+  name                  = "%[1]s"
+  local_area_id         = "cn-north-4"
+  remote_area_id        = "cn-south-1"
+  charge_mode           = "bandwidth"
+  billing_mode          = 5
+  bandwidth             = 4
+  resource_id           = huaweicloud_cc_connection.test.id
+  resource_type         = "cloud_connection"
+  interflow_mode        = "Region"
+  spec_code             = "Beijing4toGuangzhou"
+
+  tags = {
+    foo   = "bar"
+    owner = "value"
+  }
+}
+`, name)
+}

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
@@ -82,6 +82,20 @@ func ResourceBandwidthPackage() *schema.Resource {
 				Computed:    true,
 				Description: `Project ID.`,
 			},
+			"interflow_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Interflow mode of the bandwidth package.`,
+			},
+			"spec_code": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specification code of the bandwidth package.`,
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -187,6 +201,8 @@ func buildCreateBandwidthPackageBodyParams(d *schema.ResourceData, cfg *config.C
 			"resource_id":           utils.ValueIngoreEmpty(d.Get("resource_id")),
 			"resource_type":         utils.ValueIngoreEmpty(d.Get("resource_type")),
 			"tags":                  utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+			"interflow_mode":        utils.ValueIngoreEmpty(d.Get("interflow_mode")),
+			"spec_code":             utils.ValueIngoreEmpty(d.Get("spec_code")),
 		},
 	}
 
@@ -247,6 +263,8 @@ func resourceBandwidthPackageRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("resource_id", utils.PathSearch("bandwidth_package.resource_id", getBandwidthPackageRespBody, nil)),
 		d.Set("resource_type", utils.PathSearch("bandwidth_package.resource_type", getBandwidthPackageRespBody, nil)),
 		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("bandwidth_package.tags", getBandwidthPackageRespBody, nil))),
+		d.Set("interflow_mode", utils.PathSearch("bandwidth_package.interflow_mode", getBandwidthPackageRespBody, nil)),
+		d.Set("spec_code", utils.PathSearch("bandwidth_package.spec_code", getBandwidthPackageRespBody, nil)),
 		d.Set("status", utils.PathSearch("bandwidth_package.status", getBandwidthPackageRespBody, nil)),
 	)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add interflow_mode, spec_code attribute to cc bandwidth package

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add interflow_mode, spec_code attribute to cc bandwidth package
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccBandwidthPackage_regionalInterflow"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccBandwidthPackage_regionalInterflow -timeout 360m -parallel 4
=== RUN   TestAccBandwidthPackage_regionalInterflow
=== PAUSE TestAccBandwidthPackage_regionalInterflow
=== CONT  TestAccBandwidthPackage_regionalInterflow
--- PASS: TestAccBandwidthPackage_regionalInterflow (17.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        17.390s

```
