### PR TITLE
feat(cdn): add a new data source to query the list of CDN domains

### DIFF
--- a/docs/data-sources/cdn_domains.md
+++ b/docs/data-sources/cdn_domains.md
@@ -1,0 +1,138 @@
+---
+subcategory: Content Delivery Network (CDN)
+---
+
+# huaweicloud_cdn_domains
+
+Use this data source to get a list of CDN domains.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cdn_domains" "test" {
+  type          = "web"
+  domain_status = "online"
+  service_area  = "mainland_china"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_id` - (Optional, String) Specifies the ID of accelerate domain.
+
+* `name` - (Optional, String) Specifies the name of accelerate domain, using fuzzy matching.
+  The valid length is limited from **1** to **255**.
+
+* `type` - (Optional, String) Specifies the business type of accelerate domain.
+  The valid values are as follows;
+  + **web**: Accelerate for the website.
+  + **download**: Accelerate for file downloads.
+  + **video**: Accelerate for on-demand.
+  + **wholeSite**: Accelerate for the entire site.
+
+* `domain_status` - (Optional, String) Specifies the status of accelerate domain.
+  The valid value can be **online**, **offline**, **configuring**, **configuring_failed**, **checking**,
+  **check_failed** or **deleting**.
+
+* `service_area` - (Optional, String) Specifies the area covered by the accelerate service.
+  The valid value can be **mainland_china**, **outside_mainland_china** or **global**.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the CDN domain.
+  When the user turns on the enterprise project function, this parameter takes effect,
+  indicating that the project to which the resource belongs is queried.
+  "all" indicates all projects.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `domains` - A list of CDN domains.
+  The [domains](#block-domains) structure is documented below.
+
+<a name="block-domains"></a>
+The `domains` block supports:
+
+* `id` - The ID of CDN domain.
+
+* `name` - The name of accelerate domain.
+
+* `type` - The business type of accelerate domain.
+
+* `domain_status` - The status of accelerate domain.
+
+* `cname` - The CNAME of the accelerate domain.
+
+* `sources` - An array of one or more objects specifies the domain of the origin server.
+  The [sources](#block-sources) structure is documented below.
+
+* `domain_origin_host` - The back-to-origin HOST configuration of accelerate domain.
+  The [domain_origin_host](#block-domain_origin_host) structure is documented below.
+
+* `https_status` - The status of the https. The valid values are as follows:
+  + **0**: Disable HTTPS acceleration.
+  + **1**: Turn on HTTPS acceleration.
+
+* `created_at` - The creation time of accelerate domain.
+
+* `updated_at` - The update time of accelerate domain.
+
+* `disabled` - Ban status. The valid values are as follows:
+  + **0**: The domain is not banned.
+  + **1**: The domain is banned.
+
+* `locked` - Lock status. The valid values are as follows:
+  + **0**: The domain is not locked
+  + **1**: The domain is locked.
+
+* `auto_refresh_preheat` - Whether to automatically refresh preheating. The valid values are as follows:
+  + **0**: Auto_refresh_preheat is off.
+  + **1**: Auto_refresh_preheat is on.
+
+* `service_area` - The area covered by the accelerate service.
+
+* `range_based_retrieval_enabled` - Whether to enable range-based retrieval.
+  The valid value can be **true** or **false**.
+
+* `follow_status` - The status of back-to-source following.
+  The valid value can be **on** or **off**.
+
+* `origin_status` - Whether to pause origin site return to origin.
+  The valid value can be **on** or **off**.
+
+* `banned_reason` - The reason why the domain was banned.
+
+* `locked_reason` - The reason why the domain was locked.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `tags` - The key/value pairs to associate with the domain.
+
+<a name="block-sources"></a>
+The `sources` block supports:
+
+* `origin` - The domain name or IP address of the origin server.
+
+* `origin_type` - The origin server type. The valid values can be **ipaddr**, **domain** or **obs_bucket**.
+
+* `active` - Whether an origin server is active or standby. The valid values are ad follows:
+  + **1**: The origin source is primary source site.
+  + **0**: The origin source is backup source site.
+
+* `obs_web_hosting_enabled` - Whether to enable static website hosting for the OBS bucket.
+  The valid value can be **true** or **false**.
+
+<a name="block-domain_origin_host"></a>
+The `domain_origin_host` block supports:
+
+* `origin_host_type` - The type of origin host. The valid values are as follows:
+  + **accelerate**: Select the accelerate domain as the back-to-origin host domain.
+  + **customize**: Use a custom domain as the back-to-origin host domain.
+
+* `customize_domain` - The name of origin host. Return the host domain set by the primary origin site
+  of the accelerate domain. If the accelerate domain has multiple primary origin sites and corresponds
+  to multiple back-to-origin hosts, the host domain corresponding to the first primary origin site in
+  the origin site configuration will be returned.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -426,6 +426,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ccm_private_certificate_export": ccm.DataSourceCcmPrivateCertificateExport(),
 
 			"huaweicloud_cdn_domain_statistics": cdn.DataSourceStatistics(),
+			"huaweicloud_cdn_domains":           cdn.DataSourceCdnDomains(),
 
 			"huaweicloud_cfw_firewalls": cfw.DataSourceFirewalls(),
 

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domains_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domains_test.go
@@ -1,0 +1,128 @@
+package cdn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCDNDomains_basic(t *testing.T) {
+	rName := "data.huaweicloud_cdn_domains.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCDN(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDomains_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.domain_status"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.cname"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.https_status"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.service_area"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.enterprise_project_id"),
+
+					resource.TestCheckOutput("domain_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckOutput("domain_status_filter_is_useful", "true"),
+					resource.TestCheckOutput("service_area_filter_is_useful", "true"),
+					resource.TestCheckOutput("enterprise_project_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDomains_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_cdn_domains" "test" {
+  depends_on = [huaweicloud_cdn_domain.test]
+}
+
+data "huaweicloud_cdn_domains" "domain_id_filter" {
+  domain_id = huaweicloud_cdn_domain.test.id
+}
+locals {
+  domain_id = huaweicloud_cdn_domain.test.id
+}
+output "domain_id_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_domains.domain_id_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_domains.domain_id_filter.domains[*].id : v == local.domain_id]
+  )  
+}
+
+data "huaweicloud_cdn_domains" "name_filter" {
+  name = data.huaweicloud_cdn_domains.test.domains.0.name
+}
+locals {
+  name = data.huaweicloud_cdn_domains.test.domains.0.name
+}
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_domains.name_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_domains.name_filter.domains[*].name : v == local.name]
+  )  
+}
+
+data "huaweicloud_cdn_domains" "type_filter" {
+  type = data.huaweicloud_cdn_domains.test.domains.0.type
+}
+locals {
+  type = data.huaweicloud_cdn_domains.test.domains.0.type
+}
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_domains.type_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_domains.type_filter.domains[*].type : v == local.type]
+  )  
+}
+
+data "huaweicloud_cdn_domains" "service_area_filter" {
+  service_area = data.huaweicloud_cdn_domains.test.domains.0.service_area
+}
+locals {
+  service_area = data.huaweicloud_cdn_domains.test.domains.0.service_area
+}
+output "service_area_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_domains.service_area_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_domains.service_area_filter.domains[*].service_area : v == local.service_area]
+  )  
+}
+
+data "huaweicloud_cdn_domains" "domain_status_filter" {
+  domain_status = data.huaweicloud_cdn_domains.test.domains.0.domain_status
+}
+locals {
+  domain_status = data.huaweicloud_cdn_domains.test.domains.0.domain_status
+}
+output "domain_status_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_domains.domain_status_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_domains.domain_status_filter.domains[*].domain_status : v == local.domain_status]
+  )  
+}
+
+data "huaweicloud_cdn_domains" "enterprise_project_id_filter" {
+  enterprise_project_id = data.huaweicloud_cdn_domains.test.domains.0.enterprise_project_id
+}
+locals {
+  enterprise_project_id = data.huaweicloud_cdn_domains.test.domains.0.enterprise_project_id
+}
+output "enterprise_project_id_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_domains.enterprise_project_id_filter.domains) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_domains.enterprise_project_id_filter.domains[*].enterprise_project_id : v == local.enterprise_project_id]
+  )  
+}
+`, testAccCdnDomainV1_basic)
+}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domains.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domains.go
@@ -1,0 +1,311 @@
+package cdn
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN GET /v1.0/cdn/domains
+func DataSourceCdnDomains() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceDomainsRead,
+
+		Schema: map[string]*schema.Schema{
+			"domain_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"service_area": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domains": {
+				Type:     schema.TypeList,
+				Elem:     cdnDomainSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func cdnDomainSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"domain_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cname": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     sourceSchema(),
+			},
+			"domain_origin_host": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"https_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disabled": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"locked": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"auto_refresh_preheat": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"service_area": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"range_based_retrieval_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"follow_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"origin_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"banned_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"locked_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": common.TagsComputedSchema(),
+		},
+	}
+	return &sc
+}
+
+func sourceSchema() *schema.Resource {
+	sc := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"origin_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"active": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"obs_web_hosting_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+
+	return sc
+}
+
+func datasourceDomainsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		getCDNDomainsHttpUrl = "v1.0/cdn/domains"
+		getCDNDomainsProduct = "cdn"
+	)
+	getCDNDomainsClient, err := cfg.NewServiceClient(getCDNDomainsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CDN client: %s", err)
+	}
+
+	getCDNDomainsPath := getCDNDomainsClient.Endpoint + getCDNDomainsHttpUrl + "?page_size=10"
+	epsId := cfg.GetEnterpriseProjectID(d)
+	if epsId != "" {
+		getCDNDomainsPath += fmt.Sprintf("&enterprise_project_id=%v", epsId)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		getCDNDomainsPath += fmt.Sprintf("&domain_name=%v", v)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		getCDNDomainsPath += fmt.Sprintf("&business_type=%v", v)
+	}
+	if v, ok := d.GetOk("domain_status"); ok {
+		getCDNDomainsPath += fmt.Sprintf("&domain_status=%v", v)
+	}
+	if v, ok := d.GetOk("service_area"); ok {
+		getCDNDomainsPath += fmt.Sprintf("&service_area=%v", v)
+	}
+	getCDNDomainsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	currentTotal := 1
+	rst := make([]interface{}, 0)
+	for {
+		currentPath := fmt.Sprintf("%s&page_number=%v", getCDNDomainsPath, currentTotal)
+		getCDNDomainsResp, err := getCDNDomainsClient.Request("GET", currentPath, &getCDNDomainsOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		getCDNDomainsRespBody, err := utils.FlattenResponse(getCDNDomainsResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		domains := utils.PathSearch("domains", getCDNDomainsRespBody, make([]interface{}, 0)).([]interface{})
+		if len(domains) == 0 {
+			break
+		}
+		rst = append(rst, domains...)
+		currentTotal++
+	}
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("domains", filterListDomainsBody(flattenListDomainsBody(rst), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListDomainsBody(domains []interface{}) []interface{} {
+	rst := make([]interface{}, 0)
+	for _, v := range domains {
+		createTime := utils.PathSearch("create_time", v, 0)
+		updateTime := utils.PathSearch("modify_time", v, 0)
+		rst = append(rst, map[string]interface{}{
+			"id":                            utils.PathSearch("id", v, nil),
+			"name":                          utils.PathSearch("domain_name", v, nil),
+			"type":                          utils.PathSearch("business_type", v, nil),
+			"domain_status":                 utils.PathSearch("domain_status", v, nil),
+			"cname":                         utils.PathSearch("cname", v, nil),
+			"sources":                       flattenSources(v),
+			"domain_origin_host":            utils.PathSearch("domain_origin_host", v, nil),
+			"https_status":                  utils.PathSearch("https_status", v, nil),
+			"created_at":                    utils.FormatTimeStampRFC3339(int64(createTime.(float64))/1000, false),
+			"updated_at":                    utils.FormatTimeStampRFC3339(int64(updateTime.(float64))/1000, false),
+			"disabled":                      utils.PathSearch("disabled", v, nil),
+			"locked":                        utils.PathSearch("locked", v, nil),
+			"auto_refresh_preheat":          utils.PathSearch("auto_refresh_preheat", v, nil),
+			"service_area":                  utils.PathSearch("service_area", v, nil),
+			"range_based_retrieval_enabled": converseRangeStatusToBool(utils.PathSearch("range_status", v, "").(string)),
+			"follow_status":                 utils.PathSearch("follow_status", v, nil),
+			"origin_status":                 utils.PathSearch("origin_status", v, nil),
+			"banned_reason":                 utils.PathSearch("banned_reason", v, nil),
+			"locked_reason":                 utils.PathSearch("locked_reason", v, nil),
+			"enterprise_project_id":         utils.PathSearch("enterprise_project_id", v, nil),
+			"tags":                          utils.FlattenTagsToMap(utils.PathSearch("tags", v, make(map[string]interface{}, 0))),
+		})
+	}
+	return rst
+}
+
+func converseRangeStatusToBool(status interface{}) bool {
+	return status == "on"
+}
+
+func converseOBSWebHostStatusToBool(status interface{}) bool {
+	return status == 1
+}
+
+func filterListDomainsBody(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("domain_id"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("id", v, nil)) {
+			continue
+		}
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func flattenSources(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("sources", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"origin":                  utils.PathSearch("ip_or_domain", v, nil),
+			"origin_type":             utils.PathSearch("origin_type", v, nil),
+			"active":                  utils.PathSearch("active_standby", v, nil),
+			"obs_web_hosting_enabled": converseOBSWebHostStatusToBool(utils.PathSearch("enable_obs_web_hosting", v, nil)),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
+ add a new data source to query the list of CDN domains

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
+ This interface is a global interface and there is no need to select a region.
+ The paging method is page_number+page_size, there is no public method, and the for loop query is used in the code.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccDatasourceCDNDomains_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceCDNDomains_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCDNDomains_basic
=== PAUSE TestAccDatasourceCDNDomains_basic
=== CONT  TestAccDatasourceCDNDomains_basic
--- PASS: TestAccDatasourceCDNDomains_basic (262.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       262.908s
```
