### PR TITLE
fix(ELB): change param autoscaling_enabled and min_l7_flavor_id to deprecated

### DIFF
--- a/docs/resources/elb_loadbalancer.md
+++ b/docs/resources/elb_loadbalancer.md
@@ -192,12 +192,6 @@ The following arguments are supported:
 
 * `auto_renew` - (Optional, String) Specifies whether auto renew is enabled. Valid values are **true** and **false**.
 
-* `autoscaling_enabled` - (Optional, Bool) Specifies whether autoscaling is enabled. Valid values are **true** and
-  **false**.
-
-* `min_l7_flavor_id` - (Optional, String) Specifies the ID of the minimum Layer-7 flavor for elastic scaling.
-  This parameter cannot be left blank if there are HTTP or HTTPS listeners.
-
 * `force_delete` - (Optional, Bool) Specifies whether to forcibly delete the LoadBalancer, remove the LoadBalancer,
   listeners, unbind associated pools. Defaults to **false**.
 

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -251,6 +251,10 @@ func ResourceLoadBalancerV3() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
+				Description: utils.SchemaDesc(``,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					}),
 			},
 			"min_l7_flavor_id": {
 				Type:     schema.TypeString,
@@ -259,6 +263,10 @@ func ResourceLoadBalancerV3() *schema.Resource {
 				RequiredWith: []string{
 					"l7_flavor_id",
 				},
+				Description: utils.SchemaDesc(``,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					}),
 			},
 		},
 	}
@@ -685,9 +693,7 @@ func buildUpdateLoadBalancerBodyParams(d *schema.ResourceData) loadbalancers.Upd
 			updateOpts.AutoScaling.MinL7Flavor = ""
 		}
 	} else if d.HasChange("min_l7_flavor_id") && d.Get("autoscaling_enabled").(bool) {
-		if autoscalingEnabled := d.Get("autoscaling_enabled").(bool); autoscalingEnabled {
-			updateOpts.AutoScaling.MinL7Flavor = d.Get("min_l7_flavor_id").(string)
-		}
+		updateOpts.AutoScaling.MinL7Flavor = d.Get("min_l7_flavor_id").(string)
 	}
 
 	log.Printf("[DEBUG] Updating LoadBalancer %s with options: %#v", d.Id(), updateOpts)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  change param autoscaling_enabled and min_l7_flavor_id to deprecated
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  change param autoscaling_enabled and min_l7_flavor_id to deprecated
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccElbV3LoadBalancer_' TEST_PARALLELISM=6
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbV3LoadBalancer_ -timeout 360m -parallel 6
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== PAUSE TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid
=== RUN   TestAccElbV3LoadBalancer_availabilityZone
=== PAUSE TestAccElbV3LoadBalancer_availabilityZone
=== CONT  TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== CONT  TestAccElbV3LoadBalancer_withEpsId
=== CONT  TestAccElbV3LoadBalancer_withEIP
=== CONT  TestAccElbV3LoadBalancer_prePaid
=== CONT  TestAccElbV3LoadBalancer_availabilityZone
--- PASS: TestAccElbV3LoadBalancer_withEpsId (40.26s)
--- PASS: TestAccElbV3LoadBalancer_withEIP (45.99s)
--- PASS: TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id (54.06s)
--- PASS: TestAccElbV3LoadBalancer_availabilityZone (134.67s)
--- PASS: TestAccElbV3LoadBalancer_basic (139.37s)
--- PASS: TestAccElbV3LoadBalancer_prePaid (274.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       274.834s
```
