### PR TITLE
feat(ga): add a new datasource to get the list of the listeners

### DIFF
--- a/docs/data-sources/ga_listeners.md
+++ b/docs/data-sources/ga_listeners.md
@@ -1,0 +1,79 @@
+---
+subcategory: "GA (Global Accelerator)"
+---
+
+# huaweicloud_ga_listeners
+
+Use this data source to get the list of listeners.
+
+## Example Usage
+
+```hcl
+variable "listener_name" {}
+
+data "huaweicloud_ga_listeners" "test" {
+  name = var.listener_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `listener_id` - (Optional, String) Specifies the ID of the listener.
+
+* `name` - (Optional, String) Specifies the name of the listener.
+
+* `status` - (Optional, String) Specifies the current status of the listener.
+  The valid values are as follows:
+  + **ACTIVE**: The status of the listener is normal operation.
+  + **ERROR**: The status of the listener is error.
+
+* `accelerator_id` - (Optional, String) Specifies the ID of the accelerator to which the listener belongs.
+
+* `protocol` - (Optional, String) Specifies the network transmission protocol type of the listener.
+  The valid values are as follows:
+  + **TCP**
+  + **UDP**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `listeners` - The list of the listeners.
+  The [listeners](#ga_listeners) structure is documented below.
+
+<a name="ga_listeners"></a>
+The `listeners` block supports:
+
+* `id` - The ID of the listener.
+
+* `name` - The name of the listener.  
+
+* `description` - The description of the listener.
+
+* `status` - The current status of the listener.
+
+* `protocol` - The network transmission protocol type of the listener.
+
+* `port_ranges` - The listening port range list of the listener.
+  The [port_ranges](#listener_port_ranges) structure is documented below.
+
+* `client_affinity` - The client affinity of the listener.
+
+* `accelerator_id` - The ID of the accelerator to which the listener belongs.
+
+* `tags` - The key/value pairs to associate with the listener.
+
+* `created_at` - The creation time of the listener.
+
+* `updated_at` - The latest update time of the listener.
+
+<a name="listener_port_ranges"></a>
+The `port_ranges` block supports:
+
+* `from_port` - The listening to start port of the listener.
+
+* `to_port` - The listening to end port of the listener.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -514,6 +514,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_functions":             fgs.DataSourceFunctionGraphFunctions(),
 
 			"huaweicloud_ga_accelerators": ga.DataSourceAccelerators(),
+			"huaweicloud_ga_listeners":    ga.DataSourceListeners(),
 
 			"huaweicloud_gaussdb_cassandra_dedicated_resource": gaussdb.DataSourceGeminiDBDehResource(),
 			"huaweicloud_gaussdb_cassandra_flavors":            gaussdb.DataSourceCassandraFlavors(),

--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_listeners_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_listeners_test.go
@@ -1,0 +1,205 @@
+package ga
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceListeners_basic(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceNameWithDash()
+		dataSourceName = "data.huaweicloud_ga_listeners.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byListenerId   = "data.huaweicloud_ga_listeners.filter_by_listener_id"
+		dcByListenerId = acceptance.InitDataSourceCheck(byListenerId)
+
+		byName   = "data.huaweicloud_ga_listeners.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byAcceleratorId   = "data.huaweicloud_ga_listeners.filter_by_accelerator_id"
+		dcByAcceleratorId = acceptance.InitDataSourceCheck(byAcceleratorId)
+
+		byStatus   = "data.huaweicloud_ga_listeners.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byProtocol   = "data.huaweicloud_ga_listeners.filter_by_protocol"
+		dcByProtocol = acceptance.InitDataSourceCheck(byProtocol)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceListeners_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "listeners.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "listeners.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "listeners.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "listeners.0.protocol"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "listeners.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "listeners.0.port_ranges.0.from_port"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "listeners.0.port_ranges.0.to_port"),
+					dcByListenerId.CheckResourceExists(),
+					resource.TestCheckOutput("listener_id_filter_is_useful", "true"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+
+					dcByAcceleratorId.CheckResourceExists(),
+					resource.TestCheckOutput("accelerator_id_filter_is_useful", "true"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+
+					dcByProtocol.CheckResourceExists(),
+					resource.TestCheckOutput("protocol_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceListeners_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ga_accelerator" "test" {
+  name        = "%[1]s"
+  description = "terraform test"
+
+  ip_sets {
+    area = "CM"
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_ga_listener" "test" {
+  accelerator_id = huaweicloud_ga_accelerator.test.id
+  name           = "%[1]s"
+  protocol       = "TCP"
+  description    = "Terraform test"
+
+  port_ranges {
+    from_port = 90
+    to_port   = 99
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name)
+}
+
+func testAccDataSourceListeners_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_ga_listeners" "test" {
+  depends_on = [
+    huaweicloud_ga_listener.test
+  ]
+}
+
+locals {
+  listener_id = data.huaweicloud_ga_listeners.test.listeners[0].id
+}
+
+data "huaweicloud_ga_listeners" "filter_by_listener_id" {
+  listener_id = local.listener_id
+}
+
+locals {
+  listener_id_filter_result = [
+    for v in data.huaweicloud_ga_listeners.filter_by_listener_id.listeners[*].id : v == local.listener_id
+  ]
+}
+
+output "listener_id_filter_is_useful" {
+  value = alltrue(local.listener_id_filter_result) && length(local.listener_id_filter_result) > 0
+}
+
+locals {
+  name = data.huaweicloud_ga_listeners.test.listeners[0].name
+}
+
+data "huaweicloud_ga_listeners" "filter_by_name" {
+  name = local.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_ga_listeners.filter_by_name.listeners[*].name : v == local.name
+  ]
+}
+
+output "name_filter_is_useful" {
+  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
+}
+
+locals {
+  accelerator_id = data.huaweicloud_ga_listeners.test.listeners[0].accelerator_id
+}
+
+data "huaweicloud_ga_listeners" "filter_by_accelerator_id" {
+  accelerator_id = local.accelerator_id
+}
+
+locals {
+  accelerator_id_filter_result = [
+    for v in data.huaweicloud_ga_listeners.filter_by_accelerator_id.listeners[*].accelerator_id : 
+    v == local.accelerator_id
+  ]
+}
+
+output "accelerator_id_filter_is_useful" {
+  value = alltrue(local.accelerator_id_filter_result) && length(local.accelerator_id_filter_result) > 0
+}
+
+locals {
+  status = data.huaweicloud_ga_listeners.test.listeners[0].status
+}
+
+data "huaweicloud_ga_listeners" "filter_by_status" {
+  status = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_ga_listeners.filter_by_status.listeners[*].status : v == local.status
+  ]
+}
+
+output "status_filter_is_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+
+locals {
+  protocol = data.huaweicloud_ga_listeners.test.listeners[0].protocol
+}
+
+data "huaweicloud_ga_listeners" "filter_by_protocol" {
+  protocol = local.protocol
+}
+
+locals {
+  protocol_filter_result = [
+    for v in data.huaweicloud_ga_listeners.filter_by_protocol.listeners[*].protocol : v == local.protocol
+  ]
+}
+
+output "protocol_filter_is_useful" {
+  value = alltrue(local.protocol_filter_result) && length(local.protocol_filter_result) > 0
+}
+`, testAccDataSourceListeners_base(name))
+}

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_listeners.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_listeners.go
@@ -1,0 +1,263 @@
+package ga
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GA GET /v1/listeners
+func DataSourceListeners() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceListenersRead,
+		Schema: map[string]*schema.Schema{
+			"listener_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the listener.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the listener.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The current status of the listener.",
+			},
+			"accelerator_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the accelerator to which the listener belongs.",
+			},
+			"protocol": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The network transmission protocol type of the listener.",
+			},
+			"listeners": {
+				Type:        schema.TypeList,
+				Elem:        listenersSchema(),
+				Computed:    true,
+				Description: "The list of the listeners.",
+			},
+		},
+	}
+}
+
+func listenersSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the listener.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the listener.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the listener.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The current status of the listener.",
+			},
+			"protocol": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The network transmission protocol type of the listener.",
+			},
+			"port_ranges": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The listening port range list of the listener.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"from_port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The listening to start port of the listener.",
+						},
+						"to_port": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The listening to end port of the listener.",
+						},
+					},
+				},
+			},
+			"client_affinity": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The client affinity of the listener.",
+			},
+			"accelerator_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the accelerator to which the listener belongs.",
+			},
+			"tags": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The key/value pairs to associate with the listener.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the listener.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the listener.",
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceListenersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// listListeners: Query the list of listeners
+	var (
+		listListenersHttpUrl = "v1/listeners"
+		listListenersProduct = "ga"
+	)
+	listListenersClient, err := cfg.NewServiceClient(listListenersProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GA client: %s", err)
+	}
+
+	listListenersPath := listListenersClient.Endpoint + listListenersHttpUrl
+
+	listListenersqueryParams := buildListListenersQueryParams(d)
+	listListenersPath += listListenersqueryParams
+
+	listListenersResp, err := pagination.ListAllItems(
+		listListenersClient,
+		"marker",
+		listListenersPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving listeners")
+	}
+
+	listListenersRespJson, err := json.Marshal(listListenersResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listListenersRespBody interface{}
+	err = json.Unmarshal(listListenersRespJson, &listListenersRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("listeners", filterListListenersResponseBody(flattenListListenersResponseBody(listListenersRespBody), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListListenersResponseBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("listeners", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":              utils.PathSearch("id", v, nil),
+			"name":            utils.PathSearch("name", v, nil),
+			"status":          utils.PathSearch("status", v, nil),
+			"description":     utils.PathSearch("description", v, nil),
+			"protocol":        utils.PathSearch("protocol", v, nil),
+			"port_ranges":     flattenPortRanges(utils.PathSearch("port_ranges", v, make([]interface{}, 0))),
+			"client_affinity": utils.PathSearch("client_affinity", v, nil),
+			"accelerator_id":  utils.PathSearch("accelerator_id", v, nil),
+			"tags":            utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
+			"created_at":      utils.PathSearch("created_at", v, nil),
+			"updated_at":      utils.PathSearch("updated_at", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenPortRanges(raw interface{}) []map[string]interface{} {
+	curArray := raw.([]interface{})
+	result := make([]map[string]interface{}, len(curArray))
+	for i, portRanges := range curArray {
+		result[i] = map[string]interface{}{
+			"from_port": utils.PathSearch("from_port", portRanges, nil),
+			"to_port":   utils.PathSearch("to_port", portRanges, nil),
+		}
+	}
+	return result
+}
+
+func filterListListenersResponseBody(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("protocol"); ok &&
+			fmt.Sprint(param) != utils.PathSearch("protocol", v, nil) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func buildListListenersQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("listener_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("accelerator_id"); ok {
+		res = fmt.Sprintf("%s&accelerator_id=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new datasource to get the list of the listeners.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new datasource to get the list of the listeners.
2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_listener)$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccDatasourceListeners_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccDatasourceListeners_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceListeners_basic
=== PAUSE TestAccDatasourceListeners_basic
=== CONT  TestAccDatasourceListeners_basic
--- PASS: TestAccDatasourceListeners_basic (105.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        105.853s
```
