### PR TITLE
feat(iotda): support derived authentication

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -279,6 +279,7 @@ var (
 
 	HW_ECS_LAUNCH_TEMPLATE_ID = os.Getenv("HW_ECS_LAUNCH_TEMPLATE_ID")
 
+	HW_IOTDA_ACCESS_ADDRESS      = os.Getenv("HW_IOTDA_ACCESS_ADDRESS")
 	HW_IOTDA_BATCHTASK_FILE_PATH = os.Getenv("HW_IOTDA_BATCHTASK_FILE_PATH")
 
 	HW_DWS_MUTIL_AZS = os.Getenv("HW_DWS_MUTIL_AZS")
@@ -1315,6 +1316,13 @@ func TestAccPreCheckAKAndSK(t *testing.T) {
 func TestAccPreCheckECSLaunchTemplateID(t *testing.T) {
 	if HW_ECS_LAUNCH_TEMPLATE_ID == "" {
 		t.Skip("HW_ECS_LAUNCH_TEMPLATE_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckHWIOTDAAccessAddress(t *testing.T) {
+	if HW_IOTDA_ACCESS_ADDRESS == "" {
+		t.Skip("HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/iotda/derived.go
+++ b/huaweicloud/services/acceptance/iotda/derived.go
@@ -1,0 +1,22 @@
+package iotda
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func withDerivedAuth() bool {
+	endpoint := acceptance.HW_IOTDA_ACCESS_ADDRESS
+	if endpoint == "" {
+		return false
+	}
+
+	subStr := fmt.Sprintf(".iotda-app.%s.", acceptance.HW_REGION_NAME)
+	if index := strings.Index(endpoint, subStr); index > 0 {
+		return true
+	}
+
+	return false
+}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getAmqpResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_batchtask_file_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_batchtask_file_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func getBatchTaskFileResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getDataForwardingRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_certificate_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_certificate_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getDeviceCertificateResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getDeviceGroupResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getDeviceLinkageRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getDeviceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_product_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_product_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getProductResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_space_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_space_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getSpaceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_upgrade_package_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_upgrade_package_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getUpgradePackageResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME)
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/derived.go
+++ b/huaweicloud/services/iotda/derived.go
@@ -1,0 +1,27 @@
+package iotda
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// withDerivedAuth calculate whether derived authentication is required by the endpoint.
+// currently, this method only applies for HuaweiCloud.
+// A sample endpoint: https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com
+func withDerivedAuth(cfg *config.Config, region string) bool {
+	endpoint := config.GetServiceEndpoint(cfg, "iotda", region)
+	if endpoint == "" {
+		log.Printf("[WARN ]failed to get the endpoint of IoTDA service in region %s", region)
+		return false
+	}
+
+	subStr := fmt.Sprintf(".iotda-app.%s.", region)
+	if index := strings.Index(endpoint, subStr); index > 0 {
+		return true
+	}
+
+	return false
+}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
@@ -55,7 +55,8 @@ func ResourceAmqp() *schema.Resource {
 func resourceAmqpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -83,7 +84,8 @@ func resourceAmqpCreate(ctx context.Context, d *schema.ResourceData, meta interf
 func resourceAmqpRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -109,7 +111,8 @@ func resourceAmqpRead(_ context.Context, d *schema.ResourceData, meta interface{
 func resourceAmqpDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_batchtask_file.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_batchtask_file.go
@@ -57,7 +57,8 @@ func ResourceBatchTaskFile() *schema.Resource {
 func resourceBatchTaskFileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -93,7 +94,8 @@ func resourceBatchTaskFileCreate(ctx context.Context, d *schema.ResourceData, me
 func resourceBatchTaskFileRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -128,7 +130,8 @@ func resourceBatchTaskFileRead(_ context.Context, d *schema.ResourceData, meta i
 func resourceBatchTaskFileDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
@@ -309,7 +309,8 @@ func ResourceDataForwardingRule() *schema.Resource {
 func ResourceDataForwardingRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -360,7 +361,8 @@ func ResourceDataForwardingRuleCreate(ctx context.Context, d *schema.ResourceDat
 func ResourceDataForwardingRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -388,7 +390,8 @@ func ResourceDataForwardingRuleRead(_ context.Context, d *schema.ResourceData, m
 func ResourceDataForwardingRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -468,7 +471,8 @@ func ResourceDataForwardingRuleUpdate(ctx context.Context, d *schema.ResourceDat
 func ResourceDataForwardingRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
@@ -173,7 +173,8 @@ func ResourceDevice() *schema.Resource {
 func ResourceDeviceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -209,7 +210,8 @@ func ResourceDeviceCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func ResourceDeviceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -248,7 +250,8 @@ func ResourceDeviceRead(_ context.Context, d *schema.ResourceData, meta interfac
 func ResourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -314,7 +317,8 @@ func ResourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 func ResourceDeviceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_certificate.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_certificate.go
@@ -92,7 +92,8 @@ func ResourceDeviceCertificate() *schema.Resource {
 func resourceDeviceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -120,7 +121,8 @@ func resourceDeviceCertificateCreate(ctx context.Context, d *schema.ResourceData
 func resourceDeviceCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -151,7 +153,8 @@ func resourceDeviceCertificateRead(_ context.Context, d *schema.ResourceData, me
 func resourceDeviceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -175,7 +178,8 @@ func resourceDeviceCertificateUpdate(ctx context.Context, d *schema.ResourceData
 func resourceDeviceCertificateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_group.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_group.go
@@ -88,7 +88,8 @@ func ResourceDeviceGroup() *schema.Resource {
 func resourceDeviceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -126,7 +127,8 @@ func resourceDeviceGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceDeviceGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -150,7 +152,8 @@ func resourceDeviceGroupRead(_ context.Context, d *schema.ResourceData, meta int
 func resourceDeviceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -195,7 +198,8 @@ func resourceDeviceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 func resourceDeviceGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go
@@ -358,7 +358,8 @@ func ResourceDeviceLinkageRule() *schema.Resource {
 func ResourceDeviceLinkageRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -386,7 +387,8 @@ func ResourceDeviceLinkageRuleCreate(ctx context.Context, d *schema.ResourceData
 func ResourceDeviceLinkageRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -414,7 +416,8 @@ func ResourceDeviceLinkageRuleRead(_ context.Context, d *schema.ResourceData, me
 func ResourceDeviceLinkageRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -455,7 +458,8 @@ func ResourceDeviceLinkageRuleUpdate(ctx context.Context, d *schema.ResourceData
 func ResourceDeviceLinkageRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_product.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_product.go
@@ -292,7 +292,8 @@ func propertySchema(category string) *schema.Resource {
 func ResourceProductCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -316,7 +317,8 @@ func ResourceProductCreate(ctx context.Context, d *schema.ResourceData, meta int
 func ResourceProductRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -346,7 +348,8 @@ func ResourceProductRead(_ context.Context, d *schema.ResourceData, meta interfa
 func ResourceProductUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -364,7 +367,8 @@ func ResourceProductUpdate(ctx context.Context, d *schema.ResourceData, meta int
 func ResourceProductDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_space.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_space.go
@@ -56,7 +56,8 @@ func ResourceSpace() *schema.Resource {
 func resourceSpaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -84,7 +85,8 @@ func resourceSpaceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 func resourceSpaceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -106,7 +108,8 @@ func resourceSpaceRead(_ context.Context, d *schema.ResourceData, meta interface
 func resourceSpaceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	client, err := c.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(c, region)
+	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_upgrade_package.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_upgrade_package.go
@@ -157,7 +157,8 @@ func buildUpgradePackageCreateParams(d *schema.ResourceData) *model.CreateOtaPac
 func resourceUpgradePackageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -180,7 +181,8 @@ func resourceUpgradePackageCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceUpgradePackageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}
@@ -243,7 +245,8 @@ func flattenObsLocation(resp *model.ObsLocation) []interface{} {
 func resourceUpgradePackageDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	client, err := cfg.HcIoTdaV5Client(region)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the derived AK/SK signature algorithm. 
For details, see [SDKs for the Application Side](https://support.huaweicloud.com/intl/en-us/sdkreference-iothub/iot_10_1000.html).

now, we should support the derived AK/SK signature algorithm according to the guide.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### IoTDA
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccSpace_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccSpace_basic -timeout 360m -parallel 4
=== RUN   TestAccSpace_basic
--- PASS: TestAccSpace_basic (14.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     14.134s

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceLinkageRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceLinkageRule_basic -timeout 360m -parallel 4
=== RUN   TestAccDeviceLinkageRule_basic
=== PAUSE TestAccDeviceLinkageRule_basic
=== CONT  TestAccDeviceLinkageRule_basic
--- PASS: TestAccDeviceLinkageRule_basic (110.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     110.265s
```

### TMS (global)
```
$ make testacc TEST="./huaweicloud/services/acceptance/tms" TESTARGS="-run TestAccTmsTag_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/tms -v -run TestAccTmsTag_basic -timeout 360m -parallel 4
=== RUN   TestAccTmsTag_basic
--- PASS: TestAccTmsTag_basic (14.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/tms       14.790s
```

### VPC
```
$ make testacc TEST="./huaweicloud/services/acceptance/vpc" TESTARGS="-run TestAccVpcAddressGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcAddressGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcAddressGroup_basic
=== PAUSE TestAccVpcAddressGroup_basic
=== CONT  TestAccVpcAddressGroup_basic
--- PASS: TestAccVpcAddressGroup_basic (27.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       27.962s
```
