### PR TITLE
feat(CC): add exclude_er_connections attribute to CC central network policy resource

### DIFF
--- a/docs/resources/cc_central_network_policy.md
+++ b/docs/resources/cc_central_network_policy.md
@@ -8,6 +8,8 @@ Manages a central network policy resource of Cloud Connect within HuaweiCloud.
 
 ## Example Usage
 
+### Create a basic policy
+
 ```hcl
 variable "central_network_id" {}
 variable "project_id" {}
@@ -31,6 +33,83 @@ resource "huaweicloud_cc_central_network_policy" "test" {
     project_id           = var.project_id
     region_id            = var.region_id
     enterprise_router_id = var.enterprise_router_id
+  }
+}
+```
+
+### Create a policy that needs to exclude some ER connections
+  
+```hcl
+variable "central_network_id" {}
+variable "project_id_1" {}
+variable "project_id_2" {}
+variable "project_id_3" {}
+variable "region_id_1" {}
+variable "region_id_2" {}
+variable "region_id_3" {}
+variable "enterprise_router_id_1" {}
+variable "enterprise_router_id_2" {}
+variable "enterprise_router_id_3" {}
+variable "enterprise_router_table_id_1" {}
+variable "enterprise_router_table_id_2" {}
+variable "enterprise_router_table_id_3" {}
+
+resource "huaweicloud_cc_central_network_policy" "test" {
+  central_network_id = var.central_network_id
+ 
+  planes {
+    associate_er_tables {
+      project_id                 = var.project_id_1
+      region_id                  = var.region_id_1
+      enterprise_router_id       = var.enterprise_router_id_1
+      enterprise_router_table_id = var.enterprise_router_table_id_1
+    }
+
+    associate_er_tables {
+      project_id                 = var.project_id_2
+      region_id                  = var.region_id_2
+      enterprise_router_id       = var.enterprise_router_id_2
+      enterprise_router_table_id = var.enterprise_router_table_id_2
+    }
+
+    associate_er_tables {
+      project_id                 = var.project_id_3
+      region_id                  = var.region_id_3
+      enterprise_router_id       = var.enterprise_router_id_3
+      enterprise_router_table_id = var.enterprise_router_table_id_3
+    }
+
+    exclude_er_connections {
+      exclude_er_instances {
+        project_id           = var.project_id_1
+        region_id            = var.region_id_1
+        enterprise_router_id = var.enterprise_router_id_1
+      }
+
+      exclude_er_instances {
+        project_id           = var.project_id_2
+        region_id            = var.region_id_2
+        enterprise_router_id = var.enterprise_router_id_2
+      }
+    }
+  }
+ 
+  er_instances {
+    project_id           = var.project_id_1
+    region_id            = var.region_id_1
+    enterprise_router_id = var.enterprise_router_id_1
+  }
+
+  er_instances {
+    project_id           = var.project_id_2
+    region_id            = var.region_id_2
+    enterprise_router_id = var.enterprise_router_id_2
+  }
+
+  er_instances {
+    project_id           = var.project_id_3
+    region_id            = var.region_id_3
+    enterprise_router_id = var.enterprise_router_id_3
   }
 }
 ```
