### PR TITLE
fix(SWR): fix SWR organization datasource error without returning the access_user_count and repo_count

### DIFF
--- a/huaweicloud/services/swr/data_source_huaweicloud_swr_organizations.go
+++ b/huaweicloud/services/swr/data_source_huaweicloud_swr_organizations.go
@@ -113,8 +113,8 @@ func dataSourceOrganizationsRead(_ context.Context, d *schema.ResourceData, meta
 			"name":              utils.PathSearch("name", organization, nil),
 			"creator":           utils.PathSearch("creator_name", organization, nil),
 			"permission":        resourceSWRAuthToPermission(int(permission)),
-			"access_user_count": int(utils.PathSearch("access_user_count", organization, 0).(float64)),
-			"repo_count":        int(utils.PathSearch("repo_count", organization, 0).(float64)),
+			"access_user_count": int(utils.PathSearch("access_user_count", organization, float64(0)).(float64)),
+			"repo_count":        int(utils.PathSearch("repo_count", organization, float64(0)).(float64)),
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

fix SWR organization datasource access_user_count and repo_count attribute error without returning the field

**Special notes for your reviewer**:

**Release note**:

```
fix SWR organization datasource access_user_count and repo_count attribute error without returning the field
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/swr" TESTARGS="-run TestAccDataSourceOrganization
s_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/swr -v -run TestAccDataSourceOrganizations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceOrganizations_basic
=== PAUSE TestAccDataSourceOrganizations_basic
=== CONT  TestAccDataSourceOrganizations_basic
--- PASS: TestAccDataSourceOrganizations_basic (26.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/swr       26.892s
```
