### PR TITLE
feat(nat): add a new data source to get the list of the snat rules

### DIFF
--- a/docs/data-sources/nat_snat_rules.md
+++ b/docs/data-sources/nat_snat_rules.md
@@ -1,0 +1,93 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# huaweicloud_nat_snat_rules
+
+Use this data source to get the list of SNAT rules.
+
+## Example Usage
+
+```hcl
+variable "rule_id" {}
+
+data "huaweicloud_nat_snat_rules" "test" {
+  rule_id = var.rule_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the SNAT rules are located.
+  If omitted, the provider-level region will be used.
+
+* `rule_id` - (Optional, String) Specifies the ID of the SNAT rule.
+
+* `gateway_id` - (Optional, String) Specifies the ID of the NAT gateway to which the SNAT rule belongs.
+
+* `floating_ip_id` - (Optional, String) Specifies the ID of the EIP associated with SNAT rule.
+
+* `floating_ip_address` - (Optional, String) Specifies the IP of the EIP associated with SNAT rule.
+
+* `cidr` - (Optional, String) Specifies the CIDR block to which the SNAT rule belongs.
+
+* `subnet_id` - (Optional, String) Specifies the ID of the subnet to which the SNAT rule belongs.
+
+* `source_type` - (Optional, String) Specifies the source type of the SNAT rule.
+  The value can be one of the following:
+  + **0** : The use scenario is VPC.
+  + **1** : The use scenario is DC.
+
+* `status` - (Optional, String) Specifies the status of the SNAT rule.
+  The value can be one of the following:
+  + **ACTIVE**: The SNAT rule is available.
+  + **EIP_FREEZED**: The global EIP is frozen associated with SNAT rule.
+  + **INACTIVE**: The SNAT rule is unavailable.
+
+* `global_eip_id` - (Optional, String) Specifies the ID of the global EIP associated with SNAT rule.
+
+* `global_eip_address` - (Optional, String) Specifies the IP of the global EIP associated with SNAT rule.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - The list of the SNAT rules.
+  The [rules](#nat_snat_rules) structure is documented below.
+
+<a name="nat_snat_rules"></a>
+The `rules` block supports:
+
+* `id` - The ID of the SNAT rule.
+
+* `gateway_id` - The ID of the NAT gateway to which the SNAT rule belongs.
+
+* `cidr` - The CIDR block to which the SNAT rule belongs.
+
+* `subnet_id` - The ID of the subnet to which the SNAT rule belongs.
+
+* `source_type` - The source type of the SNAT rule.
+
+* `floating_ip_id` - The IDs of the EIP associated with SNAT rule, multiple EIP IDs separate by commas.
+  e.g. **ID1,ID2**.
+
+* `floating_ip_address` - The IPs of the EIP associated with SNAT rule, multiple EIP IPs separate by commas.
+  e.g. **IP1,IP2**.
+
+* `description` - The description of the SNAT rule.
+
+* `status` - The status of the SNAT rule.
+
+* `global_eip_id` - The IDs of the global EIP associated with SNAT rule, multiple global EIP IDs separate by commas.
+  e.g. **ID1,ID2**.
+
+* `global_eip_address` - The IPs of the global EIP associated with SNAT rule, multiple global EIP IPs separate by commas.
+  e.g. **IP1,IP2**.
+
+* `freezed_ip_address` - The IP of the frozen global EIP associated with SNAT rule.
+
+* `created_at` - The creation time of the SNAT rule.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -581,6 +581,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_nat_private_gateways":    nat.DataSourcePrivateGateways(),
 			"huaweicloud_nat_private_snat_rules":  nat.DataSourcePrivateSnatRules(),
 			"huaweicloud_nat_private_transit_ips": nat.DataSourcePrivateTransitIps(),
+			"huaweicloud_nat_snat_rules":          nat.DataSourceSnatRules(),
 
 			"huaweicloud_networking_port":           vpc.DataSourceNetworkingPortV2(),
 			"huaweicloud_networking_secgroup":       vpc.DataSourceNetworkingSecGroup(),

--- a/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_snat_rules_test.go
+++ b/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_snat_rules_test.go
@@ -1,0 +1,367 @@
+package nat
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDatasourceSnatRules_basic(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceName()
+		baseConfig     = testAccSnatRulesDataSource_base(name)
+		dataSourceName = "data.huaweicloud_nat_snat_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byRuleId   = "data.huaweicloud_nat_snat_rules.filter_by_rule_id"
+		dcByRuleId = acceptance.InitDataSourceCheck(byRuleId)
+
+		byGatewayId   = "data.huaweicloud_nat_snat_rules.filter_by_gateway_id"
+		dcByGatewayId = acceptance.InitDataSourceCheck(byGatewayId)
+
+		bySourceType   = "data.huaweicloud_nat_snat_rules.filter_by_source_type"
+		dcBySourceType = acceptance.InitDataSourceCheck(bySourceType)
+
+		bySubnetId   = "data.huaweicloud_nat_snat_rules.filter_by_subnet_id"
+		dcBySubnetId = acceptance.InitDataSourceCheck(bySubnetId)
+
+		byEipId   = "data.huaweicloud_nat_snat_rules.filter_by_floating_ip_id"
+		dcByEipId = acceptance.InitDataSourceCheck(byEipId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceSnatRules_basic(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					dcByRuleId.CheckResourceExists(),
+					resource.TestCheckOutput("rule_id_filter_is_useful", "true"),
+
+					dcByGatewayId.CheckResourceExists(),
+					resource.TestCheckOutput("gateway_id_filter_is_useful", "true"),
+
+					dcBySourceType.CheckResourceExists(),
+					resource.TestCheckOutput("source_type_filter_is_useful", "true"),
+
+					dcBySubnetId.CheckResourceExists(),
+					resource.TestCheckOutput("subnet_id_filter_is_useful", "true"),
+
+					dcByEipId.CheckResourceExists(),
+					resource.TestCheckOutput("floating_ip_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSnatRulesDataSource_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_gateway" "test" {
+  name                  = "%[2]s"
+  description           = "created by terraform"
+  spec                  = "1"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[2]s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_nat_snat_rule" "test" {
+  nat_gateway_id = huaweicloud_nat_gateway.test.id
+  floating_ip_id = huaweicloud_vpc_eip.test.id
+  subnet_id      = huaweicloud_vpc_subnet.test.id
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccDatasourceSnatRules_basic(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_nat_snat_rules" "test" {
+  depends_on = [
+    huaweicloud_nat_snat_rule.test
+  ]
+}
+
+locals {
+  rule_id = data.huaweicloud_nat_snat_rules.test.rules[0].id
+}
+
+data "huaweicloud_nat_snat_rules" "filter_by_rule_id" {
+  rule_id = local.rule_id
+}
+
+locals {
+  rule_id_filter_result = [
+    for v in data.huaweicloud_nat_snat_rules.filter_by_rule_id.rules[*].id : v == local.rule_id
+  ]
+}
+
+output "rule_id_filter_is_useful" {
+  value = alltrue(local.rule_id_filter_result) && length(local.rule_id_filter_result) > 0
+}
+
+locals {
+  gateway_id = data.huaweicloud_nat_snat_rules.test.rules[0].gateway_id
+}
+
+data "huaweicloud_nat_snat_rules" "filter_by_gateway_id" {
+  gateway_id = local.gateway_id
+}
+
+locals {
+  gateway_id_filter_result = [
+    for v in data.huaweicloud_nat_snat_rules.filter_by_gateway_id.rules[*].gateway_id : v == local.gateway_id
+  ]
+}
+
+output "gateway_id_filter_is_useful" {
+  value = alltrue(local.gateway_id_filter_result) && length(local.gateway_id_filter_result) > 0
+}
+
+locals {
+  source_type = data.huaweicloud_nat_snat_rules.test.rules[0].source_type
+}
+
+data "huaweicloud_nat_snat_rules" "filter_by_source_type" {
+  source_type = local.source_type
+}
+
+locals {
+  source_type_filter_result = [
+    for v in data.huaweicloud_nat_snat_rules.filter_by_source_type.rules[*].source_type : v == local.source_type
+  ]
+}
+
+output "source_type_filter_is_useful" {
+  value = alltrue(local.source_type_filter_result) && length(local.source_type_filter_result) > 0
+}
+
+locals {
+  subnet_id = data.huaweicloud_nat_snat_rules.test.rules[0].subnet_id
+}
+
+data "huaweicloud_nat_snat_rules" "filter_by_subnet_id" {
+  subnet_id = local.subnet_id
+}
+
+locals {
+  subnet_id_filter_result = [
+    for v in data.huaweicloud_nat_snat_rules.filter_by_subnet_id.rules[*].subnet_id : v == local.subnet_id
+  ]
+}
+
+output "subnet_id_filter_is_useful" {
+  value = alltrue(local.subnet_id_filter_result) && length(local.subnet_id_filter_result) > 0
+}
+
+locals {
+  floating_ip_id = data.huaweicloud_nat_snat_rules.test.rules[0].floating_ip_id
+}
+
+data "huaweicloud_nat_snat_rules" "filter_by_floating_ip_id" {
+  floating_ip_id = local.floating_ip_id
+}
+
+locals {
+  floating_ip_id_filter_result = [
+    for v in data.huaweicloud_nat_snat_rules.filter_by_floating_ip_id.rules[*].floating_ip_id : 
+    v == local.floating_ip_id
+  ]
+}
+
+output "floating_ip_id_filter_is_useful" {
+  value = alltrue(local.floating_ip_id_filter_result) && length(local.floating_ip_id_filter_result) > 0
+}
+`, baseConfig)
+}
+
+func TestAccDatasourceSnatRules_direct(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceName()
+		baseConfig     = testAccSnatRulesDataSource_direct_base(name)
+		dataSourceName = "data.huaweicloud_nat_snat_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byCidr   = "data.huaweicloud_nat_snat_rules.filter_by_cidr"
+		dcByCidr = acceptance.InitDataSourceCheck(byCidr)
+
+		bySourceType   = "data.huaweicloud_nat_snat_rules.filter_by_source_type"
+		dcBySourceType = acceptance.InitDataSourceCheck(bySourceType)
+
+		byStatus   = "data.huaweicloud_nat_snat_rules.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byEipAddress   = "data.huaweicloud_nat_snat_rules.filter_by_floating_ip_address"
+		dcByEipAddress = acceptance.InitDataSourceCheck(byEipAddress)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceSnatRules_direct(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					dcByCidr.CheckResourceExists(),
+					resource.TestCheckOutput("cidr_filter_is_useful", "true"),
+
+					dcBySourceType.CheckResourceExists(),
+					resource.TestCheckOutput("source_type_filter_is_useful", "true"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+
+					dcByEipAddress.CheckResourceExists(),
+					resource.TestCheckOutput("floating_ip_address_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSnatRulesDataSource_direct_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_gateway" "test" {
+  name                  = "%[2]s"
+  description           = "created by terraform"
+  spec                  = "1"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[2]s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_nat_snat_rule" "direct" {
+  nat_gateway_id = huaweicloud_nat_gateway.test.id
+  floating_ip_id = huaweicloud_vpc_eip.test.id
+  source_type    = 1
+  cidr           = "192.168.1.0/24"  
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccDatasourceSnatRules_direct(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_nat_snat_rules" "test" {
+  depends_on = [
+    huaweicloud_nat_snat_rule.direct
+  ]
+}
+
+locals {
+  cidr = data.huaweicloud_nat_snat_rules.test.rules[0].cidr
+}
+
+data "huaweicloud_nat_snat_rules" "filter_by_cidr" {
+  cidr = local.cidr
+}
+
+locals {
+  cidr_filter_result = [
+    for v in data.huaweicloud_nat_snat_rules.filter_by_cidr.rules[*].cidr : 
+    v == local.cidr
+  ]
+}
+
+output "cidr_filter_is_useful" {
+  value = alltrue(local.cidr_filter_result) && length(local.cidr_filter_result) > 0
+}
+
+locals {
+  source_type = data.huaweicloud_nat_snat_rules.test.rules[0].source_type
+}
+
+data "huaweicloud_nat_snat_rules" "filter_by_source_type" {
+  source_type = local.source_type
+}
+
+locals {
+  source_type_filter_result = [
+    for v in data.huaweicloud_nat_snat_rules.filter_by_source_type.rules[*].source_type : 
+    v == local.source_type
+  ]
+}
+
+output "source_type_filter_is_useful" {
+  value = alltrue(local.source_type_filter_result) && length(local.source_type_filter_result) > 0
+}
+
+locals {
+  status = data.huaweicloud_nat_snat_rules.test.rules[0].status
+}
+
+data "huaweicloud_nat_snat_rules" "filter_by_status" {
+  status = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_nat_snat_rules.filter_by_status.rules[*].status : 
+    v == local.status
+  ]
+}
+
+output "status_filter_is_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+
+locals {
+  floating_ip_address = data.huaweicloud_nat_snat_rules.test.rules[0].floating_ip_address
+}
+
+data "huaweicloud_nat_snat_rules" "filter_by_floating_ip_address" {
+  floating_ip_address = local.floating_ip_address
+}
+
+locals {
+  floating_ip_address_filter_result = [
+    for v in data.huaweicloud_nat_snat_rules.filter_by_floating_ip_address.rules[*].floating_ip_address : 
+    v == local.floating_ip_address
+  ]
+}
+
+output "floating_ip_address_filter_is_useful" {
+  value = alltrue(local.floating_ip_address_filter_result) && length(local.floating_ip_address_filter_result) > 0
+}
+`, baseConfig)
+}

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_snat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_snat_rules.go
@@ -1,0 +1,299 @@
+package nat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API NAT GET /v2/{project_id}/snat_rules
+func DataSourceSnatRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSnatRulesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The region where the SNAT rules are located.",
+			},
+			"rule_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the SNAT rule.",
+			},
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the NAT gateway to which the SNAT rule belongs.",
+			},
+			"floating_ip_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the EIP associated with SNAT rule.",
+			},
+			"floating_ip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The IP of the EIP associated with SNAT rule.",
+			},
+			"cidr": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The CIDR block to which the SNAT rule belongs.",
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the subnet to which the SNAT rule belongs.",
+			},
+			"source_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The source type of the SNAT rule.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The status of the SNAT rule.",
+			},
+			"global_eip_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The IDs of the global EIP associated with SNAT rule.",
+			},
+			"global_eip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The IPs of the global EIP associated with SNAT rule.",
+			},
+			"rules": {
+				Type:        schema.TypeList,
+				Elem:        snatRuleSchema(),
+				Computed:    true,
+				Description: "The list of the SNAT rules.",
+			},
+		},
+	}
+}
+
+func snatRuleSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the SNAT rule.",
+			},
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the NAT gateway to which the SNAT rule belongs.",
+			},
+			"cidr": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The CIDR block to which the SNAT rule belongs.",
+			},
+			"floating_ip_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the EIP associated with SNAT rule.",
+			},
+			"floating_ip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IP of the EIP associated with SNAT rule.",
+			},
+			"source_type": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The source type of the SNAT rule.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the SNAT rule.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the SNAT rule.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the SNAT rule.",
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the subnet to which the SNAT rule belongs.",
+			},
+			"global_eip_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the global EIP associated with SNAT rule.",
+			},
+			"global_eip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IP of the global EIP associated with SNAT rule.",
+			},
+			"freezed_ip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IP of the frozen global EIP associated with SNAT rule",
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceSnatRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// listSnatRules: Query the public SNAT rule list
+	var (
+		listSnatRulesHttpUrl = "v2/{project_id}/snat_rules"
+		listSnatRulesProduct = "nat"
+	)
+	listSnatRulesClient, err := cfg.NewServiceClient(listSnatRulesProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating NAT client: %s", err)
+	}
+
+	listSnatRulesPath := listSnatRulesClient.Endpoint + listSnatRulesHttpUrl
+	listSnatRulesPath = strings.ReplaceAll(listSnatRulesPath, "{project_id}", listSnatRulesClient.ProjectID)
+
+	listSnatRulesQueryParams := buildListSnatRuleQueryParams(d)
+	listSnatRulesPath += listSnatRulesQueryParams
+
+	listSnatRulesResp, err := pagination.ListAllItems(
+		listSnatRulesClient,
+		"marker",
+		listSnatRulesPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving SNAT rules")
+	}
+
+	listSnatRulesRespJson, err := json.Marshal(listSnatRulesResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listSnatRulesRespBody interface{}
+	err = json.Unmarshal(listSnatRulesRespJson, &listSnatRulesRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("rules", filterListSnatRulesResponseBody(flattenListSnatRulesResponseBody(listSnatRulesRespBody), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListSnatRulesResponseBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("snat_rules", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                  utils.PathSearch("id", v, nil),
+			"gateway_id":          utils.PathSearch("nat_gateway_id", v, nil),
+			"cidr":                utils.PathSearch("cidr", v, nil),
+			"source_type":         utils.PathSearch("source_type", v, nil),
+			"floating_ip_id":      utils.PathSearch("floating_ip_id", v, nil),
+			"floating_ip_address": utils.PathSearch("floating_ip_address", v, nil),
+			"description":         utils.PathSearch("description", v, nil),
+			"status":              utils.PathSearch("status", v, nil),
+			"created_at":          utils.PathSearch("created_at", v, nil),
+			"subnet_id":           utils.PathSearch("network_id", v, nil),
+			"global_eip_id":       utils.PathSearch("global_eip_id", v, nil),
+			"global_eip_address":  utils.PathSearch("global_eip_address", v, nil),
+			"freezed_ip_address":  utils.PathSearch("freezed_ip_address", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterListSnatRulesResponseBody(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("global_eip_id"); ok &&
+			fmt.Sprint(param) != utils.PathSearch("global_eip_id", v, nil) {
+			continue
+		}
+
+		if param, ok := d.GetOk("global_eip_address"); ok &&
+			fmt.Sprint(param) != utils.PathSearch("global_eip_address", v, nil) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func buildListSnatRuleQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("rule_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("gateway_id"); ok {
+		res = fmt.Sprintf("%s&nat_gateway_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("cidr"); ok {
+		res = fmt.Sprintf("%s&cidr=%v", res, v)
+	}
+	if v, ok := d.GetOk("subnet_id"); ok {
+		res = fmt.Sprintf("%s&network_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("floating_ip_id"); ok {
+		res = fmt.Sprintf("%s&floating_ip_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("floating_ip_address"); ok {
+		res = fmt.Sprintf("%s&floating_ip_address=%v", res, v)
+	}
+	if v, ok := d.GetOk("source_type"); ok {
+		res = fmt.Sprintf("%s&source_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new datasource to get the list of the snat rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new datasource to get the list of the public snat rules.
2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_snat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourceSnatRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourceSnatRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceSnatRules_basic
=== PAUSE TestAccDatasourceSnatRules_basic
=== CONT  TestAccDatasourceSnatRules_basic
--- PASS: TestAccDatasourceSnatRules_basic (125.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       125.427s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_snat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourceSnatRules_direct"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourceSnatRules_direct -timeout 360m -parallel 4
=== RUN   TestAccDatasourceSnatRules_direct
=== PAUSE TestAccDatasourceSnatRules_direct
=== CONT  TestAccDatasourceSnatRules_direct
--- PASS: TestAccDatasourceSnatRules_direct (119.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       120.006s
```