### PR TITLE
feat(RAM): add a dataource to get the RAM shared resource list

### DIFF
--- a/docs/data-sources/ram_shared_resources.md
+++ b/docs/data-sources/ram_shared_resources.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Resource Access Manager (RAM)"
+---
+
+# huaweicloud_ram_shared_resources
+
+Use this data source to get the list of RAM shared resources.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_ram_shared_resources" "test" {
+  resource_owner = "self"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_owner` - (Required, String) Specifies the owner associated with the RAM share.
+  Value options are as follows:
+    + **self**: Shared to other users by myself.
+    + **other-accounts**: Shared to me by other users.
+
+* `principal` - (Optional, String) Specifies the principal associated with the RAM share.
+  The principal could be account ID or organization ID.
+  + If set to account ID, please make sure the account ID is not your owner account ID.
+  + If set to organization ID, you first need to use the RAM console to enable sharing with Organization. Please refer
+  to the [document](https://support.huaweicloud.com/intl/en-us/qs-ram/ram_02_0004.html).
+
+* `resource_ids` - (Optional, List) Specifies the list of resource IDs associated with the RAM share.
+
+* `resource_region` - (Optional, String) Specifies the resource region associated with the RAM share.
+
+* `resource_share_ids` - (Optional, List) Specifies the list of resource share IDs.
+
+* `resource_type` - (Optional, String) Specifies the resource type associated with the RAM share.
+
+* `resource_urns` - (Optional, List) Specifies one or more resources urns associated with the
+  RAM share. The format of URN is: `<service-name>:<region>:<account-id>:<type-name>:<resource-path>`.
+  Sharable cloud services and resource types refer to
+  [document](https://support.huaweicloud.com/intl/en-us/productdesc-ram/ram_01_0007.html).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `shared_resources` - The list of shared resources.
+  The [shared_resources](#attrblock--shared_resources) structure is documented below.
+
+<a name="attrblock--shared_resources"></a>
+The `shared_resources` block supports:
+
+* `resource_share_id` - The resource share ID.
+
+* `resource_type` - The resource type associated with the RAM share.
+
+* `resource_urn` - The resource urn associated with the RAM share.
+
+* `status` - The status of the RAM share.
+
+* `created_at` - The creation time of the RAM share.
+
+* `updated_at` - The latest update time of the RAM share.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -601,6 +601,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
 
 			"huaweicloud_ram_resource_permissions": ram.DataSourceRAMPermissions(),
+			"huaweicloud_ram_shared_resources":     ram.DataSourceRAMSharedResources(),
 
 			"huaweicloud_rds_flavors":              rds.DataSourceRdsFlavor(),
 			"huaweicloud_rds_engine_versions":      rds.DataSourceRdsEngineVersionsV3(),

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_shared_resources_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_shared_resources_test.go
@@ -1,0 +1,62 @@
+package ram
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceRAMSharedResources_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_ram_shared_resources.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceRAMSharedReources_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "shared_resources.0.resource_urn"),
+					resource.TestCheckResourceAttrSet(rName, "shared_resources.0.resource_type"),
+					resource.TestCheckResourceAttrSet(rName, "shared_resources.0.resource_share_id"),
+					resource.TestCheckResourceAttrSet(rName, "shared_resources.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "shared_resources.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "shared_resources.0.updated_at"),
+
+					resource.TestCheckOutput("resource_type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceRAMSharedReources_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_ram_shared_resources" "test" {
+  resource_owner = "self"
+}
+
+data "huaweicloud_ram_shared_resources" "resource_type_filter" {
+  resource_owner = "self"
+  resource_type  = data.huaweicloud_ram_shared_resources.test.shared_resources.0.resource_type
+}
+
+locals {
+  resource_type = data.huaweicloud_ram_shared_resources.test.shared_resources.0.resource_type
+}
+
+output "resource_type_filter_is_useful" {
+  value = length(data.huaweicloud_ram_shared_resources.test.shared_resources) > 0 && alltrue(
+    [for v in data.huaweicloud_ram_shared_resources.resource_type_filter.shared_resources[*].resource_type : v == local.resource_type]
+  )
+}
+`, testRAMShare_basic(name))
+}

