### PR TITLE
chore(dws): add content-type  for api

### DIFF
--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_queue_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_queue_test.go
@@ -32,6 +32,7 @@ func getWorkloadQueueResourceFunc(cfg *config.Config, state *terraform.ResourceS
 	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
 	getPath = strings.ReplaceAll(getPath, "{cluster_id}", state.Primary.Attributes["cluster_id"])
 	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
 		KeepResponseBody: true,
 	}
 

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
@@ -30,6 +30,10 @@ const (
 	createDuplicateNameMsg       = "logical cluster already existed"
 )
 
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+}
+
 // @API DWS POST /v2/{project_id}/clusters/{cluster_id}/logical-clusters
 // @API DWS GET /v2/{project_id}/clusters/{cluster_id}/logical-clusters
 // @API DWS DELETE /v2/{project_id}/clusters/{cluster_id}/logical-clusters/{logical_cluster_id}
@@ -171,6 +175,7 @@ func resourceLogicalClusterCreate(ctx context.Context, d *schema.ResourceData, m
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
 	createPath = strings.ReplaceAll(createPath, "{cluster_id}", d.Get("cluster_id").(string))
 	createOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		JSONBody:         buildCreateLogicalClusterBodyParams(d),
 	}
@@ -433,6 +438,7 @@ func resourceLogicalClusterDelete(ctx context.Context, d *schema.ResourceData, m
 	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", d.Get("cluster_id").(string))
 	deletePath = strings.ReplaceAll(deletePath, "{logical_cluster_id}", d.Id())
 	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 	}
 

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_workload_queue.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_workload_queue.go
@@ -93,6 +93,7 @@ func resourceWorkLoadQueueCreate(ctx context.Context, d *schema.ResourceData, me
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
 	createPath = strings.ReplaceAll(createPath, "{cluster_id}", d.Get("cluster_id").(string))
 	createOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		JSONBody:         utils.RemoveNil(buildCreateWorkloadQueueBodyParams(d)),
 	}
@@ -153,6 +154,7 @@ func resourceWorkLoadQueueRead(_ context.Context, d *schema.ResourceData, meta i
 	getPath = strings.ReplaceAll(getPath, "{project_id}", getClient.ProjectID)
 	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
 	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 	}
 
@@ -200,6 +202,7 @@ func resourceWorkLoadQueueDelete(_ context.Context, d *schema.ResourceData, meta
 	deletePath = strings.ReplaceAll(deletePath, "{name}", d.Get("name").(string))
 	// Due to API restrictions, the request body must pass in an empty JSON.
 	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		JSONBody:         json.RawMessage("{}"),
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add 'application/json;charset=UTF-8' to all API request headers.
If content-type is missing, the service interceptor will throw an error in non cn-north-4 region.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add 'application/json;charset=UTF-8' to all API request headers.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceWorkloadQueue_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceWorkloadQueue_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceWorkloadQueue_basic
=== PAUSE TestAccResourceWorkloadQueue_basic
=== CONT  TestAccResourceWorkloadQueue_basic

--- PASS: TestAccResourceWorkloadQueue_basic (1220.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1220.409s
```
