### PR TITLE
chore(eip): support updating charge mode in bandwidth

### DIFF
--- a/docs/resources/vpc_bandwidth.md
+++ b/docs/resources/vpc_bandwidth.md
@@ -25,12 +25,16 @@ The following arguments are supported:
 * `name` - (Required, String) Specifies the bandwidth name. The value is a string of 1 to 64 characters that
   can contain letters, digits, underscores (_), hyphens (-), and periods (.).
 
-* `size` - (Required, Int) Specifies the size of the Shared Bandwidth. The value ranges from 5 Mbit/s to 2000 Mbit/s.
+* `size` - (Required, Int) Specifies the size of the Shared Bandwidth.
+  If `charge_mode` is **bandwidth**, the value ranges from 5 Mbit/s to 2000 Mbit/s.
+  If `charge_mode` is **95peak_plus**, the value ranges from 300 Mbit/s to 2000 Mbit/s.
 
-* `charge_mode` - (Optional, String, ForceNew) Specifies whether the billing is based on bandwidth or
+* `charge_mode` - (Optional, String) Specifies whether the billing is based on bandwidth or
   95th percentile bandwidth (enhanced). Possible values can be **bandwidth** and **95peak_plus**.
   The default value is **bandwidth**, and **95peak_plus** is only valid for v4 and v5 Customer.
-  Changing this creates a new bandwidth.
+  
+-> **NOTE:** When `charging_mode` is **prePaid**, only **bandwidth** is valid, please updating `charge_mode`
+  to **bandwidth** before changing to **prePaid** billing mode.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the Shared Bandwidth.
   Changing this creates a new bandwidth.

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_bandwidth_test.go
@@ -49,17 +49,19 @@ func TestAccVpcBandWidth_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "NORMAL"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
 					resource.TestCheckResourceAttr(resourceName, "publicips.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "charge_mode", "bandwidth"),
 				),
 			},
 			{
-				Config: testAccVpcBandWidth_basic(randName+"_update", 6),
+				Config: testAccVpcBandWidth_update(randName+"_update", 300),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", randName+"_update"),
-					resource.TestCheckResourceAttr(resourceName, "size", "6"),
+					resource.TestCheckResourceAttr(resourceName, "size", "300"),
 					resource.TestCheckResourceAttr(resourceName, "share_type", "WHOLE"),
 					resource.TestCheckResourceAttr(resourceName, "status", "NORMAL"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
+					resource.TestCheckResourceAttr(resourceName, "charge_mode", "95peak_plus"),
 				),
 			},
 			{
@@ -258,6 +260,17 @@ resource "huaweicloud_vpc_bandwidth" "test" {
   size = "%d"
 
   charging_mode = "postPaid"
+}
+`, rName, size)
+}
+
+func testAccVpcBandWidth_update(rName string, size int) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_bandwidth" "test" {
+  name = "%s"
+  size = "%d"
+
+  charge_mode = "95peak_plus"
 }
 `, rName, size)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support updating `charge_mode` in `huaweicloud_vpc_bandwidth` and `huaweicloud_vpc_bandwidth_v1`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccVpcBandWidth_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccVpcBandWidth_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcBandWidth_basic
=== PAUSE TestAccVpcBandWidth_basic
=== CONT  TestAccVpcBandWidth_basic
--- PASS: TestAccVpcBandWidth_basic (35.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       35.447s
```
