### PR TITLE
fix(CodeArts): remove the setting action for password fields

### DIFF
--- a/docs/resources/codearts_inspector_website.md
+++ b/docs/resources/codearts_inspector_website.md
@@ -103,8 +103,8 @@ $ terraform import huaweicloud_codearts_inspector_website.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `auth_type`.
-It is generally recommended running `terraform plan` after importing a resource.
+API response, security or some other reason. The missing attributes include: `auth_type`, `login_password`, `login_cookie`,
+`http_headers`. It is generally recommended running `terraform plan` after importing a resource.
 You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
 with the resource. Also, you can ignore changes as below.
 
@@ -115,6 +115,9 @@ resource "huaweicloud_codearts_inspector_website" "test" {
   lifecycle {
     ignore_changes = [
       auth_type,
+      login_password,
+      login_cookie,
+      http_headers,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_inspector_website_test.go
+++ b/huaweicloud/services/acceptance/codearts/resource_huaweicloud_codearts_inspector_website_test.go
@@ -137,6 +137,9 @@ func TestAccInspectorWebsite_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"auth_type",
+					"login_password",
+					"login_cookie",
+					"http_headers",
 				},
 			},
 		},
@@ -194,6 +197,9 @@ func TestAccInspectorWebsite_publicIPAddress(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"auth_type",
+					"login_password",
+					"login_cookie",
+					"http_headers",
 				},
 			},
 		},

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website.go
@@ -296,10 +296,7 @@ func resourceInspectorWebsiteRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("auth_status", utils.PathSearch("auth_status", getResp, nil)),
 		d.Set("login_url", utils.PathSearch("login_url", getSettingsResp, nil)),
 		d.Set("login_username", utils.PathSearch("login_username", getSettingsResp, nil)),
-		d.Set("login_password", utils.PathSearch("login_password", getSettingsResp, nil)),
-		d.Set("login_cookie", utils.PathSearch("login_cookies", getSettingsResp, nil)),
 		d.Set("verify_url", utils.PathSearch("verify_url", getSettingsResp, nil)),
-		d.Set("http_headers", utils.PathSearch("http_headers", getSettingsResp, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Remove the setting action for password fields, cause fields `login_password`, `login_cookie` and `http_headers` do not return from detail API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccInspectorWebsite_publicIPAddress'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccInspectorWebsite_publicIPAddress -timeout 360m -parallel 4
=== RUN   TestAccInspectorWebsite_publicIPAddress
=== PAUSE TestAccInspectorWebsite_publicIPAddress
=== CONT  TestAccInspectorWebsite_publicIPAddress
--- PASS: TestAccInspectorWebsite_publicIPAddress (11.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  11.068s
```

```
make testacc TEST='./huaweicloud/services/acceptance/codearts' TESTARGS='-run TestAccInspectorWebsite_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/codearts -v -run TestAccInspectorWebsite_basic -timeout 360m -parallel 4
=== RUN   TestAccInspectorWebsite_basic
=== PAUSE TestAccInspectorWebsite_basic
=== CONT  TestAccInspectorWebsite_basic
--- PASS: TestAccInspectorWebsite_basic (27.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  27.892s
```
