### PR TITLE
feat(DEW): kms support to manage the key material of the external key

### DIFF
--- a/docs/resources/kms_key_material.md
+++ b/docs/resources/kms_key_material.md
@@ -1,0 +1,95 @@
+---
+subcategory: "Data Encryption Workshop (DEW)"
+---
+
+# huaweicloud_kms_key_material
+
+Manages a KMS key material resource within HuaweiCloud.
+
+-> NOTE: Please confirm that the state of the imported key is pending import.
+
+## Example Usage
+
+variable "key_id" {}
+variable "import_token" {}
+variable "encrypted_key_material" {}
+
+```hcl
+resource "huaweicloud_kms_key_material" "test" {
+  key_id                 = var.key_id
+  import_token           = var.import_token
+  encrypted_key_material = var.encrypted_key_material
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `key_id` - (Required, String, ForceNew) Specifies the ID of the KMS key.
+  Changing this creates a new resource.
+
+* `import_token` - (Required, String, ForceNew) Specifies the key import token in Base64 format.
+  The value contains `200` to `6144` characters, including letters, digits, slashes(/) and equals(=). This value is
+  obtained through the interface [Obtaining Key Import Parameters](https://support.huaweicloud.com/intl/en-us/api-dew/CreateParametersForImport.html).
+  Changing this creates a new resource.
+
+* `encrypted_key_material` - (Required, String, ForceNew) Specifies the encrypted symmetric key material in Base64 format.
+  The value contains `344` to `360` characters, including letters, digits, slashes(/) and equals(=).
+  If an asymmetric key is imported, this parameter is a temporary intermediate key used to encrypt the private key.
+  This value is obtained refer to
+  [documentation](https://support.huaweicloud.com/intl/en-us/usermanual-dew/dew_01_0089.html).
+  Changing this creates a new resource.
+
+* `encrypted_privatekey` - (Optional, String, ForceNew) Specifies the private key encrypted using a temporary
+  intermediate key. The value contains `200` to `6144` characters, including letters, digits, slashes(/)
+  and equals(=). This parameter is required for importing an asymmetric key.
+  Changing this creates a new resource.
+
+* `expiration_time` - (Optional, String, ForceNew) Specifies the expiration time of the key material.
+  This field is only valid for symmetric keys. The time is in the format of timestamp, that is, the
+  offset seconds from 1970-01-01 00:00:00 UTC to the specified time.
+  The time must be greater than the current time. Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals the `key_id`.
+
+* `key_usage` - The key usage. The value can be **ENCRYPT_DECRYPT** or **SIGN_VERIFY**.
+
+* `key_state` - The status of the kms key. The valid values are as follows:
+  **1**: To be activated
+  **2**: Enabled.
+  **3**: Disabled.
+  **4**: Pending deletion.
+  **5**: Pending import.
+
+## Import
+
+The KMS key material can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_kms_key_material.test 7056d636-ac60-4663-8a6c-82d3c32c1c64
+```
+
+Note that the imported state may not be identical to your resource definition,
+due to `import_token`, `encrypted_key_material` and `encrypted_privatekey` are missing from the API response.
+It is generally recommended running `terraform plan` after importing a KMS key material.
+You can then decide if changes should be applied to the KMS key material, or the resource
+definition should be updated to align with the KMS key material. Also you can ignore changes as below.
+
+```
+resource "huaweicloud_kms_key_material" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [ import_token, encrypted_key_material, encrypted_privatekey ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1159,6 +1159,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_keypair":            dew.ResourceKeypair(),
 			"huaweicloud_kms_grant":              dew.ResourceKmsGrant(),
 			"huaweicloud_kms_dedicated_keystore": dew.ResourceKmsDedicatedKeystore(),
+			"huaweicloud_kms_key_material":       dew.ResourceKmsKeyMaterial(),
 
 			"huaweicloud_lb_certificate":  lb.ResourceCertificateV2(),
 			"huaweicloud_lb_l7policy":     lb.ResourceL7PolicyV2(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -135,8 +135,12 @@ var (
 	HW_FGS_TEMPLATE_ID = os.Getenv("HW_FGS_TEMPLATE_ID")
 	HW_FGS_GPU_TYPE    = os.Getenv("HW_FGS_GPU_TYPE")
 
-	HW_KMS_ENVIRONMENT    = os.Getenv("HW_KMS_ENVIRONMENT")
-	HW_KMS_HSM_CLUSTER_ID = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
+	HW_KMS_ENVIRONMENT     = os.Getenv("HW_KMS_ENVIRONMENT")
+	HW_KMS_HSM_CLUSTER_ID  = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
+	HW_KMS_KEY_ID          = os.Getenv("HW_KMS_KEY_ID")
+	HW_KMS_IMPORT_TOKEN    = os.Getenv("HW_KMS_IMPORT_TOKEN")
+	HW_KMS_KEY_MATERIAL    = os.Getenv("HW_KMS_KEY_MATERIAL")
+	HW_KMS_KEY_PRIVATE_KEY = os.Getenv("HW_KMS_KEY_PRIVATE_KEY")
 
 	HW_MULTI_ACCOUNT_ENVIRONMENT            = os.Getenv("HW_MULTI_ACCOUNT_ENVIRONMENT")
 	HW_ORGANIZATIONS_OPEN                   = os.Getenv("HW_ORGANIZATIONS_OPEN")
@@ -848,6 +852,34 @@ func TestAccPreCheckKms(t *testing.T) {
 func TestAccPreCheckKmsHsmClusterId(t *testing.T) {
 	if HW_KMS_HSM_CLUSTER_ID == "" {
 		t.Skip("HW_KMS_HSM_CLUSTER_ID must be set for KMS dedicated keystore acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKmsImportToken(t *testing.T) {
+	if HW_KMS_IMPORT_TOKEN == "" {
+		t.Skip("HW_KMS_IMPORT_TOKEN must be set for KMS key material acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKmsKeyID(t *testing.T) {
+	if HW_KMS_KEY_ID == "" {
+		t.Skip("HW_KMS_KEY_ID must be set for KMS key material acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKmsKeyMaterial(t *testing.T) {
+	if HW_KMS_KEY_MATERIAL == "" {
+		t.Skip("HW_KMS_KEY_MATERIAL must be set for KMS key material acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckKmsKeyPrivateKey(t *testing.T) {
+	if HW_KMS_KEY_PRIVATE_KEY == "" {
+		t.Skip("HW_KMS_KEY_PRIVATE_KEY must be set for KMS key material acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_key_material_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_key_material_test.go
@@ -1,0 +1,139 @@
+package dew
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/kms/v1/keys"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dew"
+)
+
+func getKmsKeyMaterialResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.KmsKeyV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating KMS client: %s", err)
+	}
+
+	key, err := keys.Get(client, state.Primary.ID).ExtractKeyInfo()
+
+	if key.KeyState == dew.PendingDeletionState || key.KeyState == dew.PendingImportState {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return key, err
+}
+
+func TestAccKmsKeyMaterial_Symmetric(t *testing.T) {
+	var resourceName = "huaweicloud_kms_key_material.test"
+	var key keys.Key
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&key,
+		getKmsKeyMaterialResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// The key status must be pending import.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckKms(t)
+			acceptance.TestAccPreCheckKmsKeyID(t)
+			acceptance.TestAccPreCheckKmsImportToken(t)
+			acceptance.TestAccPreCheckKmsKeyMaterial(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsKeyMaterial_Symmetric(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "key_state", "2"),
+					resource.TestCheckResourceAttr(resourceName, "expiration_time", "2999886177"),
+					resource.TestCheckResourceAttr(resourceName, "region", acceptance.HW_REGION_NAME),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"import_token", "encrypted_key_material", "encrypted_privatekey",
+				},
+			},
+		},
+	})
+}
+
+func testAccKmsKeyMaterial_Symmetric() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_key_material" "test" {
+  key_id                 = "%[1]s"
+  import_token           = "%[2]s"
+  encrypted_key_material = "%[3]s"
+  expiration_time        = "2999886177"
+}
+`, acceptance.HW_KMS_KEY_ID, acceptance.HW_KMS_IMPORT_TOKEN, acceptance.HW_KMS_KEY_MATERIAL)
+}
+
+// The key material of the asymmetric key does not support deletion.
+func TestAccKmsKeyMaterial_Asymmetric(t *testing.T) {
+	var resourceName = "huaweicloud_kms_key_material.test"
+	var key keys.Key
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&key,
+		getKmsKeyMaterialResourceFunc,
+	)
+	// Avoid CheckDestroy because the asymmetric key material can not be destroyed.
+	// lintignore:AT001
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// The key status must be pending import.
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckKms(t)
+			acceptance.TestAccPreCheckKmsKeyID(t)
+			acceptance.TestAccPreCheckKmsImportToken(t)
+			acceptance.TestAccPreCheckKmsKeyMaterial(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsKeyMaterial_Asymmetric(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "key_state", "2"),
+					resource.TestCheckResourceAttr(resourceName, "region", acceptance.HW_REGION_NAME),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"import_token", "encrypted_key_material", "encrypted_privatekey",
+				},
+			},
+		},
+	})
+}
+
+func testAccKmsKeyMaterial_Asymmetric() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_key_material" "test" {
+  key_id                 = "%[1]s"
+  import_token           = "%[2]s"
+  encrypted_key_material = "%[3]s"
+  encrypted_privatekey   = "%[4]s"
+}
+`, acceptance.HW_KMS_KEY_ID, acceptance.HW_KMS_IMPORT_TOKEN, acceptance.HW_KMS_KEY_MATERIAL, acceptance.HW_KMS_KEY_PRIVATE_KEY)
+}

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_key_material.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_key_material.go
@@ -1,0 +1,204 @@
+package dew
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/kms/v1/keys"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API DEW POST /v1.0/{project_id}/kms/delete-imported-key-material
+// @API DEW POST /v1.0/{project_id}/kms/import-key-material
+// @API DEW POST /v1.0/{project_id}/kms/describe-key
+func ResourceKmsKeyMaterial() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: ResourceKmsKeyMaterialCreate,
+		ReadContext:   ResourceKmsKeyMaterialRead,
+		DeleteContext: ResourceKmsKeyMaterialDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"key_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"import_token": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"encrypted_key_material": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"encrypted_privatekey": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"expiration_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"key_usage": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func ResourceKmsKeyMaterialCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	kmsKeyV1Client, err := cfg.KmsKeyV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating KMS client: %s", err)
+	}
+
+	importMaterialOpts := &keys.ImportMaterialOpts{
+		KeyID:                d.Get("key_id").(string),
+		ImportToken:          d.Get("import_token").(string),
+		EncryptedKeyMaterial: d.Get("encrypted_key_material").(string),
+		EncryptedPrivatekey:  d.Get("encrypted_privatekey").(string),
+		ExpirationTime:       d.Get("expiration_time").(string),
+	}
+
+	v, err := keys.ImportKeyMaterial(kmsKeyV1Client, importMaterialOpts).Extract()
+	if err != nil || v == nil {
+		return diag.Errorf("error importing KMS key material: %s", err)
+	}
+
+	d.SetId(d.Get("key_id").(string))
+
+	return ResourceKmsKeyMaterialRead(ctx, d, meta)
+}
+
+func ResourceKmsKeyMaterialRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	kmsKeyV1Client, err := cfg.KmsKeyV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating KMS key client: %s", err)
+	}
+
+	v, err := keys.Get(kmsKeyV1Client, d.Id()).ExtractKeyInfo()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving the KMS key")
+	}
+	if v.KeyState == PendingDeletionState || v.KeyState == PendingImportState {
+		return common.CheckDeletedDiag(d, err,
+			"The KMS key is pending deletion or the key material is pending import")
+	}
+
+	expirationTime := flatternExpirationTime(v.ExpirationTime)
+
+	d.SetId(v.KeyID)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("key_id", v.KeyID),
+		d.Set("key_state", v.KeyState),
+		d.Set("expiration_time", expirationTime),
+		d.Set("key_usage", v.KeyUsage),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flatternExpirationTime(expTimeStr string) string {
+	if expTimeStr == "" {
+		return ""
+	}
+	expTime, _ := strconv.ParseInt(expTimeStr, 10, 64)
+	return strconv.FormatInt(expTime/1000, 10)
+}
+
+func ResourceKmsKeyMaterialDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	kmsKeyV1Client, err := cfg.KmsKeyV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating KMS key client: %s", err)
+	}
+
+	v, err := keys.Get(kmsKeyV1Client, d.Id()).ExtractKeyInfo()
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving the KMS key")
+	}
+	if v.KeyState == PendingDeletionState || v.KeyState == PendingImportState {
+		return common.CheckDeletedDiag(d, err, "The KMS key is pending deletion or the key material is deleted")
+	}
+
+	deleteMaterialOpts := &keys.DeleteKeyMaterialOpts{
+		KeyID: d.Id(),
+	}
+
+	// The key material of the asymmetric key does not support deletion.
+	// Deleting the key material of an asymmetric key will return {"error":{"error_msg":"xx","error_code":"KMS.2702"}}
+	// The key material of the symmetric key support deletion.
+	_, err = keys.DeleteKeyMaterial(kmsKeyV1Client, deleteMaterialOpts).Extract()
+	if _, ok := err.(golangsdk.ErrDefault400); ok {
+		errCode, errMessage := parseDeleteResponseError(err)
+		if errCode == "KMS.2702" {
+			log.Printf("[WARN] failed to delete key material, errCode : %s, errMsg: %s", errCode, errMessage)
+			errorMessage := "The asymmetric key material can't be deleted. The project is only removed from the state," +
+				" but it remains in the cloud."
+			return diag.Diagnostics{
+				diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  errorMessage,
+				},
+			}
+		}
+	}
+	if err != nil {
+		diag.Errorf("error deleting key material (%s): %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func parseDeleteResponseError(err error) (errorCode, errorMsg string) {
+	var response interface{}
+	if jsonErr := json.Unmarshal(err.(golangsdk.ErrDefault400).Body, &response); jsonErr == nil {
+		errorCode, parseErr := jmespath.Search("error.error_code", response)
+		if parseErr != nil {
+			log.Printf("[WARN] failed to parse error_code from response body: %s", parseErr)
+		}
+		errMsg, parseErr := jmespath.Search("error.error_msg", response)
+		if parseErr != nil {
+			log.Printf("[WARN] failed to parse error_msg from response body: %s", parseErr)
+		}
+		return errorCode.(string), errMsg.(string)
+	}
+	log.Printf("[WARN] failed to parse KMS error message from response body: %s", err)
+	return "", ""
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
kms support to manage the key material of the external key
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. This resource support import key material for external key
2. Only support delete symmetric key material, it will clear the .tfstate of the resource when delete asymmetric key material. 
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
make testacc TEST=./huaweicloud/services/acceptance/dew TESTARGS='-run TestAccKmsKeyMaterial_Symmetric'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKmsKeyMaterial_Symmetric -timeout 360m -parallel 4
=== RUN   TestAccKmsKeyMaterial_Symmetric
--- PASS: TestAccKmsKeyMaterial_Symmetric (18.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       18.541s
```

```
