### PR TITLE
fix(DWS): DWS logical cluster resource support retry operations

### DIFF
--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_logical_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_logical_cluster_test.go
@@ -59,9 +59,7 @@ func getLogicalClusterResourceFunc(cfg *config.Config, state *terraform.Resource
 	return cluster, nil
 }
 
-// Two logical clusters are created to cover the deletion logic.
-// At the current stage, multiple logical clusters cannot be created simultaneously under the same cluster.
-// This is a legacy feature and will be added later.
+// Two logical clusters are created to test concurrent creation and deletion scenarios.
 func TestAccLogicalCluster_basic(t *testing.T) {
 	var obj interface{}
 
@@ -184,10 +182,6 @@ resource "huaweicloud_dws_logical_cluster" "test2" {
       }
     }
   }
-
-  depends_on = [
-    huaweicloud_dws_logical_cluster.test
-  ]
 }
 `, testLogicalCluster_base(name), name, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- This PR is a feature addition. DWS logical cluster support retrying when creation and deletion fail.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The purpose of adding retry logic is to adapt to concurrent creation and deletion scenarios.
- This PR does not modify the business logic.
- When deleting a resource that does not exist, the phenomenon is as follows：
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/f7048863-6e58-4bfc-a6ee-f30f491754b8)

- When the first logical cluster is deleted, the phenomenon is as follows：
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/162edf09-9d6d-4edc-9927-c19184d7f8a2)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dws' TESTARGS='-run TestAccLogicalCluster_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccLogicalCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccLogicalCluster_basic
=== PAUSE TestAccLogicalCluster_basic
=== CONT  TestAccLogicalCluster_basic
--- PASS: TestAccLogicalCluster_basic (1881.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1881.758s
```
