### PR TITLE
feat(RDS): add RDS SQLServer accounts data source

### DIFF
--- a/docs/data-sources/rds_sqlserver_accounts.md
+++ b/docs/data-sources/rds_sqlserver_accounts.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_sqlserver_accounts
+
+Use this data source to get the list of RDS SQLServer accounts.
+
+## Example Usage
+
+```hcl
+var "instance_id" {}
+
+data "huaweicloud_rds_sqlserver_accounts" "test" {
+  instance_id = var.instance_id
+  user_name   = "test"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RDS SQLServer instance.
+
+* `user_name` - (Optional, String) Specifies the username of the database account.
+
+* `state` - (Optional, String) Specifies the database user status. Its value can be any of the following:
+  + **unavailable**: The database user is unavailable.
+  + **available**: The database user is available.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `users` - Indicates the list of users.
+  The [users](#RDS_sqlserver_users) structure is documented below.
+
+<a name="RDS_sqlserver_users"></a>
+The `users` block supports:
+
+* `name` - Indicates the username of the database account.
+
+* `state` - Indicates the database user status.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -610,6 +610,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_storage_types":             rds.DataSourceStoragetype(),
 			"huaweicloud_rds_sqlserver_collations":      rds.DataSourceSQLServerCollations(),
 			"huaweicloud_rds_sqlserver_databases":       rds.DataSourceSQLServerDatabases(),
+			"huaweicloud_rds_sqlserver_accounts":        rds.DataSourceRdsSQLServerAccounts(),
 			"huaweicloud_rds_pg_plugins":                rds.DataSourcePgPlugins(),
 			"huaweicloud_rds_pg_accounts":               rds.DataSourcePgAccounts(),
 			"huaweicloud_rds_pg_databases":              rds.DataSourcePgDatabases(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sqlserver_accounts_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sqlserver_accounts_test.go
@@ -1,0 +1,80 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSQLServerAccounts_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_rds_sqlserver_accounts.test"
+	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
+		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSQLServerAccounts_basic(name, dbPwd),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "users.#"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.state"),
+					resource.TestCheckOutput("user_name_filter_is_useful", "true"),
+					resource.TestCheckOutput("state_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSQLServerAccounts_basic(name string, dbPwd string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rds_sqlserver_accounts" "test" {
+  depends_on  = [huaweicloud_rds_sqlserver_account.test]
+  instance_id = huaweicloud_rds_sqlserver_account.test.instance_id
+}
+
+data "huaweicloud_rds_sqlserver_accounts" "user_name_filter" {
+  depends_on  = [huaweicloud_rds_sqlserver_account.test]
+  instance_id = huaweicloud_rds_sqlserver_account.test.instance_id
+  user_name   = huaweicloud_rds_sqlserver_account.test.name
+}
+
+locals {
+  user_name = huaweicloud_rds_sqlserver_account.test.name
+}
+
+output "user_name_filter_is_useful" {
+  value = length(data.huaweicloud_rds_sqlserver_accounts.user_name_filter.users) > 0 && alltrue(
+    [for v in data.huaweicloud_rds_sqlserver_accounts.user_name_filter.users[*].name : v == local.user_name]
+  )
+}
+
+data "huaweicloud_rds_sqlserver_accounts" "state_filter" {
+  depends_on  = [huaweicloud_rds_sqlserver_account.test]
+  instance_id = huaweicloud_rds_sqlserver_account.test.instance_id
+  state       = huaweicloud_rds_sqlserver_account.test.state
+}
+
+locals {
+  state = huaweicloud_rds_sqlserver_account.test.state
+}
+
+output "state_filter_is_useful" {
+  value = length(data.huaweicloud_rds_sqlserver_accounts.state_filter.users) > 0 && alltrue(
+    [for v in data.huaweicloud_rds_sqlserver_accounts.state_filter.users[*].state : v == local.state]
+  )
+}
+`, testSQLServerAccount_basic(name, dbPwd))
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_sqlserver_accounts.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_sqlserver_accounts.go
@@ -1,0 +1,159 @@
+package rds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RDS GET /v3/{project_id}/instances/{instance_id}/db_user/detail
+func DataSourceRdsSQLServerAccounts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsSQLServerAccountsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"users": {
+				Type:     schema.TypeList,
+				Elem:     sqlServerUsersSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func sqlServerUsersSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceRdsSQLServerAccountsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		listSQLServerAccountsHttpUrl = "v3/{project_id}/instances/{instance_id}/db_user/detail?page=1&limit=100"
+		listSQLServerAccountsProduct = "rds"
+	)
+	listSQLServerAccountsClient, err := cfg.NewServiceClient(listSQLServerAccountsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	listSQLServerAccountsPath := listSQLServerAccountsClient.Endpoint + listSQLServerAccountsHttpUrl
+	listSQLServerAccountsPath = strings.ReplaceAll(listSQLServerAccountsPath, "{project_id}",
+		listSQLServerAccountsClient.ProjectID)
+	listSQLServerAccountsPath = strings.ReplaceAll(listSQLServerAccountsPath, "{instance_id}",
+		fmt.Sprintf("%v", d.Get("instance_id")))
+
+	listSQLServerAccountsResp, err := pagination.ListAllItems(
+		listSQLServerAccountsClient,
+		"page",
+		listSQLServerAccountsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving RDS SQLServer accounts %S", err)
+	}
+
+	listSQLServerAccountsRespJson, err := json.Marshal(listSQLServerAccountsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listSQLServerAccountsRespBody interface{}
+	err = json.Unmarshal(listSQLServerAccountsRespJson, &listSQLServerAccountsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("users", flattenListSQLServerAccountsBody(filterListSQLServerAccounts(d, listSQLServerAccountsRespBody))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListSQLServerAccountsBody(resp []interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(resp))
+
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"name":  utils.PathSearch("name", v, nil),
+			"state": utils.PathSearch("state", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterListSQLServerAccounts(d *schema.ResourceData, resp interface{}) []interface{} {
+	usersJson := utils.PathSearch("users", resp, make([]interface{}, 0))
+	userArray := usersJson.([]interface{})
+	if len(userArray) < 1 {
+		return nil
+	}
+	result := make([]interface{}, 0)
+
+	rawName, rawNameOK := d.GetOk("user_name")
+	rawState, rawStateOk := d.GetOk("state")
+
+	for _, user := range userArray {
+		name := utils.PathSearch("name", user, nil)
+		state := utils.PathSearch("state", user, nil)
+		if rawNameOK && rawName != name {
+			continue
+		}
+		if rawStateOk && rawState != state {
+			continue
+		}
+		result = append(result, user)
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add RDS SQLServer accounts data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add RDS SQLServer accounts data source
```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST='./huaweicloud/services/acceptance/rds/' TESTARGS='-run TestAccSQLServerAccounts_basic'                                                                                                               
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccSQLServerAccounts_basic -timeout 360m -parallel 4 
=== RUN   TestAccSQLServerAccounts_basic 
=== PAUSE TestAccSQLServerAccounts_basic
=== CONT  TestAccSQLServerAccounts_basic
--- PASS: TestAccSQLServerAccounts_basic (1276.50s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1276.546s
```
