### PR TITLE
chore(eip): change charging mode in eip

### DIFF
--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -70,21 +70,24 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the EIP.
 
-* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the EIP.  
-  The valid values are **prePaid** and **postPaid**, defaults to **postPaid**. Changing this will create a new resource.
+* `charging_mode` - (Optional, String) Specifies the charging mode of the EIP.  
+  The valid values are **prePaid** and **postPaid**, defaults to **postPaid**.
 
-* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the EIP.  
+-> **NOTE:** Please update the `charge_mode` of `bandwidth` to **bandwidth** before changing to **prePaid** billing mode.
+
+* `period_unit` - (Optional, String) Specifies the charging period unit of the EIP.  
   Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
-  Changing this will create a new resource.
 
-* `period` - (Optional, Int, ForceNew) Specifies the charging period of the EIP.
+* `period` - (Optional, Int) Specifies the charging period of the EIP.
   + If `period_unit` is set to **month**, the value ranges from `1` to `9`.
   + If `period_unit` is set to **year**, the value ranges from `1` to `3`.
 
-  This parameter is mandatory if `charging_mode` is set to **prePaid**. Changing this will create a new resource.
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.
 
 * `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.  
   Valid values are **true** and **false**. Defaults to **false**.
+
+-> **NOTE:** `period_unit`, `period` and `auto_renew` can only be updated when changing to **prePaid** billing mode.
 
 <a name="vpc_eip_publicip"></a>
 The `publicip` block supports:
@@ -117,7 +120,7 @@ The `bandwidth` block supports:
   This parameter is mandatory when `share_type` is set to **WHOLE**. Changing this will create a new resource.
 
 * `charge_mode` - (Optional, String) Specifies whether the bandwidth is billed by traffic or by bandwidth
-  size. The value can be **traffic** or **bandwidth**. Changing this will create a new resource.
+  size. The value can be **traffic** or **bandwidth**. If the `charging_mode` is **prePaid**, only **bandwidth** is valid.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240204092642-2df7c7cae0c2
+	github.com/chnsz/golangsdk v0.0.0-20240206034529-5489fc02d550
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240204092642-2df7c7cae0c2 h1:oni89yKmN8LEIegqilXeMY1aYB1slHIXkX9l2LTH1SQ=
-github.com/chnsz/golangsdk v0.0.0-20240204092642-2df7c7cae0c2/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240206034529-5489fc02d550 h1:FXkLWb94+06Ukv5Tsvzw6rKSvEAg0QNifHhSAu9sCpo=
+github.com/chnsz/golangsdk v0.0.0-20240206034529-5489fc02d550/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
@@ -2,6 +2,7 @@ package eip
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -234,6 +235,78 @@ func TestAccVpcEip_prePaid(t *testing.T) {
 	})
 }
 
+func TestAccVpcEip_ChangeToPeriod(t *testing.T) {
+	var (
+		eip          eips.PublicIp
+		randName     = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_vpc_eip.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&eip,
+		getEipResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckChargingMode(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcEip_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+				),
+			},
+			{
+				Config: testAccVpcEip_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.charge_mode", "bandwidth"),
+				),
+			},
+			{
+				Config: testAccVpcEip_prePaid(randName, 8, true),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.charge_mode", "bandwidth"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
+				),
+			},
+			{
+				Config:      testAccVpcEip_prePaidChangeToPostPaid(randName, 8, true),
+				ExpectError: regexp.MustCompile(`error updating the charging mode of the EIP`),
+			},
+			{
+				Config: testAccVpcEip_prePaid(randName, 8, false),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth.0.charge_mode", "bandwidth"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"charging_mode", "period", "period_unit", "auto_renew"},
+			},
+		},
+	})
+}
+
 func TestAccVpcEip_deprecated(t *testing.T) {
 	var (
 		eip eips.PublicIp
@@ -373,9 +446,10 @@ resource "huaweicloud_vpc_eip" "test" {
   }
 
   bandwidth {
-    share_type = "PER"
-    name       = "%[1]s"
-    size       = %[2]d
+    share_type  = "PER"
+    name        = "%[1]s"
+    size        = %[2]d
+    charge_mode = "bandwidth"
   }
 
   charging_mode = "prePaid"
@@ -419,4 +493,25 @@ resource "huaweicloud_vpc_eip" "test" {
   }
 }
 `, rName)
