### PR TITLE
feat(eip): add data source global eips

### DIFF
--- a/docs/data-sources/global_eips.md
+++ b/docs/data-sources/global_eips.md
@@ -1,0 +1,111 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# huaweicloud_global_eips
+
+Use this data source to get the list of global EIPs.
+
+## Example Usage
+
+### Get all global EIPs
+
+```hcl
+data "huaweicloud_global_eips" "all" {}
+```
+
+### Get specific global EIPs
+
+```hcl
+data "huaweicloud_global_eips" "test" {
+  status = "inuse"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `geip_id` - (Optional, String) Specifies the GEIP ID.
+
+* `internet_bandwidth_id` - (Optional, String) Specifies the global internet bandwidth ID which the GEIP associates to.
+
+* `ip_address` - (Optional, String) Specifies the GEIP IP address.
+
+* `name` - (Optional, String) Specifies the GEIP name.
+
+* `status` - (Optional, String) Specifies the GEIP status.
+  
+  Valid valus are as follows:
+  + **idle**: Not associates with instance.
+  + **inuse**: Associates with instance.
+  + **pending_create**: Creating.
+  + **pending_update**: Updating.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the GEIP.
+
+* `tags` - (Optional, Map) Specifies the tags of the GEIP.
+
+* `associate_instance_id` - (Optional, String) Specifies the instance ID which the GEIP associates to.
+
+* `associate_instance_type` - (Optional, String) Specifies the type of instance which the GEIP associates to.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `global_eips` - The GEIP list.
+  The [global_eips](#attrblock--global_eips) structure is documented below.
+
+<a name="attrblock--global_eips"></a>
+The `global_eips` block supports:
+
+* `id` - The GEIP ID.
+
+* `access_site` - The access site name.
+
+* `geip_pool_name` - The GEIP pool name.
+
+* `internet_bandwidth_id` - The global internet bandwidth ID which the GEIP associates to.
+
+* `ip_address` - The IP address of GEIP.
+
+* `ip_version` - The IP version of GEIP.
+
+* `isp` - The the internet service provider of the global EIP.
+
+* `name` - The GEIP name.
+
+* `enterprise_project_id` - The enterprise project ID of GEIP.
+
+* `status` - The status of GEIP.
+
+* `polluted` - The global EIP is polluted or not.
+
+* `description` - The description of GEIP.
+
+* `tags` - The tags of GEIP.
+
+* `global_connection_bandwidth_id` - The ID of the global connection bandwidth.
+
+* `global_connection_bandwidth_type` - The type of the global connection bandwidth.
+
+* `associate_instance_region` - The region of the associate instance.
+
+* `associate_instance_id` - The ID of the associate instance.
+
+* `associate_instance_type` - The type of the associate instance.
+
+* `frozen` - The global EIP is frozen or not.
+
+* `frozen_info` - The frozen info of the global EIP.
+
+* `polluted` - The global EIP is polluted or not.
+
+* `status` - The status of the global EIP.
+
+* `created_at` - The create time of the global EIP.
+
+* `updated_at` - The update time of the global EIP.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -672,6 +672,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_global_eip_pools":           eip.DataSourceGlobalEIPPools(),
 			"huaweicloud_global_eip_access_sites":    eip.DataSourceGlobalEIPAccessSites(),
 			"huaweicloud_global_internet_bandwidths": eip.DataSourceGlobalInternetBandwidths(),
+			"huaweicloud_global_eips":                eip.DataSourceGlobalEIPs(),
 
 			"huaweicloud_vpc":                    vpc.DataSourceVpcV1(),
 			"huaweicloud_vpcs":                   vpc.DataSourceVpcs(),

--- a/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eips_test.go
+++ b/huaweicloud/services/acceptance/eip/data_source_huaweicloud_global_eips_test.go
@@ -1,0 +1,148 @@
+package eip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGlobalEIPs_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_global_eips.all"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGlobalEIPsDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "global_eips.#"),
+
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_internet_bandwidth_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					resource.TestCheckOutput("is_ip_address_filter_useful", "true"),
+					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGlobalEIPsDataSource_basic() string {
+	rNameWithDash := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_global_eips" "all" {
+  depends_on = [huaweicloud_global_eip.test]
+}
+
+// filter by ID
+data "huaweicloud_global_eips" "filter_by_id" {
+  geip_id = huaweicloud_global_eip.test.id
+}
+
+locals {
+  filter_result_by_id = [for v in data.huaweicloud_global_eips.filter_by_id.global_eips[*].id : 
+    v == huaweicloud_global_eip.test.id]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.filter_result_by_id) == 1 && alltrue(local.filter_result_by_id) 
+}
+
+// filter by name
+data "huaweicloud_global_eips" "filter_by_name" {
+  name = huaweicloud_global_eip.test.name
+}
+
+locals {
+  filter_result_by_name = [for v in data.huaweicloud_global_eips.filter_by_name.global_eips[*].name : 
+    v == "%[2]s"]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.filter_result_by_name) > 0 && alltrue(local.filter_result_by_name) 
+}
+
+// filter by internet bandwidth id
+data "huaweicloud_global_eips" "filter_by_internet_bandwidth_id" {
+  internet_bandwidth_id = huaweicloud_global_eip.test.internet_bandwidth_id
+}
+
+output "is_internet_bandwidth_id_filter_useful" {
+  value = length(data.huaweicloud_global_eips.filter_by_internet_bandwidth_id.global_eips) > 0 && alltrue(
+	[for v in data.huaweicloud_global_eips.filter_by_internet_bandwidth_id.global_eips[*].internet_bandwidth_id : 
+      v == huaweicloud_global_eip.test.internet_bandwidth_id]
+  )
+}
+
+// filter by ip address
+data "huaweicloud_global_eips" "filter_by_ip_address" {
+  ip_address = huaweicloud_global_eip.test.ip_address
+}
+
+locals {
+  filter_result_by_ip_address = [for v in data.huaweicloud_global_eips.filter_by_ip_address.global_eips[*].ip_address : 
+    v == huaweicloud_global_eip.test.ip_address]
+}
+
+output "is_ip_address_filter_useful" {
+  value = length(local.filter_result_by_ip_address) > 0 && alltrue(local.filter_result_by_ip_address) 
+}
+
+// filter by status
+data "huaweicloud_global_eips" "filter_by_status" {
+  status = huaweicloud_global_eip.test.status
+}
+
+locals {
+  filter_result_by_status = [for v in data.huaweicloud_global_eips.filter_by_status.global_eips[*].status : 
+    v == huaweicloud_global_eip.test.status]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.filter_result_by_status) > 0 && alltrue(local.filter_result_by_status) 
+}
+
+// filter by eps ID
+data "huaweicloud_global_eips" "filter_by_eps_id" {
+  enterprise_project_id = huaweicloud_global_eip.test.enterprise_project_id
+}
+
+locals {
+  filter_result_by_eps_id = [for v in data.huaweicloud_global_eips.filter_by_eps_id.global_eips[*].enterprise_project_id : 
+    v == huaweicloud_global_eip.test.enterprise_project_id]
+}
+
+output "is_eps_id_filter_useful" {
+  value = length(local.filter_result_by_eps_id) > 0 && alltrue(local.filter_result_by_eps_id) 
+}
+
+// filter by tags
+data "huaweicloud_global_eips" "filter_by_tags" {
+  tags = huaweicloud_global_eip.test.tags
+}
+
+locals {
+  filter_result_by_tags = [for v in data.huaweicloud_global_eips.filter_by_tags.global_eips[*].tags : 
+    v == huaweicloud_global_eip.test.tags]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.filter_result_by_tags) > 0 && alltrue(local.filter_result_by_tags) 
+}
+`, testAccGEIP_basic(rNameWithDash), rNameWithDash)
+}

