### PR TITLE
fix(gaussdb): fix gaussdb nosql/opengauss/redis datasource lint error

### DIFF
--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors_test.go
@@ -1,7 +1,6 @@
 package gaussdb
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -163,13 +162,13 @@ func TestAccGaussDBNoSQLFlavors_az(t *testing.T) {
 }
 
 func testAccGaussDBNoSQLFlavors_default() string {
-	return fmt.Sprintf(`
+	return (`
 data "huaweicloud_gaussdb_nosql_flavors" "test" {}
 `)
 }
 
 func testAccGaussDBNoSQLFlavors_cassandra() string {
-	return fmt.Sprintf(`
+	return (`
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
   engine = "cassandra"
 }
@@ -177,7 +176,7 @@ data "huaweicloud_gaussdb_nosql_flavors" "test" {
 }
 
 func testAccGaussDBNoSQLFlavors_mongodb() string {
-	return fmt.Sprintf(`
+	return (`
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
   engine = "mongodb"
 }
@@ -185,7 +184,7 @@ data "huaweicloud_gaussdb_nosql_flavors" "test" {
 }
 
 func testAccGaussDBNoSQLFlavors_influxdb() string {
-	return fmt.Sprintf(`
+	return (`
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
   engine = "influxdb"
 }
@@ -193,7 +192,7 @@ data "huaweicloud_gaussdb_nosql_flavors" "test" {
 }
 
 func testAccGaussDBNoSQLFlavors_redis() string {
-	return fmt.Sprintf(`
+	return (`
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
   engine = "redis"
 }
@@ -201,7 +200,7 @@ data "huaweicloud_gaussdb_nosql_flavors" "test" {
 }
 
 func testAccGaussDBNoSQLFlavors_vcpus() string {
-	return fmt.Sprintf(`
+	return (`
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
   vcpus = 4
 }
@@ -209,7 +208,7 @@ data "huaweicloud_gaussdb_nosql_flavors" "test" {
 }
 
 func testAccGaussDBNoSQLFlavors_memory() string {
-	return fmt.Sprintf(`
+	return (`
 data "huaweicloud_gaussdb_nosql_flavors" "test" {
   memory = 8
 }
@@ -217,7 +216,7 @@ data "huaweicloud_gaussdb_nosql_flavors" "test" {
 }
 
 func testAccGaussDBNoSQLFlavors_az() string {
-	return fmt.Sprintf(`
+	return (`
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_gaussdb_nosql_flavors" "test" {

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instance_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccOpenGaussInstanceDataSource_basic(t *testing.T) {
@@ -58,11 +57,11 @@ func testAccCheckOpenGaussInstanceDataSourceID(n string) resource.TestCheckFunc 
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find GaussDB opengauss instance data source: %s ", n)
+			return fmt.Errorf("can't find GaussDB opengauss instance data source: %s ", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("GaussDB opengauss data source ID not set ")
+			return fmt.Errorf("the GaussDB opengauss data source ID not set ")
 		}
 
 		return nil

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccOpenGaussInstancesDataSource_basic(t *testing.T) {
@@ -60,11 +59,11 @@ func testAccCheckOpenGaussInstancesDataSourceID(n string) resource.TestCheckFunc
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find GaussDB opengauss instances data source: %s ", n)
+			return fmt.Errorf("can't find GaussDB opengauss instances data source: %s ", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("GaussDB opengauss data source ID not set ")
+			return fmt.Errorf("the GaussDB opengauss data source ID not set ")
 		}
 
 		return nil

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_redis_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_redis_instance_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func TestAccGaussRedisInstanceDataSource_basic(t *testing.T) {
@@ -34,11 +33,11 @@ func testAccCheckGaussRedisInstanceDataSourceID(n string) resource.TestCheckFunc
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmtp.Errorf("Can't find GaussDB Redis instance data source: %s ", n)
+			return fmt.Errorf("can't find GaussDB Redis instance data source: %s ", n)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmtp.Errorf("GaussDB Redis instance data source ID not set ")
+			return fmt.Errorf("the GaussDB Redis instance data source ID not set ")
 		}
 
 		return nil

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances.go
@@ -13,7 +13,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 // @API GaussDB GET /v3/{project_id}/instances
@@ -229,12 +228,12 @@ func DataSourceOpenGaussInstances() *schema.Resource {
 	}
 }
 
-func dataSourceOpenGaussInstancesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.OpenGaussV3Client(region)
+func dataSourceOpenGaussInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.OpenGaussV3Client(region)
 	if err != nil {
-		return fmtp.DiagErrorf("Error creating HuaweiCloud GaussDB client: %s", err)
+		return diag.Errorf("error creating GaussDB client: %s", err)
 	}
 
 	listOpts := instances.ListGaussDBInstanceOpts{
@@ -245,12 +244,12 @@ func dataSourceOpenGaussInstancesRead(ctx context.Context, d *schema.ResourceDat
 
 	pages, err := instances.List(client, listOpts).AllPages()
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to list instances: %s", err)
+		return diag.Errorf("unable to list instances: %s", err)
 	}
 
 	allInstances, err := instances.ExtractGaussDBInstances(pages)
 	if err != nil {
-		return fmtp.DiagErrorf("Unable to retrieve instances: %s", err)
+		return diag.Errorf("unable to retrieve instances: %s", err)
 	}
 
 	var instancesToSet []map[string]interface{}
@@ -280,12 +279,12 @@ func dataSourceOpenGaussInstancesRead(ctx context.Context, d *schema.ResourceDat
 		instancesIds = append(instancesIds, instanceID)
 
 		if len(instanceInAll.PrivateIps) > 0 {
-			private_ips := instanceInAll.PrivateIps[0]
-			ip_list := strings.Split(private_ips, "/")
-			for i := 0; i < len(ip_list); i++ {
-				ip_list[i] = strings.Trim(ip_list[i], " ")
+			privateIps := instanceInAll.PrivateIps[0]
+			ipList := strings.Split(privateIps, "/")
+			for i := 0; i < len(ipList); i++ {
+				ipList[i] = strings.Trim(ipList[i], " ")
 			}
-			instanceToSet["private_ips"] = ip_list
+			instanceToSet["private_ips"] = ipList
 		}
 
 		// set data store

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_redis_instance.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_redis_instance.go
@@ -1,10 +1,14 @@
 package gaussdb
 
 import (
+	"context"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk/openstack/common/tags"
@@ -12,15 +16,13 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
 // @API GaussDBforNoSQL GET /v3/{project_id}/instances/{id}/tags
 // @API GaussDBforNoSQL GET /v3/{project_id}/instances
 func DataSourceGaussRedisInstance() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceGaussRedisInstanceRead,
+		ReadContext: dataSourceGaussRedisInstanceRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -170,12 +172,12 @@ func DataSourceGaussRedisInstance() *schema.Resource {
 	}
 }
 
-func dataSourceGaussRedisInstanceRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	region := config.GetRegion(d)
-	client, err := config.GeminiDBV3Client(region)
+func dataSourceGaussRedisInstanceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.GeminiDBV3Client(region)
 	if err != nil {
-		return fmtp.Errorf("Error creating HuaweiCloud GaussDB for Redis client: %s", err)
+		return diag.Errorf("error creating GaussDB for Redis client: %s", err)
 	}
 
 	listOpts := instances.ListGeminiDBInstanceOpts{
@@ -186,38 +188,40 @@ func dataSourceGaussRedisInstanceRead(d *schema.ResourceData, meta interface{}) 
 
 	pages, err := instances.List(client, listOpts).AllPages()
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	allInstances, err := instances.ExtractGeminiDBInstances(pages)
 	if err != nil {
-		return fmtp.Errorf("Unable to retrieve instances: %s", err)
+		return diag.Errorf("unable to retrieve instances: %s", err)
 	}
 
 	if allInstances.TotalCount < 1 {
-		return fmtp.Errorf("Your query returned no results. " +
-			"Please change your search criteria and try again.")
+		return diag.Errorf("your query returned no results. " +
+			"please change your search criteria and try again.")
 	}
 
 	if allInstances.TotalCount > 1 {
-		return fmtp.Errorf("Your query returned more than one result." +
-			" Please try a more specific search criteria")
+		return diag.Errorf("your query returned more than one result." +
+			" please try a more specific search criteria")
 	}
 
 	instance := allInstances.Instances[0]
 
-	logp.Printf("[DEBUG] Retrieved Instance %s: %+v", instance.Id, instance)
+	log.Printf("[DEBUG] retrieved instance %s: %+v", instance.Id, instance)
 	d.SetId(instance.Id)
 
-	d.Set("region", instance.Region)
-	d.Set("name", instance.Name)
-	d.Set("vpc_id", instance.VpcId)
-	d.Set("subnet_id", instance.SubnetId)
-	d.Set("status", instance.Status)
-	d.Set("mode", instance.Mode)
-	d.Set("security_group_id", instance.SecurityGroupId)
-	d.Set("enterprise_project_id", instance.EnterpriseProjectId)
-	d.Set("db_user_name", instance.DbUserName)
+	mErr := multierror.Append(
+		d.Set("region", instance.Region),
+		d.Set("name", instance.Name),
+		d.Set("vpc_id", instance.VpcId),
+		d.Set("subnet_id", instance.SubnetId),
+		d.Set("status", instance.Status),
+		d.Set("mode", instance.Mode),
+		d.Set("security_group_id", instance.SecurityGroupId),
+		d.Set("enterprise_project_id", instance.EnterpriseProjectId),
+		d.Set("db_user_name", instance.DbUserName),
+	)
 
 	if dbPort, err := strconv.Atoi(instance.Port); err == nil {
 		d.Set("port", dbPort)
@@ -263,7 +267,7 @@ func dataSourceGaussRedisInstanceRead(d *schema.ResourceData, meta interface{}) 
 			d.Set("volume_size", volSize)
 		}
 		if specCode != "" {
-			logp.Printf("[DEBUG] Node SpecCode: %s", specCode)
+			log.Printf("[DEBUG] node specCode: %s", specCode)
 			d.Set("flavor", specCode)
 		}
 	}
@@ -288,11 +292,11 @@ func dataSourceGaussRedisInstanceRead(d *schema.ResourceData, meta interface{}) 
 	if resourceTags, err := tags.Get(client, "instances", d.Id()).Extract(); err == nil {
 		tagmap := utils.TagsToMap(resourceTags.Tags)
 		if err := d.Set("tags", tagmap); err != nil {
-			return fmtp.Errorf("Error saving tags to state for geminidb (%s): %s", d.Id(), err)
+			return diag.Errorf("error saving tags to state for geminidb (%s): %s", d.Id(), err)
 		}
 	} else {
-		logp.Printf("[WARN] Error fetching tags of geminidb (%s): %s", d.Id(), err)
+		log.Printf("[WARN] error fetching tags of geminidb (%s): %s", d.Id(), err)
 	}
 
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: fix gaussdb nosql/opengauss/redis datasource lint error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. region = cn-north-4.
2. run redis instance with volume_size = 16.
3. due to security group rules partial deletion, not run automatic execution opengauss instance and opengauss instances.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_basic
=== PAUSE TestAccGaussDBNoSQLFlavors_basic
=== CONT  TestAccGaussDBNoSQLFlavors_basic
--- PASS: TestAccGaussDBNoSQLFlavors_basic (25.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   25.618s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_mongodb"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_mongodb -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_mongodb
=== PAUSE TestAccGaussDBNoSQLFlavors_mongodb
=== CONT  TestAccGaussDBNoSQLFlavors_mongodb
--- PASS: TestAccGaussDBNoSQLFlavors_mongodb (17.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   17.481s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_influxdb"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_influxdb -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_influxdb
=== PAUSE TestAccGaussDBNoSQLFlavors_influxdb
=== CONT  TestAccGaussDBNoSQLFlavors_influxdb
--- PASS: TestAccGaussDBNoSQLFlavors_influxdb (23.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   23.152s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_redis"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_redis -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_redis
=== PAUSE TestAccGaussDBNoSQLFlavors_redis
=== CONT  TestAccGaussDBNoSQLFlavors_redis
--- PASS: TestAccGaussDBNoSQLFlavors_redis (22.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   22.189s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_vcpus"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_vcpus -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_vcpus
=== PAUSE TestAccGaussDBNoSQLFlavors_vcpus
=== CONT  TestAccGaussDBNoSQLFlavors_vcpus
--- PASS: TestAccGaussDBNoSQLFlavors_vcpus (13.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   13.735s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_memory"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_memory -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_memory
=== PAUSE TestAccGaussDBNoSQLFlavors_memory
=== CONT  TestAccGaussDBNoSQLFlavors_memory
--- PASS: TestAccGaussDBNoSQLFlavors_memory (13.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   13.715s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_az"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_az -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_az
=== PAUSE TestAccGaussDBNoSQLFlavors_az
=== CONT  TestAccGaussDBNoSQLFlavors_az
--- PASS: TestAccGaussDBNoSQLFlavors_az (19.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   19.536s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussRedisInstanceDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussRedisInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussRedisInstanceDataSource_basic
=== PAUSE TestAccGaussRedisInstanceDataSource_basic
=== CONT  TestAccGaussRedisInstanceDataSource_basic
--- PASS: TestAccGaussRedisInstanceDataSource_basic (1361.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1361.529s
```
