### PR TITLE
feat(nat): public snat rule resource support global_eip_id parameter

### DIFF
--- a/docs/resources/nat_snat_rule.md
+++ b/docs/resources/nat_snat_rule.md
@@ -22,6 +22,30 @@ resource "huaweicloud_nat_snat_rule" "test" {
 }
 ```
 
+```hcl
+variable "gateway_id" {}
+variable "geip_id" {}
+variable "subent_id" {}
+
+resource "huaweicloud_global_eip" "test" {
+  ...
+}
+
+resource "huaweicloud_global_eip_associate" "test" {
+  ...
+}
+
+resource "huaweicloud_nat_snat_rule" "test" {
+  depends_on = [
+    huaweicloud_global_eip_associate.test
+  ]
+
+  nat_gateway_id = var.gateway_id
+  global_eip_id  = var.geip_id
+  subnet_id      = var.subent_id
+}
+```
+
 ### SNAT rule in DC (Direct Connect) scenario
 
 ```hcl
@@ -31,6 +55,30 @@ variable "publicip_id" {}
 resource "huaweicloud_nat_snat_rule" "test" {
   nat_gateway_id = var.gateway_id
   floating_ip_id = var.publicip_id
+  source_type    = 1
+  cidr           = "192.168.10.0/24"
+}
+```
+
+```hcl
+variable "gateway_id" {}
+variable "geip_id" {}
+
+resource "huaweicloud_global_eip" "test" {
+  ...
+}
+
+resource "huaweicloud_global_eip_associate" "test" {
+  ...
+}
+
+resource "huaweicloud_nat_snat_rule" "test" {
+  depends_on = [
+    huaweicloud_global_eip_associate.test
+  ]
+
+  nat_gateway_id = var.gateway_id
+  global_eip_id  = var.geip_id
   source_type    = 1
   cidr           = "192.168.10.0/24"
 }
@@ -46,8 +94,13 @@ The following arguments are supported:
 * `nat_gateway_id` - (Required, String, ForceNew) Specifies the ID of the gateway to which the SNAT rule belongs.  
   Changing this will create a new resource.
 
-* `floating_ip_id` - (Required, String) Specifies the IDs of floating IPs connected by SNAT rule.  
+* `floating_ip_id` - (Optional, String) Specifies the IDs of floating IPs connected by SNAT rule.  
   Multiple floating IPs are separated using commas (,). The number of floating IP IDs cannot exceed `20`.
+
+* `global_eip_id` - (Optional, String) Specifies the IDs of global EIPs connected by SNAT rule.  
+  Multiple global EIPs are separated using commas (,). The number of global EIP IDs cannot exceed `20`.
+
+-> Fields `floating_ip_id` and `global_eip_id` cannot be set or empty simultaneously.
 
 * `subnet_id` - (Optional, String, ForceNew) Specifies the network IDs of subnet connected by SNAT rule (VPC side).  
   This parameter and `cidr` are alternative. Changing this will create a new resource.
@@ -69,6 +122,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Specifies a resource ID in UUID format.
 
 * `floating_ip_address` - The actual floating IP address.
+
+* `global_eip_address` - The global EIP addresses (separated by commas) connected by SNAT rule.
 
 * `status` - The status of the SNAT rule.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240227032415-74802e04042b
