### PR TITLE
feat(cc): add resource global connection bandwidth

### DIFF
--- a/docs/resources/cc_global_connection_bandwidth.md
+++ b/docs/resources/cc_global_connection_bandwidth.md
@@ -1,0 +1,117 @@
+---
+subcategory: Cloud Connect (CC)
+---
+
+# huaweicloud_cc_global_connection_bandwidth
+
+Manages a CC global connection bandwidth within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "gcb_name" {}
+
+resource "huaweicloud_cc_global_connection_bandwidth" "test" {
+  name        = var.gcb_name
+  type        = "Region"
+  bordercross = false
+  charge_mode = "bwd"
+  size        = 5
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) Specifies the GCB name.
+
+* `type` - (Required, String, ForceNew) Specifies the GCB type.
+  
+  Valid values are as follows:
+  + **TrsArea**: Cross geographic region.
+  + **Area**: Geographic region.
+  + **SubArea**: Homezones region.
+  + **Region**: Multi-city region.
+
+  Changing this creates a new resource.
+
+* `bordercross` - (Required, Bool, ForceNew) Specifies whether the GCB involves traveling from Chinese mainland to other
+  countries. Changing this creates a new resource.
+
+* `charge_mode` - (Required, String) Specifies the GCB charge mode.
+
+  Valid values are as follows:
+  + **bwd**: Billed by bandwidth.
+  + **95**: Billed by 95th percentile bandwidth.
+
+  Only support changing **bwd** to **95**.
+
+* `size` - (Required, Int) Specifies the GCB size. If `charge_mode` is **bwd**, value ranges from 2 to 300 Mbit/s. If
+  `charge_mode` is **95**, value ranges from 100 to 300 Mbit/s.
+
+* `sla_level` - (Optional, String) Specifies the network level. From high to low, divided into **Pt**(platinum),
+  **Au**(gold), and **Ag**(silver). The default is **Au**.
+
+* `local_area` - (Optional, String, ForceNew) Specifies the local access point. The valid length is limited between `1`
+  to `64`, Only Chinese and English letters, digits, hyphens (-), underscores (_) and dots (.) are allowed. If `type` is
+  **Region**, it is **optional**, otherwise it is **Required**.
+  Changing this creates a new resource.
+
+* `remote_area` - (Optional, String, ForceNew) Specifies the remote access point. The valid length is limited between `1`
+  to `64`, Only Chinese and English letters, digits, hyphens (-), underscores (_) and dots (.) are allowed. If `type` is
+  **Region**, it is **optional**, otherwise it is **Required**.
+  Changing this creates a new resource.
+
+* `spec_code_id` - (Optional, String) Specifies the line specification code UUID.
+
+* `binding_service` - (Optional, String) Specifies whether to limit the GCB only bind with specific instance. Default is
+  **ALL**.
+
+  Valid values are as follows:
+  + **CC**: Cloud Connection.
+  + **GEIP**: Global EIP.
+  + **GCN**: Central Network.
+  + **GSN**: Site Network.
+  + **ALL**: All.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the GCB belongs.
+  Changing this creates a new resource.
+
+* `description` - (Optional, String) Specifies the description of GCB. Not support angle brackets (<>).
+
+* `tags` - (Optional, Map) Specifies the tags of GCB.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `enable_share` - Indicates the GCB whether to support binding multiple instances.
+
+* `frozen` - Indicates the GCB is frozen or not.
+
+* `instances` - The instances which the GCB binding with.
+  The [instances](#attrblock--instances) structure is documented below.
+
+* `created_at` - The create time of GCB.
+
+* `updated_at` - The update time of GCB.
+
+<a name="attrblock--instances"></a>
+The `instances` block supports:
+
+* `id` - The instance ID.
+
+* `region` - The region of the instance.
+
+* `type` - The type of the instance.
+
+## Import
+
+The global connection bandwidth can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_cc_global_connection_bandwidth.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -843,6 +843,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cc_central_network_policy":       cc.ResourceCentralNetworkPolicy(),
 			"huaweicloud_cc_central_network_policy_apply": cc.ResourceCentralNetworkPolicyApply(),
 			"huaweicloud_cc_central_network_attachment":   cc.ResourceCentralNetworkAttachment(),
+			"huaweicloud_cc_global_connection_bandwidth":  cc.ResourceGlobalConnectionBandwidth(),
 
 			"huaweicloud_cce_cluster":     cce.ResourceCluster(),
 			"huaweicloud_cce_node":        cce.ResourceNode(),

--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_global_connection_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_global_connection_bandwidth_test.go
@@ -1,0 +1,136 @@
+package cc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getGCBResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("cc", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CC client: %s", err)
+	}
+	getGCBHttpUrl := "v3/{domain_id}/gcb/gcbandwidths/{id}"
+	getGCBPath := client.Endpoint + getGCBHttpUrl
+	getGCBPath = strings.ReplaceAll(getGCBPath, "{domain_id}", cfg.DomainID)
+	getGCBPath = strings.ReplaceAll(getGCBPath, "{id}", state.Primary.ID)
+
+	getGCBOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getGCBResp, err := client.Request("GET", getGCBPath, &getGCBOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving global connection bandwidth: %s", err)
+	}
+	return utils.FlattenResponse(getGCBResp)
+}
+
+func TestAccGCB_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cc_global_connection_bandwidth.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getGCBResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGCB_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "Region"),
+					resource.TestCheckResourceAttr(rName, "bordercross", "false"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "bwd"),
+					resource.TestCheckResourceAttr(rName, "size", "5"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "sla_level", "Ag"),
+					resource.TestCheckResourceAttr(rName, "description", "test"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "frozen"),
+				),
+			},
+			{
+				Config: testAccGCB_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
+					resource.TestCheckResourceAttr(rName, "charge_mode", "95"),
+					resource.TestCheckResourceAttr(rName, "size", "100"),
+					resource.TestCheckResourceAttr(rName, "description", "test-update"),
+					resource.TestCheckResourceAttr(rName, "sla_level", "Au"),
+					resource.TestCheckResourceAttr(rName, "binding_service", "GEIP"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccGCB_basic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_global_connection_bandwidth" "test" {
+  name                  = "%[1]s"
+  type                  = "Region"  
+  bordercross           = false
+  charge_mode           = "bwd"
+  size                  = 5
+  enterprise_project_id = "%[2]s"
+  description           = "test"
+  sla_level             = "Ag"
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccGCB_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_global_connection_bandwidth" "test" {
+  name                  = "%[1]s-update"
+  type                  = "Region"  
+  bordercross           = false
+  charge_mode           = "95"
+  size                  = 100
+  enterprise_project_id = "%[2]s"
+  description           = "test-update"
+  sla_level             = "Au"
+  binding_service       = "GEIP"
+
+  tags = {
+    key = "value"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_global_connection_bandwidth.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_global_connection_bandwidth.go
@@ -1,0 +1,405 @@
+package cc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CC POST /v3/{domain_id}/gcb/gcbandwidths
+// @API CC GET /v3/{domain_id}/gcb/gcbandwidths/{id}
+// @API CC PUT /v3/{domain_id}/gcb/gcbandwidths/{id}
+// @API CC DELETE /v3/{domain_id}/gcb/gcbandwidths/{id}
+// @API CC POST /v3/gcb/{resource_id}/tags/create
+// @API CC POST /v3/gcb/{resource_id}/tags/delete
+func ResourceGlobalConnectionBandwidth() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGlobalConnectionBandwidthCreate,
+		UpdateContext: resourceGlobalConnectionBandwidthUpdate,
+		ReadContext:   resourceGlobalConnectionBandwidthRead,
+		DeleteContext: resourceGlobalConnectionBandwidthDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"bordercross": {
+				Type:     schema.TypeBool,
+				Required: true,
+				ForceNew: true,
+			},
+			"size": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"charge_mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"sla_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"local_area": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"remote_area": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"spec_code_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"binding_service": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_share": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"frozen": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGlobalConnectionBandwidthCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cc", region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	createGCBHttpUrl := "v3/{domain_id}/gcb/gcbandwidths"
+	createGCBPath := client.Endpoint + createGCBHttpUrl
+	createGCBPath = strings.ReplaceAll(createGCBPath, "{domain_id}", cfg.DomainID)
+	createGCBOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"globalconnection_bandwidth": utils.RemoveNil(buildCreateGCBParams(d, cfg.GetEnterpriseProjectID(d))),
+		},
+	}
+
+	createGCBResp, err := client.Request("POST", createGCBPath, &createGCBOpt)
+	if err != nil {
+		return diag.Errorf("error creating global connection bandwidth: %s", err)
+	}
+	createGCBRespBody, err := utils.FlattenResponse(createGCBResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	id, err := jmespath.Search("globalconnection_bandwidth.id", createGCBRespBody)
+	if err != nil {
+		return diag.Errorf("error creating global connection bandwidth: %s is not found in API response", "id")
+	}
+
+	d.SetId(id.(string))
+
+	if v, ok := d.GetOk("binding_service"); ok && v.(string) != "ALL" {
+		err = updateGCB(client, d, cfg.DomainID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceGlobalConnectionBandwidthRead(ctx, d, meta)
+}
+
+func buildCreateGCBParams(d *schema.ResourceData, epsID string) map[string]interface{} {
+	params := map[string]interface{}{
+		"name":                  d.Get("name"),
+		"type":                  d.Get("type"),
+		"size":                  d.Get("size"),
+		"charge_mode":           d.Get("charge_mode"),
+		"bordercross":           d.Get("bordercross"),
+		"enterprise_project_id": utils.ValueIngoreEmpty(epsID),
+		"sla_level":             utils.ValueIngoreEmpty(d.Get("sla_level")),
+		"local_area":            utils.ValueIngoreEmpty(d.Get("local_area")),
+		"remote_area":           utils.ValueIngoreEmpty(d.Get("remote_area")),
+		"spec_code_id":          utils.ValueIngoreEmpty(d.Get("spec_code_id")),
+		"description":           utils.ValueIngoreEmpty(d.Get("description")),
+		"tags":                  utils.ValueIngoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
+	}
+	return params
+}
+
+func resourceGlobalConnectionBandwidthRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cc", region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	getGCBHttpUrl := "v3/{domain_id}/gcb/gcbandwidths/{id}"
+	getGCBPath := client.Endpoint + getGCBHttpUrl
+	getGCBPath = strings.ReplaceAll(getGCBPath, "{domain_id}", cfg.DomainID)
+	getGCBPath = strings.ReplaceAll(getGCBPath, "{id}", d.Id())
+	getGCBOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getGCBResp, err := client.Request("GET", getGCBPath, &getGCBOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving global connection bandwidth")
+	}
+	getGCBRespBody, err := utils.FlattenResponse(getGCBResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	getGCBRespBody, err = jmespath.Search("globalconnection_bandwidth", getGCBRespBody)
+	if err != nil {
+		return diag.Errorf("error getting global connection bandwidth: %s is not found in API response",
+			"globalconnection_bandwidth")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("name", utils.PathSearch("name", getGCBRespBody, nil)),
+		d.Set("type", utils.PathSearch("type", getGCBRespBody, nil)),
+		d.Set("size", int(utils.PathSearch("size", getGCBRespBody, float64(0)).(float64))),
+		d.Set("charge_mode", utils.PathSearch("charge_mode", getGCBRespBody, nil)),
+		d.Set("bordercross", utils.PathSearch("bordercross", getGCBRespBody, false)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", getGCBRespBody, nil)),
+		d.Set("sla_level", utils.PathSearch("sla_level", getGCBRespBody, nil)),
+		d.Set("local_area", utils.PathSearch("local_site_code", getGCBRespBody, nil)),
+		d.Set("remote_area", utils.PathSearch("remote_site_code", getGCBRespBody, nil)),
+		d.Set("spec_code_id", utils.PathSearch("spec_code_id", getGCBRespBody, nil)),
+		d.Set("description", utils.PathSearch("description", getGCBRespBody, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("tags", getGCBRespBody, nil))),
+		d.Set("enable_share", utils.PathSearch("enable_share", getGCBRespBody, false)),
+		d.Set("binding_service", utils.PathSearch("binding_service", getGCBRespBody, nil)),
+		d.Set("instances", flattenInstances(utils.PathSearch("instances", getGCBRespBody, make([]interface{}, 0)))),
+		d.Set("frozen", utils.PathSearch("frozen", getGCBRespBody, false)),
+		d.Set("created_at", utils.PathSearch("created_at", getGCBRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("updated_at", getGCBRespBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenInstances(rawParams interface{}) []map[string]interface{} {
+	rawArray, _ := rawParams.([]interface{})
+	if len(rawArray) == 0 {
+		return nil
+	}
+	rst := make([]map[string]interface{}, 0)
+	for _, val := range rawArray {
+		params := map[string]interface{}{
+			"id":     utils.PathSearch("id", val, nil),
+			"type":   utils.PathSearch("type", val, nil),
+			"region": utils.PathSearch("region_id", val, nil),
+		}
+		rst = append(rst, params)
+	}
+	return rst
+}
+
+func resourceGlobalConnectionBandwidthUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cc", region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	updateChanges := []string{
+		"name",
+		"size",
+		"charge_mode",
+		"sla_level",
+		"binding_service",
+		"spec_code_id",
+		"description",
+	}
+
+	if d.HasChanges(updateChanges...) {
+		err = updateGCB(client, d, cfg.DomainID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChanges("tags") {
+		tagErr := updateTags(client, d)
+		if tagErr != nil {
+			return diag.Errorf("error updating tags of global connection bandwidth (%s): %s", d.Id(), tagErr)
+		}
+	}
+
+	return resourceGlobalConnectionBandwidthRead(ctx, d, meta)
+}
+
+func updateTags(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	oRaw, nRaw := d.GetChange("tags")
+	oMap := oRaw.(map[string]interface{})
+	nMap := nRaw.(map[string]interface{})
+
+	manageTagsHttpUrl := "v3/gcb/{resource_id}/tags/{action}"
+	manageTagsPath := client.Endpoint + manageTagsHttpUrl
+	manageTagsPath = strings.ReplaceAll(manageTagsPath, "{resource_id}", d.Id())
+	manageTagsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	// remove old tags
+	if len(oMap) > 0 {
+		manageTagsOpt.JSONBody = map[string]interface{}{
+			"tags": utils.ExpandResourceTags(oMap),
+		}
+		deleteTagsPath := strings.ReplaceAll(manageTagsPath, "{action}", "delete")
+		_, err := client.Request("POST", deleteTagsPath, &manageTagsOpt)
+		if err != nil {
+			return err
+		}
+	}
+
+	// set new tags
+	if len(nMap) > 0 {
+		manageTagsOpt.JSONBody = map[string]interface{}{
+			"tags": utils.ExpandResourceTags(nMap),
+		}
+		createTagsPath := strings.ReplaceAll(manageTagsPath, "{action}", "create")
+		_, err := client.Request("POST", createTagsPath, &manageTagsOpt)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func updateGCB(client *golangsdk.ServiceClient, d *schema.ResourceData, domainID string) error {
+	updateGCBHttpUrl := "v3/{domain_id}/gcb/gcbandwidths/{id}"
+	updateGCBPath := client.Endpoint + updateGCBHttpUrl
+	updateGCBPath = strings.ReplaceAll(updateGCBPath, "{domain_id}", domainID)
+	updateGCBPath = strings.ReplaceAll(updateGCBPath, "{id}", d.Id())
+	updateGCBOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"globalconnection_bandwidth": utils.RemoveNil(buildUpdateGCBParams(d)),
+		},
+	}
+
+	_, err := client.Request("PUT", updateGCBPath, &updateGCBOpt)
+	if err != nil {
+		return fmt.Errorf("error updating global connection bandwidth: %s", err)
+	}
+
+	return nil
+}
+
+func buildUpdateGCBParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"name":            d.Get("name"),
+		"size":            d.Get("size"),
+		"charge_mode":     d.Get("charge_mode"),
+		"sla_level":       utils.ValueIngoreEmpty(d.Get("sla_level")),
+		"binding_service": utils.ValueIngoreEmpty(d.Get("binding_service")),
+		"spec_code_id":    utils.ValueIngoreEmpty(d.Get("spec_code_id")),
+		"description":     d.Get("description"),
+	}
+	return params
+}
+
+func resourceGlobalConnectionBandwidthDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cc", region)
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	deleteGCBHttpUrl := "v3/{domain_id}/gcb/gcbandwidths/{id}"
+	deleteGCBPath := client.Endpoint + deleteGCBHttpUrl
+	deleteGCBPath = strings.ReplaceAll(deleteGCBPath, "{domain_id}", cfg.DomainID)
+	deleteGCBPath = strings.ReplaceAll(deleteGCBPath, "{id}", d.Id())
+	deleteGCBOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deleteGCBPath, &deleteGCBOpt)
+	if err != nil {
+		return diag.Errorf("error deleting global connection bandwidth: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add resource `huaweicloud_cc_global_connection_bandwidth`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccGCB_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccGCB_basic -timeout 360m -parallel 4
=== RUN   TestAccGCB_basic
=== PAUSE TestAccGCB_basic
=== CONT  TestAccGCB_basic
--- PASS: TestAccGCB_basic (26.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        26.632s
```
