### PR TITLE
feat(AOM): prometheus instance support parameter prom version and prom type

### DIFF
--- a/docs/resources/aom_prom_instance.md
+++ b/docs/resources/aom_prom_instance.md
@@ -38,6 +38,8 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of the
   AOM prometheus instance. Changing this parameter will create a new resource.
 
+* `prom_version` - (Optional, String, ForceNew) Specifies the version of AOM prometheus instance.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -47,8 +49,6 @@ In addition to all arguments above, the following attributes are exported:
 * `created_at` - The creation time of AOM prometheus instance.
 
 * `prom_http_api_endpoint` - The url for calling the AOM Prometheus instance.
-
-* `prom_version` - The version of AOM prometheus instance.
 
 * `remote_read_url` - The remote read address of AOM Prometheus instance.
 

--- a/docs/resources/aom_prom_instance.md
+++ b/docs/resources/aom_prom_instance.md
@@ -31,7 +31,7 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
 
 * `prom_type` - (Required, String, ForceNew) Specifies the type of the AOM prometheus instance.
-  The value can be: **DEFAULT**, **ECS**, **VPC**, **CCE**, **REMOTE_WRITE**, **KUBERNETES**,
+  The value can be: **ECS**, **VPC**, **CCE**, **REMOTE_WRITE**, **KUBERNETES**,
   **CLOUD_SERVICE** or **ACROSS_ACCOUNT**.
   Changing this parameter will create a new resource.
 

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
@@ -74,6 +74,7 @@ func TestAccPromInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "prom_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "prom_type", "VPC"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "prom_version", "1.5"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "remote_write_url"),
 					resource.TestCheckResourceAttrSet(resourceName, "remote_read_url"),
@@ -95,6 +96,7 @@ resource "huaweicloud_aom_prom_instance" "test" {
   prom_name             = "%s"
   prom_type             = "VPC"
   enterprise_project_id = "0"
+  prom_version          = "1.5"
 }
 `, name)
 }

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
@@ -72,7 +72,7 @@ func TestAccPromInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "prom_name", rName),
-					resource.TestCheckResourceAttr(resourceName, "prom_type", "DEFAULT"),
+					resource.TestCheckResourceAttr(resourceName, "prom_type", "VPC"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "remote_write_url"),
@@ -93,7 +93,7 @@ func tesAOMPromInstance_basic(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_aom_prom_instance" "test" {
   prom_name             = "%s"
-  prom_type             = "DEFAULT"
+  prom_type             = "VPC"
   enterprise_project_id = "0"
 }
 `, name)

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
@@ -55,7 +55,11 @@ func ResourcePromInstance() *schema.Resource {
 				ForceNew: true,
 				Optional: true,
 			},
-
+			"prom_version": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
 			// attributes
 			"remote_write_url": {
 				Type:     schema.TypeString,
@@ -66,10 +70,6 @@ func ResourcePromInstance() *schema.Resource {
 				Computed: true,
 			},
 			"prom_http_api_endpoint": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"prom_version": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -123,6 +123,7 @@ func buildCreatePrometheusInstanceBodyParams(d *schema.ResourceData, cfg *config
 	bodyParams := map[string]interface{}{
 		"prom_name":             d.Get("prom_name"),
 		"prom_type":             d.Get("prom_type"),
+		"prom_version":          d.Get("prom_version"),
 		"enterprise_project_id": utils.ValueIngoreEmpty(cfg.GetEnterpriseProjectID(d)),
 	}
 	return bodyParams

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_prom_instance.go
@@ -108,8 +108,8 @@ func resourcePromInstanceCreate(ctx context.Context, d *schema.ResourceData, met
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	id, err := jmespath.Search("prometheus[0].prom_id", createPrometheusInstanceRespBody)
+	expression := fmt.Sprintf("prometheus[?prom_name== '%s'].prom_id | [0]", d.Get("prom_name"))
+	id, err := jmespath.Search(expression, createPrometheusInstanceRespBody)
 	if err != nil || id == nil {
 		return diag.Errorf("error creating AOM prometheus instance: ID is not found in API response")
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The prom instance API has upgrade:
1. prom type value range changed, the service not allowed to create default type instance, so remove the default type.
2. the list API response object order changed. 
3. support new parameter prom version.

**Special notes for your reviewer**:

**Release note**:
1.modify testcase to ensure normal service.
2.support new parameter prom version.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/aom TESTARGS='-run TestAccPromInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccPromInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccPromInstance_basic
=== PAUSE TestAccPromInstance_basic
=== CONT  TestAccPromInstance_basic
--- PASS: TestAccPromInstance_basic (14.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       14.505s

