### PR TITLE
feat(apig/instance): the elb type instance support ingress EIP

### DIFF
--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -94,6 +94,8 @@ The following arguments are supported:
 
 * `eip_id` - (Optional, String) Specifies the EIP ID associated with the dedicated instance.
 
+  -> This parameter is only available if the `loadbalancer_provider` is **lvs**.
+
 * `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether public access with an IPv6 address is supported.  
   Changing this will create a new resource.
 

--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -116,6 +116,17 @@ The following arguments are supported:
   -> This parameter is only available if the `loadbalancer_provider` is **elb**.
      Only enable and update operations are supported, and disable operation is not supported.
 
+* `ingress_bandwidth_size` - (Optional, Int) Specifies the ingress bandwidth size of the dedicated instance.  
+  The minimum value is `5`
+
+* `ingress_bandwidth_charging_mode` - (Optional, String) Specifies the ingress bandwidth billing type of the dedicated instance.
+  The valid values are as follows:
+  + **bandwidth**: Billed by bandwidth.
+  + **traffic**: Billed by traffic.
+
+  -> The `ingress_bandwidth_size` and `ingress_bandwidth_size` parameter is only available if the `loadbalancer_provider`
+     is **elb**.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the dedicated instance.
 
 ## Attribute Reference

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240202074445-3087a09b8e02
+	github.com/chnsz/golangsdk v0.0.0-20240204092642-2df7c7cae0c2
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240202074445-3087a09b8e02 h1:/l4o/99C7zAL3CeWT4JdjAYQSreNsBJdvj6/r1semLs=
-github.com/chnsz/golangsdk v0.0.0-20240202074445-3087a09b8e02/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240204092642-2df7c7cae0c2 h1:oni89yKmN8LEIegqilXeMY1aYB1slHIXkX9l2LTH1SQ=
+github.com/chnsz/golangsdk v0.0.0-20240204092642-2df7c7cae0c2/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -226,6 +226,7 @@ resource "huaweicloud_apig_instance" "test" {
   subnet_id             = huaweicloud_vpc_subnet.test.id
   security_group_id     = huaweicloud_networking_secgroup.test.id
   availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  loadbalancer_provider = "elb"
   edition               = "BASIC"
   name                  = "%[2]s"
   enterprise_project_id = "%[3]s"
@@ -275,8 +276,8 @@ func TestAccInstance_ingress(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
-					resource.TestCheckResourceAttrSet(resourceName, "eip_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_size", "5"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_charging_mode", "bandwidth"),
 				),
 			},
 			{
@@ -285,8 +286,8 @@ func TestAccInstance_ingress(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
-					resource.TestCheckResourceAttrSet(resourceName, "eip_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_size", "6"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_charging_mode", "traffic"),
 				),
 			},
 			{
@@ -351,29 +352,18 @@ func testAccInstance_ingress(rName string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
-resource "huaweicloud_vpc_eip" "test" {
-  publicip {
-    type = "5_bgp"
-  }
-
-  bandwidth {
-    name        = "%[2]s"
-    size        = 3
-    share_type  = "PER"
-    charge_mode = "traffic"
-  }
-}
-
 resource "huaweicloud_apig_instance" "test" {
   vpc_id             = huaweicloud_vpc.test.id
   subnet_id          = huaweicloud_vpc_subnet.test.id
   security_group_id  = huaweicloud_networking_secgroup.test.id
   availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
-  edition               = "BASIC"
-  name                  = "%[2]s"
-  enterprise_project_id = "%[3]s"
-  eip_id                = huaweicloud_vpc_eip.test.id
+  edition                         = "BASIC"
+  name                            = "%[2]s"
+  enterprise_project_id           = "%[3]s"
+  maintain_begin                  = "14:00:00"
+  ingress_bandwidth_size          = 5
+  ingress_bandwidth_charging_mode = "bandwidth"
 }
 `, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
@@ -384,29 +374,18 @@ func testAccInstance_ingressUpdate(rName string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
-resource "huaweicloud_vpc_eip" "update" {
-  publicip {
-    type = "5_bgp"
-  }
-  bandwidth {
-    name        = "%[2]s"
-    size        = 4
-    share_type  = "PER"
-    charge_mode = "traffic"
-  }
-}
-
 resource "huaweicloud_apig_instance" "test" {
   vpc_id             = huaweicloud_vpc.test.id
   subnet_id          = huaweicloud_vpc_subnet.test.id
   security_group_id  = huaweicloud_networking_secgroup.test.id
   availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
-  edition               = "BASIC"
-  name                  = "%[2]s"
-  enterprise_project_id = "%[3]s"
-  maintain_begin        = "14:00:00"
-  eip_id                = huaweicloud_vpc_eip.update.id
+  edition                         = "BASIC"
+  name                            = "%[2]s"
+  enterprise_project_id           = "%[3]s"
+  maintain_begin                  = "14:00:00"
+  ingress_bandwidth_size          = 6
+  ingress_bandwidth_charging_mode = "traffic"
 }
 `, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances/results.go
@@ -342,3 +342,12 @@ func ExtractFeatures(r pagination.Page) ([]Feature, error) {
 	err := r.(FeaturePage).Result.ExtractIntoSlicePtr(&s, "features")
 	return s, err
 }
+
+type EnableElbIngressResp struct {
+	// ID of the APIG dedicated instance.
+	Instance_id string `json:"instance_id"`
+	// Task information of binding the ingress EIP.
+	Message string `json:"message"`
+	// Job ID of binding the ingress EIP.
+	JobId string `json:"job_id"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances/urls.go
@@ -20,6 +20,10 @@ func ingressURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(rootPath, id, "eip")
 }
 
+func elbIngressURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id, "ingress-eip")
+}
+
 func featureURL(c *golangsdk.ServiceClient, instanceId string) string {
 	return c.ServiceURL(rootPath, instanceId, "features")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240202074445-3087a09b8e02
+# github.com/chnsz/golangsdk v0.0.0-20240204092642-2df7c7cae0c2
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 1. Because **eip_id** is available only when **loadbalancer_provider** is set to **lvs**.
 2. The dedicated instance support ingress EIP when **loadbalancer_provider** is set to **elb**. 


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccInstance_ -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== RUN   TestAccInstance_egress
=== PAUSE TestAccInstance_egress
=== RUN   TestAccInstance_ingress
=== PAUSE TestAccInstance_ingress
=== CONT  TestAccInstance_basic
=== CONT  TestAccInstance_ingress
=== CONT  TestAccInstance_egress
--- PASS: TestAccInstance_basic (605.71s)
--- PASS: TestAccInstance_egress (693.56s)
--- PASS: TestAccInstance_ingress (740.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      740.115s
```
