### PR TITLE
feat(nat): public dnat rule resource support global_eip_id parameter

### DIFF
--- a/docs/resources/nat_dnat_rule.md
+++ b/docs/resources/nat_dnat_rule.md
@@ -28,6 +28,32 @@ resource "huaweicloud_nat_dnat_rule" "test" {
 }
 ```
 
+```hcl
+variable "gateway_id" {}
+variable "geip_id" {}
+
+resource "huaweicloud_compute_instance" "test" {
+  ...
+}
+
+resource "huaweicloud_global_eip_associate" "test" {
+  ...
+}
+
+resource "huaweicloud_nat_dnat_rule" "test" {
+  depends_on = [
+    huaweicloud_global_eip_associate.test
+  ]
+
+  nat_gateway_id        = var.gateway_id
+  global_eip_id         = var.geip_id
+  port_id               = huaweicloud_compute_instance.test.network[0].port
+  protocol              = "tcp"
+  internal_service_port = 23
+  external_service_port = 8023
+}
+```
+
 ### DNAT rule in VPC scenario and specify the port ranges
 
 ```hcl
@@ -48,6 +74,32 @@ resource "huaweicloud_nat_dnat_rule" "test" {
 }
 ```
 
+```hcl
+variable "gateway_id" {}
+variable "geip_id" {}
+
+resource "huaweicloud_compute_instance" "test" {
+  ...
+}
+
+resource "huaweicloud_global_eip_associate" "test" {
+  ...
+}
+
+resource "huaweicloud_nat_dnat_rule" "test" {
+  depends_on = [
+    huaweicloud_global_eip_associate.test
+  ]
+
+  nat_gateway_id              = var.gateway_id
+  global_eip_id               = var.geip_id
+  port_id                     = huaweicloud_compute_instance.test.network[0].port
+  protocol                    = "tcp"
+  internal_service_port_range = "23-823"
+  external_service_port_range = "8023-8823"
+}
+```
+
 ### DNAT rule in Direct Connect scenario
 
 ```hcl
