### PR TITLE
fix(AS): fix AS lifecycle hooks type fliter error

### DIFF
--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_lifecycle_hooks_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_lifecycle_hooks_test.go
@@ -103,7 +103,7 @@ data "huaweicloud_as_lifecycle_hooks" "filter_by_type" {
 }
 
 output "type_filter_is_useful" {
-  value = length(data.huaweicloud_as_lifecycle_hooks.filter_by_type.lifecycle_hooks) >= 0 && alltrue( 
+  value = length(data.huaweicloud_as_lifecycle_hooks.filter_by_type.lifecycle_hooks) > 0 && alltrue( 
     [for v in data.huaweicloud_as_lifecycle_hooks.filter_by_type.lifecycle_hooks[*].type : v == local.type]
   )  
 }

--- a/huaweicloud/services/as/data_source_huaweicloud_as_lifecycle_hooks.go
+++ b/huaweicloud/services/as/data_source_huaweicloud_as_lifecycle_hooks.go
@@ -130,20 +130,21 @@ func dataSourceLifeCycleHooksRead(_ context.Context, d *schema.ResourceData, met
 func flattenLifecycleHooks(d *schema.ResourceData, hooks *[]lifecyclehooks.Hook) ([]map[string]interface{}, error) {
 	rst := make([]map[string]interface{}, 0, len(*hooks))
 	for _, hook := range *hooks {
+		hookType, ok := convertHookTypeMap[hook.Type]
+		if !ok {
+			return nil, fmt.Errorf("lifecycle hook type (%s) is not in the map (%#v)", hook.Type, convertHookTypeMap)
+		}
+
 		if val, ok := d.GetOk("name"); ok && val.(string) != hook.Name {
 			continue
 		}
-		if val, ok := d.GetOk("type"); ok && val.(string) != hook.Type {
+		if val, ok := d.GetOk("type"); ok && val.(string) != hookType {
 			continue
 		}
 		if val, ok := d.GetOk("default_result"); ok && val.(string) != hook.DefaultResult {
 			continue
 		}
 
-		hookType, ok := convertHookTypeMap[hook.Type]
-		if !ok {
-			return nil, fmt.Errorf("lifecycle hook type (%s) is not in the map (%#v)", hook.Type, convertHookTypeMap)
-		}
 		lifecycleHookMap := map[string]interface{}{
 			"name":                    hook.Name,
 			"type":                    hookType,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #L136

When filtering the response, the user input (provider mapping values ​​ADD and REMOVE) is directly compared with the API response value (INSTANCE_LAUNCHING and INSTANCE_TERMINATING), triggering the continue

**Special notes for your reviewer**:

**Release note**:

```
 fix AS lifecycle hooks type fliter error
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccDataSourceLifecycleHook
s_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceLifecycleHooks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceLifecycleHooks_basic
=== PAUSE TestAccDataSourceLifecycleHooks_basic
=== CONT  TestAccDataSourceLifecycleHooks_basic
--- PASS: TestAccDataSourceLifecycleHooks_basic (243.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        243.705s
```
