### PR TITLE
feat(DEW): add datasource to get the list of CSMS secrets

### DIFF
--- a/docs/data-sources/csms_secrets.md
+++ b/docs/data-sources/csms_secrets.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+---
+
+# huaweicloud_csms_secrets
+
+Use this data source to get the list of CSMS secrets.
+
+## Example Usage
+
+```hcl
+variable "secret_name" {}
+
+data "huaweicloud_csms_secrets" "test" {
+  name = var.secret_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the secret.
+
+* `secret_id` - (Optional, String) Specifies the ID of the secret.
+
+* `status` - (Optional, String) Specifies the secret status. Valid values are **ENABLED**, **DISABLED**,
+  **PENDING_DELETE** and **FROZEN**.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+
+* `event_name` - (Optional, String) Specifies the event name related to the secret.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `secrets` - Indicates the secrets list.
+  The [secrets](#CSMS_secrets) structure is documented below.
+
+<a name="CSMS_secrets"></a>
+The `secrets` block supports:
+
+* `id` - The secret ID.
+
+* `name` - Indicates the secret name.
+
+* `status` - Indicates the secret status.
+
+* `kms_key_id` - Indicates the ID of KMS key used to encrypt secret.
+
+* `description` - Indicates the secret description.
+
+* `created_at` - Indicates the time when the secret created, in UTC format.
+
+* `updated_at` - Indicates the time when the secret updated, in UTC format.
+
+* `scheduled_deleted_at` - Indicates the time when the secret is scheduled to be deleted, in UTC format.
+
+* `secret_type` - Indicates the secret type. Valid values are **COMMON** and **RDS**.
+
+* `auto_rotation` - Indicates whether to enable the secret automatic rotation.
+
+* `rotation_period` - Indicates the secret rotation period. Valid when `auto_rotation` is **true**.
+
+* `rotation_config` - Indicates the secret rotation config. Valid when `auto_rotation` is **true**.
+
+* `rotation_at` - Indicates the secret rotation time, in UTC format. Valid when `auto_rotation` is **true**.
+
+* `next_rotation_at` - Indicates the secret next rotation time, in UTC format. Valid when `auto_rotation` is **true**.
+
+* `event_subscriptions` - Indicates the list of events subscribed to by secret.
+
+* `enterprise_project_id` - Indicates the enterprise project ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -450,6 +450,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cph_phone_flavors":  cph.DataSourcePhoneFlavors(),
 			"huaweicloud_cph_phone_images":   cph.DataSourcePhoneImages(),
 
+			"huaweicloud_csms_secrets":        dew.DataSourceDewCsmsSecrets(),
 			"huaweicloud_csms_secret_version": dew.DataSourceDewCsmsSecret(),
 			"huaweicloud_css_flavors":         css.DataSourceCssFlavors(),
 

--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_secrets_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_secrets_test.go
@@ -1,0 +1,131 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCsmsSecrets_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	rName := "data.huaweicloud_csms_secrets.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCsmsSecrets_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.kms_key_id"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.updated_at"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.secret_type"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.auto_rotation"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.event_subscriptions.#"),
+					resource.TestCheckResourceAttrSet(rName, "secrets.0.enterprise_project_id"),
+
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("secretId_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("enterpriseProjectId_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("eventName_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCsmsSecrets_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_csms_secrets" "test" {
+  depends_on = [huaweicloud_csms_secret.test]
+}
+
+data "huaweicloud_csms_secrets" "name_filter" {
+  name = huaweicloud_csms_secret.test.name
+}
+
+locals {
+  name = huaweicloud_csms_secret.test.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_csms_secrets.name_filter.secrets) > 0 && alltrue(
+    [for v in data.huaweicloud_csms_secrets.name_filter.secrets[*].name : v == local.name]
+  )
+}
+
+data "huaweicloud_csms_secrets" "secretId_filter" {
+  secret_id = huaweicloud_csms_secret.test.secret_id
+}
+
+locals {
+  secret_id = huaweicloud_csms_secret.test.secret_id
+}
+
+output "secretId_filter_is_useful" {
+  value = length(data.huaweicloud_csms_secrets.secretId_filter.secrets) > 0 && alltrue(
+    [for v in data.huaweicloud_csms_secrets.secretId_filter.secrets[*].id : v == 
+  local.secret_id]
+ )  
+}
+
+data "huaweicloud_csms_secrets" "status_filter" {
+  status = huaweicloud_csms_secret.test.status
+}
+
+locals {
+  status = huaweicloud_csms_secret.test.status
+}
+
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_csms_secrets.status_filter.secrets) > 0 && alltrue(
+    [for v in data.huaweicloud_csms_secrets.status_filter.secrets[*].status : v == local.status]
+  )
+}
+
+data "huaweicloud_csms_secrets" "enterpriseProjectId_filter" {
+  enterprise_project_id = data.huaweicloud_csms_secrets.test.secrets.0.enterprise_project_id
+}
+
+locals {
+  enterprise_project_id = data.huaweicloud_csms_secrets.test.secrets.0.enterprise_project_id
+}
+
+output "enterpriseProjectId_filter_is_useful" {
+  value = length(data.huaweicloud_csms_secrets.enterpriseProjectId_filter.secrets) > 0 && alltrue(
+    [for v in data.huaweicloud_csms_secrets.enterpriseProjectId_filter.secrets[*].enterprise_project_id : v == local.enterprise_project_id]
+  )
+}
+
+data "huaweicloud_csms_secrets" "eventName_filter" {
+  event_name = data.huaweicloud_csms_secrets.test.secrets.0.event_subscriptions.0
+}
+
+locals {
+  event_name = data.huaweicloud_csms_secrets.test.secrets.0.event_subscriptions.0
+}
+
+output "eventName_filter_is_useful" {
+  value = length(data.huaweicloud_csms_secrets.eventName_filter.secrets) > 0 && alltrue(
+    [for v in data.huaweicloud_csms_secrets.eventName_filter.secrets[*].event_subscriptions.0 : v == local.event_name]
+  )
+}
+`, testAccDewCsmsSecret_basic(name))
+}

