### PR TITLE
feat(vpcep): the vpc endpoint resource support routetables parameter

### DIFF
--- a/docs/resources/vpcep_endpoint.md
+++ b/docs/resources/vpcep_endpoint.md
@@ -70,8 +70,10 @@ The following arguments are supported:
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC where the VPC endpoint is to be created. Changing
   this creates a new VPC endpoint.
 
-* `network_id` - (Required, String, ForceNew) Specifies the network ID of the subnet in the VPC specified by `vpc_id`.
+* `network_id` - (Optional, String, ForceNew) Specifies the network ID of the subnet in the VPC specified by `vpc_id`.
   Changing this creates a new VPC endpoint.
+
+  -> This field is required when creating a VPC endpoint for connecting an interface VPC endpoint service.
 
 * `ip_address` - (Optional, String, ForceNew) Specifies the IP address for accessing the associated VPC endpoint
   service. Only IPv4 addresses are supported. Changing this creates a new VPC endpoint.
@@ -79,9 +81,17 @@ The following arguments are supported:
 * `enable_dns` - (Optional, Bool, ForceNew) Specifies whether to create a private domain name. The default value is
   true. Changing this creates a new VPC endpoint.
 
+  -> This field is valid only when creating a VPC endpoint for connecting an interface VPC endpoint service.
+
 * `description` - (Optional, String, ForceNew) Specifies the description of the VPC endpoint.
 
   Changing this creates a new VPC endpoint.
+
+* `routetables` - (Optional, List, ForceNew) Specifies the IDs of the route tables associated with the VPC endpoint.
+  Changing this creates a new VPC endpoint.
+
+  -> This field is valid only when creating a VPC endpoint for connecting a gateway VPC endpoint service.
+    The default route table will be used when this field is not specified.
 
 * `enable_whitelist` - (Optional, Bool) Specifies whether to enable access control. The default value is
   false.
@@ -121,4 +131,23 @@ VPC endpoint can be imported using the `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_vpcep_endpoint.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `enable_dns`.
+
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
+with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_vpcep_endpoint" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      enable_dns,
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -303,6 +303,8 @@ var (
 	HW_LTS_AGENCY_PROJECT_ID  = os.Getenv("HW_LTS_AGENCY_PROJECT_ID")
 	HW_LTS_AGENCY_DOMAIN_NAME = os.Getenv("HW_LTS_AGENCY_DOMAIN_NAME")
 	HW_LTS_AGENCY_NAME        = os.Getenv("HW_LTS_AGENCY_NAME")
+
+	HW_VPCEP_SERVICE_ID = os.Getenv("HW_VPCEP_SERVICE_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -1414,5 +1416,12 @@ func TestAccPreCheckLTSCrossAccountAccess(t *testing.T) {
 		HW_LTS_LOG_GROUP_NAME == "" || HW_LTS_LOG_GROUP_ID == "" {
 		t.Skip("The delegatee account config of HW_LTS_LOG_STREAM_NAME, HW_LTS_LOG_STREAM_ID, HW_LTS_LOG_GROUP_NAME" +
 			" and HW_LTS_LOG_GROUP_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckVPCEPServiceId(t *testing.T) {
+	if HW_VPCEP_SERVICE_ID == "" {
+		t.Skip("HW_VPCEP_SERVICE_ID must be set for the acceptance test")
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The vpc endpoint resource support routetables parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. create a interface type vpc endpoint, can ignored the parameter.
2. create a gateway type vpc endpoint, the parameter must be set, the default value is the default route table.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_vpcep)$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccEndpoint_RouteTables"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccEndpoint_RouteTables -timeout 360m -parallel 4
=== RUN   TestAccEndpoint_RouteTables
=== PAUSE TestAccEndpoint_RouteTables
=== CONT  TestAccEndpoint_RouteTables
--- PASS: TestAccEndpoint_RouteTables (162.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     162.513s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_vpcep)$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccVPCEndpoint_Basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpoint_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_Basic
=== PAUSE TestAccVPCEndpoint_Basic
=== CONT  TestAccVPCEndpoint_Basic
--- PASS: TestAccVPCEndpoint_Basic (271.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     271.928s
```
```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_vpcep)$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccVPCEndpoint_Public"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpoint_Public -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_Public
=== PAUSE TestAccVPCEndpoint_Public
=== CONT  TestAccVPCEndpoint_Public
--- PASS: TestAccVPCEndpoint_Public (45.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     45.883s
```
