### PR TITLE
test(RDS): fix rds tests

### DIFF
--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_accounts_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_accounts_test.go
@@ -73,5 +73,5 @@ output "host_filter_is_useful" {
     [for v in data.huaweicloud_rds_mysql_accounts.host_filter.users[*].hosts : contains(v, local.host)]
   )
 }
-`, testMysqlAccount_basic(name, ""))
+`, testMysqlAccount_basic(name))
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_database_privileges_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_database_privileges_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -13,8 +12,6 @@ import (
 func TestAccMysqlDatabasePrivileges_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_mysql_database_privileges.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
-		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
 
 	dc := acceptance.InitDataSourceCheck(rName)
 
@@ -23,7 +20,7 @@ func TestAccMysqlDatabasePrivileges_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMysqlDatabasePrivileges_basic(name, dbPwd),
+				Config: testAccMysqlDatabasePrivileges_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(rName, "users.#"),
@@ -37,7 +34,7 @@ func TestAccMysqlDatabasePrivileges_basic(t *testing.T) {
 	})
 }
 
-func testAccMysqlDatabasePrivileges_basic(name string, dbPwd string) string {
+func testAccMysqlDatabasePrivileges_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -81,5 +78,5 @@ output "readonly_filter_is_useful" {
 )
 }
 
-`, testAccRdsDatabasePrivilege_basic(name, dbPwd))
+`, testAccRdsDatabasePrivilege_basic(name))
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_databases_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_databases_test.go
@@ -74,5 +74,5 @@ output "character_set_filter_is_useful" {
   [for v in data.huaweicloud_rds_mysql_databases.character_set_filter.databases[*].character_set : v == local.character_set]
   )
 }
-`, testMysqlDatabase_basic(name, "", "test_database"))
+`, testMysqlDatabase_basic(name, "test_database"))
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_cross_region_backup_strategy_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_cross_region_backup_strategy_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -64,8 +63,6 @@ func TestAccBackupStrategy_basic(t *testing.T) {
 
 	name := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_rds_cross_region_backup_strategy.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
-		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -82,7 +79,7 @@ func TestAccBackupStrategy_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testBackupStrategy_basic(name, dbPwd),
+				Config: testBackupStrategy_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -94,7 +91,7 @@ func TestAccBackupStrategy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testBackupStrategy_basic_update1(name, dbPwd),
+				Config: testBackupStrategy_basic_update1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -106,7 +103,7 @@ func TestAccBackupStrategy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testBackupStrategy_basic_update2(name, dbPwd),
+				Config: testBackupStrategy_basic_update2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -126,7 +123,7 @@ func TestAccBackupStrategy_basic(t *testing.T) {
 	})
 }
 
-func testBackupStrategy_basic(name, dbPwd string) string {
+func testBackupStrategy_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -137,10 +134,10 @@ resource "huaweicloud_rds_cross_region_backup_strategy" "test" {
   destination_region     = "%s"
   destination_project_id = "%s"
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd), acceptance.HW_DEST_REGION, acceptance.HW_DEST_PROJECT_ID)
+`, testAccRdsInstance_mysql_step1(name), acceptance.HW_DEST_REGION, acceptance.HW_DEST_PROJECT_ID)
 }
 
-func testBackupStrategy_basic_update1(name, dbPwd string) string {
+func testBackupStrategy_basic_update1(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -151,10 +148,10 @@ resource "huaweicloud_rds_cross_region_backup_strategy" "test" {
   destination_region     = "%s"
   destination_project_id = "%s"
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd), acceptance.HW_DEST_REGION, acceptance.HW_DEST_PROJECT_ID)
+`, testAccRdsInstance_mysql_step1(name), acceptance.HW_DEST_REGION, acceptance.HW_DEST_PROJECT_ID)
 }
 
