### PR TITLE
fix(CBH): upgrade cbh datasource API version to V2

### DIFF
--- a/docs/data-sources/cbh_instances.md
+++ b/docs/data-sources/cbh_instances.md
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `flavor_id` - (Optional, String) Specifies the specification of the instance.
 
-* `version` - (Optional, String) Specifies the current version of the instance image
+* `version` - (Optional, String) Specifies the current version of the instance image.
 
 ## Attribute Reference
 
@@ -47,10 +47,10 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The data source ID.
 
 * `instances` - Indicates the list of CBH instance.
-  The [Instance](#CbhInstances_Instance) structure is documented below.
+  The [instances](#CbhInstances_Instance) structure is documented below.
 
 <a name="CbhInstances_Instance"></a>
-The `Instance` block supports:
+The `instances` block supports:
 
 * `id` - Indicates the ID of the instance.
 
@@ -60,7 +60,7 @@ The `Instance` block supports:
 
 * `name` - Indicates the instance name.
 
-* `private_ip` - Indicates the private ip of the instance.
+* `private_ip` - Indicates the private IP address of the instance.
 
 * `status` - Indicates the status of the instance.
 

--- a/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_instances_test.go
+++ b/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_instances_test.go
@@ -22,19 +22,28 @@ func TestAccDatasourceCbhInstances_basic(t *testing.T) {
 				Config: testAccDatasourceCbhInstances_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "instances.0.name", name),
-					resource.TestCheckResourceAttr(dataSourceName, "instances.0.flavor_id", "cbh.basic.10"),
-					resource.TestCheckResourceAttr(dataSourceName, "instances.0.status", "ACTIVE"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "instances.0.vpc_id",
-						"data.huaweicloud_vpc.test", "id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "instances.0.subnet_id",
-						"data.huaweicloud_vpc_subnet.test", "id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "instances.0.security_group_id",
-						"data.huaweicloud_networking_secgroup.test", "id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "instances.0.public_ip_id",
-						"huaweicloud_vpc_eip.test", "id"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "instances.0.public_ip",
-						"huaweicloud_vpc_eip.test", "address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.private_ip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.vpc_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.subnet_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.security_group_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.availability_zone"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.version"),
+
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("vpc_id_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("subnet_id_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("security_group_id_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("flavor_id_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("version_filter_is_useful", "true"),
 				),
 			},
 		},
@@ -46,11 +55,121 @@ func testAccDatasourceCbhInstances_basic(name string) string {
 %s
 
 data "huaweicloud_cbh_instances" "test" {
-  name              = huaweicloud_cbh_instance.test.name
-  vpc_id            = data.huaweicloud_vpc.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  flavor_id         = "cbh.basic.10"
+  depends_on = [huaweicloud_cbh_instance.test]
+}
+
+locals {
+  name = data.huaweicloud_cbh_instances.test.instances[0].name
+}
+
+data "huaweicloud_cbh_instances" "filter_by_name" {
+  name = local.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_cbh_instances.filter_by_name.instances[*].name : 
+    v == local.name
+  ]
+}
+
+output "name_filter_is_useful" {
+  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
+}
+
+locals {
+  vpc_id = data.huaweicloud_cbh_instances.test.instances[0].vpc_id
+}
+
+data "huaweicloud_cbh_instances" "filter_by_vpc_id" {
+  vpc_id = local.vpc_id
+}
+
+locals {
+  vpc_id_filter_result = [
+    for v in data.huaweicloud_cbh_instances.filter_by_vpc_id.instances[*].vpc_id : 
+    v == local.vpc_id
+  ]
+}
+
+output "vpc_id_filter_is_useful" {
+  value = alltrue(local.vpc_id_filter_result) && length(local.vpc_id_filter_result) > 0
+}
+
+locals {
+  subnet_id = data.huaweicloud_cbh_instances.test.instances[0].subnet_id
+}
+
+data "huaweicloud_cbh_instances" "filter_by_subnet_id" {
+  subnet_id = local.subnet_id
+}
+
+locals {
+  subnet_id_filter_result = [
+    for v in data.huaweicloud_cbh_instances.filter_by_subnet_id.instances[*].subnet_id : 
+    v == local.subnet_id
+  ]
+}
+
+output "subnet_id_filter_is_useful" {
+  value = alltrue(local.subnet_id_filter_result) && length(local.subnet_id_filter_result) > 0
+}
+
+locals {
+  security_group_id = data.huaweicloud_cbh_instances.test.instances[0].security_group_id
+}
+
+data "huaweicloud_cbh_instances" "filter_by_security_group_id" {
+  security_group_id = local.security_group_id
+}
+
+locals {
+  security_group_id_filter_result = [
+    for v in data.huaweicloud_cbh_instances.filter_by_security_group_id.instances[*].security_group_id : 
+    v == local.security_group_id
+  ]
+}
+
+output "security_group_id_filter_is_useful" {
+  value = alltrue(local.security_group_id_filter_result) && length(local.security_group_id_filter_result) > 0
+}
+
+locals {
+  flavor_id = data.huaweicloud_cbh_instances.test.instances[0].flavor_id
+}
+
+data "huaweicloud_cbh_instances" "filter_by_flavor_id" {
+  flavor_id = local.flavor_id
+}
+
+locals {
+  flavor_id_filter_result = [
+    for v in data.huaweicloud_cbh_instances.filter_by_flavor_id.instances[*].flavor_id : 
+    v == local.flavor_id
+  ]
+}
+
+output "flavor_id_filter_is_useful" {
+  value = alltrue(local.flavor_id_filter_result) && length(local.flavor_id_filter_result) > 0
+}
+
+locals {
+  version = data.huaweicloud_cbh_instances.test.instances[0].version
+}
+
+data "huaweicloud_cbh_instances" "filter_by_version" {
+  version = local.version
+}
+
+locals {
+  version_filter_result = [
+    for v in data.huaweicloud_cbh_instances.filter_by_version.instances[*].version : 
+    v == local.version
+  ]
+}
+
+output "version_filter_is_useful" {
+  value = alltrue(local.version_filter_result) && length(local.version_filter_result) > 0
 }
 `, testCBHInstance_basic(name))
 }

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
@@ -22,7 +22,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API CBH GET /v1/{project_id}/cbs/instance/list
 // @API CBH POST /v2/{project_id}/cbs/instance/{server_id}/eip/bind
 // @API CBH POST /v2/{project_id}/cbs/instance/{server_id}/eip/unbind
 // @API CBH POST /v2/{project_id}/cbs/instance
@@ -403,36 +402,6 @@ func waitingForCBHInstanceActive(ctx context.Context, client *golangsdk.ServiceC
 
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
-}
-
-// This method will be deleted when the datasource API is upgraded.
-func getInstanceList(client *golangsdk.ServiceClient) ([]interface{}, error) {
-	// getCbhInstances: Query the List of CBH instances
-	var (
-		getCbhInstancesHttpUrl = "v1/{project_id}/cbs/instance/list"
-	)
-
-	getCbhInstancesPath := client.Endpoint + getCbhInstancesHttpUrl
-	getCbhInstancesPath = strings.ReplaceAll(getCbhInstancesPath, "{project_id}", client.ProjectID)
-
-	getCbhInstancesOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-	}
-	getCbhInstancesResp, err := client.Request("GET", getCbhInstancesPath, &getCbhInstancesOpt)
-
-	if err != nil {
-		return nil, err
-	}
-
-	getCbhInstancesRespBody, err := utils.FlattenResponse(getCbhInstancesResp)
-	if err != nil {
-		return nil, err
-	}
-	instances := utils.PathSearch("instance", getCbhInstancesRespBody, make([]interface{}, 0)).([]interface{})
-	return instances, nil
 }
 
 func resourceCBHInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Upgrade cbh datasource API version to V2.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Currently, the datasource `huaweicloud_cbh_instances` uses the V1 version of the API. The V1 version of the API will be offline and needs to be upgraded to the V2 version.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cbh' TESTARGS='-run TestAccDatasourceCbhInstances_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccDatasourceCbhInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCbhInstances_basic
=== PAUSE TestAccDatasourceCbhInstances_basic
=== CONT  TestAccDatasourceCbhInstances_basic
--- PASS: TestAccDatasourceCbhInstances_basic (1093.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1093.072s
```
