### PR TITLE
feat(VPN): VPN connection resource support tags field

### DIFF
--- a/docs/resources/vpn_connection.md
+++ b/docs/resources/vpn_connection.md
@@ -108,6 +108,8 @@ The [ipsecpolicy](#Connection_CreateRequestIpsecPolicy) structure is documented 
 * `policy_rules` - (Optional, List) The policy rules. Only works when vpn_type is set to **policy**
 The [policy_rules](#Connection_PolicyRule) structure is documented below.
 
+* `tags` - (Optional, Map) Specifies the tags of the VPN connection.
+
 <a name="Connection_CreateRequestIkePolicy"></a>
 The `ikepolicy` block supports:
 

--- a/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_test.go
+++ b/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_test.go
@@ -80,6 +80,8 @@ func TestAccConnection_basic(t *testing.T) {
 						"huaweicloud_vpn_gateway.test", "master_eip.0.id"),
 					resource.TestCheckResourceAttrPair(rName, "customer_gateway_id",
 						"huaweicloud_vpn_customer_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "val"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 				),
 			},
 			{
@@ -93,6 +95,8 @@ func TestAccConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "ipsecpolicy.0.authentication_algorithm", "sha2-512"),
 					resource.TestCheckResourceAttr(rName, "ipsecpolicy.0.encryption_algorithm", "aes-256"),
 					resource.TestCheckResourceAttr(rName, "ipsecpolicy.0.lifetime_seconds", "7200"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "val"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar-update"),
 				),
 			},
 			{
@@ -165,6 +169,11 @@ resource "huaweicloud_vpn_connection" "test" {
   peer_subnets        = ["192.168.55.0/24"]
   vpn_type            = "static"
   psk                 = "Test@123"
+
+  tags = {
+    key = "val"
+    foo = "bar"
+  }
 }
 `, testGateway_basic(name), testCustomerGateway_basic(name, ipAddress), name)
 }
@@ -193,6 +202,11 @@ resource "huaweicloud_vpn_connection" "test" {
     authentication_algorithm = "sha2-512"
     encryption_algorithm     = "aes-256"
     lifetime_seconds         = 7200
+  }
+
+  tags = {
+    key = "val"
+    foo = "bar-update"
   }
 }
 `, testGateway_basic(name), testCustomerGateway_basic(name, ipAddress), name)


### PR DESCRIPTION
**What this PR does / why we need it**:
VPN connection resource support tags field

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
VPN connection resource support tags field
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccConnection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccConnection_basic
=== PAUSE TestAccConnection_basic
=== CONT  TestAccConnection_basic
--- PASS: TestAccConnection_basic (469.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       469.820s
```
