### PR TITLE
feat(VPN): VPN connection resource support ha_role field

### DIFF
--- a/docs/resources/vpn_connection.md
+++ b/docs/resources/vpn_connection.md
@@ -110,6 +110,17 @@ The [policy_rules](#Connection_PolicyRule) structure is documented below.
 
 * `tags` - (Optional, Map) Specifies the tags of the VPN connection.
 
+* `ha_role` - (Optional, String, ForceNew) Specifies the mode of the VPN connection.
+  The valid values are **master** and **slave**, defaults to **master**.
+  This parameter is optional when you create a connection for a VPN gateway in **active-active** mode.
+  When you create a connection for a VPN gateway in **active-standby** mode, **master** indicates
+  the active connection, and **slave** indicates the standby connection.
+  In **active-active** mode, this field must be set to **master** for the connection established
+  using the active EIP or active private IP address of the VPN gateway, and must be set to **slave**
+  for the connection established using active EIP 2 or active private IP address 2 of the VPN gateway.
+
+  Changing this parameter will create a new resource.
+
 <a name="Connection_CreateRequestIkePolicy"></a>
 The `ikepolicy` block supports:
 

--- a/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_test.go
+++ b/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_test.go
@@ -156,6 +156,52 @@ func TestAccConnection_policy(t *testing.T) {
 	})
 }
 
+func TestAccConnection_haRole(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_vpn_connection.test"
+	ipAddress := "172.16.1.3"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getConnectionResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testConnection_haRole(name, ipAddress),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "vpn_type", "POLICY"),
+					resource.TestCheckResourceAttr(rName, "policy_rules.0.source", "192.168.11.0/24"),
+					resource.TestCheckResourceAttr(rName, "policy_rules.0.destination.0", "192.168.12.0/24"),
+					resource.TestCheckResourceAttr(rName, "policy_rules.0.destination.1", "192.168.13.0/24"),
+					resource.TestCheckResourceAttr(rName, "ikepolicy.0.authentication_algorithm", "sha2-512"),
+					resource.TestCheckResourceAttr(rName, "ikepolicy.0.encryption_algorithm", "aes-256"),
+					resource.TestCheckResourceAttr(rName, "ikepolicy.0.lifetime_seconds", "172800"),
+					resource.TestCheckResourceAttr(rName, "ipsecpolicy.0.authentication_algorithm", "sha2-512"),
+					resource.TestCheckResourceAttr(rName, "ipsecpolicy.0.encryption_algorithm", "aes-256"),
+					resource.TestCheckResourceAttr(rName, "ipsecpolicy.0.lifetime_seconds", "7200"),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"huaweicloud_vpn_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "gateway_ip",
+						"huaweicloud_vpn_gateway.test", "eip2.0.id"),
+					resource.TestCheckResourceAttrPair(rName, "customer_gateway_id",
+						"huaweicloud_vpn_customer_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "ha_role", "slave"),
+				),
+			},
+		},
+	})
+}
+
 func testConnection_basic(name, ipAddress string) string {
 	return fmt.Sprintf(`
 %s
@@ -245,4 +291,40 @@ resource "huaweicloud_vpn_connection" "test" {
   }
 }
 `, testGateway_basic(name), testCustomerGateway_basic(name, ipAddress), name)
+}
+
+func testConnection_haRole(name, ipAddress string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "huaweicloud_vpn_connection" "test" {
+  name                = "%s"
+  gateway_id          = huaweicloud_vpn_gateway.test.id
+  gateway_ip          = huaweicloud_vpn_gateway.test.eip2[0].id
+  customer_gateway_id = huaweicloud_vpn_customer_gateway.test.id
+  peer_subnets        = ["192.168.55.0/24"]
+  vpn_type            = "policy"
+  psk                 = "Test@123"
+  ha_role             = "slave"
+
+  policy_rules {
+    source      = "192.168.11.0/24"
+    destination = ["192.168.12.0/24", "192.168.13.0/24"]
+  }
+
+  ikepolicy {
+    authentication_algorithm = "sha2-512"
+    encryption_algorithm     = "aes-256"
+    lifetime_seconds         = 172800
+  }
+
+  ipsecpolicy {
+    authentication_algorithm = "sha2-512"
+    encryption_algorithm     = "aes-256"
+    lifetime_seconds         = 7200
+  }
+}
+`, testGateway_activeStandbyHAMode(name), testCustomerGateway_basic(name, ipAddress), name)
 }

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
@@ -133,6 +133,12 @@ func ResourceConnection() *schema.Resource {
 				Description: `The policy rules. Only works when vpn_type is set to **policy**`,
 			},
 			"tags": common.TagsSchema(),
+			"ha_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -422,6 +428,7 @@ func buildCreateConnectionVpnConnectionChildBody(d *schema.ResourceData) map[str
 		"ipsecpolicy":          buildCreateConnectionIpsecpolicyChildBody(d),
 		"policy_rules":         buildCreateConnectionPolicyRulesChildBody(d),
 		"tags":                 utils.ValueIngoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
+		"ha_role":              utils.ValueIngoreEmpty(d.Get("ha_role")),
 	}
 
 	if enableNqa, ok := d.GetOk("enable_nqa"); ok {
@@ -645,6 +652,7 @@ func resourceConnectionRead(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("created_at", utils.PathSearch("vpn_connection.created_at", getConnectionRespBody, nil)),
 		d.Set("updated_at", utils.PathSearch("vpn_connection.updated_at", getConnectionRespBody, nil)),
 		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("vpn_connection.tags", getConnectionRespBody, nil))),
+		d.Set("ha_role", utils.PathSearch("vpn_connection.ha_role", getConnectionRespBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
**What this PR does / why we need it**:
VPN connection resource support ha_role field

This parameter is optional when you create a connection for a VPN gateway in active-active mode. When you create a connection for a VPN gateway in active-standby mode, master indicates the active connection, and slave indicates the standby connection. The default value is master.

Constraints: In active-active mode, this field must be set to master for the connection established using the active EIP or active private IP address of the VPN gateway, and must be set to slave for the connection established using active EIP 2 or active private IP address 2 of the VPN gateway.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
VPN connection resource support ha_role field
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccConnection_haRole"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccConnection_haRole -timeout 360m -parallel 4
=== RUN   TestAccConnection_haRole
=== PAUSE TestAccConnection_haRole
=== CONT  TestAccConnection_haRole
--- PASS: TestAccConnection_haRole (400.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       400.645s
```
