### PR TITLE
feat(iotda): add spaces datasource support

### DIFF
--- a/docs/data-sources/iotda_spaces.md
+++ b/docs/data-sources/iotda_spaces.md
@@ -1,0 +1,69 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_spaces
+
+Use this data source to get the list of IoTDA spaces within HuaweiCloud.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "space_id" {}
+
+data "huaweicloud_iotda_spaces" "test" {
+  space_id = var.space_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the spaces.
+  If omitted, the provider-level region will be used.
+
+* `space_id` - (Optional, String) Specifies the ID of the space to be queried.
+
+* `space_name` - (Optional, String) Specifies the name of the space to be queried.
+
+* `is_default` - (Optional, String) Specifies whether to query the default space.
+  The valid values are as follows:
+  + **true**: Query the default space.
+  + **false**: Query all non default spaces.
+  If omitted, query all spaces under the current instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `spaces` - All spaces that match the filter parameters.
+  The [spaces](#iotda_spaces) structure is documented below.
+
+<a name="iotda_spaces"></a>
+The `spaces` block supports:
+
+* `id` - The space ID.
+
+* `name` - The space name.
+
+* `created_at` - The creation time of the space. The format is **yyyyMMdd'T'HHmmss'Z**. e.g. **20190528T153000Z**.
+
+* `is_default` - Is it the default space.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -572,6 +572,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_data_key": dew.DataSourceKmsDataKeyV1(),
 			"huaweicloud_kps_keypairs": dew.DataSourceKeypairs(),
 
+			"huaweicloud_iotda_spaces":   iotda.DataSourceSpaces(),
 			"huaweicloud_iotda_products": iotda.DataSourceProducts(),
 
 			"huaweicloud_koogallery_assets": koogallery.DataSourceKooGalleryAssets(),

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_spaces_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_spaces_test.go
@@ -1,0 +1,165 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceSpaces_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_spaces.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSpaces_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.0.is_default"),
+
+					resource.TestCheckOutput("is_space_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_space_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_default_true_filter_useful", "true"),
+					resource.TestCheckOutput("is_default_false_filter_useful", "true"),
+					resource.TestCheckOutput("is_default_empty_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSpaces_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_spaces.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSpaces_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spaces.0.is_default"),
+
+					resource.TestCheckOutput("is_space_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_space_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_default_true_filter_useful", "true"),
+					resource.TestCheckOutput("is_default_false_filter_useful", "true"),
+					resource.TestCheckOutput("is_default_empty_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSpaces_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_iotda_spaces" "test" {
+  depends_on = [huaweicloud_iotda_space.test]
+}
+
+# Filter using space ID.
+locals {
+  space_id = data.huaweicloud_iotda_spaces.test.spaces[0].id
+}
+
+data "huaweicloud_iotda_spaces" "space_id_filter" {
+  space_id = local.space_id
+}
+
+output "is_space_id_filter_useful" {
+  value = length(data.huaweicloud_iotda_spaces.space_id_filter.spaces) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_spaces.space_id_filter.spaces[*].id : v == local.space_id]
+  )
+}
+
+# Filter using space name.
+locals {
+  space_name = data.huaweicloud_iotda_spaces.test.spaces[0].name
+}
+
+data "huaweicloud_iotda_spaces" "space_name_filter" {
+  space_name = local.space_name
+}
+
+output "is_space_name_filter_useful" {
+  value = length(data.huaweicloud_iotda_spaces.space_name_filter.spaces) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_spaces.space_name_filter.spaces[*].name : v == local.space_name]
+  )
+}
+
+# Filter with is_default field set to true. There will definitely be a default space.
+data "huaweicloud_iotda_spaces" "is_default_true_filter" {
+  depends_on = [huaweicloud_iotda_space.test]
+
+  is_default = "true"
+}
+
+output "is_default_true_filter_useful" {
+  value = length(data.huaweicloud_iotda_spaces.is_default_true_filter.spaces) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_spaces.is_default_true_filter.spaces[*].is_default : v == true]
+  )
+}
+
+# Filter with is_default field set to false. Set to false to query non default spaces.
+data "huaweicloud_iotda_spaces" "is_default_false_filter" {
+  depends_on = [huaweicloud_iotda_space.test]
+
+  is_default = "false"
+}
+
+output "is_default_false_filter_useful" {
+  value = length(data.huaweicloud_iotda_spaces.is_default_false_filter.spaces) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_spaces.is_default_false_filter.spaces[*].is_default : v == false]
+  )
+}
+
+# Filter with is_default field is empty. Set to empty to query all spaces.
+data "huaweicloud_iotda_spaces" "is_default_empty_filter" {
+  depends_on = [huaweicloud_iotda_space.test]
+}
+
+output "is_default_empty_filter_useful" {
+  value = length(data.huaweicloud_iotda_spaces.is_default_empty_filter.spaces) > 1
+}
+
+# Filter using non existent space name.
+data "huaweicloud_iotda_spaces" "not_found" {
+  space_name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_spaces.not_found.spaces) == 0
+}
+`, testSpace_basic(name))
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_products.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_products.go
@@ -105,7 +105,7 @@ func DataSourceProducts() *schema.Resource {
 func dataSourceProductsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_spaces.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_spaces.go
@@ -1,0 +1,143 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/apps
+func DataSourceSpaces() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSpacesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"space_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_default": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"spaces": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_default": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSpacesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := WithDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	listOpts := &model.ShowApplicationsRequest{}
+	isDefault := d.Get("is_default").(string)
+	if isDefault == "true" || isDefault == "false" {
+		listOpts.DefaultApp = utils.StringToBool(isDefault)
+	}
+
+	listResp, listErr := client.ShowApplications(listOpts)
+	if listErr != nil {
+		return diag.Errorf("error querying IoTDA spaces: %s", listErr)
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuId)
+
+	targetSpaces := filterListSpaces(*listResp.Applications, d)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("spaces", flattenSpaces(targetSpaces)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterListSpaces(spaces []model.ApplicationDto, d *schema.ResourceData) []model.ApplicationDto {
+	if len(spaces) == 0 {
+		return nil
+	}
+
+	rst := make([]model.ApplicationDto, 0, len(spaces))
+	for _, v := range spaces {
+		if spaceID, ok := d.GetOk("space_id"); ok &&
+			fmt.Sprint(spaceID) != utils.StringValue(v.AppId) {
+			continue
+		}
+
+		if spaceName, ok := d.GetOk("space_name"); ok &&
+			fmt.Sprint(spaceName) != utils.StringValue(v.AppName) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func flattenSpaces(spaces []model.ApplicationDto) []interface{} {
+	if len(spaces) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(spaces))
+	for _, v := range spaces {
+		rst = append(rst, map[string]interface{}{
+			"id":         v.AppId,
+			"name":       v.AppName,
+			"created_at": v.CreateTime,
+			"is_default": v.DefaultApp,
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add spaces datasource support
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add spaces datasource support
2. add test and document for derived auth
3. fix using WithDerivedAuth method as public method in datasource products
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

## Basic
```
$ export HW_REGION_NAME=cn-north-4 
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceSpaces_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceSpaces_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSpaces_basic
=== PAUSE TestAccDataSourceSpaces_basic
=== CONT  TestAccDataSourceSpaces_basic
--- PASS: TestAccDataSourceSpaces_basic (7.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     7.158s

```

## Skip
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceSpaces_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceSpaces_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSpaces_derived
=== PAUSE TestAccDataSourceSpaces_derived
=== CONT  TestAccDataSourceSpaces_derived
    acceptance.go:1359: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccDataSourceSpaces_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.038s

```

## Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceSpaces_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceSpaces_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSpaces_derived
=== PAUSE TestAccDataSourceSpaces_derived
=== CONT  TestAccDataSourceSpaces_derived
--- PASS: TestAccDataSourceSpaces_derived (14.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     14.604s

```