### PR TITLE
feat(DEW): add datasource to get the list of CSMS events

### DIFF
--- a/docs/data-sources/csms_events.md
+++ b/docs/data-sources/csms_events.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+---
+
+# huaweicloud_csms_events
+
+Use this data source to get the list of CSMS events.
+
+## Example Usage
+
+```hcl
+variable "event_name" {}
+
+data "huaweicloud_csms_events" "test" {
+  name = var.event_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the event.
+
+* `event_id` - (Optional, String) Specifies the ID of the event.
+
+* `status` - (Optional, String) Specifies the event status. Valid values are **ENABLED** and **DISABLED**.
+  Only the event in **ENABLED** status can be triggered.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `events` - Indicates the events list.
+  The [events](#CSMS_events) structure is documented below.
+
+<a name="CSMS_events"></a>
+The `events` block supports:
+
+* `name` - Indicates the event name.
+
+* `event_id` - The event ID.
+
+* `event_types` - Indicates the event type. Valid values are:
+  + **SECRET_VERSION_CREATED**: Triggered when a version of a secret is created.
+  + **SECRET_VERSION_EXPIRED**: Triggered when a secret version expires, and only once per expiration.
+  + **SECRET_ROTATED**: Triggered when a secret is rotated. Currently, only RDS secrets can be automatically rotated.
+  + **SECRET_DELETED**: Triggered when a secret is deleted.
+
+* `status` - Indicates the event status.
+
+* `created_at` - Indicates the time when the event created, in UTC format.
+
+* `updated_at` - Indicates the time when the event updated, in UTC format.
+
+* `notification` - Indicates the event notification list.
+  The [notification](#notification) structure is documented below.
+
+<a name="notification"></a>
+The `notification` block supports:
+* `target_type` - Indicates the object type of the event notification.
+* `target_id` - Indicates the object ID of the event notification.
+* `target_name` - Indicates the object name of the event notification.

--- a/docs/data-sources/csms_events.md
+++ b/docs/data-sources/csms_events.md
@@ -63,6 +63,7 @@ The `events` block supports:
 
 <a name="notification"></a>
 The `notification` block supports:
+
 * `target_type` - Indicates the object type of the event notification.
 * `target_id` - Indicates the object ID of the event notification.
 * `target_name` - Indicates the object name of the event notification.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -451,6 +451,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cph_phone_images":   cph.DataSourcePhoneImages(),
 
 			"huaweicloud_csms_secret_version": dew.DataSourceDewCsmsSecret(),
+			"huaweicloud_csms_events":         dew.DataSourceDewCsmsEvents(),
 			"huaweicloud_css_flavors":         css.DataSourceCssFlavors(),
 
 			"huaweicloud_dataarts_studio_workspaces":                  dataarts.DataSourceDataArtsStudioWorkspaces(),

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_events_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_events_test.go
@@ -1,0 +1,95 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCsmsEvents_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_csms_events.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCsmsEvents_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "events.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "events.0.event_id"),
+					resource.TestCheckResourceAttrSet(rName, "events.0.event_types.#"),
+					resource.TestCheckResourceAttrSet(rName, "events.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "events.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "events.0.updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "events.0.notification.#"),
+
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("eventId_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCsmsEvents_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_csms_events" "test" {
+  depends_on = [huaweicloud_csms_event.test]
+}
+
+data "huaweicloud_csms_events" "name_filter" {
+  name = huaweicloud_csms_event.test.name
+}
+
+locals {
+  name = huaweicloud_csms_event.test.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_csms_events.name_filter.events) > 0 && alltrue(
+    [for v in data.huaweicloud_csms_events.name_filter.events[*].name : v == local.name]
+  )
+}
+
+data "huaweicloud_csms_events" "eventId_filter" {
+  event_id = huaweicloud_csms_event.test.event_id
+}
+
+locals {
+  event_id = huaweicloud_csms_event.test.event_id
+}
+
+output "eventId_filter_is_useful" {
+  value = length(data.huaweicloud_csms_events.eventId_filter.events) > 0 && alltrue(
+    [for v in data.huaweicloud_csms_events.eventId_filter.events[*].event_id : v == 
+  local.event_id]
+  )  
+}
+
+data "huaweicloud_csms_events" "status_filter" {
+  status = huaweicloud_csms_event.test.status
+}
+
+locals {
+  status = huaweicloud_csms_event.test.status
+}
+
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_csms_events.status_filter.events) > 0 && alltrue(
+    [for v in data.huaweicloud_csms_events.status_filter.events[*].status : v == local.status]
+  )
+}
+`, testCsmsEvent_basic(name))
+}

