### PR TITLE
fix(DCS): fix dcs instance operation error and test

### DIFF
--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
@@ -65,7 +65,7 @@ func TestAccDcsInstances_basic(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_updated(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
@@ -128,7 +128,7 @@ func TestAccDcsInstances_ha_change_capacity(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_ha_expand_capacity(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
@@ -139,7 +139,7 @@ func TestAccDcsInstances_ha_change_capacity(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_ha_reduce_capacity(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
@@ -196,7 +196,7 @@ func TestAccDcsInstances_ha_expand_replica(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_ha_expand_replica(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
@@ -253,7 +253,7 @@ func TestAccDcsInstances_ha_to_proxy(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_ha_to_proxy(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
@@ -310,7 +310,7 @@ func TestAccDcsInstances_rw_change_capacity(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_rw_expand_capacity(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "16"),
@@ -321,7 +321,7 @@ func TestAccDcsInstances_rw_change_capacity(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_rw_reduce_capacity(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
@@ -378,7 +378,7 @@ func TestAccDcsInstances_rw_expand_replica(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_rw_expand_replica(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
@@ -435,7 +435,7 @@ func TestAccDcsInstances_rw_to_proxy(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_rw_to_proxy(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
@@ -492,7 +492,7 @@ func TestAccDcsInstances_proxy_change_capacity(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_proxy_expand_capacity(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "16"),
@@ -503,7 +503,7 @@ func TestAccDcsInstances_proxy_change_capacity(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_proxy_reduce_capacity(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
@@ -560,7 +560,7 @@ func TestAccDcsInstances_proxy_to_ha(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_proxy_to_ha(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
@@ -617,7 +617,7 @@ func TestAccDcsInstances_proxy_to_rw(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_proxy_to_rw(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
@@ -674,7 +674,7 @@ func TestAccDcsInstances_cluster_change_capacity(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_cluster_expand_capacity(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "8"),
@@ -685,7 +685,7 @@ func TestAccDcsInstances_cluster_change_capacity(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_cluster_reduce_capacity(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
@@ -742,7 +742,7 @@ func TestAccDcsInstances_cluster_expand_replica(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_cluster_expand_replica(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "capacity", "4"),
@@ -1028,7 +1028,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 1
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1125,7 +1125,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 4
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1160,7 +1160,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 1
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1195,7 +1195,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 1
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1230,7 +1230,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 4
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1300,7 +1300,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 16
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1335,7 +1335,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 8
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1370,7 +1370,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 8
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1405,7 +1405,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 8
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1475,7 +1475,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 16
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1510,7 +1510,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test_update"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 8
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1545,7 +1545,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 4
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1580,7 +1580,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 8
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1650,7 +1650,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 8
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1685,7 +1685,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 4
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
@@ -1720,7 +1720,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6389
+  port               = 6388
   capacity           = 4
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -53,6 +53,8 @@ var (
 	operateErrorCode = map[string]bool{
 		// current state not support
 		"DCS.4026": true,
+		// instance status is not running
+		"DCS.4049": true,
 		// backup
 		"DCS.4096": true,
 		// restore
@@ -1340,24 +1342,8 @@ func handleOperationError(err error) (bool, error) {
 		if errorCodeErr != nil {
 			return false, fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
 		}
-		if operateErrorCode[errorCode.(string)] {
-			return true, err
-		}
-	}
-	// unsubscribe fail
-	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
-		var apiError interface{}
-		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
-			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
-		}
-
-		errorCode, errorCodeErr := jmespath.Search("error_code", apiError)
-		if errorCodeErr != nil {
-			return false, fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
-		}
-
 		// CBC.99003651: Another operation is being performed.
-		if errorCode == "CBC.99003651" {
+		if operateErrorCode[errorCode.(string)] || errorCode == "CBC.99003651" {
 			return true, err
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. fix handle operation error method
2. fix port of test

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dcs instance operation error and test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDcsInstances_' TEST_PARALLELISM=17
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsInstances_ -timeout 360m -parallel 17
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_ha_change_capacity
=== PAUSE TestAccDcsInstances_ha_change_capacity
=== RUN   TestAccDcsInstances_ha_expand_replica
=== PAUSE TestAccDcsInstances_ha_expand_replica
=== RUN   TestAccDcsInstances_ha_to_proxy
=== PAUSE TestAccDcsInstances_ha_to_proxy
=== RUN   TestAccDcsInstances_rw_change_capacity
=== PAUSE TestAccDcsInstances_rw_change_capacity
=== RUN   TestAccDcsInstances_rw_expand_replica
=== PAUSE TestAccDcsInstances_rw_expand_replica
=== RUN   TestAccDcsInstances_rw_to_proxy
=== PAUSE TestAccDcsInstances_rw_to_proxy
=== RUN   TestAccDcsInstances_proxy_change_capacity
=== PAUSE TestAccDcsInstances_proxy_change_capacity
=== RUN   TestAccDcsInstances_proxy_to_ha
=== PAUSE TestAccDcsInstances_proxy_to_ha
=== RUN   TestAccDcsInstances_proxy_to_rw
=== PAUSE TestAccDcsInstances_proxy_to_rw
=== RUN   TestAccDcsInstances_cluster_change_capacity
=== PAUSE TestAccDcsInstances_cluster_change_capacity
=== RUN   TestAccDcsInstances_cluster_expand_replica
=== PAUSE TestAccDcsInstances_cluster_expand_replica
=== RUN   TestAccDcsInstances_withEpsId
=== PAUSE TestAccDcsInstances_withEpsId
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== RUN   TestAccDcsInstances_prePaid
=== PAUSE TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_tiny
=== CONT  TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_rw_to_proxy
=== CONT  TestAccDcsInstances_rw_expand_replica
=== CONT  TestAccDcsInstances_rw_change_capacity
=== CONT  TestAccDcsInstances_ha_to_proxy
=== CONT  TestAccDcsInstances_ha_expand_replica
=== CONT  TestAccDcsInstances_proxy_change_capacity
=== CONT  TestAccDcsInstances_ha_change_capacity
=== CONT  TestAccDcsInstances_withEpsId
=== CONT  TestAccDcsInstances_cluster_change_capacity
=== CONT  TestAccDcsInstances_proxy_to_rw
=== CONT  TestAccDcsInstances_cluster_expand_replica
=== CONT  TestAccDcsInstances_proxy_to_ha
=== CONT  TestAccDcsInstances_single
--- PASS: TestAccDcsInstances_single (132.21s)
--- PASS: TestAccDcsInstances_withEpsId (169.57s)
--- PASS: TestAccDcsInstances_tiny (203.45s)
--- PASS: TestAccDcsInstances_prePaid (291.17s)
--- PASS: TestAccDcsInstances_whitelists (296.86s)
--- PASS: TestAccDcsInstances_ha_expand_replica (303.79s)
--- PASS: TestAccDcsInstances_rw_expand_replica (303.92s)
--- PASS: TestAccDcsInstances_basic (307.11s)
--- PASS: TestAccDcsInstances_rw_change_capacity (315.03s)
--- PASS: TestAccDcsInstances_ha_change_capacity (340.06s)
--- PASS: TestAccDcsInstances_cluster_expand_replica (586.63s)
--- PASS: TestAccDcsInstances_rw_to_proxy (606.78s)
--- PASS: TestAccDcsInstances_ha_to_proxy (645.72s)
--- PASS: TestAccDcsInstances_proxy_to_ha (781.58s)
--- PASS: TestAccDcsInstances_proxy_to_rw (791.20s)
--- PASS: TestAccDcsInstances_cluster_change_capacity (1448.30s)
--- PASS: TestAccDcsInstances_proxy_change_capacity (2233.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       2234.018s
```
