### PR TITLE
fix: OBS kms remove default project id configuration

### DIFF
--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -793,11 +793,7 @@ func resourceObsBucketEncryptionUpdate(config *config.Config, obsClient *obs.Obs
 		if input.SSEAlgorithm == obs.DEFAULT_SSE_KMS_ENCRYPTION_OBS {
 			if raw, ok := d.GetOk("kms_key_id"); ok {
 				input.KMSMasterKeyID = raw.(string)
-				if v, ok := d.GetOk("kms_key_project_id"); ok {
-					input.ProjectID = v.(string)
-				} else {
-					input.ProjectID = config.GetProjectID(config.GetRegion(d))
-				}
+				input.ProjectID = d.Get("kms_key_project_id").(string)
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

OBS KMS remove default project id configuration

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- When `kms_key_project_id` is not configured, there is no need to fill in the default project ID.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/7df32232-9047-477c-8011-39ba4de19f6f)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/obs' TESTARGS='-run TestAccObsBucket_encryption'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/obs -v -run TestAccObsBucket_encryption -timeout 360m -parallel 4
=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== CONT  TestAccObsBucket_encryption
--- PASS: TestAccObsBucket_encryption (55.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       55.242s
```
