### PR TITLE
feat(DCS): dcs supports ssl updated

### DIFF
--- a/docs/resources/dcs_instance.md
+++ b/docs/resources/dcs_instance.md
@@ -138,6 +138,8 @@ The following arguments are supported:
 * `security_group_id` - (Optional, String) The ID of the security group which the instance belongs to.
   This parameter is mandatory for Memcached and Redis 3.0 version.
 
+* `ssl_enable` - (Optional, Bool) Specifies whether to enable the SSL. Value options: **true**, **false**.
+
 * `private_ip` - (Optional, String, ForceNew) The IP address of the DCS instance,
   which can only be the currently available IP address the selected subnet.
   You can specify an available IP for the Redis instance (except for the Redis Cluster type).

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85
+	github.com/chnsz/golangsdk v0.0.0-20240227032415-74802e04042b
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85 h1:esf07r1+SPWoZeG7G3lHdNiyyvDs640qUKZTBDoqfzA=
-github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240227032415-74802e04042b h1:m7PoIvQXCSxYdkxxLHoTTfz4mrMGTUl2tnF3f4YBqb4=
+github.com/chnsz/golangsdk v0.0.0-20240227032415-74802e04042b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -94,6 +94,8 @@ var (
 // @API DCS POST /v2/{project_id}/instances
 // @API DCS GET /v2/{project_id}/instances/{id}/tags
 // @API DCS POST /v2/{project_id}/dcs/{id}/tags/action
+// @API DCS GET /v2/{project_id}/instances/{instance_id}/ssl
+// @API DCS PUT /v2/{project_id}/instances/{instance_id}/ssl
 func ResourceDcsInstance() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDcsInstancesCreate,
@@ -215,6 +217,11 @@ func ResourceDcsInstance() *schema.Resource {
 						},
 					},
 				},
