### PR TITLE
fix(evs): Add test cases to test whether common.WaitOrderAllResourceComplete is successful

### DIFF
--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -305,7 +305,7 @@ func resourceEvsVolumeCreate(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.Errorf("the order is not completed while creating EVS volume (%s): %#v", d.Id(), err)
 		}
-		_, err = common.WaitOrderResourceComplete(ctx, bssClient, job.OrderID, d.Timeout(schema.TimeoutCreate))
+		_, err = common.WaitOrderAllResourceComplete(ctx, bssClient, job.OrderID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
+ Add test cases to test whether common.WaitOrderAllResourceComplete is successful.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
+ You need to set the server_id for evs to bind evs to ecs, and the charging_mode of both evs and ecs must be prePaid.
+  New public method common.WaitOrderAllResourceCompletecan succeed regardless of whether ecs is bound to ecs or not.
+ When expanding the capacity of evs, the public method common.WaitOrderAllResourceCompletecan also succeed.
+ The original prePaid test case is no longer applicable and is replaced with the new test case testAccEvsVolume_prePaid_withoutServerId.
+ The test case fails before replaced by the new public method:
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/106511595/60ead845-8518-45f6-b988-46a81f7e3b58)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccEvsVolume_prePaid_withoutServerId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_prePaid_withoutServerId -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_prePaid_withoutServerId
=== PAUSE TestAccEvsVolume_prePaid_withoutServerId
=== CONT  TestAccEvsVolume_prePaid_withoutServerId
--- PASS: TestAccEvsVolume_prePaid_withoutServerId (187.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       187.242s
make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccEvsVolume_prePaid_withServerId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolume_prePaid_serverId -timeout 360m -parallel 4
=== RUN   TestAccEvsVolume_prePaid_withServerId
=== PAUSE TestAccEvsVolume_prePaid_withServerId
=== CONT  TestAccEvsVolume_prePaid_withServerId
--- PASS: TestAccEvsVolume_prePaid_withServerId (660.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       660.670s
```
