### PR TITLE
fix(refresh): update function return to avoid loop continue

### DIFF
--- a/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_elastic_resource_pool.go
@@ -186,7 +186,8 @@ func elasticResourcePoolStatusRefreshFunc(client *golangsdk.ServiceClient, d *sc
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
 				log.Printf("[DEBUG] The DLI elastic resource pool (%s) has been deleted", resourceName)
-				return respBody, "COMPLETED", nil
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return "Resource Not Found", "COMPLETED", nil
 			}
 			return respBody, "ERROR", err
 		}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
@@ -373,7 +373,8 @@ func dnsCustomLineStatusRefreshFunc(d *schema.ResourceData, client *golangsdk.Se
 		customLineMap, err := flattenCustomLineResponseBody(getDNSCustomLineRespBody, d)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return customLineMap, "DELETED", nil
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return "Resource Not Found", "DELETED", nil
 			}
 			return customLineMap, "", err
 		}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_line_group.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_line_group.go
@@ -325,7 +325,8 @@ func dnsLineGroupStatusRefreshFunc(d *schema.ResourceData, client *golangsdk.Ser
 		getDNSLineGroupResp, err := client.Request("GET", getDNSLineGroupPath, &getDNSLineGroupOpt)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return getDNSLineGroupResp, "DELETED", nil
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return "Resource Not Found", "DELETED", nil
 			}
 			return nil, "", err
 		}

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
@@ -526,7 +526,8 @@ func dnsRecordsetStatusRefreshFunc(client *golangsdk.ServiceClient, waitForConfi
 		getDNSRecordsetResp, err := client.Request("GET", getDNSRecordsetPath, &getDNSRecordsetOpt)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return getDNSRecordsetResp, "DELETED", nil
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return "Resource Not Found", "DELETED", nil
 			}
 			return nil, "", err
 		}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
@@ -1177,12 +1177,14 @@ func deleteClusterWaitingForCompleted(ctx context.Context, d *schema.ResourceDat
 			deleteDwsClusterWaitingResp, err := deleteDwsClusterWaitingClient.Request("GET", deleteDwsClusterWaitingPath, &deleteDwsClusterWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteDwsClusterWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				err = parseClusterNotFoundError(err)
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteDwsClusterWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 				return nil, "ERROR", err
 			}

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_auto_launch_group.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_auto_launch_group.go
@@ -455,7 +455,8 @@ func autoLaunchGroupStatusRefreshFunc(id string, cfg *config.Config,
 		getPrivateCAResp, err := client.Request("GET", getAutoLaunchGroupPath, &getPrivateCAOpt)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return getPrivateCAResp, "DELETED", nil
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return "Resource Not Found", "DELETED", nil
 			}
 			return nil, "ERROR", err
 		}