-func testBackupStrategy_basic_update2(name, dbPwd string) string {
+func testBackupStrategy_basic_update2(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -165,5 +162,5 @@ resource "huaweicloud_rds_cross_region_backup_strategy" "test" {
   destination_region     = "%s"
   destination_project_id = "%s"
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd), acceptance.HW_DEST_REGION, acceptance.HW_DEST_PROJECT_ID)
+`, testAccRdsInstance_mysql_step1(name), acceptance.HW_DEST_REGION, acceptance.HW_DEST_PROJECT_ID)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -21,10 +21,6 @@ func TestAccRdsInstance_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	resourceType := "huaweicloud_rds_instance"
 	resourceName := "huaweicloud_rds_instance.test"
-	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
-	newPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -32,7 +28,7 @@ func TestAccRdsInstance_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstance_basic(name, pwd),
+				Config: testAccRdsInstance_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -47,13 +43,12 @@ func TestAccRdsInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.210"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8634"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "09:00"),
 				),
 			},
 			{
-				Config: testAccRdsInstance_update(name, newPwd),
+				Config: testAccRdsInstance_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-update", name)),
@@ -67,104 +62,21 @@ func TestAccRdsInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.230"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8636"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "15:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "17:00"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"db",
-					"status",
-					"availability_zone",
-				},
-			},
-		},
-	})
-}
-
-func TestAccRdsInstance_without_password(t *testing.T) {
-	var instance instances.RdsInstanceResponse
-	name := acceptance.RandomAccResourceName()
-	resourceType := "huaweicloud_rds_instance"
-	resourceName := "huaweicloud_rds_instance.test"
-	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRdsInstance_without_password(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "description", "test_description"),
-					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.n1.large.2"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8634"),
-				),
-			},
-			{
-				Config: testAccRdsInstance_without_password_update(name, pwd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "description", "test_description"),
-					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.pg.n1.large.2"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8634"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"db",
-					"status",
-					"availability_zone",
-				},
-			},
-		},
-	})
-}
-
-func TestAccRdsInstance_withEpsId(t *testing.T) {
-	var instance instances.RdsInstanceResponse
-	name := acceptance.RandomAccResourceName()
-	resourceType := "huaweicloud_rds_instance"
-	resourceName := "huaweicloud_rds_instance.test"
-	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRdsInstance_basic(name, pwd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
-				),
-			},
-			{
-				Config: testAccRdsInstance_epsId(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(resourceName, "db.0.password"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"db",
+					"status",
+					"availability_zone",
+				},
 			},
 		},
 	})
@@ -221,10 +133,6 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 	updateName := acceptance.RandomAccResourceName()
 	resourceType := "huaweicloud_rds_instance"
 	resourceName := "huaweicloud_rds_instance.test"
-	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
-	newPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -232,7 +140,7 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstance_mysql_step1(name, pwd),
+				Config: testAccRdsInstance_mysql_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -243,11 +151,12 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "15"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3306"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "div_precision_increment"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "12"),
 				),
 			},
 			{
-				Config: testAccRdsInstance_mysql_step2(updateName, newPwd),
+				Config: testAccRdsInstance_mysql_step2(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
@@ -258,11 +167,13 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "20"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3308"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "connect_timeout"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "14"),
+					resource.TestCheckResourceAttrSet(resourceName, "db.0.password"),
 				),
 			},
 			{
-				Config: testAccRdsInstance_mysql_step3(updateName, newPwd),
+				Config: testAccRdsInstance_mysql_step3(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.limit_size", "0"),
@@ -278,8 +189,6 @@ func TestAccRdsInstance_sqlserver(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	resourceType := "huaweicloud_rds_instance"
 	resourceName := "huaweicloud_rds_instance.test"
-	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -287,7 +196,7 @@ func TestAccRdsInstance_sqlserver(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstance_sqlserver(name, pwd),
+				Config: testAccRdsInstance_sqlserver(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -297,7 +206,7 @@ func TestAccRdsInstance_sqlserver(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRdsInstance_sqlserver_update(name, pwd),
+				Config: testAccRdsInstance_sqlserver_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -315,8 +224,6 @@ func TestAccRdsInstance_mariadb(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	resourceType := "huaweicloud_rds_instance"
 	resourceName := "huaweicloud_rds_instance.test"
-	pwd := fmt.Sprintf("%s%s%s%d", acctest.RandString(8), acctest.RandStringFromCharSet(1, "!#%^*"),
-		acctest.RandStringFromCharSet(1, "ABCDEFG"), acctest.RandIntRange(10, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -324,7 +231,7 @@ func TestAccRdsInstance_mariadb(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstance_mariadb(name, pwd),
+				Config: testAccRdsInstance_mariadb(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -332,7 +239,7 @@ func TestAccRdsInstance_mariadb(t *testing.T) {
 						"data.huaweicloud_rds_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "40"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3306"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
+					resource.TestCheckResourceAttrSet(resourceName, "db.0.password"),
 				),
 			},
 		},
@@ -346,8 +253,6 @@ func TestAccRdsInstance_prePaid(t *testing.T) {
 		resourceType = "huaweicloud_rds_instance"
 		resourceName = "huaweicloud_rds_instance.test"
 		name         = acceptance.RandomAccResourceName()
-		password     = fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-			acctest.RandIntRange(10, 99))
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -359,7 +264,7 @@ func TestAccRdsInstance_prePaid(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstance_prePaid(name, password, false),
+				Config: testAccRdsInstance_prePaid(name, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
@@ -367,73 +272,11 @@ func TestAccRdsInstance_prePaid(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRdsInstance_prePaid_update(name, password, true),
+				Config: testAccRdsInstance_prePaid_update(name, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccRdsInstance_withConfiguration(t *testing.T) {
-	var instance instances.RdsInstanceResponse
-	name := acceptance.RandomAccResourceName()
-	resourceType := "huaweicloud_rds_instance"
-	resourceName := "huaweicloud_rds_instance.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRdsInstance_configuration(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-				),
-			},
-			{
-				Config: testAccRdsInstance_configuration_update(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-				),
-			},
-		},
-	})
-}
-
-func TestAccRdsInstance_withParameters(t *testing.T) {
-	var instance instances.RdsInstanceResponse
-	name := acceptance.RandomAccResourceName()
-	resourceType := "huaweicloud_rds_instance"
-	resourceName := "huaweicloud_rds_instance.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRdsInstance_parameters(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "div_precision_increment"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "12"),
-				),
-			},
-			{
-				Config: testAccRdsInstance_newParameters(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "connect_timeout"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "14"),
 				),
 			},
 		},
@@ -445,10 +288,6 @@ func TestAccRdsInstance_restore_mysql(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	resourceType := "huaweicloud_rds_instance"
 	resourceName := "huaweicloud_rds_instance.test_backup"
-	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
-	newPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -456,7 +295,7 @@ func TestAccRdsInstance_restore_mysql(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstance_restore_mysql(name, pwd),
+				Config: testAccRdsInstance_restore_mysql(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -467,22 +306,6 @@ func TestAccRdsInstance_restore_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "15"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3306"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
-				),
-			},
-			{
-				Config: testAccRdsInstance_restore_mysql_update(name, newPwd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttrPair(resourceName, "flavor",
-						"data.huaweicloud_rds_flavors.test", "flavors.1.name"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.limit_size", "500"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "20"),
-					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "false"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3308"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
 				),
 			},
 		},
@@ -494,10 +317,6 @@ func TestAccRdsInstance_restore_sqlserver(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	resourceType := "huaweicloud_rds_instance"
 	resourceName := "huaweicloud_rds_instance.test_backup"
-	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
-	newPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -505,7 +324,7 @@ func TestAccRdsInstance_restore_sqlserver(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsInstance_restore_sqlserver(name, pwd),
+				Config: testAccRdsInstance_restore_sqlserver(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -514,20 +333,6 @@ func TestAccRdsInstance_restore_sqlserver(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8634"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
-				),
-			},
-			{
-				Config: testAccRdsInstance_restore_sqlserver_update(name, newPwd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttrPair(resourceName, "flavor",
-						"data.huaweicloud_rds_flavors.test", "flavors.1.name"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8636"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
 				),
 			},
 		},
@@ -540,8 +345,6 @@ func TestAccRdsInstance_restore_pg(t *testing.T) {
 	resourceType := "huaweicloud_rds_instance"
 	resourceName := "huaweicloud_rds_instance.test_backup"
 	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
-	newPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
 		acctest.RandIntRange(10, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -559,20 +362,6 @@ func TestAccRdsInstance_restore_pg(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8732"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", pwd),
-				),
-			},
-			{
-				Config: testAccRdsInstance_restore_pg_update(name, newPwd),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRdsInstanceExists(resourceName, &instance),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttrPair(resourceName, "flavor",
-						"data.huaweicloud_rds_flavors.test", "flavors.1.name"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
-					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8733"),
-					resource.TestCheckResourceAttr(resourceName, "db.0.password", newPwd),
 				),
 			},
 		},
@@ -653,12 +442,12 @@ data "huaweicloud_networking_secgroup" "test" {
 }`
 }
 