--- a/huaweicloud/services/dew/data_source_huaweicloud_csms_secrets.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_csms_secrets.go
@@ -1,0 +1,261 @@
+package dew
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DEW GET /v1/{project_id}/secrets
+func DataSourceDewCsmsSecrets() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceDewCsmsSecretsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"secret_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"event_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"secrets": {
+				Type:     schema.TypeList,
+				Elem:     secretsSchema(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func secretsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"scheduled_deleted_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secret_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto_rotation": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"rotation_period": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rotation_config": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"rotation_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"next_rotation_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"event_subscriptions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceDewCsmsSecretsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		listSecretsHttpUrl = "v1/{project_id}/secrets"
+		listSecretsProduct = "kms"
+	)
+	listSecretsClient, err := cfg.NewServiceClient(listSecretsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	listSecretsPath := listSecretsClient.Endpoint + listSecretsHttpUrl
+	listSecretsPath = strings.ReplaceAll(listSecretsPath, "{project_id}", listSecretsClient.ProjectID)
+
+	listSecretsQueryParams := buildListSecretsQueryParams(d)
+	listSecretsPath += listSecretsQueryParams
+
+	listSecretsResp, err := pagination.ListAllItems(
+		listSecretsClient,
+		"marker",
+		listSecretsPath,
+		&pagination.QueryOpts{MarkerField: "name"})
+
+	if err != nil {
+		return diag.Errorf("error retrieving CSMS secrets: %s", err)
+	}
+
+	listSecretsRespJson, err := json.Marshal(listSecretsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listSecretsRespBody interface{}
+	err = json.Unmarshal(listSecretsRespJson, &listSecretsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("secrets", filterListSecretsBody(
+			flattenListSecretsBody(listSecretsRespBody), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListSecretsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curJson := utils.PathSearch("secrets", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		createAt := utils.PathSearch("create_time", v, float64(0))
+		updateAt := utils.PathSearch("update_time", v, float64(0))
+		scheduledDeletedAt := utils.PathSearch("scheduled_delete_time", v, float64(0))
+		rotationAt := utils.PathSearch("rotation_time", v, float64(0))
+		nextRotationAt := utils.PathSearch("next_rotation_time", v, float64(0))
+		rst = append(rst, map[string]interface{}{
+			"id":                    utils.PathSearch("id", v, nil),
+			"name":                  utils.PathSearch("name", v, nil),
+			"status":                utils.PathSearch("state", v, nil),
+			"kms_key_id":            utils.PathSearch("kms_key_id", v, nil),
+			"description":           utils.PathSearch("description", v, nil),
+			"created_at":            utils.FormatTimeStampRFC3339(int64(createAt.(float64))/1000, false),
+			"updated_at":            utils.FormatTimeStampRFC3339(int64(updateAt.(float64))/1000, false),
+			"scheduled_deleted_at":  utils.FormatTimeStampRFC3339(int64(scheduledDeletedAt.(float64))/1000, false),
+			"secret_type":           utils.PathSearch("secret_type", v, nil),
+			"auto_rotation":         utils.PathSearch("auto_rotation", v, nil),
+			"rotation_period":       utils.PathSearch("rotation_period", v, nil),
+			"rotation_config":       utils.PathSearch("rotation_config", v, nil),
+			"rotation_at":           utils.FormatTimeStampRFC3339(int64(rotationAt.(float64))/1000, false),
+			"next_rotation_at":      utils.FormatTimeStampRFC3339(int64(nextRotationAt.(float64))/1000, false),
+			"event_subscriptions":   utils.PathSearch("event_subscriptions", v, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterListSecretsBody(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+
+	for _, v := range all {
+		if param, ok := d.GetOk("name"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("name", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("secret_id"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("id", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("status"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("status", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("enterprise_project_id"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("enterprise_project_id", v, nil)) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func buildListSecretsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("event_name"); ok {
+		res = fmt.Sprintf("%s&event_name=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add datasource to get the list of CSMS secrets

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dew/' TESTARGS='-run TestAccDatasourceCsmsSecrets_basic'
...
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew/ -v -run TestAccDatasourceCsmsSecrets_basic -timeout 360m -parallel 4 
=== RUN   TestAccDatasourceCsmsSecrets_basic 
=== PAUSE TestAccDatasourceCsmsSecrets_basic 
=== CONT  TestAccDatasourceCsmsSecrets_basic
--- PASS: TestAccDatasourceCsmsSecrets_basic (46.95s) 
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       46.989s
```
