### PR TITLE
fix(dws/cluster): if the cluster fails to be created, it won't deleted

### DIFF
--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
@@ -709,6 +709,7 @@ func clusterWaitingForAvailable(ctx context.Context, d *schema.ResourceData, met
 			unexpectedStatus := []string{
 				"FAILED",
 				"CREATE_FAILED",
+				"CREATION FAILED",
 			}
 			if utils.StrSliceContains(unexpectedStatus, status) {
 				return clusterWaitingRespBody, status, nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add **CREATION FAILED** status.
If the value of **node_type** is sold out, the cluster fails to be created and it status is  **CREATION FAILED**. However, this status is missing in the code, so the cluster will not be deleted.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add **CREATION FAILED** status.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceCluster_basicV2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_basicV2 -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== CONT  TestAccResourceCluster_basicV2
--- PASS: TestAccResourceCluster_basicV2 (2235.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       2235.772s
```