+			},
+			"ssl_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
 			},
 			"maintain_begin": {
 				Type:         schema.TypeString,
@@ -544,6 +551,13 @@ func buildWhiteListParams(d *schema.ResourceData) whitelists.WhitelistOpts {
 	return whitelistOpts
 }
 
+func buildSslParam(enable bool) instances.SslOpts {
+	sslOpts := instances.SslOpts{
+		Enable: &enable,
+	}
+	return sslOpts
+}
+
 func waitForWhiteListCompleted(ctx context.Context, c *golangsdk.ServiceClient, d *schema.ResourceData) error {
 	enable := d.Get("whitelist_enable").(bool)
 	stateConf := &resource.StateChangeConf{
@@ -700,6 +714,19 @@ func resourceDcsInstancesCreate(ctx context.Context, d *schema.ResourceData, met
 			if err = restartDcsInstance(ctx, d.Timeout(schema.TimeoutCreate), client, id); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if sslEnabled := d.Get("ssl_enable").(bool); sslEnabled {
+		sslOpts := buildSslParam(sslEnabled)
+		_, err := instances.UpdateSsl(client, id, sslOpts)
+		if err != nil {
+			return diag.Errorf("error updating SSL for the instance (%s): %s", id, err)
+		}
+
+		err = waitForSslCompleted(ctx, client, d)
+		if err != nil {
+			return diag.Errorf("error waiting for updating SSL to complete: %s", err)
 		}
 	}
 
@@ -929,6 +956,7 @@ func resourceDcsInstancesRead(ctx context.Context, d *schema.ResourceData, meta 
 		d.Set("user_id", r.UserId),
 		d.Set("user_name", r.UserName),
 		d.Set("access_user", r.AccessUser),
+		d.Set("ssl_enable", r.EnableSsl),
 	)
 
 	if mErr.ErrorOrNil() != nil {
@@ -1148,6 +1176,21 @@ func resourceDcsInstancesUpdate(ctx context.Context, d *schema.ResourceData, met
 		}
 		if err := common.MigrateEnterpriseProject(ctx, cfg, d, migrateOpts); err != nil {
 			return diag.FromErr(err)
+		}
+	}
+
+	// update SSL
+	if d.HasChange("ssl_enable") {
+		sslOpts := buildSslParam(d.Get("ssl_enable").(bool))
+		_, err = instances.UpdateSsl(client, instanceId, sslOpts)
+		if err != nil {
+			return diag.Errorf("error updating SSL for the instance (%s): %s", instanceId, err)
+		}
+
+		// wait for SSL updated
+		err = waitForSslCompleted(ctx, client, d)
+		if err != nil {
+			return diag.Errorf("error waiting for updating SSL to complete: %s", err)
 		}
 	}
 
@@ -1453,4 +1496,28 @@ func getAvailableZoneCodeByID(client *golangsdk.ServiceClient, azIds []interface
 	}
 
 	return azCodes, nil
+}
+
+func waitForSslCompleted(ctx context.Context, c *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	enable := d.Get("ssl_enable").(bool)
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{strconv.FormatBool(!enable)},
+		Target:       []string{strconv.FormatBool(enable)},
+		Refresh:      updateSslStatusRefreshFunc(c, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        2 * time.Second,
+		PollInterval: 2 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func updateSslStatusRefreshFunc(c *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		r, err := instances.GetSsl(c, id)
+		if err != nil {
+			return nil, "Error", err
+		}
+		return r, strconv.FormatBool(r.Enable), nil
+	}
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
@@ -329,6 +329,35 @@ func Operation(c *golangsdk.ServiceClient, id, action string) (r OperationResult
 	return
 }
 
+type ResizeOpts struct {
+	FavorResize string             `json:"flavorResize" required:"true"`
+	ExtendParam *ResizeExtendParam `json:"extendParam,omitempty"`
+}
+
+type ResizeExtendParam struct {
+	DecMasterFlavor string `json:"decMasterFlavor,omitempty"`
+	IsAutoPay       string `json:"isAutoPay,omitempty"`
+}
+
+type ResizeResp struct {
+	JobID   string `json:"jobID"`
+	OrderID string `json:"orderID"`
+}
+
+func Resize(c *golangsdk.ServiceClient, id string, opts ResizeOpts) (ResizeResp, error) {
+	var r ResizeResp
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return r, err
+	}
+
+	_, err = c.Post(operationURL(c, id, "resize"), b, &r, &golangsdk.RequestOpts{
+		OkCodes:     []int{201},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return r, err
+}
+
 type UpdateTagsOpts struct {
 	Tags []tags.ResourceTag `json:"tags" required:"true"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/requests.go
@@ -272,3 +272,34 @@ func GetConfigurations(c *golangsdk.ServiceClient, instanceID string) (*Configur
 	}
 	return nil, err
 }
+
+type SslOpts struct {
+	Enable *bool `json:"enabled" required:"true"`
+}
+
+func UpdateSsl(client *golangsdk.ServiceClient, id string, opts SslOpts) (*golangsdk.Result, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r golangsdk.Result
+	_, err = client.Put(sslURL(client, id), b, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+func GetSsl(client *golangsdk.ServiceClient, id string) (*GetSslResponse, error) {
+	var rst golangsdk.Result
+	_, err := client.Get(sslURL(client, id), &rst.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200, 204},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r GetSslResponse
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/results.go
@@ -108,3 +108,12 @@ type RedisConfig struct {
 	SupportDataVersion string `json:"support_data_version"`
 	Customized         bool   `json:"customized"`
 }
+
+type GetSslResponse struct {
+	Enable       bool   `json:"enabled"`
+	Ip           string `json:"ip"`
+	SslValidated bool   `json:"ssl_validated"`
+	Port         string `json:"port"`
+	DomainName   string `json:"domain_name"`
+	SslExpiredAt string `json:"ssl_expired_at"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dcs/v2/instances/urls.go
@@ -29,3 +29,7 @@ func restartOrFlushInstanceURL(c *golangsdk.ServiceClient) string {
 func configurationsURL(c *golangsdk.ServiceClient, instancesId string) string {
 	return c.ServiceURL(c.ProjectID, "instances", instancesId, "configs")
 }
+
+func sslURL(client *golangsdk.ServiceClient, instancesId string) string {
+	return client.ServiceURL(client.ProjectID, "instances", instancesId, "ssl")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
@@ -189,6 +189,13 @@ type UpdateMetadataOpts struct {
 	RestoreHookTimeout int `json:"restore_hook_timeout,omitempty"`
 }
 
+type StrategyConfig struct {
+	Concurrency *int `json:"concurrency,omitempty"`
+	// The number of concurrent requests supported by single instance. The valid value range is 1 to 1000.
+	//  This parameter is only supported by the `v2` version of the function.
+	ConcurrencyNum *int `json:"concurrent_num,omitempty"`
+}
+
 type FuncLogConfig struct {
 	// Name of the log group bound to the function.
 	GroupName string `json:"group_name,omitempty"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
@@ -176,10 +176,6 @@ type FuncVpc struct {
 	Gateway    string `json:"gateway,omitempty"`
 }
 
-type StrategyConfig struct {
-	Concurrency *int `json:"concurrency"`
-}
-
 type commonResult struct {
 	golangsdk.Result
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240222124152-fe51ca385a85
+# github.com/chnsz/golangsdk v0.0.0-20240227032415-74802e04042b
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TESTARGS='-run TestAccDcsInstances'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v -run TestAccDcsInstances -timeout 360m -parallel 4
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_ha_change_capacity
=== PAUSE TestAccDcsInstances_ha_change_capacity
=== RUN   TestAccDcsInstances_ha_expand_replica
=== PAUSE TestAccDcsInstances_ha_expand_replica
=== RUN   TestAccDcsInstances_ha_to_proxy
=== PAUSE TestAccDcsInstances_ha_to_proxy
=== RUN   TestAccDcsInstances_rw_change_capacity
=== PAUSE TestAccDcsInstances_rw_change_capacity
=== RUN   TestAccDcsInstances_rw_expand_replica
=== PAUSE TestAccDcsInstances_rw_expand_replica
=== RUN   TestAccDcsInstances_rw_to_proxy
=== PAUSE TestAccDcsInstances_rw_to_proxy
=== RUN   TestAccDcsInstances_proxy_change_capacity
=== PAUSE TestAccDcsInstances_proxy_change_capacity
=== RUN   TestAccDcsInstances_proxy_to_ha
=== PAUSE TestAccDcsInstances_proxy_to_ha
=== RUN   TestAccDcsInstances_proxy_to_rw
=== PAUSE TestAccDcsInstances_proxy_to_rw
=== RUN   TestAccDcsInstances_cluster_change_capacity
=== PAUSE TestAccDcsInstances_cluster_change_capacity
=== RUN   TestAccDcsInstances_cluster_expand_replica
=== PAUSE TestAccDcsInstances_cluster_expand_replica
=== RUN   TestAccDcsInstances_withEpsId
=== PAUSE TestAccDcsInstances_withEpsId
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== RUN   TestAccDcsInstances_prePaid
=== PAUSE TestAccDcsInstances_prePaid
=== RUN   TestAccDcsInstances_ssl
=== PAUSE TestAccDcsInstances_ssl
=== CONT  TestAccDcsInstances_basic
=== CONT  TestAccDcsInstances_proxy_to_rw
=== CONT  TestAccDcsInstances_rw_expand_replica
=== CONT  TestAccDcsInstances_rw_change_capacity
--- PASS: TestAccDcsInstances_basic (211.95s)
=== CONT  TestAccDcsInstances_ssl
--- PASS: TestAccDcsInstances_rw_expand_replica (271.76s)
=== CONT  TestAccDcsInstances_prePaid
    acceptance.go:612: This environment does not support prepaid tests
--- SKIP: TestAccDcsInstances_prePaid (0.01s)
=== CONT  TestAccDcsInstances_single
--- PASS: TestAccDcsInstances_rw_change_capacity (308.10s)
=== CONT  TestAccDcsInstances_tiny
--- PASS: TestAccDcsInstances_ssl (176.87s)
=== CONT  TestAccDcsInstances_whitelists
--- PASS: TestAccDcsInstances_single (131.66s)
=== CONT  TestAccDcsInstances_withEpsId
    acceptance.go:425: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccDcsInstances_withEpsId (0.01s)
=== CONT  TestAccDcsInstances_cluster_expand_replica
--- PASS: TestAccDcsInstances_tiny (133.49s)
=== CONT  TestAccDcsInstances_cluster_change_capacity
--- PASS: TestAccDcsInstances_whitelists (180.13s)
=== CONT  TestAccDcsInstances_ha_expand_replica
--- PASS: TestAccDcsInstances_proxy_to_rw (646.78s)
=== CONT  TestAccDcsInstances_ha_to_proxy
--- PASS: TestAccDcsInstances_ha_expand_replica (253.38s)
=== CONT  TestAccDcsInstances_proxy_change_capacity
--- PASS: TestAccDcsInstances_cluster_expand_replica (473.71s)
=== CONT  TestAccDcsInstances_proxy_to_ha
--- PASS: TestAccDcsInstances_ha_to_proxy (552.39s)
=== CONT  TestAccDcsInstances_rw_to_proxy
--- PASS: TestAccDcsInstances_proxy_to_ha (667.89s)
=== CONT  TestAccDcsInstances_ha_change_capacity
--- PASS: TestAccDcsInstances_cluster_change_capacity (1114.05s)
--- PASS: TestAccDcsInstances_rw_to_proxy (565.32s)
--- PASS: TestAccDcsInstances_ha_change_capacity (318.15s)
--- PASS: TestAccDcsInstances_proxy_change_capacity (1737.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       2560.092s

```
