### PR TITLE
feat(eip): add data source global internet bandwidths

### DIFF
--- a/docs/data-sources/global_internet_bandwidths.md
+++ b/docs/data-sources/global_internet_bandwidths.md
@@ -1,0 +1,87 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# huaweicloud_global_internet_bandwidths
+
+Use this data source to get a list of global internet bandwidths.
+
+## Example Usage
+
+### Get all global internet bandwidths
+
+```hcl
+data "huaweicloud_global_internet_bandwidths" "all" {}
+```
+
+### Get specific global internet bandwidths
+
+```hcl
+data "huaweicloud_global_internet_bandwidths" "test" {
+  access_site = "cn-south-guangzhou"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bandwidth_id` - (Optional, String) Specifies the global internet bandwidth ID.
+
+* `name` - (Optional, String) Specifies the global internet bandwidth name.
+
+* `size` - (Optional, String) Specifies the global internet bandwidth size.
+
+* `access_site` - (Optional, String) Specifies the access site to which the global internet bandwidth belongs.
+
+* `type` - (Optional, String) Specifies the global internet bandwidth type.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the global internet bandwidth.
+
+* `status` - (Optional, String) Specifies the global internet bandwidth status. Valid values are **freezed** and **normal**.
+
+* `tags` - (Optional, Map) Specifies the global internet bandwidth tags.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `internet_bandwidths` - The global internet bandwidths list.
+  The [internet_bandwidths](#attrblock--internet_bandwidths) structure is documented below.
+
+<a name="attrblock--internet_bandwidths"></a>
+The `internet_bandwidths` block supports:
+
+* `id` - The global internet bandwidth ID.
+
+* `access_site` - The access site of the global internet bandwidth.
+
+* `isp` - The internet service provider of the global internet bandwidth.
+
+* `type` - The global internet bandwidth type.
+
+* `charge_mode` - The charge mode of the global internet bandwidth.
+
+* `size` - The global internet bandwidth size.
+
+* `name` - The global internet bandwidth name.
+
+* `enterprise_project_id` - The enterprise project ID of the global internet bandwidth.
+
+* `ingress_size` - The ingress size of the global internet bandwidth.
+
+* `ratio_95peak` - The enhanced 95% guaranteed rate of the global internet bandwidth.
+
+* `frozen_info` - The frozen info of the global internet bandwidth.
+
+* `status` - The status of the global internet bandwidth.
+
+* `tags` - The tags of the global internet bandwidth.
+
+* `description` - The description of the global internet bandwidth.
+
+* `created_at` - The create time of the global internet bandwidth.
+
+* `updated_at` - The update time of the global internet bandwidth.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -661,13 +661,14 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_tms_resource_types": tms.DataSourceResourceTypes(),
 
-			"huaweicloud_vpc_bandwidth":           eip.DataSourceBandWidth(),
-			"huaweicloud_vpc_bandwidths":          eip.DataSourceBandWidths(),
-			"huaweicloud_vpc_eip":                 eip.DataSourceVpcEip(),
-			"huaweicloud_vpc_eips":                eip.DataSourceVpcEips(),
-			"huaweicloud_vpc_internet_gateways":   eip.DataSourceVPCInternetGateways(),
-			"huaweicloud_global_eip_pools":        eip.DataSourceGlobalEIPPools(),
-			"huaweicloud_global_eip_access_sites": eip.DataSourceGlobalEIPAccessSites(),
+			"huaweicloud_vpc_bandwidth":              eip.DataSourceBandWidth(),
+			"huaweicloud_vpc_bandwidths":             eip.DataSourceBandWidths(),
+			"huaweicloud_vpc_eip":                    eip.DataSourceVpcEip(),
+			"huaweicloud_vpc_eips":                   eip.DataSourceVpcEips(),
+			"huaweicloud_vpc_internet_gateways":      eip.DataSourceVPCInternetGateways(),
+			"huaweicloud_global_eip_pools":           eip.DataSourceGlobalEIPPools(),
+			"huaweicloud_global_eip_access_sites":    eip.DataSourceGlobalEIPAccessSites(),
+			"huaweicloud_global_internet_bandwidths": eip.DataSourceGlobalInternetBandwidths(),
 
 			"huaweicloud_vpc":                    vpc.DataSourceVpcV1(),
 			"huaweicloud_vpcs":                   vpc.DataSourceVpcs(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_internet_bandwidths_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_internet_bandwidths_test.go
@@ -1,0 +1,165 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGlobalInternetBandwidths_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_global_internet_bandwidths.all"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalInternetBandwidthsDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "internet_bandwidths.#"),
+
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_size_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_access_site_filter_useful", "true"),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGlobalInternetBandwidthsDataSource_basic() string {
+	rNameWithDash := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_global_internet_bandwidths" "all" {
+  depends_on = [huaweicloud_global_internet_bandwidth.test]
+}
+
+// filter by ID
+data "huaweicloud_global_internet_bandwidths" "filter_by_id" {
+  bandwidth_id = huaweicloud_global_internet_bandwidth.test.id
+}
+
+locals {
+  filter_result_by_id = [for v in data.huaweicloud_global_internet_bandwidths.filter_by_id.internet_bandwidths[*].id : 
+    v == huaweicloud_global_internet_bandwidth.test.id]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.filter_result_by_id) == 1 && alltrue(local.filter_result_by_id) 
+}
+
+// filter by name
+data "huaweicloud_global_internet_bandwidths" "filter_by_name" {
+  name = huaweicloud_global_internet_bandwidth.test.name
+}
+
+locals {
+  filter_result_by_name = [for v in data.huaweicloud_global_internet_bandwidths.filter_by_name.internet_bandwidths[*].name : 
+    v == "%[2]s"]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.filter_result_by_name) > 0 && alltrue(local.filter_result_by_name) 
+}
+
+// filter by size
+data "huaweicloud_global_internet_bandwidths" "filter_by_size" {
+  size = huaweicloud_global_internet_bandwidth.test.size
+}
+
+locals {
+  filter_result_by_size = [for v in data.huaweicloud_global_internet_bandwidths.filter_by_size.internet_bandwidths[*].size : 
+    v == huaweicloud_global_internet_bandwidth.test.size]
+}
+
+output "is_size_filter_useful" {
+  value = length(local.filter_result_by_size) > 0 && alltrue(local.filter_result_by_size) 
+}
+
+// filter by access site
+data "huaweicloud_global_internet_bandwidths" "filter_by_access_site" {
+  access_site = huaweicloud_global_internet_bandwidth.test.access_site
+}
+
+locals {
+  filter_result_by_access_site = [for v in data.huaweicloud_global_internet_bandwidths.filter_by_access_site.internet_bandwidths[*].access_site : 
+    v == huaweicloud_global_internet_bandwidth.test.access_site]
+}
+
+output "is_access_site_filter_useful" {
+  value = length(local.filter_result_by_access_site) > 0 && alltrue(local.filter_result_by_access_site) 
+}
+
+// filter by type
+data "huaweicloud_global_internet_bandwidths" "filter_by_type" {
+  type = huaweicloud_global_internet_bandwidth.test.type
+}
+
+locals {
+  filter_result_by_type = [for v in data.huaweicloud_global_internet_bandwidths.filter_by_type.internet_bandwidths[*].type : 
+    v == huaweicloud_global_internet_bandwidth.test.type]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.filter_result_by_type) > 0 && alltrue(local.filter_result_by_type) 
+}
+
+// filter by status
+data "huaweicloud_global_internet_bandwidths" "filter_by_status" {
+  status = huaweicloud_global_internet_bandwidth.test.status
+}
+
+locals {
+  filter_result_by_status = [for v in data.huaweicloud_global_internet_bandwidths.filter_by_status.internet_bandwidths[*].status : 
+    v == huaweicloud_global_internet_bandwidth.test.status]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.filter_result_by_status) > 0 && alltrue(local.filter_result_by_status) 
+}
+
+// filter by eps ID
+data "huaweicloud_global_internet_bandwidths" "filter_by_eps_id" {
+  enterprise_project_id = huaweicloud_global_internet_bandwidth.test.enterprise_project_id
+}
+
+locals {
+  filter_result_by_eps_id = [for v in data.huaweicloud_global_internet_bandwidths.filter_by_eps_id.internet_bandwidths[*].enterprise_project_id : 
+    v == huaweicloud_global_internet_bandwidth.test.enterprise_project_id]
+}
+
+output "is_eps_id_filter_useful" {
+  value = length(local.filter_result_by_eps_id) > 0 && alltrue(local.filter_result_by_eps_id) 
+}
+
+// filter by tags
+data "huaweicloud_global_internet_bandwidths" "filter_by_tags" {
+  tags = huaweicloud_global_internet_bandwidth.test.tags
+}
+
+locals {
+  filter_result_by_tags = [for v in data.huaweicloud_global_internet_bandwidths.filter_by_tags.internet_bandwidths[*].tags : 
+    v == huaweicloud_global_internet_bandwidth.test.tags]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.filter_result_by_tags) > 0 && alltrue(local.filter_result_by_tags) 
+}
+`, testAccInternetBandwidth_basic(rNameWithDash), rNameWithDash)
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_internet_bandwidths.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_internet_bandwidths.go
@@ -1,0 +1,247 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/{domain_id}/geip/internet-bandwidths
+func DataSourceGlobalInternetBandwidths() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalInternetBandwidthsRead,
+
+		Schema: map[string]*schema.Schema{
+			"bandwidth_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"size": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"access_site": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"internet_bandwidths": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"access_site": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"isp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"charge_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ingress_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ratio_95peak": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"frozen_info": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGlobalInternetBandwidthsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	getInternetBandwidthsHttpUrl := "v3/{domain_id}/geip/internet-bandwidths"
+	getInternetBandwidthsPath := client.Endpoint + getInternetBandwidthsHttpUrl
+	getInternetBandwidthsPath = strings.ReplaceAll(getInternetBandwidthsPath, "{domain_id}", cfg.DomainID)
+	getInternetBandwidthsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getInternetBandwidthsPath += fmt.Sprintf("?limit=%v", pageLimit)
+	if id, ok := d.GetOk("bandwidth_id"); ok {
+		getInternetBandwidthsPath += fmt.Sprintf("&id=%s", id)
+	}
+	if size, ok := d.GetOk("size"); ok {
+		getInternetBandwidthsPath += fmt.Sprintf("&size=%s", size)
+	}
+	if name, ok := d.GetOk("name"); ok {
+		getInternetBandwidthsPath += fmt.Sprintf("&name=%s", name)
+	}
+	if accessSite, ok := d.GetOk("access_site"); ok {
+		getInternetBandwidthsPath += fmt.Sprintf("&access_site=%s", accessSite)
+	}
+	if bwType, ok := d.GetOk("type"); ok {
+		getInternetBandwidthsPath += fmt.Sprintf("&type=%s", bwType)
+	}
+	if status, ok := d.GetOk("status"); ok {
+		getInternetBandwidthsPath += fmt.Sprintf("&status=%s", status)
+	}
+	if epsID, ok := d.GetOk("enterprise_project_id"); ok {
+		getInternetBandwidthsPath += fmt.Sprintf("&enterprise_project_id=%s", epsID)
+	}
+	if rawTags, ok := d.GetOk("tags"); ok {
+		tagsList := expandTagsMapToStringList(rawTags.(map[string]interface{}))
+		for _, v := range tagsList {
+			getInternetBandwidthsPath += fmt.Sprintf("&tags=%s", v)
+		}
+	}
+
+	currentTotal := 0
+	results := make([]map[string]interface{}, 0)
+	for {
+		currentPath := getInternetBandwidthsPath + fmt.Sprintf("&offset=%d", currentTotal)
+		getInternetBandwidthsResp, err := client.Request("GET", currentPath, &getInternetBandwidthsOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		getInternetBandwidthsRespBody, err := utils.FlattenResponse(getInternetBandwidthsResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		bws := utils.PathSearch("internet_bandwidths", getInternetBandwidthsRespBody, make([]interface{}, 0)).([]interface{})
+		for _, bw := range bws {
+			results = append(results, map[string]interface{}{
+				"id":                    utils.PathSearch("id", bw, nil),
+				"access_site":           utils.PathSearch("access_site", bw, nil),
+				"isp":                   utils.PathSearch("isp", bw, nil),
+				"charge_mode":           utils.PathSearch("charge_mode", bw, nil),
+				"size":                  utils.PathSearch("size", bw, 0),
+				"ingress_size":          utils.PathSearch("ingress_size", bw, 0),
+				"description":           utils.PathSearch("description", bw, nil),
+				"name":                  utils.PathSearch("name", bw, nil),
+				"type":                  utils.PathSearch("type", bw, nil),
+				"enterprise_project_id": utils.PathSearch("enterprise_project_id", bw, nil),
+				"ratio_95peak":          utils.PathSearch("ratio_95peak", bw, 0),
+				"frozen_info":           utils.PathSearch("frozen_info", bw, nil),
+				"status":                utils.PathSearch("status", bw, nil),
+				"created_at":            utils.PathSearch("created_at", bw, nil),
+				"updated_at":            utils.PathSearch("updated_at", bw, nil),
+				"tags":                  utils.FlattenTagsToMap(utils.PathSearch("tags", bw, nil)),
+			})
+		}
+
+		// `current_count` means the number of `internet_banwidths` in this page, and the limit of page is `10`.
+		currentCount := utils.PathSearch("page_info.current_count", getInternetBandwidthsRespBody, float64(0))
+		if currentCount.(float64) < pageLimit {
+			break
+		}
+		currentTotal += len(bws)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("internet_bandwidths", results),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func expandTagsMapToStringList(tagMap map[string]interface{}) []string {
+	if len(tagMap) < 1 {
+		return nil
+	}
+
+	taglist := make([]string, 0)
+	for k, v := range tagMap {
+		tag := k + "|" + v.(string)
+		taglist = append(taglist, tag)
+	}
+
+	return taglist
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add `data.huaweicloud_global_internet_bandwidths`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGlobalInternetBandwidths_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGlobalInternetBandwidths_basic -timeout 360m -parallel 4
=== RUN   TestAccGlobalInternetBandwidths_basic
=== PAUSE TestAccGlobalInternetBandwidths_basic
=== CONT  TestAccGlobalInternetBandwidths_basic
--- PASS: TestAccGlobalInternetBandwidths_basic (64.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       64.469s
```
