### PR TITLE
feat(Kafka): kafka supports parameters updated

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -50,6 +50,11 @@ resource "huaweicloud_dms_kafka_instance" "test" {
 
   access_user = "user"
   password    = var.access_password
+
+  parameters {
+    name  = "min.insync.replicas"
+    value = "2"
+  }
 }
 ```
 
@@ -194,6 +199,9 @@ The following arguments are supported:
   produced to or consumed from a topic that does not exist.
   The default value is false.
 
+* `parameters` - (Optional, List) Specifies the array of one or more parameters to be set to the Kafka instance after
+  launched. The [parameters](#dms_parameters) structure is documented below.
+
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the Kafka instance.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the DMS Kafka instance.
@@ -218,6 +226,13 @@ The following arguments are supported:
 The `cross_vpc_accesses` block supports:
 
 * `advertised_ip` - (Optional, String) The advertised IP Address or domain name.
+
+<a name="dms_parameters"></a>
+The `parameters` block supports:
+
+* `name` - (Required, String) Specifies the parameter name. Static parameter needs to restart the instance to take effect.
+
+* `value` - (Required, String) Specifies the parameter value.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271
+	github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271 h1:gnCt4XZukMwIHfGXbHxGia2VMtG5R2TjTIgpSf5Jy6U=
-github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85 h1:esf07r1+SPWoZeG7G3lHdNiyyvDs640qUKZTBDoqfzA=
+github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go
@@ -232,6 +232,8 @@ func TestAccKafkaInstance_newFormat(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.1.advertised_ip", "www.terraform-test.com"),
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.2.advertised_ip", "192.168.0.53"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "min.insync.replicas"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "2"),
 				),
 			},
 			{
@@ -251,6 +253,8 @@ func TestAccKafkaInstance_newFormat(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.1.advertised_ip", "test.terraform.com"),
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.2.advertised_ip", "192.168.0.62"),
 					resource.TestCheckResourceAttr(resourceName, "cross_vpc_accesses.3.advertised_ip", "192.168.0.63"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "auto.create.groups.enable"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "false"),
 				),
 			},
 		},
@@ -389,8 +393,6 @@ func testAccKafkaInstance_compatible(rName string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
-data "huaweicloud_dms_az" "test" {}
-
 data "huaweicloud_dms_product" "test" {
   engine            = "kafka"
   instance_type     = "cluster"
@@ -403,8 +405,10 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   name        = "%s"
   description = "kafka test"
 
-  # use deprecated argument "available_zones"
-  available_zones   = [data.huaweicloud_dms_az.test.id]
+  availability_zones    = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
   vpc_id            = huaweicloud_vpc.test.id
   network_id        = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -476,6 +480,11 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   cross_vpc_accesses {
     advertised_ip = "192.168.0.53"
   }
+
+  parameters {
+    name  = "min.insync.replicas"
+    value = "2"
+  }
 }`, common.TestBaseNetwork(rName), rName)
 }
 