--- a/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go
@@ -364,7 +364,8 @@ func flowLogStatusRefreshFunc(d *schema.ResourceData, meta interface{}, isDelete
 		resp, err := getFlowLogInfo(d, meta)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok && isDelete {
-				return resp, "DELETED", nil
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return "Resource Not Found", "DELETED", nil
 			}
 
 			return nil, "ERROR", err

--- a/huaweicloud/services/er/resource_huaweicloud_er_instance.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_instance.go
@@ -567,7 +567,8 @@ func deleteInstanceWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 			deleteInstanceWaitingResp, err := deleteInstanceWaitingClient.Request("GET", deleteInstanceWaitingPath, &deleteInstanceWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteInstanceWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_application.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_application.go
@@ -259,7 +259,8 @@ func applicationStatusRefreshFunc(client *golangsdk.ServiceClient, d *schema.Res
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
 				log.Printf("[DEBUG] The FunctionGraph application (%s) has been deleted", applicationId)
-				return respBody, "COMPLETED", nil
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return "Resource Not Found", "COMPLETED", nil
 			}
 			return respBody, "ERROR", err
 		}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger.go
@@ -175,7 +175,7 @@ func functionTriggerStatusRefreshFunc(client *golangsdk.ServiceClient, d *schema
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
 				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
-				return triggerId, "COMPLETED", nil
+				return "Resource Not Found", "COMPLETED", nil
 			}
 			return respBody, "ERROR", err
 		}

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_accelerator.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_accelerator.go
@@ -635,7 +635,8 @@ func deleteAcceleratorWaitingForStateCompleted(ctx context.Context, d *schema.Re
 				deleteAcceleratorWaitingPath, &deleteAcceleratorWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteAcceleratorWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_address_group.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_address_group.go
@@ -592,7 +592,8 @@ func waitIpAddressGroupStatusRefreshFunc(d *schema.ResourceData, meta interface{
 		resp, err := getIpAddressGroupInfo(d, meta)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok && isDelete {
-				return resp, "DELETED", nil
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return "Resource Not Found", "DELETED", nil
 			}
 
 			return nil, "ERROR", err

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint.go
@@ -482,7 +482,8 @@ func deleteEndpointWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 			deleteEndpointWaitingResp, err := deleteEndpointWaitingClient.Request("GET", deleteEndpointWaitingPath, &deleteEndpointWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteEndpointWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint_group.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint_group.go
@@ -526,7 +526,8 @@ func deleteEndpointGroupWaitingForStateCompleted(ctx context.Context, d *schema.
 				deleteEndpointGroupWaitingPath, &deleteEndpointGroupWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteEndpointGroupWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go
@@ -494,7 +494,8 @@ func deleteHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.Re
 				deleteHealthCheckWaitingPath, &deleteHealthCheckWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteHealthCheckWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_listener.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_listener.go
@@ -584,7 +584,8 @@ func deleteListenerWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 			deleteListenerWaitingResp, err := deleteListenerWaitingClient.Request("GET", deleteListenerWaitingPath, &deleteListenerWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteListenerWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err

--- a/huaweicloud/services/ges/resource_huaweicloud_ges_graph.go
+++ b/huaweicloud/services/ges/resource_huaweicloud_ges_graph.go
@@ -794,7 +794,8 @@ func deleteGraphWaitingForStateCompleted(ctx context.Context, d *schema.Resource
 			deleteGraphWaitingResp, err := deleteGraphWaitingClient.Request("GET", deleteGraphWaitingPath, &deleteGraphWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteGraphWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_service.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_service.go
@@ -968,13 +968,14 @@ func deleteServiceWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 			deleteServiceWaitingResp, err := deleteServiceWaitingClient.Request("GET", deleteServiceWaitingPath, &deleteServiceWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteServiceWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err
 			}
 
-			return nil, "PENDING", nil
+			return deleteServiceWaitingResp, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        30 * time.Second,

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_workspace.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_workspace.go
@@ -394,12 +394,14 @@ func deleteWorkspaceWaitingForStateCompleted(ctx context.Context, d *schema.Reso
 			deleteWorkspaceWaitingResp, err := deleteWorkspaceWaitingClient.Request("GET", deleteWorkspaceWaitingPath, &deleteWorkspaceWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteWorkspaceWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				err = parseWorkspaceNotFoundError(err)
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteWorkspaceWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 				return nil, "ERROR", err
 			}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
@@ -468,7 +468,8 @@ func deleteBackupWaitingForStateCompleted(ctx context.Context, d *schema.Resourc
 			deleteBackupWaitingResp, err := deleteBackupWaitingClient.Request("GET", deleteBackupWaitingPath, &deleteBackupWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteBackupWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err

--- a/huaweicloud/services/rms/resource_huaweicloud_rms_assignment_package.go
+++ b/huaweicloud/services/rms/resource_huaweicloud_rms_assignment_package.go
@@ -315,7 +315,8 @@ func rmsAssignmentPackageStateRefreshFunc(client *golangsdk.ServiceClient, cfg *
 		getAssignmentPackageRespBody, err := getAssignmentPackage(client, cfg, id)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
-				return getAssignmentPackageRespBody, "DELETED", nil
+				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				return "Resource Not Found", "DELETED", nil
 			}
 			return nil, "", err
 		}

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
@@ -1010,7 +1010,8 @@ func deleteConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 			deleteConnectionWaitingResp, err := deleteConnectionWaitingClient.Request("GET", deleteConnectionWaitingPath, &deleteConnectionWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteConnectionWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_gateway.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_gateway.go
@@ -1113,7 +1113,8 @@ func deleteGatewayWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 			deleteGatewayWaitingResp, err := deleteGatewayWaitingClient.Request("GET", deleteGatewayWaitingPath, &deleteGatewayWaitingOpt)
 			if err != nil {
 				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					return deleteGatewayWaitingResp, "COMPLETED", nil
+					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is a problem with the value design of the parameter return list of the refresh function:
When the returned error and interface{} are both empty, the loop will continue.
Because at this time, the get request query showed a 404 error but the response body in the code was empty, which caused the above situation and failed to exit the status polling normally, extending the test time.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update function return to avoid loop continue.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

Before fixing
```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFunctionTrigger_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFunctionTrigger_basic -timeout 360m -parallel 4
=== RUN   TestAccFunctionTrigger_basic
=== PAUSE TestAccFunctionTrigger_basic
=== CONT  TestAccFunctionTrigger_basic
--- PASS: TestAccFunctionTrigger_basic (217.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       217.414s
```

After modification
```make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccFunctionTrigger_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccFunctionTrigger_basic -timeout 360m -parallel 4
=== RUN   TestAccFunctionTrigger_basic
=== PAUSE TestAccFunctionTrigger_basic
=== CONT  TestAccFunctionTrigger_basic
--- PASS: TestAccFunctionTrigger_basic (41.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       41.692s

```
