### PR TITLE
feat(EVS): EVS snapshot support metadata field parameter

### DIFF
--- a/docs/resources/evs_snapshot.md
+++ b/docs/resources/evs_snapshot.md
@@ -42,6 +42,9 @@ The following arguments are supported:
 
 * `name` - (Required, String) The name of the snapshot. The value can contain a maximum of 255 bytes.
 
+* `metadata` - (Optional, Map, ForceNew) Specifies the user-defined metadata key-value pair. Changing the parameter
+  creates a new snapshot.
+
 * `description` - (Optional, String) The description of the snapshot. The value can contain a maximum of 255 bytes.
 
 * `force` - (Optional, Bool) Specifies the flag for forcibly creating a snapshot. Default to false.

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_snapshot_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_snapshot_test.go
@@ -32,6 +32,8 @@ func TestAccEvsSnapshotV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "Daily backup"),
 					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.key", "value"),
 				),
 			},
 		},
@@ -107,6 +109,10 @@ resource "huaweicloud_evs_snapshot" "test" {
   volume_id   = huaweicloud_evs_volume.test.id
   name        = "%s"
   description = "Daily backup"
+  metadata    = {
+    foo = "bar"
+    key = "value"
+  }
 }
 `, rName, rName)
 }

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_snapshot.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_snapshot.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API EVS DELETE /v2/{project_id}/cloudsnapshots/{snapshot_id}
@@ -54,6 +55,13 @@ func ResourceEvsSnapshotV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			// To avoid triggering changes metadata is not backfilled during read.
+			"metadata": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -87,6 +95,7 @@ func resourceEvsSnapshotV2Create(ctx context.Context, d *schema.ResourceData, me
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
 		Force:       d.Get("force").(bool),
+		Metadata:    utils.ExpandToStringMap(d.Get("metadata").(map[string]interface{})),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
EVS snapshot support metadata field parameter

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
To avoid triggering changes metadata is not backfilled during read.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/evs/' TESTARGS='-run TestAccEvsSnapshotV2_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs/ -v -run TestAccEvsSnapshotV2_basic -timeout 360m -parallel 4 
=== RUN   TestAccEvsSnapshotV2_basic 
=== PAUSE TestAccEvsSnapshotV2_basic
=== CONT  TestAccEvsSnapshotV2_basic
--- PASS: TestAccEvsSnapshotV2_basic (66.74s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       66.783s
```
