### PR TITLE
fix(iotda): deprecate batchtask file resource

### DIFF
--- a/docs/resources/iotda_batchtask_file.md
+++ b/docs/resources/iotda_batchtask_file.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "IoT Device Access (IoTDA)"
+subcategory: "Deprecated"
 ---
 
 # huaweicloud_iotda_batchtask_file
+
+!> **WARNING:** It has been deprecated.
 
 Manages an IoTDA batch task file within HuaweiCloud.
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1157,7 +1157,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_amqp":                iotda.ResourceAmqp(),
 			"huaweicloud_iotda_device_certificate":  iotda.ResourceDeviceCertificate(),
 			"huaweicloud_iotda_device_linkage_rule": iotda.ResourceDeviceLinkageRule(),
-			"huaweicloud_iotda_batchtask_file":      iotda.ResourceBatchTaskFile(),
 			"huaweicloud_iotda_upgrade_package":     iotda.ResourceUpgradePackage(),
 			"huaweicloud_iotda_batchtask":           iotda.ResourceBatchTask(),
 
@@ -1619,6 +1618,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpnaas_ipsec_policy":    deprecated.ResourceVpnIPSecPolicyV2(),
 			"huaweicloud_vpnaas_service":         deprecated.ResourceVpnServiceV2(),
 			"huaweicloud_vpnaas_site_connection": deprecated.ResourceVpnSiteConnectionV2(),
+
+			"huaweicloud_iotda_batchtask_file": deprecated.ResourceBatchTaskFile(),
 		},
 	}
 

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_iotda_batchtask_file_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_iotda_batchtask_file_test.go
@@ -1,4 +1,4 @@
-package iotda
+package deprecated
 
 import (
 	"fmt"
@@ -13,10 +13,11 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda"
 )
 
 func getBatchTaskFileResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, iotda.WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/derived.go
