### PR TITLE
feat(iotda): add acceptance for space with derived auth

### DIFF
--- a/docs/resources/iotda_space.md
+++ b/docs/resources/iotda_space.md
@@ -10,6 +10,21 @@ A resource space is the basic unit of service management and provides independen
 configuration capabilities at the service layer. Resources (such as products and devices) must be created on
 a resource space.
 
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify
+  the IoTDA service endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  *9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com*, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
 ## Example Usage
 
 ```hcl

--- a/huaweicloud/services/acceptance/iotda/derived.go
+++ b/huaweicloud/services/acceptance/iotda/derived.go
@@ -20,3 +20,24 @@ func withDerivedAuth() bool {
 
 	return false
 }
+
+// When accessing an IoTDA standard or enterprise edition instance, you need to specify
+// the IoTDA service endpoint in `provider` block.
+// You can login to the IoTDA console, choose the instance Overview and click Access Details
+// to view the HTTPS application access address. An example of the access address might be
+// "9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com".
+func buildIoTDAEndpoint() string {
+	endpoint := acceptance.HW_IOTDA_ACCESS_ADDRESS
+	if endpoint == "" {
+		return ""
+	}
+
+	// lintignore:AT004
+	return fmt.Sprintf(`
+provider "huaweicloud" {
+  endpoints = {
+    iotda = "%s"
+  }
+}
+`, endpoint)
+}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_space_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_space_test.go
@@ -56,10 +56,49 @@ func TestAccSpace_basic(t *testing.T) {
 	})
 }
 
+func TestAccSpace_derived(t *testing.T) {
+	var obj model.ShowApplicationRequest
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_iotda_space.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getSpaceResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSpace_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "is_default", "false"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testSpace_basic(name string) string {
 	return fmt.Sprintf(`
+%s
+
 resource "huaweicloud_iotda_space" "test" {
   name = "%s"
 }
-`, name)
+`, buildIoTDAEndpoint(), name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

+ add acceptance for `huaweicloud_iotda_space` with derived auth and update docs

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

### Derived Auth

```bash
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=https://e3331d****.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccSpace_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccSpace_derived -timeout 360m -parallel 4
=== RUN   TestAccSpace_derived
--- PASS: TestAccSpace_derived (17.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     17.718s
```

### Basic

```bash
$ unset HW_IOTDA_ACCESS_ADDRESS
$ export HW_REGION_NAME=cn-north-4
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccSpace_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccSpace_basic -timeout 360m -parallel 4
=== RUN   TestAccSpace_basic
--- PASS: TestAccSpace_basic (11.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     11.169s
```

### Skip

```bash
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccSpace_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccSpace_derived -timeout 360m -parallel 4
=== RUN   TestAccSpace_derived
    acceptance.go:1325: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccSpace_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.038s
```
