### PR TITLE
fix(CSS): fix CSS cluster prePaid creation logic

### DIFF
--- a/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
@@ -722,7 +722,7 @@ func buildClusterCreateParameters(d *schema.ResourceData, config *config.Config)
 		}
 	}
 
-	if payModel, ok := d.GetOk("period_unit"); ok || d.Get("charging_mode").(string) == "prePaid" {
+	if payModel, ok := d.GetOk("period_unit"); ok && d.Get("charging_mode").(string) != "postPaid" {
 		createOpts.PayInfo = &cssv2model.PayInfoBody{
 			Period:    int32(d.Get("period").(int)),
 			IsAutoPay: utils.Int32(1),


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

When building parameters, if period_unit is not empty, or charging_mode is prePaid, annual/monthly instances will be created.
Customers only want to use the charging_mode parameter to control annual/monthly instance creation.

**Special notes for your reviewer**:

**Release note**:

```
fix CSS cluster prePaid creation logic
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssCluster_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_basic
=== PAUSE TestAccCssCluster_basic
=== CONT  TestAccCssCluster_basic
--- PASS: TestAccCssCluster_basic (1565.67s)
PASS
```
```
 make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssCluster_prePaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_prePaid -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_prePaid
=== PAUSE TestAccCssCluster_prePaid
=== CONT  TestAccCssCluster_prePaid
--- PASS: TestAccCssCluster_prePaid (1138.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1138.763s
```
