### PR TITLE
feat(ModelArts): modelarts resource pool support privilege resource pool

### DIFF
--- a/docs/resources/modelarts_resource_pool.md
+++ b/docs/resources/modelarts_resource_pool.md
@@ -8,6 +8,8 @@ Manages a ModelArts dedicated resource pool resource within HuaweiCloud.
 
 ## Example Usage
 
+### create a basic resource pool
+
 ```hcl
 variable "modelarts_network_id" {}
 
@@ -24,6 +26,64 @@ resource "huaweicloud_modelarts_resource_pool" "test" {
 }
 ```
 
+### create a lite resource pool
+
+```hcl
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "cce_cluster_id" {}
+variable "login_user_password" {}
+variable "security_group_ids" {
+  type = list(string)
+} 
+
+resource "huaweicloud_modelarts_resource_pool" "test" {
+  name        = "demo"
+  prefix      = "test-prefix"
+  description = "This is a demo"
+  vpc_id      = var.vpc_id
+  subnet_id   = var.subnet_id
+
+  clusters {
+    provider_id = var.cce_cluster_id
+  }
+
+  user_login {
+    password = var.login_user_password
+  }
+  
+  resources {
+    flavor_id          = "modelarts.vm.cpu.8ud"
+    count              = 1
+    node_pool          = "test-name"
+    vpc_id             = var.vpc_id
+    subnet_id          = var.subnet_id
+    security_group_ids = var.security_group_ids
+
+    labels = {
+      aaa = "111"
+      bbb = "222"
+    }
+
+    tags = {
+      key   = "terraform"
+      owner = "value"
+    }
+
+    taints {
+      key    = "key"
+      value  = "value"
+      effect = "NoSchedule"
+    }
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = false
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -31,54 +91,166 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String, ForceNew) The name of the dedicated resource pool.  
-    The name can contain `4` to `32` characters, only lowercase letters, digits and hyphens (-) are allowed.
-    The name must start with a lowercase letter and end with a lowercase letter or digit.
+* `name` - (Required, String, ForceNew) Specifies the name of the dedicated resource pool.  
+  The name can contain **4** to **32** characters, only lowercase letters, digits and hyphens (-) are allowed.
+  The name must start with a lowercase letter and end with a lowercase letter or digit.
 
   Changing this parameter will create a new resource.
 
-* `scope` - (Required, List) List of job types supported by the resource pool.  
-  The options are as follows:
-    + **Train**: training job.
-    + **Infer**: inference job.
-    + **Notebook**: Notebook job.
-
-* `resources` - (Required, List) List of resource specifications in the resource pool.  
+* `resources` - (Required, List) Specifies the list of resource specifications in the resource pool.  
   Including resource flavors and the number of resources of the corresponding flavors.
   The [resources](#ModelartsResourcePool_ResourceFlavor) structure is documented below.
 
-* `network_id` - (Required, String, ForceNew) The ModelArt network ID of the resource pool.
+* `scope` - (Optional, List) Specifies the list of job types supported by the resource pool. It is mandatory when
+  `network_id` is specified and can not be specified when `vpc_id` is specified. The options are as follows:
+  + **Train**: training job.
+  + **Infer**: inference job.
+  + **Notebook**: Notebook job.
+
+* `network_id` - (Optional, String, ForceNew) Specifies the ModelArt network ID of the resource pool.
 
   Changing this parameter will create a new resource.
 
-* `workspace_id` - (Optional, String, ForceNew) Workspace ID, which defaults to 0.  
+* `vpc_id` - (Optional, String, ForceNew) Specifies the VPC ID.
 
   Changing this parameter will create a new resource.
 
-* `description` - (Optional, String) The description of the dedicated resource pool.  
+-> **NOTE:** Exactly one of `network_id`, `vpc_id` should be specified.
+
+* `subnet_id` - (Optional, String, ForceNew) Specifies the network ID of a subnet. It is mandatory when `vpc_id` is
+  specified.
+  
+  Changing this parameter will create a new resource.
+
+* `clusters` - (Optional, List, ForceNew) Specifies the list of the CCE clusters. It is mandatory when `vpc_id` is
+  specified and can not be specified when `network_id` is specified.
+  The [clusters](#ModelartsResourcePool_Clusters) structure is documented below.
+
+  Changing this parameter will create a new resource.
+
+* `user_login` - (Optional, List, ForceNew) Specifies the user login info of the resource pool. It is mandatory when
+  `vpc_id` is specified and can not be specified when `network_id` is specified.
+  The [user_login](#ModelartsResourcePool_User_login) structure is documented below.
+
+  Changing this parameter will create a new resource.
+
+* `workspace_id` - (Optional, String, ForceNew) Specifies the workspace ID, which defaults to **0**.
+
+  Changing this parameter will create a new resource.
+
+* `prefix` - (Optional, String, ForceNew) Specifies the prefix of the user-defined node name of the resource pool.
+
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of the dedicated resource pool.  
+
+* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the resource pool.
+  Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.
+  Changing this parameter will create a new resource.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the resource pool.
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this parameter will create a new resource.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the resource pool.
+  If `period_unit` is set to **month**, the value ranges from **1** to **9**.
+  If `period_unit` is set to **year**, the value ranges from **1** to **3**.
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this parameter will create a new resource.
+
+* `auto_renew` - (Optional, String) Specifies whether auto-renew is enabled. Valid values are **true** and **false**.
+
+-> **NOTE:** `charging_mode`, `period_unit`, `period`, `auto_renew` are mandatory when `vpc_id` is specified.
 
 <a name="ModelartsResourcePool_ResourceFlavor"></a>
 The `resources` block supports:
 
-* `flavor_id` - (Required, String) The resource flavor ID.  
+* `flavor_id` - (Required, String) Specifies the resource flavor ID.  
 
-* `count` - (Required, Int) Number of resources of the corresponding flavors.
+* `count` - (Required, Int) Specifies the number of resources of the corresponding flavors.
 
-* `azs` - (Optional, List) AZs for resource pool nodes.
-  The [azs](#ModelartsResourcePool_ResourceFlavor_azs) structure is documented below.
+* `node_pool` - (Optional, String) Specifies the name of resource pool nodes. It can contain **1** to **50**
+  characters, and should start with a letter and ending with a letter or digit, only lowercase letters, digits,
+  hyphens (-) are allowed, and cannot end with a hyphen (-).
 
-<a name="ModelartsResourcePool_ResourceFlavor_azs"></a>
+* `max_count` - (Optional, Int) Specifies the max number of resources of the corresponding flavors.
+
+* `vpc_id` - (Optional, String) Specifies the VPC ID. It is mandatory when `resources.subnet_id`,
+  `resources.security_group_ids` is specified, and can not be specified when `network_id` is specified.
+
+* `subnet_id` - (Optional, String) Specifies the network ID of a subnet. It is mandatory when
+  `resources.security_group_ids`is specified, and can not be specified when `network_id` is specified.
+
+* `security_group_ids` - (Optional, List) Specifies the security group IDs. It can not be specified when `network_id` is
+  specified.
+
+* `azs` - (Optional, List) Specifies the AZs for resource pool nodes.
+  The [azs](#ModelartsResourcePool_Resources_azs) structure is documented below.
+
+* `labels` - (Optional, Map) Specifies the labels of resource pool nodes.
+
+* `taints` - (Optional, List) Specifies the taints added to nodes. It can not be specified when `network_id` is specified.
+  The [taints](#ModelartsResourcePool_Resources_taints) structure is documented below.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the resource pool. It can not be specified
+  when `network_id` is specified.
+
+* `post_install` - (Optional, String) Specifies the script to be executed after security. The value should be a Base64
+  encoded string.
+
+<a name="ModelartsResourcePool_Resources_azs"></a>
 The `azs` block supports:
 
-* `az` - (Optional, String) The AZ name.
+* `az` - (Optional, String) Specifies the AZ name.
 
-* `count` - (Optional, Int) Number of nodes.
+* `count` - (Optional, Int) Specifies the number of nodes.
+
+<a name="ModelartsResourcePool_Resources_taints"></a>
+The `taints` block supports:
+
+* `key` - (Required, String) Specifies the key of the taint.
+
+* `value` - (Optional, String) Specifies the value of the taint.
+
+* `effect` - (Required, String) Specifies the effect of the taint. Value options: **NoSchedule**, **PreferNoSchedule**,
+  **NoExecute**.
+
+<a name="ModelartsResourcePool_Clusters"></a>
+The `clusters` block supports:
+
+* `provider_id` - (Required, String, ForceNew) Specifies the ID of the CCE cluster.
+
+<a name="ModelartsResourcePool_User_login"></a>
+The `user_login` block supports:
+
+* `password` - (Optional, String, ForceNew) Specifies the password of the login user. The value needs to be salted,
+  encrypted and base64 encoded. Default user is **root**.
+
+  Changing this parameter will create a new resource.
+
+* `key_pair_name` - (Optional, String, ForceNew) Specifies key pair name of the login user.
+
+  Changing this parameter will create a new resource.
+
+  -> **NOTE:** Exactly one of `password`, `key_pair_name` should be specified.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
+* `status` - Indicates the status of the resource pool.
+
+* `resource_pool_id` - Indicates the resource ID of the resource pool.
+
+* `clusters` - Indicates the list of the CCE clusters.
+  The [clusters](#ModelartsResourcePool_Clusters) structure is documented below.
+
+<a name="ModelartsResourcePool_Clusters"></a>
+The `clusters` block supports:
+
+* `name` - Indicates the name of the CCE cluster.
 
 ## Timeouts
 
@@ -93,5 +265,23 @@ This resource provides the following timeouts configuration options:
 The ModelArts resource pool can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_modelarts_resource_pool.test 0ce123456a00f2591fabc00385ff1234
+$ terraform import huaweicloud_modelarts_resource_pool.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `period_unit`, `period`, `auto_renew`,
+`user_login.0.password`. It is generally recommended running `terraform plan` after importing a ModelArts resource pool.
+You can then decide if changes should be applied to the ModelArts resource pool, or the resource definition should be
+updated to align with the ModelArts resource pool. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_modelarts_resource_pool" "resource_pool" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      period_unit, period, auto_renew, user_login.0.password
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -194,6 +194,7 @@ var (
 	HW_SECMASTER_PIPELINE_ID = os.Getenv("HW_SECMASTER_PIPELINE_ID")
 
 	HW_MODELARTS_HAS_SUBSCRIBE_MODEL = os.Getenv("HW_MODELARTS_HAS_SUBSCRIBE_MODEL")
+	HW_MODELARTS_USER_LOGIN_PASSWORD = os.Getenv("HW_MODELARTS_USER_LOGIN_PASSWORD")
 
 	// The CMDB sub-application ID of AOM service
 	HW_AOM_SUB_APPLICATION_ID = os.Getenv("HW_AOM_SUB_APPLICATION_ID")
@@ -1045,6 +1046,13 @@ func TestAccPreCheckModelArtsHasSubscribeModel(t *testing.T) {
 	if HW_MODELARTS_HAS_SUBSCRIBE_MODEL == "" {
 		t.Skip("Subscribe two free models from market and set HW_MODELARTS_HAS_SUBSCRIBE_MODEL" +
 			" for modelarts service acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckModelartsUserLoginPassword(t *testing.T) {
+	if HW_MODELARTS_USER_LOGIN_PASSWORD == "" {
+		t.Skip("HW_MODELARTS_USER_LOGIN_PASSWORD must be set for modelarts privilege resource pool acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_resource_pool_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_resource_pool_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -38,7 +39,8 @@ func getModelartsResourcePoolResourceFunc(cfg *config.Config, state *terraform.R
 		MoreHeaders: map[string]string{"Content-Type": "application/json"},
 	}
 
-	getModelartsResourcePoolResp, err := getModelartsResourcePoolClient.Request("GET", getModelartsResourcePoolPath, &getModelartsResourcePoolOpt)
+	getModelartsResourcePoolResp, err := getModelartsResourcePoolClient.Request("GET", getModelartsResourcePoolPath,
+		&getModelartsResourcePoolOpt)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving Modelarts resource pool: %s", err)
 	}
@@ -64,7 +66,9 @@ func TestAccModelartsResourcePool_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
@@ -100,6 +104,142 @@ func TestAccModelartsResourcePool_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccModelartsResourcePool_privilege_pool(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceNameWithDash()
+	prefix := acceptance.RandomAccResourceNameWithDash()
+	rName := "huaweicloud_modelarts_resource_pool.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getModelartsResourcePoolResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckModelartsUserLoginPassword(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testModelartsResourcePool_privilege_pool(name, prefix),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "prefix", prefix),
+					resource.TestCheckResourceAttr(rName, "description", "This is a demo"),
+					resource.TestCheckResourceAttrPair(rName, "vpc_id",
+						"huaweicloud_cce_cluster.test", "vpc_id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id",
+						"huaweicloud_cce_cluster.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(rName, "clusters.0.provider_id",
+						"huaweicloud_cce_cluster.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "clusters.0.name",
+						"huaweicloud_cce_cluster.test", "name"),
+					resource.TestCheckResourceAttr(rName, "resources.0.flavor_id", "modelarts.vm.cpu.8ud"),
+					resource.TestCheckResourceAttr(rName, "resources.0.count", "1"),
+					resource.TestCheckResourceAttr(rName, "resources.0.node_pool", fmt.Sprintf("%s-node-pool", name)),
+					resource.TestCheckResourceAttr(rName, "resources.0.max_count", "1"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.vpc_id",
+						"huaweicloud_cce_cluster.test", "vpc_id"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.subnet_id",
+						"huaweicloud_cce_cluster.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.security_group_ids.0",
+						"huaweicloud_cce_cluster.test", "security_group_id"),
+					resource.TestCheckResourceAttr(rName, "resources.0.azs.0.count", "1"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.azs.0.az",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(rName, "resources.0.labels.aaa", "value_aaa"),
+					resource.TestCheckResourceAttr(rName, "resources.0.labels.bbb", "value_bbb"),
+					resource.TestCheckResourceAttr(rName, "resources.0.tags.key", "terraform"),
+					resource.TestCheckResourceAttr(rName, "resources.0.tags.owner", "value"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.0.key", "node_1_key_1"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.0.value", "node_1_value_1"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.1.key", "node_1_key_2"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.1.value", "node_1_value_2"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.1.effect", "PreferNoSchedule"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.2.key", "node_1_key_3"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.2.value", "node_1_value_3"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.2.effect", "NoExecute"),
+					resource.TestCheckResourceAttr(rName, "resources.0.post_install", "test_post_install"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "resource_pool_id"),
+				),
+			},
+			{
+				Config: testModelartsResourcePool_privilege_pool_update(name, prefix),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "prefix", prefix),
+					resource.TestCheckResourceAttr(rName, "description", "This is a demo update"),
+					resource.TestCheckResourceAttrPair(rName, "vpc_id",
+						"huaweicloud_cce_cluster.test", "vpc_id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id",
+						"huaweicloud_cce_cluster.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(rName, "clusters.0.provider_id",
+						"huaweicloud_cce_cluster.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "clusters.0.name",
+						"huaweicloud_cce_cluster.test", "name"),
+					resource.TestCheckResourceAttr(rName, "resources.0.flavor_id", "modelarts.vm.cpu.8ud"),
+					resource.TestCheckResourceAttr(rName, "resources.0.count", "1"),
+					resource.TestCheckResourceAttr(rName, "resources.0.node_pool", fmt.Sprintf("%s-node-pool", name)),
+					resource.TestCheckResourceAttr(rName, "resources.0.max_count", "1"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.vpc_id",
+						"huaweicloud_cce_cluster.test", "vpc_id"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.subnet_id",
+						"huaweicloud_cce_cluster.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.security_group_ids.0",
+						"huaweicloud_cce_cluster.test", "security_group_id"),
+					resource.TestCheckResourceAttr(rName, "resources.0.azs.0.count", "1"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.azs.0.az",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(rName, "resources.0.taints.#", "0"),
+
+					resource.TestCheckResourceAttr(rName, "resources.1.flavor_id", "modelarts.vm.cpu.16u64g.d"),
+					resource.TestCheckResourceAttr(rName, "resources.1.count", "1"),
+					resource.TestCheckResourceAttr(rName, "resources.1.node_pool", fmt.Sprintf("%s-node-pool-2", name)),
+					resource.TestCheckResourceAttr(rName, "resources.1.max_count", "1"),
+					resource.TestCheckResourceAttrPair(rName, "resources.1.vpc_id",
+						"huaweicloud_cce_cluster.test", "vpc_id"),
+					resource.TestCheckResourceAttrPair(rName, "resources.1.subnet_id",
+						"huaweicloud_cce_cluster.test", "subnet_id"),
+					resource.TestCheckResourceAttrPair(rName, "resources.1.security_group_ids.0",
+						"huaweicloud_cce_cluster.test", "security_group_id"),
+					resource.TestCheckResourceAttr(rName, "resources.1.azs.0.count", "1"),
+					resource.TestCheckResourceAttrPair(rName, "resources.0.azs.0.az",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(rName, "resources.1.labels.aaa_2", "value_aaa_2"),
+					resource.TestCheckResourceAttr(rName, "resources.1.labels.bbb_2", "value_bbb_2"),
+					resource.TestCheckResourceAttr(rName, "resources.1.tags.key_2", "terraform_2"),
+					resource.TestCheckResourceAttr(rName, "resources.1.tags.owner_2", "value_2"),
+					resource.TestCheckResourceAttr(rName, "resources.1.taints.0.key", "node_2_key_1"),
+					resource.TestCheckResourceAttr(rName, "resources.1.taints.0.value", "node_2_value_1"),
+					resource.TestCheckResourceAttr(rName, "resources.1.taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(rName, "resources.1.taints.1.key", "node_2_key_2"),
+					resource.TestCheckResourceAttr(rName, "resources.1.taints.1.value", "node_2_value_2"),
+					resource.TestCheckResourceAttr(rName, "resources.1.taints.1.effect", "PreferNoSchedule"),
+					resource.TestCheckResourceAttr(rName, "resources.1.taints.2.key", "node_2_key_3"),
+					resource.TestCheckResourceAttr(rName, "resources.1.taints.2.value", "node_2_value_3"),
+					resource.TestCheckResourceAttr(rName, "resources.1.taints.2.effect", "NoExecute"),
+					resource.TestCheckResourceAttr(rName, "resources.1.post_install", "test_post_install"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"period_unit", "period", "auto_renew", "user_login"},
 			},
 		},
 	})
@@ -152,4 +292,181 @@ resource "huaweicloud_modelarts_network" "test" {
   name = "%s"
   cidr = "172.16.0.0/12"
 }`, name)