+++ b/huaweicloud/services/acceptance/iotda/derived.go
@@ -7,7 +7,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func withDerivedAuth() bool {
+func WithDerivedAuth() bool {
 	endpoint := acceptance.HW_IOTDA_ACCESS_ADDRESS
 	if endpoint == "" {
 		return false

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getAmqpResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_batchtask_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_batchtask_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getBatchTaskResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getDataForwardingRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_certificate_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_certificate_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getDeviceCertificateResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getDeviceGroupResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getDeviceLinkageRuleResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getDeviceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_product_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_product_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getProductResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_space_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_space_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getSpaceResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_upgrade_package_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_upgrade_package_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getUpgradePackageResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, withDerivedAuth())
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
 	if err != nil {
 		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
 	}

--- a/huaweicloud/services/deprecated/resource_huaweicloud_iotda_batchtask_file.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_iotda_batchtask_file.go
@@ -1,4 +1,4 @@
-package iotda
+package deprecated
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iotda"
 )
 
 // @API IoTDA POST /v5/iot/{project_id}/batchtask-files
@@ -29,6 +30,7 @@ func ResourceBatchTaskFile() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+		DeprecationMessage: "batchtask file has been deprecated.",
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -57,7 +59,7 @@ func ResourceBatchTaskFile() *schema.Resource {
 func resourceBatchTaskFileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := iotda.WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -94,7 +96,7 @@ func resourceBatchTaskFileCreate(ctx context.Context, d *schema.ResourceData, me
 func resourceBatchTaskFileRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := iotda.WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -130,7 +132,7 @@ func resourceBatchTaskFileRead(_ context.Context, d *schema.ResourceData, meta i
 func resourceBatchTaskFileDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := iotda.WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/derived.go
+++ b/huaweicloud/services/iotda/derived.go
@@ -8,10 +8,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
-// withDerivedAuth calculate whether derived authentication is required by the endpoint.
+// WithDerivedAuth calculate whether derived authentication is required by the endpoint.
 // currently, this method only applies for HuaweiCloud.
 // A sample endpoint: https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com
-func withDerivedAuth(cfg *config.Config, region string) bool {
+func WithDerivedAuth(cfg *config.Config, region string) bool {
 	endpoint := config.GetServiceEndpoint(cfg, "iotda", region)
 	if endpoint == "" {
 		log.Printf("[WARN ]failed to get the endpoint of IoTDA service in region %s", region)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_amqp.go
@@ -55,7 +55,7 @@ func ResourceAmqp() *schema.Resource {
 func resourceAmqpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -84,7 +84,7 @@ func resourceAmqpCreate(ctx context.Context, d *schema.ResourceData, meta interf
 func resourceAmqpRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -111,7 +111,7 @@ func resourceAmqpRead(_ context.Context, d *schema.ResourceData, meta interface{
 func resourceAmqpDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_batchtask.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_batchtask.go
@@ -174,7 +174,7 @@ func ResourceBatchTask() *schema.Resource {
 func resourceBatchTaskCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -323,7 +323,7 @@ func batchTaskStateRefreshFunc(client *iotdav5.IoTDAClient, taskId string) resou
 func resourceBatchTaskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -423,7 +423,7 @@ func flattenErrorInfo(errorInfo *model.ErrorInfo) []interface{} {
 func resourceBatchTaskDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_dataforwarding_rule.go
@@ -309,7 +309,7 @@ func ResourceDataForwardingRule() *schema.Resource {
 func ResourceDataForwardingRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -361,7 +361,7 @@ func ResourceDataForwardingRuleCreate(ctx context.Context, d *schema.ResourceDat
 func ResourceDataForwardingRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -390,7 +390,7 @@ func ResourceDataForwardingRuleRead(_ context.Context, d *schema.ResourceData, m
 func ResourceDataForwardingRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -471,7 +471,7 @@ func ResourceDataForwardingRuleUpdate(ctx context.Context, d *schema.ResourceDat
 func ResourceDataForwardingRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
@@ -173,7 +173,7 @@ func ResourceDevice() *schema.Resource {
 func ResourceDeviceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -210,7 +210,7 @@ func ResourceDeviceCreate(ctx context.Context, d *schema.ResourceData, meta inte
 func ResourceDeviceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -250,7 +250,7 @@ func ResourceDeviceRead(_ context.Context, d *schema.ResourceData, meta interfac
 func ResourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -317,7 +317,7 @@ func ResourceDeviceUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 func ResourceDeviceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_certificate.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_certificate.go
@@ -92,7 +92,7 @@ func ResourceDeviceCertificate() *schema.Resource {
 func resourceDeviceCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -121,7 +121,7 @@ func resourceDeviceCertificateCreate(ctx context.Context, d *schema.ResourceData
 func resourceDeviceCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -153,7 +153,7 @@ func resourceDeviceCertificateRead(_ context.Context, d *schema.ResourceData, me
 func resourceDeviceCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -178,7 +178,7 @@ func resourceDeviceCertificateUpdate(ctx context.Context, d *schema.ResourceData
 func resourceDeviceCertificateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_group.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_group.go
@@ -88,7 +88,7 @@ func ResourceDeviceGroup() *schema.Resource {
 func resourceDeviceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -127,7 +127,7 @@ func resourceDeviceGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 func resourceDeviceGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -152,7 +152,7 @@ func resourceDeviceGroupRead(_ context.Context, d *schema.ResourceData, meta int
 func resourceDeviceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -198,7 +198,7 @@ func resourceDeviceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 func resourceDeviceGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_linkage_rule.go
@@ -358,7 +358,7 @@ func ResourceDeviceLinkageRule() *schema.Resource {
 func ResourceDeviceLinkageRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -387,7 +387,7 @@ func ResourceDeviceLinkageRuleCreate(ctx context.Context, d *schema.ResourceData
 func ResourceDeviceLinkageRuleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -416,7 +416,7 @@ func ResourceDeviceLinkageRuleRead(_ context.Context, d *schema.ResourceData, me
 func ResourceDeviceLinkageRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -458,7 +458,7 @@ func ResourceDeviceLinkageRuleUpdate(ctx context.Context, d *schema.ResourceData
 func ResourceDeviceLinkageRuleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_product.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_product.go
@@ -292,7 +292,7 @@ func propertySchema(category string) *schema.Resource {
 func ResourceProductCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -317,7 +317,7 @@ func ResourceProductCreate(ctx context.Context, d *schema.ResourceData, meta int
 func ResourceProductRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -348,7 +348,7 @@ func ResourceProductRead(_ context.Context, d *schema.ResourceData, meta interfa
 func ResourceProductUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -367,7 +367,7 @@ func ResourceProductUpdate(ctx context.Context, d *schema.ResourceData, meta int
 func ResourceProductDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_space.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_space.go
@@ -56,7 +56,7 @@ func ResourceSpace() *schema.Resource {
 func resourceSpaceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -85,7 +85,7 @@ func resourceSpaceCreate(ctx context.Context, d *schema.ResourceData, meta inter
 func resourceSpaceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -108,7 +108,7 @@ func resourceSpaceRead(_ context.Context, d *schema.ResourceData, meta interface
 func resourceSpaceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*config.Config)
 	region := c.GetRegion(d)
-	isDerived := withDerivedAuth(c, region)
+	isDerived := WithDerivedAuth(c, region)
 	client, err := c.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_upgrade_package.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_upgrade_package.go
@@ -157,7 +157,7 @@ func buildUpgradePackageCreateParams(d *schema.ResourceData) *model.CreateOtaPac
 func resourceUpgradePackageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -181,7 +181,7 @@ func resourceUpgradePackageCreate(ctx context.Context, d *schema.ResourceData, m
 func resourceUpgradePackageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)
@@ -245,7 +245,7 @@ func flattenObsLocation(resp *model.ObsLocation) []interface{} {
 func resourceUpgradePackageDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	isDerived := withDerivedAuth(cfg, region)
+	isDerived := WithDerivedAuth(cfg, region)
 	client, err := cfg.HcIoTdaV5Client(region, isDerived)
 	if err != nil {
 		return diag.Errorf("error creating IoTDA v5 client: %s", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
deprecate batchtask file resource. Because when the batch task file is successfully created and used by other resources, the batchtask file will disappear (API behavior).
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. deprecate batchtask file resource
2. modify the method of derived auth in IoTDA to public
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

## Using batchtask resource as an example for testing
### Basic
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_basic -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_basic
--- PASS: TestAccBatchTask_basic (26.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     26.869s

```

### Skip
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_derived -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_derived
    acceptance.go:1359: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccBatchTask_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.049s

```

### Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_derived -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_derived
--- PASS: TestAccBatchTask_derived (23.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     23.739s

```