--- a/huaweicloud/services/eip/data_source_huaweicloud_global_eips.go
+++ b/huaweicloud/services/eip/data_source_huaweicloud_global_eips.go
@@ -1,0 +1,270 @@
+package eip
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EIP GET /v3/{domain_id}/global-eips
+func DataSourceGlobalEIPs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGlobalEIPsRead,
+
+		Schema: map[string]*schema.Schema{
+			"geip_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"internet_bandwidth_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"associate_instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"associate_instance_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"global_eips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"access_site": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"geip_pool_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internet_bandwidth_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"isp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_version": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ip_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"frozen": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"frozen_info": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"polluted": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"global_connection_bandwidth_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"global_connection_bandwidth_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"associate_instance_region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"associate_instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"associate_instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGlobalEIPsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("geip", region)
+	if err != nil {
+		return diag.Errorf("error creating GEIP client: %s", err)
+	}
+
+	getGEIPHttpUrl := "v3/{domain_id}/global-eips"
+	getGEIPPath := client.Endpoint + getGEIPHttpUrl
+	getGEIPPath = strings.ReplaceAll(getGEIPPath, "{domain_id}", cfg.DomainID)
+	getGEIPOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getGEIPPath += fmt.Sprintf("?limit=%v", pageLimit)
+	if id, ok := d.GetOk("geip_id"); ok {
+		getGEIPPath += fmt.Sprintf("&id=%s", id)
+	}
+	if name, ok := d.GetOk("name"); ok {
+		getGEIPPath += fmt.Sprintf("&name=%s", name)
+	}
+	if bwID, ok := d.GetOk("internet_bandwidth_id"); ok {
+		getGEIPPath += fmt.Sprintf("&internet_bandwidth_id=%s", bwID)
+	}
+	if ipAddress, ok := d.GetOk("ip_address"); ok {
+		getGEIPPath += fmt.Sprintf("&ip_address=%s", ipAddress)
+	}
+	if status, ok := d.GetOk("status"); ok {
+		getGEIPPath += fmt.Sprintf("&status=%s", status)
+	}
+	if epsID, ok := d.GetOk("enterprise_project_id"); ok {
+		getGEIPPath += fmt.Sprintf("&enterprise_project_id=%s", epsID)
+	}
+	if rawTags, ok := d.GetOk("tags"); ok {
+		tagsList := expandTagsMapToStringList(rawTags.(map[string]interface{}))
+		for _, v := range tagsList {
+			getGEIPPath += fmt.Sprintf("&tags=%s", v)
+		}
+	}
+	if associateInstanceID, ok := d.GetOk("associate_instance_id"); ok {
+		getGEIPPath += fmt.Sprintf("&associate_instance_info.instance_id=%s", associateInstanceID)
+	}
+	if associateInstanceType, ok := d.GetOk("associate_instance_type"); ok {
+		getGEIPPath += fmt.Sprintf("&associate_instance_info.instance_type=%s", associateInstanceType)
+	}
+
+	currentTotal := 0
+	results := make([]map[string]interface{}, 0)
+	for {
+		currentPath := getGEIPPath + fmt.Sprintf("&offset=%d", currentTotal)
+		getGEIPResp, err := client.Request("GET", currentPath, &getGEIPOpt)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		getGEIPRespBody, err := utils.FlattenResponse(getGEIPResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		geips := utils.PathSearch("global_eips", getGEIPRespBody, make([]interface{}, 0)).([]interface{})
+		for _, geip := range geips {
+			results = append(results, map[string]interface{}{
+				"id":                               utils.PathSearch("id", geip, nil),
+				"access_site":                      utils.PathSearch("access_site", geip, nil),
+				"geip_pool_name":                   utils.PathSearch("geip_pool_name", geip, nil),
+				"internet_bandwidth_id":            utils.PathSearch("internet_bandwidth_info.id", geip, nil),
+				"isp":                              utils.PathSearch("isp", geip, nil),
+				"ip_version":                       int(utils.PathSearch("ip_version", geip, float64(0)).(float64)),
+				"description":                      utils.PathSearch("description", geip, nil),
+				"name":                             utils.PathSearch("name", geip, nil),
+				"ip_address":                       utils.PathSearch("ip_address", geip, nil),
+				"enterprise_project_id":            utils.PathSearch("enterprise_project_id", geip, nil),
+				"frozen":                           utils.PathSearch("frozen_info", geip, false),
+				"frozen_info":                      utils.PathSearch("frozen_info", geip, nil),
+				"polluted":                         utils.PathSearch("polluted", geip, false),
+				"status":                           utils.PathSearch("status", geip, nil),
+				"created_at":                       utils.PathSearch("created_at", geip, nil),
+				"updated_at":                       utils.PathSearch("updated_at", geip, nil),
+				"tags":                             utils.FlattenTagsToMap(utils.PathSearch("tags", geip, nil)),
+				"global_connection_bandwidth_id":   utils.PathSearch("global_connection_bandwidth_info.gcb_id", geip, nil),
+				"global_connection_bandwidth_type": utils.PathSearch("global_connection_bandwidth_info.gcb_type", geip, nil),
+				"associate_instance_region":        utils.PathSearch("associate_instance_info.region", geip, nil),
+				"associate_instance_id":            utils.PathSearch("associate_instance_info.instance_id", geip, nil),
+				"associate_instance_type":          utils.PathSearch("associate_instance_info.instance_type", geip, nil),
+			})
+		}
+
+		// `current_count` means the number of `global_eips` in this page, and the limit of page is `10`.
+		currentCount := utils.PathSearch("page_info.current_count", getGEIPRespBody, float64(0))
+		if currentCount.(float64) < pageLimit {
+			break
+		}
+		currentTotal += len(geips)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("global_eips", results),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add `data.huaweicloud_global_eips`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGlobalEIPs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGlobalEIPs_basic -timeout 360m -parallel 4
=== RUN   TestAccGlobalEIPs_basic
=== PAUSE TestAccGlobalEIPs_basic
=== CONT  TestAccGlobalEIPs_basic
--- PASS: TestAccGlobalEIPs_basic (82.99s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       83.051s
```