+	github.com/chnsz/golangsdk v0.0.0-20240305033540-ec855f7fd015
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240227032415-74802e04042b h1:m7PoIvQXCSxYdkxxLHoTTfz4mrMGTUl2tnF3f4YBqb4=
-github.com/chnsz/golangsdk v0.0.0-20240227032415-74802e04042b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240305033540-ec855f7fd015 h1:zFKPLfrg8MEE5Kx3MIJfy/A9fF87tSqsANuAO3/6JcE=
+github.com/chnsz/golangsdk v0.0.0-20240305033540-ec855f7fd015/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_snat_rule_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_snat_rule_test.go
@@ -138,3 +138,185 @@ resource "huaweicloud_nat_snat_rule" "test" {
 }
 `, testAccPublicSnatRule_base(name))
 }
+
+func TestAccPublicSnatRule_associatedGlobalEIP(t *testing.T) {
+	var (
+		obj snats.Rule
+
+		rName = "huaweicloud_nat_snat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPublicSnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckProjectID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPublicSnatRule_associatedGlobalEIP_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "nat_gateway_id", "huaweicloud_nat_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "global_eip_id", "huaweicloud_global_eip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+				),
+			},
+			{
+				Config: testAccPublicSnatRule_associatedGlobalEIP_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "nat_gateway_id", "huaweicloud_nat_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "global_eip_id", "huaweicloud_global_eip.retest", "id"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPublicSnatRule_associatedGlobalEIP_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_gateway" "test" {
+  name                  = "%[2]s"
+  description           = "created by terraform"
+  spec                  = "1"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = "0"
+}
+
+data "huaweicloud_global_eip_pools" "all" {}
+
+resource "huaweicloud_global_internet_bandwidth" "test" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  charge_mode           = "95peak_guar"
+  enterprise_project_id = "0"
+  size                  = 300
+  isp                   = data.huaweicloud_global_eip_pools.all.geip_pools[0].isp
+  name                  = "%[2]s-b1"
+  type                  = data.huaweicloud_global_eip_pools.all.geip_pools[0].allowed_bandwidth_types[0].type
+}
+
+resource "huaweicloud_global_eip" "test" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  enterprise_project_id = "0"
+  geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
+  internet_bandwidth_id = huaweicloud_global_internet_bandwidth.test.id
+  name                  = "%[2]s-g1"
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+resource "huaweicloud_global_eip_associate" "test" {
+  global_eip_id  = huaweicloud_global_eip.test.id
+  is_reserve_gcb = false
+
+  associate_instance {
+    region        = huaweicloud_nat_gateway.test.region
+    project_id    = "%[3]s"
+    instance_type = "NATGW"
+    instance_id   = huaweicloud_nat_gateway.test.id
+  }
+
+  gc_bandwidth {
+    name        = "%[2]s-gc1"
+    charge_mode = "bwd"
+    size        = 5
+  }
+}
+
+resource "huaweicloud_global_internet_bandwidth" "retest" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  charge_mode           = "95peak_guar"
+  enterprise_project_id = "0"
+  size                  = 300
+  isp                   = data.huaweicloud_global_eip_pools.all.geip_pools[0].isp
+  name                  = "%[2]s-b2"
+  type                  = data.huaweicloud_global_eip_pools.all.geip_pools[0].allowed_bandwidth_types[0].type
+}
+
+resource "huaweicloud_global_eip" "retest" {
+  access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
+  enterprise_project_id = "0"
+  geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
+  internet_bandwidth_id = huaweicloud_global_internet_bandwidth.retest.id
+  name                  = "%[2]s-g2"
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+resource "huaweicloud_global_eip_associate" "retest" {
+  global_eip_id  = huaweicloud_global_eip.retest.id
+  is_reserve_gcb = false
+
+  associate_instance {
+    region        = huaweicloud_nat_gateway.test.region
+    project_id    = "%[3]s"
+    instance_type = "NATGW"
+    instance_id   = huaweicloud_nat_gateway.test.id
+  }
+
+  gc_bandwidth {
+    name        = "%[2]s-gc2"
+    charge_mode = "bwd"
+    size        = 5
+  }
+}
+`, common.TestBaseNetwork(name), name, acceptance.HW_PROJECT_ID)
+}
+
+func testAccPublicSnatRule_associatedGlobalEIP_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_snat_rule" "test" {
+  depends_on = [
+    huaweicloud_global_eip_associate.test
+  ]
+
+  nat_gateway_id = huaweicloud_nat_gateway.test.id
+  subnet_id      = huaweicloud_vpc_subnet.test.id
+  global_eip_id  = huaweicloud_global_eip.test.id
+  description    = "Created by terraform"
+}
+`, testAccPublicSnatRule_associatedGlobalEIP_base(name))
+}
+
+func testAccPublicSnatRule_associatedGlobalEIP_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_snat_rule" "test" {
+  depends_on = [
+    huaweicloud_global_eip_associate.retest
+  ]
+
+  nat_gateway_id = huaweicloud_nat_gateway.test.id
+  subnet_id      = huaweicloud_vpc_subnet.test.id
+  global_eip_id  = huaweicloud_global_eip.retest.id
+  description    = "Created by terraform"
+}
+`, testAccPublicSnatRule_associatedGlobalEIP_base(name))
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/snats/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/snats/requests.go
@@ -9,7 +9,9 @@ type CreateOpts struct {
 	// The ID of the gateway to which the SNAT rule belongs.
 	GatewayId string `json:"nat_gateway_id" required:"true"`
 	//  IDs of floating IPs connected by SNAT rules (separated by commas).
-	FloatingIpId string `json:"floating_ip_id" required:"true"`
+	FloatingIpId string `json:"floating_ip_id,omitempty"`
+	// The IDs (separated by commas) of global EIPs connected by SNAT rule.
+	GlobalEipId string `json:"global_eip_id,omitempty"`
 	// The description of the SNAT rule.
 	Description string `json:"description,omitempty"`
 	// The network IDs of subnet connected by SNAT rule (VPC side).
@@ -56,6 +58,8 @@ type UpdateOpts struct {
 	GatewayId string `json:"nat_gateway_id" required:"true"`
 	// The floating IP addresses (separated by commas) connected by SNAT rule.
 	FloatingIpAddress string `json:"public_ip_address,omitempty"`
+	// The IDs (separated by commas) of global EIPs connected by SNAT rule.
+	GlobalEipId string `json:"global_eip_id,omitempty"`
 	// The description of the SNAT rule.
 	Description *string `json:"description,omitempty"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/snats/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/snats/results.go
@@ -14,6 +14,10 @@ type Rule struct {
 	FloatingIpId string `json:"floating_ip_id"`
 	// The floating IP addresses (separated by commas) connected by SNAT rule.
 	FloatingIpAddress string `json:"floating_ip_address"`
+	// The IDs (separated by commas) of the global EIPs connected by SNAT rule.
+	GlobalEipId string `json:"global_eip_id"`
+	// The global EIP addresses (separated by commas) connected by SNAT rule.
+	GlobalEipAddress string `json:"global_eip_address"`
 	// The description of the SNAT rule.
 	Description string `json:"description"`
 	// The status of the SNAT rule.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240227032415-74802e04042b
+# github.com/chnsz/golangsdk v0.0.0-20240305033540-ec855f7fd015
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Public snat rule resource support global_eip_id parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Before, create public snat rule the choice of public IP type only support eip.
2.Now, the choice of public IP type can be either geip or eip to create a snat rule .
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_snat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicSnatRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicSnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicSnatRule_basic
=== PAUSE TestAccPublicSnatRule_basic
=== CONT  TestAccPublicSnatRule_basic
--- PASS: TestAccPublicSnatRule_basic (283.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       283.202s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (br_snat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicSnatRule_associatedGlobalEIP"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicSnatRule_associatedGlobalEIP -timeout 360m -parallel 4
=== RUN   TestAccPublicSnatRule_associatedGlobalEIP
=== PAUSE TestAccPublicSnatRule_associatedGlobalEIP
=== CONT  TestAccPublicSnatRule_associatedGlobalEIP
--- PASS: TestAccPublicSnatRule_associatedGlobalEIP (256.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       256.056s
```
