### PR TITLE
fix(dli): supple the is_success check and return the error message

### DIFF
--- a/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_auth.go
@@ -169,9 +169,17 @@ func resourceDatasourceAuthCreate(ctx context.Context, d *schema.ResourceData, m
 		},
 	}
 	createDatasourceAuthOpt.JSONBody = utils.RemoveNil(buildCreateDatasourceAuthBodyParams(d, cfg))
-	_, err = createDatasourceAuthClient.Request("POST", createDatasourceAuthPath, &createDatasourceAuthOpt)
+	requestResp, err := createDatasourceAuthClient.Request("POST", createDatasourceAuthPath, &createDatasourceAuthOpt)
 	if err != nil {
 		return diag.Errorf("error creating DatasourceAuth: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if !utils.PathSearch("is_success", respBody, true).(bool) {
+		return diag.Errorf("unable to create the authentication: %s",
+			utils.PathSearch("message", respBody, "Message Not Found"))
 	}
 
 	d.SetId(d.Get("name").(string))
@@ -234,6 +242,10 @@ func resourceDatasourceAuthRead(_ context.Context, d *schema.ResourceData, meta 
 	getDatasourceAuthRespBody, err := utils.FlattenResponse(getDatasourceAuthResp)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !utils.PathSearch("is_success", getDatasourceAuthRespBody, true).(bool) {
+		return diag.Errorf("unable to query the authentication: %s",
+			utils.PathSearch("message", getDatasourceAuthRespBody, "Message Not Found"))
 	}
 
 	v := utils.PathSearch("auth_infos[0]", getDatasourceAuthRespBody, nil)
@@ -304,9 +316,17 @@ func resourceDatasourceAuthUpdate(ctx context.Context, d *schema.ResourceData, m
 			},
 		}
 		updateDatasourceAuthOpt.JSONBody = utils.RemoveNil(buildUpdateDatasourceAuthBodyParams(d, cfg))
-		_, err = updateDatasourceAuthClient.Request("PUT", updateDatasourceAuthPath, &updateDatasourceAuthOpt)
+		requestResp, err := updateDatasourceAuthClient.Request("PUT", updateDatasourceAuthPath, &updateDatasourceAuthOpt)
 		if err != nil {
 			return diag.Errorf("error updating DatasourceAuth: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if !utils.PathSearch("is_success", respBody, true).(bool) {
+			return diag.Errorf("unable to update the authentication: %s",
+				utils.PathSearch("message", respBody, "Message Not Found"))
 		}
 	}
 	return resourceDatasourceAuthRead(ctx, d, meta)
@@ -351,9 +371,17 @@ func resourceDatasourceAuthDelete(_ context.Context, d *schema.ResourceData, met
 			200,
 		},
 	}
-	_, err = deleteDatasourceAuthClient.Request("DELETE", deleteDatasourceAuthPath, &deleteDatasourceAuthOpt)
+	requestResp, err := deleteDatasourceAuthClient.Request("DELETE", deleteDatasourceAuthPath, &deleteDatasourceAuthOpt)
 	if err != nil {
 		return diag.Errorf("error deleting DatasourceAuth: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if !utils.PathSearch("is_success", respBody, true).(bool) {
+		return diag.Errorf("unable to delete the authentication: %s",
+			utils.PathSearch("message", respBody, "Message Not Found"))
 	}
 
 	return nil

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_connection_privilege.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_connection_privilege.go
@@ -113,7 +113,8 @@ func modifyDatasourceConnectionPrivileges(client *golangsdk.ServiceClient, d *sc
 		return err
 	}
 	if !utils.PathSearch("is_success", respBody, "").(bool) {
-		return fmt.Errorf("unable to %s the privileges: %s", action, utils.PathSearch("message", respBody, ""))
+		return fmt.Errorf("unable to %s the privileges: %s", action,
+			utils.PathSearch("message", respBody, "Message Not Found"))
 	}
 	return nil
 }
