### PR TITLE
feat(iam): support login protect for user

### DIFF
--- a/docs/resources/identity_user.md
+++ b/docs/resources/identity_user.md
@@ -58,6 +58,14 @@ The following arguments are supported:
 * `external_identity_type` - (Optional, String) Specifies the type of the IAM user in the external system.
   Only **TenantIdp** is supported now. This parameter must be used together with `external_identity_id`.
 
+* `login_protect_verification_method` - (Optional, String) Specifies the verification method of login protect. If it is
+  empty, the login protection will be disabled.
+  
+  Valid values are as follows:
+  + **sms**: Use phone number to verify.
+  + **email**: Use email to verify.
+  + **vmfa**: Use MFA to verify.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240218110804-4d47bb676743
+	github.com/chnsz/golangsdk v0.0.0-20240219092729-295c3df465f5
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240218110804-4d47bb676743 h1:+ocIU8A4TtLT265B1+fI/xHDecIIQoAw8wB6mB5AkyY=
-github.com/chnsz/golangsdk v0.0.0-20240218110804-4d47bb676743/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240219092729-295c3df465f5 h1:sViq3n28/01XH5scvIEHnuapjZMxfMPRBRSobAZcMjI=
+github.com/chnsz/golangsdk v0.0.0-20240219092729-295c3df465f5/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_test.go
@@ -52,6 +52,7 @@ func TestAccIdentityUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "pwd_reset", "true"),
 					resource.TestCheckResourceAttr(resourceName, "email", "user_1@abc.com"),
 					resource.TestCheckResourceAttr(resourceName, "password_strength", "Strong"),
+					resource.TestCheckResourceAttr(resourceName, "login_protect_verification_method", "email"),
 				),
 			},
 			{
@@ -71,6 +72,7 @@ func TestAccIdentityUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "pwd_reset", "false"),
 					resource.TestCheckResourceAttr(resourceName, "email", "user_1@abcd.com"),
+					resource.TestCheckResourceAttr(resourceName, "login_protect_verification_method", ""),
 				),
 			},
 			{
@@ -146,6 +148,8 @@ resource "huaweicloud_identity_user" "user_1" {
   enabled     = true
   email       = "user_1@abc.com"
   description = "tested by terraform"
+  
+  login_protect_verification_method = "email"
 }
 `, name, password)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/users/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/users/requests.go
@@ -141,3 +141,43 @@ func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
 	return
 }
+
+// UpdateLoginProtectOpts provides options for updating a user account login protect.
+type UpdateLoginProtectOpts struct {
+	Enabled            *bool  `json:"enabled" required:"true"`
+	VerificationMethod string `json:"verification_method" required:"true"`
+}
+
+// UpdateLoginProtectOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateLoginProtectOptsBuilder interface {
+	ToLoginProtectUpdateMap() (map[string]interface{}, error)
+}
+
+// ToLoginProtectUpdateMap formats a UpdateLoginProtectOpts into an update request.
+func (opts UpdateLoginProtectOpts) ToLoginProtectUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "login_protect")
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// UpdateLoginProtect updates login protect for user account.
+func UpdateLoginProtect(client *golangsdk.ServiceClient, userID string,
+	opts UpdateLoginProtectOpts) (r UpdateLoginProtectResult) {
+	b, err := opts.ToLoginProtectUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Put(loginProtectURL(client, userID), &b, &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+// Get retrieves details on a single user login protect, by user ID.
+func GetLoginProtect(client *golangsdk.ServiceClient, id string) (r GetLoginProtectResult) {
+	_, r.Err = client.Get(loginProtectURL(client, id), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/users/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/users/results.go
@@ -49,6 +49,24 @@ type UpdateResult struct {
 	userResult
 }
 
+// LoginProtect represents a LoginProtect in the OpenStack Identity LoginProtect Service.
+type LoginProtect struct {
+	Enabled            bool   `json:"enabled"`
+	VerificationMethod string `json:"verification_method"`
+}
+
+// UpdateLoginProtectResult is the response from an UpdateLoginProtect operation. Call its
+// ExtractLoginProtect method to interpret it as a LoginProtect.
+type UpdateLoginProtectResult struct {
+	userResult
+}
+
+// GetLoginProtectResult is the response from a GetLoginProtect operation. Call its
+// ExtractLoginProtect method to interpret it as a LoginProtect.
+type GetLoginProtectResult struct {
+	userResult
+}
+
 // Extract interprets any user results as a User.
 func (r userResult) Extract() (*User, error) {
 	var s struct {
@@ -56,4 +74,13 @@ func (r userResult) Extract() (*User, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.User, err
+}
+
+// ExtractLoginProtect interprets any user login protect results as a LoginProtect.
+func (r userResult) ExtractLoginProtect() (*LoginProtect, error) {
+	var s struct {
+		LoginProtect *LoginProtect `json:"login_protect"`
+	}
+	err := r.ExtractInto(&s)
+	return s.LoginProtect, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/users/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/v3.0/users/urls.go
@@ -15,3 +15,7 @@ func updateURL(client *golangsdk.ServiceClient, userID string) string {
 func getURL(client *golangsdk.ServiceClient, userID string) string {
 	return client.ServiceURL(rootPath, "users", userID)
 }
+
+func loginProtectURL(client *golangsdk.ServiceClient, userID string) string {
+	return client.ServiceURL(rootPath, "users", userID, "login-protect")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240218110804-4d47bb676743
+# github.com/chnsz/golangsdk v0.0.0-20240219092729-295c3df465f5
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support login protect for `huaweicloud_identity_user`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityUser_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityUser_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityUser_basic
=== PAUSE TestAccIdentityUser_basic
=== CONT  TestAccIdentityUser_basic
--- PASS: TestAccIdentityUser_basic (39.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       39.198s
```
