### PR TITLE
feat(iotda/device): device access authentication information supports new parameters

### DIFF
--- a/docs/resources/iotda_device.md
+++ b/docs/resources/iotda_device.md
@@ -60,12 +60,34 @@ Changing this parameter will create a new resource.
 Only letters, digits, hyphens (-) and underscore (_) are allowed. If omitted, the platform will automatically allocate
 a device ID. Changing this parameter will create a new resource.
 
-* `secret` - (Optional, String) Specifies a secret for identity authentication, which contains 8 to 32 characters.
+* `secret` - (Optional, String) Specifies a primary secret for identity authentication, which contains 8 to 32 characters.
 Only letters, digits, hyphens (-) and underscore (_) are allowed.
 
-* `fingerprint` - (Optional, String) Specifies a fingerprint of X.509 certificate for identity authentication,
+* `secondary_secret` - (Optional, String) Specifies a secondary secret for identity authentication.
+  When the primary secret verification fails, the secondary secret verification will be enabled, and the secondary
+  secret has the same effect as the primary secret; The secondary secret is not effective for devices connected to the
+  COAP protocol. Which contains 8 to 32 characters. Only letters, digits, hyphens (-) and underscore (_) are allowed.
+
+* `fingerprint` - (Optional, String) Specifies a primary fingerprint of X.509 certificate for identity authentication,
 which is a 40-digit or 64-digit hexadecimal string. For more detail, please see
 [Registering a Device Authenticated by an X.509 Certificate](https://support.huaweicloud.com/en-us/usermanual-iothub/iot_01_0055.html).
+
+* `secondary_fingerprint` - (Optional, String) Specifies a secondary fingerprint of X.509 certificate for identity
+  authentication. When primary fingerprint verification fails, secondary fingerprint verification will be enabled, and
+  the secondary fingerprint has the same effectiveness as the primary fingerprint.
+  Which is a 40-digit or 64-digit hexadecimal string. For more detail, please see
+  [Registering a Device Authenticated by an X.509 Certificate](https://support.huaweicloud.com/en-us/usermanual-iothub/iot_01_0055.html).
+
+-> Only one identity authentication method can be used, either secret or fingerprint. The `secret`, `secondary_secret`
+  fields and `fingerprint`, `secondary_fingerprint` fields cannot be set simultaneously.
+
+* `secure_access` - (Optional, Bool) Specifies whether the device is connected through a secure protocol.
+  The default value is **true**. If specified as **false**, this means accessing via an insecure protocol, and the
+  device accessed through insecure methods are susceptible to security risks such as counterfeiting.
+  Please use with caution.
+
+* `force_disconnect` - (Optional, Bool) Specifies whether to force device disconnection when resetting secrets or
+  fingerprints, currently, only long connections are allowed. The default value is **false**.
 
 * `gateway_id` - (Optional, String) Specifies the gateway ID which is the device ID of the parent device.
 The child device is not directly connected to the platform. If omitted, it means to create a device directly connected
@@ -102,4 +124,22 @@ Devices can be imported using the `id`, e.g.
 
 ```
 $ terraform import huaweicloud_iotda_device.test 10022532f4f94f26b01daa1e424853e1
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `force_disconnect`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition
+should be updated to align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_iotda_device" "test" { 
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      force_disconnect,
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
@@ -48,6 +48,8 @@ func TestAccDevice_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", nodeId),
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "secret", "1234567890"),
+					resource.TestCheckResourceAttr(rName, "secondary_secret", "test123456"),
+					resource.TestCheckResourceAttr(rName, "secure_access", "false"),
 					resource.TestCheckResourceAttr(rName, "description", "demo"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "status", "INACTIVE"),
@@ -67,6 +69,8 @@ func TestAccDevice_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", updateName),
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "fingerprint", "1234567890123456789012345678901234567890"),
+					resource.TestCheckResourceAttr(rName, "secondary_fingerprint", "dc0f1016f495157344ac5f1296335cff725ef22f"),
+					resource.TestCheckResourceAttr(rName, "secure_access", "true"),
 					resource.TestCheckResourceAttr(rName, "description", "demo_update"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar_update"),
 					resource.TestCheckResourceAttr(rName, "status", "FROZEN"),
@@ -84,6 +88,9 @@ func TestAccDevice_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_disconnect",
+				},
 			},
 		},
 	})
@@ -95,12 +102,15 @@ func testDevice_basic(name, nodeId string) string {
 %s
 
 resource "huaweicloud_iotda_device" "test" {
-  node_id     = "%[3]s"
-  name        = "%[2]s"
-  space_id    = huaweicloud_iotda_space.test.id
-  product_id  = huaweicloud_iotda_product.test.id
-  secret      = "1234567890"
-  description = "demo"
+  node_id          = "%[3]s"
+  name             = "%[2]s"
+  space_id         = huaweicloud_iotda_space.test.id
+  product_id       = huaweicloud_iotda_product.test.id
+  secret           = "1234567890"
+  secondary_secret = "test123456"
+  secure_access    = false
+  force_disconnect = true
+  description      = "demo"
 
   tags = {
     foo = "bar"
@@ -124,13 +134,14 @@ func testDevice_basic_update(name, nodeId string) string {
 %s
 
 resource "huaweicloud_iotda_device" "test" {
-  node_id     = "%[3]s"
-  name        = "%[2]s"
-  space_id    = huaweicloud_iotda_space.test.id
-  product_id  = huaweicloud_iotda_product.test.id
-  fingerprint = "1234567890123456789012345678901234567890"
-  description = "demo_update"
-  frozen      = true
+  node_id               = "%[3]s"
+  name                  = "%[2]s"
+  space_id              = huaweicloud_iotda_space.test.id
+  product_id            = huaweicloud_iotda_product.test.id
+  fingerprint           = "1234567890123456789012345678901234567890"
+  secondary_fingerprint = "dc0f1016f495157344ac5f1296335cff725ef22f"
+  description           = "demo_update"
+  frozen                = true
 
   tags = {
     foo = "bar_update"

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
@@ -100,33 +100,35 @@ func ResourceDevice() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				Sensitive:     true,
-				ConflictsWith: []string{"fingerprint"},
-				ValidateFunc: validation.All(
-					validation.StringLenBetween(8, 32),
-					validation.StringMatch(regexp.MustCompile(`^[A-Za-z-_0-9]*$`),
-						"Only letters, digits, underscores (_) and hyphens (-) are allowed."),
-				),
+				ConflictsWith: []string{"fingerprint", "secondary_fingerprint"},
 			},
-
+			"secondary_secret": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"fingerprint", "secondary_fingerprint"},
+			},
 			"fingerprint": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ConflictsWith: []string{"secret"},
-				ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
-					v, ok := i.(string)
-					if !ok {
-						errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
-						return warnings, errors
-					}
-
-					if len(v) != 40 && len(v) != 64 {
-						errors = append(errors,
-							fmt.Errorf("expected the fingerprint is a 40-digit or 64-digit hexadecimal string"))
-					}
-
-					return warnings, errors
-				},
+				ConflictsWith: []string{"secret", "secondary_secret"},
+			},
+			"secondary_fingerprint": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"secret", "secondary_secret"},
+			},
+			"secure_access": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"force_disconnect": {
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 
 			"gateway_id": {
@@ -190,6 +192,22 @@ func ResourceDeviceCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(*resp.DeviceId)
 
+	// Set Secondary Secret.
+	if v, ok := d.Get("secondary_secret").(string); ok && v != "" {
+		err = resetDeviceSecondarySecret(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Set Secondary Fingerprint.
+	if v, ok := d.Get("secondary_fingerprint").(string); ok && v != "" {
+		err = resetDeviceSecondaryFingerprint(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	// bind tags
 	err = bindDeviceTags(client, d.Id(), nil, d.Get("tags").(map[string]interface{}))
 	if err != nil {
@@ -237,7 +255,10 @@ func ResourceDeviceRead(_ context.Context, d *schema.ResourceData, meta interfac
 	if response.AuthInfo != nil {
 		mErr = multierror.Append(mErr,
 			d.Set("secret", response.AuthInfo.Secret),
+			d.Set("secondary_secret", response.AuthInfo.SecondarySecret),
 			d.Set("fingerprint", response.AuthInfo.Fingerprint),
+			d.Set("secondary_fingerprint", response.AuthInfo.SecondaryFingerprint),
+			d.Set("secure_access", response.AuthInfo.SecureAccess),
 			d.Set("auth_type", response.AuthInfo.AuthType),
 		)
 	}
@@ -253,8 +274,8 @@ func ResourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
 
-	// name,desc
-	if d.HasChanges("name", "description") {
+	// Update name,desc,secure_access
+	if d.HasChanges("name", "description", "secure_access") {
 		updateOpts := buildDeviceUpdateParams(d)
 		_, err = client.UpdateDevice(updateOpts)
 		if err != nil {
@@ -262,30 +283,50 @@ func ResourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	// Reset Device Secret
+	// Reset Device Primary Secret.
 	if d.HasChange("secret") {
 		_, err = client.ResetDeviceSecret(&model.ResetDeviceSecretRequest{
 			DeviceId: d.Id(),
 			ActionId: "resetSecret",
 			Body: &model.ResetDeviceSecret{
-				Secret: utils.StringIgnoreEmpty(d.Get("secret").(string)),
+				Secret:          utils.StringIgnoreEmpty(d.Get("secret").(string)),
+				ForceDisconnect: utils.Bool(d.Get("force_disconnect").(bool)),
+				SecretType:      utils.String("PRIMARY"),
 			},
 		})
 		if err != nil {
-			return diag.Errorf("error updating the secret of IoTDA device: %s", err)
+			return diag.Errorf("error updating the primary secret of IoTDA device: %s", err)
 		}
 	}
 
-	// Reset Fingerprint
+	// Reset Device Secondary Secret.
+	if d.HasChange("secondary_secret") {
+		err = resetDeviceSecondarySecret(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// Reset Primary Fingerprint.
 	if d.HasChange("fingerprint") {
 		_, err = client.ResetFingerprint(&model.ResetFingerprintRequest{
 			DeviceId: d.Id(),
 			Body: &model.ResetFingerprint{
-				Fingerprint: utils.StringIgnoreEmpty(d.Get("fingerprint").(string)),
+				Fingerprint:     utils.StringIgnoreEmpty(d.Get("fingerprint").(string)),
+				ForceDisconnect: utils.Bool(d.Get("force_disconnect").(bool)),
+				FingerprintType: utils.String("PRIMARY"),
 			},
 		})
 		if err != nil {
-			return diag.Errorf("error updating the fingerprint of IoTDA device: %s", err)
+			return diag.Errorf("error updating the primary fingerprint of IoTDA device: %s", err)
+		}
+	}
+
+	// Reset Secondary Fingerprint.
+	if d.HasChange("secondary_fingerprint") {
+		err = resetDeviceSecondaryFingerprint(client, d)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
@@ -309,6 +350,39 @@ func ResourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	return ResourceDeviceRead(ctx, d, meta)
+}
+
+func resetDeviceSecondarySecret(client *iotdav5.IoTDAClient, d *schema.ResourceData) error {
+	_, err := client.ResetDeviceSecret(&model.ResetDeviceSecretRequest{
+		DeviceId: d.Id(),
+		ActionId: "resetSecret",
+		Body: &model.ResetDeviceSecret{
+			Secret:          utils.StringIgnoreEmpty(d.Get("secondary_secret").(string)),
+			ForceDisconnect: utils.Bool(d.Get("force_disconnect").(bool)),
+			SecretType:      utils.String("SECONDARY"),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error updating the secondary secret of IoTDA device: %s", err)
+	}
+
+	return nil
+}
+
+func resetDeviceSecondaryFingerprint(client *iotdav5.IoTDAClient, d *schema.ResourceData) error {
+	_, err := client.ResetFingerprint(&model.ResetFingerprintRequest{
+		DeviceId: d.Id(),
+		Body: &model.ResetFingerprint{
+			Fingerprint:     utils.StringIgnoreEmpty(d.Get("secondary_fingerprint").(string)),
+			ForceDisconnect: utils.Bool(d.Get("force_disconnect").(bool)),
+			FingerprintType: utils.String("SECONDARY"),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error updating the secondary fingerprint of IoTDA device: %s", err)
+	}
+
+	return nil
 }
 
 func ResourceDeviceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -393,7 +467,7 @@ func buildDeviceCreateParams(d *schema.ResourceData) *model.AddDeviceRequest {
 			GatewayId:   utils.StringIgnoreEmpty(d.Get("gateway_id").(string)),
 			Description: utils.StringIgnoreEmpty(d.Get("description").(string)),
 			AppId:       utils.StringIgnoreEmpty(d.Get("space_id").(string)),
-			AuthInfo:    buildAuthInfo(d.Get("secret").(string), d.Get("fingerprint").(string)),
+			AuthInfo:    buildAuthInfo(d.Get("secret").(string), d.Get("fingerprint").(string), d.Get("secure_access").(bool)),
 		},
 	}
 	return &req
@@ -405,23 +479,28 @@ func buildDeviceUpdateParams(d *schema.ResourceData) *model.UpdateDeviceRequest 
 		Body: &model.UpdateDevice{
 			DeviceName:  utils.StringIgnoreEmpty(d.Get("name").(string)),
 			Description: utils.StringIgnoreEmpty(d.Get("description").(string)),
+			AuthInfo: &model.AuthInfoWithoutSecret{
+				SecureAccess: utils.Bool(d.Get("secure_access").(bool)),
+			},
 		},
 	}
 	return &req
 }
 
-func buildAuthInfo(secret, fingerprint string) *model.AuthInfo {
+func buildAuthInfo(secret, fingerprint string, secureAccess bool) *model.AuthInfo {
 	if len(secret) > 0 {
 		return &model.AuthInfo{
-			AuthType: utils.String("SECRET"),
-			Secret:   &secret,
+			AuthType:     utils.String("SECRET"),
+			Secret:       &secret,
+			SecureAccess: &secureAccess,
 		}
 	}
 
 	if len(fingerprint) > 0 {
 		return &model.AuthInfo{
-			AuthType:    utils.String("CERTIFICATES"),
-			Fingerprint: &fingerprint,
+			AuthType:     utils.String("CERTIFICATES"),
+			Fingerprint:  &fingerprint,
+			SecureAccess: &secureAccess,
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
device access authentication information supports new parameters
1. secondary_secret: device secondary secret
2. secondary_fingerprint: device secondary fingerprint
3. secure_access: is the device connected through a security protocol
4. force_disconnect: do I force the device to disconnect when resetting the secrets and fingerprints

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
6. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
device access authentication information supports new parameters
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDevice_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDevice_basic -timeout 360m -parallel 4
=== RUN   TestAccDevice_basic
--- PASS: TestAccDevice_basic (15.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     15.166s
```
