### PR TITLE
chore(dws): request ok codes using the default ok codes

### DIFF
--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_flavors.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_flavors.go
@@ -168,9 +168,6 @@ func resourceDwsFlavorsRead(_ context.Context, d *schema.ResourceData, meta inte
 	listFlavorsOpt := golangsdk.RequestOpts{
 		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	listFlavorsResp, err := listFlavorsClient.Request("GET", listFlavorsPath, &listFlavorsOpt)
 

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_alarm_subscription.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_alarm_subscription.go
@@ -107,9 +107,6 @@ func resourceDwsAlarmSubsCreate(ctx context.Context, d *schema.ResourceData, met
 	createDwsAlarmSubsOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	createDwsAlarmSubsOpt.JSONBody = utils.RemoveNil(buildCreateDwsAlarmSubsBodyParams(d))
 	createDwsAlarmSubsResp, err := createDwsAlarmSubsClient.Request("POST", createDwsAlarmSubsPath, &createDwsAlarmSubsOpt)
@@ -235,9 +232,6 @@ func resourceDwsAlarmSubsUpdate(ctx context.Context, d *schema.ResourceData, met
 		updateDwsAlarmSubsOpt := golangsdk.RequestOpts{
 			MoreHeaders:      requestOpts.MoreHeaders,
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
 		}
 		updateDwsAlarmSubsOpt.JSONBody = utils.RemoveNil(buildUpdateDwsAlarmSubsBodyParams(d))
 		_, err = updateDwsAlarmSubsClient.Request("PUT", updateDwsAlarmSubsPath, &updateDwsAlarmSubsOpt)

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
@@ -462,10 +462,7 @@ func resourceDwsClusterCreateV2(ctx context.Context, d *schema.ResourceData, met
 
 	createDwsClusterOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: requestOpts.MoreHeaders,
+		MoreHeaders:      requestOpts.MoreHeaders,
 	}
 
 	createDwsClusterOpt.JSONBody = utils.RemoveNil(buildCreateDwsClusterBodyParams(d, cfg))
@@ -535,10 +532,7 @@ func resourceDwsClusterCreateV1(ctx context.Context, d *schema.ResourceData, met
 
 	createDwsClusterOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: requestOpts.MoreHeaders,
+		MoreHeaders:      requestOpts.MoreHeaders,
 	}
 
 	createDwsClusterOpt.JSONBody = utils.RemoveNil(buildCreateDwsClusterBodyParamsV1(d, cfg))
@@ -682,10 +676,7 @@ func clusterWaitingForAvailable(ctx context.Context, d *schema.ResourceData, met
 
 			clusterWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-				MoreHeaders: requestOpts.MoreHeaders,
+				MoreHeaders:      requestOpts.MoreHeaders,
 			}
 
 			clusterWaitingResp, err := clusterWaitingClient.Request("GET", clusterWaitingPath,
@@ -760,10 +751,7 @@ func resourceDwsClusterRead(_ context.Context, d *schema.ResourceData, meta inte
 
 	getDwsClusterOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: requestOpts.MoreHeaders,
+		MoreHeaders:      requestOpts.MoreHeaders,
 	}
 
 	getDwsClusterResp, err := getDwsClusterClient.Request("GET", getDwsClusterPath, &getDwsClusterOpt)
@@ -929,10 +917,7 @@ func resourceDwsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		expandInstanceStorageOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
-			MoreHeaders: requestOpts.MoreHeaders,
+			MoreHeaders:      requestOpts.MoreHeaders,
 		}
 
 		expandInstanceStorageOpt.JSONBody = utils.RemoveNil(buildExpandInstanceStorageBodyParams(d))
@@ -961,10 +946,7 @@ func resourceDwsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		resetPasswordOfClusterOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
-			MoreHeaders: requestOpts.MoreHeaders,
+			MoreHeaders:      requestOpts.MoreHeaders,
 		}
 
 		resetPasswordOfClusterOpt.JSONBody = utils.RemoveNil(buildResetPasswordOfClusterBodyParams(d))
@@ -994,10 +976,7 @@ func resourceDwsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		scaleOutClusterOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
-			MoreHeaders: requestOpts.MoreHeaders,
+			MoreHeaders:      requestOpts.MoreHeaders,
 		}
 
 		scaleOutClusterOpt.JSONBody = utils.RemoveNil(buildScaleOutClusterBodyParams(d))
@@ -1119,10 +1098,7 @@ func resourceDwsClusterDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 	deleteDwsClusterOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200, 202,
-		},
-		MoreHeaders: requestOpts.MoreHeaders,
+		MoreHeaders:      requestOpts.MoreHeaders,
 	}
 
 	deleteDwsClusterOpt.JSONBody = utils.RemoveNil(buildDeleteDwsClusterBodyParams(d))
