### PR TITLE
feat(dws): modify cluster to support multiple availability zones

### DIFF
--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -74,7 +74,8 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
 
 * `availability_zone` - (Required, String, ForceNew) The availability zone in which to create the cluster instance.
-  Changing this parameter will create a new resource.
+  If there are multiple available zones, separate by commas, e.g. **cn-north-4a,cn-north-4b,cn-north-4g**.
+  Currently, multi-AZ clusters only support selecting `3` AZs. Changing this parameter will create a new resource.
 
 * `enterprise_project_id` - (Optional, String) The enterprise project ID.
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -276,6 +276,8 @@ var (
 	HW_ECS_LAUNCH_TEMPLATE_ID = os.Getenv("HW_ECS_LAUNCH_TEMPLATE_ID")
 
 	HW_IOTDA_BATCHTASK_FILE_PATH = os.Getenv("HW_IOTDA_BATCHTASK_FILE_PATH")
+
+	HW_DWS_MUTIL_AZS = os.Getenv("HW_DWS_MUTIL_AZS")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -1278,5 +1280,12 @@ func TestAccPreCheckECSLaunchTemplateID(t *testing.T) {
 func TestAccPreCheckIOTDABatchTaskFilePath(t *testing.T) {
 	if HW_IOTDA_BATCHTASK_FILE_PATH == "" {
 		t.Skip("HW_IOTDA_BATCHTASK_FILE_PATH must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckMutilAZ(t *testing.T) {
+	if HW_DWS_MUTIL_AZS == "" {
+		t.Skip("HW_DWS_MUTIL_AZS must be set for the acceptance test")
 	}
 }

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
@@ -564,6 +564,7 @@ func resourceDwsClusterCreateV1(ctx context.Context, d *schema.ResourceData, met
 }
 
 func buildCreateDwsClusterBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
+	availabilityZones := strings.Split(d.Get("availability_zone").(string), ",")
 	bodyParams := map[string]interface{}{
 		"cluster": map[string]interface{}{
 			"name":                  utils.ValueIngoreEmpty(d.Get("name")),
@@ -573,7 +574,7 @@ func buildCreateDwsClusterBodyParams(d *schema.ResourceData, cfg *config.Config)
 			"db_name":               utils.ValueIngoreEmpty(d.Get("user_name")),
 			"db_password":           utils.ValueIngoreEmpty(d.Get("user_pwd")),
 			"db_port":               utils.ValueIngoreEmpty(d.Get("port")),
-			"availability_zones":    []string{d.Get("availability_zone").(string)},
+			"availability_zones":    availabilityZones,
 			"vpc_id":                utils.ValueIngoreEmpty(d.Get("vpc_id")),
 			"subnet_id":             utils.ValueIngoreEmpty(d.Get("network_id")),
 			"security_group_id":     utils.ValueIngoreEmpty(d.Get("security_group_id")),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
modify cluster to support multiple availability zones.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
modify cluster to support multiple availability zones.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceCluster_basicV2_mutilAZs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_basicV2_mutilAZs -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV2_mutilAZs
=== PAUSE TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
--- PASS: TestAccResourceCluster_basicV2_mutilAZs (1329.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1329.481s