+}
+
+func testModelartsResourcePool_privilege_pool(name, prefix string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_resource_pool" "test" {
+  name        = "%[2]s"
+  prefix      = "%[3]s"
+  description = "This is a demo"
+  vpc_id      = huaweicloud_cce_cluster.test.vpc_id
+  subnet_id   = huaweicloud_cce_cluster.test.subnet_id
+
+  clusters {
+    provider_id = huaweicloud_cce_cluster.test.id
+  }
+
+  user_login {
+    password = "%[4]s"
+  }
+
+  resources {
+    flavor_id          = "modelarts.vm.cpu.8ud"
+    count              = 1
+    node_pool          = "%[2]s-node-pool"
+    max_count          = "1"
+    vpc_id             = huaweicloud_cce_cluster.test.vpc_id
+    subnet_id          = huaweicloud_cce_cluster.test.subnet_id
+    security_group_ids = [huaweicloud_cce_cluster.test.security_group_id]
+
+    azs {
+      count = 1
+      az    = data.huaweicloud_availability_zones.test.names[0]
+    }
+
+    labels = {
+      aaa = "value_aaa"
+      bbb = "value_bbb"
+    }
+
+    tags = {
+      key   = "terraform"
+      owner = "value"
+    }
+
+    taints {
+      key    = "node_1_key_1"
+      value  = "node_1_value_1"
+      effect = "NoSchedule"
+    }
+    taints {
+      key    = "node_1_key_2"
+      value  = "node_1_value_2"
+      effect = "PreferNoSchedule"
+    }
+    taints {
+      key    = "node_1_key_3"
+      value  = "node_1_value_3"
+      effect = "NoExecute"
+    }
+
+    post_install = "test_post_install"
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = true
+}
+`, testModelartsResourcePool_privilege_pool_base(name), name, prefix, acceptance.HW_MODELARTS_USER_LOGIN_PASSWORD)
+}
+
+func testModelartsResourcePool_privilege_pool_update(name, prefix string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_modelarts_resource_pool" "test" {
+  name        = "%[2]s"
+  prefix      = "%[3]s"
+  description = "This is a demo update"
+  vpc_id      = huaweicloud_cce_cluster.test.vpc_id
+  subnet_id   = huaweicloud_cce_cluster.test.subnet_id
+
+  clusters {
+    provider_id = huaweicloud_cce_cluster.test.id
+  }
+
+   user_login {
+    password = "%[4]s"
+  }
+
+  resources {
+    flavor_id          = "modelarts.vm.cpu.8ud"
+    count              = 1
+    node_pool          = "%[2]s-node-pool"
+    max_count          = "1"
+    vpc_id             = huaweicloud_cce_cluster.test.vpc_id
+    subnet_id          = huaweicloud_cce_cluster.test.subnet_id
+    security_group_ids = [huaweicloud_cce_cluster.test.security_group_id]
+
+    azs {
+      count = 1
+      az    = data.huaweicloud_availability_zones.test.names[0]
+    }
+  }
+
+  resources {
+    flavor_id          = "modelarts.vm.cpu.16u64g.d"
+    count              = 1
+    node_pool          = "%[2]s-node-pool-2"
+    max_count          = "1"
+    vpc_id             = huaweicloud_cce_cluster.test.vpc_id
+    subnet_id          = huaweicloud_cce_cluster.test.subnet_id
+    security_group_ids = [huaweicloud_cce_cluster.test.security_group_id]
+
+    azs {
+      count = 1
+      az    = data.huaweicloud_availability_zones.test.names[0]
+    }
+
+    labels = {
+      aaa_2 = "value_aaa_2"
+      bbb_2 = "value_bbb_2"
+    }
+
+    tags = {
+      key_2   = "terraform_2"
+      owner_2 = "value_2"
+    }
+
+    taints {
+      key    = "node_2_key_1"
+      value  = "node_2_value_1"
+      effect = "NoSchedule"
+    }
+    taints {
+      key    = "node_2_key_2"
+      value  = "node_2_value_2"
+      effect = "PreferNoSchedule"
+    }
+    taints {
+      key    = "node_2_key_3"
+      value  = "node_2_value_3"
+      effect = "NoExecute"
+    }
+    post_install = "test_post_install"
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = true
+}
+`, testModelartsResourcePool_privilege_pool_base(name), name, prefix, acceptance.HW_MODELARTS_USER_LOGIN_PASSWORD)
+}
+
+func testModelartsResourcePool_privilege_pool_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_cce_cluster" "test" {
+  name                   = "%[2]s"
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+  service_network_cidr   = "10.248.0.0/16"
+  cluster_version        = "v1.25"
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = "1"
+  auto_renew    = "true"
+}
+`, common.TestVpc(name), name)
 }

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_resource_pool.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -59,7 +60,8 @@ func ResourceModelartsResourcePool() *schema.Resource {
 			"scope": {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: `List of job types supported by the resource pool.`,
 			},
 			"resources": {
@@ -69,10 +71,51 @@ func ResourceModelartsResourcePool() *schema.Resource {
 				Description: `List of resource specifications in the resource pool.`,
 			},
 			"network_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"vpc_id"},
+				Description:  `The ModelArts network ID of the resource pool.`,
+			},
+			"prefix": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
-				Description: `The ModelArts network ID of the resource pool.`,
+				Description: `The prefix of the user-defined node name of the resource pool.`,
+			},
+			"vpc_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"subnet_id", "clusters", "user_login"},
+				Description:  `The VPC ID.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The network ID of a subnet.`,
+			},
+			"clusters": {
+				Type:        schema.TypeList,
+				Elem:        modelartsResourcePoolClustersSchema(),
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The list of the CCE clusters.`,
+			},
+			"user_login": {
+				Type:        schema.TypeList,
+				Elem:        modelartsResourcePoolUserLoginSchema(),
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				MaxItems:    1,
+				Description: `The user login info of the resource pool.`,
 			},
 			"workspace_id": {
 				Type:        schema.TypeString,
@@ -84,8 +127,21 @@ func ResourceModelartsResourcePool() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
 				Description: `The description of the resource pool.`,
+			},
+			"charging_mode": common.SchemaChargingMode(nil),
+			"period_unit":   common.SchemaPeriodUnit(nil),
+			"period":        common.SchemaPeriod(nil),
+			"auto_renew":    common.SchemaAutoRenewUpdatable(nil),
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the resource pool.`,
+			},
+			"resource_pool_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource ID of the resource pool.`,
 			},
 		},
 	}
