### PR TITLE
fix(gaussdb): fix test gaussdb case issues

### DIFF
--- a/docs/resources/gaussdb_redis_instance.md
+++ b/docs/resources/gaussdb_redis_instance.md
@@ -15,7 +15,7 @@ resource "huaweicloud_gaussdb_redis_instance" "test" {
   name              = "gaussdb_redis_instance_1"
   password          = var.password
   flavor            = "geminidb.redis.xlarge.4"
-  volume_size       = 100
+  volume_size       = 16
   vpc_id            = var.vpc_id
   subnet_id         = var.subnet_id
   security_group_id = var.secgroup_id
@@ -35,7 +35,7 @@ resource "huaweicloud_gaussdb_redis_instance" "test" {
   name              = "gaussdb_redis_instance_1"
   password          = var.password
   flavor            = "geminidb.redis.xlarge.4"
-  volume_size       = 100
+  volume_size       = 16
   vpc_id            = var.vpc_id
   subnet_id         = var.subnet_id
   security_group_id = var.secgroup_id

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instance_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccOpenGaussInstanceDataSource_basic(t *testing.T) {
@@ -72,71 +71,24 @@ func testAccOpenGaussInstanceDataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_gaussdb_opengauss_instance" "test" {
-  name        = "%[2]s"
-  password    = "Test@12345678"
-  flavor      = "gaussdb.opengauss.ee.dn.m6.2xlarge.8.in"
-  vpc_id      = huaweicloud_vpc.test.id
-  subnet_id   = huaweicloud_vpc_subnet.test.id
-
-  availability_zone = "cn-north-4a,cn-north-4a,cn-north-4a"
-  security_group_id = huaweicloud_networking_secgroup.test.id
-
-  ha {
-    mode             = "enterprise"
-    replication_mode = "sync"
-    consistency      = "strong"
-  }
-  volume {
-    type = "ULTRAHIGH"
-    size = 40
-  }
-
-  sharding_num = 1
-  coordinator_num = 2
-}
-
 data "huaweicloud_gaussdb_opengauss_instance" "test" {
   name = huaweicloud_gaussdb_opengauss_instance.test.name
   depends_on = [
     huaweicloud_gaussdb_opengauss_instance.test,
   ]
 }
-`, common.TestBaseNetwork(rName), rName)
+`, testAccOpenGaussInstance_basic(rName, fmt.Sprintf("%s@123", acctest.RandString(5)), 2))
 }
 
 func testAccOpenGaussInstanceDataSource_haModeCentralized(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_gaussdb_opengauss_instance" "test" {
-  name        = "%[2]s"
-  password    = "Test@12345678"
-  flavor      = "gaussdb.opengauss.ee.m6.2xlarge.x868.ha"
-  vpc_id      = huaweicloud_vpc.test.id
-  subnet_id   = huaweicloud_vpc_subnet.test.id
-
-  availability_zone = "cn-north-4a,cn-north-4a,cn-north-4a"
-  security_group_id = huaweicloud_networking_secgroup.test.id
-
-  ha {
-    mode             = "centralization_standard"
-    replication_mode = "sync"
-    consistency      = "strong"
-  }
-  volume {
-    type = "ULTRAHIGH"
-    size = 40
-  }
-
-  replica_num = 3
-}
-
 data "huaweicloud_gaussdb_opengauss_instance" "test" {
   name = huaweicloud_gaussdb_opengauss_instance.test.name
   depends_on = [
     huaweicloud_gaussdb_opengauss_instance.test,
   ]
 }
-`, common.TestBaseNetwork(rName), rName)
+`, testAccOpenGaussInstance_haModeCentralized(rName, fmt.Sprintf("%s@123", acctest.RandString(5))))
 }

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccOpenGaussInstancesDataSource_basic(t *testing.T) {
@@ -74,87 +73,24 @@ func testAccOpenGaussInstancesDataSource_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_networking_secgroup_rule" "test" {
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  remote_ip_prefix  = "0.0.0.0/0"
-}
-
-resource "huaweicloud_gaussdb_opengauss_instance" "test" {
-  name      = "%[2]s"
-  password  = "Test@12345678"
-  flavor    = "gaussdb.opengauss.ee.dn.m6.2xlarge.8.in"
-  vpc_id    = huaweicloud_vpc.test.id
-  subnet_id = huaweicloud_vpc_subnet.test.id
-
-  availability_zone = "cn-north-4a,cn-north-4a,cn-north-4a"
-  security_group_id = huaweicloud_networking_secgroup.test.id
-
-  ha {
-    mode             = "enterprise"
-    replication_mode = "sync"
-    consistency      = "strong"
-  }
-  volume {
-    type = "ULTRAHIGH"
-    size = 40
-  }
-
-  sharding_num    = 1
-  coordinator_num = 2
-}
-
 data "huaweicloud_gaussdb_opengauss_instances" "test" {
   name = huaweicloud_gaussdb_opengauss_instance.test.name
   depends_on = [
     huaweicloud_gaussdb_opengauss_instance.test,
   ]
 }