+}
+
+func testAccVpcEip_prePaidChangeToPostPaid(rName string, size int, _ bool) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_eip" "test" {
+  name = "%[1]s"
+
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "%[1]s"
+    size        = %[2]d
+    charge_mode = "bandwidth"
+  }
+
+  charging_mode = "postPaid"
+}
+`, rName, size)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/results.go
@@ -47,6 +47,16 @@ type PublicIp struct {
 	IpVersion                int      `json:"ip_version"`
 	Alias                    string   `json:"alias"`
 	AllowShareBandwidthTypes []string `json:"allow_share_bandwidth_types"`
+
+	Profile Profile  `json:"profile"`
+	Tags    []string `json:"tags"`
+}
+
+type Profile struct {
+	UserID    string `json:"user_id"`
+	ProductID string `json:"product_id"`
+	RegionID  string `json:"region_id"`
+	OrderID   string `json:"order_id"`
 }
 
 // GetResult is a return struct of get method

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v3/eips/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v3/eips/requests.go
@@ -1,6 +1,9 @@
 package eips
 
-import "github.com/chnsz/golangsdk"
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
 
 type GetResult struct {
 	golangsdk.Result
@@ -10,4 +13,108 @@ type GetResult struct {
 func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
+}
+
+type ListOpts struct {
+	// Specifies the resource ID of pagination query. If the parameter
+	// is left blank, only resources on the first page are queried.
+	Marker string `q:"marker"`
+
+	// Specifies the number of records returned on each page. The
+	// value ranges from 0 to [2000], of which [2000] is the site difference item.
+	// The specific value is determined by the site.
+	Limit int `q:"limit"`
+
+	// Specifies the query field you want.
+	Fields []string `q:"fields"`
+
+	// Sort key, valid values are id, public_ip_address, public_ipv6_address,
+	// ip_version, created_at, updated_at and public_border_group.
+	SortKey string `q:"sort_key"`
+
+	// Sorting direction, valid values are asc and desc.
+	SortDir string `q:"sort_dir"`
+
+	Id []string `q:"id"`
+
+	// Value range: 4, 6
+	IPVersion int `q:"ip_version"`
+
+	// EIP name
+	Alias []string `q:"alias"`
+
+	PublicIp   []string `q:"public_ip_address"`
+	PublicIpv6 []string `q:"public_ipv6_address"`
+
+	// Private IP address
+	PrivateIp []string `q:"vnic.private_ip_address"`
+
+	// Associated port id
+	PortId []string `q:"vnic.port_id"`
+
+	EnterpriseProjectId string `q:"enterprise_project_id"`
+
+	// Type, valid values are EIP and DUALSTACK.
+	Type []string `q:"type"`
+
+	// Network Type, valid values are 5_telcom, 5_union, 5_bgp, 5_sbgp, 5_ipv6 and 5_graybgp
+	NetworkType []string `q:"network_type"`
+
+	// Public Pool Name
+	PublicPoolName []string `q:"public_pool_name"`
+
+	// Status, valid values are FREEZED、DOWN、ACTIVE、ERROR.
+	Status []string `q:"status"`
+
+	// Device ID
+	DeviceID []string `q:"vnic.device_id"`
+
+	// Device owner
+	DeviceOwner []string `q:"vnic.device_owner"`
+
+	VPCID []string `q:"vnic.vpc_id"`
+
+	// Instance type the port associated with
+	InstanceType []string `q:"vnic.instance_type"`
+
+	// Instance ID the port associated with
+	InstanceID []string `q:"vnic.instance_id"`
+
+	// Associated instance type
+	AssociateInstanceType []string `q:"associate_instance_type"`
+
+	// Associated instance ID
+	AssociateInstanceID []string `q:"associate_instance_id"`
+
+	BandwidthID         []string `q:"bandwidth.id"`
+	BandwidthName       []string `q:"bandwidth.name"`
+	BandwidthSize       []string `q:"bandwidth.size"`
+	BandwidthShareType  []string `q:"bandwidth.share_type"`
+	BandwidthChargeMode []string `q:"bandwidth.charge_mode"`
+
+	// Public border group
+	PublicBorderGroup []string `q:"public_border_group"`
+
+	AllowShareBandwidthTypeAny []string `q:"allow_share_bandwidth_type_any"`
+}
+
+// List is a method used to query the public ips with given parameters.
+func List(client *golangsdk.ServiceClient, opts ListOpts) ([]PublicIp, error) {
+	url := listURL(client)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := PublicIPPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractPublicIPs(pages)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v3/eips/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v3/eips/urls.go
@@ -7,3 +7,7 @@ const resourcePath = "publicips"
 func getURL(client *golangsdk.ServiceClient, id string) string {
 	return client.ServiceURL("eip", resourcePath, id)
 }
+
+func listURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("eip", resourcePath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240204092642-2df7c7cae0c2
+# github.com/chnsz/golangsdk v0.0.0-20240206034529-5489fc02d550
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Change `charging_mode` in `resource.huaweicloud_vpc_eip`, remove the `ForceNew` to support update.
Add eipv3 sdk.


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcEip_ChangeToPeriod"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcEip_ChangeToPeriod -timeout 360m -parallel 4
=== RUN   TestAccVpcEip_ChangeToPeriod
=== PAUSE TestAccVpcEip_ChangeToPeriod
=== CONT  TestAccVpcEip_ChangeToPeriod
--- PASS: TestAccVpcEip_ChangeToPeriod (99.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       99.177s
```