--- a/huaweicloud/services/ram/data_source_huaweicloud_ram_shared_resources.go
+++ b/huaweicloud/services/ram/data_source_huaweicloud_ram_shared_resources.go
@@ -1,0 +1,184 @@
+package ram
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const pageLimit = 20
+
+// @API RAM POST /v1/shared-resources/search
+func DataSourceRAMSharedResources() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceRAMSharedResourcesRead,
+		Schema: map[string]*schema.Schema{
+			"resource_owner": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"principal": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"resource_urns": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"resource_share_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"resource_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"shared_resources": {
+				Type:     schema.TypeList,
+				Elem:     sharedResourcesSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func sharedResourcesSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resource_urn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_share_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceRAMSharedResourcesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		getRAMSharedResourcesHttpUrl = "v1/shared-resources/search"
+		getRAMSharedResourcesProduct = "ram"
+	)
+	getRAMSharedResourcesClient, err := cfg.NewServiceClient(getRAMSharedResourcesProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RAM client: %s", err)
+	}
+
+	getRAMSharedResourcesPath := getRAMSharedResourcesClient.Endpoint + getRAMSharedResourcesHttpUrl
+
+	getRAMSharedResourcesOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	allSharedResources := make([]interface{}, 0)
+	var nextMarker string
+	getRAMSharedResourcesOpt.JSONBody = utils.RemoveNil(buildgetRAMSharedResourcesBodyParams(d))
+	getRAMSharedResourcesJSONBody := getRAMSharedResourcesOpt.JSONBody.(map[string]interface{})
+	for {
+		getRAMSharedResourcesResp, err := getRAMSharedResourcesClient.Request("POST", getRAMSharedResourcesPath, &getRAMSharedResourcesOpt)
+		if err != nil {
+			return common.CheckDeletedDiag(d, err, "error retrieving RAM shared resources")
+		}
+
+		getRAMSharedResourcesRespBody, err := utils.FlattenResponse(getRAMSharedResourcesResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		sharedResources := utils.PathSearch("shared_resources", getRAMSharedResourcesRespBody, make([]interface{}, 0)).([]interface{})
+		if len(sharedResources) > 0 {
+			allSharedResources = append(allSharedResources, sharedResources...)
+		}
+
+		nextMarker = utils.PathSearch("page_info.next_marker", getRAMSharedResourcesRespBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+		getRAMSharedResourcesJSONBody["marker"] = nextMarker
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("shared_resources", flattenGetSharedResourcesResponseBody(allSharedResources)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildgetRAMSharedResourcesBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"principal":          utils.ValueIngoreEmpty(d.Get("principal")),
+		"resource_urns":      utils.ValueIngoreEmpty(d.Get("resource_urns")),
+		"resource_ids":       utils.ValueIngoreEmpty(d.Get("resource_ids")),
+		"resource_owner":     d.Get("resource_owner"),
+		"resource_share_ids": utils.ValueIngoreEmpty(d.Get("resource_share_ids")),
+		"resource_type":      utils.ValueIngoreEmpty(d.Get("resource_type")),
+		"resource_region":    utils.ValueIngoreEmpty(d.Get("resource_region")),
+		"limit":              pageLimit,
+	}
+	return bodyParams
+}
+
+func flattenGetSharedResourcesResponseBody(curArray []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"resource_urn":      utils.PathSearch("resource_urn", v, nil),
+			"resource_type":     utils.PathSearch("resource_type", v, nil),
+			"resource_share_id": utils.PathSearch("resource_share_id", v, nil),
+			"status":            utils.PathSearch("status", v, nil),
+			"created_at":        utils.PathSearch("created_at", v, nil),
+			"updated_at":        utils.PathSearch("updated_at", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a dataource to get the RAM shared resource list
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add a dataource to get the RAM shared resource list
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST=./huaweicloud/services/acceptance/ram TESTARGS='-run TestAccDatasourceRAMSharedResources_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccDatasourceRAMSharedResources_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceRAMSharedResources_basic
=== PAUSE TestAccDatasourceRAMSharedResources_basic
=== CONT  TestAccDatasourceRAMSharedResources_basic
--- PASS: TestAccDatasourceRAMSharedResources_basic (28.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       28.256s
```
