### PR TITLE
feat(apig): supports binding domain names to specified group

### DIFF
--- a/docs/resources/apig_group.md
+++ b/docs/resources/apig_group.md
@@ -52,6 +52,12 @@ The following arguments are supported:
 * `environment` - (Optional, List) Specifies an array of one or more environments of the associated group.  
   The [object](#group_environment) structure is documented below.
 
+* `url_domains` - (Optional, List) Specifies independent domain names of the associated with group.  
+  The [url_domains](#group_url_domains) structure is documented below.
+
+  -> Different groups under the same dedicated instance cannot be bound to the same independent domain name.
+     Each API group can be associated with up to `5` domain names.
+
 <a name="group_environment"></a>
 The `environment` block supports:
 
@@ -77,6 +83,24 @@ The `variable` block supports:
   Only letters, digits and special characters (_-/.:) are allowed.
 
   -> **NOTE:** The variable value will be displayed in plain text on the console.
+
+<a name="group_url_domains"></a>
+The `url_domains` block supports:
+
+* `name` - (Required, String) Specifies the domain name. The valid must comply with the domian name specifications.
+
+* `min_ssl_version` - (Optional, String) Specifies the minimum TLS version that can be used to access the domain name,
+  the default value is `TLSv1.2`.
+  The valid values are as follows:
+  + **TLSv1.1**
+  + **TLSv1.2**
+
+  -> This parameter applies only to `HTTPS` and does not take effect for `HTTP` and other access modes.
+     Configure `HTTPS` cipher suites using the `ssl_ciphers` parameter on the parameters tab,
+     please refer to the [documentation](https://support.huaweicloud.com/intl/en-us/usermanual-apig/apig_03_0039.html).
+
+* `is_http_redirect_to_https` - (Optional, Bool) Specifies whether to enable redirection from `HTTP` to `HTTPS`.
+  The default value is `false`.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240312014615-b4bc349645a9
+	github.com/chnsz/golangsdk v0.0.0-20240313030239-1fcac6291cab
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240312014615-b4bc349645a9 h1:mdojkNXXxUTH0wOCbgu56ieii4tefcq8Q4CXGbWwqVI=
-github.com/chnsz/golangsdk v0.0.0-20240312014615-b4bc349645a9/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240313030239-1fcac6291cab h1:iaBOAQOdBq1pF5CecLFmOciktTwMkbiFw9uxCbEftbs=
+github.com/chnsz/golangsdk v0.0.0-20240313030239-1fcac6291cab/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups/requests.go
@@ -103,3 +103,39 @@ func Delete(client *golangsdk.ServiceClient, instanceId, groupId string) (r Dele
 	_, r.Err = client.Delete(resourceURL(client, instanceId, groupId), nil)
 	return
 }
+
+// AssociateDomainOpts is the structure that used to bind domain name to specified API group.
+type AssociateDomainOpts struct {
+	// The dedicated instance ID.
+	InstanceId string `json:"-" requires:"true"`
+	// The API group ID.
+	GroupId string `json:"-" requires:"true"`
+	// Custom domain name.
+	// The valid length is limited from 0 to 255 characters and must comply with the domian name specifications.
+	UrlDomain string `json:"url_domain" requires:"true"`
+	// The minimum TLS version that can be used to access the domain name, the default value is TLSv1.2.
+	// The valid value are as follows:
+	// + TLSv1.1.
+	// + TLSv1.2.
+	MinSSLVersion string `json:"min_ssl_version,omitempty"`
+	// Whether to enable redirection from HTTP to HTTPS, the default value is false.
+	IsHttpRedirectToHttps bool `json:"is_http_redirect_to_https,omitempty"`
+}
+
+// AssociateDomain is a method that used to bind domain name to specified API group.
+func AssociateDomain(client *golangsdk.ServiceClient, opts AssociateDomainOpts) (*AssociateDoaminResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssociateDoaminResp
+	_, err = client.Post(associateDomainURL(client, opts.InstanceId, opts.GroupId), b, &r, nil)
+	return &r, err
+}
+
+// AssociateDomain is a method that used to unbind domain name to specified API group.
+func DisAssociateDomain(client *golangsdk.ServiceClient, intanceId string, groupId string, domainId string) error {
+	_, err := client.Delete(disAssociateDomainURL(client, intanceId, groupId, domainId), nil)
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups/results.go
@@ -73,6 +73,8 @@ type UrlDomian struct {
 	//     TLSv1.1
 	//     TLSv1.2
 	MinSSLVersion string `json:"min_ssl_version"`
+	// Whether to enable redirection from HTTP to HTTPS.
+	IsHttpRedirectToHttps bool `json:"is_http_redirect_to_https"`
 }
 
 func (r commonResult) Extract() (*Group, error) {
@@ -95,4 +97,24 @@ func ExtractGroups(r pagination.Page) ([]Group, error) {
 // DeleteResult represents a result of the Delete method.
 type DeleteResult struct {
 	golangsdk.ErrResult
+}
+
+// AssociateDoaminResp is the structure that represents the API response of AssociateDomain method request.
+type AssociateDoaminResp struct {
+	// Domain ID.
+	ID string `json:"id"`
+	// Custom domain name.
+	UrlDoamin string `json:"url_domain"`
+	// CNAME resolution status of the domain name.
+	// + 1: not resolved
+	// + 2: resolving
+	// + 3: resolved
+	// + 4: resolving failed
+	Status int `json:"status"`
+	// The minimum SSL version supported.
+	MinSSLVersion string `json:"min_ssl_version"`
+	// Whether to enable redirection from HTTP to HTTPS.
+	IsHttpRedirectToHttps bool `json:"is_http_redirect_to_https"`
+	// Whether to enable client certificate verification.
+	VerifiedClientCertificateEnabled bool `json:"verified_client_certificate_enabled"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups/urls.go
@@ -11,3 +11,10 @@ func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
 func resourceURL(c *golangsdk.ServiceClient, instanceId, groupId string) string {
 	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId)
 }
+
+func associateDomainURL(c *golangsdk.ServiceClient, instanceId string, groupId string) string {
+	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId, "domains")
+}
+func disAssociateDomainURL(c *golangsdk.ServiceClient, instanceId string, groupId string, domainId string) string {
+	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId, "domains", domainId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240312014615-b4bc349645a9
+# github.com/chnsz/golangsdk v0.0.0-20240313030239-1fcac6291cab
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The resource supports binding independent domain names to specified group.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports binging domain names to specified group.
2. add related document and acceptance test.
3. different groups under the same dedicated instance cannot be bound to the same independent domain name.
4. each API group can be associated with up to 5 domain names.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccGroup_urlDomains'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccGroup_urlDomains -timeout 360m -parallel 4
=== RUN   TestAccGroup_urlDomains
=== PAUSE TestAccGroup_urlDomains
=== CONT  TestAccGroup_urlDomains
--- PASS: TestAccGroup_urlDomains (627.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      627.179s
```
