### PR TITLE
feat: chore(fgs): support a new function trigger to replace the old one

### DIFF
--- a/docs/resources/fgs_function_trigger.md
+++ b/docs/resources/fgs_function_trigger.md
@@ -1,0 +1,96 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# huaweicloud_fgs_function_trigger
+
+Manages the function trigger resource within HuaweiCloud.
+
+## Example Usage
+
+### Create the Timing Triggers with rate and cron schedule types
+
+```hcl
+variable "function_urn" {}
+variable "trigger_name" {}
+
+// Timing trigger (with rate schedule type)
+resource "huaweicloud_fgs_function_trigger" "test" {
+  function_urn = var.function_urn
+  type         = "TIMER"
+  event_data   = jsonencode({
+    "name": format("%s_rate", var.trigger_name),
+    "schedule_type": "Rate",
+    "user_event": "Created by terraform script",
+    "schedule": "3m"
+  })
+}
+
+// Timing trigger (with cron schedule type)
+resource "huaweicloud_fgs_function_trigger" "timer_cron" {
+  function_urn = var.function_urn
+  type         = "TIMER"
+  event_data   = jsonencode({
+    "name": format("%s_cron", var.trigger_name),
+    "schedule_type": "Cron",
+    "user_event": "Created by terraform script",
+    "schedule": "@every 1h30m"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the function trigger is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `function_urn` - (Required, String, ForceNew) Specifies the function URN to which the function trigger belongs.  
+  Changing this will create a new resource.
+
+* `type` - (Required, String, ForceNew) Specifies the type of the function trigger.  
+  The valid values are **TIMER**, **APIG**, **CTS**, **DDS**, **DEDICATEDGATEWAY**, etc.
+  Changing this will create a new resource.
+
+  -> For more available values, please refer to the [documentation table 3](https://support.huaweicloud.com/intl/en-us/api-functiongraph/functiongraph_06_0122.html#section2).
+
+* `event_data` - (Required, String) Specifies the detailed configuration of the function trigger event.  
+  For various types of trigger parameter configurations, please refer to the
+  [documentation](https://support.huaweicloud.com/intl/en-us/api-functiongraph/functiongraph_06_0122.html#functiongraph_06_0122__request_TriggerEventDataRequestBody).
+
+  -> Please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-functiongraph/functiongraph_06_0124.html#functiongraph_06_0124__request_UpdateriggerEventData)
+     for updateable fields.
+
+* `status` - (Optional, String) Specifies the status of the function trigger.  
+  The valid values are **ACTIVE** and **DISABLED**.  
+  About `DDS` and `Kafka` triggers, the default value is **DISABLED**, for the other triggers, the default value is
+  **ACTIVE**.
+
+  -> Currently, only some triggers support setting the **DISABLED** value, such as `TIMER`, `DDS`, `DMS`, `KAFKA` and
+     `LTS`. For more details, please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/api-functiongraph/functiongraph_06_0122.html).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - resource ID in UUID format.
+
+* `created_at` - The creation time of the function trigger.
+
+* `updated_at` - The latest update time of the function trigger.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `update` - Default is 5 minutes.
+* `delete` - Default is 3 minutes.
+
+## Import
+
+Function trigger can be imported using the `function_urn`, `type` and `id`, separated by the slashes (/), e.g.
+
+```bash
+$ terraform import huaweicloud_fgs_function_trigger.test <function_urn>/<type>/<id>
+```

--- a/docs/resources/fgs_trigger.md
+++ b/docs/resources/fgs_trigger.md
@@ -1,10 +1,11 @@
 ---
-subcategory: "FunctionGraph"
+subcategory: "Deprecated"
 ---
 
 # huaweicloud_fgs_trigger
 
-Manages a trigger resource within HuaweiCloud FunctionGraph.
+Manages a trigger resource within HuaweiCloud FunctionGraph.  
+It's recommend to use `huaweicloud_fgs_function_trigger`, which makes a great improvement of managing function triggers.
 
 ## Example Usage
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1059,7 +1059,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_function":                   fgs.ResourceFgsFunctionV2(),
 			"huaweicloud_fgs_function_event":             fgs.ResourceFunctionEvent(),
 			"huaweicloud_fgs_function_trigger":           fgs.ResourceFunctionTrigger(),
-			"huaweicloud_fgs_trigger":                    fgs.ResourceFunctionGraphTrigger(),
 
 			"huaweicloud_ga_accelerator":    ga.ResourceAccelerator(),
 			"huaweicloud_ga_address_group":  ga.ResourceIpAddressGroup(),
@@ -1549,6 +1548,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_csbs_backup_policy":             deprecated.ResourceCSBSBackupPolicyV1(),
 			"huaweicloud_csbs_backup_policy_v1":          deprecated.ResourceCSBSBackupPolicyV1(),
 			"huaweicloud_csbs_backup_v1":                 deprecated.ResourceCSBSBackupV1(),
+			"huaweicloud_fgs_trigger":                    deprecated.ResourceFunctionGraphTrigger(),
 			"huaweicloud_networking_network_v2":          deprecated.ResourceNetworkingNetworkV2(),
 			"huaweicloud_networking_subnet_v2":           deprecated.ResourceNetworkingSubnetV2(),
 			"huaweicloud_networking_floatingip_v2":       deprecated.ResourceNetworkingFloatingIPV2(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1058,6 +1058,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_dependency_version":         fgs.ResourceDependencyVersion(),
 			"huaweicloud_fgs_function":                   fgs.ResourceFgsFunctionV2(),
 			"huaweicloud_fgs_function_event":             fgs.ResourceFunctionEvent(),
+			"huaweicloud_fgs_function_trigger":           fgs.ResourceFunctionTrigger(),
 			"huaweicloud_fgs_trigger":                    fgs.ResourceFunctionGraphTrigger(),
 
 			"huaweicloud_ga_accelerator":    ga.ResourceAccelerator(),

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fgs_trigger_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_fgs_trigger_test.go
@@ -1,4 +1,4 @@
-package fgs
+package deprecated
 
 import (
 	"fmt"

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_trigger_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_trigger_test.go
@@ -1,0 +1,187 @@
+package fgs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/fgs/v2/function"
+	"github.com/chnsz/golangsdk/openstack/fgs/v2/trigger"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
+)
+
+func getFunctionTriggerFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("fgs", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	return fgs.GetTriggerById(client, state.Primary.Attributes["function_urn"], state.Primary.Attributes["type"],
+		state.Primary.ID)
+}
+
+func TestAccFunctionTrigger_basic(t *testing.T) {
+	var (
+		relatedFunc      function.Function
+		timeTrigger      trigger.Trigger
+		randName         = acceptance.RandomAccResourceName()
+		resNameFunc      = "huaweicloud_fgs_function.test"
+		resNameTimerRate = "huaweicloud_fgs_function_trigger.timer_rate"
+		resNameTimerCron = "huaweicloud_fgs_function_trigger.timer_cron"
+
+		rcFunc      = acceptance.InitResourceCheck(resNameFunc, &relatedFunc, getResourceObj)
+		rcTimerRate = acceptance.InitResourceCheck(resNameTimerRate, &timeTrigger, getFunctionTriggerFunc)
+		rcTimerCron = acceptance.InitResourceCheck(resNameTimerCron, &timeTrigger, getFunctionTriggerFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rcFunc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionTimingTrigger_basic_step1(randName),
+				Check: resource.ComposeTestCheckFunc(
+					// Timing trigger (with rate schedule type)
+					rcTimerRate.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resNameTimerRate, "function_urn",
+						"${huaweicloud_fgs_function.test.urn}"),
+					resource.TestCheckResourceAttr(resNameTimerRate, "type", "TIMER"),
+					resource.TestCheckResourceAttr(resNameTimerRate, "status", "ACTIVE"),
+					// Timing trigger (with cron schedule type)
+					rcTimerCron.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resNameTimerCron, "type", "TIMER"),
+					resource.TestCheckResourceAttr(resNameTimerCron, "status", "ACTIVE"),
+				),
+			},
+			{
+				Config: testAccFunctionTimingTrigger_basic_step2(randName),
+				Check: resource.ComposeTestCheckFunc(
+					// Timing trigger (with rate schedule type)
+					rcTimerRate.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resNameTimerRate, "status", "DISABLED"),
+					// Timing trigger (with cron schedule type)
+					rcTimerCron.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resNameTimerCron, "status", "DISABLED"),
+				),
+			},
+			{
+				ResourceName:      resNameTimerRate,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccFunctionTriggerImportStateFunc(resNameTimerRate),
+			},
+			{
+				ResourceName:      resNameTimerCron,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccFunctionTriggerImportStateFunc(resNameTimerCron),
+			},
+		},
+	})
+}
+
+func testAccFunctionTriggerImportStateFunc(rsName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var functionUrn, triggerType, triggerId string
+		rs, ok := s.RootModule().Resources[rsName]
+		if !ok {
+			return "", fmt.Errorf("the resource (%s) of function trigger is not found in the tfstate", rsName)
+		}
+		functionUrn = rs.Primary.Attributes["function_urn"]
+		triggerType = rs.Primary.Attributes["type"]
+		triggerId = rs.Primary.ID
+		if functionUrn == "" || triggerType == "" || triggerId == "" {
+			return "", fmt.Errorf("the function trigger is not exist or related function URN is missing")
+		}
+		return fmt.Sprintf("%s/%s/%s", functionUrn, triggerType, triggerId), nil
+	}
+}
+
+func testAccFunctionTrigger_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_fgs_function" "test" {
+  name        = "%[1]s"
+  app         = "default"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 10
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgW1wcyhldybiBvdXRwdXQ="
+}`, name)
+}
+
+// Test triggers with a limited number (except for Kafka triggers, when released, the elastic network card will be
+// locked for one hour and the subnet cannot be deleted).
+// The current quantity constraint rules for function triggers are as follows:
+//   - The total number of DDS, GAUSSMONGO, DIS, LTS, Kafka and TIMER triggers that can be created under one function
+//     version is up to 10.
+//   - The maximum number of CTS triggers that can be created under one project is 10.
+//   - There is no limit to the number of other triggers.
+func testAccFunctionTimingTrigger_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+// Timing trigger (with rate schedule type)
+resource "huaweicloud_fgs_function_trigger" "timer_rate" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "TIMER"
+  event_data   = jsonencode({
+    "name": "%[2]s_rate",
+    "schedule_type": "Rate",
+    "user_event": "Created by acc test",
+    "schedule": "3m"
+  })
+}
+
+// Timing trigger (with cron schedule type)
+resource "huaweicloud_fgs_function_trigger" "timer_cron" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "TIMER"
+  event_data   = jsonencode({
+    "name": "%[2]s_cron",
+    "schedule_type": "Cron",
+    "user_event": "Created by acc test",
+    "schedule": "@every 1h30m"
+  })
+}
+`, testAccFunctionTrigger_base(name), name)
+}
+
+func testAccFunctionTimingTrigger_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%s
+
+// Timing trigger (with rate schedule type)
+resource "huaweicloud_fgs_function_trigger" "timer_rate" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "TIMER"
+  status       = "DISABLED"
+  event_data   = jsonencode({
+    "name": "%[2]s_rate",
+    "schedule_type": "Rate",
+    "user_event": "Created by acc test",
+    "schedule": "3m"
+  })
+}
+
+// Timing trigger (with cron schedule type)
+resource "huaweicloud_fgs_function_trigger" "timer_cron" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = "TIMER"
+  status       = "DISABLED"
+  event_data   = jsonencode({
+    "name": "%[2]s_cron",
+    "schedule_type": "Cron",
+    "user_event": "Created by acc test",
+    "schedule": "@every 1h30m"
+  })
+}
+`, testAccFunctionTrigger_base(name), name)
+}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_fgs_trigger.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_fgs_trigger.go
@@ -1,4 +1,4 @@
-package fgs
+package deprecated
 
 import (
 	"context"

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger.go
@@ -1,0 +1,390 @@
+package fgs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	triggerStatusActive   = "ACTIVE"
+	triggerStatusDisabled = "DISABLED"
+)
+
+// @API FunctionGraph POST /v2/{project_id}/fgs/triggers/{function_urn}
+// @API FunctionGraph GET /v2/{project_id}/fgs/triggers/{function_urn}/{trigger_type_code}/{trigger_id}
+// @API FunctionGraph PUT /v2/{project_id}/fgs/triggers/{function_urn}/{trigger_type_code}/{trigger_id}
+// @API FunctionGraph DELETE /v2/{project_id}/fgs/triggers/{function_urn}/{trigger_type_code}/{trigger_id}
+func ResourceFunctionTrigger() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFunctionTriggerCreate,
+		ReadContext:   resourceFunctionTriggerRead,
+		UpdateContext: resourceFunctionTriggerUpdate,
+		DeleteContext: resourceFunctionTriggerDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceFunctionTriggermportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the function trigger is located.`,
+			},
+			"function_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The function URN to which the function trigger belongs.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The type of the function trigger.`,
+			},
+			"event_data": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  `The detailed configuration of the function trigger.`,
+			},
+			// INFO:
+			// + Currently, only some triggers support setting the **DISABLED** value, such as `TIMER`, `DDS`, `DMS`,
+			//   `KAFKA` and `LTS`.
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					triggerStatusActive, triggerStatusDisabled,
+				}, false),
+				Description: `The expected status of the function trigger.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the function trigger.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the function trigger.`,
+			},
+		},
+	}
+}
+
+func resourceFunctionTriggerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/fgs/triggers/{function_urn}"
+		functionUrn = d.Get("function_urn").(string)
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{function_urn}", functionUrn)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateFunctionTriggerBodyParams(d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating function trigger: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resourceId := utils.PathSearch("trigger_id", respBody, "")
+	d.SetId(resourceId.(string))
+
+	return resourceFunctionTriggerRead(ctx, d, meta)
+}
+
+func buildCreateFunctionTriggerBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := d.Get("event_data").(string)
+	parseResult := make(map[string]interface{})
+	err := json.Unmarshal([]byte(params), &parseResult)
+	if err != nil {
+		log.Printf("[ERROR] Invalid type of the params, not json format")
+	}
+	return map[string]interface{}{
+		"trigger_type_code": d.Get("type"),
+		"trigger_status":    d.Get("status"),
+		"event_data":        parseResult,
+	}
+}
+
+func waitForFunctionTriggerStatusCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      functionTriggerStatusRefreshFunc(client, d, []string{"ACTIVE", "DISABLED"}),
+		Timeout:      d.Timeout(schema.TimeoutUpdate),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func functionTriggerStatusRefreshFunc(client *golangsdk.ServiceClient, d *schema.ResourceData, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			functionUrn = d.Get("function_urn").(string)
+			triggerType = d.Get("type").(string)
+			triggerId   = d.Id()
+		)
+		respBody, err := GetTriggerById(client, functionUrn, triggerType, triggerId)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return triggerId, "COMPLETED", nil
+			}
+			return respBody, "ERROR", err
+		}
+
+		status := utils.PathSearch("trigger_status", respBody, "").(string)
+		// The values of the trigger status only 'ACTIVE' and 'DISABLED', and does not include abnormal status.
+		if utils.StrSliceContains(targets, status) {
+			return respBody, "COMPLETED", nil
+		}
+		return respBody, "PENDING", nil
+	}
+}
+
+func GetTriggerById(client *golangsdk.ServiceClient, functionUrn, triggerType, triggerId string) (interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/fgs/triggers/{function_urn}/{trigger_type_code}/{trigger_id}"
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{function_urn}", functionUrn)
+	getPath = strings.ReplaceAll(getPath, "{trigger_type_code}", triggerType)
+	getPath = strings.ReplaceAll(getPath, "{trigger_id}", triggerId)
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, parseTriggerQueryError(err)
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func parseTriggerQueryError(err error) error {
+	var errCode golangsdk.ErrDefault500
+	if errors.As(err, &errCode) {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return err
+		}
+
+		errorCode, errorCodeErr := jmespath.Search("error_code", apiError)
+		if errorCodeErr != nil {
+			return err
+		}
+
+		// Error code FSS.0500 indicates that the function to which the trigger belongs has been deleted.
+		if errorCode == "FSS.0500" {
+			return golangsdk.ErrDefault404(errCode)
+		}
+	}
+	return err
+}
+
+func parseEventData(eventData interface{}) interface{} {
+	jsonEventData, err := json.Marshal(eventData)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert the event data of the function trigger, not json format")
+		return nil
+	}
+	return string(jsonEventData)
+}
+
+func resourceFunctionTriggerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		functionUrn = d.Get("function_urn").(string)
+		triggerType = d.Get("type").(string)
+		triggerId   = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	respBody, err := GetTriggerById(client, functionUrn, triggerType, triggerId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Function trigger")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("type", utils.PathSearch("trigger_type_code", respBody, nil)),
+		d.Set("status", utils.PathSearch("trigger_status", respBody, nil)),
+		d.Set("event_data", parseEventData(utils.PathSearch("event_data", respBody, nil))),
+		d.Set("created_at", utils.PathSearch("created_time", respBody, nil)),
+		d.Set("updated_at", utils.PathSearch("last_updated_time", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateFunctionTriggerBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := d.Get("event_data").(string)
+	parseResult := make(map[string]interface{})
+	err := json.Unmarshal([]byte(params), &parseResult)
+	if err != nil {
+		log.Printf("[ERROR] Invalid type of the params, not json format")
+	}
+	return map[string]interface{}{
+		"trigger_status": d.Get("status"),
+		"event_data":     parseResult,
+	}
+}
+
+func resourceFunctionTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/fgs/triggers/{function_urn}/{trigger_type_code}/{trigger_id}"
+		functionUrn = d.Get("function_urn").(string)
+		triggerType = d.Get("type").(string)
+		triggerId   = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{function_urn}", functionUrn)
+	updatePath = strings.ReplaceAll(updatePath, "{trigger_type_code}", triggerType)
+	updatePath = strings.ReplaceAll(updatePath, "{trigger_id}", triggerId)
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildUpdateFunctionTriggerBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpts)
+	if err != nil {
+		return diag.Errorf("error deleting function trigger: %s", err)
+	}
+
+	err = waitForFunctionTriggerStatusCompleted(ctx, client, d)
+	if err != nil {
+		diag.Errorf("error waiting for the function trigger (%s) status to become available: %s", triggerId, err)
+	}
+	return nil
+}
+
+func resourceFunctionTriggerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/fgs/triggers/{function_urn}/{trigger_type_code}/{trigger_id}"
+		functionUrn = d.Get("function_urn").(string)
+		triggerType = d.Get("type").(string)
+		triggerId   = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{function_urn}", functionUrn)
+	deletePath = strings.ReplaceAll(deletePath, "{trigger_type_code}", triggerType)
+	deletePath = strings.ReplaceAll(deletePath, "{trigger_id}", triggerId)
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting function trigger: %s", err)
+	}
+
+	err = waitForFunctionTriggerDeleted(ctx, client, d)
+	if err != nil {
+		diag.Errorf("error waiting for the function trigger (%s) status to become deleted: %s", triggerId, err)
+	}
+	return nil
+}
+
+func waitForFunctionTriggerDeleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      functionTriggerStatusRefreshFunc(client, d, nil),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        5 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
+func resourceFunctionTriggermportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	var (
+		importId = d.Id()
+		parts    = strings.Split(importId, "/")
+	)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid resource ID format for function trigger, want '<function_urn>/<type>/<id>', but got '%s'", importId)
+	}
+	d.SetId(parts[2])
+	mErr := multierror.Append(
+		d.Set("function_urn", parts[0]),
+		d.Set("type", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The design of the old function trigger resource depends on the structure and corresponding method of the `golangsdk`. The type of `event_data` is not defined as `interface{}` at the beginning of the design, but as an object parameter of a specific structure. When a new type of trigger is connected, extra code needs to be added and maintained, which requires heavy workload. The readability of the current code is not as good as before, and the code needs to be rewritten.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new function trigger to replace the old one.
2. deprecate the resource, acceptance test and document for old function trigger.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFunctionTrigger_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFunctionTrigger_basic -timeout 360m -parallel 4
=== RUN   TestAccFunctionTrigger_basic
=== PAUSE TestAccFunctionTrigger_basic
=== CONT  TestAccFunctionTrigger_basic
--- PASS: TestAccFunctionTrigger_basic (42.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       42.532s
```