@@ -104,19 +160,91 @@ func modelartsResourcePoolResourceFlavorSchema() *schema.Resource {
 				Required:    true,
 				Description: `Number of resources of the corresponding flavors.`,
 			},
-			"azs": {
-				Type:        schema.TypeList,
-				Elem:        modelartsResourcePoolResourceFlavorAzsSchema(),
+			"node_pool": {
+				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
+				Description: `The name of resource pool nodes.`,
+			},
+			"max_count": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: `The max number of resources of the corresponding flavors.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The VPC ID.`,
+			},
+			"subnet_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The network ID of a subnet.`,
+			},
+			"security_group_ids": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Computed:    true,
+				Description: `The security group IDs.`,
+			},
+			"azs": {
+				Type:        schema.TypeList,
+				Elem:        modelartsResourcePoolResourcesAzsSchema(),
+				Optional:    true,
 				Description: `AZs for resource pool nodes.`,
+			},
+			"taints": {
+				Type:        schema.TypeList,
+				Elem:        modelartsResourcePoolResourcesTaintSchema(),
+				Optional:    true,
+				Description: `The taints added to nodes.`,
+			},
+			"labels": {
+				Type:        schema.TypeMap,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: `The labels of resource pool.`,
+			},
+			"tags": common.TagsSchema(),
+			"post_install": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The script to be executed after security.`,
 			},
 		},
 	}
 	return &sc
 }
 
-func modelartsResourcePoolResourceFlavorAzsSchema() *schema.Resource {
+func modelartsResourcePoolResourcesTaintSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The key of the taint.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The value of the taint.`,
+			},
+			"effect": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The effect of the taint.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func modelartsResourcePoolResourcesAzsSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"az": {
@@ -130,6 +258,47 @@ func modelartsResourcePoolResourceFlavorAzsSchema() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: `Number of nodes.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func modelartsResourcePoolClustersSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"provider_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the CCE cluster.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the CCE cluster.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func modelartsResourcePoolUserLoginSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Sensitive:   true,
+				Description: `The password of the login user.`,
+			},
+			"key_pair_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The key pair name of the login user.`,
 			},
 		},
 	}
