### PR TITLE
feat(cdn): add a new data source to query CDN certificate https list

### DIFF
--- a/docs/data-sources/cdn_domain_certificates.md
+++ b/docs/data-sources/cdn_domain_certificates.md
@@ -1,0 +1,67 @@
+---
+subcategory: Content Delivery Network (CDN)
+---
+
+# huaweicloud_cdn_domain_certificates
+
+Use this data source to get the list of domains bound to HTTPS certificate of CDN.
+
+## Example Usage
+
+```hcl
+variable "name" {}
+
+data "huaweicloud_cdn_domain_certificates" "test" {
+  name = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Optional, String) Specifies the name of the acceleration domain.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project that the datesource belongs to.
+  This parameter is valid only when the enterprise project function is enabled.
+  The value **all** indicates all projects. This parameter is mandatory when you use an IAM user.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `domain_certificates` - The list of certificates information bound to accelerate domain.
+  The [domain_certificates](#block-domain_certificates) structure is documented below.
+
+<a name="block-domain_certificates"></a>
+The `domain_certificates` block supports:
+
+* `domain_id` - The ID of the CDN domain.
+
+* `domain_name` - The acceleration domain name.
+
+* `certificate_name` - The certificate name.
+
+* `certificate_body` - The content of the certificate used by the HTTPS protocol.
+
+* `certificate_source` - The certificate type. The value can be:
+  + **1**: Huawei-managed certificate.
+  + **0**: Your own certificate.
+
+* `expire_at` - The expiration time.
+
+* `https_status` - The status of the https. The value can be:
+  + **0**: Do not enable HTTPS certificates.
+  + **1**: Enable HTTPS acceleration and protocol follow back to origin.
+  + **2**: Enable HTTPS acceleration and HTTP back to origin.
+
+* `force_redirect_https` - Whether client requests are forced to be redirected. The value can be：
+  + **0**: Client requests will not be forced to redirect.
+  + **1**: Client requests will be forced to redirect.
+  + **2**: Client requests will be forced to jump to HTTP.
+
+* `http2_enabled` - Whether HTTP2.0 is used. The value can be：
+  + **0**: Not use HTTP2.0.
+  + **1**: Use HTTP2.0.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -426,8 +426,9 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_ccm_private_certificate_export": ccm.DataSourceCcmPrivateCertificateExport(),
 
-			"huaweicloud_cdn_domain_statistics": cdn.DataSourceStatistics(),
-			"huaweicloud_cdn_domains":           cdn.DataSourceCdnDomains(),
+			"huaweicloud_cdn_domain_statistics":   cdn.DataSourceStatistics(),
+			"huaweicloud_cdn_domains":             cdn.DataSourceCdnDomains(),
+			"huaweicloud_cdn_domain_certificates": cdn.DataSourceDomainCertificates(),
 
 			"huaweicloud_cfw_firewalls": cfw.DataSourceFirewalls(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -76,6 +76,7 @@ var (
 	HW_CDN_DOMAIN_NAME              = os.Getenv("HW_CDN_DOMAIN_NAME")
 	HW_CDN_CERT_PATH                = os.Getenv("HW_CDN_CERT_PATH")
 	HW_CDN_PRIVATE_KEY_PATH         = os.Getenv("HW_CDN_PRIVATE_KEY_PATH")
+	HW_CDN_ENABLE_FLAG              = os.Getenv("HW_CDN_ENABLE_FLAG")
 	HW_CERTIFICATE_KEY_PATH         = os.Getenv("HW_CERTIFICATE_KEY_PATH")
 	HW_CERTIFICATE_CHAIN_PATH       = os.Getenv("HW_CERTIFICATE_CHAIN_PATH")
 	HW_CERTIFICATE_PRIVATE_KEY_PATH = os.Getenv("HW_CERTIFICATE_PRIVATE_KEY_PATH")
@@ -1160,6 +1161,13 @@ func TestAccPreCheckCDN(t *testing.T) {
 func TestAccPreCheckCERT(t *testing.T) {
 	if HW_CDN_CERT_PATH == "" || HW_CDN_PRIVATE_KEY_PATH == "" {
 		t.Skip("This environment does not support CDN certificate tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCDNDomainCertificates(t *testing.T) {
+	if HW_CDN_ENABLE_FLAG == "" {
+		t.Skip("Skip the CDN acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_certificates_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_certificates_test.go
@@ -1,0 +1,60 @@
+package cdn
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before executing this use case, please create several pieces of data first.
+func TestAccDatasourceCDNDomainCertificates_basic(t *testing.T) {
+	rName := "data.huaweicloud_cdn_domain_certificates.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCDNDomainCertificates(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDomainCertificates_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "domain_certificates.0.domain_id"),
+					resource.TestCheckResourceAttrSet(rName, "domain_certificates.0.domain_name"),
+					resource.TestCheckResourceAttrSet(rName, "domain_certificates.0.certificate_name"),
+					resource.TestCheckResourceAttrSet(rName, "domain_certificates.0.certificate_body"),
+					resource.TestCheckResourceAttrSet(rName, "domain_certificates.0.certificate_source"),
+					resource.TestCheckResourceAttrSet(rName, "domain_certificates.0.expire_at"),
+					resource.TestCheckResourceAttrSet(rName, "domain_certificates.0.https_status"),
+					resource.TestCheckResourceAttrSet(rName, "domain_certificates.0.force_redirect_https"),
+					resource.TestCheckResourceAttrSet(rName, "domain_certificates.0.http2_enabled"),
+
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDomainCertificates_basic() string {
+	return `
+data "huaweicloud_cdn_domain_certificates" "test" {}
+
+data "huaweicloud_cdn_domain_certificates" "name_filter" {
+  name = data.huaweicloud_cdn_domain_certificates.test.domain_certificates.0.domain_name
+}
+locals {
+  name = data.huaweicloud_cdn_domain_certificates.test.domain_certificates.0.domain_name
+}
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_domain_certificates.name_filter.domain_certificates) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_domain_certificates.name_filter.domain_certificates[*].domain_name : v == local.name]
+  )  
+}
+`
+}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_certificates.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_certificates.go
@@ -1,0 +1,161 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN GET /v1.0/cdn/domains/https-certificate-info
+func DataSourceDomainCertificates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceDomainCertificatesRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain_certificates": {
+				Type:     schema.TypeList,
+				Elem:     domainCertificateschema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func domainCertificateschema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"domain_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_body": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_source": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"expire_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"https_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"force_redirect_https": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"http2_enabled": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDomainCertificatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		domainCertificatesHttpUrl = "v1.0/cdn/domains/https-certificate-info"
+		domainCertificatesProduct = "cdn"
+	)
+	domainCertificatesClient, err := conf.NewServiceClient(domainCertificatesProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	domainCertificatesPath := domainCertificatesClient.Endpoint + domainCertificatesHttpUrl + "?page_size=10"
+	epsId := conf.GetEnterpriseProjectID(d)
+	if epsId != "" {
+		domainCertificatesPath += fmt.Sprintf("&enterprise_project_id=%v", epsId)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		domainCertificatesPath += fmt.Sprintf("&domain_name=%v", v)
+	}
+	getCDNCertificateDomainsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	currentTotal := 1
+	rst := make([]interface{}, 0)
+	for {
+		currentPath := fmt.Sprintf("%s&page_number=%v", domainCertificatesPath, currentTotal)
+		getCDNCertificateDomainsResp, err := domainCertificatesClient.Request("GET", currentPath, &getCDNCertificateDomainsOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		getCDNCertificateDomainsRespBody, err := utils.FlattenResponse(getCDNCertificateDomainsResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		domainCertificates := utils.PathSearch("https", getCDNCertificateDomainsRespBody, make([]interface{}, 0)).([]interface{})
+		if len(domainCertificates) == 0 {
+			break
+		}
+		rst = append(rst, domainCertificates...)
+		currentTotal++
+	}
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("domain_certificates", flattenListCertificateDomainsBody(rst)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListCertificateDomainsBody(domainCertificates []interface{}) []interface{} {
+	rst := make([]interface{}, 0)
+	for _, v := range domainCertificates {
+		expirationTime := utils.PathSearch("expiration_time", v, 0)
+		rst = append(rst, map[string]interface{}{
+			"domain_id":            utils.PathSearch("domain_id", v, nil),
+			"domain_name":          utils.PathSearch("domain_name", v, nil),
+			"certificate_name":     utils.PathSearch("cert_name", v, nil),
+			"certificate_body":     utils.PathSearch("certificate", v, nil),
+			"certificate_source":   utils.PathSearch("certificate_type", v, nil),
+			"expire_at":            utils.FormatTimeStampRFC3339(int64(expirationTime.(float64))/1000, false),
+			"https_status":         utils.PathSearch("https_status", v, nil),
+			"force_redirect_https": utils.PathSearch("force_redirect_https", v, nil),
+			"http2_enabled":        utils.PathSearch("http2", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
+ Add a new data source to query CDN certificate https list

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
+ A domain name is created in advance and a certificate is bound to it. The test case is tested based on this data.
+ The paging method is page_number+page_size. The public paging method is not available, so use a for loop to query.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccDatasourceCDNDomainCertificates_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceCDNDomainCertificates_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCDNDomainCertificates_basic
=== PAUSE TestAccDatasourceCDNDomainCertificates_basic
=== CONT  TestAccDatasourceCDNDomainCertificates_basic
--- PASS: TestAccDatasourceCDNDomainCertificates_basic (23.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       23.873s
```