@@ -186,6 +187,10 @@ func resourceDatasourceConnectionPrivilegeRead(_ context.Context, d *schema.Reso
 	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {
 		return diag.FromErr(err)
+	}
+	if !utils.PathSearch("is_success", respBody, true).(bool) {
+		return diag.Errorf("unable to query the privileges: %s",
+			utils.PathSearch("message", respBody, "Message Not Found"))
 	}
 
 	privilege := utils.PathSearch(fmt.Sprintf("privileges[?project_id=='%v']|[0]", d.Get("project_id")), respBody, nil)

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flinkjar_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flinkjar_job.go
@@ -357,7 +357,7 @@ func resourceFlinkJarJobDelete(_ context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("delete DLI flink jar job failed. %q:%s", jobId, dErr)
 	}
 	if deleteRst != nil && !deleteRst.IsSuccess {
-		return diag.Errorf("delete DLI flink jar job failed. %q", jobId)
+		return diag.Errorf("delete DLI flink jar job (%d) failed: %s", jobId, deleteRst.Message)
 	}
 
 	return nil

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
@@ -370,7 +370,7 @@ func resourceFlinkSqlJobDelete(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("delete DLI flink job failed. %q:%s", jobId, err)
 	}
 	if deleteRst != nil && !deleteRst.IsSuccess {
-		return diag.Errorf("delete DLI flink job failed. %q", jobId)
+		return diag.Errorf("delete DLI flink job (%d) failed: %s", jobId, deleteRst.Message)
 	}
 
 	return nil
@@ -503,7 +503,7 @@ func authorizeObsBucket(client *golangsdk.ServiceClient, d *schema.ResourceData)
 		}
 
 		if rst != nil && !rst.IsSuccess {
-			return diag.Errorf("DLI Authorization on the following OBS buckets failed= %s", value)
+			return diag.Errorf("DLI Authorization on the following OBS buckets failed: %s", rst.Message)
 		}
 	}
 

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_package.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_package.go
@@ -243,9 +243,12 @@ func ResourceDliDependentPackageV2Update(ctx context.Context, d *schema.Resource
 		GroupName:    d.Get("group_name").(string),
 		NewOwner:     d.Get("owner").(string),
 	}
