### PR TITLE
feat(BMS): add datasource to query the list of BMS instances

### DIFF
--- a/docs/data-sources/bms_instances.md
+++ b/docs/data-sources/bms_instances.md
@@ -1,0 +1,136 @@
+---
+subcategory: "Bare Metal Server (BMS)"
+---
+
+# huaweicloud_bms_instances
+
+Use this data source to get the list of BMS instances.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_bms_instances" "test" {
+  status = "active"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of BMS instance.
+
+* `flavor_id` - (Optional, String) Specifies the flavor ID of the desired flavor for the BMS instance.
+
+* `name` - (Optional, String) Specifies the name of the BMS instance.
+
+* `status` - (Optional, String) Specifies the status of the instance.
+  Value options are as follows:
+  + **ACTIVE**: running, stopping, deleting.
+  + **BUILD**: creating.
+  + **ERROR**: faulty.
+  + **HARD_REBOOT**: forcibly restarting.
+  + **REBOOT**: restarting.
+  + **SHUTOFF**: stopped, starting, deleting, rebuilding, reinstalling OS, OS reinstallation failed, frozen.
+
+* `tags` - (Optional, String) Specifies the BMS tags. The value can be: **__type_baremetal** or other custom tags.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `servers` - The list of BMS instances.
+  The [servers](#attrblock--servers) structure is documented below.
+
+<a name="attrblock--servers"></a>
+The `servers` block supports:
+
+* `id` - The ID of the BMS instance.
+
+* `name` - The name of the BMS instance.
+
+* `availability_zone` - The availability zone in which to create the BMS instance.
+
+* `disk_config` - The disk configuration.
+
+* `enterprise_project_id` - The enterprise project ID of BMS instance.
+
+* `flavor_id` - The ID of the BMS flavor.
+
+* `flavor_name` - The name of the BMS flavor.
+
+* `vcpus` - The number of vCPUs.
+
+* `memory` - The memory size in GB.
+
+* `disk` - The system disk size(GB) in the BMS flavor. The value `0` indicates that the disk size is not limited.
+
+* `image_id` - The image ID of the desired image for the BMS instance.
+
+* `vpc_id` - The ID of vpc in which to create the BMS instance.
+
+* `agency_name` - The IAM agency name which is created on IAM to provide temporary credentials for BMS
+  to access cloud services.
+
+* `image_name` - The image name of the desired image for the BMS instance.
+
+* `image_type` - The image type of the desired image for the BMS instance.
+
+* `key_pair` - The name of a key pair for logging in to the BMS using key pair authentication.
+
+* `launched_at` - The start time of the BMS instance.
+
+* `locked` - Whether the BMS instance is locked.
+
+* `nics` - The list of one or more networks to attach to the BMS instance.
+  The [nics](#attrblock--servers--nics) structure is documented below.
+
+* `root_device_name` - The device name of the BMS system disk.
+
+* `security_groups` - The list of one or more security group IDs to associate with the BMS instance.
+
+* `status` - The status of the BMS instance.
+
+* `user_data` - The user data to be injected during the BMS instance creation.
+
+* `user_id` - The user ID.
+
+* `vm_state` - The stable status of the BMS instance.
+
+* `created_at` - The creation time of the BMS instance.
+
+* `updated_at` - The latest update time of the BMS instance.
+
+* `description` - The description of the BMS instance.
+
+* `tags` - The key/value pairs to associate with the BMS instance.
+
+* `volumes_attached` - The list of disks attached to the BMS instance.
+  The [volumes_attached](#attrblock--servers--volumes_attached) structure is documented below.
+
+<a name="attrblock--servers--nics"></a>
+The `nics` block supports:
+
+* `subnet_id` - The ID of subnet to attach to the BMS instance.
+
+* `ip_address` - The fixed IPv4 address to be used on this network.
+
+* `mac_address` - The MAC address of the nic.
+
+* `port_id` - The port ID corresponding to the IP address.
+
+<a name="attrblock--servers--volumes_attached"></a>
+The `volumes_attached` block supports:
+
+* `id` - The disk ID in UUID format.
+
+* `boot_index` - Whether it is a boot disk. `0` specifies a boot disk, and `-1` specifies a non-boot disk.
+
+* `delete_on_termination` - Whether to delete the disk when deleting the BMS.
+
+* `device` - The device name of the disk.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240219092729-295c3df465f5
+	github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240219092729-295c3df465f5 h1:sViq3n28/01XH5scvIEHnuapjZMxfMPRBRSobAZcMjI=
-github.com/chnsz/golangsdk v0.0.0-20240219092729-295c3df465f5/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271 h1:gnCt4XZukMwIHfGXbHxGia2VMtG5R2TjTIgpSf5Jy6U=
+github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -405,7 +405,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_account":            DataSourceAccount(),
 			"huaweicloud_availability_zones": DataSourceAvailabilityZones(),
 
-			"huaweicloud_bms_flavors": bms.DataSourceBmsFlavors(),
+			"huaweicloud_bms_flavors":   bms.DataSourceBmsFlavors(),
+			"huaweicloud_bms_instances": bms.DataSourceBmsInstances(),
 
 			"huaweicloud_cbr_backup":   cbr.DataSourceBackup(),
 			"huaweicloud_cbr_vaults":   cbr.DataSourceVaults(),

--- a/huaweicloud/services/acceptance/bms/data_source_huaweicloud_bms_instances_test.go
+++ b/huaweicloud/services/acceptance/bms/data_source_huaweicloud_bms_instances_test.go
@@ -1,0 +1,119 @@
+package bms
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccBmsInstancesDataSource_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	resourceName := "data.huaweicloud_bms_instances.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBmsInstancesDataSource_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBmsFlavorDataSourceID(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.nics.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.flavor_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.disk"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.vcpus"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.memory"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.status"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.agency_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.image_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.image_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.description"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.locked"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.user_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.key_pair"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.volumes_attached.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.vm_state"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.disk_config"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.availability_zone"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.root_device_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.user_data"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.security_groups.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "servers.0.image_id"),
+
+					resource.TestCheckOutput("flavor_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+					resource.TestCheckOutput("enterprise_project_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBmsInstancesDataSource_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_bms_instances" "test" {
+  depends_on = [huaweicloud_bms_instance.test]
+}
+
+data "huaweicloud_bms_instances" "flavor_id_filter" {
+  flavor_id = data.huaweicloud_bms_instances.test.servers.0.flavor_id
+}
+locals {
+  flavor_id = data.huaweicloud_bms_instances.test.servers.0.flavor_id
+}
+output "flavor_id_filter_is_useful" {
+  value = length(data.huaweicloud_bms_instances.flavor_id_filter.servers) > 0 && alltrue(
+    [for v in data.huaweicloud_bms_instances.flavor_id_filter.servers[*].flavor_id : v == local.flavor_id]
+  )  
+}
+
+data "huaweicloud_bms_instances" "name_filter" {
+  name = huaweicloud_bms_instance.test.name
+}
+locals {
+  name = data.huaweicloud_bms_instances.test.servers.0.name
+}
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_bms_instances.name_filter.servers) > 0 && alltrue(
+    [for v in data.huaweicloud_bms_instances.name_filter.servers[*].name : v == local.name]
+  )  
+}
+
+data "huaweicloud_bms_instances" "status_filter" {
+  status = data.huaweicloud_bms_instances.test.servers.0.status
+}
+locals {
+  status = data.huaweicloud_bms_instances.test.servers.0.status
+}
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_bms_instances.status_filter.servers) > 0 && alltrue(
+    [for v in data.huaweicloud_bms_instances.status_filter.servers[*].status : v == local.status]
+  )  
+}
+
+data "huaweicloud_bms_instances" "enterprise_project_id_filter" {
+  enterprise_project_id = data.huaweicloud_bms_instances.test.servers.0.enterprise_project_id
+} 
+locals {
+  enterprise_project_id = data.huaweicloud_bms_instances.test.servers.0.enterprise_project_id
+}
+output "enterprise_project_id_filter_is_useful" {
+  value = length(data.huaweicloud_bms_instances.enterprise_project_id_filter.servers) > 0 && alltrue(
+    [for v in data.huaweicloud_bms_instances.enterprise_project_id_filter.servers[*].enterprise_project_id : v == local.enterprise_project_id]
+  )  
+}
+`, testAccBmsInstance_basic(name))
+}

--- a/huaweicloud/services/bms/data_source_huaweicloud_bms_instances.go
+++ b/huaweicloud/services/bms/data_source_huaweicloud_bms_instances.go
@@ -1,0 +1,337 @@
+package bms
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API BMS GET /v1/{project_id}/baremetalservers/detail
+// @API BMS GET /v1/{project_id}/baremetalservers/{server_id}/tags
+func DataSourceBmsInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBmsInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"servers": {
+				Type:     schema.TypeList,
+				Elem:     serversSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func serversSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"nics": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ip_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mac_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"subnet_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flavor_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vcpus": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agency_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": common.TagsComputedSchema(),
+			"locked": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_pair": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"volumes_attached": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"delete_on_termination": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"boot_index": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"device": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"vm_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_config": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"root_device_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"launched_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_groups": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceBmsInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	bmsClient, err := cfg.BmsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating BMS client: %s", err)
+	}
+
+	listOpts := baremetalservers.ListOpts{
+		FlavorId:            d.Get("flavor_id").(string),
+		Name:                d.Get("name").(string),
+		Status:              d.Get("status").(string),
+		EnterpriseProjectId: cfg.DataGetEnterpriseProjectID(d),
+		Tags:                d.Get("tags").(string),
+	}
+
+	allInstances, err := baremetalservers.List(bmsClient, listOpts)
+	if err != nil {
+		return diag.Errorf("unable to retrieve BMS instances: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("servers", flattenListBMSInstances(d, meta, bmsClient, allInstances)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListBMSInstances(d *schema.ResourceData, meta interface{}, bmsClient *golangsdk.ServiceClient,
+	allInstances []baremetalservers.CloudServer) []map[string]interface{} {
+	if allInstances == nil {
+		return nil
+	}
+
+	servers := make([]map[string]interface{}, len(allInstances))
+	for i, v := range allInstances {
+		servers[i] = map[string]interface{}{
+			"id":                    v.ID,
+			"name":                  v.Name,
+			"status":                v.Status,
+			"nics":                  flattenBmsInstanceNicsV1(d, meta, v.Addresses),
+			"flavor_id":             v.Flavor.ID,
+			"flavor_name":           v.Flavor.Name,
+			"vcpus":                 v.Flavor.Vcpus,
+			"memory":                v.Flavor.RAM,
+			"disk":                  v.Flavor.Disk,
+			"created_at":            v.Created,
+			"updated_at":            v.Updated,
+			"launched_at":           v.Launched,
+			"vpc_id":                v.Metadata.VpcID,
+			"agency_name":           v.Metadata.AgencyName,
+			"locked":                v.Locked,
+			"tags":                  faltternBmsTags(v.ID, bmsClient),
+			"user_id":               v.UserID,
+			"key_pair":              v.KeyName,
+			"description":           v.Description,
+			"volumes_attached":      falttenVolumesAtached(v.VolumeAttached),
+			"vm_state":              v.VMState,
+			"disk_config":           v.DiskConfig,
+			"availability_zone":     v.AvailabilityZone,
+			"root_device_name":      v.RootDeviceName,
+			"enterprise_project_id": v.EnterpriseProjectID,
+			"user_data":             v.UserData,
+			"security_groups":       flattenSecurityGroupIDs(v.SecurityGroups),
+			"image_id":              v.Image.ID,
+			"image_name":            v.Metadata.ImageName,
+			"image_type":            v.Metadata.Imagetype,
+		}
+	}
+	return servers
+}
+
+func faltternBmsTags(instanceId string, bmsClient *golangsdk.ServiceClient) map[string]string {
+	var tagsmap map[string]string
+	resourceTags, err := tags.Get(bmsClient, "baremetalservers", instanceId).Extract()
+	if err != nil {
+		return nil
+	}
+	tagsmap = utils.TagsToMap(resourceTags.Tags)
+	return tagsmap
+}
+
+func flattenSecurityGroupIDs(securityGroups []baremetalservers.SecurityGroups) []string {
+	var secGrpIDs []string
+	for _, sg := range securityGroups {
+		secGrpIDs = append(secGrpIDs, sg.ID)
+	}
+
+	return secGrpIDs
+}
+
+func falttenVolumesAtached(volumesAttached []baremetalservers.VolumeAttached) []map[string]interface{} {
+	var volumes []map[string]interface{}
+	for _, va := range volumesAttached {
+		v := map[string]interface{}{
+			"id":                    va.ID,
+			"delete_on_termination": va.DeleteOnTermination,
+			"boot_index":            va.BootIndex,
+			"device":                va.Device,
+		}
+		volumes = append(volumes, v)
+	}
+	return volumes
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers/results.go
@@ -2,6 +2,7 @@ package baremetalservers
 
 import (
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
 )
 
 type cloudServerResult struct {
@@ -121,6 +122,9 @@ type CloudServer struct {
 	OsSchedulerHints    OsSchedulerHints     `json:"os:scheduler_hints"`
 	EnterpriseProjectID string               `json:"enterprise_project_id"`
 	SysTags             []SysTags            `json:"sys_tags"`
+	Created             string               `json:"created"`
+	Updated             string               `json:"updated"`
+	Launched            string               `json:"OS-SRV-USG:launched_at"`
 }
 
 // GetResult is the response from a Get operation. Call its Extract
@@ -153,4 +157,16 @@ func (r UpdateMetadataResult) Extract() (interface{}, interface{}) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Metadata, err
+}
+
+// InstanceDetailPage is a single page maximum result representing a query by offset page.
+type InstanceDetailPage struct {
+	pagination.OffsetPageBase
+}
+
+// ExtractServers is a method to extract the list of BMS instances detail.
+func ExtractServers(r pagination.Page) ([]CloudServer, error) {
+	var s []CloudServer
+	err := r.(InstanceDetailPage).Result.ExtractIntoSlicePtr(&s, "servers")
+	return s, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/bms/v1/baremetalservers/urls.go
@@ -13,6 +13,10 @@ func getURL(sc *golangsdk.ServiceClient, serverID string) string {
 	return sc.ServiceURL(resourcePath, serverID)
 }
 
+func listURL(sc *golangsdk.ServiceClient) string {
+	return sc.ServiceURL(resourcePath, "detail")
+}
+
 func jobURL(sc *golangsdk.ServiceClient, jobId string) string {
 	return sc.ServiceURL("jobs", jobId)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240219092729-295c3df465f5
+# github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add datasource to query the list of BMS instances
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/bms TESTARGS='-run TestAccBmsInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms -v -run TestAccBmsInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccBmsInstancesDataSource_basic
=== PAUSE TestAccBmsInstancesDataSource_basic
=== CONT  TestAccBmsInstancesDataSource_basic
--- PASS: TestAccBmsInstancesDataSource_basic (550.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       550.662s
```
