### PR TITLE
feat(endpoint): manage the service endpoint in different regions

### DIFF
--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -307,6 +307,10 @@ func (c *Config) NewServiceClient(srv, region string) (*golangsdk.ServiceClient,
 	if !ok {
 		return nil, fmt.Errorf("service type %s is invalid or not supportted", srv)
 	}
+	// update the service catalog name if necessary
+	if name := getServiceCatalogNameByRegion(srv, region); name != "" {
+		serviceCatalog.Name = name
+	}
 
 	if !c.SecurityKeyExpiresAt.IsZero() {
 		c.SecurityKeyLock.Lock()

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -939,6 +939,11 @@ func GetServiceEndpoint(c *Config, srv, region string) string {
 		return ""
 	}
 
+	// update the service catalog name if necessary
+	if name := getServiceCatalogNameByRegion(srv, region); name != "" {
+		catalog.Name = name
+	}
+
 	var ep string
 	if catalog.Scope == "global" && !c.RegionClient {
 		ep = fmt.Sprintf("https://%s.%s/", catalog.Name, c.Cloud)

--- a/huaweicloud/config/service_endpoints.go
+++ b/huaweicloud/config/service_endpoints.go
@@ -1,0 +1,25 @@
+package config
+
+// For cloud services like GaussDB, the endpoints are different in different regions.
+// Therefore, we have add a map to manage their endpoints.
+// please refer to https://developer.huaweicloud.com/intl/en-us/endpoint
+var serviceRegionCatalogName = map[string]interface{}{
+	// the prefix(catalog name) of GaussDB is "gaussdb" in other regions
+	"gaussdb": map[string]string{
+		"ap-southeast-1": "gaussdbformysql",
+		"ap-southeast-2": "gaussdbformysql",
+		"cn-north-11":    "gaussdbformysql",
+		"tr-west-1":      "gaussdbformysql",
+		"af-south-1":     "gaussdb-mysql",
+	},
+}
+
+func getServiceCatalogNameByRegion(service, region string) string {
+	if v, ok := serviceRegionCatalogName[service]; ok {
+		if regionMap, ok := v.(map[string]string); ok {
+			return regionMap[region]
+		}
+	}
+
+	return ""
+}

--- a/huaweicloud/endpoints_test.go
+++ b/huaweicloud/endpoints_test.go
@@ -353,6 +353,46 @@ func TestAccServiceEndpoints_Database(t *testing.T) {
 	t.Logf("DRS endpoint:\t %s", actualURL)
 }
 
+func TestAccServiceEndpoints_GaussDBForMySQL(t *testing.T) {
+	testProvider := Provider()
+	raw := make(map[string]interface{})
+	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	if diags.HasError() {
+		t.Fatalf("Unexpected error when configure HuaweiCloud provider: %s", diags[0].Summary)
+	}
+
+	var expectedURL, actualURL string
+	var serviceClient *golangsdk.ServiceClient
+	var err error
+	cfg := testProvider.Meta().(*config.Config)
+
+	// test the endpoint of gaussdb service in cn-north-4
+	region := "cn-north-4"
+	serviceClient, err = cfg.GaussdbV3Client(region)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud gaussdb client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://gaussdb.%s.%s/", region, cfg.Cloud)
+	actualURL = serviceClient.Endpoint
+	if actualURL != expectedURL {
+		t.Fatalf("gaussdb endpoint in %s: expected %s but got %s", region, green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("gaussdb endpoint in %s:\t %s", region, actualURL)
+
+	// test the endpoint of gaussdb service in ap-southeast-1
+	region = "ap-southeast-1"
+	serviceClient, err = cfg.GaussdbV3Client(region)
+	if err != nil {
+		t.Fatalf("Error creating HuaweiCloud gaussdb client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://gaussdbformysql.%s.%s/", region, cfg.Cloud)
+	actualURL = serviceClient.Endpoint
+	if actualURL != expectedURL {
+		t.Fatalf("gaussdb endpoint in %s: expected %s but got %s", region, green(expectedURL), yellow(actualURL))
+	}
+	t.Logf("gaussdb endpoint in %s:\t %s", region, actualURL)
+}
+
 func TestAccServiceEndpoints_Security(t *testing.T) {
 	testAccPreCheckServiceEndpoints(t)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

For cloud services like **GaussDB**, the endpoints are different in different regions.
Therefore, we have add a map to manage their endpoints.
please refer to https://developer.huaweicloud.com/intl/en-us/endpoint

```
$ export HW_REGION_NAME=ap-southeast-1
$ make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== PAUSE TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== CONT  TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
    data_source_huaweicloud_gaussdb_mysql_flavors_test.go:14: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: error fetching flavors for gaussdb mysql, error: Get "https://gaussdb.ap-southeast-1.myhuaweicloud.com/v3/0970dd9c1a0026a62fddc0038c52b5eb/flavors/gaussdb-mysql?availability_zone_mode=multi&version_name=8.0": connection error, retries exhausted. Aborting. Last error was: EOF

          with data.huaweicloud_gaussdb_mysql_flavors.flavor,
          on terraform_plugin_test.tf line 2, in data "huaweicloud_gaussdb_mysql_flavors" "flavor":
           2: data "huaweicloud_gaussdb_mysql_flavors" "flavor" {

--- FAIL: TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic (69.81s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   69.841s
FAIL
make: *** [GNUmakefile:21: testacc] Error 1
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud" TESTARGS="-run TestAccServiceEndpoints_GaussDBForMySQL"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud -v -run TestAccServiceEndpoints_GaussDBForMySQL -timeout 360m -parallel 4
=== RUN   TestAccServiceEndpoints_GaussDBForMySQL
    endpoints_test.go:380: gaussdb endpoint in cn-north-4:       https://gaussdb.cn-north-4.myhuaweicloud.com/
    endpoints_test.go:393: gaussdb endpoint in ap-southeast-1:   https://gaussdbformysql.ap-southeast-1.myhuaweicloud.com/
--- PASS: TestAccServiceEndpoints_GaussDBForMySQL (0.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       0.681s

$ export HW_REGION_NAME=cn-north-4
$ make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== PAUSE TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== CONT  TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
--- PASS: TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic (25.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   25.235s

$ export HW_REGION_NAME=ap-southeast-1
$ make testacc TEST="./huaweicloud/services/acceptance/gaussdb" TESTARGS="-run TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb -v -run TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== PAUSE TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
=== CONT  TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic
--- PASS: TestAccHuaweiCloudGaussdbMysqlFlavorsDataSource_basic (14.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   14.708s
```
