### PR TITLE
fix(gaussdb): fix gaussdb cassandra datasource lint error

### DIFF
--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_cassandra_dedicated_resource_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_cassandra_dedicated_resource_test.go
@@ -1,13 +1,13 @@
 package gaussdb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccGeminiDBDehResourceDataSource_basic(t *testing.T) {
@@ -29,11 +29,11 @@ func testAccCheckGeminiDBDehResourceDataSourceID(n string) resource.TestCheckFun
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find GaussDB cassandra dedicated resource data source: %s ", n)
+			return fmt.Errorf("can't find GaussDB cassandra dedicated resource data source: %s ", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("GaussDB cassandra dedicated resource data source ID not set ")
+			return fmt.Errorf("the GaussDB cassandra dedicated resource data source ID not set ")
 		}
 
 		return nil

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_cassandra_flavors_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_cassandra_flavors_test.go
@@ -1,13 +1,13 @@
 package gaussdb
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccCassandraFlavorsDataSource_basic(t *testing.T) {
@@ -29,11 +29,11 @@ func testAccCheckCassandraFlavorsDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find GaussDB cassandra flavors data source: %s ", n)
+			return fmt.Errorf("can't find GaussDB cassandra flavors data source: %s ", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("GaussDB cassandra flavors data source ID not set ")
+			return fmt.Errorf("the GaussDB cassandra flavors data source ID not set ")
 		}
 
 		return nil

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_cassandra_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_cassandra_instance_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccGeminiDBInstanceDataSource_basic(t *testing.T) {
@@ -34,11 +33,11 @@ func testAccCheckGeminiDBInstanceDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find GaussDB cassandra instance data source: %s ", n)
+			return fmt.Errorf("can't find GaussDB cassandra instance data source: %s ", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("GaussDB cassandra instance data source ID not set ")
+			return fmt.Errorf("the GaussDB cassandra instance data source ID not set ")
 		}
 
 		return nil

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_cassandra_instances_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_cassandra_instances_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccGeminiDBInstancesDataSource_basic(t *testing.T) {
@@ -35,11 +34,11 @@ func testAccCheckGeminiDBInstancesDataSourceID(n string) resource.TestCheckFunc 
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find GaussDB cassandra instance data source: %s ", n)
+			return fmt.Errorf("can't find GaussDB cassandra instance data source: %s ", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("GaussDB cassandra instances data source ID not set ")
+			return fmt.Errorf("the GaussDB cassandra instances data source ID not set ")
 		}
 
 		return nil

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_cassandra_dedicated_resource.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_cassandra_dedicated_resource.go
@@ -1,19 +1,22 @@
 package gaussdb
 
 import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/geminidb/v3/instances"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 // @API GaussDBforNoSQL GET /v3/{project_id}/dedicated-resources
 func DataSourceGeminiDBDehResource() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceGeminiDBDehResourceRead,
+		ReadContext: dataSourceGeminiDBDehResourceRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -54,59 +57,61 @@ func DataSourceGeminiDBDehResource() *schema.Resource {
 	}
 }
 
-func dataSourceGeminiDBDehResourceRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.GeminiDBV3Client(region)
+func dataSourceGeminiDBDehResourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.GeminiDBV3Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
+		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
 	pages, err := instances.ListDeh(client).AllPages()
 	if err != nil {
-		return err
+		return diag.Errorf("error getting GaussDB cassandra dedicated list: %s", err)
 	}
 
 	allResources, err := instances.ExtractDehResources(pages)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve dedicated resources: %s", err)
+		return diag.Errorf("unable to retrieve dedicated resources: %s", err)
 	}
 
-	resource_name := d.Get("resource_name").(string)
+	resourceName := d.Get("resource_name").(string)
 	refinedResources := []instances.DehResource{}
 	for _, refResource := range allResources.Resources {
 		if refResource.EngineName != "cassandra" {
 			continue
 		}
-		if resource_name != "" && refResource.ResourceName != resource_name {
+		if resourceName != "" && refResource.ResourceName != resourceName {
 			continue
 		}
 		refinedResources = append(refinedResources, refResource)
 	}
 
 	if len(refinedResources) < 1 {
-		return fmtp.Errorf("Your query returned no results. " +
-			"Please change your search criteria and try again.")
+		return diag.Errorf("your query returned no results. " +
+			"please change your search criteria and try again.")
 	}
 
 	if len(refinedResources) > 1 {
-		return fmtp.Errorf("Your query returned more than one result." +
-			" Please try a more specific search criteria")
+		return diag.Errorf("your query returned more than one result." +
+			" please try a more specific search criteria")
 	}
 
 	resource := refinedResources[0]
 
-	logp.Printf("[DEBUG] Retrieved Resource %s: %+v", resource.Id, resource)
+	log.Printf("[DEBUG] Retrieved Resource %s: %+v", resource.Id, resource)
 	d.SetId(resource.Id)
 
-	d.Set("resource_name", resource.ResourceName)
-	d.Set("availability_zone", resource.AvailabilityZone)
-	d.Set("architecture", resource.Architecture)
-	d.Set("vcpus", resource.Capacity.Vcpus)
-	d.Set("ram", resource.Capacity.Ram)
-	d.Set("volume", resource.Capacity.Volume)
-	d.Set("status", resource.Status)
-	d.Set("region", region)
+	mErr := multierror.Append(
+		d.Set("resource_name", resource.ResourceName),
+		d.Set("availability_zone", resource.AvailabilityZone),
+		d.Set("architecture", resource.Architecture),
+		d.Set("vcpus", resource.Capacity.Vcpus),
+		d.Set("ram", resource.Capacity.Ram),
+		d.Set("volume", resource.Capacity.Volume),
+		d.Set("status", resource.Status),
+		d.Set("region", region),
+	)
 
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_cassandra_flavors.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_cassandra_flavors.go
@@ -2,6 +2,7 @@ package gaussdb
 
 import (
 	"context"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -11,8 +12,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 // @API GaussDBforNoSQL GET /v3.1/{project_id}/flavors
@@ -72,11 +71,11 @@ func DataSourceCassandraFlavors() *schema.Resource {
 }
 
 func dataSourceCassandraFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.GeminiDBV31Client(region)
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.GeminiDBV31Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud GaussDB client: %s", err)
+		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
 	listOpts := flavors.ListFlavorOpts{
@@ -85,12 +84,12 @@ func dataSourceCassandraFlavorsRead(_ context.Context, d *schema.ResourceData, m
 
 	pages, err := flavors.List(client, listOpts).AllPages()
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to list flavors: %s", err)
+		return diag.Errorf("unable to list flavors: %s", err)
 	}
 
 	allFlavors, err := flavors.ExtractFlavors(pages)
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to extract flavors: %s", err)
+		return diag.Errorf("unable to extract flavors: %s", err)
 	}
 
 	filter := map[string]interface{}{
@@ -101,9 +100,9 @@ func dataSourceCassandraFlavorsRead(_ context.Context, d *schema.ResourceData, m
 
 	filterFlavors, err := utils.FilterSliceWithField(allFlavors.Flavors, filter)
 	if err != nil {
-		return fmtp.DiagErrorf("filter Gaussdb cassandra flavors failed: %s", err)
+		return diag.Errorf("filter GaussDB cassandra flavors failed: %s", err)
 	}
-	logp.Printf("filter %d Gaussdb cassandra flavors from %d through options %v", len(filterFlavors), len(allFlavors.Flavors), filter)
+	log.Printf("[DEBUG] filter %d GaussDB cassandra flavors from %d through options %v", len(filterFlavors), len(allFlavors.Flavors), filter)
 
 	var flavorsToSet []map[string]interface{}
 	var flavorsIds []string

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_cassandra_instances.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_cassandra_instances.go
@@ -1,10 +1,13 @@
 package gaussdb
 
 import (
+	"context"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/common/tags"
@@ -13,15 +16,13 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 // @API GaussDBforNoSQL GET /v3/{project_id}/instances/{id}/tags
 // @API GaussDBforNoSQL GET /v3/{project_id}/instances
 func DataSourceGeminiDBInstances() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceGeminiDBInstancesRead,
+		ReadContext: dataSourceGeminiDBInstancesRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -195,12 +196,12 @@ func DataSourceGeminiDBInstances() *schema.Resource {
 	}
 }
 
-func dataSourceGeminiDBInstancesRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.GeminiDBV3Client(region)
+func dataSourceGeminiDBInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.GeminiDBV3Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud GaussDB client: %s", err)
+		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
 	listOpts := instances.ListGeminiDBInstanceOpts{
@@ -211,12 +212,12 @@ func dataSourceGeminiDBInstancesRead(d *schema.ResourceData, meta interface{}) e
 
 	pages, err := instances.List(client, listOpts).AllPages()
 	if err != nil {
-		return err
+		return diag.Errorf("error getting GaussDB Cassandra Instances list: %s", err)
 	}
 
 	allInstances, err := instances.ExtractGeminiDBInstances(pages)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve instances: %s", err)
+		return diag.Errorf("unable to retrieve instances: %s", err)
 	}
 
 	var instancesToSet []map[string]interface{}
@@ -291,7 +292,7 @@ func dataSourceGeminiDBInstancesRead(d *schema.ResourceData, meta interface{}) e
 		instanceID := instanceInAll.Id
 		instancesIds = append(instancesIds, instanceID)
 
-		//remove duplicate az
+		// remove duplicate az
 		azList = utils.RemoveDuplicateElem(azList)
 		sort.Strings(azList)
 		instanceToSet["availability_zone"] = strings.Join(azList, ",")
@@ -306,12 +307,12 @@ func dataSourceGeminiDBInstancesRead(d *schema.ResourceData, meta interface{}) e
 		backupStrategyList = append(backupStrategyList, backupStrategy)
 		instanceToSet["backup_strategy"] = backupStrategyList
 
-		//save geminidb tags
+		// save geminidb tags
 		if resourceTags, err := tags.Get(client, "instances", instanceID).Extract(); err == nil {
 			tagmap := utils.TagsToMap(resourceTags.Tags)
 			instanceToSet["tags"] = tagmap
 		} else {
-			logp.Printf("[WARN] Error fetching tags of geminidb (%s): %s", instanceID, err)
+			log.Printf("[WARN] error fetching tags of geminidb (%s): %s", instanceID, err)
 		}
 
 		instancesToSet = append(instancesToSet, instanceToSet)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: fix gaussdb cassandra datasource lint error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   region: cn-north-4
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGeminiDBDehResourceDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGeminiDBDehResourceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBDehResourceDataSource_basic
=== PAUSE TestAccGeminiDBDehResourceDataSource_basic
=== CONT  TestAccGeminiDBDehResourceDataSource_basic
--- PASS: TestAccGeminiDBDehResourceDataSource_basic (8.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   8.856s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccCassandraFlavorsDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccCassandraFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCassandraFlavorsDataSource_basic
=== PAUSE TestAccCassandraFlavorsDataSource_basic
=== CONT  TestAccCassandraFlavorsDataSource_basic
--- PASS: TestAccCassandraFlavorsDataSource_basic (15.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   15.046s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGeminiDBInstanceDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGeminiDBInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBInstanceDataSource_basic
=== PAUSE TestAccGeminiDBInstanceDataSource_basic
=== CONT  TestAccGeminiDBInstanceDataSource_basic
--- PASS: TestAccGeminiDBInstanceDataSource_basic (1308.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1308.406s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGeminiDBInstancesDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGeminiDBInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBInstancesDataSource_basic
=== PAUSE TestAccGeminiDBInstancesDataSource_basic
=== CONT  TestAccGeminiDBInstancesDataSource_basic
--- PASS: TestAccGeminiDBInstancesDataSource_basic (1287.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1287.768s
```
