### PR TITLE
feat(RDS): rds instance support binlog

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -267,6 +267,9 @@ The following arguments are supported:
 * `parameters` - (Optional, List) Specify an array of one or more parameters to be set to the RDS instance after
   launched. You can check on console to see which parameters supported. Structure is documented below.
 
+* `binlog_retention_hours` - (Optional, Int) Specify the binlog retention period in hours. This parameter applies only to
+  MySQL Server databases. Value range: **0** to **168 (7x24)**.
+
 The `db` block supports:
 
 * `type` - (Required, String, ForceNew) Specifies the DB engine. Available value are **MySQL**, **PostgreSQL**,

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240315031130-07e73fc4f0a1
+	github.com/chnsz/golangsdk v0.0.0-20240318023259-a2906a92bcce
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240315031130-07e73fc4f0a1 h1:iArF+W5nR/K/paJiUexg3ekBpdfQqFtReZJ0da6i7RI=
-github.com/chnsz/golangsdk v0.0.0-20240315031130-07e73fc4f0a1/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240318023259-a2906a92bcce h1:4t/WALfJ4GZvt2YQiBOk9WZKujden13CniKbJ+lOxRI=
+github.com/chnsz/golangsdk v0.0.0-20240318023259-a2906a92bcce/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -153,6 +153,7 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3306"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "div_precision_increment"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "12"),
+					resource.TestCheckResourceAttr(resourceName, "binlog_retention_hours", "12"),
 				),
 			},
 			{
@@ -169,6 +170,7 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3308"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "connect_timeout"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "14"),
+					resource.TestCheckResourceAttr(resourceName, "binlog_retention_hours", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "db.0.password"),
 				),
 			},
@@ -178,6 +180,7 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					testAccCheckRdsInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.limit_size", "0"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "0"),
+					resource.TestCheckResourceAttr(resourceName, "binlog_retention_hours", "6"),
 				),
 			},
 		},
