### PR TITLE
feat(iotda): add products datasource support

### DIFF
--- a/docs/data-sources/iotda_products.md
+++ b/docs/data-sources/iotda_products.md
@@ -1,0 +1,86 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_products
+
+Use this data source to get the list of IoTDA products within HuaweiCloud.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "product_id" {}
+
+data "huaweicloud_iotda_products" "test" {
+  product_id = var.product_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the products.
+  If omitted, the provider-level region will be used.
+
+* `product_id` - (Optional, String) Specifies the ID of the product to be queried.
+
+* `product_name` - (Optional, String) Specifies the name of the product to be queried.
+
+* `space_id` - (Optional, String) Specifies the space ID of the products to be queried.
+  If omitted, query all products under the current instance.
+
+* `space_name` - (Optional, String) Specifies the space name of the products to be queried.
+
+* `device_type` - (Optional, String) Specifies the device type of the products to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `products` - All products that match the filter parameters.
+  The [products](#iotda_products) structure is documented below.
+
+<a name="iotda_products"></a>
+The `products` block supports:
+
+* `space_id` - The space ID to which the product belongs.
+
+* `space_name` - The space name to which the product belongs.
+
+* `id` - The product ID.
+
+* `name` - The product name.
+
+* `device_type` - The device type of the product.
+
+* `protocol_type` - The protocol type used by devices under the product.
+  The value can be **MQTT**, **CoAP**, **HTTP**, **HTTPS**, **Modbus**, **ONVIF**, **OPC-UA**, **OPC-DA**, or **Other**.
+
+* `data_type` - The format of data reported by devices under the product.
+  The value can be **json** or **binary**.
+
+* `manufacturer_name` - The manufacturer name.
+
+* `industry` - The industry to which the devices under the product belongs.
+
+* `description` - The description of the product.
+
+* `created_at` - The creation time of the product. The format is **yyyyMMdd'T'HHmmss'Z**. e.g. **20190528T153000Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -571,6 +571,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_data_key": dew.DataSourceKmsDataKeyV1(),
 			"huaweicloud_kps_keypairs": dew.DataSourceKeypairs(),
 
+			"huaweicloud_iotda_products": iotda.DataSourceProducts(),
+
 			"huaweicloud_koogallery_assets": koogallery.DataSourceKooGalleryAssets(),
 
 			"huaweicloud_lb_listeners":    lb.DataSourceListeners(),

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_products_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_products_test.go
@@ -1,0 +1,218 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceProducts_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_products.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceProducts_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.space_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.space_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.device_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.data_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.manufacturer_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.industry"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.created_at"),
+
+					resource.TestCheckOutput("is_product_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_product_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_space_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_space_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_device_type_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceProducts_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_products.test_derived"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceProducts_derived(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.space_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.space_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.device_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.data_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.manufacturer_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.industry"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "products.0.created_at"),
+
+					resource.TestCheckOutput("is_product_id_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceProducts_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_iotda_products" "test" {
+  depends_on = [huaweicloud_iotda_product.test]
+}
+
+# Filter using product ID.
+locals {
+  product_id = data.huaweicloud_iotda_products.test.products[0].id
+}
+
+data "huaweicloud_iotda_products" "product_id_filter" {
+  product_id = local.product_id
+}
+
+output "is_product_id_filter_useful" {
+  value = length(data.huaweicloud_iotda_products.product_id_filter.products) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_products.product_id_filter.products[*].id : v == local.product_id]
+  )
+}
+
+# Filter using product name.
+locals {
+  product_name = data.huaweicloud_iotda_products.test.products[0].name
+}
+
+data "huaweicloud_iotda_products" "product_name_filter" {
+  product_name = local.product_name
+}
+
+output "is_product_name_filter_useful" {
+  value = length(data.huaweicloud_iotda_products.product_name_filter.products) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_products.product_name_filter.products[*].name : v == local.product_name]
+  )
+}
+
+# Filter using space ID.
+locals {
+  space_id = data.huaweicloud_iotda_products.test.products[0].space_id
+}
+
+data "huaweicloud_iotda_products" "space_id_filter" {
+  space_id = local.space_id
+}
+
+output "is_space_id_filter_useful" {
+  value = length(data.huaweicloud_iotda_products.space_id_filter.products) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_products.space_id_filter.products[*].space_id : v == local.space_id]
+  )
+}
+
+# Filter using space name.
+locals {
+  space_name = data.huaweicloud_iotda_products.test.products[0].space_name
+}
+
+data "huaweicloud_iotda_products" "space_name_filter" {
+  space_name = local.space_name
+}
+
+output "is_space_name_filter_useful" {
+  value = length(data.huaweicloud_iotda_products.space_name_filter.products) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_products.space_name_filter.products[*].space_name : v == local.space_name]
+  )
+}
+
+# Filter using device type.
+locals {
+  device_type = data.huaweicloud_iotda_products.test.products[0].device_type
+}
+
+data "huaweicloud_iotda_products" "device_type_filter" {
+  device_type = local.device_type
+}
+
+output "is_device_type_filter_useful" {
+  value = length(data.huaweicloud_iotda_products.device_type_filter.products) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_products.device_type_filter.products[*].device_type : v == local.device_type]
+  )
+}
+
+# Filter using non existent product name.
+data "huaweicloud_iotda_products" "not_found" {
+  product_name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_products.not_found.products) == 0
+}
+`, testProduct_basic(name))
+}
+
+func testAccDataSourceProducts_derived() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+data "huaweicloud_iotda_products" "test_derived" {
+  depends_on = [huaweicloud_iotda_product.test]
+}
+
+# Filter using product ID.
+locals {
+  product_id = data.huaweicloud_iotda_products.test_derived.products[0].id
+}
+
+data "huaweicloud_iotda_products" "product_id_filter" {
+  product_id = local.product_id
+}
+
+output "is_product_id_filter_useful" {
+  value = length(data.huaweicloud_iotda_products.product_id_filter.products) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_products.product_id_filter.products[*].id : v == local.product_id]
+  )
+}
+
+# Filter using non existent product name.
+data "huaweicloud_iotda_products" "not_found" {
+  product_name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_products.not_found.products) == 0
+}
+`, testProduct_basic(name), buildIoTDAEndpoint())
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_products.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_products.go
@@ -1,0 +1,206 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/products
+func DataSourceProducts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceProductsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"product_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"space_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"device_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"products": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"space_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"space_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"device_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protocol_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"manufacturer_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"industry": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceProductsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := withDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allProducts []model.ProductSummary
+		limit       = int32(50)
+		offset      int32
+	)
+
+	for {
+		listOpts := model.ListProductsRequest{
+			AppId:       utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+			ProductName: utils.StringIgnoreEmpty(d.Get("product_name").(string)),
+			Limit:       utils.Int32(limit),
+			Offset:      &offset,
+		}
+
+		listResp, listErr := client.ListProducts(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error querying IoTDA products: %s", listErr)
+		}
+
+		if len(*listResp.Products) == 0 {
+			break
+		}
+		allProducts = append(allProducts, *listResp.Products...)
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuId)
+
+	targetProducts := filterListProducts(allProducts, d)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("products", flattenProducts(targetProducts)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterListProducts(products []model.ProductSummary, d *schema.ResourceData) []model.ProductSummary {
+	if len(products) == 0 {
+		return nil
+	}
+
+	rst := make([]model.ProductSummary, 0, len(products))
+	for _, v := range products {
+		if productID, ok := d.GetOk("product_id"); ok &&
+			fmt.Sprint(productID) != utils.StringValue(v.ProductId) {
+			continue
+		}
+
+		if spaceName, ok := d.GetOk("space_name"); ok &&
+			fmt.Sprint(spaceName) != utils.StringValue(v.AppName) {
+			continue
+		}
+
+		if deviceType, ok := d.GetOk("device_type"); ok &&
+			fmt.Sprint(deviceType) != utils.StringValue(v.DeviceType) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func flattenProducts(products []model.ProductSummary) []interface{} {
+	if len(products) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(products))
+	for _, v := range products {
+		rst = append(rst, map[string]interface{}{
+			"space_id":          v.AppId,
+			"space_name":        v.AppName,
+			"id":                v.ProductId,
+			"name":              v.Name,
+			"device_type":       v.DeviceType,
+			"protocol_type":     v.ProtocolType,
+			"data_type":         v.DataFormat,
+			"manufacturer_name": v.ManufacturerName,
+			"industry":          v.Industry,
+			"description":       v.Description,
+			"created_at":        v.CreateTime,
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add products datasource support
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add products datasource support
2. add test and document for derived auth
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

## Basic
```
$ export HW_REGION_NAME=cn-north-4 
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceProducts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceProducts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceProducts_basic
=== PAUSE TestAccDataSourceProducts_basic
=== CONT  TestAccDataSourceProducts_basic
--- PASS: TestAccDataSourceProducts_basic (7.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     7.836s

```

## Skip
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceProducts_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceProducts_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceProducts_derived
=== PAUSE TestAccDataSourceProducts_derived
=== CONT  TestAccDataSourceProducts_derived
    acceptance.go:1359: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccDataSourceProducts_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.042s

```

## Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceProducts_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceProducts_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceProducts_derived
=== PAUSE TestAccDataSourceProducts_derived
=== CONT  TestAccDataSourceProducts_derived
--- PASS: TestAccDataSourceProducts_derived (17.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     17.119s

```