### PR TITLE
chore(apig): change loadbalancer_provider is computed and mark eip_id as deprecated

### DIFF
--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -13,7 +13,6 @@ variable "instance_name" {}
 variable "vpc_id" {}
 variable "subnet_id" {}
 variable "security_group_id" {}
-variable "eip_id" {}
 variable "enterprise_project_id" {}
 
 data "huaweicloud_availability_zones" "test" {}
@@ -28,7 +27,6 @@ resource "huaweicloud_apig_instance" "test" {
   maintain_begin        = "06:00:00"
   description           = "Created by script"
   bandwidth_size        = 3
-  eip_id                = var.eip_id
 
   available_zones = [
     data.huaweicloud_availability_zones.test.names[0],
@@ -92,19 +90,7 @@ The following arguments are supported:
 * `maintain_begin` - (Optional, String) Specifies the start time of the maintenance time window.  
   The format is **xx:00:00**, the value of **xx** can be `02`, `06`, `10`, `14`, `18` or `22`.
 
-* `eip_id` - (Optional, String) Specifies the EIP ID associated with the dedicated instance.
-
-  -> This parameter is only available if the `loadbalancer_provider` is **lvs**.
-
 * `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether public access with an IPv6 address is supported.  
-  Changing this will create a new resource.
-
-* `loadbalancer_provider` - (Optional, String, ForceNew) Specifies the provider type of load balancer used by the
-  dedicated instance.  
-  The valid values are as follows:
-  + **lvs**: Linux virtual server.
-  + **elb**: Elastic load balance.
-
   Changing this will create a new resource.
 
 * `vpcep_service_name` - (Optional, String) Specifies the name of the VPC endpoint service.
@@ -113,8 +99,7 @@ The following arguments are supported:
   If this parameter is specified, the system automatically generates a name in the
   "{region}.{vpcep_service_name}.{service_id}" format.
 
-  -> This parameter is only available if the `loadbalancer_provider` is **elb**.
-     Only enable and update operations are supported, and disable operation is not supported.
+  -> Only enable and update operations are supported, and disable operation is not supported.
 
 * `ingress_bandwidth_size` - (Optional, Int) Specifies the ingress bandwidth size of the dedicated instance.  
   The minimum value is `5`
@@ -123,9 +108,6 @@ The following arguments are supported:
   The valid values are as follows:
   + **bandwidth**: Billed by bandwidth.
   + **traffic**: Billed by traffic.
-
-  -> The `ingress_bandwidth_size` and `ingress_bandwidth_size` parameter is only available if the `loadbalancer_provider`
-     is **elb**.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the dedicated instance.
 
@@ -144,6 +126,10 @@ In addition to all arguments above, the following attributes are exported:
 * `vpcep_service_address` - The address (full name) of the VPC endpoint service, in the
   "{region}.{vpcep_service_name}.{service_id}" format. If this parameter is not specified, the system automatically
   generates a name in the "{region}.apig.{service_id}" format.
+
+* `loadbalancer_provider` - The type of load balancer used by the dedicated instance.  
+  The valid value is as follows:
+  + **elb**: Elastic load balance.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -99,7 +99,6 @@ resource "huaweicloud_apig_instance" "test" {
   subnet_id             = huaweicloud_vpc_subnet.test.id
   security_group_id     = huaweicloud_networking_secgroup.test.id
   availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
-  loadbalancer_provider = "elb"
 
   edition               = "BASIC"
   name                  = "%[2]s"
@@ -127,7 +126,6 @@ resource "huaweicloud_apig_instance" "test" {
   subnet_id             = huaweicloud_vpc_subnet.test.id
   security_group_id     = huaweicloud_networking_secgroup.new.id
   availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
-  loadbalancer_provider = "elb"
   vpcep_service_name    = "new_custom_apig"
 
   edition               = "BASIC"
@@ -226,7 +224,6 @@ resource "huaweicloud_apig_instance" "test" {
   subnet_id             = huaweicloud_vpc_subnet.test.id
   security_group_id     = huaweicloud_networking_secgroup.test.id
   availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
-  loadbalancer_provider = "elb"
   edition               = "BASIC"
   name                  = "%[2]s"
   enterprise_project_id = "%[3]s"

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -157,31 +157,12 @@ func ResourceApigInstanceV2() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 2000),
 				Description:  `The egress bandwidth size of the dedicated instance.`,
 			},
-			"eip_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ConflictsWith: []string{
-					"ingress_bandwidth_size", "ingress_bandwidth_charging_mode",
-				},
-				Description: `The EIP ID associated with the dedicated instance.`,
-			},
 			"ipv6_enable": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
 				Description: `Whether public access with an IPv6 address is supported.`,
-			},
-			"loadbalancer_provider": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(ProviderTypeLvs), string(ProviderTypeElb),
-				}, false),
-				Description: `The type of loadbalancer provider used by the instance.`,
 			},
 			"maintain_begin": {
 				Type:     schema.TypeString,
@@ -266,6 +247,33 @@ func ResourceApigInstanceV2() *schema.Resource {
 				Computed:    true,
 				Deprecated:  "Use 'created_at' instead",
 				Description: `schema: Deprecated; Time when the dedicated instance is created.`,
+			},
+			"eip_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ConflictsWith: []string{
+					"ingress_bandwidth_size", "ingress_bandwidth_charging_mode",
+				},
+				Description: utils.SchemaDesc(
+					`The EIP ID associated with the dedicated instance.`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					}),
+			},
+			"loadbalancer_provider": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(ProviderTypeLvs), string(ProviderTypeElb),
+				}, false),
+				Description: utils.SchemaDesc(
+					`The type of loadbalancer provider used by the instance.`,
+					utils.SchemaDescInput{
+						Computed: true,
+					}),
 			},
 		},
 	}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -39,9 +39,6 @@ const (
 	Ipv6EditionProfessional Edition = "PROFESSIONAL_IPv6" // IPv6 instance of the Professional Edition.
 	Ipv6EditionEnterprise   Edition = "ENTERPRISE_IPv6"   // IPv6 instance of the Enterprise Edition.
 	Ipv6EditionPlatinum     Edition = "PLATINUM_IPv6"     // IPv6 instance of the Platinum Edition.
-
-	ProviderTypeLvs ProviderType = "lvs" // Linux virtual server.
-	ProviderTypeElb ProviderType = "elb" // Elastic load balance.
 )
 
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/eip
@@ -266,9 +263,6 @@ func ResourceApigInstanceV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(ProviderTypeLvs), string(ProviderTypeElb),
-				}, false),
 				Description: utils.SchemaDesc(
 					`The type of loadbalancer provider used by the instance.`,
 					utils.SchemaDescInput{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Changing **loadbalancer_provider** parameter is attribute  and marking **eip_id** and parameter as deprecated.
2.  Remove validateFunc of the loadbalancer_provider parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

the **loadbalancer_provider** parameter in the API id deprecated. Currently, only cn-north-1 and na-mexico-1 region support the **lvs** type. APIG instance will support the **elb** type in the future, therefor,  **eip_id**  parameters is marked as deprecated, the **loadbalancer_provider**  parameters changed computed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccInstance_ -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== RUN   TestAccInstance_egress
=== PAUSE TestAccInstance_egress
=== RUN   TestAccInstance_ingress
=== PAUSE TestAccInstance_ingress
=== CONT  TestAccInstance_basic
=== CONT  TestAccInstance_ingress
=== CONT  TestAccInstance_egress
--- PASS: TestAccInstance_basic (634.58s)
--- PASS: TestAccInstance_egress (687.88s)
--- PASS: TestAccInstance_ingress (763.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      763.645s
```
