### PR TITLE
feat(dws): add a new datasource to get list of workload queues

### DIFF
--- a/docs/data-sources/dws_workload_queues.md
+++ b/docs/data-sources/dws_workload_queues.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# huaweicloud_dws_workload_queues
+
+Use this data source to get the list of workload queues.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+data "huaweicloud_dws_workload_queues" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the workload queues.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the cluster ID to which the workload queues belong.
+
+* `name` - (Optional, String) Specifies the name of the workload queue.
+
+* `logical_cluster_name` - (Optional, String) Specifies the name of the cluster. Required
+  if the cluster is a logical cluster.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `queues` - The list of the workload queues.
+  The [queues](#attrblock_queues) structure is documented below.
+
+<a name="attrblock_queues"></a>
+The `queues` block supports:
+
+* `configuration` - The configuration information for workload queue.
+  The [configuration](#attrblock_queues_configuration) structure is documented below.
+
+* `logical_cluster_name` - The logical cluster name.
+
+* `name` - The name of the workload queue.
+
+* `short_query_concurrency_num` - The concurrency of short queries in the workload queue.
+
+* `short_query_optimize` - Short query acceleration switch.
+  + **true**: Support short query acceleration.
+  + **false**: Short query acceleration not supported.
+
+<a name="attrblock_queues_configuration"></a>
+The `configuration` block supports:
+
+* `resource_name` - The resource name.
+
+* `resource_value` - The resource attribute value.
+
+* `value_unit` - The resource attribute unit.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -717,6 +717,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_disaster_recovery_tasks": dws.DataSourceDisasterRecoveryTasks(),
 			"huaweicloud_dws_event_subscriptions":     dws.DataSourceEventSubscriptions(),
 
+			"huaweicloud_dws_workload_queues": dws.DataSourceWorkloadQueues(),
+
 			"huaweicloud_workspace_desktops": workspace.DataSourceDesktops(),
 			"huaweicloud_workspace_flavors":  workspace.DataSourceWorkspaceFlavors(),
 

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_workload_queues_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_workload_queues_test.go
@@ -1,0 +1,79 @@
+package dws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccWorkloadQueuesDataSource_basic(t *testing.T) {
+	resourceName := "data.huaweicloud_dws_workload_queues.test"
+	dc := acceptance.InitDataSourceCheck(resourceName)
+	name := acceptance.RandomAccResourceName()
+	// The cluster password requires a minimum length of 12 characters, and the string 'gap' is used to fill in the gap.
+	password := acceptance.RandomPassword() + "gap"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWorkloadQueuesDataSourceBasic(name, password),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "queues.#"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("no_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_not_exist_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccWorkloadQueuesDataSourceBasic(name, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_dws_workload_queues" "test" {
+  cluster_id = huaweicloud_dws_cluster.test.id
+
+  depends_on = [huaweicloud_dws_workload_queue.test]
+}
+
+data "huaweicloud_dws_workload_queues" "name_filter" {
+  cluster_id = huaweicloud_dws_cluster.test.id
+  name       = huaweicloud_dws_workload_queue.test.name
+}
+
+data "huaweicloud_dws_workload_queues" "name_not_exist_filter" {
+  cluster_id = huaweicloud_dws_cluster.test.id
+  name       = "name_not_exist"
+
+  depends_on = [huaweicloud_dws_workload_queue.test]
+}
+
+locals {
+  no_filter = data.huaweicloud_dws_workload_queues.test.queues[*]
+
+  name_filter = [for v in data.huaweicloud_dws_workload_queues.name_filter.queues[*] : 
+  strcontains(v.name, huaweicloud_dws_workload_queue.test.name)]
+
+  name_not_exist_filter = data.huaweicloud_dws_workload_queues.name_not_exist_filter.queues[*]
+}
+
+output "no_filter_is_useful" {
+  value = length(local.name_filter) > 0
+}
+
+output "name_filter_is_useful" {
+  value = alltrue(local.name_filter) && length(local.name_filter) > 0
+}
+
+output "name_not_exist_filter_is_useful" {
+  value = length(local.name_not_exist_filter) == 0
+}
+`, testAccWorkloadQueue_basic(name, password))
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_workload_queues.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_workload_queues.go
@@ -1,0 +1,228 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v2/{project_id}/clusters/{cluster_id}/workload/queues
+// @API DWS GET /v2/{project_id}/clusters/{cluster_id}/workload/queues/{queue_name}
+func DataSourceWorkloadQueues() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceWorkloadQueuesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the cluster ID to which the workload queue belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the workload queue.`,
+			},
+			"logical_cluster_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the cluster. Required if the cluster is a logical cluster.`,
+			},
+			"queues": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the workload queue.`,
+						},
+						"logical_cluster_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The logical cluster name.`,
+						},
+						"short_query_optimize": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Short query acceleration switch.`,
+						},
+						"short_query_concurrency_num": {
+							Type:        schema.TypeFloat,
+							Computed:    true,
+							Description: `The concurrency of short queries in the workload queue.`,
+						},
+						"configuration": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"resource_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The resource name.`,
+									},
+									"resource_value": {
+										Type:        schema.TypeFloat,
+										Computed:    true,
+										Description: `The resource attribute value.`,
+									},
+									"value_unit": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The resource attribute unit.`,
+									},
+								},
+							},
+							Description: `The configuration information for workload queue.`,
+						},
+					},
+				},
+				Description: `The list of the workload queues.`,
+			},
+		},
+	}
+}
+
+func resourceWorkloadQueuesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/clusters/{cluster_id}/workload/queues"
+		product = "dws"
+	)
+
+	getClient, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	getPath := getClient.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", getClient.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
+
+	// If cluster is logical cluster should add parameter
+	if logicalName, ok := d.GetOk("logical_cluster_name"); ok {
+		getPath += "?logical_cluster_name=" + logicalName.(string)
+	}
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
+		KeepResponseBody: true,
+	}
+
+	getResp, err := getClient.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	queuesListJson := utils.PathSearch("workload_queue_name_list", getRespBody, make([]interface{}, 0))
+	queuesList := queuesListJson.([]interface{})
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("queues", filterQueues(queuesList, d, getClient)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterQueues(all []interface{}, d *schema.ResourceData, client *golangsdk.ServiceClient) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("name"); ok {
+			if !strings.Contains(v.(string), fmt.Sprint(param)) {
+				continue
+			}
+		}
+
+		rst = append(rst, getQueueDetail(v.(string), d, client))
+	}
+	return rst
+}
+
+func getQueueDetail(queueName string, d *schema.ResourceData, client *golangsdk.ServiceClient) interface{} {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/workload/queues/{queue_name}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{queue_name}", queueName)
+	// If cluster is logical cluster should add parameter
+	if logicalName, ok := d.GetOk("logical_cluster_name"); ok {
+		getPath += "?logical_cluster_name=" + logicalName.(string)
+	}
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders:      requestOpts.MoreHeaders,
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		log.Printf("[WARN] failed to get the workload queue detail: %s", err)
+		return nil
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		log.Printf("[WARN] failed to flatten the workload queue detail: %s", err)
+		return nil
+	}
+
+	queueDetail := utils.PathSearch("workload_queue", getRespBody, nil)
+	// When short query optimize is t means support short query acceleration.
+	shorQueryStr := utils.PathSearch("short_query_optimize", queueDetail, "").(string)
+	shorQuery := false
+	if shorQueryStr == "t" {
+		shorQuery = true
+	}
+	rst := map[string]interface{}{
+		"name":                        utils.PathSearch("queue_name", queueDetail, ""),
+		"logical_cluster_name":        utils.PathSearch("logical_cluster_name", queueDetail, ""),
+		"short_query_optimize":        shorQuery,
+		"short_query_concurrency_num": utils.PathSearch("short_query_concurrency_num", queueDetail, 0.0).(float64),
+		"configuration": flattenConfiguration(utils.PathSearch("resource_item_list", queueDetail,
+			make([]interface{}, 0)).([]interface{})),
+	}
+
+	return rst
+}
+
+func flattenConfiguration(queue []interface{}) []interface{} {
+	if len(queue) == 0 {
+		return nil
+	}
+	rst := make([]interface{}, len(queue))
+	for i, queueDetail := range queue {
+		rst[i] = map[string]interface{}{
+			"resource_name":  utils.PathSearch("resource_name", queueDetail, ""),
+			"resource_value": utils.PathSearch("resource_value", queueDetail, 0.0).(float64),
+			"value_unit":     utils.PathSearch("value_unit", queueDetail, ""),
+		}
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new datasource to get list of workload queues.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:


```release-note
add a new datasource to get list of workload queues.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccWorkloadQueuesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccWorkloadQueuesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccWorkloadQueuesDataSource_basic
=== PAUSE TestAccWorkloadQueuesDataSource_basic
=== CONT  TestAccWorkloadQueuesDataSource_basic
--- PASS: TestAccWorkloadQueuesDataSource_basic (1443.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1443.663s