@@ -529,6 +538,11 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   }
   cross_vpc_accesses {
     advertised_ip = "192.168.0.63"
+  }
+
+  parameters {
+    name  = "auto.create.groups.enable"
+    value = "false"
   }
 }`, common.TestBaseNetwork(rName), rName)
 }

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go
@@ -26,8 +26,11 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
+
+type ctxType string
 
 // @API Kafka GET /v2/available-zones
 // @API Kafka POST /v2/{project_id}/instances/{instance_id}/crossvpc/modify
@@ -41,6 +44,9 @@ import (
 // @API Kafka POST /v2/{project_id}/instances/{instance_id}/autotopic
 // @API Kafka GET /v2/{project_id}/instances/{instance_id}/tasks
 // @API Kafka POST /v2/{project_id}/instances/{instance_id}/password
+// @API Kafka PUT /v2/{project_id}/instances/{instance_id}/configs
+// @API Kafka GET /v2/{project_id}/instances/{instance_id}/configs
+// @API Kafka POST /v2/{project_id}/instances/action
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/subscriptions/resources/autorenew/{instance_id}
 // @API BSS DELETE /v2/orders/subscriptions/resources/autorenew/{instance_id}
@@ -201,6 +207,24 @@ func ResourceDmsKafkaInstance() *schema.Resource {
 			},
 			"enable_auto_topic": {
 				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"parameters": {
+				Type: schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Set:      parameterToHash,
 				Optional: true,
 				Computed: true,
 			},
@@ -472,6 +496,12 @@ func resourceDmsKafkaInstanceCreate(ctx context.Context, d *schema.ResourceData,
 	if _, ok := d.GetOk("cross_vpc_accesses"); ok {
 		if err = updateCrossVpcAccess(ctx, client, d); err != nil {
 			return diag.Errorf("failed to update default advertised IP: %s", err)
+		}
+	}
+
+	if parameters := d.Get("parameters").(*schema.Set); parameters.Len() > 0 {
+		if err = initializeParameters(ctx, d, client); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
@@ -851,7 +881,7 @@ func setKafkaFlavorId(d *schema.ResourceData, flavorId string) error {
 	return d.Set("flavor_id", flavorId)
 }
 
-func resourceDmsKafkaInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDmsKafkaInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
@@ -942,6 +972,50 @@ func resourceDmsKafkaInstanceRead(_ context.Context, d *schema.ResourceData, met
 		return diag.Errorf("failed to set attributes for DMS kafka instance: %s", mErr)
 	}
 
+	return setKafkaInstanceParameters(ctx, d, client)
+}
+
+func setKafkaInstanceParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) diag.Diagnostics {
+	// set parameters
+	configs, err := instances.GetConfigurations(client, d.Id()).Extract()
+	if err != nil {
+		log.Printf("[WARN] error fetching parameters of the instance (%s): %s", d.Id(), err)
+		return nil
+	}
+
+	var restart []string
+	var params []map[string]interface{}
+	for _, parameter := range d.Get("parameters").(*schema.Set).List() {
+		name := parameter.(map[string]interface{})["name"]
+		for _, kafkaParam := range configs.KafkaConfigs {
+			if kafkaParam.Name == name {
+				p := map[string]interface{}{
+					"name":  kafkaParam.Name,
+					"value": kafkaParam.Value,
+				}
+				params = append(params, p)
+				if kafkaParam.ConfigType == "static" {
+					restart = append(restart, kafkaParam.Name)
+				}
+				break
+			}
+		}
+	}
+
+	if len(params) > 0 {
+		if err = d.Set("parameters", params); err != nil {
+			log.Printf("[WARN] error saving parameters to the Kafka instance (%s): %s", d.Id(), err)
+		}
+		if len(restart) > 0 && ctx.Value(ctxType("parametersChanged")) == "true" {
+			return diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Parameters Changed",
+					Detail:   fmt.Sprintf("Parameters %s changed which needs reboot.", restart),
+				},
+			}
+		}
+	}
 	return nil
 }
 
@@ -1081,6 +1155,10 @@ func resourceDmsKafkaInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 			e := fmt.Errorf("error resetting password: %s", err)
 			mErr = multierror.Append(mErr, e)
 		}
+	}
+
+	if ctx, err = updateKafkaParameters(ctx, d, client); err != nil {
+		return diag.FromErr(err)
 	}
 
 	if mErr.ErrorOrNil() != nil {
@@ -1467,4 +1545,190 @@ func autoTopicTaskRefreshFunc(client *golangsdk.ServiceClient, instanceID string
 		status := utils.PathSearch("status", task, nil)
 		return task, fmt.Sprint(status), nil
 	}
+}
+
+func buildKafkaInstanceParameters(params *schema.Set) instances.KafkaConfigs {
+	paramList := make([]instances.ConfigParam, 0, params.Len())
+	for _, v := range params.List() {
+		paramList = append(paramList, instances.ConfigParam{
+			Name:  v.(map[string]interface{})["name"].(string),
+			Value: v.(map[string]interface{})["value"].(string),
+		})
+	}
+	configOpts := instances.KafkaConfigs{
+		KafkaConfigs: paramList,
+	}
+	return configOpts
+}
+
+func initializeParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	parametersRaw := d.Get("parameters").(*schema.Set)
+	configOpts := buildKafkaInstanceParameters(parametersRaw)
+	err := modifyParameters(ctx, d, client, &configOpts)
+	if err != nil {
+		return err
+	}
+
+	// Check if we need to restart
+	restart, err := checkKafkaInstanceRestart(client, d.Id(), parametersRaw.List())
+	if err != nil {
+		return err
+	}
+
+	if restart {
+		return restartKafkaInstance(ctx, d.Timeout(schema.TimeoutCreate), client, d.Id())
+	}
+	return nil
+}
+
+func modifyParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	configOpts *instances.KafkaConfigs) error {
+	retryFunc := func() (interface{}, bool, error) {
+		_, err := instances.ModifyConfiguration(client, d.Id(), *configOpts).Extract()
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
+	}
+	_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     KafkaInstanceStateRefreshFunc(client, d.Id()),
+		WaitTarget:   []string{"RUNNING"},
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("error modifying parameters for the Kafka instance (%s): %s", d.Id(), err)
+	}
+
+	return checkParameterUpdateCompleted(ctx, d, client, d.Timeout(schema.TimeoutUpdate))
+}
+
+func checkParameterUpdateCompleted(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"CREATED"},
+		Target:       []string{"SUCCESS"},
+		Refresh:      kafkaInstanceParamRefreshFunc(client, d.Id(), "kafkaConfigModify"),
+		Timeout:      timeout,
+		Delay:        2 * time.Second,
+		PollInterval: 2 * time.Second,
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for the Kafka instance (%s) parameter to be updated: %s ", d.Id(), err)
+	}
+	return nil
+}
+
+func checkKafkaInstanceRestart(client *golangsdk.ServiceClient, instanceID string, parameters []interface{}) (bool, error) {
+	configs, err := instances.GetConfigurations(client, instanceID).Extract()
+	if err != nil {
+		return false, fmt.Errorf("error fetching the instance parameters (%s): %s", instanceID, err)
+	}
+
+	for _, parameter := range parameters {
+		name := parameter.(map[string]interface{})["name"]
+		for _, v := range configs.KafkaConfigs {
+			// static parameter needs to reboot the instance
+			if v.Name == name && v.ConfigType == "static" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func restartKafkaInstance(ctx context.Context, timeout time.Duration, client *golangsdk.ServiceClient,
+	instanceID string) error {
+	// If static parameter is changed, reboot the instance.
+	restartInstanceOpts := instances.RestartInstanceOpts{
+		Action:    "restart",
+		Instances: []string{instanceID},
+	}
+
+	retryFunc := func() (interface{}, bool, error) {
+		_, err := instances.RebootInstance(client, restartInstanceOpts).Extract()
+		retry, err := handleMultiOperationsError(err)
+		return nil, retry, err
+	}
+	_, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     KafkaInstanceStateRefreshFunc(client, instanceID),
+		WaitTarget:   []string{"RUNNING"},
+		Timeout:      timeout,
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("error rebooting the Kafka instance (%s): %s", instanceID, err)
+	}
+
+	// wait for the instance state to be 'RUNNING'.
+	stateConf := &resource.StateChangeConf{
+		Target:       []string{"RUNNING"},
+		Refresh:      KafkaInstanceStateRefreshFunc(client, instanceID),
+		Timeout:      timeout,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
+	}
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for the Kafka instance (%s) become RUNNING status: %s", instanceID, err)
+	}
+	return nil
+}
+
+func updateKafkaParameters(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) (context.Context, error) {
+	if !d.HasChange("parameters") {
+		return ctx, nil
+	}
+
+	o, n := d.GetChange("parameters")
+	os, ns := o.(*schema.Set), n.(*schema.Set)
+	change := ns.Difference(os).List()
+	paramList := make([]instances.ConfigParam, 0, len(change))
+	if len(change) > 0 {
+		for _, v := range change {
+			configOpts := instances.ConfigParam{
+				Name:  v.(map[string]interface{})["name"].(string),
+				Value: v.(map[string]interface{})["value"].(string),
+			}
+			paramList = append(paramList, configOpts)
+		}
+
+		configOpts := instances.KafkaConfigs{
+			KafkaConfigs: paramList,
+		}
+
+		err := modifyParameters(ctx, d, client, &configOpts)
+		if err != nil {
+			return ctx, nil
+		}
+	}
+
+	// Sending parametersChanged to Read to warn users the instance needs a reboot.
+	ctx = context.WithValue(ctx, ctxType("parametersChanged"), "true")
+
+	return ctx, nil
+}
+
+func kafkaInstanceParamRefreshFunc(client *golangsdk.ServiceClient, instanceID, taskName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		taskResp, err := instances.GetTasks(client, instanceID).Extract()
+		if err != nil {
+			return nil, "QUERY ERROR", err
+		}
+		task := utils.PathSearch(fmt.Sprintf("tasks|[?name=='%s']|[0]", taskName), taskResp, nil)
+		if task == nil {
+			return nil, "NIL ERROR", fmt.Errorf("failed to find parameters task")
+		}
+
+		status := utils.PathSearch("status", task, nil)
+		return task, fmt.Sprint(status), nil
+	}
+}
+
+func parameterToHash(v interface{}) int {
+	m := v.(map[string]interface{})
+	return hashcode.String(m["name"].(string) + m["value"].(string))
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/requests.go
@@ -58,6 +58,8 @@ type CreateOpts struct {
 	Feature string `json:"feature,omitempty"`
 
 	Tags []tags.ResourceTag `json:"tags,omitempty"`
+	// The name of the elastic resource pool.
+	ElasticResourcePoolName string `json:"elastic_resource_pool_name,omitempty"`
 }
 
 type ListOpts struct {
@@ -106,7 +108,6 @@ This API is used to create a queue.
 @cloudAPI-version: v1.0
 
 @since: 2021-07-07 12:12:12
-
 */
 func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
 	requstbody, err := opts.ToDomainCreateMap()
@@ -127,7 +128,6 @@ This API is used to delete a queue.
 @cloudAPI-version: v1.0
 
 @since: 2021-07-07 12:12:12
-
 */
 func Delete(c *golangsdk.ServiceClient, queueName string) (r DeleteResult) {
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
@@ -143,7 +143,6 @@ This API is used to query all Queue  list
 @cloudAPI-version: v1.0
 
 @since: 2021-07-07 12:12:12
-
 */
 func List(c *golangsdk.ServiceClient, listOpts ListOptsBuilder) (r GetResult) {
 	listResult := new(ListResult)
@@ -172,7 +171,6 @@ This API is used to query the Details of a Queue
 @cloudAPI-version: v1.0
 
 @since: 2021-07-07 12:12:12
-
 */
 func Get(c *golangsdk.ServiceClient, queueName string) (r GetResult) {
 	result := new(Queue4Get)

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/results.go
@@ -74,6 +74,8 @@ type Queue struct {
 	Container: containerized cluster (k8s)
 	**/
 	QueueResourceType string `json:"queue_resource_type"`
+	// The name of the elastic resource pool.
+	ElasticResourcePoolName string `json:"elastic_resource_pool_name"`
 }
 
 type Queue4Get struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
@@ -396,3 +396,47 @@ func ResetPassword(client *golangsdk.ServiceClient, id string, opts ResetPasswor
 	})
 	return
 }
+
+type ConfigParam struct {
+	Name  string `json:"name" required:"true"`
+	Value string `json:"value" required:"true"`
+}
+
+type KafkaConfigs struct {
+	KafkaConfigs []ConfigParam `json:"kafka_configs"`
+}
+
+type RestartInstanceOpts struct {
+	Action    string   `json:"action" required:"true"`
+	Instances []string `json:"instances" required:"true"`
+}
+
+func ModifyConfiguration(c *golangsdk.ServiceClient, instanceID string, opts KafkaConfigs) (r ModifyConfigurationResult) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Put(configurationsURL(c, instanceID), b, &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+func GetConfigurations(c *golangsdk.ServiceClient, instanceID string) (r GetConfigurationResult) {
+	_, r.Err = c.Get(configurationsURL(c, instanceID), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	return
+}
+
+func RebootInstance(c *golangsdk.ServiceClient, params RestartInstanceOpts) (r RebootResult) {
+	_, r.Err = c.Post(actionURL(c), params, &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+func GetTasks(c *golangsdk.ServiceClient, instanceID string) (r GetTasksResult) {
+	_, r.Err = c.Get(tasksURL(c, instanceID), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
@@ -175,3 +175,85 @@ type AutoTopicResult struct {
 type ResetPasswordResult struct {
 	golangsdk.Result
 }
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type ModifyConfigurationResult struct {
+	commonResult
+}
+
+type GetConfigurationResult struct {
+	commonResult
+}
+
+type RebootResult struct {
+	commonResult
+}
+
+type GetTasksResult struct {
+	commonResult
+}
+
+type ModifyConfigurationResp struct {
+	JobId         string `json:"job_id"`
+	DynamicConfig int    `json:"dynamic_config"`
+	StaticConfig  int    `json:"static_config"`
+}
+
+func (r ModifyConfigurationResult) Extract() (*ModifyConfigurationResp, error) {
+	var response ModifyConfigurationResp
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type Result struct {
+	Result   string `json:"result"`
+	Instance string `json:"instance"`
+}
+
+type RebootResp struct {
+	Results []Result `json:"results"`
+}
+
+func (r RebootResult) Extract() (*RebootResp, error) {
+	var response RebootResp
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type KafkaParam struct {
+	Name         string `json:"name"`
+	Value        string `json:"value"`
+	DefaultValue string `json:"default_value"`
+	ConfigType   string `json:"config_type"`
+	ValidValues  string `json:"valid_values"`
+	ValueType    string `json:"value_type"`
+}
+
+type GetConfigurationResp struct {
+	KafkaConfigs []KafkaParam `json:"kafka_configs"`
+}
+
+func (r GetConfigurationResult) Extract() (*GetConfigurationResp, error) {
+	var response GetConfigurationResp
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type TaskParams struct {
+	Name   string `json:"name"`
+	Params string `json:"params"`
+	Status string `json:"status"`
+}
+
+type GetTaskResp struct {
+	Tasks []TaskParams `json:"tasks"`
+}
+
+func (r GetTasksResult) Extract() (*GetTaskResp, error) {
+	var response GetTaskResp
+	err := r.ExtractInto(&response)
+	return &response, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/urls.go
@@ -46,3 +46,15 @@ func autoTopicURL(c *golangsdk.ServiceClient, id string) string {
 func resetPasswordURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL(c.ProjectID, resourcePath, id, "password")
 }
+
+func configurationsURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, "instances", id, "configs")
+}
+
+func actionURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, "instances", "action")
+}
+
+func tasksURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, "instances", id, "tasks")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
@@ -455,3 +455,92 @@ func DeleteResourceTags(c *golangsdk.ServiceClient, functionUrn string, opts Tag
 	})
 	return err
 }
+
+// UpdateReservedInstanceObj is the structure that used to modify information of reserved instance.
+type UpdateReservedInstanceObj struct {
+	// Function URN.
+	FunctionUrn string `json:"-" required:"true"`
+	// The number of reserved instance.
+	Count *int `json:"count" required:"true"`
+	// Whether to enable the idle mode configuration.
+	IdleMode *bool `json:"idle_mode,omitempty"`
+	// The auto scaling policy configuration.
+	TacticsConfig *TacticsConfigObj `json:"tactics_config,omitempty"`
+}
+
+// TacticsConfigObj is the structure that represents the configuration details of the reserved instance policy.
+type TacticsConfigObj struct {
+	// The list of scheduled configurations.
+	CronConfigs []CronConfigObj `json:"cron_configs,omitempty"`
+	// The list of traffic configurations.
+	MetricConfigs []MetricConfigObj `json:"metric_configs,omitempty"`
+}
+
+// CronConfigsObj is the structure that represents the list of scheduled configurations.
+type CronConfigObj struct {
+	// The policy name of scheduled configuration.
+	Name string `json:"name,omitempty"`
+	// The function cron expression.
+	Cron string `json:"cron,omitempty"`
+	// The number of reserved instance to which the policy belongs.
+	Count int `json:"count,omitempty"`
+	// The start timestamp of policy.
+	StartTime int `json:"start_time,omitempty"`
+	// The expiration timestamp of policy.
+	ExpiredTime int `json:"expired_time,omitempty"`
+}
+
+// CronConfigsObj is the structure that represents the list of traffic configurations.
+type MetricConfigObj struct {
+	// The policy name of traffic configuration.
+	Name string `json:"name,omitempty"`
+	// The type of traffic configuration.
+	// + Concurrency: Reserved instance usage.
+	Type string `json:"type,omitempty"`
+	// The traffic threshold.
+	Threshold int `json:"threshold,omitempty"`
+	// The minimun of traffic.
+	Min int `json:"min,omitempty"`
+}
+
+// UpdateReservedInstanceConfig is the method that used to config reserved instance information.
+func UpdateReservedInstanceConfig(c *golangsdk.ServiceClient, opts UpdateReservedInstanceObj) (*UpdateReservedInstanceObj, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r UpdateReservedInstanceObj
+	_, err = c.Put(reservedInstanceConfigUrl(c, opts.FunctionUrn), b, &r, nil)
+	return &r, err
+}
+
+// ListReservedInstanceConfigOpts is the structure that used to query of list reserved instance configurations.
+type ListReservedInstanceConfigOpts struct {
+	// Function URN.
+	FunctionUrn string `q:"function_urn,omitempty"`
+	// The current query index. Default 0.
+	Marker int `q:"marker,omitempty"`
+	// Maximum number of templates to obtain in a request. Default 100, maximum 500.
+	Limit int `q:"limit,omitempty"`
+}
+
+// ListReservedInstanceConfigs is the method that used to get of list reserved instance configurations.
+func ListReservedInstanceConfigs(c *golangsdk.ServiceClient, opts ListReservedInstanceConfigOpts) ([]ReservedInstancePolicy, error) {
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	url := getReservedInstanceConfigUrl(c) + query.String()
+	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := ReservedInstanceConfigPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractReservedInstanceConfigs(pages)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
@@ -1,6 +1,8 @@
 package function
 
 import (
+	"strconv"
+
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/pagination"
 )
@@ -271,4 +273,80 @@ type AsyncInvokeConfig struct {
 	UpdatedAt string `json:"last_modified"`
 	// Whether to enable asynchronous invocation status persistence.
 	EnableAsyncStatusLog bool `json:"enable_async_status_log"`
+}
+
+// ReservedInstanceConfigResp is the structure that represents the response of the GetReservedInstanceConfig method.
+type ReservedInstanceConfigResp struct {
+	// The list of reserved instance policy.
+	ReservedInstances []ReservedInstancePolicy `json:"reserved_instances"`
+	// The page information.
+	PageInfo PageInfoObj `json:"page_info"`
+	// Number of function.
+	Count int `json:"count"`
+}
+
+// ReservedInstancePolicy is the structure that represents the reserved instance policy configuration.
+type ReservedInstancePolicy struct {
+	// Function URN.
+	FunctionUrn string `json:"function_urn"`
+	// Limited type, the supported values are version and alias.
+	QualifierType string `json:"qualifier_type"`
+	// The value of the limited type.
+	QualifierName string `json:"qualifier_name"`
+	// The number of instance reserved.
+	MinCount int `json:"min_count"`
+	// Whether to enable the idle mode configuration.
+	IdleMode bool `json:"idle_mode"`
+	// The auto scaling policy configuration.
+	TacticsConfig TacticsConfigObj `json:"tactics_config"`
+}
+
+// PageInfoObj is the structure that represents pagination information of the function reserved instance.
+type PageInfoObj struct {
+	// Next record location.
+	NextMarker int `json:"next_marker"`
+	// Last record location.
+	PreviousMarker int `json:"previous_marker"`
+	// Total number of current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// ReservedInstanceConfigPage represents the response pages of the GetReservedInstanceConfig method.
+type ReservedInstanceConfigPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if no reserved instance.
+func (r ReservedInstanceConfigPage) IsEmpty() (bool, error) {
+	resp, err := extractReservedInstanceConfigs(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in reserved instance list.
+func (r ReservedInstanceConfigPage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.CurrentCount == 0 {
+		return "", nil
+	}
+	return strconv.Itoa(resp.NextMarker), nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*PageInfoObj, error) {
+	var s ReservedInstanceConfigResp
+	err := r.(ReservedInstanceConfigPage).Result.ExtractInto(&s)
+
+	return &s.PageInfo, err
+}
+
+// extractReservedInstanceConfigs is a method which to extract the response to reserved instance configuration list.
+func extractReservedInstanceConfigs(p pagination.Page) ([]ReservedInstancePolicy, error) {
+	var resp ReservedInstanceConfigResp
+	err := p.(ReservedInstanceConfigPage).Result.ExtractInto(&resp)
+
+	return resp.ReservedInstances, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/urls.go
@@ -25,7 +25,7 @@ func deleteURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return c.ServiceURL(FGS, FUNCTION, functionUrn)
 }
 
-//function code
+// function code
 func getCodeURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return c.ServiceURL(FGS, FUNCTION, functionUrn, CODE)
 }
@@ -34,7 +34,7 @@ func updateCodeURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return getCodeURL(c, functionUrn)
 }
 
-//function metadata
+// function metadata
 func getMetadataURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return c.ServiceURL(FGS, FUNCTION, functionUrn, CONFIG)
 }
@@ -43,7 +43,7 @@ func updateMetadataURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return getMetadataURL(c, functionUrn)
 }
 
-//function invoke
+// function invoke
 func invokeURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return c.ServiceURL(FGS, FUNCTION, functionUrn, INVOKE)
 }
@@ -52,7 +52,7 @@ func asyncInvokeURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return c.ServiceURL(FGS, FUNCTION, functionUrn, ASINVOKE)
 }
 
-//function version
+// function version
 func createVersionURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return c.ServiceURL(FGS, FUNCTION, functionUrn, VERSION)
 }
@@ -61,7 +61,7 @@ func listVersionURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return createVersionURL(c, functionUrn)
 }
 
-//function alias
+// function alias
 func createAliasURL(c *golangsdk.ServiceClient, functionUrn string) string {
 	return c.ServiceURL(FGS, FUNCTION, functionUrn, ALIAS)
 }
@@ -92,4 +92,12 @@ func maxInstanceNumberURL(c *golangsdk.ServiceClient, functionUrn string) string
 
 func tagsActionURL(c *golangsdk.ServiceClient, functionUrn, action string) string {
 	return c.ServiceURL("functions", functionUrn, "tags", action)
+}
+
+func reservedInstanceConfigUrl(c *golangsdk.ServiceClient, functionUrn string) string {
+	return c.ServiceURL("fgs/functions", functionUrn, "reservedinstances")
+}
+
+func getReservedInstanceConfigUrl(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("fgs/functions/reservedinstanceconfigs")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240221032900-52efd7f05271
+# github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
kafka supports parameters updated
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
kafka supports parameters updated
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dms/ TESTARGS='-run TestAccKafkaInstance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms/ -v -run TestAccKafkaInstance -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstancesDataSource_basic
=== PAUSE TestAccKafkaInstancesDataSource_basic
=== RUN   TestAccKafkaInstance_basic
=== PAUSE TestAccKafkaInstance_basic
=== RUN   TestAccKafkaInstance_prePaid
=== PAUSE TestAccKafkaInstance_prePaid
=== RUN   TestAccKafkaInstance_withEpsId
=== PAUSE TestAccKafkaInstance_withEpsId
=== RUN   TestAccKafkaInstance_compatible
=== PAUSE TestAccKafkaInstance_compatible
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstancesDataSource_basic
=== CONT  TestAccKafkaInstance_withEpsId
=== CONT  TestAccKafkaInstance_newFormat
=== CONT  TestAccKafkaInstance_compatible
--- PASS: TestAccKafkaInstance_withEpsId (911.72s)
=== CONT  TestAccKafkaInstance_prePaid
--- PASS: TestAccKafkaInstancesDataSource_basic (945.88s)
=== CONT  TestAccKafkaInstance_basic
--- PASS: TestAccKafkaInstance_compatible (1069.03s)
--- PASS: TestAccKafkaInstance_prePaid (874.37s)
--- PASS: TestAccKafkaInstance_newFormat (2434.74s)
--- PASS: TestAccKafkaInstance_basic (1589.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       2535.766s

```
