### PR TITLE
chore(dli): use new parameter user_name instead of username parameter

### DIFF
--- a/docs/resources/dli_datasource_auth.md
+++ b/docs/resources/dli_datasource_auth.md
@@ -92,9 +92,10 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `username` - (Optional, String) Username for accessing the security cluster or datasource.
+* `user_name` - (Optional, String) Specifies the user name for accessing the security cluster or datasource.
 
 * `password` - (Optional, String) The password for accessing the security cluster or datasource.
+  This parameter must be used together with `user_name`.
 
 * `certificate_location` - (Optional, String, ForceNew) Path of the security cluster certificate.  
  Currently, only OBS paths and CER files are supported.

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_auth_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_auth_test.go
@@ -76,7 +76,7 @@ func TestAccDatasourceAuth_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "type", "passwd"),
-					resource.TestCheckResourceAttr(rName, "username", "test"),
+					resource.TestCheckResourceAttr(rName, "user_name", "test"),
 					resource.TestCheckResourceAttrSet(rName, "owner"),
 				),
 			},
@@ -85,7 +85,7 @@ func TestAccDatasourceAuth_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "username", "test123"),
+					resource.TestCheckResourceAttr(rName, "user_name", "test123"),
 				),
 			},
 			{
@@ -106,10 +106,10 @@ func TestAccDatasourceAuth_basic(t *testing.T) {
 func testDatasourceAuth_basic(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dli_datasource_auth" "test" {
-  name     = "%s"
-  type     = "passwd"
-  username = "test"
-  password = "Huawei12!"
+  name      = "%s"
+  type      = "passwd"
+  user_name = "test"
+  password  = "Huawei12!"
 }
 `, name)
 }
@@ -117,10 +117,10 @@ resource "huaweicloud_dli_datasource_auth" "test" {
 func testDatasourceAuth_basic_update(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dli_datasource_auth" "test" {
-  name     = "%s"
-  type     = "passwd"
-  username = "test123"
-  password = "Huawei12!"
+  name      = "%s"
+  type      = "passwd"
+  user_name = "test123"
+  password  = "Huawei12!"
 }
 `, name)
 }
@@ -151,7 +151,7 @@ func TestAccDatasourceAuth_css(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "type", "CSS"),
-					resource.TestCheckResourceAttr(rName, "username", "test"),
+					resource.TestCheckResourceAttr(rName, "user_name", "test"),
 					resource.TestCheckResourceAttrSet(rName, "owner"),
 				),
 			},