-func testAccRdsInstance_basic(name, password string) string {
+func testAccRdsInstance_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%s"
+  name              = "%[2]s"
   description       = "test_description"
   flavor            = "rds.pg.n1.large.2"
   availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
@@ -671,7 +460,6 @@ resource "huaweicloud_rds_instance" "test" {
   maintain_end      = "09:00"
 
   db {
-    password = "%s"
     type     = "PostgreSQL"
     version  = "12"
     port     = 8634
@@ -690,28 +478,29 @@ resource "huaweicloud_rds_instance" "test" {
     foo = "bar"
   }
 }
-`, testAccRdsInstance_base(), name, password)
+`, testAccRdsInstance_base(), name)
 }
 
 // name, volume.size, backup_strategy, flavor, tags and password will be updated
-func testAccRdsInstance_update(name, password string) string {
+func testAccRdsInstance_update(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%s-update"
-  flavor            = "rds.pg.n1.large.2"
-  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  time_zone         = "UTC+08:00"
-  fixed_ip          = "192.168.0.230"
-  maintain_begin    = "15:00"
-  maintain_end      = "17:00"
+  name                  = "%[2]s-update"
+  flavor                = "rds.pg.n1.large.2"
+  availability_zone     = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id     = data.huaweicloud_networking_secgroup.test.id
+  subnet_id             = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                = data.huaweicloud_vpc.test.id
+  enterprise_project_id = "%[3]s"
+  time_zone             = "UTC+08:00"
+  fixed_ip              = "192.168.0.230"
+  maintain_begin        = "15:00"
+  maintain_end          = "17:00"
 
   db {
-    password = "%s"
+    password = "Huangwei!120521"
     type     = "PostgreSQL"
     version  = "12"
     port     = 8636
@@ -728,94 +517,6 @@ resource "huaweicloud_rds_instance" "test" {
   tags = {
     key1 = "value"
     foo  = "bar_updated"
-  }
-}
-`, testAccRdsInstance_base(), name, password)
-}
-
-func testAccRdsInstance_without_password(name string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_rds_instance" "test" {
-  name              = "%s"
-  description       = "test_description"
-  flavor            = "rds.pg.n1.large.2"
-  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  time_zone         = "UTC+08:00"
-
-  db {
-    type    = "PostgreSQL"
-    version = "12"
-    port    = 8634
-  }
-
-  volume {
-    type = "CLOUDSSD"
-    size = 50
-  }
-}
-`, testAccRdsInstance_base(), name)
-}
-
-func testAccRdsInstance_without_password_update(name, password string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_rds_instance" "test" {
-  name              = "%s"
-  description       = "test_description"
-  flavor            = "rds.pg.n1.large.2"
-  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  time_zone         = "UTC+08:00"
-
-  db {
-    password = "%s"
-    type     = "PostgreSQL"
-    version  = "12"
-    port     = 8634
-  }
-
-  volume {
-    type = "CLOUDSSD"
-    size = 50
-  }
-}
-`, testAccRdsInstance_base(), name, password)
-}
-
-func testAccRdsInstance_epsId(name string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_rds_instance" "test" {
-  name                  = "%s"
-  flavor                = "rds.pg.n1.large.2"
-  availability_zone     = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id     = data.huaweicloud_networking_secgroup.test.id
-  subnet_id             = data.huaweicloud_vpc_subnet.test.id
-  vpc_id                = data.huaweicloud_vpc.test.id
-  enterprise_project_id = "%s"
-
-  db {
-    password = "Huangwei!120521"
-    type     = "PostgreSQL"
-    version  = "12"
-    port     = 8634
-  }
-  volume {
-    type = "CLOUDSSD"
-    size = 50
-  }
-  backup_strategy {
-    start_time = "08:00-09:00"
-    keep_days  = 1
   }
 }
 `, testAccRdsInstance_base(), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
@@ -866,7 +567,7 @@ resource "huaweicloud_rds_instance" "test" {
 // the binding relationship between instance and security group or subnet cannot be unbound
 // when deleting the instance in this period time, so we cannot create a new vpc, subnet and
 // security group in the test case, otherwise, they cannot be deleted when destroy the resource
-func testAccRdsInstance_mysql_step1(name, pwd string) string {
+func testAccRdsInstance_mysql_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -887,7 +588,6 @@ resource "huaweicloud_rds_instance" "test" {
   ssl_enable        = true  
 
   db {
-    password = "%[3]s"
     type     = "MySQL"
     version  = "8.0"
     port     = 3306
@@ -905,13 +605,20 @@ resource "huaweicloud_rds_instance" "test" {
     limit_size        = 400
     trigger_threshold = 15
   }
+
+  parameters {
+    name  = "div_precision_increment"
+    value = "12"
+  }
 }
-`, testAccRdsInstance_base(), name, pwd)
+`, testAccRdsInstance_base(), name)
 }
 
-func testAccRdsInstance_mysql_step2(name, pwd string) string {
+func testAccRdsInstance_mysql_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+
+%[2]s
 
 data "huaweicloud_rds_flavors" "test" {
   db_type       = "MySQL"
@@ -921,16 +628,17 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%[2]s"
+  name              = "%[3]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
   security_group_id = data.huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
   ssl_enable        = false
+  param_group_id    = huaweicloud_rds_parametergroup.pg_1.id
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "MySQL"
     version  = "8.0"
     port     = 3308
@@ -948,13 +656,20 @@ resource "huaweicloud_rds_instance" "test" {
     limit_size        = 500
     trigger_threshold = 20
   }
+
+  parameters {
+    name  = "connect_timeout"
+    value = "14"
+  }
 }
-`, testAccRdsInstance_base(), name, pwd)
+`, testAccRdsInstance_base(), testAccRdsConfig_basic(name), name)
 }
 
-func testAccRdsInstance_mysql_step3(name, pwd string) string {
+func testAccRdsInstance_mysql_step3(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+
+%[2]s
 
 data "huaweicloud_rds_flavors" "test" {
   db_type       = "MySQL"
@@ -964,16 +679,17 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%[2]s"
+  name              = "%[3]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
   security_group_id = data.huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
   ssl_enable        = false
+  param_group_id    = huaweicloud_rds_parametergroup.pg_1.id
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "MySQL"
     version  = "8.0"
     port     = 3308
@@ -983,11 +699,16 @@ resource "huaweicloud_rds_instance" "test" {
     type = "CLOUDSSD"
     size = 40
   }
+
+  parameters {
+    name  = "connect_timeout"
+    value = "14"
+  }
 }
-`, testAccRdsInstance_base(), name, pwd)
+`, testAccRdsInstance_base(), testAccRdsConfig_basic(name), name)
 }
 
-func testAccRdsInstance_sqlserver(name, pwd string) string {
+func testAccRdsInstance_sqlserver(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1023,7 +744,7 @@ resource "huaweicloud_rds_instance" "test" {
   ]
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "SQLServer"
     version  = "2017_EE"
     port     = 8634
@@ -1034,10 +755,10 @@ resource "huaweicloud_rds_instance" "test" {
     size = 40
   }
 }
-`, common.TestBaseNetwork(name), name, pwd)
+`, common.TestBaseNetwork(name), name)
 }
 
