### PR TITLE
fix(CSS): fix CSS resource lint error

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -363,8 +363,8 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-CSS cluster can be imported by `id`. For example,
+CSS cluster can be imported by `id`, e.g.
 
-```
-terraform import huaweicloud_css_cluster.example 6d793124-3d5d-47be-bf09-f694fdf2d9ed
+```bash
+terraform import huaweicloud_css_cluster.test <id>
 ```

--- a/docs/resources/css_configuration.md
+++ b/docs/resources/css_configuration.md
@@ -77,5 +77,5 @@ This resource provides the following timeouts configuration options:
 The CSS configuration can be imported using the `id` which equals the `cluster_id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_css_configuration.test 0ce123456a00f2591fabc00385ff1234
+$ terraform import huaweicloud_css_configuration.test <id>
 ```

--- a/docs/resources/css_snapshot.md
+++ b/docs/resources/css_snapshot.md
@@ -61,6 +61,6 @@ This resource provides the following timeouts configuration options:
 
 This resource can be imported by specifying the CSS cluster ID and snapshot ID separated by a slash, e.g.:
 
-```
-$ terraform import huaweicloud_css_snapshot.snapshot_1 < cluster_id >/< snapshot_id >
+```bash
+$ terraform import huaweicloud_css_snapshot.snapshot_1 <cluster_id>/<snapshot_id>
 ```

--- a/docs/resources/css_thesaurus.md
+++ b/docs/resources/css_thesaurus.md
@@ -61,8 +61,8 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-CSS thesaurus can be imported by `id`. For example,
+CSS thesaurus can be imported by `id`, e.g.
 
