### PR TITLE
chore: update the format of random password

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -525,6 +525,9 @@ func RandomCidrAndGatewayIp() (string, string) {
 	return fmt.Sprintf("172.16.%d.0/24", seed), fmt.Sprintf("172.16.%d.1", seed)
 }
 
+// RandomPassword can generate a 12-character random password. The password format is
+// uppercase letters*3 + lowercase letters*3 + special characters*2 + numbers*4
+// You can use "customChars" to overwrite the special characters.
 func RandomPassword(customChars ...string) string {
 	var specialChars string
 	if len(customChars) < 1 {
@@ -533,7 +536,7 @@ func RandomPassword(customChars ...string) string {
 		specialChars = customChars[0]
 	}
 	return fmt.Sprintf("%s%s%s%d",
-		acctest.RandStringFromCharSet(2, "ABCDEFGHIJKLMNOPQRSTUVWXZY"),
+		acctest.RandStringFromCharSet(3, "ABCDEFGHIJKLMNOPQRSTUVWXZY"),
 		acctest.RandStringFromCharSet(3, acctest.CharSetAlpha),
 		acctest.RandStringFromCharSet(2, specialChars),
 		acctest.RandIntRange(1000, 9999))

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_disaster_recovry_tasks_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_disaster_recovry_tasks_test.go
@@ -13,8 +13,8 @@ func TestAccDisasterRecoveryTasksDataSource_basic(t *testing.T) {
 	resourceName := "data.huaweicloud_dws_disaster_recovery_tasks.name_filter"
 	dc := acceptance.InitDataSourceCheck(resourceName)
 	name := acceptance.RandomAccResourceName()
-	// The cluster password requires a minimum length of 12 characters, and the string 'gap' is used to fill in the gap.
-	password := acceptance.RandomPassword() + "gap"
+	password := acceptance.RandomPassword()
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_disaster_recovery_task_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_disaster_recovery_task_test.go
@@ -50,7 +50,7 @@ func TestAccResourceDisasterRecoveryTask_basic(t *testing.T) {
 		obj          interface{}
 		resourceName = "huaweicloud_dws_disaster_recovery_task.test"
 		name         = acceptance.RandomAccResourceName()
-		password     = acceptance.RandomPassword() + "a"
+		password     = acceptance.RandomPassword()
 	)
 	rc := acceptance.InitResourceCheck(
 		resourceName,

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_plan_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_plan_test.go
@@ -114,7 +114,6 @@ resource "huaweicloud_dws_cluster" "test" {
 
 func testAccWorkLoadPlan_basic(name string) string {
 	password := acceptance.RandomPassword("@#%&_=!")
-	password += "123"
 
 	return fmt.Sprintf(`
 %s


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*


**RandomPassword** will generate a 12-character random password.
The password format is uppercase letters\*3 + lowercase letters\*3 + special characters\*2 + numbers\*4
You can use "customChars" to overwrite the special characters.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/dws" TESTARGS="-run TestAccDwsExtDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDwsExtDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccDwsExtDataSource_basic
=== PAUSE TestAccDwsExtDataSource_basic
=== CONT  TestAccDwsExtDataSource_basic
--- PASS: TestAccDwsExtDataSource_basic (1458.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1458.461s

$ make testacc TEST="./huaweicloud/services/acceptance/dws" TESTARGS="-run TestAccResourceDisasterRecoveryTask_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceDisasterRecoveryTask_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDisasterRecoveryTask_basic
=== PAUSE TestAccResourceDisasterRecoveryTask_basic
=== CONT  TestAccResourceDisasterRecoveryTask_basic
--- PASS: TestAccResourceDisasterRecoveryTask_basic (2949.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       2949.202s
```