-func testAccRdsInstance_sqlserver_update(name, pwd string) string {
+func testAccRdsInstance_sqlserver_update(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1073,7 +794,7 @@ resource "huaweicloud_rds_instance" "test" {
   ]
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "SQLServer"
     version  = "2017_EE"
     port     = 8634
@@ -1084,10 +805,10 @@ resource "huaweicloud_rds_instance" "test" {
     size = 40
   }
 }
-`, common.TestBaseNetwork(name), name, pwd)
+`, common.TestBaseNetwork(name), name)
 }
 
-func testAccRdsInstance_mariadb(name, pwd string) string {
+func testAccRdsInstance_mariadb(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1107,7 +828,7 @@ resource "huaweicloud_rds_instance" "test" {
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "MariaDB"
     version  = "10.5"
     port     = 3306
@@ -1118,10 +839,10 @@ resource "huaweicloud_rds_instance" "test" {
     size = 40
   }
 }
-`, testAccRdsInstance_base(), name, pwd)
+`, testAccRdsInstance_base(), name)
 }
 
-func testAccRdsInstance_prePaid(name, pwd string, isAutoRenew bool) string {
+func testAccRdsInstance_prePaid(name string, isAutoRenew bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1147,7 +868,7 @@ resource "huaweicloud_rds_instance" "test" {
   collation = "Chinese_PRC_CI_AS"
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "SQLServer"
     version  = "2019_SE"
     port     = 8638
@@ -1161,12 +882,12 @@ resource "huaweicloud_rds_instance" "test" {
   charging_mode = "prePaid"
   period_unit   = "month"
   period        = 1
-  auto_renew    = "%[4]v"
+  auto_renew    = "%[3]v"
 }
-`, testAccRdsInstance_base(), name, pwd, isAutoRenew)
+`, testAccRdsInstance_base(), name, isAutoRenew)
 }
 
-func testAccRdsInstance_prePaid_update(name, pwd string, isAutoRenew bool) string {
+func testAccRdsInstance_prePaid_update(name string, isAutoRenew bool) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1192,7 +913,7 @@ resource "huaweicloud_rds_instance" "test" {
   collation = "Chinese_PRC_CI_AS"
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "SQLServer"
     version  = "2019_SE"
     port     = 8638
@@ -1206,9 +927,9 @@ resource "huaweicloud_rds_instance" "test" {
   charging_mode = "prePaid"
   period_unit   = "month"
   period        = 1
-  auto_renew    = "%[4]v"
+  auto_renew    = "%[3]v"
 }
-`, testAccRdsInstance_base(), name, pwd, isAutoRenew)
+`, testAccRdsInstance_base(), name, isAutoRenew)
 }
 
 func testAccRdsInstance_configuration(name string) string {
@@ -1371,7 +1092,7 @@ resource "huaweicloud_rds_instance" "test" {
 `, testAccRdsInstance_base(), name)
 }
 
-func testAccRdsInstance_restore_mysql(name, pwd string) string {
+func testAccRdsInstance_restore_mysql(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1390,7 +1111,7 @@ resource "huaweicloud_rds_instance" "test_backup" {
   }
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "MySQL"
     version  = "8.0"
     port     = 3306
@@ -1409,51 +1130,10 @@ resource "huaweicloud_rds_instance" "test_backup" {
     trigger_threshold = 15
   }
 }
-`, testBackup_mysql_basic(name), name, pwd)
+`, testBackup_mysql_basic(name), name)
 }
 
-func testAccRdsInstance_restore_mysql_update(name, pwd string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_rds_instance" "test_backup" {
-  name              = "%[2]s"
-  flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
-  ssl_enable        = false
-
-  restore {
-    instance_id = huaweicloud_rds_backup.test.instance_id
-    backup_id   = huaweicloud_rds_backup.test.id
-  }
-
-  db {
-    password = "%[3]s"
-    type     = "MySQL"
-    version  = "8.0"
-    port     = 3308
-  }
-
-  backup_strategy {
-    start_time = "18:15-19:15"
-    keep_days  = 5
-    period     = 3
-  }
-
-  volume {
-    type              = "CLOUDSSD"
-    size              = 60
-    limit_size        = 500
-    trigger_threshold = 20
-  }
-}
-`, testBackup_mysql_basic(name), name, pwd)
-}
-
-func testAccRdsInstance_restore_sqlserver(name, pwd string) string {
+func testAccRdsInstance_restore_sqlserver(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -1471,7 +1151,7 @@ resource "huaweicloud_rds_instance" "test_backup" {
   }
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "SQLServer"
     version  = "2019_SE"
     port     = 8634
@@ -1482,39 +1162,7 @@ resource "huaweicloud_rds_instance" "test_backup" {
     size = 50
   }
 }
-`, testBackup_sqlserver_basic(name), name, pwd)
-}
-
-func testAccRdsInstance_restore_sqlserver_update(name, pwd string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_rds_instance" "test_backup" {
-  name              = "%[2]s"
-  flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
-
-  restore {
-    instance_id = huaweicloud_rds_backup.test.instance_id
-    backup_id   = huaweicloud_rds_backup.test.id
-  }
-
-  db {
-    password = "%[3]s"
-    type     = "SQLServer"
-    version  = "2019_SE"
-    port     = 8636
-  }
-
-  volume {
-    type = "CLOUDSSD"
-    size = 60
-  }
-}
-`, testBackup_sqlserver_basic(name), name, pwd)
+`, testBackup_sqlserver_basic(name), name)
 }
 
 func testAccRdsInstance_restore_pg(name, pwd string) string {
@@ -1535,7 +1183,7 @@ resource "huaweicloud_rds_instance" "test_backup" {
   }
 
   db {
-    password = "%[3]s"
+    password = "Huangwei!120521"
     type     = "PostgreSQL"
     version  = "14"
     port     = 8732
@@ -1544,38 +1192,6 @@ resource "huaweicloud_rds_instance" "test_backup" {
   volume {
     type = "CLOUDSSD"
     size = 50
-  }
-}
-`, testBackup_pg_basic(name), name, pwd)
-}
-
-func testAccRdsInstance_restore_pg_update(name, pwd string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_rds_instance" "test_backup" {
-  name              = "%[2]s"
-  flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
-
-  restore {
-    instance_id = huaweicloud_rds_backup.test.instance_id
-    backup_id   = huaweicloud_rds_backup.test.id
-  }
-
-  db {
-    password = "%[3]s"
-    type     = "PostgreSQL"
-    version  = "14"
-    port     = 8733
-  }
-
-  volume {
-    type = "CLOUDSSD"
-    size = 60
   }
 }
 `, testBackup_pg_basic(name), name, pwd)

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_lts_log_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_lts_log_test.go
@@ -64,7 +64,6 @@ func getRdsLtsLogResourceFunc(cfg *config.Config, state *terraform.ResourceState
 func TestAccRdsLtsLog_basic(t *testing.T) {
 	var obj interface{}
 	rName := acceptance.RandomAccResourceName()
-	pwd := acceptance.RandomPassword()
 	resourceName := "huaweicloud_rds_lts_log.test"
 
 	rc := acceptance.InitResourceCheck(
@@ -79,7 +78,7 @@ func TestAccRdsLtsLog_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsLtsLog_basic(rName, pwd),
+				Config: testAccRdsLtsLog_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_rds_instance.test", "id"),
@@ -90,7 +89,7 @@ func TestAccRdsLtsLog_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRdsLtsLog_update(rName, pwd),
+				Config: testAccRdsLtsLog_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_rds_instance.test", "id"),
@@ -109,7 +108,7 @@ func TestAccRdsLtsLog_basic(t *testing.T) {
 	})
 }
 
-func testAccRdsLtsLog_basic(rName, pwd string) string {
+func testAccRdsLtsLog_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -129,10 +128,10 @@ resource "huaweicloud_rds_lts_log" "test" {
   log_type      = "error_log"
   lts_group_id  = huaweicloud_lts_group.test.id
   lts_stream_id = huaweicloud_lts_stream.test.id
-}`, testAccRdsInstance_mysql_step1(rName, pwd), rName)
+}`, testAccRdsInstance_mysql_step1(rName), rName)
 }
 
-func testAccRdsLtsLog_update(rName, pwd string) string {
+func testAccRdsLtsLog_update(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -152,5 +151,5 @@ resource "huaweicloud_rds_lts_log" "test" {
   log_type      = "error_log"
   lts_group_id  = huaweicloud_lts_group.test.id
   lts_stream_id = huaweicloud_lts_stream.test.id
-}`, testAccRdsInstance_mysql_step1(rName, pwd), rName)
+}`, testAccRdsInstance_mysql_step1(rName), rName)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_account_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_account_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -75,8 +74,6 @@ func TestAccMysqlAccount_basic(t *testing.T) {
 
 	name := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_rds_mysql_account.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
-		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -90,7 +87,7 @@ func TestAccMysqlAccount_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testMysqlAccount_basic(name, dbPwd),
+				Config: testMysqlAccount_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -101,7 +98,7 @@ func TestAccMysqlAccount_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testMysqlAccount_basic_update(name, dbPwd),
+				Config: testMysqlAccount_basic_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -121,7 +118,7 @@ func TestAccMysqlAccount_basic(t *testing.T) {
 	})
 }
 
-func testMysqlAccount_basic(name, dbPwd string) string {
+func testMysqlAccount_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -135,10 +132,10 @@ resource "huaweicloud_rds_mysql_account" "test" {
     "10.10.%%"
   ]
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd), name)
+`, testAccRdsInstance_mysql_step1(name), name)
 }
 
