### PR TITLE
feat(dli): add new resource of elastic resource pool

### DIFF
--- a/docs/resources/dli_elastic_resource_pool.md
+++ b/docs/resources/dli_elastic_resource_pool.md
@@ -1,0 +1,97 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# huaweicloud_dli_elastic_resource_pool
+
+Manages an elastic resource pool within HuaweiCloud.
+
+~> The elastic resource pool will regularly change the current number of CUs.
+   The resource pool in the expansion status cannot be changed or deleted.
+   Please refer to the [status](#dli_resource_pool_status) parameter.
+
+## Example Usage
+
+### Create an elastic resource pool under the default enterprise project
+
+```hcl
+variable "resoure_pool_name" {}
+
+resource "huaweicloud_dli_elastic_resource_pool" "test" {
+  name                  = var.resoure_pool_name
+  description           = "Created by terraform script"
+  min_cu                = 64
+  max_cu                = 80
+  cidr                  = "192.168.128.0/18"
+  enterprise_project_id = "0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the elastic resource pool is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the elastic resource pool.  
+  The valid length is limited from `1` to `128`, only lowercase letters, digits and underscores (_) are allowed.  
+  The name cannot contain only numbers or start with a number or an underscore.
+  Changing this will create a new resource.
+
+* `max_cu` - (Required, Int) Specifies the maximum number of CUs for elastic resource pool scaling.
+  The valid value ranges from `64` to `32,000`, the interval is `16`.
+
+* `min_cu` - (Required, Int) Specifies the minimum number of CUs for elastic resource pool scaling.
+  The valid value ranges from `64` to `32,000`, the interval is `16`.
+
+  ~> If the value needs to be updated, the `min_cu` value cannot be greater than the `current_cu` value.
+
+* `description` - (Optional, String) Specifies the description of the elastic resource pool.  
+  The valid length is limited from `1` to `128`.
+
+* `cidr` - (Optional, String, ForceNew) Specifies the CIDR block of network to associate with the elastic resource pool.
+  Defaults to `172.16.0.0/12`. Changing this will create a new resource.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the elastic resource
+  pool belongs.
+
+* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the elastic resource pool.  
+  Changing this will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -The resource ID in UUID format.
+
+<a name="dli_resource_pool_status"></a>
+
+* `status` - The current status of the elastic resource pool.
+
+  + **AVAILABLE**: The resource pool can be used normally.
+  + **SCALING**: The resource pool is changing CUs. There are not allow update and delete during this period.
+  + **FAILED**: The resource pool is abnormal.
+
+* `current_cu` - The current CU number of the elastic resource pool.
+
+* `actual_cu` - The current CU number of the elastic resource pool.
+
+* `created_at` - The creation time of the elastic resource pool.  
+  The format is `YYYY-MM-DDThh:mm:ss{timezone}`, e.g. `2024-01-01T08:00:00+08:00`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+Elastic resource pools can be imported by their `name`, e.g.
+
+```bash
+$ terraform import huaweicloud_dli_elastic_resource_pool.test <name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -936,6 +936,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dis_stream": dis.ResourceDisStream(),
 
 			"huaweicloud_dli_database":              dli.ResourceDliSqlDatabaseV1(),
+			"huaweicloud_dli_elastic_resource_pool": dli.ResourceElasticResourcePool(),
 			"huaweicloud_dli_package":               dli.ResourceDliPackageV2(),
 			"huaweicloud_dli_queue":                 dli.ResourceDliQueue(),
 			"huaweicloud_dli_spark_job":             dli.ResourceDliSparkJobV2(),

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
@@ -1,0 +1,167 @@
+package dli
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getElasticResourcePoolFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dli", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DLI client: %s", err)
+	}
+
+	return dli.GetElasticResourcePoolByName(client, state.Primary.Attributes["name"])
+}
+
+func TestAccElasticResourcePool_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_dli_elastic_resource_pool.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getElasticResourcePoolFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElasticResourcePool_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "min_cu", "80"),
+					resource.TestCheckResourceAttr(resourceName, "max_cu", "96"),
+					resource.TestCheckResourceAttr(resourceName, "cidr", "172.16.0.0/12"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "current_cu"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					// The number of parameter 'actual_cu' needs to be returned after the queues are created, and will
+					// not be tested for the time being.
+				),
+			},
+			{
+				Config: testAccElasticResourcePool_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "min_cu", "64"),
+					resource.TestCheckResourceAttr(resourceName, "max_cu", "112"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					waitForDeletionCooldownComplete(),
+					waitForCUModificationComplete(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccElasticResourcePoolImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func waitForDeletionCooldownComplete() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// After elastic resource pool is created, it cannot be deleted within one hour.
+		// lintignore:R018
+		time.Sleep(time.Hour)
+		return nil
+	}
+}
+
+func waitForCUModificationComplete(resName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resName]
+		if !ok {
+			return fmt.Errorf("resource (%s) not found", resName)
+		}
+		cfg := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := cfg.NewServiceClient("dli", acceptance.HW_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating DLI client: %s", err)
+		}
+
+		startTime := time.Now() // Record the start time of the loop.
+		for {
+			respBody, err := dli.GetElasticResourcePoolByName(client, rs.Primary.Attributes["name"])
+			if err != nil {
+				return fmt.Errorf("error querying elastic resource pool (%s): %s", rs.Primary.Attributes["name"], err)
+			}
+			status := utils.PathSearch("status", respBody, "").(string)
+			if status == "FAILED" {
+				failReason := utils.PathSearch("fail_reason", respBody, "").(string)
+				return fmt.Errorf("the CU number modification failed: %s", failReason)
+			}
+			if status == "AVAILABLE" {
+				return nil
+			}
+			if time.Since(startTime) > time.Hour {
+				break
+			}
+			// lintignore:R018
+			time.Sleep(30 * time.Second)
+		}
+		return fmt.Errorf("modification timeout for the CU number")
+	}
+}
+
+func testAccElasticResourcePoolImportStateFunc(resName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resName, rs)
+		}
+		poolName := rs.Primary.Attributes["name"]
+		if poolName == "" {
+			return "", fmt.Errorf("the resource pool name is missing")
+		}
+		return poolName, nil
+	}
+}
+
+func testAccElasticResourcePool_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_elastic_resource_pool" "test" {
+  name                  = upper("%[1]s")
+  description           = "Created by terraform script"
+  max_cu                = 96
+  min_cu                = 80
+  enterprise_project_id = "0"
+}
+`, name)
+}
+
+func testAccElasticResourcePool_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_elastic_resource_pool" "test" {
+  name                  = "%[1]s"
+  max_cu                = 112
+  min_cu                = 64
+  enterprise_project_id = "%[2]s"
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
@@ -1,0 +1,435 @@
+package dli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DLI POST /v3/{project_id}/elastic-resource-pools
+// @API DLI GET /v3/{project_id}/elastic-resource-pools
+// @API DLI PUT /v3/{project_id}/elastic-resource-pools/{elastic_resource_pool_name}
+// @API DLI DELETE /v3/{project_id}/elastic-resource-pools/{elastic_resource_pool_name}
+func ResourceElasticResourcePool() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceElasticResourcePoolCreate,
+		ReadContext:   resourceElasticResourcePoolRead,
+		UpdateContext: resourceElasticResourcePoolUpdate,
+		DeleteContext: resourceElasticResourcePoolDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			// Create and Update method both using custom default timeout as general timeout of the corresponding
+			// refresh function.
+			Default: schema.DefaultTimeout(30 * time.Minute),
+			Delete:  schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAssociationImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the elastic resource pool is located.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The name of the elastic resource pool.`,
+				// The server will automatically convert uppercase letters to lowercase letters.
+				DiffSuppressFunc: utils.SuppressCaseDiffs,
+			},
+			"max_cu": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The maximum number of CUs for elastic resource pool scaling.`,
+			},
+			"min_cu": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The minimum number of CUs for elastic resource pool scaling.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the elastic resource pool.`,
+			},
+			"cidr": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The CIDR block of network to associate with the elastic resource pool.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the enterprise project to which the elastic resource pool belongs.`,
+			},
+			"tags": common.TagsForceNewSchema(),
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the elastic resource pool.`,
+			},
+			"current_cu": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The current CU number of the elastic resource pool.`,
+			},
+			"actual_cu": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The actual CU number of the elastic resource pool.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the elastic resource pool.`,
+			},
+		},
+	}
+}
+
+func resourceElasticResourcePoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/elastic-resource-pools"
+	)
+
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateElasticResourcePoolBodyParams(cfg, d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error creating DLI elastic resource pool: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceName := utils.PathSearch("elastic_resource_pool_name", respBody, "").(string)
+	respBody, err = GetElasticResourcePoolByName(client, resourceName)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	resourceId := utils.PathSearch("resource_id", respBody, "").(string)
+	d.SetId(resourceId)
+
+	err = waitForElasticResourcePoolStatusCompleted(ctx, client, d)
+	if err != nil {
+		diag.Errorf("error waiting for the elastic resource pool (%s) status to become success: %s", resourceId, err)
+	}
+
+	return resourceElasticResourcePoolRead(ctx, d, meta)
+}
+
+func buildCreateElasticResourcePoolBodyParams(cfg *config.Config, d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"elastic_resource_pool_name": d.Get("name"),
+		"description":                d.Get("description"),
+		"max_cu":                     d.Get("max_cu"),
+		"min_cu":                     d.Get("min_cu"),
+		"cidr_in_vpc":                utils.StringIgnoreEmpty(d.Get("cidr").(string)),
+		"enterprise_project_id":      cfg.GetEnterpriseProjectID(d),
+		"tags":                       utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{})),
+	}
+}
+
+func waitForElasticResourcePoolStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      elasticResourcePoolStatusRefreshFunc(client, d, []string{"AVAILABLE"}),
+		Timeout:      d.Timeout(schema.TimeoutDefault),
+		Delay:        10 * time.Second,
+		PollInterval: 20 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func elasticResourcePoolStatusRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resourceName := d.Get("name").(string)
+		respBody, err := GetElasticResourcePoolByName(client, resourceName)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				log.Printf("[DEBUG] The DLI elastic resource pool (%s) has been deleted", resourceName)
+				return respBody, "COMPLETED", nil
+			}
+			return respBody, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", respBody, "").(string)
+		unexpectedStatuses := []string{
+			"FAILED",
+		}
+		if utils.StrSliceContains(unexpectedStatuses, status) {
+			return respBody, "ERROR", fmt.Errorf("unexpect status (%s)", status)
+		}
+
+		if utils.StrSliceContains(targets, status) {
+			return respBody, "COMPLETED", nil
+		}
+		return respBody, "PENDING", nil
+	}
+}
+
+func resourceElasticResourcePoolRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	respBody, err := GetElasticResourcePoolByName(client, d.Get("name").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "DLI elastic resource pool")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("elastic_resource_pool_name", respBody, nil)),
+		d.Set("max_cu", int(utils.PathSearch("max_cu", respBody, float64(0)).(float64))),
+		d.Set("min_cu", int(utils.PathSearch("min_cu", respBody, float64(0)).(float64))),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("cidr", utils.PathSearch("cidr_in_vpc", respBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("current_cu", utils.PathSearch("current_cu", respBody, nil)),
+		d.Set("actual_cu", utils.PathSearch("actual_cu", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("create_time", respBody, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+// GetElasticResourcePools is a method used to query all elastic resource pools in a specified region.
+func GetElasticResourcePools(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl  = "v3/{project_id}/elastic-resource-pools"
+		listOpts = golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			OkCodes: []int{
+				200,
+			},
+		}
+		offset = 0
+		limit  = 100
+		result = make([]interface{}, 0)
+	)
+
+	basePath := client.Endpoint + httpUrl
+	basePath = strings.ReplaceAll(basePath, "{project_id}", client.ProjectID)
+
+	for {
+		listPath := basePath + fmt.Sprintf("?offset=%d&limit=%d", offset, limit)
+		requestResp, err := client.Request("GET", listPath, &listOpts)
+		if err != nil {
+			return nil, fmt.Errorf("error query DLI elastic resource pool list: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		pools := utils.PathSearch("elastic_resource_pools", respBody, make([]interface{}, 0)).([]interface{})
+		if len(pools) < 1 {
+			break
+		}
+		result = append(result, pools...)
+		offset += len(pools)
+	}
+
+	return result, nil
+}
+
+// GetElasticResourcePoolByName is the method used to query the elastic resource pool matching the name.
+func GetElasticResourcePoolByName(client *golangsdk.ServiceClient, resourceName string) (interface{}, error) {
+	pools, err := GetElasticResourcePools(client)
+	if err != nil {
+		return nil, err
+	}
+
+	// The elastic resource pool name in the API response does not contain uppercase letters (will be automatically converted).
+	lowercaseName := strings.ToLower(resourceName)
+	if pool := utils.PathSearch(fmt.Sprintf("[*]|[?elastic_resource_pool_name=='%s']|[0]", lowercaseName), pools, nil); pool != nil {
+		return pool, nil
+	}
+	return nil, golangsdk.ErrDefault404{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte(fmt.Sprintf("unable to find the elastic resource pool using its name (%s)", lowercaseName)),
+		},
+	}
+}
+
+func updateElasticResourcePoolMetadata(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	resourceName := d.Get("name").(string)
+	httpUrl := "v3/{project_id}/elastic-resource-pools/{elastic_resource_pool_name}"
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{elastic_resource_pool_name}", resourceName)
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildUpdateElasticResourcePoolBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", updatePath, &updateOpts)
+	if err != nil {
+		return fmt.Errorf("error updating DLI elastic resource pool: %s", err)
+	}
+
+	err = waitForElasticResourcePoolStatusCompleted(ctx, client, d)
+	if err != nil {
+		return fmt.Errorf("error waiting for the elastic resource pool (%s) status to become success: %s", resourceName, err)
+	}
+	return nil
+}
+
+func resourceElasticResourcePoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		resourceId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	if d.HasChanges("description", "min_cu", "max_cu") {
+		if err := updateElasticResourcePoolMetadata(ctx, client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("enterprise_project_id") {
+		migrateOpts := enterpriseprojects.MigrateResourceOpts{
+			ResourceId:   resourceId,
+			ResourceType: "dli-elastic-resource-pool",
+			RegionId:     region,
+			ProjectId:    client.ProjectID,
+		}
+		if err := common.MigrateEnterpriseProject(ctx, cfg, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceElasticResourcePoolRead(ctx, d, meta)
+}
+
+func buildUpdateElasticResourcePoolBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"description": d.Get("description"),
+		"max_cu":      utils.IntIgnoreEmpty(d.Get("max_cu").(int)),
+		"min_cu":      utils.IntIgnoreEmpty(d.Get("min_cu").(int)),
+	}
+}
+
+func resourceElasticResourcePoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		httpUrl      = "v3/{project_id}/elastic-resource-pools/{elastic_resource_pool_name}"
+		resourceName = d.Get("name").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{elastic_resource_pool_name}", resourceName)
+	// Due to API restrictions, the request body must pass in an empty JSON.
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting DLI elastic resource pool (%s): %s", resourceName, err)
+	}
+
+	err = waitForElasticResourcePoolDeleted(ctx, client, d)
+	if err != nil {
+		diag.Errorf("error waiting for the elastic resource pool (%s) status to become deleted: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func waitForElasticResourcePoolDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      elasticResourcePoolStatusRefreshFunc(client, d, nil),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceAssociationImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData,
+	error) {
+	var (
+		cfg          = meta.(*config.Config)
+		resourceName = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dli", cfg.GetRegion(d))
+	if err != nil {
+		return nil, fmt.Errorf("error creating DLI client: %s", err)
+	}
+
+	respBody, err := GetElasticResourcePoolByName(client, resourceName)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := utils.PathSearch("resource_id", respBody, "").(string)
+	d.SetId(resourceId)
+	return []*schema.ResourceData{d}, d.Set("name", resourceName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource support for DLI service.
Resource Name: huaweicloud_dli_elastic_resource_pool
Notes: 
1. Resource pools cannot be deleted within one hour of creation.
2. The resource pool will auto change the CU numbers every once in a while, and cannot be deleted or updated during this period.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource support.
2. add related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccElasticResourcePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccElasticResourcePool_basic -timeout 360m -parallel 4
=== RUN   TestAccElasticResourcePool_basic
=== PAUSE TestAccElasticResourcePool_basic
=== CONT  TestAccElasticResourcePool_basic
--- PASS: TestAccElasticResourcePool_basic (4527.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       4527.921s
```
