### PR TITLE
feat(dataarts): dataarts_studio_instance support update enterprise_project_id

### DIFF
--- a/docs/resources/dataarts_studio_instance.md
+++ b/docs/resources/dataarts_studio_instance.md
@@ -68,8 +68,7 @@ The following arguments are supported:
 * `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
   Valid values are `true` and `false`, defaults to `false`. Changing this parameter will create a new resource.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the instance.
-  Changing this creates a new instance.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the instance.
 
   -> 1. Only **one** DataArts Studio instance can be purchased in an enterprise project.
   <br/> 2. If DataArts Studio needs to communicate with other cloud services, ensure that the enterprise project

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_studio_instance.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/dayu/v1/instances"
+	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
@@ -26,6 +27,7 @@ func ResourceStudioInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceStudioInstanceCreate,
 		ReadContext:   resourceStudioInstanceRead,
+		UpdateContext: resourceStudioInstanceupdate,
 		DeleteContext: resourceStudioInstanceDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -94,7 +96,6 @@ func ResourceStudioInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 
 			"charging_mode": {
@@ -223,6 +224,26 @@ func resourceStudioInstanceRead(_ context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error setting DataArts Studio instance fields: %s", err)
 	}
 	return nil
+}
+
+func resourceStudioInstanceupdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	instanceID := d.Id()
+
+	if d.HasChange("enterprise_project_id") {
+		migrateOpts := enterpriseprojects.MigrateResourceOpts{
+			ResourceId:   instanceID,
+			ResourceType: "dayu-instance",
+			RegionId:     region,
+			ProjectId:    conf.GetProjectID(region),
+		}
+		if err := common.MigrateEnterpriseProject(ctx, conf, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceStudioInstanceRead(ctx, d, meta)
 }
 
 func resourceStudioInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
…oject_id

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: dataarts_studio_instance support update enterprise_project_id

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. 'availability_zone[0]' is currently unavailable, this issue has been reported to the service provider.
2. local manual debugging passed.
3. the following test cases were tested in 'availability_zone[1]'.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dataarts" TESTARGS="-run TestAccResourceInstance_updateWithEpsId"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceInstance_updateWithEpsId -timeout 360m -parallel 4
=== RUN   TestAccResourceInstance_updateWithEpsId
=== PAUSE TestAccResourceInstance_updateWithEpsId
=== CONT  TestAccResourceInstance_updateWithEpsId
--- PASS: TestAccResourceInstance_updateWithEpsId (959.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  959.364s
```
