### PR TITLE
feat(nat): add a new data source to get the list of the dnat rules

### DIFF
--- a/docs/data-sources/nat_dnat_rules.md
+++ b/docs/data-sources/nat_dnat_rules.md
@@ -1,0 +1,102 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# huaweicloud_nat_dnat_rules
+
+Use this data source to get the list of DNAT rules.
+
+## Example Usage
+
+```hcl
+variable "protocol" {}
+
+data "huaweicloud_nat_dnat_rules" "test" {
+  protocol = var.protocol
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the DNAT rules are located.
+  If omitted, the provider-level region will be used.
+
+* `rule_id` - (Optional, String) Specifies the ID of the DNAT rule.
+
+* `gateway_id` - (Optional, String) Specifies the ID of the NAT gateway to which the DNAT rule belongs.
+
+* `protocol` - (Optional, String) Specifies the protocol type of the DNAT rule.
+  The value can be one of the following:
+  + **tcp**
+  + **udp**
+  + **any**
+
+* `port_id` - (Optional, String) Specifies the port ID of the backend instance to which the DNAT rule belongs.
+
+* `private_ip` - (Optional, String) Specifies the private IP address of the backend instance to which the DNAT rule
+  belongs.
+
+* `status` - (Optional, String) Specifies the status of the DNAT rule.
+  The value can be one of the following:
+  + **ACTIVE**: The SNAT rule is available.
+  + **EIP_FREEZED**: The EIP is frozen associated with SNAT rule.
+  + **INACTIVE**: The SNAT rule is unavailable.
+
+* `internal_service_port` - (Optional, String) Specifies the port of the backend instance to which the DNAT rule
+  belongs.
+
+* `external_service_port` - (Optional, String) Specifies the port of the EIP associated with the DNAT rule.
+
+* `floating_ip_id` - (Optional, String) Specifies the ID of the EIP associated with the DNAT rule.
+
+* `floating_ip_address` - (Optional, String) Specifies the IP address of the EIP associated with the DNAT rule.
+
+* `global_eip_id` - (Optional, String) Specifies the ID of the global EIP associated with the DNAT rule.
+
+* `global_eip_address` - (Optional, String) Specifies the IP address of the global EIP associated with the DNAT rule.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - The list ot the DNAT rules.
+  The [rules](#nat_dnat_rules) structure is documented below.
+
+<a name="nat_dnat_rules"></a>
+The `rules` block supports:
+
+* `id` - The ID of the DNAT rule.
+
+* `gateway_id` - The ID of the NAT gateway to which the DNAT rule belongs.
+
+* `protocol` - The protocol type of the DNAT rule.
+
+* `port_id` - The port ID of the backend instance to which the DNAT rule belongs.
+
+* `private_ip` - The private IP address of the backend instance to which the DNAT rule belongs.
+
+* `internal_service_port` - The port of the backend instance to which the DNAT rule belongs.
+
+* `external_service_port` - The port of the EIP associated with the DNAT rule belongs.
+
+* `floating_ip_id` - The ID of the EIP associated with the DNAT rule.
+
+* `floating_ip_address` - The IP address of the EIP associated with the DNAT rule.
+
+* `global_eip_id` - The ID of the global EIP associated with the DNAT rule.
+
+* `global_eip_address` - The IP address of the global EIP associated with the DNAT rule.
+
+* `internal_service_port_range` - The port range of the backend instance to which the DNAT rule belongs.
+
+* `external_service_port_range` - The port range of the EIP associated with the DNAT rule.
+
+* `description` - The description of the DNAT rule.
+
+* `status` - The status of the DNAT rule.
+
+* `created_at` - The creation time of the DNAT rule.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -577,6 +577,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_nat_gateway":             nat.DataSourcePublicGateway(),
 			"huaweicloud_nat_gateways":            nat.DataSourcePublicGateways(),
+			"huaweicloud_nat_dnat_rules":          nat.DataSourceDnatRules(),
 			"huaweicloud_nat_private_dnat_rules":  nat.DataSourcePrivateDnatRules(),
 			"huaweicloud_nat_private_gateways":    nat.DataSourcePrivateGateways(),
 			"huaweicloud_nat_private_snat_rules":  nat.DataSourcePrivateSnatRules(),

--- a/huaweicloud/services/acceptance/nat/data_source_huaweiclolud_nat_dnat_rules_test.go
+++ b/huaweicloud/services/acceptance/nat/data_source_huaweiclolud_nat_dnat_rules_test.go
@@ -1,0 +1,289 @@
+package nat
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDatasourceDnatRules_basic(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceName()
+		baseConfig     = testAccDnatRulesDataSource_base(name)
+		dataSourceName = "data.huaweicloud_nat_dnat_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byRuleId   = "data.huaweicloud_nat_dnat_rules.filter_by_rule_id"
+		dcByRuleId = acceptance.InitDataSourceCheck(byRuleId)
+
+		byGatewayId   = "data.huaweicloud_nat_dnat_rules.filter_by_gateway_id"
+		dcByGatewayId = acceptance.InitDataSourceCheck(byGatewayId)
+
+		byProtocol   = "data.huaweicloud_nat_dnat_rules.filter_by_protocol"
+		dcByProtocol = acceptance.InitDataSourceCheck(byProtocol)
+
+		byInternalServicePort   = "data.huaweicloud_nat_dnat_rules.filter_by_internal_service_port"
+		dcByInternalServicePort = acceptance.InitDataSourceCheck(byInternalServicePort)
+
+		byPortId   = "data.huaweicloud_nat_dnat_rules.filter_by_port_id"
+		dcByPortId = acceptance.InitDataSourceCheck(byPortId)
+
+		byPrivateIp   = "data.huaweicloud_nat_dnat_rules.filter_by_private_ip"
+		dcByPrivateIp = acceptance.InitDataSourceCheck(byPrivateIp)
+
+		byStatus   = "data.huaweicloud_nat_dnat_rules.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byFloatingIpAddress   = "data.huaweicloud_nat_dnat_rules.filter_by_floating_ip_address"
+		dcByFloatingIpAddress = acceptance.InitDataSourceCheck(byFloatingIpAddress)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDnatRules_basic(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					dcByRuleId.CheckResourceExists(),
+					resource.TestCheckOutput("rule_id_filter_is_useful", "true"),
+
+					dcByGatewayId.CheckResourceExists(),
+					resource.TestCheckOutput("gateway_id_filter_is_useful", "true"),
+
+					dcByProtocol.CheckResourceExists(),
+					resource.TestCheckOutput("protocol_filter_is_useful", "true"),
+
+					dcByInternalServicePort.CheckResourceExists(),
+					resource.TestCheckOutput("internal_service_port_filter_is_useful", "true"),
+
+					dcByPortId.CheckResourceExists(),
+					resource.TestCheckOutput("port_id_filter_is_useful", "true"),
+
+					dcByPrivateIp.CheckResourceExists(),
+					resource.TestCheckOutput("private_ip_filter_is_useful", "true"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+
+					dcByFloatingIpAddress.CheckResourceExists(),
+					resource.TestCheckOutput("floating_ip_address_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDnatRulesDataSource_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "eip-test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name              = "%[2]s"
+  flavor_id         = data.huaweicloud_compute_flavors.test.ids[0]
+  image_id          = data.huaweicloud_images_image.test.id
+  security_groups   = [huaweicloud_networking_secgroup.test.name]
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_nat_gateway" "test" {
+  name                  = "%[2]s"
+  spec                  = "1"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_nat_dnat_rule" "test" {
+  nat_gateway_id        = huaweicloud_nat_gateway.test.id
+  floating_ip_id        = huaweicloud_vpc_eip.test.id
+  private_ip            = huaweicloud_compute_instance.test.network[0].fixed_ip_v4
+  description           = "Created by acc test"
+  protocol              = "tcp"
+  internal_service_port = 60
+  external_service_port = 2000
+}
+`, common.TestBaseComputeResources(name), name)
+}
+
+func testAccDatasourceDnatRules_basic(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_nat_dnat_rules" "test" {
+  depends_on = [
+    huaweicloud_nat_dnat_rule.test
+  ]
+}
+
+locals {
+  rule_id = data.huaweicloud_nat_dnat_rules.test.rules[0].id
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_rule_id" {
+  rule_id = local.rule_id
+}
+
+locals {
+  rule_id_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_rule_id.rules[*].id : v == local.rule_id
+  ]
+}
+
+output "rule_id_filter_is_useful" {
+  value = alltrue(local.rule_id_filter_result) && length(local.rule_id_filter_result) > 0
+}
+
+locals {
+  gateway_id = data.huaweicloud_nat_dnat_rules.test.rules[0].gateway_id
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_gateway_id" {
+  gateway_id = local.gateway_id
+}
+
+locals {
+  gateway_id_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_gateway_id.rules[*].gateway_id : 
+    v == local.gateway_id
+  ]
+}
+
+output "gateway_id_filter_is_useful" {
+  value = alltrue(local.gateway_id_filter_result) && length(local.gateway_id_filter_result) > 0
+}
+
+locals {
+  protocol = data.huaweicloud_nat_dnat_rules.test.rules[0].protocol
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_protocol" {
+  protocol = local.protocol
+}
+
+locals {
+  protocol_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_protocol.rules[*].protocol : v == local.protocol
+  ]
+}
+
+output "protocol_filter_is_useful" {
+  value = alltrue(local.protocol_filter_result) && length(local.protocol_filter_result) > 0
+}
+
+locals {
+  internal_service_port = data.huaweicloud_nat_dnat_rules.test.rules[0].internal_service_port
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_internal_service_port" {
+  internal_service_port = local.internal_service_port
+}
+
+locals {
+  internal_service_port_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_internal_service_port.rules[*].internal_service_port : 
+    v == local.internal_service_port
+  ]
+}
+
+output "internal_service_port_filter_is_useful" {
+  value = alltrue(local.internal_service_port_filter_result) && length(local.internal_service_port_filter_result) > 0
+}
+
+locals {
+  port_id = data.huaweicloud_nat_dnat_rules.test.rules[0].port_id
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_port_id" {
+  port_id = local.port_id
+}
+
+locals {
+  port_id_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_port_id.rules[*].port_id : v == local.port_id
+  ]
+}
+
+output "port_id_filter_is_useful" {
+  value = alltrue(local.port_id_filter_result) && length(local.port_id_filter_result) > 0
+}
+
+locals {
+  private_ip = data.huaweicloud_nat_dnat_rules.test.rules[0].private_ip
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_private_ip" {
+  private_ip = local.private_ip
+}
+
+locals {
+  private_ip_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_private_ip.rules[*].private_ip : v == local.private_ip
+  ]
+}
+
+output "private_ip_filter_is_useful" {
+  value = alltrue(local.private_ip_filter_result) && length(local.private_ip_filter_result) > 0
+}
+
+locals {
+  status = data.huaweicloud_nat_dnat_rules.test.rules[0].status
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_status" {
+  status = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_status.rules[*].status : v == local.status
+  ]
+}
+
+output "status_filter_is_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+
+
+locals {
+  floating_ip_address = data.huaweicloud_nat_dnat_rules.test.rules[0].floating_ip_address
+}
+
+data "huaweicloud_nat_dnat_rules" "filter_by_floating_ip_address" {
+  floating_ip_address = local.floating_ip_address
+}
+
+locals {
+  floating_ip_address_filter_result = [
+    for v in data.huaweicloud_nat_dnat_rules.filter_by_floating_ip_address.rules[*].floating_ip_address : 
+    v == local.floating_ip_address
+  ]
+}
+
+output "floating_ip_address_filter_is_useful" {
+  value = alltrue(local.floating_ip_address_filter_result) && length(local.floating_ip_address_filter_result) > 0
+}
+`, baseConfig)
+}

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_dnat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_dnat_rules.go
@@ -1,0 +1,333 @@
+package nat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API NAT GET /v2/{project_id}/dnat_rules
+func DataSourceDnatRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDnatRulesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The region where the DNAT rules are located.",
+			},
+			"rule_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the DNAT rule.",
+			},
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the NAT gateway to which the DNAT rule belongs.",
+			},
+			"protocol": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The protocol type of the DNAT rule.",
+			},
+			"port_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The port ID of the backend instance to which the DNAT rule belongs.",
+			},
+			"private_ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The private IP address of the backend instance to which the DNAT rule belongs.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The status of the DNAT rule belongs.",
+			},
+			"internal_service_port": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The port of the backend instance to which the DNAT rule belongs.",
+			},
+			"external_service_port": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The port of the EIP associated with the DNAT rule belongs.",
+			},
+			"floating_ip_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the EIP associated with the DNAT rule.",
+			},
+			"floating_ip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The IP address of EIP associated with the DNAT rule.",
+			},
+			"global_eip_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the global EIP associated with the DNAT rule.",
+			},
+			"global_eip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The IP address of the global EIP associated with the DNAT rule.",
+			},
+			"rules": {
+				Type:        schema.TypeList,
+				Elem:        dnatRuleSchema(),
+				Computed:    true,
+				Description: "The list of the DNAT rules.",
+			},
+		},
+	}
+}
+
+func dnatRuleSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the DNAT rule.",
+			},
+			"gateway_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the NAT gateway to which the DNAT rule belongs.",
+			},
+			"protocol": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The protocol type of the private DNAT rule.",
+			},
+			"port_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The port ID of the backend instance to which the DNAT rule belongs.",
+			},
+			"private_ip": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The private IP address of the backend instance to which the DNAT rule belongs.",
+			},
+			"internal_service_port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The port of the backend instance to which the DNAT rule belongs.",
+			},
+			"external_service_port": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The port of the EIP associated with the DNAT rule belongs",
+			},
+			"floating_ip_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the EIP associated with the DNAT rule.",
+			},
+			"floating_ip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IP address of the EIP associated with the DNAT rule.",
+			},
+			"global_eip_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the global EIP associated with the DNAT rule.",
+			},
+			"global_eip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IP address of the global EIP associated with the DNAT rule.",
+			},
+			"internal_service_port_range": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The port range of the backend instance to which the DNAT rule belongs.",
+			},
+			"external_service_port_range": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The port range of the EIP associated with the DNAT rule belongs",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the DNAT rule.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the DNAT rule.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the DNAT rule.",
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceDnatRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// listDnatRules: Query the DNAT rule list
+	var (
+		listDnatRulesHttpUrl = "v2/{project_id}/dnat_rules"
+		listDnatRulesProduct = "nat"
+	)
+	listDnatRulesClient, err := cfg.NewServiceClient(listDnatRulesProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating NAT client: %s", err)
+	}
+
+	listDnatRulesPath := listDnatRulesClient.Endpoint + listDnatRulesHttpUrl
+	listDnatRulesPath = strings.ReplaceAll(listDnatRulesPath, "{project_id}", listDnatRulesClient.ProjectID)
+
+	listDnatRulesQueryParams := buildListDnatRuleQueryParams(d)
+	listDnatRulesPath += listDnatRulesQueryParams
+
+	listDnatRulesResp, err := pagination.ListAllItems(
+		listDnatRulesClient,
+		"marker",
+		listDnatRulesPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving private DNAT rule")
+	}
+
+	listDnatRulesRespJson, err := json.Marshal(listDnatRulesResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listDnatRulesRespBody interface{}
+	err = json.Unmarshal(listDnatRulesRespJson, &listDnatRulesRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("rules", filterListDnatRuleResponseBody(flattenListDnatRulesResponseBody(listDnatRulesRespBody), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListDnatRulesResponseBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("dnat_rules", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                          utils.PathSearch("id", v, nil),
+			"gateway_id":                  utils.PathSearch("nat_gateway_id", v, nil),
+			"protocol":                    utils.PathSearch("protocol", v, nil),
+			"port_id":                     utils.PathSearch("port_id", v, nil),
+			"private_ip":                  utils.PathSearch("private_ip", v, nil),
+			"internal_service_port":       utils.PathSearch("internal_service_port", v, nil),
+			"external_service_port":       utils.PathSearch("external_service_port", v, nil),
+			"floating_ip_id":              utils.PathSearch("floating_ip_id", v, nil),
+			"floating_ip_address":         utils.PathSearch("floating_ip_address", v, nil),
+			"global_eip_id":               utils.PathSearch("global_eip_id", v, nil),
+			"global_eip_address":          utils.PathSearch("global_eip_address", v, nil),
+			"internal_service_port_range": utils.PathSearch("internal_service_port_range", v, nil),
+			"external_service_port_range": utils.PathSearch("external_service_port_range", v, nil),
+			"description":                 utils.PathSearch("description", v, nil),
+			"status":                      utils.PathSearch("status", v, nil),
+			"created_at":                  utils.PathSearch("created_at", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterListDnatRuleResponseBody(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("global_eip_id"); ok &&
+			fmt.Sprint(param) != utils.PathSearch("global_eip_id", v, nil) {
+			continue
+		}
+
+		if param, ok := d.GetOk("global_eip_address"); ok &&
+			fmt.Sprint(param) != utils.PathSearch("global_eip_address", v, nil) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func buildListDnatRuleQueryParams(d *schema.ResourceData) string {
+	res := ""
+
+	if v, ok := d.GetOk("rule_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("gateway_id"); ok {
+		res = fmt.Sprintf("%s&nat_gateway_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("protocol"); ok {
+		res = fmt.Sprintf("%s&protocol=%v", res, v)
+	}
+	if v, ok := d.GetOk("port_id"); ok {
+		res = fmt.Sprintf("%s&port_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("private_ip"); ok {
+		res = fmt.Sprintf("%s&private_ip=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("floating_ip_id"); ok {
+		res = fmt.Sprintf("%s&floating_ip_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("floating_ip_address"); ok {
+		res = fmt.Sprintf("%s&floating_ip_address=%v", res, v)
+	}
+	if v, ok := d.GetOk("internal_service_port"); ok {
+		res = fmt.Sprintf("%s&internal_service_port=%v", res, v)
+	}
+	if v, ok := d.GetOk("external_service_port"); ok {
+		res = fmt.Sprintf("%s&external_service_port=%v", res, v)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new datasource to get the list of the dnat rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new datasource to get the list of the public dnat rules.
2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_dnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasourceDnatRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasourceDnatRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDnatRules_basic
=== PAUSE TestAccDatasourceDnatRules_basic
=== CONT  TestAccDatasourceDnatRules_basic
--- PASS: TestAccDatasourceDnatRules_basic (275.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       275.601s
```
