### PR TITLE
chore(dws): add content-type for all api

### DIFF
--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_plan_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_plan_test.go
@@ -32,6 +32,7 @@ func getWorkLoadPlanResourceFunc(cfg *config.Config, state *terraform.ResourceSt
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{cluster_id}", state.Primary.Attributes["cluster_id"])
 	listOpt := golangsdk.RequestOpts{
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
 		KeepResponseBody: true,
 	}
 

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_alarm_subscription.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_alarm_subscription.go
@@ -105,6 +105,7 @@ func resourceDwsAlarmSubsCreate(ctx context.Context, d *schema.ResourceData, met
 	createDwsAlarmSubsPath = strings.ReplaceAll(createDwsAlarmSubsPath, "{project_id}", createDwsAlarmSubsClient.ProjectID)
 
 	createDwsAlarmSubsOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,
@@ -232,6 +233,7 @@ func resourceDwsAlarmSubsUpdate(ctx context.Context, d *schema.ResourceData, met
 		updateDwsAlarmSubsPath = strings.ReplaceAll(updateDwsAlarmSubsPath, "{alarm_sub_id}", d.Id())
 
 		updateDwsAlarmSubsOpt := golangsdk.RequestOpts{
+			MoreHeaders:      requestOpts.MoreHeaders,
 			KeepResponseBody: true,
 			OkCodes: []int{
 				200,
@@ -277,6 +279,7 @@ func resourceDwsAlarmSubsDelete(_ context.Context, d *schema.ResourceData, meta 
 	deleteDwsAlarmSubsPath = strings.ReplaceAll(deleteDwsAlarmSubsPath, "{alarm_sub_id}", d.Id())
 
 	deleteDwsAlarmSubsOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
@@ -421,6 +421,7 @@ func updateDwsLogicalClusterEnable(client *golangsdk.ServiceClient, d *schema.Re
 	switchDwsClusterPath = strings.ReplaceAll(switchDwsClusterPath, "{cluster_id}", d.Id())
 
 	switchDwsClusterOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		JSONBody: map[string]interface{}{
 			"enable": d.Get("logical_cluster_enable"),
@@ -455,9 +456,7 @@ func resourceDwsClusterCreateV2(ctx context.Context, d *schema.ResourceData, met
 		OkCodes: []int{
 			200,
 		},
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders: requestOpts.MoreHeaders,
 	}
 
 	createDwsClusterOpt.JSONBody = utils.RemoveNil(buildCreateDwsClusterBodyParams(d, cfg))
@@ -522,9 +521,7 @@ func resourceDwsClusterCreateV1(ctx context.Context, d *schema.ResourceData, met
 		OkCodes: []int{
 			200,
 		},
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders: requestOpts.MoreHeaders,
 	}
 
 	createDwsClusterOpt.JSONBody = utils.RemoveNil(buildCreateDwsClusterBodyParamsV1(d, cfg))
@@ -670,9 +667,7 @@ func clusterWaitingForAvailable(ctx context.Context, d *schema.ResourceData, met
 				OkCodes: []int{
 					200,
 				},
-				MoreHeaders: map[string]string{
-					"Content-Type": "application/json;charset=UTF-8",
-				},
+				MoreHeaders: requestOpts.MoreHeaders,
 			}
 
 			clusterWaitingResp, err := clusterWaitingClient.Request("GET", clusterWaitingPath,
@@ -749,9 +744,7 @@ func resourceDwsClusterRead(_ context.Context, d *schema.ResourceData, meta inte
 		OkCodes: []int{
 			200,
 		},
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders: requestOpts.MoreHeaders,
 	}
 
 	getDwsClusterResp, err := getDwsClusterClient.Request("GET", getDwsClusterPath, &getDwsClusterOpt)
@@ -920,9 +913,7 @@ func resourceDwsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			OkCodes: []int{
 				200,
 			},
-			MoreHeaders: map[string]string{
-				"Content-Type": "application/json;charset=UTF-8",
-			},
+			MoreHeaders: requestOpts.MoreHeaders,
 		}
 
 		expandInstanceStorageOpt.JSONBody = utils.RemoveNil(buildExpandInstanceStorageBodyParams(d))
@@ -954,9 +945,7 @@ func resourceDwsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			OkCodes: []int{
 				200,
 			},
-			MoreHeaders: map[string]string{
-				"Content-Type": "application/json;charset=UTF-8",
-			},
+			MoreHeaders: requestOpts.MoreHeaders,
 		}
 
 		resetPasswordOfClusterOpt.JSONBody = utils.RemoveNil(buildResetPasswordOfClusterBodyParams(d))
@@ -989,9 +978,7 @@ func resourceDwsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			OkCodes: []int{
 				200,
 			},
-			MoreHeaders: map[string]string{
-				"Content-Type": "application/json;charset=UTF-8",
-			},
+			MoreHeaders: requestOpts.MoreHeaders,
 		}
 
 		scaleOutClusterOpt.JSONBody = utils.RemoveNil(buildScaleOutClusterBodyParams(d))
@@ -1105,9 +1092,7 @@ func resourceDwsClusterDelete(ctx context.Context, d *schema.ResourceData, meta 
 		OkCodes: []int{
 			200, 202,
 		},
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders: requestOpts.MoreHeaders,
 	}
 
 	deleteDwsClusterOpt.JSONBody = utils.RemoveNil(buildDeleteDwsClusterBodyParams(d))
@@ -1156,9 +1141,7 @@ func deleteClusterWaitingForCompleted(ctx context.Context, d *schema.ResourceDat
 				OkCodes: []int{
 					200,
 				},
-				MoreHeaders: map[string]string{
-					"Content-Type": "application/json;charset=UTF-8",
-				},
+				MoreHeaders: requestOpts.MoreHeaders,
 			}
 
 			deleteDwsClusterWaitingResp, err := deleteDwsClusterWaitingClient.Request("GET", deleteDwsClusterWaitingPath, &deleteDwsClusterWaitingOpt)
@@ -1248,9 +1231,7 @@ func addClusterTags(client *golangsdk.ServiceClient, clusterId string, rawTags [
 		OkCodes: []int{
 			200,
 		},
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders: requestOpts.MoreHeaders,
 	}
 	addTagsOpt.JSONBody = map[string]interface{}{
 		"tags": rawTags,
@@ -1277,9 +1258,7 @@ func deleteClusterTags(client *golangsdk.ServiceClient, clusterId string, rawTag
 		OkCodes: []int{
 			200,
 		},
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders: requestOpts.MoreHeaders,
 	}
 
 	deleteTagsOpt.JSONBody = map[string]interface{}{
@@ -1333,9 +1312,7 @@ func bindElb(ctx context.Context, d *schema.ResourceData, client *golangsdk.Serv
 
 	bindElbOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders:      requestOpts.MoreHeaders,
 	}
 
 	bindElbResp, err := client.Request("POST", bindElbPath, &bindElbOpt)
@@ -1383,9 +1360,7 @@ func unbindElb(ctx context.Context, d *schema.ResourceData, client *golangsdk.Se
 
 	bindElbOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders:      requestOpts.MoreHeaders,
 	}
 
 	unbindElbResp, err := client.Request("DELETE", unbindElbPath, &bindElbOpt)
@@ -1429,9 +1404,7 @@ func jobStatusRefreshFunc(client *golangsdk.ServiceClient, jobId string) resourc
 
 		getJobStatusOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			MoreHeaders: map[string]string{
-				"Content-Type": "application/json;charset=UTF-8",
-			},
+			MoreHeaders:      requestOpts.MoreHeaders,
 		}
 		getJobStatusResp, err := client.Request("GET", getJobStatusPath, &getJobStatusOpt)
 		if err != nil {

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_event_subscription.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_event_subscription.go
@@ -123,6 +123,7 @@ func resourceDwsEventSubsCreate(ctx context.Context, d *schema.ResourceData, met
 	createDwsEventSubsPath = strings.ReplaceAll(createDwsEventSubsPath, "{project_id}", createDwsEventSubsClient.ProjectID)
 
 	createDwsEventSubsOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,
@@ -259,6 +260,7 @@ func resourceDwsEventSubsUpdate(ctx context.Context, d *schema.ResourceData, met
 		updateDwsEventSubsPath = strings.ReplaceAll(updateDwsEventSubsPath, "{event_sub_id}", d.Id())
 
 		updateDwsEventSubsOpt := golangsdk.RequestOpts{
+			MoreHeaders:      requestOpts.MoreHeaders,
 			KeepResponseBody: true,
 			OkCodes: []int{
 				200,
@@ -307,6 +309,7 @@ func resourceDwsEventSubsDelete(_ context.Context, d *schema.ResourceData, meta 
 	deleteDwsEventSubsPath = strings.ReplaceAll(deleteDwsEventSubsPath, "{event_sub_id}", d.Id())
 
 	deleteDwsEventSubsOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_ext_data_source.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_ext_data_source.go
@@ -149,6 +149,7 @@ func resourceDwsExtDataSourceCreate(ctx context.Context, d *schema.ResourceData,
 	createDwsExtDataSourcePath = strings.ReplaceAll(createDwsExtDataSourcePath, "{cluster_id}", fmt.Sprintf("%v", d.Get("cluster_id")))
 
 	createDwsExtDataSourceOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,
@@ -250,9 +251,7 @@ func GetExtDataSource(cfg *config.Config, region string, d *schema.ResourceData,
 
 	getDwsExtDataSourceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders:      requestOpts.MoreHeaders,
 		OkCodes: []int{
 			200,
 		},
@@ -301,9 +300,7 @@ func resourceDwsExtDataSourceUpdate(ctx context.Context, d *schema.ResourceData,
 
 		updateDwsExtDataSourceOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			MoreHeaders: map[string]string{
-				"Content-Type": "application/json;charset=UTF-8",
-			},
+			MoreHeaders:      requestOpts.MoreHeaders,
 			OkCodes: []int{
 				200,
 			},
@@ -364,9 +361,7 @@ func resourceDwsExtDataSourceDelete(ctx context.Context, d *schema.ResourceData,
 
 	deleteDwsExtDataSourceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders:      requestOpts.MoreHeaders,
 		OkCodes: []int{
 			200,
 		},
@@ -453,9 +448,7 @@ func extDataSourceWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 
 			extDataSourceWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				MoreHeaders: map[string]string{
-					"Content-Type": "application/json;charset=UTF-8",
-				},
+				MoreHeaders:      requestOpts.MoreHeaders,
 				OkCodes: []int{
 					200,
 				},

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot.go
@@ -113,6 +113,7 @@ func resourceDwsSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta
 	createDwsSnapshotPath = strings.ReplaceAll(createDwsSnapshotPath, "{project_id}", createDwsSnapshotClient.ProjectID)
 
 	createDwsSnapshotOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,
@@ -176,9 +177,7 @@ func createDwsSnapshotWaitingForStateCompleted(ctx context.Context, d *schema.Re
 
 			createDwsSnapshotWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				MoreHeaders: map[string]string{
-					"Content-Type": "application/json;charset=UTF-8",
-				},
+				MoreHeaders:      requestOpts.MoreHeaders,
 				OkCodes: []int{
 					200,
 				},
@@ -246,9 +245,7 @@ func resourceDwsSnapshotRead(_ context.Context, d *schema.ResourceData, meta int
 
 	getDwsSnapshotOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders:      requestOpts.MoreHeaders,
 		OkCodes: []int{
 			200,
 		},
@@ -318,6 +315,7 @@ func resourceDwsSnapshotDelete(_ context.Context, d *schema.ResourceData, meta i
 	deleteDwsSnapshotPath = strings.ReplaceAll(deleteDwsSnapshotPath, "{snapshot_id}", d.Id())
 
 	deleteDwsSnapshotOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot_policy.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot_policy.go
@@ -87,6 +87,7 @@ func resourceDwsSnapshotPolicyCreate(ctx context.Context, d *schema.ResourceData
 	createDwsSnapshotPolicyPath = strings.ReplaceAll(createDwsSnapshotPolicyPath, "{cluster_id}", fmt.Sprintf("%v", d.Get("cluster_id")))
 
 	createDwsSnapshotPolicyOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,
@@ -119,9 +120,7 @@ func resourceDwsSnapshotPolicyCreate(ctx context.Context, d *schema.ResourceData
 
 	getDwsSnapshotPolicyOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders:      requestOpts.MoreHeaders,
 		OkCodes: []int{
 			200,
 		},
@@ -183,9 +182,7 @@ func resourceDwsSnapshotPolicyRead(_ context.Context, d *schema.ResourceData, me
 
 	getDwsSnapshotPolicyOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders:      requestOpts.MoreHeaders,
 		OkCodes: []int{
 			200,
 		},
@@ -239,9 +236,7 @@ func resourceDwsSnapshotPolicyDelete(_ context.Context, d *schema.ResourceData, 
 
 	deleteDwsSnapshotPolicyOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		MoreHeaders: map[string]string{
-			"Content-Type": "application/json;charset=UTF-8",
-		},
+		MoreHeaders:      requestOpts.MoreHeaders,
 		OkCodes: []int{
 			200,
 		},

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_workload_plan.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_workload_plan.go
@@ -101,6 +101,7 @@ func resourceWorkLoadPlanCreate(ctx context.Context, d *schema.ResourceData, met
 	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
 	createPath = strings.ReplaceAll(createPath, "{cluster_id}", d.Get("cluster_id").(string))
 	createOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 		JSONBody:         buildCreateWorkLoadPlanBodyParams(d),
 	}
@@ -132,6 +133,7 @@ func refreshWorkLoadPlanID(client *golangsdk.ServiceClient, d *schema.ResourceDa
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{cluster_id}", d.Get("cluster_id").(string))
 	listOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 	}
 
@@ -199,6 +201,7 @@ func resourceWorkLoadPlanRead(_ context.Context, d *schema.ResourceData, meta in
 	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
 	getPath = strings.ReplaceAll(getPath, "{plan_id}", d.Id())
 	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 	}
 
@@ -276,6 +279,7 @@ func resourceWorkLoadPlanDelete(_ context.Context, d *schema.ResourceData, meta 
 	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", d.Get("cluster_id").(string))
 	deletePath = strings.ReplaceAll(deletePath, "{plan_id}", d.Id())
 	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add 'application/json;charset=UTF-8' to all API request headers.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add 'application/json;charset=UTF-8' to all API request headers.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV1
=== PAUSE TestAccResourceCluster_basicV1
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== RUN   TestAccResourceCluster_BindingElb
=== PAUSE TestAccResourceCluster_BindingElb
=== CONT  TestAccResourceCluster_basicV1
=== CONT  TestAccResourceCluster_BindingElb
=== CONT  TestAccResourceCluster_basicV2
--- PASS: TestAccResourceCluster_BindingElb (1828.66s)
--- PASS: TestAccResourceCluster_basicV1 (1885.38s)
--- PASS: TestAccResourceCluster_basicV2 (2126.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       2126.814s

 make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceWorkLoadPlan_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceWorkLoadPlan_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceWorkLoadPlan_basic
=== PAUSE TestAccResourceWorkLoadPlan_basic
=== CONT  TestAccResourceWorkLoadPlan_basic
--- PASS: TestAccResourceWorkLoadPlan_basic (1205.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1205.995s

 make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccDwsAlarmSubs_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDwsAlarmSubs_ -timeout 360m -parallel 4
=== RUN   TestAccDwsAlarmSubs_basic
=== PAUSE TestAccDwsAlarmSubs_basic
=== CONT  TestAccDwsAlarmSubs_basic
--- PASS: TestAccDwsAlarmSubs_basic (82.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       82.895s

make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccDwsEventSubs_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDwsEventSubs_ -timeout 360m -parallel 4
=== RUN   TestAccDwsEventSubs_basic
=== PAUSE TestAccDwsEventSubs_basic
=== CONT  TestAccDwsEventSubs_basic
--- PASS: TestAccDwsEventSubs_basic (53.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       53.863s

make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccDwsExtDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDwsExtDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccDwsExtDataSource_basic
=== PAUSE TestAccDwsExtDataSource_basic
=== CONT  TestAccDwsExtDataSource_basic
--- PASS: TestAccDwsExtDataSource_basic (1366.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1367.005s

 make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccDwsSnapshotPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDwsSnapshotPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccDwsSnapshotPolicy_basic
=== PAUSE TestAccDwsSnapshotPolicy_basic
=== CONT  TestAccDwsSnapshotPolicy_basic
--- PASS: TestAccDwsSnapshotPolicy_basic (1145.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1145.304s


make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccDwsSnapshot_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDwsSnapshot_basic -timeout 360m -parallel 4
=== RUN   TestAccDwsSnapshot_basic
=== PAUSE TestAccDwsSnapshot_basic
=== CONT  TestAccDwsSnapshot_basic
--- PASS: TestAccDwsSnapshot_basic (1449.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1449.591s

```
