### PR TITLE
chore(er): fix the wrong api references and reorder them

### DIFF
--- a/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
@@ -15,7 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/attachments
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/attachments
 func DataSourceAttachments() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceAttachmentsRead,

--- a/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go
@@ -22,10 +22,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/propagations
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/route-tables
-// @API ER GET /v3/{project_id}/enterprise-router/route-tables/{routeTableId}/static-routes
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/associations
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations
+// @API ER GET /v3/{project_id}/enterprise-router/route-tables/{route_table_id}/static-routes
 func DataSourceRouteTables() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceRouteTablesRead,

--- a/huaweicloud/services/er/resource_huaweicloud_er_association.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_association.go
@@ -20,9 +20,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API ER POST /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/associate
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/associations
-// @API ER POST /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/disassociate
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associate
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/disassociate
 func ResourceAssociation() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceAssociationCreate,

--- a/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go
@@ -22,11 +22,10 @@ import (
 
 // @API ER POST /v3/{project_id}/enterprise-router/{er_id}/flow-logs
 // @API ER GET /v3/{project_id}/enterprise-router/{er_id}/flow-logs/{flow_log_id}
-// @API ER PUT /v3/{project_id}/enterprise-router/{er_id}/flow-logs/{flow_log_id}
-// @API ER DELETE /v3/{project_id}/enterprise-router/{er_id}/flow-logs/{flow_log_id}
 // @API ER POST /v3/{project_id}/enterprise-router/{er_id}/flow-logs/{flow_log_id}/enable
 // @API ER POST /v3/{project_id}/enterprise-router/{er_id}/flow-logs/{flow_log_id}/disable
-
+// @API ER PUT /v3/{project_id}/enterprise-router/{er_id}/flow-logs/{flow_log_id}
+// @API ER DELETE /v3/{project_id}/enterprise-router/{er_id}/flow-logs/{flow_log_id}
 func ResourceFlowLog() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceFlowLogCreate,

--- a/huaweicloud/services/er/resource_huaweicloud_er_instance.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_instance.go
@@ -26,13 +26,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API ER POST /v3/{project_id}/{resource_type}/{resource_id}/tags
-// @API ER DELETE /v3/{project_id}/{resource_type}/{resource_id}/tags/{key}
 // @API ER POST /v3/{project_id}/enterprise-router/instances
-// @API ER DELETE /v3/{project_id}/enterprise-router/instances/{id}
-// @API ER GET /v3/{project_id}/enterprise-router/instances/{id}
-// @API ER PUT /v3/{project_id}/enterprise-router/instances/{id}
-// @API ER POST /v3/{project_id}/enterprise-router/instances/{id}/change-availability-zone-ids
+// @API ER PUT /v3/{project_id}/enterprise-router/instances/{er_id}
+// @API ER POST /v3/{project_id}/{resource_type}/{resource_id}/tags/action
+// @API ER GET /v3/{project_id}/enterprise-router/instances/{er_id}
+// @API ER POST /v3/{project_id}/enterprise-router/instances/{er_id}/change-availability-zone-ids
+// @API ER DELETE /v3/{project_id}/enterprise-router/instances/{er_id}
 func ResourceInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceInstanceCreate,
@@ -189,7 +188,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	// updateInstanceDefaultRouteTables: Update default route tables
 	var (
-		updateInstanceDefaultRouteTablesHttpUrl = "v3/{project_id}/enterprise-router/instances/{id}"
+		updateInstanceDefaultRouteTablesHttpUrl = "v3/{project_id}/enterprise-router/instances/{er_id}"
 		updateInstanceDefaultRouteTablesProduct = "er"
 	)
 	updateInstanceDefaultRouteTablesClient, err := cfg.NewServiceClient(updateInstanceDefaultRouteTablesProduct, region)
@@ -200,7 +199,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	updateInstanceDefaultRouteTablesPath := updateInstanceDefaultRouteTablesClient.Endpoint + updateInstanceDefaultRouteTablesHttpUrl
 	updateInstanceDefaultRouteTablesPath = strings.ReplaceAll(updateInstanceDefaultRouteTablesPath, "{project_id}",
 		updateInstanceDefaultRouteTablesClient.ProjectID)
-	updateInstanceDefaultRouteTablesPath = strings.ReplaceAll(updateInstanceDefaultRouteTablesPath, "{id}", d.Id())
+	updateInstanceDefaultRouteTablesPath = strings.ReplaceAll(updateInstanceDefaultRouteTablesPath, "{er_id}", d.Id())
 
 	updateInstanceDefaultRouteTablesOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -273,7 +272,7 @@ func instanceWaitingForStateCompleted(ctx context.Context, d *schema.ResourceDat
 			region := cfg.GetRegion(d)
 			// createInstanceWaiting: Query the Enterprise router instance status
 			var (
-				createInstanceWaitingHttpUrl = "v3/{project_id}/enterprise-router/instances/{id}"
+				createInstanceWaitingHttpUrl = "v3/{project_id}/enterprise-router/instances/{er_id}"
 				createInstanceWaitingProduct = "er"
 			)
 			createInstanceWaitingClient, err := cfg.NewServiceClient(createInstanceWaitingProduct, region)
@@ -283,7 +282,7 @@ func instanceWaitingForStateCompleted(ctx context.Context, d *schema.ResourceDat
 
 			createInstanceWaitingPath := createInstanceWaitingClient.Endpoint + createInstanceWaitingHttpUrl
 			createInstanceWaitingPath = strings.ReplaceAll(createInstanceWaitingPath, "{project_id}", createInstanceWaitingClient.ProjectID)
-			createInstanceWaitingPath = strings.ReplaceAll(createInstanceWaitingPath, "{id}", d.Id())
+			createInstanceWaitingPath = strings.ReplaceAll(createInstanceWaitingPath, "{er_id}", d.Id())
 
 			createInstanceWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
@@ -331,7 +330,7 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 
 	// getInstance: Query the Enterprise router instance detail
 	var (
-		getInstanceHttpUrl = "v3/{project_id}/enterprise-router/instances/{id}"
+		getInstanceHttpUrl = "v3/{project_id}/enterprise-router/instances/{er_id}"
 		getInstanceProduct = "er"
 	)
 	getInstanceClient, err := cfg.NewServiceClient(getInstanceProduct, region)
@@ -341,7 +340,7 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 
 	getInstancePath := getInstanceClient.Endpoint + getInstanceHttpUrl
 	getInstancePath = strings.ReplaceAll(getInstancePath, "{project_id}", getInstanceClient.ProjectID)
-	getInstancePath = strings.ReplaceAll(getInstancePath, "{id}", d.Id())
+	getInstancePath = strings.ReplaceAll(getInstancePath, "{er_id}", d.Id())
 
 	getInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -402,10 +401,10 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if d.HasChanges(updateInstancehasChanges...) {
 		// updateInstance: Update the configuration of Enterprise router instance
-		updateInstanceHttpUrl := "enterprise-router/instances/{id}"
+		updateInstanceHttpUrl := "enterprise-router/instances/{er_id}"
 		updateInstancePath := client.ResourceBaseURL() + updateInstanceHttpUrl
 		updateInstancePath = strings.ReplaceAll(updateInstancePath, "{project_id}", client.ProjectID)
-		updateInstancePath = strings.ReplaceAll(updateInstancePath, "{id}", d.Id())
+		updateInstancePath = strings.ReplaceAll(updateInstancePath, "{er_id}", d.Id())
 
 		updateInstanceOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
@@ -430,10 +429,10 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if d.HasChanges(updateInstanceAvailabilityZoneshasChanges...) {
 		// updateInstanceAvailabilityZones: Update the availability zone list where the Enterprise router instance is located
-		updateInstanceAvailabilityZonesHttpUrl := "enterprise-router/instances/{id}/change-availability-zone-ids"
+		updateInstanceAvailabilityZonesHttpUrl := "enterprise-router/instances/{er_id}/change-availability-zone-ids"
 		updateInstanceAvailabilityZonesPath := client.ResourceBaseURL() + updateInstanceAvailabilityZonesHttpUrl
 		updateInstanceAvailabilityZonesPath = strings.ReplaceAll(updateInstanceAvailabilityZonesPath, "{project_id}", client.ProjectID)
-		updateInstanceAvailabilityZonesPath = strings.ReplaceAll(updateInstanceAvailabilityZonesPath, "{id}", d.Id())
+		updateInstanceAvailabilityZonesPath = strings.ReplaceAll(updateInstanceAvailabilityZonesPath, "{er_id}", d.Id())
 
 		updateInstanceAvailabilityZonesOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
@@ -494,7 +493,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 
 	// deleteInstance: Deleter an existing router instance
 	var (
-		deleteInstanceHttpUrl = "v3/{project_id}/enterprise-router/instances/{id}"
+		deleteInstanceHttpUrl = "v3/{project_id}/enterprise-router/instances/{er_id}"
 		deleteInstanceProduct = "er"
 	)
 	deleteInstanceClient, err := cfg.NewServiceClient(deleteInstanceProduct, region)
@@ -504,7 +503,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 
 	deleteInstancePath := deleteInstanceClient.Endpoint + deleteInstanceHttpUrl
 	deleteInstancePath = strings.ReplaceAll(deleteInstancePath, "{project_id}", deleteInstanceClient.ProjectID)
-	deleteInstancePath = strings.ReplaceAll(deleteInstancePath, "{id}", d.Id())
+	deleteInstancePath = strings.ReplaceAll(deleteInstancePath, "{er_id}", d.Id())
 
 	deleteInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
@@ -533,7 +532,7 @@ func deleteInstanceWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 			region := config.GetRegion(d)
 			// deleteInstanceWaiting: missing operation notes
 			var (
-				deleteInstanceWaitingHttpUrl = "v3/{project_id}/enterprise-router/instances/{id}"
+				deleteInstanceWaitingHttpUrl = "v3/{project_id}/enterprise-router/instances/{er_id}"
 				deleteInstanceWaitingProduct = "er"
 			)
 			deleteInstanceWaitingClient, err := config.NewServiceClient(deleteInstanceWaitingProduct, region)
@@ -543,7 +542,7 @@ func deleteInstanceWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 
 			deleteInstanceWaitingPath := deleteInstanceWaitingClient.Endpoint + deleteInstanceWaitingHttpUrl
 			deleteInstanceWaitingPath = strings.ReplaceAll(deleteInstanceWaitingPath, "{project_id}", deleteInstanceWaitingClient.ProjectID)
-			deleteInstanceWaitingPath = strings.ReplaceAll(deleteInstanceWaitingPath, "{id}", d.Id())
+			deleteInstanceWaitingPath = strings.ReplaceAll(deleteInstanceWaitingPath, "{er_id}", d.Id())
 
 			deleteInstanceWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,

--- a/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_propagation.go
@@ -20,9 +20,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/propagations
-// @API ER POST /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/disable-propagations
-// @API ER POST /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/enable-propagations
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/enable-propagations
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/disable-propagations
 func ResourcePropagation() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourcePropagationCreate,

--- a/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
@@ -24,14 +24,14 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/associations
-// @API ER POST /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/disable-propagations
-// @API ER POST /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/disassociate
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}/propagations
-// @API ER DELETE /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}
-// @API ER PUT /v3/{project_id}/enterprise-router/{instanceId}/route-tables/{routeTableId}
-// @API ER POST /v3/{project_id}/enterprise-router/{instanceId}/route-tables
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}
+// @API ER PUT /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/disassociate
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/disable-propagations
+// @API ER DELETE /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}
 func ResourceRouteTable() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceRouteTableCreate,

--- a/huaweicloud/services/er/resource_huaweicloud_er_static_route.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_static_route.go
@@ -16,10 +16,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API ER DELETE /v3/{project_id}/enterprise-router/route-tables/{routeTableId}/static-routes/{routeId}
-// @API ER GET /v3/{project_id}/enterprise-router/route-tables/{routeTableId}/static-routes/{routeId}
-// @API ER PUT /v3/{project_id}/enterprise-router/route-tables/{routeTableId}/static-routes/{routeId}
-// @API ER POST /v3/{project_id}/enterprise-router/route-tables/{routeTableId}/static-routes
+// @API ER POST /v3/{project_id}/enterprise-router/route-tables/{route_table_id}/static-routes
+// @API ER GET /v3/{project_id}/enterprise-router/route-tables/{route_table_id}/static-routes/{route_id}
+// @API ER PUT /v3/{project_id}/enterprise-router/route-tables/{route_table_id}/static-routes/{route_id}
+// @API ER DELETE /v3/{project_id}/enterprise-router/route-tables/{route_table_id}/static-routes/{route_id}
 func ResourceStaticRoute() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceStaticRouteCreate,

--- a/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
@@ -22,10 +22,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API ER PUT /v3/{project_id}/enterprise-router/{instanceId}/vpc-attachments/{attachmentId}
-// @API ER DELETE /v3/{project_id}/enterprise-router/{instanceId}/vpc-attachments/{attachmentId}
-// @API ER GET /v3/{project_id}/enterprise-router/{instanceId}/vpc-attachments/{attachmentId}
-// @API ER POST /v3/{project_id}/enterprise-router/{instanceId}/vpc-attachments
+// @API ER POST /v3/{project_id}/enterprise-router/{er_id}/vpc-attachments
+// @API ER PUT /v3/{project_id}/enterprise-router/{er_id}/vpc-attachments/{vpc_attachment_id}
+// @API ER DELETE /v3/{project_id}/enterprise-router/{er_id}/vpc-attachments/{vpc_attachment_id}
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/vpc-attachments/{vpc_attachment_id}
 func ResourceVpcAttachment() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceVpcAttachmentCreate,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some API references of the ER resources are wrong.
We need to update and reorder them.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the wrong api references and reorder them.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=Test -timeout 360m -parallel 4
=== RUN   TestAccAttachmentsDataSource_basic
--- PASS: TestAccAttachmentsDataSource_basic (113.04s)
=== RUN   TestAccAttachmentsDataSource_filterById
--- PASS: TestAccAttachmentsDataSource_filterById (110.20s)
=== RUN   TestAccAttachmentsDataSource_filterByType
--- PASS: TestAccAttachmentsDataSource_filterByType (105.18s)
=== RUN   TestAccAttachmentsDataSource_filterByStatus
--- PASS: TestAccAttachmentsDataSource_filterByStatus (105.16s)
=== RUN   TestAccAttachmentsDataSource_filterByTags
--- PASS: TestAccAttachmentsDataSource_filterByTags (105.05s)
=== RUN   TestAccAttachmentsDataSource_filterByResourceId
--- PASS: TestAccAttachmentsDataSource_filterByResourceId (106.80s)
=== RUN   TestAccDataSourceAZs_basic
=== PAUSE TestAccDataSourceAZs_basic
=== RUN   TestAccDatasourceFlowLogs_basic
--- PASS: TestAccDatasourceFlowLogs_basic (158.43s)
=== RUN   TestAccInstancesDataSource_basic
--- PASS: TestAccInstancesDataSource_basic (54.92s)
=== RUN   TestAccInstancesDataSource_filterById
--- PASS: TestAccInstancesDataSource_filterById (53.82s)
=== RUN   TestAccInstancesDataSource_filterByStatus
--- PASS: TestAccInstancesDataSource_filterByStatus (53.37s)
=== RUN   TestAccInstancesDataSource_filterByEpsId
--- PASS: TestAccInstancesDataSource_filterByEpsId (47.79s)
=== RUN   TestAccInstancesDataSource_filterByTags
--- PASS: TestAccInstancesDataSource_filterByTags (52.75s)
=== RUN   TestAccRouteTablesDataSource_basic
--- PASS: TestAccRouteTablesDataSource_basic (68.34s)
=== RUN   TestAccRouteTablesDataSource_byName
--- PASS: TestAccRouteTablesDataSource_byName (74.28s)
=== RUN   TestAccRouteTablesDataSource_byId
--- PASS: TestAccRouteTablesDataSource_byId (75.99s)
=== RUN   TestAccRouteTablesDataSource_byTags
--- PASS: TestAccRouteTablesDataSource_byTags (70.15s)
=== RUN   TestAccAssociation_basic
--- PASS: TestAccAssociation_basic (122.78s)
=== RUN   TestAccFlowLog_basic
--- PASS: TestAccFlowLog_basic (184.89s)
=== RUN   TestAccInstance_basic
--- PASS: TestAccInstance_basic (56.60s)
=== RUN   TestAccPropagation_basic
--- PASS: TestAccPropagation_basic (122.33s)
=== RUN   TestAccRouteTable_basic
--- PASS: TestAccRouteTable_basic (93.45s)
=== RUN   TestAccStaticRoute_basic
--- PASS: TestAccStaticRoute_basic (166.59s)
=== RUN   TestAccVpcAttachment_basic
--- PASS: TestAccVpcAttachment_basic (147.28s)
=== CONT  TestAccDataSourceAZs_basic
--- PASS: TestAccDataSourceAZs_basic (6.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        2255.499s
```
