### PR TITLE
feat(DDS): dds supports backup policy and second level monitor updated

### DIFF
--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -157,6 +157,8 @@ The following arguments are supported:
 
 **NOTE:** The instance will be restarted in the background when switching SSL. Please operate with caution.
 
+* `second_level_monitoring_enabled` - (Optional, Bool) Specifies whether to enable second level monitoring.
+
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the instance.
   The valid values are as follows:
   + `prePaid`: indicates the yearly/monthly billing mode.
@@ -235,17 +237,22 @@ The `flavor` block supports:
 
 The `backup_strategy` block supports:
 
-* `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during the
-  backup time window. The value cannot be empty. It must be a valid value in the
-  "hh:mm-HH:MM" format. The current time is in the UTC format.
+* `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during
+  the backup time window. The value cannot be empty. It must be a valid value in the "hh:mm-HH:MM" format.
+  The current time is in the UTC format.
   + The HH value must be 1 greater than the hh value.
-  + The values from mm and MM must be the same and must be set to any of the following 00, 15, 30, or 45.
+  + The values from mm and MM must be the same and must be set to **00**.
 
 * `keep_days` - (Required, Int) Specifies the number of days to retain the generated backup files. The value range is
-  from 0 to 732.
-  + If this parameter is set to 0, the automated backup policy is not set.
-  + If this parameter is not transferred, the automated backup policy is enabled by default. Backup files are stored
-      for seven days by default.
+  from 0 to 732. If this parameter is set to 0, the automated backup policy is disabled.
+
+* `period` - (Optional, String) Specifies the backup cycle. Data will be automatically backed up on the
+  selected days every week.
+  + If you set the `keep_days` to 0, this parameter is no need to set.
+  + If you set the `keep_days` within 6 days, set the parameter value to **1,2,3,4,5,6,7**, data is automatically
+    backed up on each day every week.
+  + If you set the `keep_days` between 7 and 732 days, set the parameter value to at least one day of every week.
+    For example: **1**, **3,5**.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
dds supports backup policy and second level monitor updated

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
dds supports backup policy and second level monitor updated
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dds/ TESTARGS='-run TestAccDDSV3Instance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds/ -v -run TestAccDDSV3Instance -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_basic
=== PAUSE TestAccDDSV3Instance_basic
=== RUN   TestAccDDSV3Instance_withEpsId
=== PAUSE TestAccDDSV3Instance_withEpsId
=== RUN   TestAccDDSV3Instance_prePaid
=== PAUSE TestAccDDSV3Instance_prePaid
=== RUN   TestAccDDSV3Instance_withConfigurationSharding
=== PAUSE TestAccDDSV3Instance_withConfigurationSharding
=== RUN   TestAccDDSV3Instance_withConfigurationReplicaSet
=== PAUSE TestAccDDSV3Instance_withConfigurationReplicaSet
=== RUN   TestAccDDSV3Instance_withSecondLevelMonitoring
=== PAUSE TestAccDDSV3Instance_withSecondLevelMonitoring
=== CONT  TestAccDDSV3Instance_basic
=== CONT  TestAccDDSV3Instance_withConfigurationSharding
=== CONT  TestAccDDSV3Instance_prePaid
=== CONT  TestAccDDSV3Instance_withEpsId
--- PASS: TestAccDDSV3Instance_withConfigurationSharding (862.25s)
=== CONT  TestAccDDSV3Instance_withSecondLevelMonitoring
--- PASS: TestAccDDSV3Instance_withSecondLevelMonitoring (831.67s)
=== CONT  TestAccDDSV3Instance_withConfigurationReplicaSet
--- PASS: TestAccDDSV3Instance_prePaid (1977.87s)
--- PASS: TestAccDDSV3Instance_withConfigurationReplicaSet (893.63s)
--- PASS: TestAccDDSV3Instance_withEpsId (3011.31s)
--- PASS: TestAccDDSV3Instance_basic (3016.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       3016.834s

```
