### PR TITLE
fix: fix common retry delay time

### DIFF
--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -283,7 +283,6 @@ func RetryContextWithWaitForState(param *RetryContextWithWaitForStateParam) (int
 		Pending:      []string{"retryable"},
 		Target:       []string{"success"},
 		Timeout:      param.Timeout,
-		Delay:        param.DelayTimeout,
 		PollInterval: param.PollInterval,
 		Refresh: func() (interface{}, string, error) {
 			res, retry, err := param.RetryFunc()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  it is no need to delay when calling the retry function for the first time, because it is more likely to succeed
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
  fix common retry delay time
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
