### PR TITLE
feat(iam): add resource identity user token

### DIFF
--- a/docs/resources/identity_user_token.md
+++ b/docs/resources/identity_user_token.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# huaweicloud_identity_user_token
+
+Manages an IAM user token resource within HuaweiCloud.
+
+->**Note** The token can not be destroyed. It will be invalid after expiration time. If password or AK/SK is changed,
+the token valid time will last less than 30 minutes.
+
+## Example Usage
+
+```hcl
+variable "account_name" {}
+variable "user_name" {}
+variable "password" {}
+
+resource "huaweicloud_identity_user_token" "test" {
+  account_name = var.account_name
+  user_name    = var.user_name
+  password     = var.password
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `account_name` - (Required, String, ForceNew) Specifies the account name to which the IAM user belongs.
+  Changing this will create a new token.
+
+* `user_name` - (Required, String, ForceNew) Specifies the IAM user name. Changing this will create a new token.
+
+* `password` - (Required, String, ForceNew) Specifies the IAM user password. Changing this will create a new token.
+
+* `project_name` - (Optional, String, ForceNew) Specifies the project name. If it is blank, the token applies to global
+  services, otherwise the token applies to project-level services. Changing this will create a new token.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID in format `<account_name>/<user_name>`.
+
+* `token` - The token. Validity period is 24 hours.
+
+* `expires_at` - The Time when the token will expire. The value is a UTC time in the YYYY-MM-DDTHH:mm:ss.ssssssZ format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1084,6 +1084,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_password_policy":       iam.ResourceIdentityPasswordPolicy(),
 			"huaweicloud_identity_protection_policy":     iam.ResourceIdentityProtectionPolicy(),
 			"huaweicloud_identity_virtual_mfa_device":    iam.ResourceIdentityVirtualMFADevice(),
+			"huaweicloud_identity_user_token":            iam.ResourceIdentityUserToken(),
 
 			"huaweicloud_identitycenter_user":                     identitycenter.ResourceIdentityCenterUser(),
 			"huaweicloud_identitycenter_group":                    identitycenter.ResourceIdentityCenterGroup(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_token_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_token_test.go
@@ -1,0 +1,47 @@
+package iam
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccIdentityUserToken_basic(t *testing.T) {
+	userName := acceptance.RandomAccResourceName()
+	initPassword := acceptance.RandomPassword()
+	resourceName := "huaweicloud_identity_user_token.test"
+
+	// Avoid CheckDestroy because the token can not be destroyed.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityUserToken_basic(userName, initPassword),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "token"),
+					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIdentityUserToken_basic(userName, initPassword string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_identity_user_token" "test" {
+  account_name = "%s"
+  user_name    = huaweicloud_identity_user.user_1.name
+  password     = "%s"
+}
+`, testAccIdentityUser_basic(userName, initPassword), acceptance.HW_DOMAIN_NAME, initPassword)
+}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_user_token.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_user_token.go
@@ -1,0 +1,172 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IAM POST /v3/auth/tokens
+func ResourceIdentityUserToken() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceUserTokenCreate,
+		ReadContext:   resourceUserTokenRead,
+		DeleteContext: resourceUserTokenDelete,
+
+		Schema: map[string]*schema.Schema{
+			"account_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+				ForceNew:  true,
+			},
+			"project_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expires_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceUserTokenCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	product := "identity"
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	// create token
+	err = createToken(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(d.Get("account_name").(string) + "/" + d.Get("user_name").(string))
+
+	return nil
+}
+
+func createToken(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	createTokenHttpUrl := "v3/auth/tokens"
+	createTokenPath := client.Endpoint + createTokenHttpUrl
+	createTokenOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"auth": buildCreateTokenBodyParams(d),
+		},
+	}
+
+	createTokenResp, err := client.Request("POST", createTokenPath, &createTokenOpt)
+	if err != nil {
+		return fmt.Errorf("error retrieving IAM user token: %s", err)
+	}
+
+	d.Set("token", createTokenResp.Header.Get("X-Subject-Token"))
+
+	createTokenRespBody, err := utils.FlattenResponse(createTokenResp)
+	if err != nil {
+		return fmt.Errorf("error flattening IAM user token: %s", err)
+	}
+
+	expiresAt, err := jmespath.Search("token.expires_at", createTokenRespBody)
+	if err != nil {
+		return fmt.Errorf("error retrieving IAM user token: expires_at is not found in API response")
+	}
+	d.Set("expires_at", expiresAt)
+
+	return nil
+}
+
+func buildCreateTokenBodyParams(d *schema.ResourceData) map[string]interface{} {
+	scope := map[string]interface{}{
+		"domain": map[string]interface{}{
+			"name": d.Get("account_name"),
+		},
+	}
+	if val, ok := d.GetOk("project_name"); ok {
+		scope = map[string]interface{}{
+			"project": map[string]interface{}{
+				"name": val,
+			},
+		}
+	}
+	bodyParams := map[string]interface{}{
+		"identity": map[string]interface{}{
+			"methods": []string{"password"},
+			"password": map[string]interface{}{
+				"user": map[string]interface{}{
+					"domain": map[string]interface{}{
+						"name": d.Get("account_name"),
+					},
+					"name":     d.Get("user_name"),
+					"password": d.Get("password"),
+				},
+			},
+		},
+		"scope": scope,
+	}
+	return bodyParams
+}
+
+func resourceUserTokenRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	product := "identity"
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	// If token expired, create a new token.
+	expiresAt, err := time.ParseInLocation(`2006-01-02T15:04:05Z`, d.Get("expires_at").(string), time.UTC)
+	if err != nil {
+		diag.Errorf("error parsing expires at: %s", err)
+	}
+	if time.Now().After(expiresAt) {
+		err = createToken(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return nil
+}
+
+func resourceUserTokenDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting token is not supported. The token is only removed from the state, but it remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add resource `huaweicloud_identity_user_token`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityUserToken_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityUserToken_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityUserToken_basic
=== PAUSE TestAccIdentityUserToken_basic
=== CONT  TestAccIdentityUserToken_basic
--- PASS: TestAccIdentityUserToken_basic (17.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       17.969s
```
