### PR TITLE
fix(cce): fix can't get resource ID problem when create a bms node

### DIFF
--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
@@ -580,7 +580,7 @@ func resourceNodeCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 	// The completion of the creation of the underlying resource (ECS) corresponding to the CCE node does not mean that
 	// the creation of the CCE node is completed.
-	nodeID, err := getResourceIDFromJob(ctx, nodeClient, s.Status.JobID, "CreateNode", "CreateNodeVM",
+	nodeID, err := getResourceIDFromJob(ctx, nodeClient, s.Status.JobID, "CreateNode", "InstallNode",
 		d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix can't get resource ID problem when create a bms node.
The reason is that we get resource ID from the subjob CreateNodeVM.
But there is no subjob CreateNodeVM when create bms nodes (the subjob type is CreateNodeBMS).
To resolve this problem, we can get the resource ID from the subjob InstallNode.
It's a common subjob in both creating vm nodes and creating bms nodes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNode_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNode_basic -timeout 360m -parallel 4
=== RUN   TestAccNode_basic
=== PAUSE TestAccNode_basic
=== CONT  TestAccNode_basic
--- PASS: TestAccNode_basic (967.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       968.001s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNode_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNode_prePaid -timeout 360m -parallel 4
=== RUN   TestAccNode_prePaid
=== PAUSE TestAccNode_prePaid
=== CONT  TestAccNode_prePaid
--- PASS: TestAccNode_prePaid (1123.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1123.309s
```