@@ -57,6 +109,28 @@ variable "publicip_id" {}
 resource "huaweicloud_nat_dnat_rule" "test" {
   nat_gateway_id        = var.gateway_id
   floating_ip_id        = var.publicip_id
+  private_ip            = "10.0.0.12"
+  protocol              = "any"
+  internal_service_port = 0
+  external_service_port = 0
+}
+```
+
+```hcl
+variable "gateway_id" {}
+variable "geip_id" {}
+
+resource "huaweicloud_global_eip_associate" "test" {
+  ...
+}
+
+resource "huaweicloud_nat_dnat_rule" "test" {
+  depends_on = [
+    huaweicloud_global_eip_associate.test
+  ]
+
+  nat_gateway_id        = var.gateway_id
+  global_eip_id         = var.geip_id
   private_ip            = "10.0.0.12"
   protocol              = "any"
   internal_service_port = 0
@@ -100,7 +174,11 @@ The following arguments are supported:
 * `nat_gateway_id` - (Required, String, ForceNew) Specifies the ID of the NAT gateway to which the DNAT rule belongs.  
   Changing this will create a new resource.
 
-* `floating_ip_id` - (Required, String) Specifies the ID of the floating IP address.
+* `floating_ip_id` - (Optional, String) Specifies the ID of the floating IP address.
+
+* `global_eip_id` - (Optional, String) Specifies the ID of the global EIP connected by the DNAT rule.
+
+-> Fields `floating_ip_id` and `global_eip_id` cannot be set or empty simultaneously.
 
 * `protocol` - (Required, String) Specifies the protocol type.  
   The valid values are **tcp**, **udp**, and **any**.
@@ -146,6 +224,8 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - The current status of the DNAT rule.
 
 * `floating_ip_address` - The actual floating IP address.
+
+* `global_eip_address` - The global EIP address connected by the DNAT rule.
 
 ## Timeouts
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240305121901-7301d436d26b
+	github.com/chnsz/golangsdk v0.0.0-20240307061543-48f17bb16b4d
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240305121901-7301d436d26b h1:46C4by9jh5scw6K51T9qqc7crO+M9eOMtczFvPqe8pk=
-github.com/chnsz/golangsdk v0.0.0-20240305121901-7301d436d26b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240307061543-48f17bb16b4d h1:PrlbZ+YUJB+X++SihzHH7zc1zBuWlf73ZRqMt1tEQXo=
+github.com/chnsz/golangsdk v0.0.0-20240307061543-48f17bb16b4d/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_dnat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_dnat_rule.go
@@ -48,9 +48,15 @@ func ResourcePublicDnatRule() *schema.Resource {
 				Description: "The region where the DNAT rule is located.",
 			},
 			"floating_ip_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"floating_ip_id", "global_eip_id"},
+				Description:  "The ID of the floating IP address.",
+			},
+			"global_eip_id": {
 				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The ID of the floating IP address.",
+				Optional:    true,
+				Description: "The ID of the global EIP connected by the DNAT rule.",
 			},
 			"protocol": {
 				Type:        schema.TypeString,
@@ -116,6 +122,11 @@ func ResourcePublicDnatRule() *schema.Resource {
 				Computed:    true,
 				Description: "The floating IP address of the DNAT rule.",
 			},
+			"global_eip_address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The global EIP address connected by the DNAT rule.",
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -129,6 +140,7 @@ func buildPublicDnatRuleCreateOpts(d *schema.ResourceData) dnats.CreateOpts {
 	return dnats.CreateOpts{
 		GatewayId:                d.Get("nat_gateway_id").(string),
 		FloatingIpId:             d.Get("floating_ip_id").(string),
+		GlobalEipId:              d.Get("global_eip_id").(string),
 		Protocol:                 d.Get("protocol").(string),
 		InternalServicePort:      utils.Int(d.Get("internal_service_port").(int)),
 		ExternalServicePort:      utils.Int(d.Get("external_service_port").(int)),
@@ -209,6 +221,7 @@ func resourcePublicDnatRuleRead(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("region", region),
 		d.Set("nat_gateway_id", resp.GatewayId),
 		d.Set("floating_ip_id", resp.FloatingIpId),
+		d.Set("global_eip_id", resp.GlobalEipId),
 		d.Set("protocol", resp.Protocol),
 		d.Set("internal_service_port", resp.InternalServicePort),
 		d.Set("external_service_port", resp.ExternalServicePort),
@@ -219,6 +232,7 @@ func resourcePublicDnatRuleRead(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("private_ip", resp.PrivateIp),
 		d.Set("created_at", resp.CreatedAt),
 		d.Set("floating_ip_address", resp.FloatingIpAddress),
+		d.Set("global_eip_address", resp.GlobalEipAddress),
 		d.Set("status", resp.Status),
 	)
 	if err = mErr.ErrorOrNil(); err != nil {
@@ -231,6 +245,7 @@ func buildPublicDnatRuleUpdateOpts(d *schema.ResourceData) dnats.UpdateOpts {
 	return dnats.UpdateOpts{
 		GatewayId:                d.Get("nat_gateway_id").(string),
 		FloatingIpId:             d.Get("floating_ip_id").(string),
+		GlobalEipId:              d.Get("global_eip_id").(string),
 		Protocol:                 d.Get("protocol").(string),
 		InternalServicePort:      utils.Int(d.Get("internal_service_port").(int)),
 		ExternalServicePort:      utils.Int(d.Get("external_service_port").(int)),

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/dnats/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/dnats/requests.go
@@ -7,7 +7,9 @@ type CreateOpts struct {
 	// The ID of the gateway to which the DNAT rule belongs.
 	GatewayId string `json:"nat_gateway_id" required:"true"`
 	// The IDs of floating IP connected by DNAT rule.
-	FloatingIpId string `json:"floating_ip_id" required:"true"`
+	FloatingIpId string `json:"floating_ip_id,omitempty"`
+	// The ID of the global EIP connected by the DNAT rule.
+	GlobalEipId string `json:"global_eip_id,omitempty"`
 	// The protocol type. The valid values are 'udp', 'tcp' and 'any'.
 	Protocol string `json:"protocol" required:"true"`
 	// The port used by Floating IP provide services for external systems.
@@ -67,6 +69,8 @@ type UpdateOpts struct {
 	Protocol string `json:"protocol,omitempty"`
 	// The IDs of floating IP connected by DNAT rule.
 	FloatingIpId string `json:"floating_ip_id,omitempty"`
+	// The ID of the global EIP connected by the DNAT rule.
+	GlobalEipId string `json:"global_eip_id,omitempty"`
 	// The port used by Floating IP provide services for external systems.
 	InternalServicePort *int `json:"internal_service_port,omitempty"`
 	// The port used by ECSs or BMSs to provide services for external systems.

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/dnats/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/dnats/results.go
@@ -18,6 +18,10 @@ type Rule struct {
 	FloatingIpId string `json:"floating_ip_id"`
 	// The floating IP address connected by DNAT rule.
 	FloatingIpAddress string `json:"floating_ip_address"`
+	// The ID of the global EIP connected by the DNAT rule.
+	GlobalEipId string `json:"global_eip_id"`
+	// The global EIP address connected by the DNAT rule.
+	GlobalEipAddress string `json:"global_eip_address"`
 	// The current status of the DNAT rule.
 	Status string `json:"status"`
 	// The frozen status.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240305121901-7301d436d26b
+# github.com/chnsz/golangsdk v0.0.0-20240307061543-48f17bb16b4d
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Public dnat rule resource support global_eip_id parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Before, create public dnat rule the choice of public IP type only support eip.
2.Now, the choice of public IP type can be either geip or eip to create a dnat rule.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_dnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicDnatRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicDnatRule_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicDnatRule_basic
=== PAUSE TestAccPublicDnatRule_basic
=== CONT  TestAccPublicDnatRule_basic
--- PASS: TestAccPublicDnatRule_basic (367.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       367.670s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_dnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicDnatRule_withPort"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicDnatRule_withPort -timeout 360m -parallel 4
=== RUN   TestAccPublicDnatRule_withPort
=== PAUSE TestAccPublicDnatRule_withPort
=== CONT  TestAccPublicDnatRule_withPort
--- PASS: TestAccPublicDnatRule_withPort (245.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       245.433s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_dnat)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicDnatRule_associatedGEIP"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicDnatRule_associatedGEIP -timeout 360m -parallel 4
=== RUN   TestAccPublicDnatRule_associatedGEIP
=== PAUSE TestAccPublicDnatRule_associatedGEIP
=== CONT  TestAccPublicDnatRule_associatedGEIP
--- PASS: TestAccPublicDnatRule_associatedGEIP (353.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       353.286s
```