### PR TITLE
feat(CSS): elastic cluster extending support prePaid and test case integration

### DIFF
--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_test.go
@@ -40,27 +40,36 @@ func TestAccCssCluster_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCssCluster_basic(rName, 1, 7, "bar"),
+				Config: testAccCssCluster_basic(rName, "Test@passw0rd", 7, "bar"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "7.10.2"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
 					resource.TestCheckResourceAttr(resourceName, "security_mode", "true"),
 					resource.TestCheckResourceAttr(resourceName, "https_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.flavor", "ess.spec-4u8g"),
 					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.instance_number", "1"),
-					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.volume.0.size", "40"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "7"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
+						"huaweicloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
+						"huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 			{
-				Config: testAccCssCluster_basic(rName, 2, 8, "bar_update"),
+				Config: testAccCssCluster_basic(rName, "Test@passw0rd", 8, "bar_update"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.instance_number", "2"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "8"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 		},
@@ -130,17 +139,16 @@ func TestAccCssCluster_prePaid(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCssCluster_prePaid(rName, 1, false),
+				Config: testAccCssCluster_prePaid(rName, "Test@passw0rd", 1, false),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
 					resource.TestCheckResourceAttr(resourceName, "security_mode", "true"),
 					resource.TestCheckResourceAttr(resourceName, "https_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.flavor", "ess.spec-4u8g"),
 					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.instance_number", "1"),
-					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.instance_number", "3"),
-					resource.TestCheckResourceAttr(resourceName, "client_node_config.0.instance_number", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cold_node_config.0.instance_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.volume.0.size", "40"),
 					resource.TestCheckResourceAttr(resourceName, "vpcep_endpoint.0.endpoint_with_dns_name", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpcep_endpoint_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpcep_ip"),
@@ -148,7 +156,7 @@ func TestAccCssCluster_prePaid(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCssCluster_prePaid(rName, 1, true),
+				Config: testAccCssCluster_prePaid(rName, "Test@passw0rd", 1, true),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -181,14 +189,14 @@ func TestAccCssCluster_updateWithEpsId(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCssCluster_withEpsId(rName, 1, srcEPS),
+				Config: testAccCssCluster_withEpsId(rName, srcEPS),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", srcEPS),
 				),
 			},
 			{
-				Config: testAccCssCluster_withEpsId(rName, 1, destEPS),
+				Config: testAccCssCluster_withEpsId(rName, destEPS),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", destEPS),
@@ -198,11 +206,11 @@ func TestAccCssCluster_updateWithEpsId(t *testing.T) {
 	})
 }
 
-func TestAccCssCluster_flavor(t *testing.T) {
+func TestAccCssCluster_extend(t *testing.T) {
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_css_cluster.test"
 	flavor := "ess.spec-4u8g"
-	updateFlavor := "ess.spec-8u16g"
+	updateFlavor := "ess.spec-4u16g"
 
 	var obj cluster.ClusterDetailResponse
 	rc := acceptance.InitResourceCheck(
@@ -217,27 +225,84 @@ func TestAccCssCluster_flavor(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCssCluster_flavor(rName, flavor),
+				Config: testAccCssCluster_extend(rName, flavor, 3, 3, 40),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
 					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.flavor", flavor),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.instance_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.volume.0.size", "40"),
 					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.flavor", flavor),
-					resource.TestCheckResourceAttr(resourceName, "client_node_config.0.flavor", flavor),
-					resource.TestCheckResourceAttr(resourceName, "cold_node_config.0.flavor", flavor),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.instance_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.volume.0.size", "40"),
 				),
 			},
 			{
-				Config: testAccCssCluster_flavor(rName, updateFlavor),
+				Config: testAccCssCluster_extend(rName, updateFlavor, 4, 5, 60),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
 					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.flavor", updateFlavor),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.instance_number", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.volume.0.size", "60"),
 					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.flavor", updateFlavor),
-					resource.TestCheckResourceAttr(resourceName, "client_node_config.0.flavor", updateFlavor),
-					resource.TestCheckResourceAttr(resourceName, "cold_node_config.0.flavor", updateFlavor),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.instance_number", "5"),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.volume.0.size", "40"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCssCluster_extend_prePaid(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_css_cluster.test"
+	flavor := "ess.spec-4u8g"
+	updateFlavor := "ess.spec-4u16g"
+
+	var obj cluster.ClusterDetailResponse
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCssClusterFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckChargingMode(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssCluster_extend_prePaid(rName, flavor, 3, 3, 40),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.flavor", flavor),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.instance_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.volume.0.size", "40"),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.flavor", flavor),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.instance_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.volume.0.size", "40"),
+				),
+			},
+			{
+				Config: testAccCssCluster_extend_prePaid(rName, updateFlavor, 4, 5, 60),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.flavor", updateFlavor),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.instance_number", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ess_node_config.0.volume.0.size", "60"),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.flavor", updateFlavor),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.instance_number", "5"),
+					resource.TestCheckResourceAttr(resourceName, "master_node_config.0.volume.0.size", "40"),
 				),
 			},
 		},
@@ -259,19 +324,19 @@ resource "huaweicloud_obs_bucket" "cssObs" {
 `, common.TestBaseNetwork(rName), bucketName)
 }
 
-func testAccCssCluster_basic(rName string, nodeNum int, keepDays int, tag string) string {
+func testAccCssCluster_basic(rName, pwd string, keepDays int, tag string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_css_cluster" "test" {
-  name           = "%s"
+  name           = "%[2]s"
   engine_version = "7.10.2"
   security_mode  = true
-  password       = "Test@passw0rd"
+  password       = "%[3]s"
 
   ess_node_config {
     flavor          = "ess.spec-4u8g"
-    instance_number = %d
+    instance_number = 1
     volume {
       volume_type = "HIGH"
       size        = 40
@@ -284,7 +349,7 @@ resource "huaweicloud_css_cluster" "test" {
   vpc_id            = huaweicloud_vpc.test.id
 
   backup_strategy {
-    keep_days   = %d
+    keep_days   = %[4]d
     start_time  = "00:00 GMT+08:00"
     prefix      = "snapshot"
     bucket      = huaweicloud_obs_bucket.cssObs.bucket
@@ -293,11 +358,11 @@ resource "huaweicloud_css_cluster" "test" {
   }
 
   tags = {
-    foo = "%s"
+    foo = "%[5]s"
     key = "value"
   }
 }
-`, testAccCssBase(rName), rName, nodeNum, keepDays, tag)
+`, testAccCssBase(rName), rName, pwd, keepDays, tag)
 }
 
 func testAccCssCluster_localDisk(rName string, nodeNum int) string {
@@ -328,7 +393,7 @@ resource "huaweicloud_css_cluster" "test" {
 `, testAccCssBase(rName), rName, nodeNum)
 }
 
