### PR TITLE
feat(fgs): use this data source to get the list of application templates

### DIFF
--- a/docs/data-sources/fgs_application_templates.md
+++ b/docs/data-sources/fgs_application_templates.md
@@ -1,0 +1,53 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# huaweicloud_fgs_application_templates
+
+Use this data source to get the list of application templates within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_fgs_application_templates" "test" {
+  runtime = "Python2.7"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `runtime` - (Optional, String) Specifies the runtime to match.
+  Valid values: **Node.js6.10**, **Node.js8.10**, **Node.js10.16**, **Node.js12.13**, **Node.js14.18**, **Node.js16.17**,
+  **Node.js18.15**, **Python2.7**, **Python3.6**, **Python3.9**, **Python3.10**, **Java8**, **Java11**, **Go1.x**,
+  **C#(.NET Core 2.1)**, **C#(.NET Core 3.1)**, **http**, **PHP7.3** and **Custom**.
+
+* `category` - (Optional, String) Specifies the category of the application template.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `templates` - The list of the application templates.
+  The [templates](#application_templates) structure is documented below.
+
+<a name="application_templates"></a>
+The `templates` block supports:
+
+* `id` - The template ID.
+
+* `name` - The template name.
+
+* `runtime` -  The template runtime.
+
+* `category` - The template category.
+
+* `description` - The description of template.
+
+* `type` - The type of the function application.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -503,10 +503,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_er_route_tables":       er.DataSourceRouteTables(),
 			"huaweicloud_er_availability_zones": er.DataSourceAvailabilityZones(),
 
-			"huaweicloud_evs_volumes":      evs.DataSourceEvsVolumesV2(),
-			"huaweicloud_evs_snapshots":    evs.DataSourceEvsSnapshots(),
-			"huaweicloud_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),
-			"huaweicloud_fgs_functions":    fgs.DataSourceFunctionGraphFunctions(),
+			"huaweicloud_evs_volumes":   evs.DataSourceEvsVolumesV2(),
+			"huaweicloud_evs_snapshots": evs.DataSourceEvsSnapshots(),
+
+			"huaweicloud_fgs_application_templates": fgs.DataSourceFunctionGraphApplicationTemplates(),
+			"huaweicloud_fgs_dependencies":          fgs.DataSourceFunctionGraphDependencies(),
+			"huaweicloud_fgs_functions":             fgs.DataSourceFunctionGraphFunctions(),
 
 			"huaweicloud_gaussdb_cassandra_dedicated_resource": gaussdb.DataSourceGeminiDBDehResource(),
 			"huaweicloud_gaussdb_cassandra_flavors":            gaussdb.DataSourceCassandraFlavors(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_application_templates_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_application_templates_test.go
@@ -1,0 +1,78 @@
+package fgs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccFunctionGraphApplicationTemplates_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_fgs_application_templates.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byRuntime   = "data.huaweicloud_fgs_application_templates.filter_by_runtime"
+		dcByRuntime = acceptance.InitDataSourceCheck(byRuntime)
+
+		byCategory   = "data.huaweicloud_fgs_application_templates.filter_by_category"
+		dcByCategory = acceptance.InitDataSourceCheck(byCategory)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphApplicationTemplates_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+
+					dcByRuntime.CheckResourceExists(),
+					resource.TestCheckOutput("is_runtime_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "templates.#"),
+					resource.TestCheckResourceAttrSet(byRuntime, "templates.0.id"),
+					resource.TestCheckResourceAttrSet(byRuntime, "templates.0.name"),
+
+					dcByCategory.CheckResourceExists(),
+					resource.TestCheckOutput("is_category_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccFunctionGraphApplicationTemplates_basic = `
+data "huaweicloud_fgs_application_templates" "test" {}
+
+// By runtime filter
+locals {
+  runtime = data.huaweicloud_fgs_application_templates.test.templates[0].runtime
+}
+
+data "huaweicloud_fgs_application_templates" "filter_by_runtime" {
+  runtime = local.runtime
+}
+
+output "is_runtime_filter_useful" {
+  value = length(data.huaweicloud_fgs_application_templates.filter_by_runtime.templates) >= 1 && alltrue(
+    [for v in data.huaweicloud_fgs_application_templates.filter_by_runtime.templates[*].runtime : v == local.runtime]
+  )
+}
+
+// By category filter
+locals {
+  category = data.huaweicloud_fgs_application_templates.test.templates[0].category
+}
+
+data "huaweicloud_fgs_application_templates" "filter_by_category" {
+  category = local.category
+}
+
+output "is_category_filter_useful" {
+  value = length(data.huaweicloud_fgs_application_templates.filter_by_category.templates) > 0 && alltrue(
+    [for v in data.huaweicloud_fgs_application_templates.filter_by_category.templates[*].category : v == local.category]
+  )
+}
+`

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_application_templates.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_application_templates.go
@@ -1,0 +1,133 @@
+package fgs
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/fgs/v2/application"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/fgs/application/templates
+func DataSourceFunctionGraphApplicationTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFunctionGraphApplicationTemplatesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"runtime": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"templates": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"runtime": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceFunctionGraphApplicationTemplatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.FgsV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	opts := application.ListOpts{
+		Runtime: d.Get("runtime").(string),
+	}
+	templateList, err := application.ListTemplates(client, opts)
+	if err != nil {
+		return diag.Errorf("error retrieving application templates: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("templates", flattenListTemplates(filterListTemplateByCategory(templateList, d))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListTemplates(templates []application.Template) []map[string]interface{} {
+	if len(templates) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(templates))
+	for i, template := range templates {
+		result[i] = map[string]interface{}{
+			"id":          template.ID,
+			"name":        template.Name,
+			"runtime":     template.Runtime,
+			"category":    template.Category,
+			"type":        template.Type,
+			"description": template.Description,
+		}
+	}
+	return result
+}
+
+func filterListTemplateByCategory(all []application.Template, d *schema.ResourceData) []application.Template {
+	if len(all) == 0 {
+		return nil
+	}
+	rst := make([]application.Template, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("category"); ok && v.Category != param {
+			continue
+		}
+		rst = append(rst, v)
+	}
+	return rst
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/application/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/application/requests.go
@@ -1,0 +1,41 @@
+package application
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListOpts is the structure that used to query application template list.
+type ListOpts struct {
+	// Template runtime.
+	Runtime string `q:"runtime"`
+	// Template category.
+	Category string `q:"category"`
+	// The current query index.
+	Marker int `q:"marker"`
+	// Maximum number of templates to obtain in a request.
+	MaxItems int `q:"maxitems"`
+}
+
+// ListTemplates is a method to query the list of the application templates using given parameters.
+func ListTemplates(client *golangsdk.ServiceClient, opts ListOpts) ([]Template, error) {
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url := listURL(client) + query.String()
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := TemplatePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	pageInfo, err := extractPageInfo(pages)
+	if err != nil {
+		return nil, err
+	}
+	return pageInfo.Templates, nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/application/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/application/results.go
@@ -1,0 +1,83 @@
+package application
+
+import (
+	"strconv"
+
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// Template is the structure that represents the aplication template details.
+type Template struct {
+	// Template ID.
+	ID string `json:"id"`
+	// The name of template.
+	Name string `json:"name"`
+	// Template execution runtime.
+	Runtime string `json:"runtime"`
+	// The category of template.
+	Category string `json:"category"`
+	// Template image file(Base64-encoded).
+	Image string `json:"image"`
+	// Template description.
+	Description string `json:"description"`
+	// The type of the function application.
+	Type string `json:"type"`
+}
+
+// pageInfo is the structure that represents response of the ListTemplate method.
+type pageInfo struct {
+	// The list of templates.
+	Templates []Template `json:"templates"`
+	// Next record location.
+	NextMarker int `json:"next_marker"`
+	// Total number of application template.
+	Count int `json:"count"`
+}
+
+// TemplatePage represents the response pages of the ListTemplate method.
+type TemplatePage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no application template.
+func (r TemplatePage) IsEmpty() (bool, error) {
+	resp, err := extractPageInfo(r)
+	return resp.Count == 0, err
+}
+
+// LastMarker returns the last marker index in a pageInfo.
+func (r TemplatePage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.Count == 0 {
+		return "", nil
+	}
+	return strconv.Itoa(resp.NextMarker), nil
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (r TemplatePage) NextPageURL() (string, error) {
+	currentURL := r.URL
+	mark, err := r.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+	if mark == "" {
+		return "", nil
+	}
+
+	q := currentURL.Query()
+	q.Set("marker", mark)
+	currentURL.RawQuery = q.Encode()
+
+	return currentURL.String(), nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s pageInfo
+	err := r.(TemplatePage).Result.ExtractInto(&s)
+	return &s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/application/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/application/urls.go
@@ -1,0 +1,7 @@
+package application
+
+import "github.com/chnsz/golangsdk"
+
+func listURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("fgs/application/templates")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,6 +186,7 @@ github.com/chnsz/golangsdk/openstack/evs/v2/cloudvolumes
 github.com/chnsz/golangsdk/openstack/evs/v2/snapshots
 github.com/chnsz/golangsdk/openstack/evs/v5/cloudvolumes
 github.com/chnsz/golangsdk/openstack/fgs/v2/aliases
+github.com/chnsz/golangsdk/openstack/fgs/v2/application
 github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies
 github.com/chnsz/golangsdk/openstack/fgs/v2/function
 github.com/chnsz/golangsdk/openstack/fgs/v2/trigger


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

DataSource: huaweicloud_fgs_application_templates.
The data source supports getting list of application templates.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Use this data source to get the list of application templates.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
 make testacc TEST=./huaweicloud/services/acceptance/fgs TESTARGS='-run TestAccFunctionGraphApplicationTemplates_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccFunctionGraphApplicationTemplates_basic -timeout 360m -parallel 4
=== RUN   TestAccFunctionGraphApplicationTemplates_basic
=== PAUSE TestAccFunctionGraphApplicationTemplates_basic
=== CONT  TestAccFunctionGraphApplicationTemplates_basic
--- PASS: TestAccFunctionGraphApplicationTemplates_basic (29.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       29.577s
```
