### PR TITLE
feat(DEW): csms secret resource support secret_binary and expire_time parameter

### DIFF
--- a/docs/resources/csms_secret.md
+++ b/docs/resources/csms_secret.md
@@ -29,6 +29,17 @@ resource "huaweicloud_csms_secret" "test2" {
 }
 ```
 
+### Encrypt String Binary
+
+```hcl
+variable "secret_binary" {}
+
+resource "huaweicloud_csms_secret" "test3" {
+  name          = "test_binary"
+  secret_binary = var.secret_binary
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -39,9 +50,17 @@ The following arguments are supported:
 * `name` - (Required, String, ForceNew) The secret name. The maximum length is 64 characters.
   Only digits, letters, underscores(_), hyphens(-) and dots(.) are allowed.
 
-* `secret_text` - (Required, String) The plaintext of a secret in text format. The maximum size is 32 KB.
+* `secret_text` - (Optional, String) Specifies the plaintext of a secret in text format. The maximum size is 32 KB.
 
-  -> **NOTE:** The `secret_text` is sensitive and in the state file we store its hash.
+* `secret_binary` - (Optional, String) Specifies the plaintext of a binary secret in text format encoded using Base64.
+  The maximum size is 32 KB.
+
+-> **NOTE:** Exactly one of `secret_text` and `secret_binary` should be specified.
+  The `secret_text` and `secret_binary` are sensitive and in the state file we store its hash.
+
+* `expire_time` - (Optional, Int) Specifies the expiration time of a secret, `expire_time` can only be edited
+  when `status` is **ENABLED**. The time is in the format of timestamp, that is, the offset milliseconds
+  from 1970-01-01 00:00:00 UTC to the specified time. The time must be greater than the current time.
 
 * `kms_key_id` - (Optional, String) The ID of the KMS key used to encrypt secrets.
   If this parameter is not specified when creating the secret, the default master key csms/default will be used.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240313093029-c71bd2388864
+	github.com/chnsz/golangsdk v0.0.0-20240315031130-07e73fc4f0a1
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240313093029-c71bd2388864 h1:WoOtrkEZ8GlCFiTqySTbcsFarxNaQ1jkXG+hPTis9xU=
-github.com/chnsz/golangsdk v0.0.0-20240313093029-c71bd2388864/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240315031130-07e73fc4f0a1 h1:iArF+W5nR/K/paJiUexg3ekBpdfQqFtReZJ0da6i7RI=
+github.com/chnsz/golangsdk v0.0.0-20240315031130-07e73fc4f0a1/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_secret_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_csms_secret_test.go
@@ -110,3 +110,95 @@ resource "huaweicloud_csms_secret" "test" {
 }
 `, name)
 }
+
+func TestAccDewCsmsSecret_SecretBinaryAndExpireTime(t *testing.T) {
+	var secret secrets.Secret
+	name := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_csms_secret.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&secret,
+		geCsmsSecretFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDewCsmsSecret_SecretBinary(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"secret_binary",
+						utils.HashAndHexEncode(`1010`),
+					),
+				),
+			},
+			{
+				Config: testAccDewCsmsSecret_updateSecretBinary(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"secret_binary",
+						utils.HashAndHexEncode(`0101`),
+					),
+					resource.TestCheckResourceAttr(resourceName, "expire_time", "2999886177000"),
+				),
+			},
+			{
+				Config: testAccDewCsmsSecret_updateExpireTime(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(
+						resourceName,
+						"secret_binary",
+						utils.HashAndHexEncode(`0101`),
+					),
+					resource.TestCheckResourceAttr(resourceName, "expire_time", "3999886177000"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDewCsmsSecret_SecretBinary(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_csms_secret" "test" {
+  name          = "%s"
+  secret_binary = "1010"
+}
+`, name)
+}
+
+func testAccDewCsmsSecret_updateSecretBinary(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_csms_secret" "test" {
+  name          = "%s"
+  secret_binary = "0101"
+  expire_time   = 2999886177000
+}
+`, name)
+}
+
+func testAccDewCsmsSecret_updateExpireTime(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_csms_secret" "test" {
+  name          = "%s"
+  secret_binary = "0101"
+  expire_time   = 3999886177000
+}
+`, name)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/csms/v1/secrets/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/csms/v1/secrets/results.go
@@ -28,4 +28,5 @@ type VersionMetadata struct {
 	KmsKeyID      string   `json:"kms_key_id"`
 	SecretName    string   `json:"secret_name"`
 	VersionStages []string `json:"version_stages"`
+	ExpireTime    int      `json:"expire_time"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240313093029-c71bd2388864
+# github.com/chnsz/golangsdk v0.0.0-20240315031130-07e73fc4f0a1
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
csms secret resource support secret_binary and expire_time parameter
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Exactly one of `secret_text` and `secret_binary` should be specified.
2. The expire_time can be update only when the secret key state is ENABLED.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dew TESTARGS='-run TestAccDewCsmsSecret_SecretBinaryAndExpireTime'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDewCsmsSecret_SecretBinaryAndExpireTime -timeout 360m -parallel 4
=== RUN   TestAccDewCsmsSecret_SecretBinaryAndExpireTime
=== PAUSE TestAccDewCsmsSecret_SecretBinaryAndExpireTime
=== CONT  TestAccDewCsmsSecret_SecretBinaryAndExpireTime
--- PASS: TestAccDewCsmsSecret_SecretBinaryAndExpireTime (129.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       129.402s

 make testacc TEST=./huaweicloud/services/acceptance/dew TESTARGS='-run TestAccDewCsmsSecret_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDewCsmsSecret_basic -timeout 360m -parallel 4
=== RUN   TestAccDewCsmsSecret_basic
=== PAUSE TestAccDewCsmsSecret_basic
=== CONT  TestAccDewCsmsSecret_basic
--- PASS: TestAccDewCsmsSecret_basic (61.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       61.565s
```
