### PR TITLE
feat(DC): DC virtual interface add field resource_tenant_id

### DIFF
--- a/docs/resources/dc_virtual_interface.md
+++ b/docs/resources/dc_virtual_interface.md
@@ -126,8 +126,17 @@ The following arguments are supported:
   virtual interface.  
   Changing this will create a new resource.
 
+* `resource_tenant_id` - (Optional, String, ForceNew) Specifies the project ID of another tenant in the same region
+  which is used to create virtual interface across tenant. After the across tenant virtual interface is successfully
+  created, the target tenant needs to accept the virtual interface request for the virtual interface to take effect.
+  Changing this will create a new resource.
+
+  -> 1. When `resource_tenant_id` is specified, `vgw_id` must be the target tenant virtual gateway id.
+  <br/>2. When `resource_tenant_id` is specified, the tags can only be configured after the target tenant accepts the
+  virtual interface request and the virtual interface takes effect.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the virtual
-  interface belongs.  
+  interface belongs. This field is valid only when `resource_tenant_id` is not specified.
   Changing this will create a new resource.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the virtual interface.
@@ -150,4 +159,23 @@ Virtual interfaces can be imported using their `id`, e.g.
 
 ```shell
 $ terraform import huaweicloud_dc_virtual_interface.test 5bb22e82-5b07-4845-bd1b-b064eca92e0a
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include:
+`resource_tenant_id`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also you can ignore changes as below.
+
+```bash
+resource "huaweicloud_dc_virtual_interface" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      resource_tenant_id,
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -147,9 +147,10 @@ var (
 	HW_RF_VARIABLES_ARCHIVE_URI = os.Getenv("HW_RF_VARIABLES_ARCHIVE_URI")
 
 	// The direct connection ID (provider does not support direct connection resource).
-	HW_DC_DIRECT_CONNECT_ID  = os.Getenv("HW_DC_DIRECT_CONNECT_ID")
-	HW_DC_RESOURCE_TENANT_ID = os.Getenv("HW_DC_RESOURCE_TENANT_ID")
-	HW_DC_HOSTTING_ID        = os.Getenv("HW_DC_HOSTTING_ID")
+	HW_DC_DIRECT_CONNECT_ID    = os.Getenv("HW_DC_DIRECT_CONNECT_ID")
+	HW_DC_RESOURCE_TENANT_ID   = os.Getenv("HW_DC_RESOURCE_TENANT_ID")
+	HW_DC_HOSTTING_ID          = os.Getenv("HW_DC_HOSTTING_ID")
+	HW_DC_TARGET_TENANT_VGW_ID = os.Getenv("HW_DC_TARGET_TENANT_VGW_ID")
 
 	// The CFW instance ID
 	HW_CFW_INSTANCE_ID        = os.Getenv("HW_CFW_INSTANCE_ID")
@@ -856,6 +857,20 @@ func TestAccPreCheckDcDirectConnection(t *testing.T) {
 func TestAccPreCheckDcHostedConnection(t *testing.T) {
 	if HW_DC_RESOURCE_TENANT_ID == "" || HW_DC_HOSTTING_ID == "" {
 		t.Skip("HW_DC_RESOURCE_TENANT_ID, HW_DC_HOSTTING_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDcResourceTenant(t *testing.T) {
+	if HW_DC_RESOURCE_TENANT_ID == "" {
+		t.Skip("HW_DC_RESOURCE_TENANT_ID must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckTargetTenantDcVGW(t *testing.T) {
+	if HW_DC_TARGET_TENANT_VGW_ID == "" {
+		t.Skip("HW_DC_TARGET_TENANT_VGW_ID must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go
@@ -220,6 +220,12 @@ func ResourceVirtualInterface() *schema.Resource {
 				ForceNew:    true,
 				Description: "The ID of the link aggregation group (LAG) associated with the virtual interface.",
 			},
+			"resource_tenant_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The project ID of another tenant which is used to create virtual interface across tenant.",
+			},
 			"enterprise_project_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -270,6 +276,7 @@ func buildVirtualInterfaceCreateOpts(d *schema.ResourceData, cfg *config.Config)
 		EnableBfd:           d.Get("enable_bfd").(bool),
 		EnableNqa:           d.Get("enable_nqa").(bool),
 		LagId:               d.Get("lag_id").(string),
+		ResourceTenantId:    d.Get("resource_tenant_id").(string),
 		EnterpriseProjectId: common.GetEnterpriseProjectID(d, cfg),
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
DC virtual interface add field resource_tenant_id

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
1. Virtual interfaces created across tenants must be resources in the same region for different tenants.
2. `vgw_id` must be the target tenant virtual gateway id.
3. The tags can only be configured after the target tenant accepts the virtual interface request and the virtual interface takes effect.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dc/' TESTARGS='-run TestAccVirtualInterface_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccVirtualInterface_basic -timeout 360m -parallel 4 
=== RUN   TestAccVirtualInterface_basic 
=== PAUSE TestAccVirtualInterface_basic
=== CONT  TestAccVirtualInterface_basic
--- PASS: TestAccVirtualInterface_basic (79.09s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        79.131s
```
```
make testacc TEST='./huaweicloud/services/acceptance/dc/' TESTARGS='-run TestAccVirtualInterface_acrossTenant'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc/ -v -run TestAccVirtualInterface_acrossTenant -timeout 360m -parallel 4 
=== RUN   TestAccVirtualInterface_acrossTenant 
=== PAUSE TestAccVirtualInterface_acrossTenant
=== CONT  TestAccVirtualInterface_acrossTenant
--- PASS: TestAccVirtualInterface_acrossTenant (16.33s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        16.374s
```
