### PR TITLE
feat(dws): add a new data source to get event subscriptions

### DIFF
--- a/docs/data-sources/dws_event_subscriptions.md
+++ b/docs/data-sources/dws_event_subscriptions.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# huaweicloud_dws_event_subscriptions
+
+Use this data source to get the list of event subscriptions.
+
+## Example Usage
+
+```hcl
+variable "subscription_name" {}
+
+data "huaweicloud_dws_event_subscriptions" "test" {
+  name = var.subscription_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the event subscription.
+
+* `notification_target_name` - (Optional, String) Specifies the name of notification target.
+
+* `enable` - (Optional, String) Specifies whether the event subscription is enabled.
+  The options are as follows:
+  + **1**: enabled.
+  + **0**: disabled.
+
+* `category` - (Optional, String) Specifies the category of source event.
+  The valid values are **management**, **monitor**, **security** and **system alarm**.
+  If there are multiple categories, separate by commas, e.g. **management,security**.
+
+* `severity` - (Optional, String) Specifies the severity of source event.
+  The valid values are **normal** and **warning**. If there are multiple severities, separate by commas,
+  e.g. **normal,warning**.
+
+* `source_type` - (Optional, String) Specifies the type of source event.
+  The valid values are **cluster**, **backup** and **disaster-recovery**. If there are multiple types,
+  separate by commas, e.g. **cluster,disaster-recovery**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `event_subscriptions` - The list of event subscriptions.
+  The [event_subscriptions](#attrblock_event_subscriptions) structure is documented below.
+
+<a name="attrblock_event_subscriptions"></a>
+The `event_subscriptions` block supports:
+
+* `id` - The ID of event subscription.
+
+* `name` - The name of the event subscription.
+
+* `category` - The category of source event.
+
+* `enable` - Whether the event subscription is enabled.
+
+* `name_space` - The name space of the event subscription.
+
+* `notification_target` - The notification target.
+
+* `notification_target_name` - The name of notification target.
+
+* `notification_target_type` - The type of notification target.
+
+* `project_id` - The project ID of the event subscription.
+
+* `severity` - The severity of source event.
+
+* `source_id` - The ID of source event.
+
+* `source_type` - The type of source event.
+
+* `language` - The language of the event subscription.
+
+* `time_zone` - The time zone of the event subscription.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -713,6 +713,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_flavors":                 dws.DataSourceDwsFlavors(),
 			"huaweicloud_dws_logical_cluster_rings":   dws.DataSourceLogicalClusterRings(),
 			"huaweicloud_dws_disaster_recovery_tasks": dws.DataSourceDisasterRecoveryTasks(),
+			"huaweicloud_dws_event_subscriptions":     dws.DataSourceEventSubscriptions(),
 
 			"huaweicloud_workspace_desktops": workspace.DataSourceDesktops(),
 			"huaweicloud_workspace_flavors":  workspace.DataSourceWorkspaceFlavors(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_event_subscriptions_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_event_subscriptions_test.go
@@ -1,0 +1,117 @@
+package dws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEventSubscriptionsDataSource_basic(t *testing.T) {
+	resourceName := "data.huaweicloud_dws_event_subscriptions.name_filter"
+	dc := acceptance.InitDataSourceCheck(resourceName)
+	name := acceptance.RandomAccResourceName()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventSubscriptionsDataSourceBasic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "event_subscriptions.#"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("source_type_filter_is_useful", "true"),
+					resource.TestCheckOutput("category_filter_is_useful", "true"),
+					resource.TestCheckOutput("notificate_filter_is_useful", "true"),
+					resource.TestCheckOutput("enable_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccEventSubscriptionsDataSourceBasic(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name         = "%[1]s"
+  display_name = "The display name of topic"
+}
+
+resource "huaweicloud_dws_event_subscription" "test" {
+  name                     = "%[1]s"
+  enable                   = 0
+  notification_target      = huaweicloud_smn_topic.test.id
+  notification_target_type = "SMN"
+  notification_target_name = huaweicloud_smn_topic.test.name
+  category                 = "management,security"
+  severity                 = "normal,warning"
+  source_type              = "cluster,disaster-recovery"
+  time_zone                = "GMT+09:00"
+}
+
+data "huaweicloud_dws_event_subscriptions" "name_filter" {
+  name = huaweicloud_dws_event_subscription.test.name
+}
+
+data "huaweicloud_dws_event_subscriptions" "notificate_filter" {
+  notification_target_name = huaweicloud_dws_event_subscription.test.notification_target_name
+}
+
+data "huaweicloud_dws_event_subscriptions" "enable_filter" {
+  enable = huaweicloud_dws_event_subscription.test.enable
+}
+
+data "huaweicloud_dws_event_subscriptions" "source_type_filter" {
+  source_type = "cluster,disaster-recovery"
+
+  depends_on = [huaweicloud_dws_event_subscription.test]
+}
+
+data "huaweicloud_dws_event_subscriptions" "category_filter" {
+  category = "security,management"
+
+  depends_on = [huaweicloud_dws_event_subscription.test]
+}
+
+locals {
+  name_filter = [for v in data.huaweicloud_dws_event_subscriptions.name_filter.event_subscriptions[*].name :
+  v == huaweicloud_dws_event_subscription.test.name]
+
+  notificate_filter = [for v in data.huaweicloud_dws_event_subscriptions.name_filter.event_subscriptions[*] :
+    v.notification_target_name == huaweicloud_dws_event_subscription.test.notification_target_name]
+
+  enable_filter = [for v in data.huaweicloud_dws_event_subscriptions.name_filter.event_subscriptions[*] :
+    v.enable == huaweicloud_dws_event_subscription.test.enable]
+
+  source_type_filter = [for v in data.huaweicloud_dws_event_subscriptions.source_type_filter.event_subscriptions[*] :
+    length(regexall(replace(v.source_type, ",", "|"), huaweicloud_dws_event_subscription.test.source_type)) ==
+  length(split(",", huaweicloud_dws_event_subscription.test.source_type))]
+
+  category_filter = [for v in data.huaweicloud_dws_event_subscriptions.category_filter.event_subscriptions[*] :
+    length(regexall(replace(v.category, ",", "|"), huaweicloud_dws_event_subscription.test.category)) ==
+  length(split(",", huaweicloud_dws_event_subscription.test.category))]
+}
+
+output "name_filter_is_useful" {
+  value = alltrue(local.name_filter) && length(local.name_filter) > 0
+}
+
+output "notificate_filter_is_useful" {
+  value = alltrue(local.notificate_filter) && length(local.notificate_filter) > 0
+}
+output "enable_filter_is_useful" {
+  value = alltrue(local.enable_filter) && length(local.enable_filter) > 0
+}
+
+output "source_type_filter_is_useful" {
+  value = alltrue(local.source_type_filter) && length(local.source_type_filter) > 0
+}
+
+output "category_filter_is_useful" {
+  value = alltrue(local.category_filter) && length(local.category_filter) > 0
+}
+`, name)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_event_subscriptions.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_event_subscriptions.go
@@ -1,0 +1,278 @@
+package dws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v2/{project_id}/event-subs
+func DataSourceEventSubscriptions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceEventSubscriptionsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of event subscription.`,
+			},
+			"source_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of source event.`,
+			},
+			"category": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The category of source event.`,
+			},
+			"severity": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The severity of source event.`,
+			},
+			"notification_target_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of notification target.`,
+			},
+			"enable": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Whether the event subscription is enabled.`,
+			},
+			"event_subscriptions": {
+				Type:        schema.TypeList,
+				Elem:        eventSubSchema(),
+				Computed:    true,
+				Description: `The list of event subscriptions.`,
+			},
+		},
+	}
+}
+
+func eventSubSchema() *schema.Resource {
+	nodeResource := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of event subscription.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the event subscription.`,
+			},
+			"enable": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Whether the event subscription is enabled.`,
+			},
+			"notification_target": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The notification target.`,
+			},
+			"notification_target_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of notification target.`,
+			},
+			"notification_target_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of notification target. Currently only **SMN** is supported.`,
+			},
+			"source_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of source event.`,
+			},
+			"source_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of source event.`,
+			},
+			"category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The category of source event.`,
+			},
+			"severity": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The severity of source event.`,
+			},
+			"time_zone": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The time zone of the event subscription.`,
+			},
+			"project_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The project ID of the event subscription.`,
+			},
+			"language": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The language of the event subscription.`,
+			},
+			"name_space": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name space of the event subscription.`,
+			},
+		},
+	}
+
+	return &nodeResource
+}
+
+func resourceEventSubscriptionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	// getDwsEventSubs: Query the DWS event subscription.
+	var (
+		getDwsEventSubsHttpUrl = "v2/{project_id}/event-subs"
+		getDwsEventSubsProduct = "dws"
+	)
+	getDwsEventSubsClient, err := cfg.NewServiceClient(getDwsEventSubsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	getDwsEventSubsPath := getDwsEventSubsClient.Endpoint + getDwsEventSubsHttpUrl
+	getDwsEventSubsPath = strings.ReplaceAll(getDwsEventSubsPath, "{project_id}", getDwsEventSubsClient.ProjectID)
+
+	getDwsEventSubsResp, err := pagination.ListAllItems(
+		getDwsEventSubsClient,
+		"offset",
+		getDwsEventSubsPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DWS event subscriptions")
+	}
+
+	getDwsEventSubsRespJson, err := json.Marshal(getDwsEventSubsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var getDwsEventSubsRespBody interface{}
+	err = json.Unmarshal(getDwsEventSubsRespJson, &getDwsEventSubsRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	disasterListJson := utils.PathSearch("event_subscriptions", getDwsEventSubsRespBody, make([]interface{}, 0))
+	disasterList := disasterListJson.([]interface{})
+	if len(disasterList) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving DWS event subscriptions")
+	}
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("event_subscriptions", filterEventSubs(flattenEventSubs(disasterList), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenEventSubs(resp []interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"id":                       utils.PathSearch("id", v, nil),
+			"name":                     utils.PathSearch("name", v, nil),
+			"source_id":                utils.PathSearch("source_id", v, nil),
+			"source_type":              utils.PathSearch("source_type", v, nil),
+			"category":                 utils.PathSearch("category", v, nil),
+			"severity":                 utils.PathSearch("severity", v, nil),
+			"enable":                   fmt.Sprint(utils.PathSearch("enable", v, nil)),
+			"notification_target":      utils.PathSearch("notification_target", v, nil),
+			"notification_target_name": utils.PathSearch("notification_target_name", v, nil),
+			"notification_target_type": utils.PathSearch("notification_target_type", v, nil),
+			"time_zone":                utils.PathSearch("time_zone", v, nil),
+			"project_id":               utils.PathSearch("project_id", v, nil),
+			"language":                 utils.PathSearch("language", v, nil),
+			"name_space":               utils.PathSearch("name_space", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterEventSubs(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("name"); ok {
+			if fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("name", v, nil)) {
+				continue
+			}
+		}
+		if param, ok := d.GetOk("notification_target_name"); ok {
+			if fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("notification_target_name", v, nil)) {
+				continue
+			}
+		}
+		if param, ok := d.GetOk("enable"); ok {
+			if fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("enable", v, nil)) {
+				continue
+			}
+		}
+		if param, ok := d.GetOk("source_type"); ok {
+			if !isAllContain(fmt.Sprint(param), fmt.Sprint(utils.PathSearch("source_type", v, nil))) {
+				continue
+			}
+		}
+		if param, ok := d.GetOk("severity"); ok {
+			if !isAllContain(fmt.Sprint(param), fmt.Sprint(utils.PathSearch("severity", v, nil))) {
+				continue
+			}
+		}
+		if param, ok := d.GetOk("category"); ok {
+			if !isAllContain(fmt.Sprint(param), fmt.Sprint(utils.PathSearch("category", v, nil))) {
+				continue
+			}
+		}
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func isAllContain(filter string, target string) bool {
+	filterList := strings.Split(filter, ",")
+	for _, v := range filterList {
+		if strings.Contains(target, v) {
+			continue
+		}
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new data source to get event subscriptions.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
add a new data source to get event subscriptions.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccEventSubscriptionsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccEventSubscriptionsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccEventSubscriptionsDataSource_basic
=== PAUSE TestAccEventSubscriptionsDataSource_basic
=== CONT  TestAccEventSubscriptionsDataSource_basic
--- PASS: TestAccEventSubscriptionsDataSource_basic (54.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       54.434s