-	_, err = resources.UpdateOwner(c, opt)
+	resp, err := resources.UpdateOwner(c, opt)
 	if err != nil {
 		return diag.Errorf("error updating package owner: %s", err)
+	}
+	if !resp.IsSuccess {
+		return diag.Errorf("unable to update the package: %s", resp.Message)
 	}
 
 	return ResourceDliDependentPackageV2Read(ctx, d, meta)

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_permission.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_permission.go
@@ -171,7 +171,7 @@ func queryDatabaseRelatePermission(client *golangsdk.ServiceClient, obj, userNam
 			return nil, parseDliErrorToError404(err)
 		}
 		if rst != nil && !rst.IsSuccess {
-			return nil, fmt.Errorf("error query DLI permission of database: %s", err)
+			return nil, fmt.Errorf("error query DLI permission of database: %s", rst.Message)
 		}
 
 		for _, v := range rst.Privileges {
@@ -185,7 +185,7 @@ func queryDatabaseRelatePermission(client *golangsdk.ServiceClient, obj, userNam
 			return nil, parseDliErrorToError404(err)
 		}
 		if rst != nil && !rst.IsSuccess {
-			return nil, fmt.Errorf("error query DLI permission of table: %s", err)
+			return nil, fmt.Errorf("error query DLI permission of table: %s", rst.Message)
 		}
 		for _, v := range rst.Privileges {
 			if v.Object == obj && v.UserName == userName {

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_sql_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_sql_job.go
@@ -179,7 +179,7 @@ func resourceSQLJobCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if rst == nil || !rst.IsSuccess {
-		return diag.Errorf("error creating DLI sql job")
+		return diag.Errorf("error creating DLI sql job: %s", rst.Message)
 	}
 
 	d.SetId(rst.JobId)
@@ -211,7 +211,7 @@ func resourceSQLJobRead(_ context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	if listResp == nil || !listResp.IsSuccess {
-		return diag.Errorf("error query DLI sql job")
+		return diag.Errorf("error query DLI sql job: %s", listResp.Message)
 	}
 
 	if listResp.JobCount == 0 {
@@ -250,7 +250,7 @@ func resourceSQLJobDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if detail == nil || !detail.IsSuccess {
-		return diag.Errorf("error query DLI sql job")
+		return diag.Errorf("error query DLI sql job: %s", detail.Message)
 	}
 
 	if detail.Status != sqljob.JobStatusFinished &&
@@ -261,7 +261,7 @@ func resourceSQLJobDelete(ctx context.Context, d *schema.ResourceData, meta inte
 			return diag.Errorf("cancel DLI sql job failed. %q:%s", jobId, err)
 		}
 		if cancelRst == nil || !cancelRst.IsSuccess {
-			return diag.Errorf("cancel DLI sql job failed. %q", jobId)
+			return diag.Errorf("cancel DLI sql job (%s) failed: %s", jobId, cancelRst.Message)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Too much response check without the 'is_success' and 'message' attributes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supple the is_success check and return the error message.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

Although it contains many errors, none of them enter the logic of `!is_success`.

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=Test -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAuths_basic
=== PAUSE TestAccDatasourceAuths_basic
=== RUN   TestAccDatasourceAuths_CSS
=== PAUSE TestAccDatasourceAuths_CSS
=== RUN   TestAccDatasourceAuths_Kafka_SSL
=== PAUSE TestAccDatasourceAuths_Kafka_SSL
=== RUN   TestAccDatasourceAuths_KRB
=== PAUSE TestAccDatasourceAuths_KRB
=== RUN   TestAccDatasourceConnections_basic
=== PAUSE TestAccDatasourceConnections_basic
=== RUN   TestAccDliAgency_basic
=== PAUSE TestAccDliAgency_basic
=== RUN   TestAccDliDatabase_basic
=== PAUSE TestAccDliDatabase_basic
=== RUN   TestAccDatasourceAuth_basic
=== PAUSE TestAccDatasourceAuth_basic
=== RUN   TestAccDatasourceAuth_css
=== PAUSE TestAccDatasourceAuth_css
=== RUN   TestAccDatasourceAuth_Kafka_SSL
=== PAUSE TestAccDatasourceAuth_Kafka_SSL
=== RUN   TestAccDatasourceAuth_KRB
=== PAUSE TestAccDatasourceAuth_KRB
=== RUN   TestAccDatasourceConnectionAssociate_basic
=== PAUSE TestAccDatasourceConnectionAssociate_basic
=== RUN   TestAccDatasourceConnectionPrivilege_basic
=== PAUSE TestAccDatasourceConnectionPrivilege_basic
=== RUN   TestAccDatasourceConnection_basic
=== PAUSE TestAccDatasourceConnection_basic
=== RUN   TestAccElasticResourcePool_basic
=== PAUSE TestAccElasticResourcePool_basic
=== RUN   TestAccResourceDliFlinkJarJob_basic
=== PAUSE TestAccResourceDliFlinkJarJob_basic
=== RUN   TestAccResourceDliFlinkJarJob_all
=== PAUSE TestAccResourceDliFlinkJarJob_all
=== RUN   TestAccResourceDliFlinkJob_basic
=== PAUSE TestAccResourceDliFlinkJob_basic
=== RUN   TestAccGlobalVariable_basic
=== PAUSE TestAccGlobalVariable_basic
=== RUN   TestAccDliPackage_basic
=== PAUSE TestAccDliPackage_basic
=== RUN   TestAccResourceDliAuth_basic
=== PAUSE TestAccResourceDliAuth_basic
=== RUN   TestAccResourceDliAuth_flink
=== PAUSE TestAccResourceDliAuth_flink
=== RUN   TestAccResourceDliAuth_table
=== PAUSE TestAccResourceDliAuth_table
=== RUN   TestAccResourceDliAuth_package
=== PAUSE TestAccResourceDliAuth_package
=== RUN   TestAccResourceDliAuth_queue
=== PAUSE TestAccResourceDliAuth_queue
=== RUN   TestAccDliQueue_basic
=== PAUSE TestAccDliQueue_basic
=== RUN   TestAccDliQueue_withGeneral
=== PAUSE TestAccDliQueue_withGeneral
=== RUN   TestAccDliQueue_cidr
=== PAUSE TestAccDliQueue_cidr
=== RUN   TestAccDliQueue_withElasticResourcePool
=== PAUSE TestAccDliQueue_withElasticResourcePool
=== RUN   TestAccDliQueue_associateElasticResourcePool
=== PAUSE TestAccDliQueue_associateElasticResourcePool
=== RUN   TestAccDliSparkJobV2_basic
=== PAUSE TestAccDliSparkJobV2_basic
=== RUN   TestAccResourceDliSqlJob_basic
=== PAUSE TestAccResourceDliSqlJob_basic
=== RUN   TestAccResourceDliSqlJob_query
=== PAUSE TestAccResourceDliSqlJob_query
=== RUN   TestAccResourceDliSqlJob_async
=== PAUSE TestAccResourceDliSqlJob_async
=== RUN   TestAccResourceDliTable_basic
=== PAUSE TestAccResourceDliTable_basic
=== RUN   TestAccResourceDliTable_OBS
=== PAUSE TestAccResourceDliTable_OBS
=== RUN   TestAccFlinkTemplate_basic
=== PAUSE TestAccFlinkTemplate_basic
=== RUN   TestAccSparkTemplate_basic
=== PAUSE TestAccSparkTemplate_basic
=== RUN   TestAccSQLTemplate_basic
=== PAUSE TestAccSQLTemplate_basic
=== CONT  TestAccDatasourceAuths_basic
=== CONT  TestAccResourceDliAuth_basic
=== CONT  TestAccDatasourceAuth_KRB
=== CONT  TestAccDliPackage_basic
=== CONT  TestAccDatasourceAuth_KRB
    acceptance.go:739: HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH,HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH must be set for DLI datasource Kafka Auth acceptance tests.
--- SKIP: TestAccDatasourceAuth_KRB (0.01s)
=== CONT  TestAccGlobalVariable_basic
=== CONT  TestAccResourceDliAuth_basic
    resource_huaweicloud_dli_permission_test.go:45: Step 1/3 error: Error running apply: exit status 1
        
        Error: error granting permission in DLI: Bad request with: [PUT https://dli.cn-north-4.myhuaweicloud.com/v1.0/0970dd7a1300f5672ff2c003c60ae115/user-authorization], request_id: 58a7638c4e34d0f3cdc3f0c7d2b8e1d2, error message: {"error_code":"DLI.0002","error_msg":"No such user. userName:tf_test_al6xx."}
        
          with huaweicloud_dli_permission.test,
          on terraform_plugin_test.tf line 74, in resource "huaweicloud_dli_permission" "test":
          74: resource "huaweicloud_dli_permission" "test" {
        
--- PASS: TestAccDatasourceAuths_basic (19.83s)
=== CONT  TestAccResourceDliFlinkJob_basic
--- PASS: TestAccGlobalVariable_basic (24.26s)
=== CONT  TestAccResourceDliFlinkJarJob_all
    acceptance.go:718: HW_DLI_FLINK_JAR_OBS_PATH must be set for DLI Flink Jar job acceptance tests.
--- SKIP: TestAccResourceDliFlinkJarJob_all (0.03s)
=== CONT  TestAccResourceDliFlinkJarJob_basic
    acceptance.go:718: HW_DLI_FLINK_JAR_OBS_PATH must be set for DLI Flink Jar job acceptance tests.
--- SKIP: TestAccResourceDliFlinkJarJob_basic (0.01s)
=== CONT  TestAccElasticResourcePool_basic
    acceptance.go:435: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccElasticResourcePool_basic (0.01s)
=== CONT  TestAccDatasourceConnection_basic
--- PASS: TestAccDliPackage_basic (26.09s)
=== CONT  TestAccDatasourceConnectionPrivilege_basic
--- FAIL: TestAccResourceDliAuth_basic (26.94s)
=== CONT  TestAccDatasourceConnectionAssociate_basic
=== CONT  TestAccResourceDliFlinkJob_basic
    resource_huaweicloud_dli_flinksql_job_test.go:37: Step 1/2 error: Error running apply: exit status 1
        
        Error: error run DLI flink job: Bad request with: [POST https://dli.cn-north-4.myhuaweicloud.com/v1.0/0970dd7a1300f5672ff2c003c60ae115/streaming/jobs/run], request_id: ad3504422455c4dd2e9c9d47615f8a6c, error message: [{"error_code":"DLI.13024","error_msg":"No job-running queue selected. Please select a queue for your job."}]
        
          with huaweicloud_dli_flinksql_job.test,
          on terraform_plugin_test.tf line 79, in resource "huaweicloud_dli_flinksql_job" "test":
          79: resource "huaweicloud_dli_flinksql_job" "test" {
        
--- FAIL: TestAccResourceDliFlinkJob_basic (15.45s)
=== CONT  TestAccDliSparkJobV2_basic
--- PASS: TestAccDatasourceConnectionPrivilege_basic (66.30s)
=== CONT  TestAccDliAgency_basic
    acceptance.go:746: HW_DLI_AGENCY_FLAG must be set for DLI datasource DLI agency acceptance tests.
--- SKIP: TestAccDliAgency_basic (0.01s)
=== CONT  TestAccDatasourceAuth_Kafka_SSL
    acceptance.go:732: HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH,HW_DLI_DS_AUTH_KAFKA_KEY_OBS_PATH must be set for DLI datasource Kafka Auth acceptance tests.
--- SKIP: TestAccDatasourceAuth_Kafka_SSL (0.01s)
=== CONT  TestAccSQLTemplate_basic
--- PASS: TestAccSQLTemplate_basic (16.18s)
=== CONT  TestAccDatasourceAuth_css
    acceptance.go:725: HW_DLI_DS_AUTH_CSS_OBS_PATH must be set for DLI datasource CSS Auth acceptance tests.
--- SKIP: TestAccDatasourceAuth_css (0.01s)
=== CONT  TestAccSparkTemplate_basic
--- PASS: TestAccSparkTemplate_basic (16.50s)
=== CONT  TestAccDatasourceAuth_basic
--- PASS: TestAccDatasourceAuth_basic (16.68s)
=== CONT  TestAccDliDatabase_basic
    acceptance.go:435: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccDliDatabase_basic (0.01s)
=== CONT  TestAccFlinkTemplate_basic
--- PASS: TestAccFlinkTemplate_basic (17.17s)
=== CONT  TestAccDatasourceAuths_KRB
    acceptance.go:739: HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH,HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH must be set for DLI datasource Kafka Auth acceptance tests.
--- SKIP: TestAccDatasourceAuths_KRB (0.01s)
=== CONT  TestAccResourceDliTable_OBS
    resource_huaweicloud_dli_table_test.go:103: Step 1/2 error: Check failed: Check 5/5 error: huaweicloud_dli_table.test: Attribute 'description' expected "dli table test", got "dli table test}"
--- FAIL: TestAccResourceDliTable_OBS (19.44s)
=== CONT  TestAccDatasourceConnections_basic
--- PASS: TestAccDliSparkJobV2_basic (294.14s)
=== CONT  TestAccResourceDliTable_basic
    resource_huaweicloud_dli_table_test.go:38: Step 1/2 error: Check failed: Check 5/5 error: huaweicloud_dli_table.test: Attribute 'description' expected "dli table test", got "dli table test}"
--- FAIL: TestAccResourceDliTable_basic (15.12s)
=== CONT  TestAccDatasourceAuths_Kafka_SSL
    acceptance.go:732: HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH,HW_DLI_DS_AUTH_KAFKA_KEY_OBS_PATH must be set for DLI datasource Kafka Auth acceptance tests.
--- SKIP: TestAccDatasourceAuths_Kafka_SSL (0.01s)
=== CONT  TestAccResourceDliSqlJob_async
--- PASS: TestAccDatasourceConnection_basic (327.52s)
=== CONT  TestAccDliQueue_withElasticResourcePool
=== CONT  TestAccResourceDliSqlJob_async
    resource_huaweicloud_dli_sql_job_test.go:107: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # huaweicloud_dli_table.test must be replaced
        -/+ resource "huaweicloud_dli_table" "test" {
              + bucket_location    = (known after apply)
              + data_format        = (known after apply)
              + date_format        = (known after apply)
              + delimiter          = (known after apply)
              ~ description        = "dli table test}" -> "dli table test" # forces replacement
              + escape_char        = (known after apply)
              ~ id                 = "tf_test_y6ir2/tf_test_y6ir2" -> (known after apply)
                name               = "tf_test_y6ir2"
              + quote_char         = (known after apply)
              + region             = (known after apply)
              + timestamp_format   = (known after apply)
              + with_column_header = (known after apply)
                # (2 unchanged attributes hidden)
        
              ~ columns {
                  - is_partition = false -> null
                    name         = "name"
                    # (2 unchanged attributes hidden)
                }
              ~ columns {
                  - is_partition = false -> null
                    name         = "addrss"
                    # (2 unchanged attributes hidden)
                }
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccResourceDliSqlJob_async (61.75s)
=== CONT  TestAccResourceDliSqlJob_query
    resource_huaweicloud_dli_sql_job_test.go:71: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # huaweicloud_dli_table.test must be replaced
        -/+ resource "huaweicloud_dli_table" "test" {
              + bucket_location    = (known after apply)
              + data_format        = (known after apply)
              + date_format        = (known after apply)
              + delimiter          = (known after apply)
              ~ description        = "dli table test}" -> "dli table test" # forces replacement
              + escape_char        = (known after apply)
              ~ id                 = "tf_test_p0luj/tf_test_p0luj" -> (known after apply)
                name               = "tf_test_p0luj"
              + quote_char         = (known after apply)
              + region             = (known after apply)
              + timestamp_format   = (known after apply)
              + with_column_header = (known after apply)
                # (2 unchanged attributes hidden)
        
              ~ columns {
                  - is_partition = false -> null
                    name         = "name"
                    # (2 unchanged attributes hidden)
                }
              ~ columns {
                  - is_partition = false -> null
                    name         = "addrss"
                    # (2 unchanged attributes hidden)
                }
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccResourceDliSqlJob_query (63.90s)
=== CONT  TestAccDliQueue_associateElasticResourcePool
--- PASS: TestAccDatasourceConnections_basic (308.05s)
=== CONT  TestAccResourceDliSqlJob_basic
    resource_huaweicloud_dli_sql_job_test.go:36: Step 1/2 error: Error running apply: exit status 1
        
        Error: error creating DLI sql job: Bad request with: [POST https://dli.cn-north-4.myhuaweicloud.com/v1.0/0970dd7a1300f5672ff2c003c60ae115/jobs/submit-job], request_id: 685733a82ddbe60908e3016457b17204, error message: {"error_code":"DLI.0021","error_msg":"DLI.0001: Do not support use default queue to getJobResult."}
        
          with huaweicloud_dli_sql_job.test,
          on terraform_plugin_test.tf line 28, in resource "huaweicloud_dli_sql_job" "test":
          28: resource "huaweicloud_dli_sql_job" "test" {
        
--- FAIL: TestAccResourceDliSqlJob_basic (34.23s)
=== CONT  TestAccResourceDliAuth_package
    resource_huaweicloud_dli_permission_test.go:231: Step 1/3 error: Error running apply: exit status 1
        
        Error: error granting permission in DLI: Bad request with: [PUT https://dli.cn-north-4.myhuaweicloud.com/v1.0/0970dd7a1300f5672ff2c003c60ae115/user-authorization], request_id: 702e011dc4c069378363bc55cd39cc62, error message: {"error_code":"DLI.0002","error_msg":"No such user. userName:tf_test_4ohlz."}
        
          with huaweicloud_dli_permission.test,
          on terraform_plugin_test.tf line 135, in resource "huaweicloud_dli_permission" "test":
         135: resource "huaweicloud_dli_permission" "test" {
        
--- FAIL: TestAccResourceDliAuth_package (23.96s)
=== CONT  TestAccDliQueue_basic
=== CONT  TestAccDliQueue_associateElasticResourcePool
    resource_huaweicloud_dli_queue_test.go:256: Step 2/3 error: Error running apply: exit status 1
        
        Error: error creating DLI elastic resource pool: Bad request with: [POST https://dli.cn-north-4.myhuaweicloud.com/v3/0970dd7a1300f5672ff2c003c60ae115/elastic-resource-pools], request_id: 1c3a669987b86ccbe5e953805f6287c6, error message: {"error_code":"DLI.0035","error_msg":"The requested cu quota depends on insufficient resources."}
        
          with huaweicloud_dli_elastic_resource_pool.test,
          on terraform_plugin_test.tf line 2, in resource "huaweicloud_dli_elastic_resource_pool" "test":
           2: resource "huaweicloud_dli_elastic_resource_pool" "test" {
        
--- FAIL: TestAccDliQueue_associateElasticResourcePool (257.69s)
=== CONT  TestAccDatasourceAuths_CSS
    acceptance.go:725: HW_DLI_DS_AUTH_CSS_OBS_PATH must be set for DLI datasource CSS Auth acceptance tests.
--- SKIP: TestAccDatasourceAuths_CSS (0.01s)
=== CONT  TestAccResourceDliAuth_queue
--- PASS: TestAccDliQueue_basic (251.71s)
=== CONT  TestAccDliQueue_cidr
=== CONT  TestAccResourceDliAuth_queue
    resource_huaweicloud_dli_permission_test.go:296: Step 1/3 error: Error running apply: exit status 1
        
        Error: error granting permission in DLI: Bad request with: [PUT https://dli.cn-north-4.myhuaweicloud.com/v1.0/0970dd7a1300f5672ff2c003c60ae115/queues/user-authorization], request_id: b7b556d38b273865dd7375e9362e186c, error message: {"error_code":"DLI.0002","error_msg":"No such user. userName:tf_test_l3xs2."}
        
          with huaweicloud_dli_permission.test,
          on terraform_plugin_test.tf line 72, in resource "huaweicloud_dli_permission" "test":
          72: resource "huaweicloud_dli_permission" "test" {
        
--- FAIL: TestAccResourceDliAuth_queue (261.47s)
=== CONT  TestAccResourceDliAuth_table
    resource_huaweicloud_dli_permission_test.go:167: Step 1/3 error: Error running apply: exit status 1
        
        Error: error granting permission in DLI: Bad request with: [PUT https://dli.cn-north-4.myhuaweicloud.com/v1.0/0970dd7a1300f5672ff2c003c60ae115/user-authorization], request_id: cc198f4bddac102c92c4880b5fdcee5d, error message: {"error_code":"DLI.0002","error_msg":"No such user. userName:tf_test_60oza."}
        
          with huaweicloud_dli_permission.test,
          on terraform_plugin_test.tf line 88, in resource "huaweicloud_dli_permission" "test":
          88: resource "huaweicloud_dli_permission" "test" {
        
--- FAIL: TestAccResourceDliAuth_table (26.57s)
=== CONT  TestAccDliQueue_withGeneral
--- PASS: TestAccDliQueue_cidr (260.45s)
=== CONT  TestAccResourceDliAuth_flink
    resource_huaweicloud_dli_permission_test.go:106: Step 1/3 error: Error running apply: exit status 1
        
        Error: error run DLI flink job: Bad request with: [POST https://dli.cn-north-4.myhuaweicloud.com/v1.0/0970dd7a1300f5672ff2c003c60ae115/streaming/jobs/run], request_id: 26bc0eaccd7f14dab6a009285cd52a4d, error message: [{"error_code":"DLI.13024","error_msg":"No job-running queue selected. Please select a queue for your job."}]
        
          with huaweicloud_dli_flinksql_job.test,
          on terraform_plugin_test.tf line 80, in resource "huaweicloud_dli_flinksql_job" "test":
          80: resource "huaweicloud_dli_flinksql_job" "test" {
        
--- FAIL: TestAccResourceDliAuth_flink (20.80s)
--- PASS: TestAccDliQueue_withGeneral (253.14s)
--- PASS: TestAccDatasourceConnectionAssociate_basic (4374.94s)
--- PASS: TestAccDliQueue_withElasticResourcePool (4526.36s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       4878.237s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```
