### PR TITLE
feat(dli): the resource supports associate elastic resource pool

### DIFF
--- a/docs/resources/dli_queue.md
+++ b/docs/resources/dli_queue.md
@@ -111,3 +111,21 @@ DLI queue can be imported by `name`. For example,
 ```bash
 terraform import huaweicloud_dli_queue.example terraform_dli_queue_test
 ```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `tags`.
+It is generally recommended running `terraform plan` after importing a desktop.
+You can then decide if changes should be applied to the desktop, or the resource definition should be updated to
+align with the desktop. Also you can ignore changes as below.
+
+```
+resource "huaweicloud_workspace_desktop" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+```

--- a/docs/resources/dli_queue.md
+++ b/docs/resources/dli_queue.md
@@ -90,6 +90,8 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map, ForceNew) Label of a queue. Changing this parameter will create a new resource.
 
+* `elastic_resource_pool_name` - (Optional, String) The name of the elastic resource pool.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -114,12 +116,12 @@ terraform import huaweicloud_dli_queue.example terraform_dli_queue_test
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response. The missing attributes include: `tags`.
-It is generally recommended running `terraform plan` after importing a desktop.
-You can then decide if changes should be applied to the desktop, or the resource definition should be updated to
-align with the desktop. Also you can ignore changes as below.
+It is generally recommended running `terraform plan` after importing a DLI queue.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
 
 ```
-resource "huaweicloud_workspace_desktop" "test" {
+resource "huaweicloud_dli_queue" "test" {
   ...
 
   lifecycle {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271
+	github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271 h1:gnCt4XZukMwIHfGXbHxGia2VMtG5R2TjTIgpSf5Jy6U=
-github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85 h1:esf07r1+SPWoZeG7G3lHdNiyyvDs640qUKZTBDoqfzA=
+github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -805,6 +805,10 @@ func (c *Config) DliV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("dliv2", region)
 }
 
+func (c *Config) DliV3Client(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("dliv3", region)
+}
+
 func (c *Config) DisV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("dis", region)
 }

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -36,7 +36,7 @@ var multiCatalogKeys = map[string][]string{
 	"waf":          {"waf-dedicated"},
 	"geminidb":     {"geminidbv31"},
 	"dataarts":     {"dataarts-dlf"},
-	"dli":          {"dliv2"},
+	"dli":          {"dliv2", "dliv3"},
 	"dcs":          {"dcsv1"},
 	"dis":          {"disv3"},
 	"dms":          {"dmsv2"},
@@ -665,6 +665,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"dliv2": {
 		Name:    "dli",
 		Version: "v2.0",
+		Product: "DLI",
+	},
+	"dliv3": {
+		Name:    "dli",
+		Version: "v3",
 		Product: "DLI",
 	},
 	"dis": {

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/requests.go
@@ -58,6 +58,8 @@ type CreateOpts struct {
 	Feature string `json:"feature,omitempty"`
 
 	Tags []tags.ResourceTag `json:"tags,omitempty"`
+	// The name of the elastic resource pool.
+	ElasticResourcePoolName string `json:"elastic_resource_pool_name,omitempty"`
 }
 
 type ListOpts struct {
@@ -106,7 +108,6 @@ This API is used to create a queue.
 @cloudAPI-version: v1.0
 
 @since: 2021-07-07 12:12:12
-
 */
 func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	requstbody, err := opts.ToDomainCreateMap()
@@ -127,7 +128,6 @@ This API is used to delete a queue.
 @cloudAPI-version: v1.0
 
 @since: 2021-07-07 12:12:12
-
 */
 func Delete(c *golangsdk.ServiceClient, queueName string) (r DeleteResult) {
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
@@ -143,7 +143,6 @@ This API is used to query all Queue  list
 @cloudAPI-version: v1.0
 
 @since: 2021-07-07 12:12:12
-
 */
 func List(c *golangsdk.ServiceClient, listOpts ListOptsBuilder) (r GetResult) {
 	listResult := new(ListResult)
@@ -172,7 +171,6 @@ This API is used to query the Details of a Queue
 @cloudAPI-version: v1.0
 
 @since: 2021-07-07 12:12:12
-
 */
 func Get(c *golangsdk.ServiceClient, queueName string) (r GetResult) {
 	result := new(Queue4Get)

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/results.go
@@ -74,6 +74,8 @@ type Queue struct {
 	Container: containerized cluster (k8s)
 	**/
 	QueueResourceType string `json:"queue_resource_type"`
+	// The name of the elastic resource pool.
+	ElasticResourcePoolName string `json:"elastic_resource_pool_name"`
 }
 
 type Queue4Get struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/elasticresourcepool/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/elasticresourcepool/requests.go
@@ -1,0 +1,25 @@
+package elasticresourcepool
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// AssociateQueueOpts is the structure that used to associate a queue with an elastic resource pool.
+type AssociateQueueOpts struct {
+	// The name of the elastic resource pool.
+	ElasticResourcePoolName string `json:"-" required:"true"`
+	// The name of queue.
+	QueueName string `json:"queue_name" required:"true"`
+}
+
+// AssociateQueue is a method to associate a queue with an elastic resource pool using given parameters.
+func AssociateQueue(c *golangsdk.ServiceClient, opts AssociateQueueOpts) (*AssociateQueueResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssociateQueueResp
+	_, err = c.Post(associateQueueURl(c, opts.ElasticResourcePoolName), b, &r, nil)
+	return &r, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/elasticresourcepool/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/elasticresourcepool/results.go
@@ -1,0 +1,9 @@
+package elasticresourcepool
+
+// AssociateQueueResp is the structure that represents response of the AssociateElasticResourcePool method.
+type AssociateQueueResp struct {
+	// Whether the request is successfully sent. Value true indicates that the request is successfully sent.
+	IsSuccess bool `json:"is_success"`
+	// System prompt. If execution succeeds, the parameter setting may be left blank.
+	Message string `json:"message"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/elasticresourcepool/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/elasticresourcepool/urls.go
@@ -1,0 +1,7 @@
+package elasticresourcepool
+
+import "github.com/chnsz/golangsdk"
+
+func associateQueueURl(c *golangsdk.ServiceClient, name string) string {
+	return c.ServiceURL("elastic-resource-pools", name, "queues")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271
+# github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -128,6 +128,7 @@ github.com/chnsz/golangsdk/openstack/dli/v1/sqljob
 github.com/chnsz/golangsdk/openstack/dli/v1/tables
 github.com/chnsz/golangsdk/openstack/dli/v2/batches
 github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources
+github.com/chnsz/golangsdk/openstack/dli/v3/elasticresourcepool
 github.com/chnsz/golangsdk/openstack/dms/v1/groups
 github.com/chnsz/golangsdk/openstack/dms/v1/instances
 github.com/chnsz/golangsdk/openstack/dms/v1/queues


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The docs add `ignore_changes`.
The resource suppouts associating a queue with an elastic resource pool.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the docs add ignore_changes.
2. the resource suppouts associating a queue with an elastic resource pool.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
make testacc TEST=./huaweicloud/services/acceptance/dli TESTARGS='-run TestAccDliQueue_withElasticResourcePool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDliQueue_withElasticResourcePool -timeout 360m -parallel 4
=== RUN   TestAccDliQueue_withElasticResourcePool
=== PAUSE TestAccDliQueue_withElasticResourcePool
=== CONT  TestAccDliQueue_withElasticResourcePool
--- PASS: TestAccDliQueue_withElasticResourcePool (4623.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       4623.629s

make testacc TEST=./huaweicloud/services/acceptance/dli TESTARGS='-run TestAccDliQueue_associateElasticResourcePool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDliQueue_associateElasticResourcePool -timeout 360m -parallel 4
=== RUN   TestAccDliQueue_associateElasticResourcePool
=== PAUSE TestAccDliQueue_associateElasticResourcePool
=== CONT  TestAccDliQueue_associateElasticResourcePool
--- PASS: TestAccDliQueue_associateElasticResourcePool (4729.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       4729.962s
```