@@ -78,6 +157,11 @@ The `planes` block supports:
   The [associate_er_tables](#centralNetworkPolicy_AssociateErTableDocument) structure is documented below.
   Changing this parameter will create a new resource.
 
+* `exclude_er_connections` - (Optional, List, ForceNew) List of the enterprise router connections excluded from the
+  central network policy.
+  The [exclude_er_connections](#centralNetworkPolicy_ExcludeErConnectionDocument) structure is documented below.
+  Changing this parameter will create a new resource.
+
 <a name="centralNetworkPolicy_AssociateErTableDocument"></a>
 The `associate_er_tables` block supports:
 
@@ -91,6 +175,13 @@ The `associate_er_tables` block supports:
   Changing this parameter will create a new resource.
 
 * `enterprise_router_table_id` - (Required, String, ForceNew) Enterprise router table ID.
+  Changing this parameter will create a new resource.
+
+<a name="centralNetworkPolicy_ExcludeErConnectionDocument"></a>
+The `exclude_er_connections` block supports:
+
+* `exclude_er_instances` - (Required, List, ForceNew) List of enterprise routers that will not establish a connection.
+  The [exclude_er_instances](#centralNetworkPolicy_AssociateErInstanceDocument) structure is the same as `er_instances`.
   Changing this parameter will create a new resource.
 
 ## Attribute Reference

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -13,14 +13,21 @@ import (
 )
 
 var (
-	HW_REGION_NAME                        = os.Getenv("HW_REGION_NAME")
-	HW_CUSTOM_REGION_NAME                 = os.Getenv("HW_CUSTOM_REGION_NAME")
-	HW_AVAILABILITY_ZONE                  = os.Getenv("HW_AVAILABILITY_ZONE")
-	HW_ACCESS_KEY                         = os.Getenv("HW_ACCESS_KEY")
-	HW_SECRET_KEY                         = os.Getenv("HW_SECRET_KEY")
-	HW_USER_ID                            = os.Getenv("HW_USER_ID")
-	HW_USER_NAME                          = os.Getenv("HW_USER_NAME")
-	HW_PROJECT_ID                         = os.Getenv("HW_PROJECT_ID")
+	HW_REGION_NAME        = os.Getenv("HW_REGION_NAME")
+	HW_REGION_NAME_1      = os.Getenv("HW_REGION_NAME_1")
+	HW_REGION_NAME_2      = os.Getenv("HW_REGION_NAME_2")
+	HW_REGION_NAME_3      = os.Getenv("HW_REGION_NAME_3")
+	HW_CUSTOM_REGION_NAME = os.Getenv("HW_CUSTOM_REGION_NAME")
+	HW_AVAILABILITY_ZONE  = os.Getenv("HW_AVAILABILITY_ZONE")
+	HW_ACCESS_KEY         = os.Getenv("HW_ACCESS_KEY")
+	HW_SECRET_KEY         = os.Getenv("HW_SECRET_KEY")
+	HW_USER_ID            = os.Getenv("HW_USER_ID")
+	HW_USER_NAME          = os.Getenv("HW_USER_NAME")
+	HW_PROJECT_ID         = os.Getenv("HW_PROJECT_ID")
+	HW_PROJECT_ID_1       = os.Getenv("HW_PROJECT_ID_1")
+	HW_PROJECT_ID_2       = os.Getenv("HW_PROJECT_ID_2")
+	HW_PROJECT_ID_3       = os.Getenv("HW_PROJECT_ID_3")
+
 	HW_DOMAIN_ID                          = os.Getenv("HW_DOMAIN_ID")
 	HW_DOMAIN_NAME                        = os.Getenv("HW_DOMAIN_NAME")
 	HW_ENTERPRISE_PROJECT_ID_TEST         = os.Getenv("HW_ENTERPRISE_PROJECT_ID_TEST")
@@ -812,6 +819,20 @@ func TestAccPreCheckKmsHsmClusterId(t *testing.T) {
 func TestAccPreCheckProjectID(t *testing.T) {
 	if HW_PROJECT_ID == "" {
 		t.Skip("HW_PROJECT_ID must be set for acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCCProjectID(t *testing.T) {
+	if HW_PROJECT_ID_1 == "" || HW_PROJECT_ID_2 == "" || HW_PROJECT_ID_3 == "" {
+		t.Skip("HW_PROJECT_ID_1, HW_PROJECT_ID_2, HW_PROJECT_ID_3 must be set for this acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCCRegionName(t *testing.T) {
+	if HW_REGION_NAME_1 == "" || HW_REGION_NAME_2 == "" || HW_REGION_NAME_3 == "" {
+		t.Skip("HW_REGION_NAME_1, HW_REGION_NAME_2, HW_REGION_NAME_3 must be set for this acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_central_network_policy_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_central_network_policy_test.go
@@ -193,6 +193,166 @@ resource "huaweicloud_cc_central_network_policy" "test" {
 `, name, acceptance.HW_PROJECT_ID, acceptance.HW_REGION_NAME)
 }
 
+func TestAccCentralNetworkPolicy_excludeErConnections(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cc_central_network_policy.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getCentralNetworkPolicyResourceFunc,
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCCProjectID(t)
+			acceptance.TestAccPreCheckCCRegionName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCentralNetworkPolicy_excludeErConnections(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "state", "AVAILABLE"),
+					resource.TestCheckResourceAttr(rName, "is_applied", "false"),
+					resource.TestCheckResourceAttr(rName, "planes.0.associate_er_tables.#", "3"),
+					resource.TestCheckResourceAttr(rName, "planes.0.exclude_er_connections.#", "1"),
+					resource.TestCheckResourceAttrSet(rName, "version"),
+					resource.TestCheckResourceAttrSet(rName, "document_template_version"),
+					resource.TestCheckResourceAttrPair(rName, "planes.0.associate_er_tables.0.enterprise_router_id",
+						"huaweicloud_er_instance.er1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "central_network_id",
+						"huaweicloud_cc_central_network.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testCentralNetworkPolicyImportState(rName),
+			},
+		},
+	})
+}
+
+func testCentralNetworkPolicy_excludeErConnections(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_er_availability_zones" "az1" {
+  region = "%[1]s"
+}
+
+resource "huaweicloud_er_instance" "er1" {
+  availability_zones = slice(data.huaweicloud_er_availability_zones.az1.names, 0, 1)
+
+  region                         = "%[1]s"
+  name                           = "%[4]s1"
+  asn                            = 64512
+  enable_default_propagation     = true
+  enable_default_association     = true
+  auto_accept_shared_attachments = true
+}
+
+data "huaweicloud_er_availability_zones" "az2" {
+  region = "%[2]s"
+}
+  
+resource "huaweicloud_er_instance" "er2" {
+  availability_zones = slice(data.huaweicloud_er_availability_zones.az2.names, 0, 1)
+
+  region                         = "%[2]s"
+  name                           = "%[4]s2"
+  asn                            = 64512
+  enable_default_propagation     = true
+  enable_default_association     = true
+  auto_accept_shared_attachments = true
+}
+
+data "huaweicloud_er_availability_zones" "az3" {
+  region = "%[3]s"
+}
+  
+resource "huaweicloud_er_instance" "er3" {
+  availability_zones = slice(data.huaweicloud_er_availability_zones.az3.names, 0, 1)
+
+  region                         = "%[3]s"
+  name                           = "%[4]s3"
+  asn                            = 64512
+  enable_default_propagation     = true
+  enable_default_association     = true
+  auto_accept_shared_attachments = true
+}
+
+resource "huaweicloud_cc_central_network" "test" {
+  name        = "%[4]s"
+  description = "This is an accaptance test"
+}
+ 
+resource "huaweicloud_cc_central_network_policy" "test" {
+  central_network_id = huaweicloud_cc_central_network.test.id
+ 
+  planes {
+    associate_er_tables {
+      project_id                 = "%[5]s"
+      region_id                  = "%[1]s"
+      enterprise_router_id       = huaweicloud_er_instance.er1.id
+      enterprise_router_table_id = huaweicloud_er_instance.er1.default_association_route_table_id
+    }
+
+    associate_er_tables {
+      project_id                 = "%[6]s"
+      region_id                  = "%[2]s"
+      enterprise_router_id       = huaweicloud_er_instance.er2.id
+      enterprise_router_table_id = huaweicloud_er_instance.er2.default_association_route_table_id
+    }
+
+    associate_er_tables {
+      project_id                 = "%[7]s"
+      region_id                  = "%[3]s"
+      enterprise_router_id       = huaweicloud_er_instance.er3.id
+      enterprise_router_table_id = huaweicloud_er_instance.er3.default_association_route_table_id
+    }
+
+    exclude_er_connections {
+      exclude_er_instances {
+        project_id           = "%[5]s"
+        region_id            = "%[1]s"
+        enterprise_router_id = huaweicloud_er_instance.er1.id
+      }
+
+      exclude_er_instances {
+        project_id           = "%[6]s"
+        region_id            = "%[2]s"
+        enterprise_router_id = huaweicloud_er_instance.er2.id
+      }
+    }
+  }
+ 
+  er_instances {
+    project_id           = "%[5]s"
+    region_id            = "%[1]s"
+    enterprise_router_id = huaweicloud_er_instance.er1.id
+  }
+
+  er_instances {
+    project_id           = "%[6]s"
+    region_id            = "%[2]s"
+    enterprise_router_id = huaweicloud_er_instance.er2.id
+  }
+
+  er_instances {
+    project_id           = "%[7]s"
+    region_id            = "%[3]s"
+    enterprise_router_id = huaweicloud_er_instance.er3.id
+  }
+}
+`, acceptance.HW_REGION_NAME_1, acceptance.HW_REGION_NAME_2, acceptance.HW_REGION_NAME_3,
+		name, acceptance.HW_PROJECT_ID_1, acceptance.HW_PROJECT_ID_2, acceptance.HW_PROJECT_ID_3)
+}
+
 func testCentralNetworkPolicyImportState(name string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		rs, ok := s.RootModule().Resources[name]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add exclude_er_connections attribute to CC central network policy resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add exclude_er_connections attribute to CC central network policy resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetworkPolicy_excludeErConnections"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetworkPolicy_excludeErConnections -timeout 360m -parallel 4
=== RUN   TestAccCentralNetworkPolicy_excludeErConnections
=== PAUSE TestAccCentralNetworkPolicy_excludeErConnections
=== CONT  TestAccCentralNetworkPolicy_excludeErConnections
--- PASS: TestAccCentralNetworkPolicy_excludeErConnections (114.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc 114.711s

```