@@ -1168,10 +1144,7 @@ func deleteClusterWaitingForCompleted(ctx context.Context, d *schema.ResourceDat
 
 			deleteDwsClusterWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-				MoreHeaders: requestOpts.MoreHeaders,
+				MoreHeaders:      requestOpts.MoreHeaders,
 			}
 
 			deleteDwsClusterWaitingResp, err := deleteDwsClusterWaitingClient.Request("GET", deleteDwsClusterWaitingPath, &deleteDwsClusterWaitingOpt)
@@ -1260,10 +1233,7 @@ func addClusterTags(client *golangsdk.ServiceClient, clusterId string, rawTags [
 
 	addTagsOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: requestOpts.MoreHeaders,
+		MoreHeaders:      requestOpts.MoreHeaders,
 	}
 	addTagsOpt.JSONBody = map[string]interface{}{
 		"tags": rawTags,
@@ -1287,10 +1257,7 @@ func deleteClusterTags(client *golangsdk.ServiceClient, clusterId string, rawTag
 
 	deleteTagsOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: requestOpts.MoreHeaders,
+		MoreHeaders:      requestOpts.MoreHeaders,
 	}
 
 	deleteTagsOpt.JSONBody = map[string]interface{}{

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_event_subscription.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_event_subscription.go
@@ -125,9 +125,6 @@ func resourceDwsEventSubsCreate(ctx context.Context, d *schema.ResourceData, met
 	createDwsEventSubsOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	createDwsEventSubsOpt.JSONBody = utils.RemoveNil(buildCreateDwsEventSubsBodyParams(d))
 	createDwsEventSubsResp, err := createDwsEventSubsClient.Request("POST", createDwsEventSubsPath, &createDwsEventSubsOpt)
@@ -262,9 +259,6 @@ func resourceDwsEventSubsUpdate(ctx context.Context, d *schema.ResourceData, met
 		updateDwsEventSubsOpt := golangsdk.RequestOpts{
 			MoreHeaders:      requestOpts.MoreHeaders,
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
 		}
 		updateDwsEventSubsOpt.JSONBody = utils.RemoveNil(buildUpdateDwsEventSubsBodyParams(d))
 		_, err = updateDwsEventSubsClient.Request("PUT", updateDwsEventSubsPath, &updateDwsEventSubsOpt)
@@ -311,9 +305,6 @@ func resourceDwsEventSubsDelete(_ context.Context, d *schema.ResourceData, meta 
 	deleteDwsEventSubsOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	_, err = deleteDwsEventSubsClient.Request("DELETE", deleteDwsEventSubsPath, &deleteDwsEventSubsOpt)
 	if err != nil {

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_ext_data_source.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_ext_data_source.go
@@ -151,9 +151,6 @@ func resourceDwsExtDataSourceCreate(ctx context.Context, d *schema.ResourceData,
 	createDwsExtDataSourceOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	createDwsExtDataSourceOpt.JSONBody = utils.RemoveNil(buildCreateDwsExtDataSourceBodyParams(d))
 	createDwsExtDataSourceResp, err := createDwsExtDataSourceClient.Request("POST", createDwsExtDataSourcePath,
@@ -252,9 +249,6 @@ func GetExtDataSource(cfg *config.Config, region string, d *schema.ResourceData,
 	getDwsExtDataSourceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      requestOpts.MoreHeaders,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getDwsExtDataSourceResp, err := getDwsExtDataSourceClient.Request("GET", getDwsExtDataSourcePath, &getDwsExtDataSourceOpt)
 
@@ -301,9 +295,6 @@ func resourceDwsExtDataSourceUpdate(ctx context.Context, d *schema.ResourceData,
 		updateDwsExtDataSourceOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
 			MoreHeaders:      requestOpts.MoreHeaders,
-			OkCodes: []int{
-				200,
-			},
 		}
 		updateDwsExtDataSourceOpt.JSONBody = utils.RemoveNil(buildUpdateDwsExtDataSourceBodyParams(d))
 		updateDwsExtDataSourceResp, err := updateDwsExtDataSourceClient.Request("PUT", updateDwsExtDataSourcePath, &updateDwsExtDataSourceOpt)
@@ -362,9 +353,6 @@ func resourceDwsExtDataSourceDelete(ctx context.Context, d *schema.ResourceData,
 	deleteDwsExtDataSourceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      requestOpts.MoreHeaders,
-		OkCodes: []int{
-			200,
-		},
 	}
 	deleteDwsExtDataSourceResp, err := deleteDwsExtDataSourceClient.Request("DELETE", deleteDwsExtDataSourcePath, &deleteDwsExtDataSourceOpt)
 	if err != nil {
@@ -449,9 +437,6 @@ func extDataSourceWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 			extDataSourceWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
 				MoreHeaders:      requestOpts.MoreHeaders,
-				OkCodes: []int{
-					200,
-				},
 			}
 			extDataSourceWaitingResp, err := extDataSourceWaitingClient.Request("GET", extDataSourceWaitingPath, &extDataSourceWaitingOpt)
 			if err != nil {

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot.go
@@ -115,9 +115,6 @@ func resourceDwsSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta
 	createDwsSnapshotOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	createDwsSnapshotOpt.JSONBody = utils.RemoveNil(buildCreateDwsSnapshotBodyParams(d))
 	createDwsSnapshotResp, err := createDwsSnapshotClient.Request("POST", createDwsSnapshotPath, &createDwsSnapshotOpt)
@@ -178,9 +175,6 @@ func createDwsSnapshotWaitingForStateCompleted(ctx context.Context, d *schema.Re
 			createDwsSnapshotWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
 				MoreHeaders:      requestOpts.MoreHeaders,
-				OkCodes: []int{
-					200,
-				},
 			}
 			createDwsSnapshotWaitingResp, err := createDwsSnapshotWaitingClient.Request("GET",
 				createDwsSnapshotWaitingPath, &createDwsSnapshotWaitingOpt)
@@ -246,9 +240,6 @@ func resourceDwsSnapshotRead(_ context.Context, d *schema.ResourceData, meta int
 	getDwsSnapshotOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      requestOpts.MoreHeaders,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getDwsSnapshotResp, err := getDwsSnapshotClient.Request("GET", getDwsSnapshotPath, &getDwsSnapshotOpt)
 
@@ -317,9 +308,6 @@ func resourceDwsSnapshotDelete(_ context.Context, d *schema.ResourceData, meta i
 	deleteDwsSnapshotOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	_, err = deleteDwsSnapshotClient.Request("DELETE", deleteDwsSnapshotPath, &deleteDwsSnapshotOpt)
 	if err != nil {

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot_policy.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot_policy.go
@@ -89,9 +89,6 @@ func resourceDwsSnapshotPolicyCreate(ctx context.Context, d *schema.ResourceData
 	createDwsSnapshotPolicyOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	createDwsSnapshotPolicyOpt.JSONBody = utils.RemoveNil(buildCreateDwsSnapshotPolicyBodyParams(d))
 	createDwsSnapshotPolicyResp, err := createDwsSnapshotPolicyClient.Request("PUT", createDwsSnapshotPolicyPath, &createDwsSnapshotPolicyOpt)
@@ -121,9 +118,6 @@ func resourceDwsSnapshotPolicyCreate(ctx context.Context, d *schema.ResourceData
 	getDwsSnapshotPolicyOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      requestOpts.MoreHeaders,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getDwsSnapshotPolicyResp, err := getDwsSnapshotPolicyClient.Request("GET", getDwsSnapshotPolicyPath, &getDwsSnapshotPolicyOpt)
 	if err != nil {
@@ -183,9 +177,6 @@ func resourceDwsSnapshotPolicyRead(_ context.Context, d *schema.ResourceData, me
 	getDwsSnapshotPolicyOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      requestOpts.MoreHeaders,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getDwsSnapshotPolicyResp, err := getDwsSnapshotPolicyClient.Request("GET", getDwsSnapshotPolicyPath, &getDwsSnapshotPolicyOpt)
 
@@ -237,9 +228,6 @@ func resourceDwsSnapshotPolicyDelete(_ context.Context, d *schema.ResourceData, 
 	deleteDwsSnapshotPolicyOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      requestOpts.MoreHeaders,
-		OkCodes: []int{
-			200,
-		},
 	}
 	_, err = deleteDwsSnapshotPolicyClient.Request("DELETE", deleteDwsSnapshotPolicyPath, &deleteDwsSnapshotPolicyOpt)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove the `OkCodes` definitions for all DWS resources.
We prefer to use the default ok codes to match the response code.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. request ok codes using the default ok codes
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dws' TESTARGS='-run=TestAccDwsSnapshot_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run=TestAccDwsSnapshot_basic -timeout 360m -parallel 4
=== RUN   TestAccDwsSnapshot_basic
=== PAUSE TestAccDwsSnapshot_basic
=== CONT  TestAccDwsSnapshot_basic
--- PASS: TestAccDwsSnapshot_basic (1524.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1524.640s
```
