### PR TITLE
fix(RDS): update parameter method support v3.1 client

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -903,6 +903,10 @@ func (c *Config) RdsV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("rds", region)
 }
 
+func (c *Config) RdsV31Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("rdsv31", region)
+}
+
 func (c *Config) DdsV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("dds", region)
 }

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -32,7 +32,7 @@ var multiCatalogKeys = map[string][]string{
 	"kms":          {"kmsv1", "kmsv3"},
 	"mrs":          {"mrsv2"},
 	"nat":          {"natv3"},
-	"rds":          {"rdsv1"},
+	"rds":          {"rdsv1", "rdsv31"},
 	"waf":          {"waf-dedicated"},
 	"geminidb":     {"geminidbv31"},
 	"dataarts":     {"dataarts-dlf"},
@@ -425,6 +425,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"rds": {
 		Name:    "rds",
 		Version: "v3",
+		Product: "RDS",
+	},
+	"rdsv31": {
+		Name:    "rds",
+		Version: "v3.1",
 		Product: "RDS",
 	},
 	"ram": {

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
@@ -367,8 +367,11 @@ func resourceRdsReadReplicaInstanceCreate(ctx context.Context, d *schema.Resourc
 
 	// Set Parameters
 	if parametersRaw := d.Get("parameters").(*schema.Set); parametersRaw.Len() > 0 {
-		if err = initializeParameters(ctx, d.Timeout(schema.TimeoutCreate), client, instanceID,
-			parametersRaw); err != nil {
+		clientV31, err := config.RdsV31Client(config.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating RDS V3.1 client: %s", err)
+		}
+		if err = initializeParameters(ctx, d, client, clientV31, instanceID, parametersRaw); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -471,6 +474,10 @@ func resourceRdsReadReplicaInstanceUpdate(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diag.Errorf("error creating rds v3 client: %s ", err)
 	}
+	clientV31, err := config.RdsV31Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating RDS V3.1 client: %s", err)
+	}
 
 	instanceID := d.Id()
 
@@ -510,7 +517,7 @@ func resourceRdsReadReplicaInstanceUpdate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
-	if ctx, err = updateRdsParameters(ctx, d, client, instanceID); err != nil {
+	if ctx, err = updateRdsParameters(ctx, d, client, clientV31, instanceID); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  update parameter method support v3.1 client
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
  
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  update parameter method support v3.1 client
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=12
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 12
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_without_password
=== PAUSE TestAccRdsInstance_without_password
=== RUN   TestAccRdsInstance_withEpsId
=== PAUSE TestAccRdsInstance_withEpsId
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_withParameters
=== PAUSE TestAccRdsInstance_withParameters
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_withParameters
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_withEpsId
=== CONT  TestAccRdsInstance_without_password
--- PASS: TestAccRdsInstance_withEpsId (422.37s)
--- PASS: TestAccRdsInstance_mariadb (437.70s)
--- PASS: TestAccRdsInstance_ha (466.25s)
--- PASS: TestAccRdsInstance_without_password (493.63s)
--- PASS: TestAccRdsInstance_basic (570.07s)
--- PASS: TestAccRdsInstance_withParameters (1017.86s)
--- PASS: TestAccRdsInstance_prePaid (1136.95s)
--- PASS: TestAccRdsInstance_mysql (1256.76s)
--- PASS: TestAccRdsInstance_restore_mysql (2173.44s)
--- PASS: TestAccRdsInstance_restore_pg (2264.74s)
--- PASS: TestAccRdsInstance_sqlserver (2732.06s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2960.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2960.586s
```