-func testMysqlAccount_basic_update(name, dbPwd string) string {
+func testMysqlAccount_basic_update(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -152,5 +149,5 @@ resource "huaweicloud_rds_mysql_account" "test" {
     "10.10.%%"
   ]
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd), name)
+`, testAccRdsInstance_mysql_step1(name), name)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_privilege_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_privilege_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -81,8 +80,6 @@ func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
 
 	name := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_rds_mysql_database_privilege.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -96,7 +93,7 @@ func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRdsDatabasePrivilege_basic(name, dbPwd),
+				Config: testAccRdsDatabasePrivilege_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -109,7 +106,7 @@ func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccRdsDatabasePrivilege_basic_update(name, dbPwd),
+				Config: testAccRdsDatabasePrivilege_basic_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -130,7 +127,7 @@ func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
 	})
 }
 
-func testAccRdsDatabasePrivilege_basic(rName, dbPwd string) string {
+func testAccRdsDatabasePrivilege_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -148,10 +145,10 @@ resource "huaweicloud_rds_mysql_database_privilege" "test" {
     name = huaweicloud_rds_mysql_account.test_1.name
   }
 }
-`, testMysqlDatabase_basic(rName, dbPwd, rName), rName)
+`, testMysqlDatabase_basic(rName, rName), rName)
 }
 
-func testAccRdsDatabasePrivilege_basic_update(rName, dbPwd string) string {
+func testAccRdsDatabasePrivilege_basic_update(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -170,5 +167,5 @@ resource "huaweicloud_rds_mysql_database_privilege" "test" {
     readonly = true
   }
 }
-`, testMysqlDatabase_basic(rName, dbPwd, rName), rName)
+`, testMysqlDatabase_basic(rName, rName), rName)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -74,8 +73,6 @@ func TestAccMysqlDatabase_basic(t *testing.T) {
 
 	name := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_rds_mysql_database.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
-		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -89,7 +86,7 @@ func TestAccMysqlDatabase_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testMysqlDatabase_basic(name, dbPwd, "test database"),
+				Config: testMysqlDatabase_basic(name, "test database"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -100,7 +97,7 @@ func TestAccMysqlDatabase_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testMysqlDatabase_basic(name, dbPwd, "test database update"),
+				Config: testMysqlDatabase_basic(name, "test database update"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -119,7 +116,7 @@ func TestAccMysqlDatabase_basic(t *testing.T) {
 	})
 }
 
-func testMysqlDatabase_basic(name, dbPwd, description string) string {
+func testMysqlDatabase_basic(name, description string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -129,5 +126,5 @@ resource "huaweicloud_rds_mysql_database" "test" {
   character_set = "utf8"
   description   = "%s"
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd), name, description)
+`, testAccRdsInstance_mysql_step1(name), name, description)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_test.go
@@ -109,7 +109,7 @@ resource "huaweicloud_rds_parametergroup" "pg_1" {
   }
   datastore {
     type    = "mysql"
-    version = "5.7"
+    version = "8.0"
   }
 }
 `, rName)
@@ -127,7 +127,7 @@ resource "huaweicloud_rds_parametergroup" "pg_1" {
   }
   datastore {
     type    = "mysql"
-    version = "5.7"
+    version = "8.0"
   }
 }
 `, updateName)

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_account_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_account_test.go
@@ -126,5 +126,5 @@ resource "huaweicloud_rds_pg_account" "test" {
   password    = "%s"
   description = "%s"
 }
