### PR TITLE
feat(DEW): kps keypair resource support private_key parameter

### DIFF
--- a/docs/resources/kps_keypair.md
+++ b/docs/resources/kps_keypair.md
@@ -43,9 +43,12 @@ resource "huaweicloud_kps_keypair" "test-keypair" {
 ### Import an existing keypair
 
 ```hcl
+variable "private_key" {}
+
 resource "huaweicloud_kps_keypair" "test-keypair" {
-  name       = "my-keypair"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAlJq5Pu+eizhou7nFFDxXofr2ySF8k/yuA9OnJdVF9Fbf85Z59CWNZBvcAT... root@terra-dev"
+  name        = "my-keypair"
+  public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAlJq5Pu+eizhou7nFFDxXofr2ySF8k/yuA9OnJdVF9Fbf85Z59CWNZBvcAT... root@terra-dev"
+  private_key = var.private_key
 }
 ```
 
@@ -57,36 +60,37 @@ The following arguments are supported:
   provider-level region will be used. Changing this parameter will create a new resource.
 
 * `name` - (Required, String, ForceNew) Specifies a unique name for the keypair. The name can contain a maximum of 64
- characters, including letters, digits, underscores (_) and hyphens (-).
- Changing this parameter will create a new resource.
+  characters, including letters, digits, underscores (_) and hyphens (-).
+  Changing this parameter will create a new resource.
 
 * `scope` - (Optional, String, ForceNew) Specifies the scope of key pair. The options are as follows:
   - **account**: Tenant-level, available to all users under the same account.
   - **user**: User-level, only available to that user.
-
- The default value is `user`.
- Changing this parameter will create a new resource.
+  The default value is `user`.
+  Changing this parameter will create a new resource.
 
 * `encryption_type` - (Optional, String, ForceNew) Specifies encryption mode if manages the private key by HuaweiCloud.
- The options are as follows:
+  The options are as follows:
   - **default**: The default encryption mode. Applicable to sites where KMS is not deployed.
   - **kms**: KMS encryption mode.
-
- Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
 * `kms_key_name` - (Optional, String, ForceNew) Specifies the KMS key name to encrypt private keys.
- It's mandatory when the `encryption_type` is `kms`. Changing this parameter will create a new resource.
+  It's mandatory when the `encryption_type` is `kms`. Changing this parameter will create a new resource.
 
 * `description` - (Optional, String) Specifies the description of key pair.
 
 * `public_key` - (Optional, String, ForceNew) Specifies the imported OpenSSH-formatted public key.
- Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
+
+* `private_key` - (Optional, String, ForceNew) Specifies the imported OpenSSH-formatted private key.
+  Changing this parameter will create a new resource.
 
 * `key_file` - (Optional, String, ForceNew) Specifies the path of the created private key.
- The private key file (**.pem**) is created only after the resource is created.
- Changing this parameter will create a new resource.
+  The private key file (**.pem**) is created only after the resource is created.
+  Changing this parameter will create a new resource.
 
-  ~>**NOTE:** If the private key file already exists, it will be overwritten after a new keypair is created.
+  ->**NOTE:** If the private key file already exists, it will be overwritten after a new keypair is created.
 
 ## Attribute Reference
 
@@ -118,7 +122,7 @@ $ terraform import huaweicloud_kps_keypair.my-keypair test-keypair
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `encryption_type`,
-and `kms_key_name`. It is generally recommended running `terraform plan` after importing a key pair.
+`kms_key_name` and `private_key`. It is generally recommended running `terraform plan` after importing a key pair.
 You can then decide if changes should be applied to the key pair, or the resource definition
 should be updated to align with the key pair. Also you can ignore changes as below.
 
@@ -128,7 +132,7 @@ resource "huaweicloud_kps_keypair" "test" {
 
   lifecycle {
     ignore_changes = [
-      encryption_type, kms_key_name,
+      encryption_type, kms_key_name, private_key
     ]
   }
 }

--- a/huaweicloud/services/dew/resource_huaweicloud_kps_keypair.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kps_keypair.go
@@ -102,7 +102,12 @@ func ResourceKeypair() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"key_file"},
 			},
-
+			"private_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				ForceNew:  true,
+			},
 			"key_file": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -295,6 +300,10 @@ func buildCreateParams(d *schema.ResourceData) (*model.CreateKeypairRequest, err
 		k, kmsExist := d.GetOk("kms_key_name")
 		if t == "kms" && !kmsExist {
 			return nil, fmt.Errorf("kms_key_name is mandatory when the encryption_type is kms")
+		}
+
+		if v, ok := d.GetOk("private_key"); ok {
+			keyProtection.PrivateKey = utils.String(v.(string))
 		}
 		keyProtection.Encryption.KmsKeyName = k.(string)
 		createOpts.Body.Keypair.KeyProtection = &keyProtection


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 kps keypair resource support private_key parameter
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add private_key parameter when create kps keypair.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dew TESTARGS='-run TestAccKpsKeypair_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKpsKeypair_ -timeout 360m -parallel 4
=== RUN   TestAccKpsKeypair_basic
--- PASS: TestAccKpsKeypair_basic (33.65s)
=== RUN   TestAccKpsKeypair_domain
--- PASS: TestAccKpsKeypair_domain (38.04s)
=== RUN   TestAccKpsKeypair_publicKey
--- PASS: TestAccKpsKeypair_publicKey (33.46s)
=== RUN   TestAccKpsKeypair_privateKeyAndUserID
--- PASS: TestAccKpsKeypair_privateKeyAndUserID (19.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       125.112s
```