@@ -160,7 +160,7 @@ func TestAccDatasourceAuth_css(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "username", "test_update"),
+					resource.TestCheckResourceAttr(rName, "user_name", "test_update"),
 				),
 			},
 			{
@@ -183,7 +183,7 @@ func testDatasourceAuth_css(name string) string {
 resource "huaweicloud_dli_datasource_auth" "test" {
   name                 = "%s"
   type                 = "CSS"
-  username             = "test"
+  user_name            = "test"
   password             = "Huawei12!"
   certificate_location = "%s"
 }
@@ -195,7 +195,7 @@ func testDatasourceAuth_css_update(name string) string {
 resource "huaweicloud_dli_datasource_auth" "test" {
   name                 = "%s"
   type                 = "CSS"
-  username             = "test_update"
+  user_name            = "test_update"
   password             = "Huawei12!"
   certificate_location = "%s"
 }
@@ -328,11 +328,11 @@ func TestAccDatasourceAuth_KRB(t *testing.T) {
 func testDatasourceAuth_KRB(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dli_datasource_auth" "test" {
-  name      = "%s"
-  type      = "KRB"
-  username  = "test"
-  krb5_conf = "%s"
-  keytab    = "%s"
+  name       = "%s"
+  type       = "KRB"
+  user_name  = "test"
+  krb5_conf  = "%s"
+  keytab     = "%s"
 }
 `, name, acceptance.HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH, acceptance.HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH)
 }

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
@@ -55,7 +55,7 @@ func ResourceDatasourceAuth() *schema.Resource {
 				ForceNew:    true,
 				Description: `Data source type.`,
 			},
-			"username": {
+			"user_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
@@ -70,9 +70,6 @@ func ResourceDatasourceAuth() *schema.Resource {
 				Computed:    true,
 				Sensitive:   true,
 				Description: `The password for accessing the security cluster or datasource.`,
-				RequiredWith: []string{
-					"username",
-				},
 			},
 			"certificate_location": {
 				Type:        schema.TypeString,
@@ -141,6 +138,20 @@ func ResourceDatasourceAuth() *schema.Resource {
 				Computed:    true,
 				Description: `The user name of owner.`,
 			},
+			// Deprecated arguments
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ConflictsWith: []string{
+					"truststore_location",
+				},
+				Description: utils.SchemaDesc(
+					`Username for accessing the security cluster or datasource. Use 'user_name' instead.`,
+					utils.SchemaDescInput{
+						Deprecated: true,
+					}),
+			},
 		},
 	}
 }
@@ -179,11 +190,20 @@ func resourceDatasourceAuthCreate(ctx context.Context, d *schema.ResourceData, m
 	return resourceDatasourceAuthRead(ctx, d, meta)
 }
 
+func buildUserName(d *schema.ResourceData) interface{} {
+	userName := d.Get("user_name")
+	if userName.(string) == "" {
+		userName = d.Get("username")
+	}
+
+	return utils.ValueIngoreEmpty(userName)
+}
+
 func buildCreateDatasourceAuthBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"auth_info_name":       utils.ValueIngoreEmpty(d.Get("name")),
 		"datasource_type":      utils.ValueIngoreEmpty(d.Get("type")),
-		"username":             utils.ValueIngoreEmpty(d.Get("username")),
+		"user_name":            buildUserName(d),
 		"password":             utils.ValueIngoreEmpty(d.Get("password")),
 		"certificate_location": utils.ValueIngoreEmpty(d.Get("certificate_location")),
 		"truststore_location":  utils.ValueIngoreEmpty(d.Get("truststore_location")),
@@ -246,7 +266,7 @@ func resourceDatasourceAuthRead(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("region", region),
 		d.Set("name", utils.PathSearch("auth_infos[0].auth_info_name", getDatasourceAuthRespBody, nil)),
 		d.Set("type", utils.PathSearch("auth_infos[0].datasource_type", getDatasourceAuthRespBody, nil)),
-		d.Set("username", utils.PathSearch("auth_infos[0].user_name", getDatasourceAuthRespBody, nil)),
+		d.Set("user_name", utils.PathSearch("auth_infos[0].user_name", getDatasourceAuthRespBody, nil)),
 		d.Set("certificate_location", utils.PathSearch("auth_infos[0].certificate_location", getDatasourceAuthRespBody, nil)),
 		d.Set("truststore_location", utils.PathSearch("auth_infos[0].truststore_location", getDatasourceAuthRespBody, nil)),
 		d.Set("keystore_location", utils.PathSearch("auth_infos[0].keystore_location", getDatasourceAuthRespBody, nil)),
@@ -275,6 +295,7 @@ func resourceDatasourceAuthUpdate(ctx context.Context, d *schema.ResourceData, m
 	updateDatasourceAuthChanges := []string{
 		"name",
 		"username",
+		"user_name",
 		"password",
 		"truststore_location",
 		"truststore_password",
@@ -315,7 +336,7 @@ func resourceDatasourceAuthUpdate(ctx context.Context, d *schema.ResourceData, m
 func buildUpdateDatasourceAuthBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"auth_info_name":      utils.ValueIngoreEmpty(d.Get("name")),
-		"username":            utils.ValueIngoreEmpty(d.Get("username")),
+		"user_name":           buildUserName(d),
 		"password":            utils.ValueIngoreEmpty(d.Get("password")),
 		"truststore_location": utils.ValueIngoreEmpty(d.Get("truststore_location")),
 		"truststore_password": utils.ValueIngoreEmpty(d.Get("truststore_password")),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The **username** parameter has been changed to **user_name** in the API document. Therefore, deprecated the parameter **username** and append a new parameter **user_name** to instead.

When using only the **user_name** parameter：
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/6d8cbd8e-f7b7-4d23-b8aa-6dc3c827bd56)

![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/0cdab11d-60c0-4864-932c-4bce58e5c772)

When using only the **username** parameter：
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/88cd3738-3090-4ce4-82ba-ff85e7ed55c8)

![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/c8627e23-4fbc-4944-bcba-b80ff0790287)

When the **user_name** and **username** parameters are used at the same time, only user_name takes effect.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/59c1095c-f825-4dc5-a7f1-34fb30743664)
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/82ff077e-eb34-467a-9f60-a006998bd14e)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. use new parameter user_name instead of username parameter in the schema.
2. modify related the document and the acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST=./huaweicloud/services/acceptance/dli TESTARGS='-run TestAccDatasourceAuth_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDatasourceAuth_ -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAuth_basic
=== PAUSE TestAccDatasourceAuth_basic
=== RUN   TestAccDatasourceAuth_css
=== PAUSE TestAccDatasourceAuth_css
=== RUN   TestAccDatasourceAuth_Kafka_SSL
=== PAUSE TestAccDatasourceAuth_Kafka_SSL
=== RUN   TestAccDatasourceAuth_KRB
=== PAUSE TestAccDatasourceAuth_KRB
=== CONT  TestAccDatasourceAuth_basic
=== CONT  TestAccDatasourceAuth_Kafka_SSL
=== CONT  TestAccDatasourceAuth_css
=== CONT  TestAccDatasourceAuth_KRB
--- PASS: TestAccDatasourceAuth_KRB (29.69s)
--- PASS: TestAccDatasourceAuth_basic (39.94s)
--- PASS: TestAccDatasourceAuth_css (42.39s)
--- PASS: TestAccDatasourceAuth_Kafka_SSL (45.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       45.367s
```
