### PR TITLE
fix(fgs): update the function code that no error is returned if no results found

### DIFF
--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_dependencies.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_dependencies.go
@@ -103,15 +103,14 @@ func dataSourceFunctionGraphDependenciesRead(_ context.Context, d *schema.Resour
 	if err != nil {
 		return diag.Errorf("error retrieving dependent packages: %s", err)
 	}
-	resp, _ := dependencies.ExtractDependencies(allPages)
-	if len(resp.Dependencies) < 1 {
-		return diag.Errorf("no dependent package found, please check your parameters")
-	}
+
 	randUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
 	d.SetId(randUUID)
+
+	resp, _ := dependencies.ExtractDependencies(allPages)
 	packages := flatFunctionGraphDependencies(resp.Dependencies)
 	mErr := multierror.Append(
 		d.Set("packages", packages),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
According to the current design rules of multiple-rule’s data sources, we should not return an error when the object cannot be queried, but should set an empty list.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the function code that no error is returned if no results found.
2. update the acceptance test and testing whether empty return is legal.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFunctionGraphDependencies_filterByName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFunctionGraphDependencies_filterByName -timeout 360m -parallel 4
=== RUN   TestAccFunctionGraphDependencies_filterByName
=== PAUSE TestAccFunctionGraphDependencies_filterByName
=== CONT  TestAccFunctionGraphDependencies_filterByName
--- PASS: TestAccFunctionGraphDependencies_filterByName (9.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       9.877s
```
