### PR TITLE
fix(BMS): add precheck verifications of USER_ID and ENTERPRISE_PROJECT_ID  in the test case

### DIFF
--- a/huaweicloud/services/acceptance/bms/data_source_huaweicloud_bms_instances_test.go
+++ b/huaweicloud/services/acceptance/bms/data_source_huaweicloud_bms_instances_test.go
@@ -13,7 +13,11 @@ func TestAccBmsInstancesDataSource_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	resourceName := "data.huaweicloud_bms_instances.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckUserId(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add precheck verification of USER_ID in the test case
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/bms TESTARGS='-run TestAccBmsInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms -v -run TestAccBmsInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccBmsInstancesDataSource_basic
=== PAUSE TestAccBmsInstancesDataSource_basic
=== CONT  TestAccBmsInstancesDataSource_basic
--- PASS: TestAccBmsInstancesDataSource_basic (563.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       563.073s


make testacc TEST=./huaweicloud/services/acceptance/bms TESTARGS='-run TestAccBmsInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms -v -run TestAccBmsInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccBmsInstancesDataSource_basic
=== PAUSE TestAccBmsInstancesDataSource_basic
=== CONT  TestAccBmsInstancesDataSource_basic
    acceptance.go:432: The environment variables does not support the user ID (HW_USER_ID) for acc tests
--- SKIP: TestAccBmsInstancesDataSource_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       0.046s


make testacc TEST=./huaweicloud/services/acceptance/bms TESTARGS='-run TestAccBmsInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/bms -v -run TestAccBmsInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccBmsInstancesDataSource_basic
=== PAUSE TestAccBmsInstancesDataSource_basic
=== CONT  TestAccBmsInstancesDataSource_basic
    acceptance.go:418: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccBmsInstancesDataSource_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/bms       0.042s

```