@@ -579,13 +582,14 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%[2]s"
-  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
-  ssl_enable        = true  
+  name                   = "%[2]s"
+  flavor                 = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id      = data.huaweicloud_networking_secgroup.test.id
+  subnet_id              = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                 = data.huaweicloud_vpc.test.id
+  availability_zone      = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+  ssl_enable             = true  
+  binlog_retention_hours = "12"
 
   db {
     type     = "MySQL"
@@ -628,14 +632,15 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%[3]s"
-  flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
-  ssl_enable        = false
-  param_group_id    = huaweicloud_rds_parametergroup.pg_1.id
+  name                   = "%[3]s"
+  flavor                 = data.huaweicloud_rds_flavors.test.flavors[1].name
+  security_group_id      = data.huaweicloud_networking_secgroup.test.id
+  subnet_id              = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                 = data.huaweicloud_vpc.test.id
+  availability_zone      = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+  ssl_enable             = false
+  param_group_id         = huaweicloud_rds_parametergroup.pg_1.id
+  binlog_retention_hours = "0"
 
   db {
     password = "Huangwei!120521"
@@ -679,14 +684,15 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%[3]s"
-  flavor            = data.huaweicloud_rds_flavors.test.flavors[1].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
-  ssl_enable        = false
-  param_group_id    = huaweicloud_rds_parametergroup.pg_1.id
+  name                   = "%[3]s"
+  flavor                 = data.huaweicloud_rds_flavors.test.flavors[1].name
+  security_group_id      = data.huaweicloud_networking_secgroup.test.id
+  subnet_id              = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                 = data.huaweicloud_vpc.test.id
+  availability_zone      = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+  ssl_enable             = false
+  param_group_id         = huaweicloud_rds_parametergroup.pg_1.id
+  binlog_retention_hours = "6"
 
   db {
     password = "Huangwei!120521"

--- a/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/requests.go
@@ -102,6 +102,7 @@ func UpdatePrivateBucketAccess(client *golangsdk.ServiceClient, domainId string,
 	return
 }
 
+// Deprecated: Use GetByName instead.
 // Get retrieves a particular CDN domain based on its unique ID.
 func Get(client *golangsdk.ServiceClient, id string, opts *ExtensionOpts) (r GetResult) {
 	url := getURL(client, id)
@@ -114,6 +115,20 @@ func Get(client *golangsdk.ServiceClient, id string, opts *ExtensionOpts) (r Get
 		url += query
 	}
 	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{OkCodes: []int{200}})
+	return
+}
+
+func GetByName(client *golangsdk.ServiceClient, domainName string, opts *ExtensionOpts) (r GetDetailResult) {
+	url := getDetailURL(client, domainName)
+	if opts != nil {
+		query, err := opts.ToExtensionQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	_, r.Err = client.Get(url, &r.Body, nil)
 	return
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/results.go
@@ -59,6 +59,45 @@ type CdnDomain struct {
 	ModifyTime time.Time `json:"-"`
 }
 
+type DomainSourcesDetail struct {
+	OriginType          string `json:"origin_type"`
+	OriginAddr          string `json:"origin_addr"`
+	Priority            int    `json:"priority"`
+	ObsWebHostingStatus string `json:"obs_web_hosting_status"`
+	HttpPort            int    `json:"http_port"`
+	HttpsPort           int    `json:"https_port"`
+	HostName            string `json:"host_name"`
+	ObsBucketType       string `json:"obs_bucket_type"`
+}
+
+// CdnDomainDetail represents a CDN domain by domain name
+type CdnDomainDetail struct {
+	// the acceleration domain name ID
+	ID string `json:"id"`
+	// the acceleration domain name
+	DomainName string `json:"domain_name"`
+	// the service type, valid values are web, download, video and wholeSite
+	BusinessType string `json:"business_type"`
+	// the status of the acceleration domain name.
+	DomainStatus string `json:"domain_status"`
+	// the CNAME of the acceleration domain name
+	CName string `json:"cname"`
+	// the sources of the domain.
+	Sources []DomainSourcesDetail `json:"sources"`
+	// whether the HTTPS certificate is enabled
+	HttpsStatus int `json:"https_status"`
+	// time when the domain name was created.
+	CreateTime int `json:"create_time"`
+	// time when the domain name was modified.
+	UpdateTime int `json:"update_time"`
+	// whether the domain name is banned. Possible values: 0 (not banned) and 1 (banned).
+	Disabled int `json:"disabled"`
+	// whether the domain name is locked. Possible values: 0 (not locked) and 1 (locked).
+	Locked int `json:"locked"`
+	// service area of the CDN service. Valid values are mainland_china, outside_mainland_china, and global.
+	ServiceArea string `json:"service_area"`
+}
+
 type PrivateBucketAccessStatus struct {
 	Status    bool      `json:"status"`
 	ErrorResp ErrorResp `json:"error"`
@@ -108,6 +147,16 @@ func (r GetResult) Extract() (*CdnDomain, error) {
 
 func (r GetResult) ExtractInto(v interface{}) error {
 	return r.Result.ExtractIntoStructPtr(v, "domain")
+}
+
+type GetDetailResult struct {
+	commonResult
+}
+
+func (r GetDetailResult) Extract() (*CdnDomainDetail, error) {
+	var domain CdnDomainDetail
+	err := r.Result.ExtractIntoStructPtr(&domain, "domain")
+	return &domain, err
 }
 
 // CreateResult is the result of a Create request.

--- a/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cdn/v1/domains/urls.go
@@ -22,6 +22,10 @@ func getURL(sc *golangsdk.ServiceClient, domainId string) string {
 	return sc.ServiceURL(rootPath, domainId, "detail")
 }
 
+func getDetailURL(sc *golangsdk.ServiceClient, domainName string) string {
+	return sc.ServiceURL("cdn/configuration/domains", domainName)
+}
+
 func enableURL(sc *golangsdk.ServiceClient, domainId string) string {
 	return sc.ServiceURL(rootPath, domainId, "enable")
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/drs/v3/jobs/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/drs/v3/jobs/results.go
@@ -62,6 +62,7 @@ type JobDetail struct {
 	SchemaType               string             `json:"schema_type"`
 	NodeNum                  string             `json:"node_num"`
 	ObjectSwitch             bool               `json:"object_switch"`
+	ObjectInfos              []ObjectInfo       `json:"object_infos"`
 	MasterJobId              string             `json:"master_job_id"`
 	FullMode                 string             `json:"full_mode"`
 	StructTrans              bool               `json:"struct_trans"`
@@ -93,6 +94,14 @@ type InstInfo struct {
 	StartTime  string `json:"start_time"`
 	Status     string `json:"status"`
 	VolumeSize int    `json:"volume_size"`
+}
+
+type ObjectInfo struct {
+	Id        string `json:"id"`
+	ParentId  string `json:"parent_id"`
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	AliasName string `json:"alias_name"`
 }
 
 type DefaultRootDb struct {
@@ -184,7 +193,7 @@ type JobInfo struct {
 }
 
 type ChildrenJobInfo struct {
-	BillingTag       string `json:"billing_tag"`
+	BillingTag       bool   `json:"billing_tag"`
 	CreateTime       string `json:"create_time"`
 	DbUseType        string `json:"db_use_type"`
 	Description      string `json:"description"`
@@ -194,7 +203,7 @@ type ChildrenJobInfo struct {
 	JobDirection     string `json:"job_direction"`
 	Name             string `json:"name"`
 	NetType          string `json:"net_type"`
-	NodeNewFramework string `json:"node_newFramework"`
+	NodeNewFramework bool   `json:"node_newFramework"`
 	Status           string `json:"status"`
 	TaskType         string `json:"task_type"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -717,3 +717,30 @@ func ModifyCollation(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, ins
 	_, r.Err = c.Put(updateURL(c, instanceId, "collations"), b, &r.Body, &golangsdk.RequestOpts{})
 	return
 }
+
+type ModifyBinlogRetentionHoursOpts struct {
+	BinlogRetentionHours int `json:"binlog_retention_hours"`
+}
+
+func (opts ModifyBinlogRetentionHoursOpts) ToActionInstanceMap() (map[string]interface{}, error) {
+	return toActionInstanceMap(opts)
+}
+
+// ModifyBinlogRetentionHours is a method used to modify binlog retention hours.
+func ModifyBinlogRetentionHours(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r ModifyCollationResult) {
+	b, err := opts.ToActionInstanceMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(binlogRetentionHoursURL(c, instanceId), b, &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+// GetBinlogRetentionHours is a method used to obtain the binlog retention hours.
+func GetBinlogRetentionHours(c *golangsdk.ServiceClient, instanceId string) (r GetBinlogRetentionHoursResult) {
+	_, r.Err = c.Get(binlogRetentionHoursURL(c, instanceId), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -42,6 +42,10 @@ type ModifyCollationResult struct {
 	commonResult
 }
 
+type ModifyBinlogRetentionHoursResult struct {
+	commonResult
+}
+
 type ModifySwitchStrategyResult struct {
 	commonResult
 }
@@ -67,6 +71,10 @@ type ModifyConfigurationResult struct {
 }
 
 type GetConfigurationResult struct {
+	commonResult
+}
+
+type GetBinlogRetentionHoursResult struct {
 	commonResult
 }
 
@@ -219,6 +227,17 @@ func (r GetConfigurationResult) Extract() (*GetConfigurationResp, error) {
 	return &response, err
 }
 
+type GetBinlogRetentionHoursResp struct {
+	BinlogRetentionHours int    `json:"binlog_retention_hours"`
+	BinlogClearType      string `json:"binlog_clear_type"`
+}
+
+func (r GetBinlogRetentionHoursResult) Extract() (*GetBinlogRetentionHoursResp, error) {
+	var response GetBinlogRetentionHoursResp
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
 type ReplicationMode struct {
 	WorkflowId      string `json:"workflowId"`
 	InstanceId      string `json:"instanceId"`
@@ -237,6 +256,16 @@ type Collation struct {
 
 func (r ModifyCollationResult) Extract() (*Collation, error) {
 	var response Collation
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type BinlogRetentionHoursResp struct {
+	Resp string `json:"resp"`
+}
+
+func (r ModifyBinlogRetentionHoursResult) Extract() (*BinlogRetentionHoursResp, error) {
+	var response BinlogRetentionHoursResp
 	err := r.ExtractInto(&response)
 	return &response, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
@@ -45,3 +45,7 @@ func actionURL(c *golangsdk.ServiceClient, instancesId string) string {
 func autoExpandURL(c *golangsdk.ServiceClient, instancesId string) string {
 	return c.ServiceURL("instances", instancesId, "disk-auto-expansion")
 }
+
+func binlogRetentionHoursURL(c *golangsdk.ServiceClient, instancesId string) string {
+	return c.ServiceURL("instances", instancesId, "binlog/clear-policy")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/requests.go
@@ -31,7 +31,9 @@ type CreateOpts struct {
 	// Specifies the whitelist for controlling access to the VPC endpoint
 	Whitelist []string `json:"whitelist,omitempty"`
 	// Specifies the IDs of route tables
-	RouteTables []string `json:"routeTables,omitempty"`
+	// The parameter is mandatory to create a gateway type VPC endpoint
+	// If the parameter is not set, will be associated with the default route table
+	RouteTables []string `json:"routetables,omitempty"`
 	// Specifies the resource tags in key/value format
 	Tags []tags.ResourceTag `json:"tags,omitempty"`
 	// Specifies the description of the VPC endpoint service

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240315031130-07e73fc4f0a1
+# github.com/chnsz/golangsdk v0.0.0-20240318023259-a2906a92bcce
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support binlog
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support binlog
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=9
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 9
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_restore_mysql
--- PASS: TestAccRdsInstance_mariadb (429.88s)
--- PASS: TestAccRdsInstance_ha (547.04s)
--- PASS: TestAccRdsInstance_basic (594.36s)
--- PASS: TestAccRdsInstance_prePaid (1301.89s)
--- PASS: TestAccRdsInstance_restore_mysql (1463.79s)
--- PASS: TestAccRdsInstance_restore_pg (1507.25s)
--- PASS: TestAccRdsInstance_mysql (1514.88s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2047.52s)
--- PASS: TestAccRdsInstance_sqlserver (3048.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3048.406s
```