-`, testAccRdsInstance_basic(name, "HuaweiTest@12345678"), name, pwd, description)
+`, testAccRdsInstance_basic(name), name, pwd, description)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_database_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_database_test.go
@@ -137,5 +137,5 @@ resource "huaweicloud_rds_pg_database" "test" {
   is_revoke_public_privilege = false
   description                = "%[3]s"
 }
-`, testAccRdsInstance_basic(name, "HuaweiTest@12345678"), name, description)
+`, testAccRdsInstance_basic(name), name, description)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_hba_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_hba_test.go
@@ -169,7 +169,7 @@ resource "huaweicloud_rds_pg_hba" "test" {
     method   = "scram-sha-256"
   }
 }
-`, testAccRdsInstance_basic(name, "HuaweiTest@12345678"))
+`, testAccRdsInstance_basic(name))
 }
 
 func testPgHba_basic_update(name string) string {
@@ -204,5 +204,5 @@ resource "huaweicloud_rds_pg_hba" "test" {
     method   = "reject"
   }
 }
-`, testAccRdsInstance_basic(name, "HuaweiTest@12345678"))
+`, testAccRdsInstance_basic(name))
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_plugin_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_plugin_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -57,8 +56,6 @@ func TestAccPgPlugin_basic(t *testing.T) {
 	var obj interface{}
 
 	randName := acceptance.RandomAccResourceName()
-	pwd := fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "!#%^*"),
-		acctest.RandIntRange(10, 99))
 
 	resourceName := "huaweicloud_rds_pg_plugin.test"
 