-`, common.TestBaseNetwork(rName), rName)
+`, testAccOpenGaussInstance_basic(rName, fmt.Sprintf("%s@123", acctest.RandString(5)), 2))
 }
 
 func testAccOpenGaussInstancesDataSource_haModeCentralized(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_networking_secgroup_rule" "test" {
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  remote_ip_prefix  = "0.0.0.0/0"
-}
-
-resource "huaweicloud_gaussdb_opengauss_instance" "test" {
-  name      = "%[2]s"
-  password  = "Test@12345678"
-  flavor    = "gaussdb.opengauss.ee.m6.2xlarge.x868.ha"
-  vpc_id    = huaweicloud_vpc.test.id
-  subnet_id = huaweicloud_vpc_subnet.test.id
-
-  availability_zone = "cn-north-4a,cn-north-4a,cn-north-4a"
-  security_group_id = huaweicloud_networking_secgroup.test.id
-
-  ha {
-    mode             = "centralization_standard"
-    replication_mode = "sync"
-    consistency      = "strong"
-  }
-  volume {
-    type = "ULTRAHIGH"
-    size = 40
-  }
-
-  replica_num = 3
-}
-
 data "huaweicloud_gaussdb_opengauss_instances" "test" {
   name = huaweicloud_gaussdb_opengauss_instance.test.name
   depends_on = [
     huaweicloud_gaussdb_opengauss_instance.test,
   ]
 }
-`, common.TestBaseNetwork(rName), rName)
+`, testAccOpenGaussInstance_haModeCentralized(rName, fmt.Sprintf("%s@123", acctest.RandString(5))))
 }

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_redis_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_redis_instance_test.go
@@ -60,7 +60,7 @@ resource "huaweicloud_gaussdb_redis_instance" "test" {
   name        = "%s"
   password    = "Test@12345678"
   flavor      = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
-  volume_size = 100
+  volume_size = 16
   vpc_id      = huaweicloud_vpc.test.id
   subnet_id   = huaweicloud_vpc_subnet.test.id
   node_num    = 4

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_redis_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_redis_instance_test.go
@@ -36,7 +36,7 @@ func TestAccGaussRedisInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "password", password),
 					resource.TestCheckResourceAttr(resourceName, "node_num", "3"),
-					resource.TestCheckResourceAttr(resourceName, "volume_size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "16"),
 					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
 					resource.TestCheckResourceAttr(resourceName, "port", "8888"),
 					resource.TestCheckResourceAttr(resourceName, "ssl", "true"),
@@ -49,7 +49,7 @@ func TestAccGaussRedisInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-update", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", newPassword),
 					resource.TestCheckResourceAttr(resourceName, "node_num", "5"),
-					resource.TestCheckResourceAttr(resourceName, "volume_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "24"),
 					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
 					resource.TestCheckResourceAttr(resourceName, "port", "8888"),
 					resource.TestCheckResourceAttr(resourceName, "ssl", "false"),
@@ -62,7 +62,7 @@ func TestAccGaussRedisInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-update", rName)),
 					resource.TestCheckResourceAttr(resourceName, "password", newPassword),
 					resource.TestCheckResourceAttr(resourceName, "node_num", "4"),
-					resource.TestCheckResourceAttr(resourceName, "volume_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "24"),
 					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
 				),
 			},
@@ -160,7 +160,7 @@ resource "huaweicloud_gaussdb_redis_instance" "test" {
   name        = "%[2]s"
   password    = "%[3]s"
   flavor      = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
-  volume_size = 50
+  volume_size = 16
   vpc_id      = data.huaweicloud_vpc.test.id
   subnet_id   = data.huaweicloud_vpc_subnet.test.id
   node_num    = 3
@@ -207,7 +207,7 @@ resource "huaweicloud_gaussdb_redis_instance" "test" {
   name        = "%[2]s-update"
   password    = "%[3]s"
   flavor      = data.huaweicloud_gaussdb_nosql_flavors.test.flavors[0].name
-  volume_size = 100
+  volume_size = 24
   vpc_id      = data.huaweicloud_vpc.test.id
   subnet_id   = data.huaweicloud_vpc_subnet.test.id
   node_num    = %[4]d


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: fix test gaussdb case issues

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussRedisInstanceDataSource_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussRedisInstanceDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussRedisInstanceDataSource_basic
=== PAUSE TestAccGaussRedisInstanceDataSource_basic
=== CONT  TestAccGaussRedisInstanceDataSource_basic
--- PASS: TestAccGaussRedisInstanceDataSource_basic (1385.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1385.352s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccOpenGaussInstanceDataSource_haModeCentralized"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccOpenGaussInstanceDataSource_haModeCentralized -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstanceDataSource_haModeCentralized
=== PAUSE TestAccOpenGaussInstanceDataSource_haModeCentralized
=== CONT  TestAccOpenGaussInstanceDataSource_haModeCentralized
--- PASS: TestAccOpenGaussInstanceDataSource_haModeCentralized (1748.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1748.143s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccOpenGaussInstancesDataSource_haModeCentralized"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccOpenGaussInstancesDataSource_haModeCentralized -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstancesDataSource_haModeCentralized
=== PAUSE TestAccOpenGaussInstancesDataSource_haModeCentralized
=== CONT  TestAccOpenGaussInstancesDataSource_haModeCentralized
--- PASS: TestAccOpenGaussInstancesDataSource_haModeCentralized (1747.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1747.392s
```

```
make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccGaussRedisInstance_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccGaussRedisInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussRedisInstance_basic
=== PAUSE TestAccGaussRedisInstance_basic
=== CONT  TestAccGaussRedisInstance_basic
--- PASS: TestAccGaussRedisInstance_basic (3744.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   3744.357s
```