-func testAccCssCluster_prePaid(rName string, nodeNum int, isAutoRenew bool) string {
+func testAccCssCluster_prePaid(rName, pwd string, period int, isAutoRenew bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -336,7 +401,7 @@ resource "huaweicloud_css_cluster" "test" {
   name           = "%[2]s"
   engine_version = "7.10.2"
   security_mode  = true
-  password       = "Test@passw0rd"
+  password       = "%[3]s"
 
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -345,37 +410,10 @@ resource "huaweicloud_css_cluster" "test" {
 
   charging_mode = "prePaid"
   period_unit   = "month"
-  period        = %[3]d
-  auto_renew    = "%[4]v"
+  period        = %[4]d
+  auto_renew    = "%[5]v"
 
   ess_node_config {
-    flavor          = "ess.spec-4u8g"
-    instance_number = 1
-    volume {
-      volume_type = "HIGH"
-      size        = 40
-    }
-  }
-
-  master_node_config {
-    flavor          = "ess.spec-4u8g"
-    instance_number = 3
-    volume {
-      volume_type = "HIGH"
-      size        = 40
-    }
-  }
-
-  client_node_config {
-    flavor          = "ess.spec-4u8g"
-    instance_number = 1
-    volume {
-      volume_type = "HIGH"
-      size        = 40
-    }
-  }
-
-  cold_node_config {
     flavor          = "ess.spec-4u8g"
     instance_number = 1
     volume {
@@ -388,10 +426,10 @@ resource "huaweicloud_css_cluster" "test" {
     endpoint_with_dns_name = true
   }
 }
-`, testAccCssBase(rName), rName, nodeNum, isAutoRenew)
+`, testAccCssBase(rName), rName, pwd, period, isAutoRenew)
 }
 
-func testAccCssCluster_withEpsId(rName string, nodeNum int, epsId string) string {
+func testAccCssCluster_withEpsId(rName string, epsId string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -406,10 +444,7 @@ resource "huaweicloud_css_cluster" "test" {
   subnet_id         = huaweicloud_vpc_subnet.test.id
   vpc_id            = huaweicloud_vpc.test.id
 
-  charging_mode         = "prePaid"
-  period_unit           = "month"
-  period                = %[3]d
-  enterprise_project_id = "%[4]s"
+  enterprise_project_id = "%[3]s"
 
   ess_node_config {
     flavor          = "ess.spec-4u8g"
@@ -419,42 +454,11 @@ resource "huaweicloud_css_cluster" "test" {
       size        = 40
     }
   }
-
-  master_node_config {
-    flavor          = "ess.spec-4u8g"
-    instance_number = 3
-    volume {
-      volume_type = "HIGH"
-      size        = 40
-    }
-  }
-
-  client_node_config {
-    flavor          = "ess.spec-4u8g"
-    instance_number = 1
-    volume {
-      volume_type = "HIGH"
-      size        = 40
-    }
-  }
-
-  cold_node_config {
-    flavor          = "ess.spec-4u8g"
-    instance_number = 1
-    volume {
-      volume_type = "HIGH"
-      size        = 40
-    }
-  }
-
-  vpcep_endpoint {
-    endpoint_with_dns_name = true
-  }
 }
-`, testAccCssBase(rName), rName, nodeNum, epsId)
+`, testAccCssBase(rName), rName, epsId)
 }
 
-func testAccCssCluster_flavor(rName, flavorNmae string) string {
+func testAccCssCluster_extend(rName, flavorNmae string, essNodeNum, masterNodeNum, size int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -469,39 +473,60 @@ resource "huaweicloud_css_cluster" "test" {
 
   ess_node_config {
     flavor          = "%[3]s"
-    instance_number = 3
+    instance_number = %[4]d
     volume {
       volume_type = "HIGH"
-      size        = 40
+      size        = %[6]d
     }
   }
 
   master_node_config {
     flavor          = "%[3]s"
-    instance_number = 3
-    volume {
-      volume_type = "HIGH"
-      size        = 40
-    }
-  }
-
-  client_node_config {
-    flavor          = "%[3]s"
-    instance_number = 3
-    volume {
-      volume_type = "HIGH"
-      size        = 40
-    }
-  }
-
-  cold_node_config {
-    flavor          = "%[3]s"
-    instance_number = 3
+    instance_number = %[5]d
     volume {
       volume_type = "HIGH"
       size        = 40
     }
   }
 }
-`, testAccCssBase(rName), rName, flavorNmae)
+`, testAccCssBase(rName), rName, flavorNmae, essNodeNum, masterNodeNum, size)
+}
+
+func testAccCssCluster_extend_prePaid(rName, flavorNmae string, essNodeNum, masterNodeNum, size int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_css_cluster" "test" {
+  name           = "%[2]s"
+  engine_version = "7.10.2"
+
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  vpc_id            = huaweicloud_vpc.test.id
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = "true"
+
+  ess_node_config {
+    flavor          = "%[3]s"
+    instance_number = %[4]d
+    volume {
+      volume_type = "HIGH"
+      size        = %[6]d
+    }
+  }
+
+  master_node_config {
+    flavor          = "%[3]s"
+    instance_number = %[5]d
+    volume {
+      volume_type = "HIGH"
+      size        = 40
+    }
+  }
+}
+`, testAccCssBase(rName), rName, flavorNmae, essNodeNum, masterNodeNum, size)
 }

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_configuration_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_configuration_test.go
@@ -118,7 +118,7 @@ resource "huaweicloud_css_configuration" "test" {
   thread_pool_force_merge_size = "3"
   http_cors_allow_credetials   = true
 }
-`, testAccCssCluster_basic(name, 1, 7, "bar"))
+`, testAccCssCluster_basic(name, "Test@passw0rd", 7, "bar"))
 }
 
 func testCssConfiguration_basic_update(name string) string {
@@ -131,5 +131,5 @@ resource "huaweicloud_css_configuration" "test" {
   http_cors_allow_credetials   = true
   http_cors_allow_headers      = "X-Requested-With, Content-Type"
 }
-`, testAccCssCluster_basic(name, 1, 7, "bar"))
+`, testAccCssCluster_basic(name, "Test@passw0rd", 7, "bar"))
 }

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_scan_task_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_scan_task_test.go
@@ -141,5 +141,5 @@ resource "huaweicloud_css_scan_task" "test" {
     smn_topic = huaweicloud_smn_topic.test.name
   }
 }
-`, testAccCssCluster_basic(rName, 1, 7, "bar"), rName)
+`, testAccCssCluster_basic(rName, "Test@passw0rd", 7, "bar"), rName)
 }

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_snapshot_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_snapshot_test.go
@@ -112,7 +112,7 @@ func testAccCheckCssSnapshotExists() resource.TestCheckFunc {
 
 func testAccCssSnapshot_basic(val string) string {
 	clusterName := acceptance.RandomAccResourceName()
-	clusterString := testAccCssCluster_basic(clusterName, 1, 1, "tag")
+	clusterString := testAccCssCluster_basic(clusterName, "Test@passw0rd", 1, "tag")
 
 	return fmt.Sprintf(`
 %s

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_thesaurus_test.go
@@ -53,7 +53,7 @@ func TestAccCssThesaurus_basic(t *testing.T) {
 }
 
 func testAccCssThesaurus_basic(rName string, bucketName string, obsObjectKey string) string {
-	cssClusterBasic := testAccCssCluster_basic(rName, 1, 1, "value")
+	cssClusterBasic := testAccCssCluster_basic(rName, "Test@passw0rd", 1, "value")
 
 	return fmt.Sprintf(`
 %s


### PR DESCRIPTION
**What this PR does / why we need it**:
1. CSS  cluster add isAutoPay parameter supported under prePaid mode.
2. You can only add instances, rather than increase storage capacity, on nodes of the ess-master and ess-client types.
3. newly added instances in a cluster cannot exceed the maximum instance storage capacity allowed when a cluster is being created. 
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
1. elasticSearch cluster extending support prePaid
4. elasticSearch cluster test case integration
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssCluster_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_basic
=== PAUSE TestAccCssCluster_basic
=== CONT  TestAccCssCluster_basic
--- PASS: TestAccCssCluster_basic (948.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       948.960s
```

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssCluster_updateWithEpsId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_updateWithEpsId -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_updateWithEpsId
=== PAUSE TestAccCssCluster_updateWithEpsId
=== CONT  TestAccCssCluster_updateWithEpsId
--- PASS: TestAccCssCluster_updateWithEpsId (913.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       913.580s
```

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssCluster_extend"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_extend -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_extend
=== PAUSE TestAccCssCluster_extend
=== CONT  TestAccCssCluster_extend
--- PASS: TestAccCssCluster_extend (3117.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       3117.163s
```