@@ -74,7 +71,7 @@ func TestAccPgPlugin_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testPgPlugin_basic(randName, pwd),
+				Config: testPgPlugin_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_rds_instance.test", "id"),
@@ -93,7 +90,7 @@ func TestAccPgPlugin_basic(t *testing.T) {
 	})
 }
 
-func testPgPlugin_basic(randName, pwd string) string {
+func testPgPlugin_basic(randName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -102,5 +99,5 @@ resource "huaweicloud_rds_pg_plugin" "test" {
   name          = "pgl_ddl_deploy"
   database_name = "postgres"
 }
-`, testAccRdsInstance_basic(randName, pwd))
+`, testAccRdsInstance_basic(randName))
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/chnsz/golangsdk/openstack/rds/v3/instances"
@@ -18,8 +17,6 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 	updateName := acceptance.RandomAccResourceName()
 	resourceType := "huaweicloud_rds_read_replica_instance"
 	resourceName := "huaweicloud_rds_read_replica_instance.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
-		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -27,7 +24,7 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReadReplicaInstance_basic(name, dbPwd),
+				Config: testAccReadReplicaInstance_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &replica),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -40,7 +37,6 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "Replica"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
 						"data.huaweicloud_networking_secgroup.test", "id"),
-					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.210"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8888"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
@@ -54,7 +50,7 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccReadReplicaInstance_update(name, updateName, dbPwd),
+				Config: testAccReadReplicaInstance_update(name, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &replica),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
@@ -66,7 +62,6 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "Replica"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
 						"data.huaweicloud_networking_secgroup.test", "id"),
-					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.220"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8889"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
@@ -96,8 +91,6 @@ func TestAccReadReplicaInstance_withEpsId(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	resourceType := "huaweicloud_rds_read_replica_instance"
 	resourceName := "huaweicloud_rds_read_replica_instance.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
-		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
 	srcEPS := acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
 	destEPS := acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST
 
@@ -110,14 +103,14 @@ func TestAccReadReplicaInstance_withEpsId(t *testing.T) {
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReadReplicaInstance_withEpsId(name, dbPwd, srcEPS),
+				Config: testAccReadReplicaInstance_withEpsId(name, srcEPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &replica),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", srcEPS),
 				),
 			},
 			{
-				Config: testAccReadReplicaInstance_withEpsId(name, dbPwd, destEPS),
+				Config: testAccReadReplicaInstance_withEpsId(name, destEPS),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &replica),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", destEPS),
@@ -127,7 +120,7 @@ func TestAccReadReplicaInstance_withEpsId(t *testing.T) {
 	})
 }
 
-func testAccReadReplicaInstance_basic(name, dbPwd string) string {
+func testAccReadReplicaInstance_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -147,7 +140,6 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
   primary_instance_id = huaweicloud_rds_instance.test.id
   availability_zone   = data.huaweicloud_availability_zones.test.names[0]
   security_group_id   = data.huaweicloud_networking_secgroup.test.id
-  fixed_ip            = "192.168.0.210"
   ssl_enable          = true
 
   db {
@@ -171,10 +163,10 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
     foo = "bar"
   }
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd), name)
+`, testAccRdsInstance_mysql_step1(name), name)
 }
 
-func testAccReadReplicaInstance_update(name, updateName, dbPwd string) string {
+func testAccReadReplicaInstance_update(name, updateName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -194,7 +186,6 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
   primary_instance_id = huaweicloud_rds_instance.test.id
   availability_zone   = data.huaweicloud_availability_zones.test.names[0]
   security_group_id   = data.huaweicloud_networking_secgroup.test.id
-  fixed_ip            = "192.168.0.220"
   ssl_enable          = false
 
   db {
@@ -218,10 +209,10 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
     foo_update = "bar_update"
   }
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd), updateName)
+`, testAccRdsInstance_mysql_step1(name), updateName)
 }
 
-func testAccReadReplicaInstance_withEpsId(name, dbPwd, epsId string) string {
+func testAccReadReplicaInstance_withEpsId(name, epsId string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -248,5 +239,5 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
     trigger_threshold = 10
   }
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd), name, epsId)
+`, testAccRdsInstance_mysql_step1(name), name, epsId)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sql_audit_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sql_audit_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -60,8 +59,6 @@ func TestAccSQLAudit_basic(t *testing.T) {
 
 	name := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_rds_sql_audit.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
-		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -75,7 +72,7 @@ func TestAccSQLAudit_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testSQLAudit_basic(name, dbPwd),
+				Config: testSQLAudit_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -85,7 +82,7 @@ func TestAccSQLAudit_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testSQLAudit_basic_update(name, dbPwd),
+				Config: testSQLAudit_basic_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -103,7 +100,7 @@ func TestAccSQLAudit_basic(t *testing.T) {
 	})
 }
 
-func testSQLAudit_basic(name, dbPwd string) string {
+func testSQLAudit_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -117,10 +114,10 @@ resource "huaweicloud_rds_sql_audit" "test" {
     "PREPARED_STATEMENT"
   ]
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd))
+`, testAccRdsInstance_mysql_step1(name))
 }
 