--- a/huaweicloud/services/dew/data_source_huaweicloud_csms_events.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_csms_events.go
@@ -1,0 +1,245 @@
+package dew
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/{project_id}/csms/events
+func DataSourceDewCsmsEvents() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceDewCsmsEventsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"event_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"events": {
+				Type:     schema.TypeList,
+				Elem:     eventsSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func eventsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"event_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"event_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"notification": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     notificationSchema(),
+			},
+		},
+	}
+	return &sc
+}
+
+func notificationSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"target_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDewCsmsEventsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		listEventsHttpUrl = "v1/{project_id}/csms/events"
+		listEventsProduct = "kms"
+	)
+	listEventsClient, err := cfg.NewServiceClient(listEventsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	listEventsPath := listEventsClient.Endpoint + listEventsHttpUrl
+	listEventsPath = strings.ReplaceAll(listEventsPath, "{project_id}", listEventsClient.ProjectID)
+
+	listEventsResp, err := pagination.ListAllItems(
+		listEventsClient,
+		"marker",
+		listEventsPath,
+		&pagination.QueryOpts{MarkerField: "name"})
+
+	if err != nil {
+		return diag.Errorf("error retrieving CSMS events: %s", err)
+	}
+
+	listEventsRespJson, err := json.Marshal(listEventsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listEventsRespBody interface{}
+	err = json.Unmarshal(listEventsRespJson, &listEventsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("events", filterListEventsBody(
+			flattenListEventsBody(listEventsRespBody), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListEventsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("events", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		createAt := utils.PathSearch("create_time", v, float64(0))
+		updateAt := utils.PathSearch("update_time", v, float64(0))
+		rst = append(rst, map[string]interface{}{
+			"name":         utils.PathSearch("name", v, nil),
+			"event_id":     utils.PathSearch("event_id", v, nil),
+			"event_types":  utils.PathSearch("event_types", v, nil),
+			"status":       utils.PathSearch("state", v, nil),
+			"created_at":   utils.FormatTimeStampRFC3339(int64(createAt.(float64))/1000, false),
+			"updated_at":   utils.FormatTimeStampRFC3339(int64(updateAt.(float64))/1000, false),
+			"notification": flattenNotification(v),
+		})
+	}
+	return rst
+}
+
+func filterListEventsBody(all []interface{}, d *schema.ResourceData) []interface{} {
+	name := d.Get("name").(string)
+	eventId := d.Get("event_id").(string)
+	status := d.Get("status").(string)
+
+	if name == "" && eventId == "" && status == "" {
+		return all
+	}
+
+	rst := make([]interface{}, 0, len(all))
+
+	for _, v := range all {
+		if name != fmt.Sprint(utils.PathSearch("name", v, nil)) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	for _, v := range all {
+		if eventId != fmt.Sprint(utils.PathSearch("event_id", v, nil)) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	for _, v := range all {
+		if status != fmt.Sprint(utils.PathSearch("status", v, nil)) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func flattenNotification(resp interface{}) []interface{} {
+	var rst []interface{}
+	curJson, err := jmespath.Search("notification", resp)
+	if err != nil {
+		log.Printf("[ERROR] Error parsing notification from response= %#v", resp)
+		return rst
+	}
+	if curJson == nil {
+		return nil
+	}
+
+	rst = []interface{}{
+		map[string]interface{}{
+			"target_type": utils.PathSearch("target_type", curJson, nil),
+			"target_id":   utils.PathSearch("target_id", curJson, nil),
+			"target_name": utils.PathSearch("target_name", curJson, nil),
+		},
+	}
+	return rst
+}

--- a/huaweicloud/services/dew/data_source_huaweicloud_csms_events.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_csms_events.go
@@ -186,34 +186,19 @@ func flattenListEventsBody(resp interface{}) []interface{} {
 }
 
 func filterListEventsBody(all []interface{}, d *schema.ResourceData) []interface{} {
-	name := d.Get("name").(string)
-	eventId := d.Get("event_id").(string)
-	status := d.Get("status").(string)
-
-	if name == "" && eventId == "" && status == "" {
-		return all
-	}
-
 	rst := make([]interface{}, 0, len(all))
 
 	for _, v := range all {
-		if name != fmt.Sprint(utils.PathSearch("name", v, nil)) {
+		if param, ok := d.GetOk("name"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("name", v, nil)) {
 			continue
 		}
-
-		rst = append(rst, v)
-	}
-
-	for _, v := range all {
-		if eventId != fmt.Sprint(utils.PathSearch("event_id", v, nil)) {
+		if param, ok := d.GetOk("event_id"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("event_id", v, nil)) {
 			continue
 		}
-
-		rst = append(rst, v)
-	}
-
-	for _, v := range all {
-		if status != fmt.Sprint(utils.PathSearch("status", v, nil)) {
+		if param, ok := d.GetOk("status"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("status", v, nil)) {
 			continue
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add datasource to get the list of CSMS events

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dew/' TESTARGS='-run TestAccDatasourceCsmsEvents_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew/ -v -run TestAccDatasourceCsmsEvents_basic -timeout 360m -parallel 4 
=== RUN   TestAccDatasourceCsmsEvents_basic 
=== PAUSE TestAccDatasourceCsmsEvents_basic
=== CONT  TestAccDatasourceCsmsEvents_basic
--- PASS: TestAccDatasourceCsmsEvents_basic (50.14s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       50.183s
```