-```
-terraform import huaweicloud_css_thesaurus.example e9ee3f48-f097-406a-aa74-cfece0af3e31
+```bash
+terraform import huaweicloud_css_thesaurus.test <id>
 ```

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_snapshot_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_snapshot_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccCssSnapshot_basic(t *testing.T) {
@@ -41,7 +40,7 @@ func TestAccCssSnapshot_basic(t *testing.T) {
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources[resourceName]
 					if !ok {
-						return "", fmtp.Errorf("Not found: %s", resourceName)
+						return "", fmt.Errorf("not found: %s", resourceName)
 					}
 					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["cluster_id"], rs.Primary.ID), nil
 				},
@@ -51,10 +50,10 @@ func TestAccCssSnapshot_basic(t *testing.T) {
 }
 
 func testAccCheckCssSnapshotDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	client, err := config.CssV1Client(acceptance.HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := conf.CssV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("Error creating css client, err=%s", err)
+		return fmt.Errorf("error creating css client, err: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -74,7 +73,7 @@ func testAccCheckCssSnapshotDestroy(s *terraform.State) error {
 
 		for _, v := range snapList {
 			if v.ID == rs.Primary.ID {
-				return fmtp.Errorf("huaweicloud css snapshot %s still exists", rs.Primary.ID)
+				return fmt.Errorf("CSS snapshot %s still exists", rs.Primary.ID)
 			}
 		}
 	}
@@ -87,12 +86,12 @@ func testAccCheckCssSnapshotExists() resource.TestCheckFunc {
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		client, err := config.CssV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("Error creating css client, err=%s", err)
+			return fmt.Errorf("error creating CSS client, err: %s", err)
 		}
 
 		rs, ok := s.RootModule().Resources["huaweicloud_css_snapshot.snapshot"]
 		if !ok {
-			return fmtp.Errorf("Error checking huaweicloud css snapshot.snapshot exist, err=not found this resource")
+			return fmt.Errorf("error checking CSS snapshot.snapshot exist, err: not found this resource")
 		}
 
 		clusterID := rs.Primary.Attributes["cluster_id"]
@@ -107,7 +106,7 @@ func testAccCheckCssSnapshotExists() resource.TestCheckFunc {
 			}
 		}
 
-		return fmtp.Errorf("huaweicloud css snapshot %s is not exist", rs.Primary.ID)
+		return fmt.Errorf("no exist CSS snapshot: %s", rs.Primary.ID)
 	}
 }
 

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccCssThesaurus_basic(t *testing.T) {
@@ -82,10 +81,10 @@ resource "huaweicloud_css_thesaurus" "test" {
 }
 
 func testAccCheckCssThesaurusDestroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
-	client, err := config.CssV1Client(acceptance.HW_REGION_NAME)
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := conf.CssV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmtp.Errorf("error creating CSS client: %s", err)
+		return fmt.Errorf("error creating CSS client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -96,14 +95,13 @@ func testAccCheckCssThesaurusDestroy(s *terraform.State) error {
 		resp, getErr := thesaurus.Get(client, rs.Primary.ID)
 		if getErr != nil {
 			if _, ok := getErr.(golangsdk.ErrDefault404); !ok {
-				return fmtp.Errorf("Get CSS thesaurus failed.error=%s", getErr)
+				return fmt.Errorf("get CSS thesaurus failed.error: %s", getErr)
 			}
 		} else {
 			if resp.Bucket != "" {
-				return fmtp.Errorf("CSS thesaurus still exists, cluster_id:%s", rs.Primary.ID)
+				return fmt.Errorf("CSS thesaurus still exists, cluster_id: %s", rs.Primary.ID)
 			}
 		}
-
 	}
 
 	return nil
@@ -114,21 +112,21 @@ func testAccCheckCssThesaurusExists(resourceName string) resource.TestCheckFunc 
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		client, err := config.CssV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmtp.Errorf("error creating CSS client: %s", err)
+			return fmt.Errorf("error creating CSS client: %s", err)
 		}
 
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
-			return fmtp.Errorf("Error checking huaweicloud_css_thesaurus exist, err=not found this resource")
+			return fmt.Errorf("error checking huaweicloud_css_thesaurus exist, err: not found this resource")
 		}
 
 		resp, errQueryDetail := thesaurus.Get(client, rs.Primary.ID)
 		if errQueryDetail != nil {
-			return fmtp.Errorf("error checking huaweicloud_css_thesaurus exist,err=send request failed:%s", errQueryDetail)
+			return fmt.Errorf("error checking huaweicloud_css_thesaurus exist, send request failed: %s", errQueryDetail)
 		}
 
 		if resp == nil || resp.Bucket == "" {
-			return fmtp.Errorf("CSS thesaurus don't exists, cluster_id:%s", rs.Primary.ID)
+			return fmt.Errorf("CSS thesaurus don't exists, cluster_id: %s", rs.Primary.ID)
 		}
 
 		return nil

--- a/huaweicloud/services/css/data_source_huaweicloud_css_flavors.go
+++ b/huaweicloud/services/css/data_source_huaweicloud_css_flavors.go
@@ -2,7 +2,9 @@ package css
 
 import (
 	"context"
+	"log"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -12,8 +14,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 // @API CSS GET /v1.0/{project_id}/es-flavors
@@ -93,22 +93,22 @@ func DataSourceCssFlavors() *schema.Resource {
 }
 
 func dataSourceCssFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.CssV1Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.CssV1Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating CSS V1 client: %s", err)
+		return diag.Errorf("error creating CSS V1 client: %s", err)
 	}
 
 	flavorsResp, err := cluster.ListFlavors(client)
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to retrieve CSS flavors: %s ", err)
+		return diag.Errorf("unable to retrieve CSS flavors: %s ", err)
 	}
 
 	allFlavors := flatternFlavors(flavorsResp)
 
 	if len(allFlavors) < 1 {
-		return fmtp.DiagErrorf("No data found. Please change your search criteria and try again.")
+		return diag.Errorf("no data found, please change your search criteria and try again")
 	}
 
 	filter := map[string]interface{}{
@@ -128,22 +128,22 @@ func dataSourceCssFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 
 	filterFlavors, err := utils.FilterSliceWithField(allFlavors, filter)
 	if err != nil {
-		return fmtp.DiagErrorf("filter CSS flavors failed: %s", err)
+		return diag.Errorf("filter CSS flavors failed: %s", err)
 	}
-	logp.Printf("filter %d CSS flavors from %d through options %v", len(filterFlavors), len(allFlavors), filter)
-
-	mErr := d.Set("flavors", buildFlavors(filterFlavors))
-	if mErr != nil {
-		return fmtp.DiagErrorf("set flavors err:%s", mErr)
-	}
+	log.Printf("[DEBUG] filter %d CSS flavors from %d through options %v", len(filterFlavors), len(allFlavors), filter)
 
 	uuid, err := uuid.GenerateUUID()
 	if err != nil {
-		return fmtp.DiagErrorf("unable to generate ID:%s", err)
+		return diag.Errorf("unable to generate ID: %s", err)
 	}
 
 	d.SetId(uuid)
-	return nil
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("flavors", buildFlavors(filterFlavors)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func flatternFlavors(flavors *cluster.EsFlavorsResp) []flavor {

--- a/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
@@ -18,7 +18,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
 
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr"
-	v1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/css/v1"
+	cssv1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/css/v1"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/css/v1/model"
 	cssv2model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/css/v2/model"
 
@@ -64,6 +64,10 @@ const (
 // @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/public/bandwidth
 // @API CSS PUT /v1.0/{project_id}/clusters/{cluster_id}/public/close
 // @API CSS PUT /v1.0/{project_id}/clusters/{cluster_id}/publickibana/close
+// @API BSS GET /v2/orders/customer-orders/details/{order_id}
+// @API BSS POST /v2/orders/suscriptions/resources/query
+// @API BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
+// @API BSS DELETE /v2/orders/subscriptions/resources/autorenew/{instance_id}
 func ResourceCssCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceCssClusterCreate,
@@ -559,25 +563,25 @@ func masterOrClientNodeSchema(min, max int) *schema.Resource {
 }
 
 func resourceCssClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	cssV1Client, err := config.HcCssV1Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	cssV1Client, err := conf.HcCssV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating CSS V1 client: %s", err)
 	}
-	cssV2Client, err := config.HcCssV2Client(region)
+	cssV2Client, err := conf.HcCssV2Client(region)
 	if err != nil {
 		return diag.Errorf("error creating CSS V2 client: %s", err)
 	}
 
-	createClusterOpts, paramErr := buildClusterCreateParameters(d, config)
+	createClusterOpts, paramErr := buildClusterCreateParameters(d, conf)
 	if paramErr != nil {
 		return diag.FromErr(paramErr)
 	}
 
 	r, err := cssV2Client.CreateCluster(createClusterOpts)
 	if err != nil {
-		return diag.Errorf("error creating CSS cluster, err=%s", err)
+		return diag.Errorf("error creating CSS cluster, err: %s", err)
 	}
 
 	if (r.Cluster == nil || r.Cluster.Id == nil) && r.OrderId == nil {
@@ -590,7 +594,7 @@ func resourceCssClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 		d.SetId(*r.Cluster.Id)
 	} else {
-		bssClient, err := config.BssV2Client(config.GetRegion(d))
+		bssClient, err := conf.BssV2Client(conf.GetRegion(d))
 		if err != nil {
 			return diag.Errorf("error creating BSS v2 client: %s", err)
 		}
@@ -617,14 +621,14 @@ func resourceCssClusterCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return resourceCssClusterRead(ctx, d, meta)
 }
 
-func buildClusterCreateParameters(d *schema.ResourceData, config *config.Config) (*cssv2model.CreateClusterRequest, error) {
+func buildClusterCreateParameters(d *schema.ResourceData, conf *config.Config) (*cssv2model.CreateClusterRequest, error) {
 	createOpts := cssv2model.CreateClusterBody{
 		Name: d.Get("name").(string),
 		Datastore: &cssv2model.CreateClusterDatastoreBody{
 			Type:    d.Get("engine_type").(string),
 			Version: d.Get("engine_version").(string),
 		},
-		EnterpriseProjectId: utils.StringIgnoreEmpty(config.GetEnterpriseProjectID(d)),
+		EnterpriseProjectId: utils.StringIgnoreEmpty(conf.GetEnterpriseProjectID(d)),
 		Tags:                buildCssTags(d.Get("tags").(map[string]interface{})),
 		BackupStrategy:      resourceCssClusterCreateBackupStrategy(d.Get("backup_strategy").([]interface{})),
 	}
@@ -793,16 +797,16 @@ func resourceCssClusterCreateBackupStrategy(backupRaw []interface{}) *cssv2model
 }
 
 func resourceCssClusterRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	cssV1Client, err := config.HcCssV1Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	cssV1Client, err := conf.HcCssV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating CSS V1 client: %s", err)
 	}
 
 	clusterDetail, err := cssV1Client.ShowClusterDetail(&model.ShowClusterDetailRequest{ClusterId: d.Id()})
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "DLI cluster")
+		return common.CheckDeletedDiag(d, err, "CSS cluster")
 	}
 
 	mErr := multierror.Append(
@@ -859,10 +863,10 @@ func flattenSecurity(authorityEnable *bool) bool {
 	return *authorityEnable
 }
 
-func setClusterBackupStrategy(d *schema.ResourceData, client *v1.CssClient) error {
+func setClusterBackupStrategy(d *schema.ResourceData, client *cssv1.CssClient) error {
 	policy, err := client.ShowAutoCreatePolicy(&model.ShowAutoCreatePolicyRequest{ClusterId: d.Id()})
 	if err != nil {
-		return fmt.Errorf("error extracting Cluster:backup_strategy, err: %s", err)
+		return fmt.Errorf("error extracting cluster: backup_strategy, err: %s", err)
 	}
 
 	var strategy []map[string]interface{}
@@ -921,7 +925,7 @@ func flattenPublicAccess(resp *model.ElbWhiteListResp, bandwidth *int32, publicI
 	return []interface{}{result}
 }
 
-func setVpcEndpointIdToState(d *schema.ResourceData, cssV1Client *v1.CssClient) error {
+func setVpcEndpointIdToState(d *schema.ResourceData, cssV1Client *cssv1.CssClient) error {
 	resp, err := cssV1Client.ShowVpcepConnection(&model.ShowVpcepConnectionRequest{ClusterId: d.Id()})
 	if err != nil {
 		if err, ok := err.(*sdkerr.ServiceResponseError); ok {
@@ -1031,10 +1035,10 @@ func setNodeConfigsAndAzToState(d *schema.ResourceData, detail *model.ShowCluste
 }
 
 func resourceCssClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
 	clusterId := d.Id()
-	cssV1Client, err := config.HcCssV1Client(region)
+	cssV1Client, err := conf.HcCssV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating CSS V1 client: %s", err)
 	}
@@ -1060,7 +1064,7 @@ func resourceCssClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		oRaw, nRaw := d.GetChange("tags")
 		err = updateCssTags(cssV1Client, clusterId, oRaw.(map[string]interface{}), nRaw.(map[string]interface{}))
 		if err != nil {
-			return diag.Errorf("error updating tags of CSS cluster= %s, err:%s", clusterId, err)
+			return diag.Errorf("error updating tags of CSS cluster: %s, err: %s", clusterId, err)
 		}
 	}
 
@@ -1089,7 +1093,7 @@ func resourceCssClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if d.HasChange("auto_renew") {
-		bssClient, err := config.BssV2Client(region)
+		bssClient, err := conf.BssV2Client(region)
 		if err != nil {
 			return diag.Errorf("error creating BSS V2 client: %s", err)
 		}
@@ -1103,9 +1107,9 @@ func resourceCssClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			ResourceId:   clusterId,
 			ResourceType: "css-cluster",
 			RegionId:     region,
-			ProjectId:    config.GetProjectID(region),
+			ProjectId:    conf.GetProjectID(region),
 		}
-		if err := common.MigrateEnterpriseProject(ctx, config, d, migrateOpts); err != nil {
+		if err := common.MigrateEnterpriseProject(ctx, conf, d, migrateOpts); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -1113,14 +1117,14 @@ func resourceCssClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return resourceCssClusterRead(ctx, d, meta)
 }
 
-func extendCluster(ctx context.Context, d *schema.ResourceData, cssV1Client *v1.CssClient) error {
+func extendCluster(ctx context.Context, d *schema.ResourceData, cssV1Client *cssv1.CssClient) error {
 	opts, err := buildCssClusterV1ExtendClusterParameters(d)
 	if err != nil {
-		return fmt.Errorf("error building the request body of api(extend_cluster), err=%s", err)
+		return fmt.Errorf("error building the request body of api(extend_cluster), err: %s", err)
 	}
 	_, err = cssV1Client.UpdateExtendInstanceStorage(opts)
 	if err != nil {
-		return fmt.Errorf("extend CSS cluster instance storage failed, cluster_id=%s, error=%s", d.Id(), err)
+		return fmt.Errorf("extend CSS cluster instance storage failed, cluster_id: %s, error: %s", d.Id(), err)
 	}
 
 	err = checkClusterOperationCompleted(ctx, cssV1Client, d.Id(), d.Timeout(schema.TimeoutUpdate))
@@ -1130,7 +1134,7 @@ func extendCluster(ctx context.Context, d *schema.ResourceData, cssV1Client *v1.
 	return nil
 }
 
-func updateBackupStrategy(d *schema.ResourceData, cssV1Client *v1.CssClient) error {
+func updateBackupStrategy(d *schema.ResourceData, cssV1Client *cssv1.CssClient) error {
 	rawList := d.Get("backup_strategy").([]interface{})
 
 	if len(rawList) == 0 {
@@ -1163,14 +1167,14 @@ func updateBackupStrategy(d *schema.ResourceData, cssV1Client *v1.CssClient) err
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("error Modifying Basic Configurations of a Cluster Snapshot: %s", err)
+				return fmt.Errorf("error modifying basic configurations of a cluster snapshot: %s", err)
 			}
 		}
 
 		// check backup strategy, if the policy was disabled, we should enable it
 		policy, err := cssV1Client.ShowAutoCreatePolicy(&model.ShowAutoCreatePolicyRequest{ClusterId: d.Id()})
 		if err != nil {
-			return fmt.Errorf("error extracting Cluster backup_strategy, err: %s", err)
+			return fmt.Errorf("error extracting cluster backup_strategy, err: %s", err)
 		}
 
 		if utils.StringValue(policy.Enable) == "false" && raw["bucket"] == nil {
@@ -1202,7 +1206,7 @@ func updateBackupStrategy(d *schema.ResourceData, cssV1Client *v1.CssClient) err
 	return nil
 }
 
-func updateVpcepEndpoint(ctx context.Context, d *schema.ResourceData, cssV1Client *v1.CssClient) error {
+func updateVpcepEndpoint(ctx context.Context, d *schema.ResourceData, cssV1Client *cssv1.CssClient) error {
 	o, n := d.GetChange("vpcep_endpoint")
 	oValue := o.([]interface{})
 	nValue := n.([]interface{})
@@ -1210,7 +1214,7 @@ func updateVpcepEndpoint(ctx context.Context, d *schema.ResourceData, cssV1Clien
 	case -1: // delete vpc endpoint
 		_, err := cssV1Client.StopVpecp(&model.StopVpecpRequest{ClusterId: d.Id()})
 		if err != nil {
-			return fmt.Errorf("error deleting the VPC endpoint of CSS cluster= %s, err: %s", d.Id(), err)
+			return fmt.Errorf("error deleting the VPC endpoint of CSS cluster: %s, err: %s", d.Id(), err)
 		}
 		err = checkClusterOperationCompleted(ctx, cssV1Client, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
@@ -1225,7 +1229,7 @@ func updateVpcepEndpoint(ctx context.Context, d *schema.ResourceData, cssV1Clien
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("error creating the VPC endpoint of CSS cluster= %s, err: %s", d.Id(), err)
+			return fmt.Errorf("error creating the VPC endpoint of CSS cluster: %s, err: %s", d.Id(), err)
 		}
 		err = checkClusterOperationCompleted(ctx, cssV1Client, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
@@ -1242,14 +1246,14 @@ func updateVpcepEndpoint(ctx context.Context, d *schema.ResourceData, cssV1Clien
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("error updating the VPC endpoint whitelist of CSS cluster= %s, err: %s", d.Id(), err)
+				return fmt.Errorf("error updating the VPC endpoint whitelist of CSS cluster: %s, err: %s", d.Id(), err)
 			}
 		}
 	}
 	return nil
 }
 
-func updateKibanaPublicAccess(ctx context.Context, d *schema.ResourceData, cssV1Client *v1.CssClient) error {
+func updateKibanaPublicAccess(ctx context.Context, d *schema.ResourceData, cssV1Client *cssv1.CssClient) error {
 	o, n := d.GetChange("kibana_public_access")
 	oValue := o.([]interface{})
 	nValue := n.([]interface{})
@@ -1258,7 +1262,7 @@ func updateKibanaPublicAccess(ctx context.Context, d *schema.ResourceData, cssV1
 	case -1: // delete kibana_public_access
 		_, err := cssV1Client.UpdateCloseKibana(&model.UpdateCloseKibanaRequest{ClusterId: d.Id()})
 		if err != nil {
-			return fmt.Errorf("error diabling the kibana public access of CSS cluster= %s, err: %s", d.Id(), err)
+			return fmt.Errorf("error diabling the kibana public access of CSS cluster: %s, err: %s", d.Id(), err)
 		}
 		err = checkClusterOperationCompleted(ctx, cssV1Client, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
@@ -1277,7 +1281,7 @@ func updateKibanaPublicAccess(ctx context.Context, d *schema.ResourceData, cssV1
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("error enabling the kibana public access of CSS cluster= %s, err: %s", d.Id(), err)
+			return fmt.Errorf("error enabling the kibana public access of CSS cluster: %s, err: %s", d.Id(), err)
 		}
 		err = checkClusterOperationCompleted(ctx, cssV1Client, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
@@ -1297,7 +1301,7 @@ func updateKibanaPublicAccess(ctx context.Context, d *schema.ResourceData, cssV1
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("error modifing bandwidth of the kibana public access of CSS cluster= %s, err: %s", d.Id(), err)
+				return fmt.Errorf("error modifing bandwidth of the kibana public access of CSS cluster: %s, err: %s", d.Id(), err)
 			}
 		}
 
@@ -1309,7 +1313,7 @@ func updateKibanaPublicAccess(ctx context.Context, d *schema.ResourceData, cssV1
 					ClusterId: d.Id(),
 				})
 				if err != nil {
-					return fmt.Errorf("error disabing the whitelist of the kibana public access of CSS cluster= %s, err: %s", d.Id(), err)
+					return fmt.Errorf("error disabing the whitelist of the kibana public access of CSS cluster: %s, err: %s", d.Id(), err)
 				}
 			} else {
 				_, err := cssV1Client.UpdatePublicKibanaWhitelist(&model.UpdatePublicKibanaWhitelistRequest{
@@ -1319,7 +1323,7 @@ func updateKibanaPublicAccess(ctx context.Context, d *schema.ResourceData, cssV1
 					},
 				})
 				if err != nil {
-					return fmt.Errorf("error modifing whitelist of the kibana public access of CSS cluster= %s, err: %s", d.Id(), err)
+					return fmt.Errorf("error modifing whitelist of the kibana public access of CSS cluster: %s, err: %s", d.Id(), err)
 				}
 			}
 		}
@@ -1328,7 +1332,7 @@ func updateKibanaPublicAccess(ctx context.Context, d *schema.ResourceData, cssV1
 	return nil
 }
 
-func updatePublicAccess(ctx context.Context, d *schema.ResourceData, cssV1Client *v1.CssClient) error {
+func updatePublicAccess(ctx context.Context, d *schema.ResourceData, cssV1Client *cssv1.CssClient) error {
 	o, n := d.GetChange("public_access")
 	oValue := o.([]interface{})
 	nValue := n.([]interface{})
@@ -1337,7 +1341,7 @@ func updatePublicAccess(ctx context.Context, d *schema.ResourceData, cssV1Client
 	case -1: // delete public_access
 		_, err := cssV1Client.UpdateUnbindPublic(&model.UpdateUnbindPublicRequest{ClusterId: d.Id()})
 		if err != nil {
-			return fmt.Errorf("error diabling public access of CSS cluster= %s, err: %s", d.Id(), err)
+			return fmt.Errorf("error diabling public access of CSS cluster: %s, err: %s", d.Id(), err)
 		}
 		err = checkClusterOperationCompleted(ctx, cssV1Client, d.Id(), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
@@ -1359,7 +1363,7 @@ func updatePublicAccess(ctx context.Context, d *schema.ResourceData, cssV1Client
 		})
 
 		if err != nil {
-			return fmt.Errorf("error enabling public access of CSS cluster= %s, err: %s", d.Id(), err)
+			return fmt.Errorf("error enabling public access of CSS cluster: %s, err: %s", d.Id(), err)
 		}
 
 		err = checkClusterOperationCompleted(ctx, cssV1Client, d.Id(), d.Timeout(schema.TimeoutUpdate))
@@ -1373,7 +1377,7 @@ func updatePublicAccess(ctx context.Context, d *schema.ResourceData, cssV1Client
 			if !d.Get("kibana_public_access.0.whitelist_enabled").(bool) {
 				_, err := cssV1Client.StopPublicWhitelist(&model.StopPublicWhitelistRequest{ClusterId: d.Id()})
 				if err != nil {
-					return fmt.Errorf("error disabling whitelist of public access of CSS cluster= %s, err: %s", d.Id(), err)
+					return fmt.Errorf("error disabling whitelist of public access of CSS cluster: %s, err: %s", d.Id(), err)
 				}
 			} else {
 				_, err := cssV1Client.StartPublicWhitelist(&model.StartPublicWhitelistRequest{
@@ -1383,7 +1387,7 @@ func updatePublicAccess(ctx context.Context, d *schema.ResourceData, cssV1Client
 					},
 				})
 				if err != nil {
-					return fmt.Errorf("error modifing whitelist of public access of CSS cluster= %s, err: %s", d.Id(), err)
+					return fmt.Errorf("error modifing whitelist of public access of CSS cluster: %s, err: %s", d.Id(), err)
 				}
 			}
 		}
@@ -1400,7 +1404,7 @@ func updatePublicAccess(ctx context.Context, d *schema.ResourceData, cssV1Client
 				},
 			})
 			if err != nil {
-				return fmt.Errorf("error disabling the whitelist of the kibana public access of CSS cluster= %s, err: %s", d.Id(), err)
+				return fmt.Errorf("error disabling the whitelist of the kibana public access of CSS cluster: %s, err: %s", d.Id(), err)
 			}
 		}
 	}
@@ -1506,16 +1510,16 @@ func buildCssClusterV1ExtendClusterParameters(d *schema.ResourceData) (*model.Up
 }
 
 func resourceCssClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	cssV1Client, err := config.HcCssV1Client(region)
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	cssV1Client, err := conf.HcCssV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating CSS V1 client: %s", err)
 	}
 
 	_, err = cssV1Client.DeleteCluster(&model.DeleteClusterRequest{ClusterId: d.Id()})
 	if err != nil {
-		return diag.Errorf("delete CSS Cluster %s failed, error= %s", d.Id(), err)
+		return diag.Errorf("delete CSS cluster %s failed, error: %s", d.Id(), err)
 	}
 
 	err = checkClusterDeleteResult(ctx, cssV1Client, d.Id(), d.Timeout(schema.TimeoutDelete))
@@ -1526,7 +1530,7 @@ func resourceCssClusterDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return nil
 }
 
-func checkClusterCreateResult(ctx context.Context, cssV1Client *v1.CssClient, clusterId string,
+func checkClusterCreateResult(ctx context.Context, cssV1Client *cssv1.CssClient, clusterId string,
 	timeout time.Duration) error {
 	createStateConf := &resource.StateChangeConf{
 		Pending: []string{ClusterStatusInProcess},
@@ -1549,7 +1553,7 @@ func checkClusterCreateResult(ctx context.Context, cssV1Client *v1.CssClient, cl
 	return nil
 }
 
-func checkClusterDeleteResult(ctx context.Context, cssV1Client *v1.CssClient, clusterId string,
+func checkClusterDeleteResult(ctx context.Context, cssV1Client *cssv1.CssClient, clusterId string,
 	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Pending"},
@@ -1585,7 +1589,7 @@ func checkClusterDeleteResult(ctx context.Context, cssV1Client *v1.CssClient, cl
 	return nil
 }
 
-func checkClusterOperationCompleted(ctx context.Context, cssV1Client *v1.CssClient, clusterId string,
+func checkClusterOperationCompleted(ctx context.Context, cssV1Client *cssv1.CssClient, clusterId string,
 	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"Pending"},
@@ -1633,7 +1637,7 @@ func checkCssClusterIsReady(detail *model.ShowClusterDetailResponse) bool {
 	return true
 }
 
-func updateCssTags(cssV1Client *v1.CssClient, id string, old, new map[string]interface{}) error {
+func updateCssTags(cssV1Client *cssv1.CssClient, id string, old, new map[string]interface{}) error {
 	// remove old tags
 	for k := range old {
 		_, err := cssV1Client.DeleteClustersTags(&model.DeleteClustersTagsRequest{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
 fix CSS resource lint error

**Special notes for your reviewer**:

**Release note**:

```
 fix CSS resource lint error
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssCluster_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_basic
=== PAUSE TestAccCssCluster_basic
=== CONT  TestAccCssCluster_basic
--- PASS: TestAccCssCluster_basic (1517.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1517.183s
```

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssCluster_prePaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_prePaid -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_prePaid
=== PAUSE TestAccCssCluster_prePaid
=== CONT  TestAccCssCluster_prePaid
--- PASS: TestAccCssCluster_prePaid (1091.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1091.913s
```

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssFlavorsDataSource_all"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssFlavorsDataSource_all -timeout 360m -parallel 4
=== RUN   TestAccCssFlavorsDataSource_all
=== PAUSE TestAccCssFlavorsDataSource_all
=== CONT  TestAccCssFlavorsDataSource_all
--- PASS: TestAccCssFlavorsDataSource_all (20.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       20.199s
```

```
 make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssSnapshot_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssSnapshot_basic -timeout 360m -parallel 4
=== RUN   TestAccCssSnapshot_basic
=== PAUSE TestAccCssSnapshot_basic
=== CONT  TestAccCssSnapshot_basic
--- PASS: TestAccCssSnapshot_basic (894.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       894.858s
```

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssThesaurus_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssThesaurus_basic -timeout 360m -parallel 4
=== RUN   TestAccCssThesaurus_basic
=== PAUSE TestAccCssThesaurus_basic
=== CONT  TestAccCssThesaurus_basic
--- PASS: TestAccCssThesaurus_basic (985.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       985.950s
```