-func testSQLAudit_basic_update(name, dbPwd string) string {
+func testSQLAudit_basic_update(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -135,5 +132,5 @@ resource "huaweicloud_rds_sql_audit" "test" {
     "BEGIN/COMMIT/ROLLBACK"
   ]
 }
-`, testAccRdsInstance_mysql_step1(name, dbPwd))
+`, testAccRdsInstance_mysql_step1(name))
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sqlserver_account_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sqlserver_account_test.go
@@ -124,5 +124,5 @@ resource "huaweicloud_rds_sqlserver_account" "test" {
   name        = "%[2]s"
   password    = "%[3]s"
 }
-`, testAccRdsInstance_sqlserver(name, password), name, password)
+`, testAccRdsInstance_sqlserver(name), name, password)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sqlserver_database_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_sqlserver_database_test.go
@@ -113,5 +113,5 @@ resource "huaweicloud_rds_sqlserver_database" "test" {
   instance_id = huaweicloud_rds_instance.test.id
   name        = "%s"
 }
-`, testAccRdsInstance_sqlserver(name, "Test@123456789"), name)
+`, testAccRdsInstance_sqlserver(name), name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds tests
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds tests
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlAccounts_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlAccounts_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlAccounts_basic
=== PAUSE TestAccMysqlAccounts_basic
=== CONT  TestAccMysqlAccounts_basic
--- PASS: TestAccMysqlAccounts_basic (645.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       645.420s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlDatabasePrivileges_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlDatabasePrivileges_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlDatabasePrivileges_basic
=== PAUSE TestAccMysqlDatabasePrivileges_basic
=== CONT  TestAccMysqlDatabasePrivileges_basic
--- PASS: TestAccMysqlDatabasePrivileges_basic (709.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       709.889s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlDatabases_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlDatabases_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlDatabases_basic
=== PAUSE TestAccMysqlDatabases_basic
=== CONT  TestAccMysqlDatabases_basic
--- PASS: TestAccMysqlDatabases_basic (649.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       649.423s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlAccount_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlAccount_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlAccount_basic

--- PASS: TestAccMysqlAccount_basic (674.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       674.932s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsDatabasePrivilege_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsDatabasePrivilege_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsDatabasePrivilege_basic
=== PAUSE TestAccRdsDatabasePrivilege_basic
=== CONT  TestAccRdsDatabasePrivilege_basic
--- PASS: TestAccRdsDatabasePrivilege_basic (718.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       718.423s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlDatabase_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlDatabase_basic
=== PAUSE TestAccMysqlDatabase_basic
=== CONT  TestAccMysqlDatabase_basic
--- PASS: TestAccMysqlDatabase_basic (602.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       602.627s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgAccount_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgAccount_basic -timeout 360m -parallel 4
=== RUN   TestAccPgAccount_basic
=== PAUSE TestAccPgAccount_basic
=== CONT  TestAccPgAccount_basic
--- PASS: TestAccPgAccount_basic (505.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       505.314s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccSQLAudit_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccSQLAudit_basic -timeout 360m -parallel 4
=== RUN   TestAccSQLAudit_basic
=== PAUSE TestAccSQLAudit_basic
=== CONT  TestAccSQLAudit_basic
--- PASS: TestAccSQLAudit_basic (674.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       674.790s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccSQLServerDatabase_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccSQLServerDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccSQLServerDatabase_basic
=== PAUSE TestAccSQLServerDatabase_basic
=== CONT  TestAccSQLServerDatabase_basic
--- PASS: TestAccSQLServerDatabase_basic (1328.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1328.891s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccSQLServerAccount_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccSQLServerAccount_basic -timeout 360m -parallel 4
=== RUN   TestAccSQLServerAccount_basic
=== PAUSE TestAccSQLServerAccount_basic
=== CONT  TestAccSQLServerAccount_basic
--- PASS: TestAccSQLServerAccount_basic (1426.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1426.718s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccReadReplicaInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccReadReplicaInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccReadReplicaInstance_basic
=== PAUSE TestAccReadReplicaInstance_basic
=== CONT  TestAccReadReplicaInstance_basic
--- PASS: TestAccReadReplicaInstance_basic (2210.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2210.529s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsConfiguration_basic
=== PAUSE TestAccRdsConfiguration_basic
=== CONT  TestAccRdsConfiguration_basic

--- PASS: TestAccRdsConfiguration_basic (18.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       18.861s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgDatabase_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccPgDatabase_basic
=== PAUSE TestAccPgDatabase_basic
=== CONT  TestAccPgDatabase_basic
--- PASS: TestAccPgDatabase_basic (515.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       515.489s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgPlugin_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgPlugin_basic -timeout 360m -parallel 4
=== RUN   TestAccPgPlugin_basic
=== PAUSE TestAccPgPlugin_basic
=== CONT  TestAccPgPlugin_basic
--- PASS: TestAccPgPlugin_basic (523.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       523.994s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgHba_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgHba_basic -timeout 360m -parallel 4
=== RUN   TestAccPgHba_basic
=== PAUSE TestAccPgHba_basic
=== CONT  TestAccPgHba_basic
--- PASS: TestAccPgHba_basic (504.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       504.770s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=9
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 9
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_ha
--- PASS: TestAccRdsInstance_mariadb (470.37s)
--- PASS: TestAccRdsInstance_ha (535.60s)
--- PASS: TestAccRdsInstance_basic (591.89s)
--- PASS: TestAccRdsInstance_prePaid (1197.02s)
--- PASS: TestAccRdsInstance_restore_pg (1420.06s)
--- PASS: TestAccRdsInstance_restore_mysql (1482.35s)
--- PASS: TestAccRdsInstance_mysql (1526.32s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2183.09s)
--- PASS: TestAccRdsInstance_sqlserver (2832.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       4038.904s
```