@@ -177,6 +346,32 @@ func resourceModelartsResourcePoolCreate(ctx context.Context, d *schema.Resource
 	}
 	d.SetId(id.(string))
 
+	if d.Get("charging_mode") == "prePaid" {
+		// wait 30 seconds so that the resource pool can be queried
+		// lintignore:R018
+		time.Sleep(30 * time.Second)
+		resourcePool, err := queryResourcePool(cfg, region, d)
+		if err != nil {
+			return diag.Errorf("error retrieving Modelarts resource pool: %s", err)
+		}
+		orderId := utils.PathSearch(`metadata.annotations."os.modelarts/order.id"`, resourcePool, nil)
+		if orderId == nil {
+			return diag.Errorf("error creating Modelarts resource pool: order ID is not found in API response")
+		}
+		bssClient, err := cfg.BssV2Client(region)
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+		err = common.WaitOrderComplete(ctx, bssClient, orderId.(string), d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		_, err = common.WaitOrderResourceComplete(ctx, bssClient, orderId.(string), d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	err = createResourcePoolWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.Errorf("error waiting for the Modelarts resource pool (%s) creation to complete: %s", d.Id(), err)
@@ -188,25 +383,141 @@ func buildCreateResourcePoolBodyParams(d *schema.ResourceData) map[string]interf
 	bodyParams := map[string]interface{}{
 		"apiVersion": "v2",
 		"kind":       "Pool",
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				"os.modelarts/name":         d.Get("name"),
-				"os.modelarts/workspace.id": utils.ValueIngoreEmpty(d.Get("workspace_id")),
-			},
-			"annotations": map[string]interface{}{
-				"os.modelarts/description": utils.ValueIngoreEmpty(d.Get("description")),
-			},
-		},
-		"spec": map[string]interface{}{
-			"type":      "Dedicate",
-			"scope":     d.Get("scope"),
-			"resources": buildResourcePoolResourceFlavor(d.Get("resources")),
-			"network": map[string]interface{}{
-				"name": d.Get("network_id"),
-			},
-		},
+		"metadata":   buildCreateResourcePoolMetaDataBodyParams(d),
+		"spec":       buildCreateResourcePoolSpecBodyParams(d),
 	}
 	return bodyParams
+}
+
+func buildCreateResourcePoolMetaDataBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"labels":      buildCreateResourcePoolMetaDataLabelsBodyParams(d),
+		"annotations": buildCreateResourcePoolMetaDataAnnotationsBodyParams(d),
+	}
+	return params
+}
+
+func buildCreateResourcePoolMetaDataLabelsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"os.modelarts/name":         d.Get("name"),
+		"os.modelarts/node.prefix":  utils.ValueIngoreEmpty(d.Get("prefix")),
+		"os.modelarts/workspace.id": utils.ValueIngoreEmpty(d.Get("workspace_id")),
+	}
+	return params
+}
+
+func buildCreateResourcePoolMetaDataAnnotationsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"os.modelarts/description": utils.ValueIngoreEmpty(d.Get("description")),
+	}
+	if d.Get("charging_mode") == "prePaid" {
+		params["os.modelarts/billing.mode"] = "1"
+		if d.Get("period_unit") == "month" {
+			params["os.modelarts/period.type"] = "2"
+		} else {
+			params["os.modelarts/period.type"] = "3"
+		}
+		params["os.modelarts/period.num"] = strconv.Itoa(d.Get("period").(int))
+		if d.Get("auto_renew").(string) == "true" {
+			params["os.modelarts/auto.renew"] = "1"
+		}
+		params["os.modelarts/auto.pay"] = "1"
+	}
+	return params
+}
+
+func buildCreateResourcePoolSpecBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"type":      "Dedicate",
+		"scope":     utils.ValueIngoreEmpty(d.Get("scope")),
+		"resources": buildResourcePoolSpecResources(d),
+		"userLogin": buildCreateResourcePoolSpecUserLoginBodyParams(d),
+		"network":   buildCreateResourcePoolSpecNetworkBodyParams(d),
+		"clusters":  buildCreateResourcePoolSpecClustersBodyParams(d),
+	}
+	return params
+}
+
+func buildCreateResourcePoolSpecUserLoginBodyParams(d *schema.ResourceData) map[string]interface{} {
+	userLoginRaw := d.Get("user_login").([]interface{})
+	if len(userLoginRaw) < 1 {
+		return nil
+	}
+	return map[string]interface{}{
+		"password":    utils.ValueIngoreEmpty(d.Get("user_login.0.password")),
+		"keyPairName": utils.ValueIngoreEmpty(d.Get("user_login.0.key_pair_name")),
+	}
+}
+
+func buildCreateResourcePoolSpecNetworkBodyParams(d *schema.ResourceData) map[string]interface{} {
+	network := make(map[string]interface{})
+	if networkId, ok := d.GetOk("network_id"); ok {
+		network["name"] = networkId
+	} else {
+		network["vpcId"] = d.Get("vpc_id")
+		network["subnetId"] = d.Get("subnet_id")
+	}
+	return network
+}
+
+func buildCreateResourcePoolSpecClustersBodyParams(d *schema.ResourceData) []interface{} {
+	if clusters, ok := d.GetOk("clusters"); ok {
+		providerIDs := make([]interface{}, 0, len(clusters.([]interface{})))
+		for _, clusterRaw := range clusters.([]interface{}) {
+			cluster := clusterRaw.(map[string]interface{})
+			providerIDs = append(providerIDs, map[string]interface{}{
+				"providerId": cluster["provider_id"],
+			})
+		}
+		return providerIDs
+	}
+	return nil
+}
+
+func buildResourcePoolSpecResources(d *schema.ResourceData) []map[string]interface{} {
+	if rawArray, ok := d.Get("resources").([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			if raw, ok := v.(map[string]interface{}); ok {
+				rst[i] = map[string]interface{}{
+					"flavor":       utils.ValueIngoreEmpty(raw["flavor_id"]),
+					"count":        utils.ValueIngoreEmpty(raw["count"]),
+					"nodePool":     utils.ValueIngoreEmpty(raw["node_pool"]),
+					"maxCount":     utils.ValueIngoreEmpty(raw["max_count"]),
+					"azs":          buildResourcePoolResourcesAzs(raw["azs"]),
+					"network":      buildResourcePoolSpecResourcesNetworkBodyParams(raw),
+					"taints":       buildResourcePoolResourcesTaints(raw["taints"]),
+					"tags":         utils.ExpandResourceTags(raw["tags"].(map[string]interface{})),
+					"labels":       utils.ValueIngoreEmpty(raw["labels"]),
+					"extendParams": buildCreateResourcePoolSpecResourcesPostInstallBodyParams(raw),
+				}
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func buildResourcePoolSpecResourcesNetworkBodyParams(rawParam map[string]interface{}) map[string]interface{} {
+	if vpcId := rawParam["vpc_id"]; len(vpcId.(string)) > 0 {
+		return map[string]interface{}{
+			"vpc":            utils.ValueIngoreEmpty(rawParam["vpc_id"]),
+			"subnet":         utils.ValueIngoreEmpty(rawParam["subnet_id"]),
+			"securityGroups": utils.ValueIngoreEmpty(rawParam["security_group_ids"]),
+		}
+	}
+	return nil
+}
+
+func buildCreateResourcePoolSpecResourcesPostInstallBodyParams(rawParam map[string]interface{}) map[string]interface{} {
+	if postInstall := rawParam["post_install"]; len(postInstall.(string)) > 0 {
+		return map[string]interface{}{"post_install": postInstall}
+	}
+	return nil
 }
 
 func createResourcePoolWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
@@ -224,6 +535,10 @@ func createResourcePoolWaitingForStateCompleted(ctx context.Context, d *schema.R
 			statusRaw := utils.PathSearch(`status.phase`, createResourcePoolWaitingRespBody, nil)
 			if statusRaw == nil {
 				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `status.phase`)
+			}
+
+			if utils.PathSearch("status.resources.abnormal", createResourcePoolWaitingRespBody, nil) != nil {
+				return nil, "ERROR", fmt.Errorf("error creating resource pool: the resource pool is abnormal")
 			}
 
 			status := fmt.Sprintf("%v", statusRaw)
@@ -247,7 +562,7 @@ func createResourcePoolWaitingForStateCompleted(ctx context.Context, d *schema.R
 		},
 		Timeout:      t,
 		Delay:        30 * time.Second,
-		PollInterval: 20 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
@@ -267,13 +582,38 @@ func resourceModelartsResourcePoolRead(_ context.Context, d *schema.ResourceData
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
-		d.Set("name", utils.PathSearch(`metadata.labels."os.modelarts/name"`, getModelartsResourcePoolRespBody, nil)),
-		d.Set("workspace_id", utils.PathSearch(`metadata.labels."os.modelarts/workspace.id"`, getModelartsResourcePoolRespBody, nil)),
-		d.Set("description", utils.PathSearch(`metadata.annotations."os.modelarts/description"`, getModelartsResourcePoolRespBody, nil)),
+		d.Set("name", utils.PathSearch(`metadata.labels."os.modelarts/name"`,
+			getModelartsResourcePoolRespBody, nil)),
+		d.Set("prefix", utils.PathSearch(`metadata.labels."os.modelarts/node.prefix"`,
+			getModelartsResourcePoolRespBody, nil)),
+		d.Set("workspace_id", utils.PathSearch(`metadata.labels."os.modelarts/workspace.id"`,
+			getModelartsResourcePoolRespBody, nil)),
+		d.Set("description", utils.PathSearch(`metadata.annotations."os.modelarts/description"`,
+			getModelartsResourcePoolRespBody, nil)),
 		d.Set("scope", utils.PathSearch("spec.scope", getModelartsResourcePoolRespBody, nil)),
-		d.Set("resources", flattenGetResourcePoolResponseBodyResourceFlavor(getModelartsResourcePoolRespBody)),
+		d.Set("resources", flattenGetResourcePoolResponseBodyResources(getModelartsResourcePoolRespBody)),
 		d.Set("network_id", utils.PathSearch("spec.network.name", getModelartsResourcePoolRespBody, nil)),
+		d.Set("vpc_id", utils.PathSearch("spec.network.vpcId", getModelartsResourcePoolRespBody, nil)),
+		d.Set("subnet_id", utils.PathSearch("spec.network.subnetId", getModelartsResourcePoolRespBody, nil)),
+		d.Set("clusters", flattenGetResourcePoolClusterBodyResources(getModelartsResourcePoolRespBody)),
+		d.Set("status", utils.PathSearch("status.phase", getModelartsResourcePoolRespBody, nil)),
+		d.Set("resource_pool_id", utils.PathSearch(`metadata.labels."os.modelarts/resource.id"`,
+			getModelartsResourcePoolRespBody, nil)),
 	)
+	chargingMode := utils.PathSearch(`metadata.annotations."os.modelarts/billing.mode"`,
+		getModelartsResourcePoolRespBody, nil)
+	if chargingMode == "1" {
+		mErr = multierror.Append(mErr, d.Set("charging_mode", "prePaid"))
+	}
+
+	keyPairName := utils.PathSearch("spec.userLogin.keyPairName", getModelartsResourcePoolRespBody, nil)
+	if keyPairName != nil {
+		rst := make([]interface{}, 0, 1)
+		rst = append(rst, map[string]interface{}{
+			"key_pair_name": keyPairName,
+		})
+		mErr = multierror.Append(mErr, d.Set("user_login", rst))
+	}
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
@@ -289,7 +629,8 @@ func queryResourcePool(cfg *config.Config, region string, d *schema.ResourceData
 	}
 
 	getModelartsResourcePoolPath := getModelartsResourcePoolClient.Endpoint + getModelartsResourcePoolHttpUrl
-	getModelartsResourcePoolPath = strings.ReplaceAll(getModelartsResourcePoolPath, "{project_id}", getModelartsResourcePoolClient.ProjectID)
+	getModelartsResourcePoolPath = strings.ReplaceAll(getModelartsResourcePoolPath, "{project_id}",
+		getModelartsResourcePoolClient.ProjectID)
 	getModelartsResourcePoolPath = strings.ReplaceAll(getModelartsResourcePoolPath, "{id}", d.Id())
 
 	getModelartsResourcePoolOpt := golangsdk.RequestOpts{
@@ -300,7 +641,8 @@ func queryResourcePool(cfg *config.Config, region string, d *schema.ResourceData
 		MoreHeaders: map[string]string{"Content-Type": "application/json"},
 	}
 
-	getModelartsResourcePoolResp, err := getModelartsResourcePoolClient.Request("GET", getModelartsResourcePoolPath, &getModelartsResourcePoolOpt)
+	getModelartsResourcePoolResp, err := getModelartsResourcePoolClient.Request("GET", getModelartsResourcePoolPath,
+		&getModelartsResourcePoolOpt)
 
 	if err != nil {
 		return nil, err
@@ -313,7 +655,7 @@ func queryResourcePool(cfg *config.Config, region string, d *schema.ResourceData
 	return getModelartsResourcePoolRespBody, nil
 }
 
-func flattenGetResourcePoolResponseBodyResourceFlavor(resp interface{}) []interface{} {
+func flattenGetResourcePoolResponseBodyResources(resp interface{}) []interface{} {
 	if resp == nil {
 		return nil
 	}
@@ -322,15 +664,40 @@ func flattenGetResourcePoolResponseBodyResourceFlavor(resp interface{}) []interf
 	rst := make([]interface{}, 0, len(curArray))
 	for _, v := range curArray {
 		rst = append(rst, map[string]interface{}{
-			"flavor_id": utils.PathSearch("flavor", v, nil),
-			"count":     utils.PathSearch("count", v, nil),
-			"azs":       flattenResourcePoolsFlavorAzs(v),
+			"flavor_id":          utils.PathSearch("flavor", v, nil),
+			"count":              utils.PathSearch("count", v, nil),
+			"max_count":          utils.PathSearch("maxCount", v, nil),
+			"node_pool":          utils.PathSearch("nodePool", v, nil),
+			"vpc_id":             utils.PathSearch("network.vpc", v, nil),
+			"subnet_id":          utils.PathSearch("network.subnet", v, nil),
+			"security_group_ids": utils.PathSearch("network.securityGroups", v, nil),
+			"azs":                flattenResourcePoolResourcesAzs(v),
+			"taints":             flattenResourcePoolResourcesTaints(v),
+			"labels":             utils.PathSearch("labels", v, nil),
+			"post_install":       utils.PathSearch("extendParams.post_install", v, nil),
+			"tags":               flattenResourcePoolResourcesTags(v),
 		})
 	}
 	return rst
 }
 
-func flattenResourcePoolsFlavorAzs(resp interface{}) []interface{} {
+func flattenGetResourcePoolClusterBodyResources(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("spec.clusters", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"provider_id": utils.PathSearch("providerId", v, nil),
+			"name":        utils.PathSearch("name", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenResourcePoolResourcesAzs(resp interface{}) []interface{} {
 	if resp == nil {
 		return nil
 	}
@@ -342,6 +709,38 @@ func flattenResourcePoolsFlavorAzs(resp interface{}) []interface{} {
 			"az":    utils.PathSearch("az", v, nil),
 			"count": utils.PathSearch("count", v, nil),
 		})
+	}
+	return rst
+}
+
+func flattenResourcePoolResourcesTaints(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("taints", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"key":    utils.PathSearch("key", v, nil),
+			"value":  utils.PathSearch("value", v, nil),
+			"effect": utils.PathSearch("effect", v, nil),
+		})
+	}
+	return rst
+}
+
+func flattenResourcePoolResourcesTags(resp interface{}) map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("tags", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make(map[string]interface{})
+	for _, v := range curArray {
+		key := utils.PathSearch("key", v, "").(string)
+		value := utils.PathSearch("value", v, "").(string)
+		rst[key] = value
 	}
 	return rst
 }
@@ -379,9 +778,33 @@ func resourceModelartsResourcePoolUpdate(ctx context.Context, d *schema.Resource
 		}
 
 		updateResourcePoolOpt.JSONBody = utils.RemoveNil(buildUpdateResourcePoolBodyParams(d))
-		_, err = updateResourcePoolClient.Request("PATCH", updateResourcePoolPath, &updateResourcePoolOpt)
+		updateModelartsResourcePoolResp, err := updateResourcePoolClient.Request("PATCH", updateResourcePoolPath, &updateResourcePoolOpt)
 		if err != nil {
 			return diag.Errorf("error updating Modelarts resource pool: %s", err)
+		}
+
+		if d.Get("charging_mode") == "prePaid" {
+			updateModelartsResourcePoolRespBody, err := utils.FlattenResponse(updateModelartsResourcePoolResp)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			orderId := utils.PathSearch(`metadata.annotations."os.modelarts/order.id"`,
+				updateModelartsResourcePoolRespBody, nil)
+			if orderId == nil {
+				return diag.Errorf("error updating Modelarts resource pool: order ID is not found in API response")
+			}
+			bssClient, err := cfg.BssV2Client(region)
+			if err != nil {
+				return diag.Errorf("error creating BSS v2 client: %s", err)
+			}
+			err = common.WaitOrderComplete(ctx, bssClient, orderId.(string), d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			_, err = common.WaitOrderAllResourceComplete(ctx, bssClient, orderId.(string), d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 		}
 		err = updateResourcePoolWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
@@ -393,41 +816,39 @@ func resourceModelartsResourcePoolUpdate(ctx context.Context, d *schema.Resource
 
 func buildUpdateResourcePoolBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"annotations": map[string]interface{}{
-				"os.modelarts/description": utils.ValueIngoreEmpty(d.Get("description")),
-			},
-		},
-		"spec": map[string]interface{}{
-			"scope":     d.Get("scope"),
-			"resources": buildResourcePoolResourceFlavor(d.Get("resources")),
-		},
+		"metadata": buildUpdateResourcePoolMetaDataBodyParams(d),
+		"spec":     buildUpdateResourcePoolSpecBodyParams(d),
 	}
 	return bodyParams
 }
 
-func buildResourcePoolResourceFlavor(rawParams interface{}) []map[string]interface{} {
-	if rawArray, ok := rawParams.([]interface{}); ok {
-		if len(rawArray) == 0 {
-			return nil
-		}
-
-		rst := make([]map[string]interface{}, len(rawArray))
-		for i, v := range rawArray {
-			if raw, ok := v.(map[string]interface{}); ok {
-				rst[i] = map[string]interface{}{
-					"flavor": utils.ValueIngoreEmpty(raw["flavor_id"]),
-					"count":  utils.ValueIngoreEmpty(raw["count"]),
-					"azs":    buildResourceFlavorResourceFlavorAzs(raw["azs"]),
-				}
-			}
-		}
-		return rst
+func buildUpdateResourcePoolMetaDataBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"annotations": buildUpdateResourcePoolMetaDataAnnotationsBodyParams(d),
 	}
-	return nil
+	return params
 }
 
-func buildResourceFlavorResourceFlavorAzs(rawParams interface{}) []map[string]interface{} {
+func buildUpdateResourcePoolMetaDataAnnotationsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"os.modelarts/description": utils.ValueIngoreEmpty(d.Get("description")),
+	}
+	if d.Get("charging_mode") == "prePaid" {
+		params["os.modelarts/order.id"] = ""
+		params["os.modelarts/auto.pay"] = "1"
+	}
+	return params
+}
+
+func buildUpdateResourcePoolSpecBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"scope":     utils.ValueIngoreEmpty(d.Get("scope")),
+		"resources": buildResourcePoolSpecResources(d),
+	}
+	return params
+}
+
+func buildResourcePoolResourcesAzs(rawParams interface{}) []map[string]interface{} {
 	if rawArray, ok := rawParams.([]interface{}); ok {
 		if len(rawArray) == 0 {
 			return nil
@@ -439,6 +860,27 @@ func buildResourceFlavorResourceFlavorAzs(rawParams interface{}) []map[string]in
 				rst[i] = map[string]interface{}{
 					"az":    utils.ValueIngoreEmpty(raw["az"]),
 					"count": utils.ValueIngoreEmpty(raw["count"]),
+				}
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func buildResourcePoolResourcesTaints(rawParams interface{}) []map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+
+		rst := make([]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			if raw, ok := v.(map[string]interface{}); ok {
+				rst[i] = map[string]interface{}{
+					"key":    utils.ValueIngoreEmpty(raw["key"]),
+					"effect": utils.ValueIngoreEmpty(raw["effect"]),
+					"value":  utils.ValueIngoreEmpty(raw["value"]),
 				}
 			}
 		}
@@ -508,8 +950,8 @@ func updateResourcePoolWaitingForStateCompleted(ctx context.Context, d *schema.R
 			return getResourcePoolRespBody, "COMPLETED", nil
 		},
 		Timeout:      t,
-		Delay:        30 * time.Second,
-		PollInterval: 20 * time.Second,
+		Delay:        5 * time.Second,
+		PollInterval: 5 * time.Second,
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
@@ -519,13 +961,36 @@ func resourceModelartsResourcePoolDelete(ctx context.Context, d *schema.Resource
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 
+	if d.Get("charging_mode").(string) == "prePaid" {
+		resourcePoolId := d.Get("resource_pool_id")
+		if resourcePoolId == nil {
+			return diag.Errorf("error getting resource ID from the resource pool(%s)", d.Id())
+		}
+		if err := common.UnsubscribePrePaidResource(d, cfg, []string{resourcePoolId.(string)}); err != nil {
+			return diag.Errorf("error unsubscribing Modelarts resource pool: %s", err)
+		}
+	} else {
+		err := deleteResourcePool(cfg, d, region)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	err := deleteResourcePoolWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return diag.Errorf("error waiting for the Modelarts resource pool (%s) deletion to complete: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func deleteResourcePool(cfg *config.Config, d *schema.ResourceData, region string) error {
 	var (
 		deleteResourcePoolHttpUrl = "v2/{project_id}/pools/{id}"
 		deleteResourcePoolProduct = "modelarts"
 	)
 	deleteResourcePoolClient, err := cfg.NewServiceClient(deleteResourcePoolProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating ModelArts client: %s", err)
+		return fmt.Errorf("error creating ModelArts client: %s", err)
 	}
 
 	deleteResourcePoolPath := deleteResourcePoolClient.Endpoint + deleteResourcePoolHttpUrl
@@ -542,12 +1007,7 @@ func resourceModelartsResourcePoolDelete(ctx context.Context, d *schema.Resource
 
 	_, err = deleteResourcePoolClient.Request("DELETE", deleteResourcePoolPath, &deleteResourcePoolOpt)
 	if err != nil {
-		return diag.Errorf("error deleting Modelarts resource pool: %s", err)
-	}
-
-	err = deleteResourcePoolWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
-	if err != nil {
-		return diag.Errorf("error waiting for the Modelarts resource pool (%s) deletion to complete: %s", d.Id(), err)
+		return fmt.Errorf("error deleting Modelarts resource pool: %s", err)
 	}
 	return nil
 }
@@ -559,21 +1019,21 @@ func deleteResourcePoolWaitingForStateCompleted(ctx context.Context, d *schema.R
 		Refresh: func() (interface{}, string, error) {
 			cfg := meta.(*config.Config)
 			region := cfg.GetRegion(d)
-			_, err := queryResourcePool(cfg, region, d)
+			res, err := queryResourcePool(cfg, region, d)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					var obj = map[string]string{"code": "COMPLETED"}
-					return obj, "COMPLETED", nil
+					res = map[string]string{"code": "COMPLETED"}
+					return res, "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err
 			}
 
-			return nil, "PENDING", nil
+			return res, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        30 * time.Second,
-		PollInterval: 20 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

modelarts resource pool support privilege resource pool

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 modelarts resource pool support privilege resource pool
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/modelarts/ TESTARGS='-run TestAccModelartsResourcePool_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts/ -v -run TestAccModelartsResourcePool_ -timeout 360m -parallel 4
=== RUN   TestAccModelartsResourcePool_basic
=== PAUSE TestAccModelartsResourcePool_basic
=== RUN   TestAccModelartsResourcePool_privilege_pool
=== PAUSE TestAccModelartsResourcePool_privilege_pool
=== CONT  TestAccModelartsResourcePool_basic
=== CONT  TestAccModelartsResourcePool_privilege_pool
--- PASS: TestAccModelartsResourcePool_basic (1152.08s)
--- PASS: TestAccModelartsResourcePool_privilege_pool (1788.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 1788.491s
```
