### PR TITLE
feat(dws): add parameter lts_enable to support LTS

### DIFF
--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -124,6 +124,8 @@ The following arguments are supported:
 
 * `elb_id` - (Optional, String) Specifies the ID of the ELB load balancer.
 
+* `lts_enable` - (Optional, Bool) Specified whether to enable LTS. The default value is **false**.
+
 <a name="DwsCluster_PublicIp"></a>
 The `PublicIp` block supports:
 
@@ -267,7 +269,7 @@ $ terraform import huaweicloud_dws_cluster.test 47ad727e-9dcc-4833-bde0-bb298607
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `user_pwd`, `number_of_cn`, `kms_key_id`,
-`volume`, `dss_pool_id`, `logical_cluster_enable`.
+`volume`, `dss_pool_id`, `logical_cluster_enable`, `lts_enable`.
 It is generally recommended running `terraform plan` after importing a cluster.
 You can then decide if changes should be applied to the cluster, or the resource definition
 should be updated to align with the cluster. Also you can ignore changes as below.
@@ -278,7 +280,7 @@ resource "huaweicloud_dws_cluster" "test" {
 
   lifecycle {
     ignore_changes = [
-      user_pwd, number_of_cn, kms_key_id, volume, dss_pool_id, logical_cluster_enable
+      user_pwd, number_of_cn, kms_key_id, volume, dss_pool_id, logical_cluster_enable, lts_enable
     ]
   }
 }

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
@@ -155,7 +155,7 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDwsCluster_basicV2(name, 3, dws.PublicBindTypeAuto, "cluster123@!", "bar", 100),
+				Config: testAccDwsCluster_basicV2(name, 3, "cluster123@!", "bar", 100, true),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -167,7 +167,7 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDwsCluster_basicV2(name, 6, dws.PublicBindTypeAuto, "cluster123@!u", "cat", 150),
+				Config: testAccDwsCluster_basicV2(name, 6, "cluster123@!u", "cat", 150, false),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -182,7 +182,7 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"user_pwd", "number_of_cn", "volume", "endpoints"},
+				ImportStateVerifyIgnore: []string{"user_pwd", "number_of_cn", "volume", "endpoints", "lts_enable"},
 			},
 		},
 	})
@@ -229,7 +229,7 @@ func TestAccResourceCluster_basicV2_mutilAZs(t *testing.T) {
 		},
 	})
 }
-func testAccDwsCluster_basicV2(rName string, numberOfNode int, publicIpBindType, password, tag string, volumeCap int) string {
+func testAccDwsCluster_basicV2(rName string, numberOfNode int, password, tag string, volumeCap int, ltsEnable bool) string {
 	baseNetwork := common.TestBaseNetwork(rName)
 
 	return fmt.Sprintf(`
@@ -255,6 +255,7 @@ resource "huaweicloud_dws_cluster" "test" {
   user_pwd          = "%s"
   version           = data.huaweicloud_dws_flavors.test.flavors[0].datastore_version
   number_of_cn      = 3
+  lts_enable        = %v
 
   public_ip {
     public_bind_type = "%s"
@@ -270,7 +271,7 @@ resource "huaweicloud_dws_cluster" "test" {
     foo = "%s"
   }
 }
-`, baseNetwork, rName, numberOfNode, password, publicIpBindType, volumeCap, tag)
+`, baseNetwork, rName, numberOfNode, password, ltsEnable, dws.PublicBindTypeAuto, volumeCap, tag)
 }
 
 func testAccDwsCluster_basicV2_mutilAZs(rName string, numberOfNode int, publicIpBindType, password, tag string, volumeCap int) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add parameter lts_enable to support LTS.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
add parameter lts_enable to support LTS.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceCluster_basicV2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_basicV2 -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== RUN   TestAccResourceCluster_basicV2_mutilAZs
=== PAUSE TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV2
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
--- PASS: TestAccResourceCluster_basicV2_mutilAZs (1265.35s)
--- PASS: TestAccResourceCluster_basicV2 (2385.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       2385.722s

