### PR TITLE
feat(dli): add new resource to manage the pools association

### DIFF
--- a/docs/resources/dli_datasource_connection_associate.md
+++ b/docs/resources/dli_datasource_connection_associate.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# huaweicloud_dli_datasource_connection_privilege
+
+Using this resource to associate the elastic resource pools to the DLI datasource **enhanced** connection within
+HuaweiCloud.
+
+-> A connection can only have one resource.
+
+## Example Usage
+
+### Grant queue binding permission to the datasource enhanced connection
+
+```hcl
+variable "connection_id" {}
+variable "associated_pool_names" {
+  type = list(string)
+}
+
+resource "huaweicloud_dli_datasource_connection_associate" "test" {
+  connection_id          = connection_id
+  elastic_resource_pools = var.associated_pool_names
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `connection_id` - (Required, String, ForceNew) Specifies the ID of the datasource **enhanced** connection to be
+  associated.  
+  Changing this parameter will create a new resource.
+
+* `elastic_resource_pools` - (Required, List) Specifies the list of elastic resoruce pool names.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also `connection_id`.
+
+## Import
+
+The associate relationship can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dli_datasource_connection_associate.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -979,6 +979,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dli_flinkjar_job":                    dli.ResourceFlinkJarJob(),
 			"huaweicloud_dli_permission":                      dli.ResourceDliPermission(),
 			"huaweicloud_dli_datasource_connection":           dli.ResourceDatasourceConnection(),
+			"huaweicloud_dli_datasource_connection_associate": dli.ResourceDatasourceConnectionAssociate(),
 			"huaweicloud_dli_datasource_connection_privilege": dli.ResourceDatasourceConnectionPrivilege(),
 			"huaweicloud_dli_datasource_auth":                 dli.ResourceDatasourceAuth(),
 			"huaweicloud_dli_template_sql":                    dli.ResourceSQLTemplate(),

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_connection_associate_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_connection_associate_test.go
@@ -1,0 +1,117 @@
+package dli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
+)
+
+func getAssociatedElasticResourcePoolsFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dli", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DLI client: %s", err)
+	}
+	return dli.GetDatasourceConnectionAssociatedPoolNames(client, state.Primary.ID)
+}
+
+func TestAccDatasourceConnectionAssociate_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_dli_datasource_connection_associate.test"
+		name         = acceptance.RandomAccResourceName()
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getAssociatedElasticResourcePoolsFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAcDatasourceConnectionAssociatec_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "connection_id",
+						"huaweicloud_dli_datasource_connection.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "elastic_resource_pools.#", "2"),
+				),
+			},
+			{
+				Config: testAcDatasourceConnectionAssociatec_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "elastic_resource_pools.#", "2"),
+					// After elastic resource pool is created, it cannot be deleted within one hour.
+					waitForDeletionCooldownComplete(),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAcDatasourceConnectionAssociatec_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id     = huaweicloud_vpc.test.id
+  name       = "%[1]s"
+  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 3, 1)
+  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 3, 1), 1)
+}
+
+resource "huaweicloud_dli_elastic_resource_pool" "test" {
+  count = 3
+
+  name                  = format("%[1]s_%%d", count.index)
+  min_cu                = 64
+  max_cu                = 64
+  enterprise_project_id = "0"
+
+  # The minimum CIDR range allowed for elastic resource pools is /19.
+  cidr = cidrsubnet(huaweicloud_vpc.test.cidr, 3, count.index+2)  # 192.168.x.0/19
+}
+
+resource "huaweicloud_dli_datasource_connection" "test" {
+  name      = "%[1]s"
+  vpc_id    = huaweicloud_vpc.test.id
+  subnet_id = huaweicloud_vpc_subnet.test.id
+}
+`, name)
+}
+
+func testAcDatasourceConnectionAssociatec_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dli_datasource_connection_associate" "test" {
+  connection_id          = huaweicloud_dli_datasource_connection.test.id
+  elastic_resource_pools = slice(huaweicloud_dli_elastic_resource_pool.test[*].name, 0, 2)
+}
+`, testAcDatasourceConnectionAssociatec_base(name), name)
+}
+
+func testAcDatasourceConnectionAssociatec_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dli_datasource_connection_associate" "test" {
+  connection_id          = huaweicloud_dli_datasource_connection.test.id
+  elastic_resource_pools = slice(huaweicloud_dli_elastic_resource_pool.test[*].name, 1, 3)
+}
+`, testAcDatasourceConnectionAssociatec_base(name), name)
+}

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_connection_associate.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_connection_associate.go
@@ -1,0 +1,231 @@
+package dli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DLI POST /v2.0/{project_id}/datasource/enhanced-connections/{connection_id}/associate-queue
+// @API DLI GET /v2.0/{project_id}/datasource/enhanced-connections/{connection_id}
+// @API DLI POST /v2.0/{project_id}/datasource/enhanced-connections/{connection_id}/disassociate-queue
+func ResourceDatasourceConnectionAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDatasourceConnectionAssociateCreate,
+		ReadContext:   resourceDatasourceConnectionAssociateRead,
+		UpdateContext: resourceDatasourceConnectionAssociateUpdate,
+		DeleteContext: resourceDatasourceConnectionAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the datasource enhanced connection and elastic resource pools are located.`,
+			},
+			"connection_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the datasource enhanced connection to be associated.`,
+			},
+			"elastic_resource_pools": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of the elastic resource pool names.`,
+			},
+		},
+	}
+}
+
+func buildCreateDatasourceConnectionAssociateBodyParams(poolNames *schema.Set) map[string]interface{} {
+	return map[string]interface{}{
+		"elastic_resource_pools": utils.ExpandToStringListBySet(poolNames),
+	}
+}
+
+func associateResourcePoolsToConnection(client *golangsdk.ServiceClient, connectionId string, poolNames *schema.Set) error {
+	httpUrl := "v2.0/{project_id}/datasource/enhanced-connections/{connection_id}/associate-queue"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{connection_id}", connectionId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDatasourceConnectionAssociateBodyParams(poolNames)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return fmt.Errorf("error associating the elastic resource pools to the enhanced connection: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return err
+	}
+	if !utils.PathSearch("is_success", respBody, true).(bool) {
+		return fmt.Errorf("unable to associate the elastic resource pools to the enhanced connection: %s",
+			utils.PathSearch("message", respBody, "Message Not Found"))
+	}
+	return nil
+}
+
+func resourceDatasourceConnectionAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		connectionId = d.Get("connection_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	err = associateResourcePoolsToConnection(client, connectionId, d.Get("elastic_resource_pools").(*schema.Set))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(connectionId)
+
+	return resourceDatasourceConnectionAssociateRead(ctx, d, meta)
+}
+
+func GetDatasourceConnectionAssociatedPoolNames(client *golangsdk.ServiceClient, connectionId string) ([]interface{}, error) {
+	respBody, err := getConnectionById(client, connectionId)
+	if err != nil {
+		return nil, err
+	}
+
+	associatedPoolNames := utils.PathSearch("elastic_resource_pools[*].name", respBody, make([]interface{}, 0)).([]interface{})
+	if len(associatedPoolNames) < 1 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return associatedPoolNames, nil
+}
+
+func resourceDatasourceConnectionAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		connectionId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	associatedPoolNames, err := GetDatasourceConnectionAssociatedPoolNames(client, connectionId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "DLI Enhanced connection associate elastic resource pools")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("connection_id", connectionId),
+		d.Set("elastic_resource_pools", associatedPoolNames),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildCreateDatasourceConnectionDisassociateBodyParams(poolNames *schema.Set) map[string]interface{} {
+	return map[string]interface{}{
+		"elastic_resource_pools": utils.ExpandToStringListBySet(poolNames),
+	}
+}
+
+func disassociateResourcePoolsToConnection(client *golangsdk.ServiceClient, connectionId string, poolNames *schema.Set) error {
+	httpUrl := "v2.0/{project_id}/datasource/enhanced-connections/{connection_id}/disassociate-queue"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{connection_id}", connectionId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateDatasourceConnectionDisassociateBodyParams(poolNames)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return fmt.Errorf("error disassociating the elastic resource pools from the enhanced connection: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return err
+	}
+	if !utils.PathSearch("is_success", respBody, true).(bool) {
+		return fmt.Errorf("unable to disassociate the elastic resource pools from the enhanced connection: %s",
+			utils.PathSearch("message", respBody, "Message Not Found"))
+	}
+	return nil
+}
+
+func resourceDatasourceConnectionAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		connectionId = d.Get("connection_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	oldRaws, newRaws := d.GetChange("elastic_resource_pools")
+	associatedPoolNames := newRaws.(*schema.Set).Difference(oldRaws.(*schema.Set))
+	disassociatedPoolNames := oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set))
+
+	if disassociatedPoolNames.Len() > 0 {
+		err = disassociateResourcePoolsToConnection(client, connectionId, disassociatedPoolNames)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if associatedPoolNames.Len() > 0 {
+		err = associateResourcePoolsToConnection(client, connectionId, associatedPoolNames)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceDatasourceConnectionAssociateRead(ctx, d, meta)
+}
+
+func resourceDatasourceConnectionAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg          = meta.(*config.Config)
+		region       = cfg.GetRegion(d)
+		connectionId = d.Id()
+	)
+
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	disassociatedPoolNames, _ := d.GetChange("elastic_resource_pools")
+	err = disassociateResourcePoolsToConnection(client, connectionId, disassociatedPoolNames.(*schema.Set))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new resource to manage the elastic resource pools association.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. excapsulate the connection query method.
2. add a new resource to manage the elastic resource pools association.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDatasourceConnectionAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDatasourceConnectionAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceConnectionAssociate_basic
=== PAUSE TestAccDatasourceConnectionAssociate_basic
=== CONT  TestAccDatasourceConnectionAssociate_basic
--- PASS: TestAccDatasourceConnectionAssociate_basic (4383.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli    4383.597s
```
