### PR TITLE
fix(gaussdb): fix gaussdb resource lint error

### DIFF
--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_cassandra_flavors.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_cassandra_flavors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -124,5 +125,9 @@ func dataSourceCassandraFlavorsRead(_ context.Context, d *schema.ResourceData, m
 	}
 
 	d.SetId(hashcode.Strings(flavorsIds))
-	return diag.FromErr(d.Set("flavors", flavorsToSet))
+	var mErr *multierror.Error
+	mErr = multierror.Append(mErr,
+		d.Set("flavors", flavorsToSet),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_instances.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_instances.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -310,7 +311,10 @@ func dataSourceGaussDBMysqlInstancesRead(_ context.Context, d *schema.ResourceDa
 	}
 
 	d.SetId(hashcode.Strings(instancesIds))
-	d.Set("instances", instancesToSet)
+	var mErr *multierror.Error
+	mErr = multierror.Append(mErr,
+		d.Set("instances", instancesToSet),
+	)
 
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_nosql_flavors.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -159,6 +160,10 @@ func dataSourceGaussDBFlavorsRead(_ context.Context, d *schema.ResourceData, met
 		return diag.Errorf("an error occurred while filtering the GaussDB NoSQL flavors: %s", err)
 	}
 	d.SetId(hashcode.Strings(names))
+	var mErr *multierror.Error
+	mErr = multierror.Append(mErr,
+		d.Set("flavors", result),
+	)
 
-	return diag.FromErr(d.Set("flavors", result))
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -331,7 +332,7 @@ func dataSourceOpenGaussInstancesRead(_ context.Context, d *schema.ResourceData,
 			instanceToSet["replica_num"] = instanceInAll.ReplicaNum
 		}
 
-		//remove duplicate az
+		// remove duplicate az
 		azList = utils.RemoveDuplicateElem(azList)
 		sort.Strings(azList)
 		instanceToSet["availability_zone"] = strings.Join(azList, ",")
@@ -366,7 +367,10 @@ func dataSourceOpenGaussInstancesRead(_ context.Context, d *schema.ResourceData,
 	}
 
 	d.SetId(hashcode.Strings(instancesIds))
-	err = d.Set("instances", instancesToSet)
+	var mErr *multierror.Error
+	mErr = multierror.Append(mErr,
+		d.Set("instances", instancesToSet),
+	)
 
-	return diag.FromErr(err)
+	return diag.FromErr(mErr.ErrorOrNil())
 }

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_redis_instance.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_redis_instance.go
@@ -274,7 +274,7 @@ func dataSourceGaussRedisInstanceRead(_ context.Context, d *schema.ResourceData,
 	d.Set("nodes", nodesList)
 	d.Set("private_ips", ipsList)
 
-	//remove duplicate az
+	// remove duplicate az
 	azList = utils.RemoveDuplicateElem(azList)
 	sort.Strings(azList)
 	d.Set("availability_zone", strings.Join(azList, ","))
@@ -288,7 +288,7 @@ func dataSourceGaussRedisInstanceRead(_ context.Context, d *schema.ResourceData,
 	backupStrategyList = append(backupStrategyList, backupStrategy)
 	d.Set("backup_strategy", backupStrategyList)
 
-	//save geminidb tags
+	// save geminidb tags
 	if resourceTags, err := tags.Get(client, "instances", d.Id()).Extract(); err == nil {
 		tagmap := utils.TagsToMap(resourceTags.Tags)
 		if err := d.Set("tags", tagmap); err != nil {

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -560,7 +560,7 @@ func resourceGaussDBInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 			id, err)
 	}
 
-	//audit-log switch
+	// audit-log switch
 	if v, ok := d.GetOk("audit_log_enabled"); ok {
 		err = switchAuditLog(client, id, v.(bool))
 		if err != nil {

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy.go
@@ -32,7 +32,7 @@ func ResourceGaussDBProxy() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
-		Schema: map[string]*schema.Schema{ //request and response parameters
+		Schema: map[string]*schema.Schema{ // request and response parameters
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: fix gaussdb resource lint error

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
region = "cn-north-4"
Because the previous Lint check was submitted in batches, missing some parts, now add them after checking.

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccCassandraFlavorsDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccCassandraFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccCassandraFlavorsDataSource_basic
=== PAUSE TestAccCassandraFlavorsDataSource_basic
=== CONT  TestAccCassandraFlavorsDataSource_basic
--- PASS: TestAccCassandraFlavorsDataSource_basic (13.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   13.793s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGeminiDBInstanceDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGeminiDBInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBInstanceDataSource_basic
=== PAUSE TestAccGeminiDBInstanceDataSource_basic
=== CONT  TestAccGeminiDBInstanceDataSource_basic
--- PASS: TestAccGeminiDBInstanceDataSource_basic (1277.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1277.563s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== PAUSE TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== CONT  TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
--- PASS: TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic (26.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   26.129s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussdbMysqlInstanceDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussdbMysqlInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussdbMysqlInstanceDataSource_basic
=== PAUSE TestAccGaussdbMysqlInstanceDataSource_basic
=== CONT  TestAccGaussdbMysqlInstanceDataSource_basic
--- PASS: TestAccGaussdbMysqlInstanceDataSource_basic (1433.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1434.023s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_basic
=== PAUSE TestAccGaussDBNoSQLFlavors_basic
=== CONT  TestAccGaussDBNoSQLFlavors_basic
--- PASS: TestAccGaussDBNoSQLFlavors_basic (24.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   24.773s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_mongodb"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_mongodb -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_mongodb
=== PAUSE TestAccGaussDBNoSQLFlavors_mongodb
=== CONT  TestAccGaussDBNoSQLFlavors_mongodb
--- PASS: TestAccGaussDBNoSQLFlavors_mongodb (19.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   19.345s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_vcpus"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_vcpus -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_vcpus
=== PAUSE TestAccGaussDBNoSQLFlavors_vcpus
=== CONT  TestAccGaussDBNoSQLFlavors_vcpus
--- PASS: TestAccGaussDBNoSQLFlavors_vcpus (14.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   14.094s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussDBNoSQLFlavors_az"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussDBNoSQLFlavors_az -timeout 360m -parallel 4
=== RUN   TestAccGaussDBNoSQLFlavors_az
=== PAUSE TestAccGaussDBNoSQLFlavors_az
=== CONT  TestAccGaussDBNoSQLFlavors_az
--- PASS: TestAccGaussDBNoSQLFlavors_az (18.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   18.849s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussRedisInstanceDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussRedisInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussRedisInstanceDataSource_basic
=== PAUSE TestAccGaussRedisInstanceDataSource_basic
=== CONT  TestAccGaussRedisInstanceDataSource_basic
--- PASS: TestAccGaussRedisInstanceDataSource_basic (1368.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1368.407s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGeminiDBInstance_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGeminiDBInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBInstance_basic
=== PAUSE TestAccGeminiDBInstance_basic
=== CONT  TestAccGeminiDBInstance_basic
--- PASS: TestAccGeminiDBInstance_basic (1252.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1252.917s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGeminiDBInstance_prePaid"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGeminiDBInstance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccGeminiDBInstance_prePaid
=== PAUSE TestAccGeminiDBInstance_prePaid
=== CONT  TestAccGeminiDBInstance_prePaid
--- PASS: TestAccGeminiDBInstance_prePaid (1269.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1269.895s
```
