### PR TITLE
feat(ga): add a new datasource to get the list of the endpoint groups

### DIFF
--- a/docs/data-sources/ga_endpoint_groups.md
+++ b/docs/data-sources/ga_endpoint_groups.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Global Accelerator (GA)"
+---
+
+# huaweicloud_ga_endpoint_groups
+
+Use this data source to get the list of endpoint groups.
+
+## Example Usage
+
+```hcl
+variable "endpoint_group_name" {}
+
+data "huaweicloud_ga_endpoint_groups" "test" {
+  name = var.endpoint_group_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `endpoint_group_id` - (Optional, String) Specifies the ID of the endpoint group.
+
+* `name` - (Optional, String) Specifies the name of the endpoint group.
+
+* `status` - (Optional, String) Specifies the status of the endpoint group.
+  The valid values are as follows:
+  + **ACTIVE**: The status of the endpoint group is normal operation.
+  + **ERROR**: The status of the endpoint group is error.
+
+* `listener_id` - (Optional, String) Specifies the ID of the listener to which the endpoint group belongs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `endpoint_groups` - The list of the endpoint groups.
+  The [endpoint_groups](#ga_endpoint_groups) structure is documented below.
+
+<a name="ga_endpoint_groups"></a>
+The `endpoint_groups` block supports:
+
+* `id` - The ID of the endpoint group.
+
+* `name` - The name of the endpoint group.  
+
+* `description` - The description of the endpoint group.
+
+* `status` - The status of the endpoint group.
+
+* `traffic_dial_percentage` - The percentage of traffic distributed to the endpoint group.
+
+* `region_id` - The region where the endpoint group belongs.
+
+* `listener_id` - The ID of the listener to which the endpoint group belongs.
+
+* `created_at` - The creation time of the endpoint group.
+
+* `updated_at` - The latest update time of the endpoint group.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -514,9 +514,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_dependencies":          fgs.DataSourceFunctionGraphDependencies(),
 			"huaweicloud_fgs_functions":             fgs.DataSourceFunctionGraphFunctions(),
 
-			"huaweicloud_ga_accelerators":   ga.DataSourceAccelerators(),
-			"huaweicloud_ga_address_groups": ga.DataSourceAddressGroups(),
-			"huaweicloud_ga_listeners":      ga.DataSourceListeners(),
+			"huaweicloud_ga_accelerators":    ga.DataSourceAccelerators(),
+			"huaweicloud_ga_address_groups":  ga.DataSourceAddressGroups(),
+			"huaweicloud_ga_endpoint_groups": ga.DataSourceEndpointGroups(),
+			"huaweicloud_ga_listeners":       ga.DataSourceListeners(),
 
 			"huaweicloud_gaussdb_cassandra_dedicated_resource": gaussdb.DataSourceGeminiDBDehResource(),
 			"huaweicloud_gaussdb_cassandra_flavors":            gaussdb.DataSourceCassandraFlavors(),

--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_endpoint_groups_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_endpoint_groups_test.go
@@ -1,0 +1,192 @@
+package ga
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceEndpointGroups_basic(t *testing.T) {
+	var (
+		name           = acceptance.RandomAccResourceNameWithDash()
+		dataSourceName = "data.huaweicloud_ga_endpoint_groups.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byEndpointGroupId   = "data.huaweicloud_ga_endpoint_groups.filter_by_endpoint_group_id"
+		dcByEndpointGroupId = acceptance.InitDataSourceCheck(byEndpointGroupId)
+
+		byName   = "data.huaweicloud_ga_endpoint_groups.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byStatus   = "data.huaweicloud_ga_endpoint_groups.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byListenerId   = "data.huaweicloud_ga_endpoint_groups.filter_by_listener_id"
+		dcByListenerId = acceptance.InitDataSourceCheck(byListenerId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceEndpointGroups_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.traffic_dial_percentage"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.region_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.listener_id"),
+					dcByEndpointGroupId.CheckResourceExists(),
+					resource.TestCheckOutput("endpoint_group_id_filter_is_useful", "true"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+
+					dcByListenerId.CheckResourceExists(),
+					resource.TestCheckOutput("listener_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceEndpointGroups_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ga_accelerator" "test" {
+  name        = "%[1]s"
+  description = "Terraform test"
+
+  ip_sets {
+    area = "CM"
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_ga_listener" "test" {
+  accelerator_id = huaweicloud_ga_accelerator.test.id
+  name           = "%[1]s"
+  protocol       = "TCP"
+  description    = "Terraform test"
+
+  port_ranges {
+    from_port = 90
+    to_port   = 99
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "huaweicloud_ga_endpoint_group" "test" {
+  name        = "%[1]s"
+  description = "created by terraform"
+  region_id   = "cn-south-1"
+
+  listeners {
+    id = huaweicloud_ga_listener.test.id
+  }
+}
+`, name)
+}
+
+func testAccDataSourceEndpointGroups_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_ga_endpoint_groups" "test" {
+  depends_on = [
+    huaweicloud_ga_endpoint_group.test
+  ]
+}
+
+locals {
+  endpoint_group_id = data.huaweicloud_ga_endpoint_groups.test.endpoint_groups[0].id
+}
+
+data "huaweicloud_ga_endpoint_groups" "filter_by_endpoint_group_id" {
+  endpoint_group_id = local.endpoint_group_id
+}
+
+locals {
+  endpoint_group_id_filter_result = [
+    for v in data.huaweicloud_ga_endpoint_groups.filter_by_endpoint_group_id.endpoint_groups[*].id : 
+    v == local.endpoint_group_id
+  ]
+}
+
+output "endpoint_group_id_filter_is_useful" {
+  value = alltrue(local.endpoint_group_id_filter_result) && length(local.endpoint_group_id_filter_result) > 0
+}
+
+locals {
+  name = data.huaweicloud_ga_endpoint_groups.test.endpoint_groups[0].name
+}
+
+data "huaweicloud_ga_endpoint_groups" "filter_by_name" {
+  name = local.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_ga_endpoint_groups.filter_by_name.endpoint_groups[*].name : v == local.name
+  ]
+}
+
+output "name_filter_is_useful" {
+  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
+}
+
+locals {
+  status = data.huaweicloud_ga_endpoint_groups.test.endpoint_groups[0].status
+}
+
+data "huaweicloud_ga_endpoint_groups" "filter_by_status" {
+  status = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_ga_endpoint_groups.filter_by_status.endpoint_groups[*].status : v == local.status
+  ]
+}
+
+output "status_filter_is_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+
+locals {
+  listener_id = data.huaweicloud_ga_endpoint_groups.test.endpoint_groups[0].listener_id
+}
+
+data "huaweicloud_ga_endpoint_groups" "filter_by_listener_id" {
+  listener_id = local.listener_id
+}
+
+locals {
+  listener_id_filter_result = [
+    for v in data.huaweicloud_ga_endpoint_groups.filter_by_listener_id.endpoint_groups[*].listener_id : 
+    v == local.listener_id
+  ]
+}
+
+output "listener_id_filter_is_useful" {
+  value = alltrue(local.listener_id_filter_result) && length(local.listener_id_filter_result) > 0
+}
+`, testAccDataSourceEndpointGroups_base(name))
+}

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_endpoint_groups.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_endpoint_groups.go
@@ -1,0 +1,206 @@
+package ga
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GA GET /v1/endpoint-groups
+func DataSourceEndpointGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEndpointGroupsRead,
+		Schema: map[string]*schema.Schema{
+			"endpoint_group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the endpoint group.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The name of the endpoint group.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The status of the endpoint group.",
+			},
+			"listener_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The ID of the listener to which the endpoint group belongs.",
+			},
+			"endpoint_groups": {
+				Type:        schema.TypeList,
+				Elem:        endpointGroupsSchema(),
+				Computed:    true,
+				Description: "The list of the endpoint groups.",
+			},
+		},
+	}
+}
+
+func endpointGroupsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the endpoint group.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The name of the endpoint group.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The description of the endpoint group.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The status of the endpoint group.",
+			},
+			"traffic_dial_percentage": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The percentage of traffic distributed to the endpoint group.",
+			},
+			"region_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The region where the endpoint group belongs.",
+			},
+			"listener_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the listener to which the endpoint group belongs.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The creation time of the endpoint group.",
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The latest update time of the endpoint group.",
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceEndpointGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// listEndpointGroups: Query the list of endpoint groups
+	var (
+		listEndpointGroupsHttpUrl = "v1/endpoint-groups"
+		listEndpointGroupsProduct = "ga"
+	)
+	listEndpointGroupsClient, err := cfg.NewServiceClient(listEndpointGroupsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating GA client: %s", err)
+	}
+
+	listEndpointGroupsPath := listEndpointGroupsClient.Endpoint + listEndpointGroupsHttpUrl
+
+	listEndpointGroupsqueryParams := buildListEndpointGroupsQueryParams(d)
+	listEndpointGroupsPath += listEndpointGroupsqueryParams
+
+	listEndpointGroupsResp, err := pagination.ListAllItems(
+		listEndpointGroupsClient,
+		"marker",
+		listEndpointGroupsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving endpoint groups")
+	}
+
+	listEndpointGroupsRespJson, err := json.Marshal(listEndpointGroupsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var listEndpointGroupsRespBody interface{}
+	err = json.Unmarshal(listEndpointGroupsRespJson, &listEndpointGroupsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("endpoint_groups", flattenListEndpointGroupsResponseBody(listEndpointGroupsRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListEndpointGroupsResponseBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("endpoint_groups", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                      utils.PathSearch("id", v, nil),
+			"name":                    utils.PathSearch("name", v, nil),
+			"status":                  utils.PathSearch("status", v, nil),
+			"description":             utils.PathSearch("description", v, nil),
+			"traffic_dial_percentage": utils.PathSearch("traffic_dial_percentage", v, float64(0)),
+			"region_id":               utils.PathSearch("region_id", v, nil),
+			"listener_id":             utils.PathSearch("listeners[0].id", v, nil),
+			"created_at":              utils.PathSearch("created_at", v, nil),
+			"updated_at":              utils.PathSearch("updated_at", v, nil),
+		})
+	}
+	return rst
+}
+
+func buildListEndpointGroupsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("endpoint_group_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("listener_id"); ok {
+		res = fmt.Sprintf("%s&listener_id=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new datasource to get the list of the endpoint groups.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new datasource to get the list of the endpoint groups.
2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_group)$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccDatasourceEndpointGroups_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccDatasourceEndpointGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceEndpointGroups_basic
=== PAUSE TestAccDatasourceEndpointGroups_basic
=== CONT  TestAccDatasourceEndpointGroups_basic
--- PASS: TestAccDatasourceEndpointGroups_basic (126.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        126.560s
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_group)$ 
```
