### PR TITLE
feat(iotda): add batchtask resource support

### DIFF
--- a/docs/resources/iotda_batchtask.md
+++ b/docs/resources/iotda_batchtask.md
@@ -1,0 +1,161 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_batchtask
+
+Manages an IoTDA batch task within HuaweiCloud.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "task_name" {}
+variable "task_type" {}
+variable "targets_file" {}
+
+resource "huaweicloud_iotda_batchtask" "test" { 
+  name         = var.task_name
+  type         = var.task_type
+  targets_file = var.targets_file
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the IoTDA batch task resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the batch task name. The length does not exceed `128`, and only
+  combinations of Chinese characters, letters, numbers, and underscores (_) are allowed.
+  Changing this parameter will create a new resource.
+
+* `type` - (Required, String, ForceNew) Specifies the batch task type.
+  Changing this parameter will create a new resource.  
+  The valid values are as follows:
+  + **createDevices**: Batch create devices task.
+  + **updateDevices**: Batch update devices task.
+  + **deleteDevices**: Batch deletion of devices task.
+  + **freezeDevices**: Batch freeze devices task.
+  + **unfreezeDevices**: Batch unfreeze devices task.
+
+* `space_id` - (Optional, String, ForceNew) Specifies the resource space ID to which the batch task belongs.
+  Changing this parameter will create a new resource.
+
+* `targets` - (Optional, List, ForceNew) Specifies an array of target device IDs for executing the batch task, which can
+  include up to `30,000` device IDs. This parameter is supported when the `type` is **deleteDevices**,
+  **freezeDevices**, or **unfreezeDevices**. Changing this parameter will create a new resource.
+
+* `targets_filter` - (Optional, List, ForceNew) Specifies the batch task target filtering parameters.
+  Using this parameter, batch tasks will filter out devices that meet the criteria as targets.
+  This parameter is supported when the `type` is **deleteDevices**, **freezeDevices**, or **unfreezeDevices**.
+  Changing this parameter will create a new resource.
+  The [targets_filter](#IoTDA_targets_filter) structure is documented below.
+
+* `targets_file` - (Optional, String, ForceNew) Specifies the batch task file path to be used for creating batch task.
+  Currently, only the **xlsx/xls** file format is supported, and the maximum number of lines in the file is `30000`.
+  This parameter is supported when the `type` is **createDevices**, **updateDevices**, **deleteDevices**,
+  **freezeDevices**, or **unfreezeDevices**. Changing this parameter will create a new resource.
+  Please following [reference](https://support.huaweicloud.com/intl/en-us/usermanual-iothub/iot_01_0032.html),
+  download the template file and fill it out.
+
+-> Exactly one of `targets`, `targets_filter`, or `targets_file` should be specified.
+
+<a name="IoTDA_targets_filter"></a>
+The `targets_filter` block supports:
+
+* `group_ids` - (Required, List, ForceNew) Specifies the list of device group IDs for executing batch task. Batch task
+  will filter out devices within the groups as targets.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The resource status. The valid values are as follows:
+  + **Success**: Batch task execution successful.
+  + **Fail**: Batch task execution failed.
+  + **PartialSuccess**: Batch task partially executed successfully, some subtasks have been executed successfully,
+    while others have failed.
+
+* `status_desc` - The batch task status description, indicating the error message of the main task failure.
+
+* `created_at` - The time of batch task creation. The format is **yyyyMMdd'T'HHmmss'Z**. e.g. **20190528T153000Z**.
+
+* `task_progress` - Subtask execution statistics results.
+  The [task_progress](#iotda_task_progress) structure is documented below.
+
+* `task_details` - List of subTask details.
+  The [task_details](#iotda_task_details) structure is documented below.
+
+<a name="iotda_task_progress"></a>
+The `task_progress` block supports:
+
+* `total` - The total number of subtasks.
+
+* `success` - The number of successfully executed subtasks.
+
+* `fail` - The number of subtasks that failed to execute.
+
+<a name="iotda_task_details"></a>
+The `task_details` block supports:
+
+* `target` - The goal of executing subtask. The value includes product ID and node ID.
+
+* `status` - The execution status of subtask. The value can be **Success** or **Fail**.
+
+* `output` - The output information of subtask execution. The value only exists when the subtask is successfully
+  executed, including device ID, space ID, device secret, and device fingerprint.
+
+* `error` - Subtask execution failure information. The value only exists when the subtask fails.
+  The [task_details](#iotda_task_details_error) structure is documented below.
+
+<a name="iotda_task_details_error"></a>
+The `error` block supports:
+
+* `error_code` - Subtask execution failure error code.
+
+* `error_msg` - Subtask execution failure error message.
+
+## Import
+
+The batch task can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_iotda_batchtask.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `space_id`, `targets`, `targets_filter`,
+ `targets_file`. It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition
+should be updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_iotda_batchtask" "test" { 
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      space_id, targets, targets_filter, targets_file,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1154,6 +1154,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_device_linkage_rule": iotda.ResourceDeviceLinkageRule(),
 			"huaweicloud_iotda_batchtask_file":      iotda.ResourceBatchTaskFile(),
 			"huaweicloud_iotda_upgrade_package":     iotda.ResourceUpgradePackage(),
+			"huaweicloud_iotda_batchtask":           iotda.ResourceBatchTask(),
 
 			"huaweicloud_kms_key":                dew.ResourceKmsKey(),
 			"huaweicloud_kps_keypair":            dew.ResourceKeypair(),

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_batchtask_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_batchtask_test.go
@@ -1,0 +1,287 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getBatchTaskResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	if err != nil {
+		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	// There is no need to handle pagination related parameters here, as it only applies to the structure of subtasks.
+	resp, err := client.ShowBatchTask(&model.ShowBatchTaskRequest{
+		TaskId: state.Primary.ID,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("error querying IoTDA batch task: %s", err)
+	}
+
+	return resp, nil
+}
+
+func TestAccBatchTask_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_iotda_batchtask.test_freeze"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getBatchTaskResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchTask_basic(name, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "freezeDevices"),
+					resource.TestCheckResourceAttrPair(resourceName, "space_id", "huaweicloud_iotda_space.test", "id"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "task_progress.0.total", "2"),
+					resource.TestCheckResourceAttr(resourceName, "task_details.#", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"space_id", "targets", "targets_filter", "targets_file"},
+			},
+		},
+	})
+}
+
+func TestAccBatchTask_withTargetsFilterField(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_iotda_batchtask.test_unfreeze"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getBatchTaskResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchTask_withTargetsFilterField(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "unfreezeDevices"),
+					resource.TestCheckResourceAttr(resourceName, "status", "Fail"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "status_desc"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "task_details.#", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"space_id", "targets", "targets_filter", "targets_file"},
+			},
+		},
+	})
+}
+
+func TestAccBatchTask_withTargetsFileField(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_iotda_batchtask.test_create"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getBatchTaskResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckIOTDABatchTaskFilePath(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchTask_withTargetsFileField(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "createDevices"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "task_details.#"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"space_id", "targets", "targets_filter", "targets_file"},
+			},
+		},
+	})
+}
+
+func TestAccBatchTask_derived(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_iotda_batchtask.test_derived"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getBatchTaskResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBatchTask_derived(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "unfreezeDevices"),
+					resource.TestCheckResourceAttr(resourceName, "status", "Fail"),
+
+					resource.TestCheckResourceAttrSet(resourceName, "status_desc"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttr(resourceName, "task_details.#", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"space_id", "targets", "targets_filter", "targets_file"},
+			},
+		},
+	})
+}
+
+func testBatchTask_base(name, nodeId string) string {
+	productBasic := testProduct_basic(name)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_device" "test1" {
+  name       = "%[2]s"
+  node_id    = "%[3]s"
+  space_id   = huaweicloud_iotda_space.test.id
+  product_id = huaweicloud_iotda_product.test.id
+}
+
+resource "huaweicloud_iotda_device" "test2" {
+  name       = "%[2]s_2"
+  node_id    = "%[3]s_2"
+  space_id   = huaweicloud_iotda_space.test.id
+  product_id = huaweicloud_iotda_product.test.id
+  secret     = "1234567890"
+}
+
+`, productBasic, name, nodeId)
+}
+
+func testBatchTask_basic(name, nodeId string) string {
+	batchTaskBase := testBatchTask_base(name, nodeId)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_batchtask" "test_freeze" {
+  name     = "%[2]s"
+  type     = "freezeDevices"
+  space_id = huaweicloud_iotda_space.test.id
+  targets  = [huaweicloud_iotda_device.test1.id, huaweicloud_iotda_device.test2.id]
+}
+`, batchTaskBase, name, nodeId)
+}
+
+func testBatchTask_withTargetsFilterField(name string) string {
+	return fmt.Sprintf(`
+
+resource "huaweicloud_iotda_batchtask" "test_unfreeze" {
+  name = "%s"
+  type = "unfreezeDevices"
+
+  # The status of batch task created with non-existent group ID must be failed.
+  targets_filter {
+    group_ids = ["123456789", "987654321"]
+  }
+}
+`, name)
+}
+
+func testBatchTask_withTargetsFileField(name string) string {
+	return fmt.Sprintf(`
+
+resource "huaweicloud_iotda_batchtask" "test_create" {
+  name         = "%[1]s"
+  type         = "createDevices"
+  targets_file = "%[2]s"
+}
+`, name, acceptance.HW_IOTDA_BATCHTASK_FILE_PATH)
+}
+
+func testBatchTask_derived(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_batchtask" "test_derived" {
+  name = "%[2]s"
+  type = "unfreezeDevices"
+
+  # The status of batch task created with non-existent group ID must be failed.
+  targets_filter {
+    group_ids = ["123456789", "987654321"]
+  }
+}
+`, buildIoTDAEndpoint(), name)
+}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_batchtask.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_batchtask.go
@@ -1,0 +1,441 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/def"
+	iotdav5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	batchTaskInitializing   = "Initializing"
+	batchTaskWaiting        = "Waitting"
+	batchTaskProcessing     = "Processing"
+	batchTaskSuccess        = "Success"
+	batchTaskFail           = "Fail"
+	batchTaskPartialSuccess = "PartialSuccess"
+)
+
+// @API IoTDA POST /v5/iot/{project_id}/batchtask-files
+// @API IoTDA DELETE /v5/iot/{project_id}/batchtask-files/{file_id}
+// @API IoTDA POST /v5/iot/{project_id}/batchtasks
+// @API IoTDA GET /v5/iot/{project_id}/batchtasks/{task_id}
+// @API IoTDA DELETE /v5/iot/{project_id}/batchtasks/{task_id}
+func ResourceBatchTask() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceBatchTaskCreate,
+		ReadContext:   resourceBatchTaskRead,
+		DeleteContext: resourceBatchTaskDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"targets": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				ForceNew:     true,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				ExactlyOneOf: []string{"targets", "targets_filter", "targets_file"},
+			},
+			"targets_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group_ids": {
+							Type:     schema.TypeList,
+							Required: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"targets_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status_desc": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"task_progress": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"total": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"success": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"fail": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"task_details": {
+				Type:      schema.TypeList,
+				Sensitive: true,
+				Computed:  true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"output": {
+							Type:      schema.TypeString,
+							Sensitive: true,
+							Computed:  true,
+						},
+						"error": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"error_code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"error_msg": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceBatchTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	// First, determine whether to upload batch task files.
+	var targetFileId *string
+	if v, ok := d.GetOk("targets_file"); ok && v.(string) != "" {
+		file, openErr := os.Open(v.(string))
+		if openErr != nil {
+			return diag.Errorf("error opening batch task file: %s", openErr)
+		}
+		defer file.Close()
+
+		uploadOpts := buildBatchTaskFileUploadParams(file)
+		uploadTaskFileResp, uploadErr := client.UploadBatchTaskFile(uploadOpts)
+		if uploadErr != nil {
+			return diag.Errorf("error uploading IoTDA batch task file: %s", uploadErr)
+		}
+
+		if uploadTaskFileResp == nil || uploadTaskFileResp.FileId == nil {
+			return diag.Errorf("error uploading IoTDA batch task file: ID is not found in API response")
+		}
+
+		targetFileId = uploadTaskFileResp.FileId
+	}
+
+	createOpts := buildBatchTaskCreateParams(d, targetFileId)
+	createTaskResp, createTaskErr := client.CreateBatchTask(createOpts)
+	if createTaskErr != nil {
+		// When creating the batch task fails, it is necessary to delete the uploaded task file.
+		var deleteTaskFileErr error
+		if targetFileId != nil {
+			deleteTaskFileErr = deleteBatchTaskFile(client, *targetFileId)
+		}
+
+		return diag.Errorf("error creating IoTDA batch task: %s, %s", createTaskErr, deleteTaskFileErr)
+	}
+
+	if createTaskResp == nil || createTaskResp.TaskId == nil {
+		var deleteTaskFileErr error
+		if targetFileId != nil {
+			deleteTaskFileErr = deleteBatchTaskFile(client, *targetFileId)
+		}
+
+		return diag.Errorf("error creating IoTDA batch task: ID is not found in API response, %s", deleteTaskFileErr)
+	}
+
+	d.SetId(*createTaskResp.TaskId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      batchTaskStateRefreshFunc(client, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for IoTDA batch task to complete: %s", err)
+	}
+
+	return resourceBatchTaskRead(ctx, d, meta)
+}
+
+func buildBatchTaskFileUploadParams(file *os.File) *model.UploadBatchTaskFileRequest {
+	req := model.UploadBatchTaskFileRequest{
+		Body: &model.UploadBatchTaskFileRequestBody{
+			File: &def.FilePart{
+				Content: file,
+			},
+		},
+	}
+	return &req
+}
+
+func buildBatchTaskCreateParams(d *schema.ResourceData, fileId *string) *model.CreateBatchTaskRequest {
+	req := model.CreateBatchTaskRequest{
+		Body: &model.CreateBatchTask{
+			TaskName:       d.Get("name").(string),
+			TaskType:       d.Get("type").(string),
+			AppId:          utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+			Targets:        utils.ExpandToStringListPointer(d.Get("targets").([]interface{})),
+			DocumentSource: fileId,
+		},
+	}
+
+	targetsFilter := d.Get("targets_filter").([]interface{})
+	if len(targetsFilter) > 0 {
+		groupIDs := targetsFilter[0].(map[string]interface{})
+		groupIDList := utils.ExpandToStringList(groupIDs["group_ids"].([]interface{}))
+
+		targetGroupIDs := make(map[string]interface{})
+		targetGroupIDs["group_ids"] = groupIDList
+
+		req.Body.TargetsFilter = targetGroupIDs
+	}
+
+	return &req
+}
+
+func deleteBatchTaskFile(client *iotdav5.IoTDAClient, fileId string) error {
+	deleteOpts := &model.DeleteBatchTaskFileRequest{
+		FileId: fileId,
+	}
+	_, err := client.DeleteBatchTaskFile(deleteOpts)
+	if err != nil {
+		return fmt.Errorf("error deleting IoTDA batch task file after failed creation of IoTDA batch task: %s", err)
+	}
+
+	return nil
+}
+
+func batchTaskStateRefreshFunc(client *iotdav5.IoTDAClient, taskId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		// There is no need to handle pagination related parameters, as it only applies to the structure of subtasks.
+		getOpts := &model.ShowBatchTaskRequest{
+			TaskId: taskId,
+		}
+		resp, err := client.ShowBatchTask(getOpts)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		status := *resp.Batchtask.Status
+
+		targetStatus := []string{
+			batchTaskSuccess, batchTaskFail, batchTaskPartialSuccess,
+		}
+		if utils.StrSliceContains(targetStatus, status) {
+			return resp, "COMPLETED", nil
+		}
+
+		pendingStatus := []string{
+			batchTaskInitializing, batchTaskWaiting, batchTaskProcessing,
+		}
+		if !utils.StrSliceContains(pendingStatus, status) {
+			return resp, *resp.Batchtask.Status, nil
+		}
+
+		return resp, "PENDING", nil
+	}
+}
+
+func resourceBatchTaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allTaskDetails []model.TaskDetail
+		targetResp     *model.ShowBatchTaskResponse
+		limit          = int32(50)
+		offset         int32
+	)
+
+	// The purpose of pagination is to get all subtasks under the batch task.
+	// The pagination parameter only takes effect on the structure of subtask details(task_details).
+	for {
+		getOpts := &model.ShowBatchTaskRequest{
+			TaskId: d.Id(),
+			Limit:  utils.Int32(limit),
+			Offset: &offset,
+		}
+		// If the resource does not exist, the API will return a 404 status code.
+		resp, getErr := client.ShowBatchTask(getOpts)
+		if getErr != nil {
+			return common.CheckDeletedDiag(d, getErr, "error querying IoTDA batch task")
+		}
+
+		if targetResp == nil {
+			targetResp = resp
+		}
+
+		if len(*resp.TaskDetails) == 0 {
+			break
+		}
+		allTaskDetails = append(allTaskDetails, *resp.TaskDetails...)
+		offset += limit
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", targetResp.Batchtask.TaskName),
+		d.Set("type", targetResp.Batchtask.TaskType),
+		d.Set("status", targetResp.Batchtask.Status),
+		d.Set("status_desc", targetResp.Batchtask.StatusDesc),
+		d.Set("created_at", targetResp.Batchtask.CreateTime),
+		d.Set("task_progress", flattenTaskProgress(targetResp.Batchtask.TaskProgress)),
+		d.Set("task_details", flattenTaskDetails(allTaskDetails)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenTaskProgress(taskProgress *model.TaskProgress) []interface{} {
+	if taskProgress == nil {
+		return nil
+	}
+
+	rst := map[string]interface{}{
+		"total":   taskProgress.Total,
+		"success": taskProgress.Success,
+		"fail":    taskProgress.Fail,
+	}
+
+	return []interface{}{rst}
+}
+
+func flattenTaskDetails(taskDetails []model.TaskDetail) []interface{} {
+	if len(taskDetails) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, len(taskDetails))
+	for i, v := range taskDetails {
+		rst[i] = map[string]interface{}{
+			"target": v.Target,
+			"status": v.Status,
+			"output": v.Output,
+			"error":  flattenErrorInfo(v.Error),
+		}
+	}
+
+	return rst
+}
+
+func flattenErrorInfo(errorInfo *model.ErrorInfo) []interface{} {
+	if errorInfo == nil {
+		return nil
+	}
+
+	rst := map[string]interface{}{
+		"error_code": errorInfo.ErrorCode,
+		"error_msg":  errorInfo.ErrorMsg,
+	}
+
+	return []interface{}{rst}
+}
+
+func resourceBatchTaskDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	deleteOpts := model.DeleteBatchTaskRequest{
+		TaskId: d.Id(),
+	}
+	_, err = client.DeleteBatchTask(&deleteOpts)
+	if err != nil {
+		return diag.Errorf("error deleting IoTDA batch task: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add batchtask resource support
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.add batchtask resource support
2.add test for derived auth
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed


## Basic
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_basic -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_basic
--- PASS: TestAccBatchTask_basic (39.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     39.043s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_withTargetsFilterField"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_withTargetsFilterField -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_withTargetsFilterField
--- PASS: TestAccBatchTask_withTargetsFilterField (17.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     17.527s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_withTargetsFileField"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_withTargetsFileField -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_withTargetsFileField
--- PASS: TestAccBatchTask_withTargetsFileField (26.81s)
PASS
```

## Derived Auth
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_derived -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_derived
--- PASS: TestAccBatchTask_derived (23.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     23.307s
```

## Skip
```
$ export HW_REGION_NAME=cn-north-4
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_derived -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_derived
    acceptance.go:1327: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccBatchTask_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.037s
```