### PR TITLE
feat(ecs): add datasource compute_instance_remote_console

### DIFF
--- a/docs/data-sources/compute_instance_remote_console.md
+++ b/docs/data-sources/compute_instance_remote_console.md
@@ -1,0 +1,38 @@
+---
+subcategory: "Elastic Cloud Server (ECS)"
+---
+
+# huaweicloud_compute_instance_remote_console
+
+Use this data source to get an available HuaweiCloud ECS compute instance remote console.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_compute_instance_remote_console" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the instances.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ECS ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `protocol` - The protocol of the ECS compute instance remote console.
+
+* `type` - The type of ECS compute instance remote console.
+
+* `url` - The url of ECS compute instance remote console.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -432,10 +432,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_cnad_advanced_available_objects": cnad.DataSourceAvailableProtectedObjects(),
 			"huaweicloud_cnad_advanced_protected_objects": cnad.DataSourceProtectedObjects(),
 
-			"huaweicloud_compute_flavors":      ecs.DataSourceEcsFlavors(),
-			"huaweicloud_compute_instance":     ecs.DataSourceComputeInstance(),
-			"huaweicloud_compute_instances":    ecs.DataSourceComputeInstances(),
-			"huaweicloud_compute_servergroups": ecs.DataSourceComputeServerGroups(),
+			"huaweicloud_compute_flavors":                 ecs.DataSourceEcsFlavors(),
+			"huaweicloud_compute_instance":                ecs.DataSourceComputeInstance(),
+			"huaweicloud_compute_instances":               ecs.DataSourceComputeInstances(),
+			"huaweicloud_compute_servergroups":            ecs.DataSourceComputeServerGroups(),
+			"huaweicloud_compute_instance_remote_console": ecs.DataSourceComputeInstanceRemoteConsole(),
 
 			"huaweicloud_cts_notifications": cts.DataSourceNotifications(),
 

--- a/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_instance_remote_console_test.go
+++ b/huaweicloud/services/acceptance/ecs/data_source_huaweicloud_compute_instance_remote_console_test.go
@@ -1,0 +1,41 @@
+package ecs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEcsInstanceRemoteConsoleDataSource_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_compute_instance_remote_console.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEcsInstanceRemoteConsoleDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "protocol"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "url"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEcsInstanceRemoteConsoleDataSource_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_compute_instance_remote_console" "test" {
+  instance_id = huaweicloud_compute_instance.test.id
+}
+`, testAccComputeInstanceDataSource_basic(acceptance.RandomAccResourceNameWithDash()))
+}

--- a/huaweicloud/services/ecs/data_source_huaweicloud_compute_instance_remote_console.go
+++ b/huaweicloud/services/ecs/data_source_huaweicloud_compute_instance_remote_console.go
@@ -1,0 +1,94 @@
+package ecs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ECS POST /v1/{project_id}/cloudservers/{server_id}/remote_console
+func DataSourceComputeInstanceRemoteConsole() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceComputeInstanceRemoteConsoleRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			// attributes
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceComputeInstanceRemoteConsoleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	instanceId := d.Get("instance_id").(string)
+	product := "ecs"
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating ECS client: %s", err)
+	}
+
+	requestOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"remote_console": utils.RemoveNil(map[string]interface{}{
+				"protocol": "vnc",
+				"type":     "novnc",
+			}),
+		},
+	}
+
+	getVNCRemoteAddressHttpUrl := "v1/{project_id}/cloudservers/{server_id}/remote_console"
+	getVNCRemoteAddressPath := client.Endpoint + getVNCRemoteAddressHttpUrl
+	getVNCRemoteAddressPath = strings.ReplaceAll(getVNCRemoteAddressPath, "{project_id}", client.ProjectID)
+	getVNCRemoteAddressPath = strings.ReplaceAll(getVNCRemoteAddressPath, "{server_id}", instanceId)
+	getVNCRemoteAddressResp, err := client.Request("POST", getVNCRemoteAddressPath, &requestOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving VNC Remote Address")
+	}
+	getVNCRemoteAddressBody, err := utils.FlattenResponse(getVNCRemoteAddressResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(instanceId)
+	remoteConsole := utils.PathSearch("remote_console", getVNCRemoteAddressBody, nil)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("protocol", utils.PathSearch("url", remoteConsole, nil)),
+		d.Set("type", utils.PathSearch("url", remoteConsole, nil)),
+		d.Set("url", utils.PathSearch("url", remoteConsole, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:  add datasource compute_instance_remote_console

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccEcsInstanceRemoteConsoleDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccEcsInstanceRemoteConsoleDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccEcsInstanceRemoteConsoleDataSource_basic
=== PAUSE TestAccEcsInstanceRemoteConsoleDataSource_basic
=== CONT  TestAccEcsInstanceRemoteConsoleDataSource_basic
--- PASS: TestAccEcsInstanceRemoteConsoleDataSource_basic (225.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       225.821s
```
