### PR TITLE
fix(DEW): fix csms secret datasource test error

### DIFF
--- a/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_secrets_test.go
+++ b/huaweicloud/services/acceptance/dew/data_source_huaweicloud_csms_secrets_test.go
@@ -26,7 +26,6 @@ func TestAccDatasourceCsmsSecrets_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "secrets.0.name"),
 					resource.TestCheckResourceAttrSet(rName, "secrets.0.status"),
 					resource.TestCheckResourceAttrSet(rName, "secrets.0.kms_key_id"),
-					resource.TestCheckResourceAttrSet(rName, "secrets.0.description"),
 					resource.TestCheckResourceAttrSet(rName, "secrets.0.created_at"),
 					resource.TestCheckResourceAttrSet(rName, "secrets.0.updated_at"),
 					resource.TestCheckResourceAttrSet(rName, "secrets.0.secret_type"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix csms secret datasource test error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Fixed the issue where the test case reported an error due to the response field `description` having no value.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run TestAccDatasourceCsmsSecrets_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDatasourceCsmsSecrets_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCsmsSecrets_basic
=== PAUSE TestAccDatasourceCsmsSecrets_basic
=== CONT  TestAccDatasourceCsmsSecrets_basic
--- PASS: TestAccDatasourceCsmsSecrets_basic (34.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       34.669s
```
