### PR TITLE
feat(RDS): rds instance support modify configuration

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -213,8 +213,7 @@ The following arguments are supported:
     + 0: Table names are stored as fixed and table names are case-sensitive.
     + 1: Table names will be stored in lower case and table names are not case-sensitive.
 
-* `param_group_id` - (Optional, String, ForceNew) Specifies the parameter group ID. Changing this parameter will create
-  a new resource.
+* `param_group_id` - (Optional, String) Specifies the parameter group ID.
 
 * `collation` - (Optional, String) Specifies the Character Set, only available to Microsoft SQL Server DB instances.
 

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_test.go
@@ -109,7 +109,7 @@ resource "huaweicloud_rds_parametergroup" "pg_1" {
   }
   datastore {
     type    = "mysql"
-    version = "5.6"
+    version = "5.7"
   }
 }
 `, rName)
@@ -127,7 +127,7 @@ resource "huaweicloud_rds_parametergroup" "pg_1" {
   }
   datastore {
     type    = "mysql"
-    version = "5.6"
+    version = "5.7"
   }
 }
 `, updateName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support fix configuration
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support fix configuration
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsConfiguration_basic
=== PAUSE TestAccRdsConfiguration_basic
=== CONT  TestAccRdsConfiguration_basic
--- PASS: TestAccRdsConfiguration_basic (19.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       19.390s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_'  TEST_PARALLELISM=13
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 13
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_without_password
=== PAUSE TestAccRdsInstance_without_password
=== RUN   TestAccRdsInstance_withEpsId
=== PAUSE TestAccRdsInstance_withEpsId
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_withConfiguration
=== PAUSE TestAccRdsInstance_withConfiguration
=== RUN   TestAccRdsInstance_withParameters
=== PAUSE TestAccRdsInstance_withParameters
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_withEpsId
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_without_password
=== CONT  TestAccRdsInstance_withParameters
=== CONT  TestAccRdsInstance_withConfiguration
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_sqlserver
--- PASS: TestAccRdsInstance_mariadb (440.27s)
--- PASS: TestAccRdsInstance_withEpsId (461.32s)
--- PASS: TestAccRdsInstance_without_password (483.67s)
--- PASS: TestAccRdsInstance_ha (524.37s)
--- PASS: TestAccRdsInstance_withConfiguration (568.06s)
--- PASS: TestAccRdsInstance_basic (582.63s)
--- PASS: TestAccRdsInstance_withParameters (891.40s)
--- PASS: TestAccRdsInstance_prePaid (1206.46s)
--- PASS: TestAccRdsInstance_mysql (1260.99s)
--- PASS: TestAccRdsInstance_restore_pg (2172.94s)
--- PASS: TestAccRdsInstance_restore_mysql (2184.73s)
--- PASS: TestAccRdsInstance_sqlserver (2573.23s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2966.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2966.598s
```
