### PR TITLE
feat(ram): add a data source to query the list of RAM shared principals

### DIFF
--- a/docs/data-sources/ram_shared_principals.md
+++ b/docs/data-sources/ram_shared_principals.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Resource Access Manager (RAM)"
+---
+
+# huaweicloud_ram_shared_principals
+
+Use this data source to get the list of RAM shared principals.
+
+## Example Usage
+
+```hcl
+variable "resource_urn" {}
+
+data "huaweicloud_ram_shared_principals" "test" {
+  resource_owner = "self"
+  resource_urn   = var.resource_urn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_owner` - (Required, String) Specifies the owner associated with the RAM share.
+  Value options are as follows:
+  + **self**: Shared to other users by myself.
+  + **other-accounts**: Shared to me by other users.
+
+* `principal` - (Optional, String) Specifies the principal associated with the RAM share.
+  The principal could be account ID or organization ID.
+  + If set to account ID, please make sure the account ID is not your owner account ID.
+  + If set to organization ID, you first need to use the RAM console to enable sharing with Organization. Please refer
+  to the [document](https://support.huaweicloud.com/intl/en-us/qs-ram/ram_02_0004.html).
+
+* `resource_urn` - (Optional, String) Specifies the resources urn associated with the
+  RAM share. The format of URN is: `<service-name>:<region>:<account-id>:<type-name>:<resource-path>`.
+
+* `resource_share_id` - (Optional, String) Specifies the ID of resource share.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `shared_principals` - The list of shared principals.
+  The [shared_principals](#attrblock-shared_principals) structure is documented below.
+
+<a name="attrblock-shared_principals"></a>
+The `shared_principals` block supports:
+
+* `id` - The ID of shared principal.
+
+* `resource_share_id` - The resource share ID.
+
+* `created_at` - The creation time of the RAM share.
+
+* `updated_at` - The latest update time of the RAM share.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -620,6 +620,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_ram_resource_permissions": ram.DataSourceRAMPermissions(),
 			"huaweicloud_ram_shared_resources":     ram.DataSourceRAMSharedResources(),
+			"huaweicloud_ram_shared_principals":    ram.DataSourceRAMSharedPrincipals(),
 
 			"huaweicloud_rds_flavors":                       rds.DataSourceRdsFlavor(),
 			"huaweicloud_rds_engine_versions":               rds.DataSourceRdsEngineVersionsV3(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -72,6 +72,7 @@ var (
 	HW_RAM_SHARE_RESOURCE_URN        = os.Getenv("HW_RAM_SHARE_RESOURCE_URN")
 	HW_RAM_SHARE_UPDATE_ACCOUNT_ID   = os.Getenv("HW_RAM_SHARE_UPDATE_ACCOUNT_ID")
 	HW_RAM_SHARE_UPDATE_RESOURCE_URN = os.Getenv("HW_RAM_SHARE_UPDATE_RESOURCE_URN")
+	HW_RAM_ENABLE_FLAG               = os.Getenv("HW_RAM_ENABLE_FLAG")
 
 	HW_CDN_DOMAIN_NAME              = os.Getenv("HW_CDN_DOMAIN_NAME")
 	HW_CDN_CERT_PATH                = os.Getenv("HW_CDN_CERT_PATH")
@@ -668,6 +669,21 @@ func TestAccPreCheckRAM(t *testing.T) {
 	if HW_RAM_SHARE_UPDATE_ACCOUNT_ID == "" || HW_RAM_SHARE_UPDATE_RESOURCE_URN == "" {
 		t.Skip("HW_RAM_SHARE_UPDATE_ACCOUNT_ID and HW_RAM_SHARE_UPDATE_RESOURCE_URN" +
 			" must be set for update ram resource tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckRAMSharedPrincipals(t *testing.T) {
+	if HW_RAM_ENABLE_FLAG == "" {
+		t.Skip("Skip the RAM acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckRAMSharedPrincipalsQueryFields(t *testing.T) {
+	if HW_RAM_SHARE_ACCOUNT_ID == "" || HW_RAM_SHARE_RESOURCE_URN == "" {
+		t.Skip("HW_RAM_SHARE_ACCOUNT_ID and HW_RAM_SHARE_RESOURCE_URN " +
+			"must be set for RAM shared principals tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_shared_principals_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_shared_principals_test.go
@@ -1,0 +1,76 @@
+package ram
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// Before executing this use case, please create several pieces of data first.
+func TestAccDatasourceRAMSharedPrincipals_basic(t *testing.T) {
+	rName := "data.huaweicloud_ram_shared_principals.test"
+	principalTestname := "data.huaweicloud_ram_shared_principals.principal_filter"
+	resourceURNTestName := "data.huaweicloud_ram_shared_principals.resource_urn_filter"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRAMSharedPrincipals(t)
+			acceptance.TestAccPreCheckRAMSharedPrincipalsQueryFields(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceRAMSharedPrincipals_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "shared_principals.0.resource_share_id"),
+					resource.TestCheckResourceAttrSet(rName, "shared_principals.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "shared_principals.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "shared_principals.0.updated_at"),
+					resource.TestCheckResourceAttrSet(principalTestname, "shared_principals.#"),
+					resource.TestCheckResourceAttrSet(resourceURNTestName, "shared_principals.#"),
+
+					resource.TestCheckOutput("resource_share_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceRAMSharedPrincipals_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_ram_shared_principals" "test" {
+  resource_owner = "self"
+}
+
+data "huaweicloud_ram_shared_principals" "principal_filter" {
+  resource_owner = "self"
+  principal      = "%[1]s"
+}
+
+data "huaweicloud_ram_shared_principals" "resource_urn_filter" {
+  resource_owner = "self"
+  resource_urn   = "%[2]s"
+}
+
+data "huaweicloud_ram_shared_principals" "resource_share_id_filter" {
+  resource_owner    = "self"
+  resource_share_id = data.huaweicloud_ram_shared_principals.test.shared_principals.0.resource_share_id
+}
+
+locals {
+  resource_share_id = data.huaweicloud_ram_shared_principals.test.shared_principals.0.resource_share_id
+}
+
+output "resource_share_id_filter_is_useful" {
+  value = length(data.huaweicloud_ram_shared_principals.test.shared_principals) > 0 && alltrue(
+    [for v in data.huaweicloud_ram_shared_principals.resource_share_id_filter.shared_principals[*].resource_share_id : v == local.resource_share_id]
+  )
+}
+`, acceptance.HW_RAM_SHARE_ACCOUNT_ID, acceptance.HW_RAM_SHARE_RESOURCE_URN)
+}

--- a/huaweicloud/services/ram/data_source_huaweicloud_ram_shared_pricipals.go
+++ b/huaweicloud/services/ram/data_source_huaweicloud_ram_shared_pricipals.go
@@ -1,0 +1,160 @@
+package ram
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RAM POST /v1/shared-principals/search
+func DataSourceRAMSharedPrincipals() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceRAMSharedPrincipalsRead,
+		Schema: map[string]*schema.Schema{
+			"resource_owner": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"principal": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_urn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_share_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"shared_principals": {
+				Type:     schema.TypeList,
+				Elem:     sharedPrincipalsSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func sharedPrincipalsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"resource_share_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func datasourceRAMSharedPrincipalsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		getRAMSharedPrincipalsHttpUrl = "v1/shared-principals/search"
+		getRAMSharedPrincipalsProduct = "ram"
+	)
+	getRAMSharedPrincipalsClient, err := cfg.NewServiceClient(getRAMSharedPrincipalsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RAM client: %s", err)
+	}
+
+	getRAMSharedPrincipalsPath := getRAMSharedPrincipalsClient.Endpoint + getRAMSharedPrincipalsHttpUrl
+
+	getRAMSharedPrincipalsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	allSharedPrincipals := make([]interface{}, 0)
+	var nextMarker string
+	getRAMSharedPrincipalsOpt.JSONBody = utils.RemoveNil(buildgetRAMSharedPrincipalsBodyParams(d))
+	getRAMSharedPrincipalsJSONBody := getRAMSharedPrincipalsOpt.JSONBody.(map[string]interface{})
+	for {
+		getRAMSharedPrincipalsResp, err := getRAMSharedPrincipalsClient.Request("POST", getRAMSharedPrincipalsPath, &getRAMSharedPrincipalsOpt)
+		if err != nil {
+			return common.CheckDeletedDiag(d, err, "error retrieving RAM shared principals")
+		}
+
+		getRAMSharedPrincipalsRespBody, err := utils.FlattenResponse(getRAMSharedPrincipalsResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		sharedPrincipals := utils.PathSearch("shared_principals", getRAMSharedPrincipalsRespBody, make([]interface{}, 0)).([]interface{})
+		if len(sharedPrincipals) > 0 {
+			allSharedPrincipals = append(allSharedPrincipals, sharedPrincipals...)
+		}
+
+		nextMarker = utils.PathSearch("page_info.next_marker", getRAMSharedPrincipalsRespBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+		getRAMSharedPrincipalsJSONBody["marker"] = nextMarker
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("shared_principals", flattenGetSharedPrincipalsResponseBody(allSharedPrincipals)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildgetRAMSharedPrincipalsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"resource_urn":   utils.ValueIngoreEmpty(d.Get("resource_urn")),
+		"resource_owner": d.Get("resource_owner"),
+		"limit":          pageLimit,
+	}
+
+	if v, ok := d.GetOk("principal"); ok {
+		bodyParams["principals"] = []interface{}{v}
+	}
+
+	if v, ok := d.GetOk("resource_share_id"); ok {
+		bodyParams["resource_share_ids"] = []interface{}{v}
+	}
+	return bodyParams
+}
+
+func flattenGetSharedPrincipalsResponseBody(curArray []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"resource_share_id": utils.PathSearch("resource_share_id", v, nil),
+			"id":                utils.PathSearch("id", v, nil),
+			"created_at":        utils.PathSearch("created_at", v, nil),
+			"updated_at":        utils.PathSearch("updated_at", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
+ add data source to query the lis of RAM shared principals

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
+ The query method is POST, so use a for loop to query。

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/ram" TESTARGS="-run TestAccDatasourceRAMSharedPrincipals_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccDatasourceRAMSharedPrincipals_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceRAMSharedPrincipals_basic
=== PAUSE TestAccDatasourceRAMSharedPrincipals_basic
=== CONT  TestAccDatasourceRAMSharedPrincipals_basic
--- PASS: TestAccDatasourceRAMSharedPrincipals_basic (25.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       25.984s
```
