### PR TITLE
fix(OBS): OBS bucket logging supports agency configuration

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -35,6 +35,8 @@ resource "huaweicloud_obs_bucket" "b" {
 ### Enable Logging
 
 ```hcl
+variable "agency_name" {} # The agency must be an OBS cloud service agency and has the `PutObject` permission.
+
 resource "huaweicloud_obs_bucket" "log_bucket" {
   bucket = "my-tf-log-bucket"
   acl    = "log-delivery-write"
@@ -47,6 +49,7 @@ resource "huaweicloud_obs_bucket" "b" {
   logging {
     target_bucket = huaweicloud_obs_bucket.log_bucket.id
     target_prefix = "log/"
+    agency        = var.agency_name
   }
 }
 ```
@@ -254,7 +257,14 @@ The `logging` object supports the following:
 
 * `target_bucket` - (Required, String) The name of the bucket that will receive the log objects. The acl policy of the
   target bucket should be `log-delivery-write`.
+
 * `target_prefix` - (Optional, String) To specify a key prefix for log objects.
+
+* `agency` - (Required, String) Specifies the IAM agency of OBS cloud service.
+
+  -> The IAM agency requires the `PutObject` permission for the target bucket.  If default encryption is enabled for the
+  target bucket, the agency also requires the `KMS Administrator` permission in the region where the target bucket is
+  located.
 
 The `website` object supports the following:
 

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -521,6 +521,11 @@ func resourceObsBucketRead(_ context.Context, d *schema.ResourceData, meta inter
 		return diag.Errorf("Error creating OBS client: %s", err)
 	}
 
+	obsClientWithSignature, err := conf.ObjectStorageClientWithSignature(region)
+	if err != nil {
+		return diag.Errorf("Error creating OBS client with signature: %s", err)
+	}
+
 	bucket := d.Id()
 	log.Printf("[DEBUG] Read OBS bucket: %s", bucket)
 	_, err = obsClient.HeadBucket(bucket)
@@ -601,10 +606,7 @@ func resourceObsBucketRead(_ context.Context, d *schema.ResourceData, meta inter
 	policyClient := obsClient
 	format := d.Get("policy_format").(string)
 	if format == "obs" {
-		policyClient, err = conf.ObjectStorageClientWithSignature(region)
-		if err != nil {
-			return diag.Errorf("Error creating OBS policy client: %s", err)
-		}
+		policyClient = obsClientWithSignature
 	}
 	if err := setObsBucketPolicy(policyClient, d); err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

-  OBS bucket logging supports agency configuration

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

This PR contains two commits
- Move the logic that generate OBS client forward, the purpose is to prepare for supporting the agency later.
- OBS bucket logging supports agency configuration.
- Using `conf.ObjectStorageClientWithSignature(region)` to replace `conf.ObjectStorageClient(region)`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket_logging'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_logging -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (16.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       16.681s
```
