### PR TITLE
refactor: fix(CDN): replace `cdnV1Client` with `cdnV2Client` and replace CDN expired detail API

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -397,10 +397,10 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-Domains can be imported using the `id`, e.g.
+The CDN domain resource can be imported using the domain `name`, e.g.
 
 ```bash
-$ terraform import huaweicloud_cdn_domain.test <id>
+$ terraform import huaweicloud_cdn_domain.test <name>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the

--- a/huaweicloud/config/hc_config.go
+++ b/huaweicloud/config/hc_config.go
@@ -20,6 +20,7 @@ import (
 	aomv2 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/aom/v2"
 	ccev3 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cce/v3"
 	cdnv1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v1"
+	cdnv2 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2"
 	cptsv1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cpts/v1"
 	cssv1 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/css/v1"
 	cssv2 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/css/v2"
@@ -274,6 +275,15 @@ func (c *Config) HcCdnV1Client(region string) (*cdnv1.CdnClient, error) {
 		return nil, err
 	}
 	return cdnv1.NewCdnClient(hcClient), nil
+}
+
+// HcCdnV2Client is the CDN service client using huaweicloud-sdk-go-v3 package
+func (c *Config) HcCdnV2Client(region string) (*cdnv2.CdnClient, error) {
+	hcClient, err := NewHcClient(c, region, "cdn", false)
+	if err != nil {
+		return nil, err
+	}
+	return cdnv2.NewCdnClient(hcClient), nil
 }
 
 // HcDmsV2Client is the DMS service client using huaweicloud-sdk-go-v3 package

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -2,7 +2,9 @@ package cdn
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -14,6 +16,7 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cdn/v1/domains"
 
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr"
 	cdnv2 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2"
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model"
 
@@ -198,7 +201,7 @@ var cacheUrlParameterFilter = schema.Schema{
 }
 
 // @API CDN POST /v1.0/cdn/domains
-// @API CDN GET /v1.0/cdn/domains/{domain_id}/detail
+// @API CDN GET /v1.0/cdn/configuration/domains/{domain_name}
 // @API CDN PUT /v1.0/cdn/domains/{domainId}/disable
 // @API CDN DELETE /v1.0/cdn/domains/{domainId}
 // @API CDN PUT /v1.1/cdn/configuration/domains/{domain_name}/configs
@@ -212,7 +215,7 @@ func ResourceCdnDomain() *schema.Resource {
 		UpdateContext: resourceCdnDomainUpdate,
 		DeleteContext: resourceCdnDomainDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceCDNDomainImportState,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -695,28 +698,40 @@ func resourceCdnDomainCreate(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		return diag.Errorf("error creating CDN domain: %s", err)
 	}
+
+	if v.ID == "" {
+		return diag.Errorf("error creating CDN domain: ID is not found in API response")
+	}
 	d.SetId(v.ID)
 
-	opts := buildResourceExtensionOpts(d, cfg)
-	if err := waitingForStatusOnline(ctx, cdnClient, d, d.Timeout(schema.TimeoutCreate), opts); err != nil {
+	hcCdnClient, err := cfg.HcCdnV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating CDN v2 client: %s", err)
+	}
+	requestOpts := buildDomainDetailRequestOpts(d, cfg)
+	if err := waitingForStatusOnline(ctx, hcCdnClient, d.Timeout(schema.TimeoutCreate), requestOpts); err != nil {
 		return diag.Errorf("error waiting for CDN domain (%s) creation to become online: %s", d.Id(), err)
 	}
 	return resourceCdnDomainUpdate(ctx, d, meta)
 }
 
-func waitingForStatusOnline(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
-	timeout time.Duration, opts *domains.ExtensionOpts) error {
+func waitingForStatusOnline(ctx context.Context, hcCdnClient *cdnv2.CdnClient, timeout time.Duration,
+	opts *model.ShowDomainDetailByNameRequest) error {
 	unexpectedStatus := []string{"offline", "configure_failed", "check_failed", "deleting"}
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			domain, err := domains.Get(client, d.Id(), opts).Extract()
-			if err != nil || domain == nil {
+			domain, err := hcCdnClient.ShowDomainDetailByName(opts)
+			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			status := domain.DomainStatus
+			if domain == nil || domain.Domain == nil {
+				return nil, "ERROR", fmt.Errorf("error retrieving CDN domain: Domain is not found in API response")
+			}
+
+			status := utils.StringValue(domain.Domain.DomainStatus)
 			if status == "online" {
 				return domain, "COMPLETED", nil
 			}
@@ -734,19 +749,23 @@ func waitingForStatusOnline(ctx context.Context, client *golangsdk.ServiceClient
 	return err
 }
 
-func waitingForStatusOffline(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
-	timeout time.Duration, opts *domains.ExtensionOpts) error {
+func waitingForStatusOffline(ctx context.Context, hcCdnClient *cdnv2.CdnClient, timeout time.Duration,
+	opts *model.ShowDomainDetailByNameRequest) error {
 	unexpectedStatus := []string{"online", "configure_failed", "check_failed", "deleting"}
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			domain, err := domains.Get(client, d.Id(), opts).Extract()
-			if err != nil || domain == nil {
+			domain, err := hcCdnClient.ShowDomainDetailByName(opts)
+			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			status := domain.DomainStatus
+			if domain == nil || domain.Domain == nil {
+				return nil, "ERROR", fmt.Errorf("error retrieving CDN domain: Domain is not found in API response")
+			}
+
+			status := utils.StringValue(domain.Domain.DomainStatus)
 			if status == "offline" {
 				return domain, "COMPLETED", nil
 			}
@@ -952,11 +971,8 @@ func flattenConfigAttrs(configsResp *model.ConfigsGetBody, d *schema.ResourceDat
 	return []map[string]interface{}{configsAttrs}
 }
 
-func queryDomainFullConfig(cfg *config.Config, d *schema.ResourceData, domainName string) (*model.ConfigsGetBody, error) {
-	hcCdnClient, err := cfg.HcCdnV2Client(cfg.GetRegion(d))
-	if err != nil {
-		return nil, fmt.Errorf("error creating CDN v2 client: %s", err)
-	}
+func queryDomainFullConfig(hcCdnClient *cdnv2.CdnClient, cfg *config.Config, d *schema.ResourceData,
+	domainName string) (*model.ConfigsGetBody, error) {
 	req := model.ShowDomainFullConfigRequest{
 		DomainName:          domainName,
 		EnterpriseProjectId: utils.StringIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
@@ -973,12 +989,7 @@ func queryDomainFullConfig(cfg *config.Config, d *schema.ResourceData, domainNam
 	return resp.Configs, nil
 }
 
-func queryAndFlattenDomainTags(cfg *config.Config, d *schema.ResourceData) (map[string]string, error) {
-	hcCdnClient, err := cfg.HcCdnV2Client(cfg.GetRegion(d))
-	if err != nil {
-		return nil, fmt.Errorf("error creating CDN v2 client: %s", err)
-	}
-
+func queryAndFlattenDomainTags(hcCdnClient *cdnv2.CdnClient, d *schema.ResourceData) (map[string]string, error) {
 	tags, err := hcCdnClient.ShowTags(&model.ShowTagsRequest{ResourceId: d.Id()})
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving CDN domain tags: %s", err)
@@ -999,41 +1010,68 @@ func queryAndFlattenDomainTags(cfg *config.Config, d *schema.ResourceData) (map[
 	return tagMap, nil
 }
 
+func flattenServiceArea(serviceArea *model.DomainsDetailServiceArea) interface{} {
+	if serviceArea == nil {
+		return nil
+	}
+	return serviceArea.Value()
+}
+
 func resourceCdnDomainRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
-	cdnClient, err := cfg.CdnV1Client(cfg.GetRegion(d))
+	hcCdnClient, err := cfg.HcCdnV2Client(cfg.GetRegion(d))
 	if err != nil {
-		return diag.Errorf("error creating CDN v1 client: %s", err)
+		return diag.Errorf("error creating CDN v2 client: %s", err)
 	}
 
-	// TODO The details API will be offline soon and needs to be replaced in the future.
-	v, err := domains.Get(cdnClient, d.Id(), buildResourceExtensionOpts(d, cfg)).Extract()
+	requestOpts := buildDomainDetailRequestOpts(d, cfg)
+	v, err := hcCdnClient.ShowDomainDetailByName(requestOpts)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving CDN domain")
+		return common.CheckDeletedDiag(d, parseDetailResponseError(err), "error retrieving CDN domain")
 	}
 
-	configsResp, err := queryDomainFullConfig(cfg, d, v.DomainName)
+	if v == nil || v.Domain == nil {
+		return diag.Errorf("error retrieving CDN domain: Domain is not found in API response")
+	}
+
+	domain := *v.Domain
+	// Backfield the id when executing the import operation
+	d.SetId(*domain.Id)
+
+	configsResp, err := queryDomainFullConfig(hcCdnClient, cfg, d, *domain.DomainName)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	tags, err := queryAndFlattenDomainTags(cfg, d)
+	tags, err := queryAndFlattenDomainTags(hcCdnClient, d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("name", v.DomainName),
-		d.Set("type", v.BusinessType),
-		d.Set("cname", v.CName),
-		d.Set("domain_status", v.DomainStatus),
-		d.Set("service_area", v.ServiceArea),
+		d.Set("name", domain.DomainName),
+		d.Set("type", domain.BusinessType),
+		d.Set("cname", domain.Cname),
+		d.Set("domain_status", domain.DomainStatus),
+		d.Set("service_area", flattenServiceArea(domain.ServiceArea)),
 		d.Set("sources", flattenSourcesAttrs(configsResp.Sources)),
 		d.Set("configs", flattenConfigAttrs(configsResp, d)),
 		d.Set("cache_settings", flattenCacheRulesAttrs(configsResp.CacheRules)),
 		d.Set("tags", tags),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+// When the domain name does not exist, the response body example of the details interface is as follows:
+// {"error": {"error_code": "CDN.0170","error_msg": "domain not exist!"}}
+func parseDetailResponseError(err error) error {
+	var responseErr *sdkerr.ServiceResponseError
+	if errors.As(err, &responseErr) {
+		if responseErr.StatusCode == http.StatusBadRequest && responseErr.ErrorCode == "CDN.0170" {
+			return golangsdk.ErrDefault404{}
+		}
+	}
+	return err
 }
 
 func resourceCdnDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -1049,12 +1087,8 @@ func resourceCdnDomainUpdate(ctx context.Context, d *schema.ResourceData, meta i
 			return diag.Errorf("error updating CDN domain configs settings: %s", err)
 		}
 
-		cdnClient, err := cfg.CdnV1Client(cfg.GetRegion(d))
-		if err != nil {
-			return diag.Errorf("error creating CDN v1 client: %s", err)
-		}
-		opts := buildResourceExtensionOpts(d, cfg)
-		if err := waitingForStatusOnline(ctx, cdnClient, d, d.Timeout(schema.TimeoutUpdate), opts); err != nil {
+		requestOpts := buildDomainDetailRequestOpts(d, cfg)
+		if err := waitingForStatusOnline(ctx, hcCdnClient, d.Timeout(schema.TimeoutUpdate), requestOpts); err != nil {
 			return diag.Errorf("error waiting for CDN domain (%s) update to become online: %s", d.Id(), err)
 		}
 	}
@@ -1127,7 +1161,12 @@ func resourceCdnDomainDelete(ctx context.Context, d *schema.ResourceData, meta i
 			return diag.Errorf("error disable CDN domain %s: %s", d.Id(), err)
 		}
 
-		if err := waitingForStatusOffline(ctx, cdnClient, d, d.Timeout(schema.TimeoutDelete), opts); err != nil {
+		hcCdnClient, err := cfg.HcCdnV2Client(cfg.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating CDN v2 client: %s", err)
+		}
+		requestOpts := buildDomainDetailRequestOpts(d, cfg)
+		if err := waitingForStatusOffline(ctx, hcCdnClient, d.Timeout(schema.TimeoutDelete), requestOpts); err != nil {
 			return diag.Errorf("error waiting for CDN domain (%s) update to become offline: %s", d.Id(), err)
 		}
 	}
@@ -1150,4 +1189,16 @@ func buildResourceExtensionOpts(d *schema.ResourceData, cfg *config.Config) *dom
 	}
 
 	return nil
+}
+
+func buildDomainDetailRequestOpts(d *schema.ResourceData, cfg *config.Config) *model.ShowDomainDetailByNameRequest {
+	return &model.ShowDomainDetailByNameRequest{
+		DomainName:          d.Get("name").(string),
+		EnterpriseProjectId: utils.StringIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
+	}
+}
+
+func resourceCDNDomainImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, d.Set("name", d.Id())
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/cdn_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/cdn_client.go
@@ -1,0 +1,846 @@
+package v2
+
+import (
+	httpclient "github.com/huaweicloud/huaweicloud-sdk-go-v3/core"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/invoker"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model"
+)
+
+type CdnClient struct {
+	HcClient *httpclient.HcHttpClient
+}
+
+func NewCdnClient(hcClient *httpclient.HcHttpClient) *CdnClient {
+	return &CdnClient{HcClient: hcClient}
+}
+
+func CdnClientBuilder() *httpclient.HcHttpClientBuilder {
+	builder := httpclient.NewHcHttpClientBuilder().WithCredentialsType("global.Credentials")
+	return builder
+}
+
+// BatchCopyDomain 批量域名复制
+//
+// 批量域名复制接口。
+//
+//	&gt; 将某个加速域名的配置批量复制到其他域名。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) BatchCopyDomain(request *model.BatchCopyDomainRequest) (*model.BatchCopyDomainResponse, error) {
+	requestDef := GenReqDefForBatchCopyDomain()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.BatchCopyDomainResponse), nil
+	}
+}
+
+// BatchCopyDomainInvoker 批量域名复制
+func (c *CdnClient) BatchCopyDomainInvoker(request *model.BatchCopyDomainRequest) *BatchCopyDomainInvoker {
+	requestDef := GenReqDefForBatchCopyDomain()
+	return &BatchCopyDomainInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// BatchDeleteTags 删除资源标签配置接口
+//
+// 用于删除资源标签。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) BatchDeleteTags(request *model.BatchDeleteTagsRequest) (*model.BatchDeleteTagsResponse, error) {
+	requestDef := GenReqDefForBatchDeleteTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.BatchDeleteTagsResponse), nil
+	}
+}
+
+// BatchDeleteTagsInvoker 删除资源标签配置接口
+func (c *CdnClient) BatchDeleteTagsInvoker(request *model.BatchDeleteTagsRequest) *BatchDeleteTagsInvoker {
+	requestDef := GenReqDefForBatchDeleteTags()
+	return &BatchDeleteTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreateDomain 创建加速域名
+//
+// 创建加速域名。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) CreateDomain(request *model.CreateDomainRequest) (*model.CreateDomainResponse, error) {
+	requestDef := GenReqDefForCreateDomain()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateDomainResponse), nil
+	}
+}
+
+// CreateDomainInvoker 创建加速域名
+func (c *CdnClient) CreateDomainInvoker(request *model.CreateDomainRequest) *CreateDomainInvoker {
+	requestDef := GenReqDefForCreateDomain()
+	return &CreateDomainInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreatePreheatingTasks 创建预热缓存任务
+//
+// 创建预热任务。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) CreatePreheatingTasks(request *model.CreatePreheatingTasksRequest) (*model.CreatePreheatingTasksResponse, error) {
+	requestDef := GenReqDefForCreatePreheatingTasks()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreatePreheatingTasksResponse), nil
+	}
+}
+
+// CreatePreheatingTasksInvoker 创建预热缓存任务
+func (c *CdnClient) CreatePreheatingTasksInvoker(request *model.CreatePreheatingTasksRequest) *CreatePreheatingTasksInvoker {
+	requestDef := GenReqDefForCreatePreheatingTasks()
+	return &CreatePreheatingTasksInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreateRefreshTasks 创建刷新缓存任务
+//
+// 创建刷新缓存任务。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) CreateRefreshTasks(request *model.CreateRefreshTasksRequest) (*model.CreateRefreshTasksResponse, error) {
+	requestDef := GenReqDefForCreateRefreshTasks()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateRefreshTasksResponse), nil
+	}
+}
+
+// CreateRefreshTasksInvoker 创建刷新缓存任务
+func (c *CdnClient) CreateRefreshTasksInvoker(request *model.CreateRefreshTasksRequest) *CreateRefreshTasksInvoker {
+	requestDef := GenReqDefForCreateRefreshTasks()
+	return &CreateRefreshTasksInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreateTags 创建资源标签配置接口
+//
+// 用于创建资源标签。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) CreateTags(request *model.CreateTagsRequest) (*model.CreateTagsResponse, error) {
+	requestDef := GenReqDefForCreateTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateTagsResponse), nil
+	}
+}
+
+// CreateTagsInvoker 创建资源标签配置接口
+func (c *CdnClient) CreateTagsInvoker(request *model.CreateTagsRequest) *CreateTagsInvoker {
+	requestDef := GenReqDefForCreateTags()
+	return &CreateTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// DeleteDomain 删除加速域名
+//
+// 删除加速域名。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) DeleteDomain(request *model.DeleteDomainRequest) (*model.DeleteDomainResponse, error) {
+	requestDef := GenReqDefForDeleteDomain()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteDomainResponse), nil
+	}
+}
+
+// DeleteDomainInvoker 删除加速域名
+func (c *CdnClient) DeleteDomainInvoker(request *model.DeleteDomainRequest) *DeleteDomainInvoker {
+	requestDef := GenReqDefForDeleteDomain()
+	return &DeleteDomainInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// DisableDomain 停用加速域名
+//
+// 停用加速域名。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) DisableDomain(request *model.DisableDomainRequest) (*model.DisableDomainResponse, error) {
+	requestDef := GenReqDefForDisableDomain()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DisableDomainResponse), nil
+	}
+}
+
+// DisableDomainInvoker 停用加速域名
+func (c *CdnClient) DisableDomainInvoker(request *model.DisableDomainRequest) *DisableDomainInvoker {
+	requestDef := GenReqDefForDisableDomain()
+	return &DisableDomainInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+// DownloadRegionCarrierExcel 下载区域运营商指标数据表格文件
+//
+// - 下载区域运营商指标数据表格文件。
+//
+// - 支持下载90天内的指标数据表格。
+//
+// - 时间跨度不能超过31天。
+//
+// - 起始时间和结束时间，左闭右开。如时间跨度为2022-10-24 00:00:00 到 2022-10-25 00:00:00，表示取 [2022-10-24 00:00:00, 2022-10-25 00:00:00)的统计数据。
+//
+// - 起始时间、结束时间必须传毫秒级时间戳，起始时间和结束时间必须同时指定。
+//
+// - 单租户调用频率：10次/min。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) DownloadRegionCarrierExcel(request *model.DownloadRegionCarrierExcelRequest) (*model.DownloadRegionCarrierExcelResponse, error) {
+	requestDef := GenReqDefForDownloadRegionCarrierExcel()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DownloadRegionCarrierExcelResponse), nil
+	}
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+// DownloadRegionCarrierExcelInvoker 下载区域运营商指标数据表格文件
+func (c *CdnClient) DownloadRegionCarrierExcelInvoker(request *model.DownloadRegionCarrierExcelRequest) *DownloadRegionCarrierExcelInvoker {
+	requestDef := GenReqDefForDownloadRegionCarrierExcel()
+	return &DownloadRegionCarrierExcelInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+// DownloadStatisticsExcel 下载统计指标数据表格文件
+//
+// - 下载统计指标数据表格文件。
+//
+// - 支持下载90天内的指标数据。
+//
+// - 时间跨度不能超过31天。
+//
+// - 起始时间和结束时间，左闭右开。如时间跨度为2022-10-24 00:00:00 到 2022-10-25 00:00:00，表示取 [2022-10-24 00:00:00, 2022-10-25 00:00:00)的统计数据。
+//
+// - 起始时间、结束时间必须传毫秒级时间戳，起始时间和结束时间必须同时指定。
+//
+// - 单租户调用频率：10次/min。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) DownloadStatisticsExcel(request *model.DownloadStatisticsExcelRequest) (*model.DownloadStatisticsExcelResponse, error) {
+	requestDef := GenReqDefForDownloadStatisticsExcel()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DownloadStatisticsExcelResponse), nil
+	}
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+// DownloadStatisticsExcelInvoker 下载统计指标数据表格文件
+func (c *CdnClient) DownloadStatisticsExcelInvoker(request *model.DownloadStatisticsExcelRequest) *DownloadStatisticsExcelInvoker {
+	requestDef := GenReqDefForDownloadStatisticsExcel()
+	return &DownloadStatisticsExcelInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// EnableDomain 启用加速域名
+//
+// 启用加速域名。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) EnableDomain(request *model.EnableDomainRequest) (*model.EnableDomainResponse, error) {
+	requestDef := GenReqDefForEnableDomain()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.EnableDomainResponse), nil
+	}
+}
+
+// EnableDomainInvoker 启用加速域名
+func (c *CdnClient) EnableDomainInvoker(request *model.EnableDomainRequest) *EnableDomainInvoker {
+	requestDef := GenReqDefForEnableDomain()
+	return &EnableDomainInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListCdnDomainTopRefers 查询统计TOP100 referer数据明细
+//
+// - 查询TOP100 referer数据。
+//
+// - 支持查询90天内的数据。
+//
+// - 查询跨度不能超过31天。
+//
+// - 单租户调用频率：2次/s。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ListCdnDomainTopRefers(request *model.ListCdnDomainTopRefersRequest) (*model.ListCdnDomainTopRefersResponse, error) {
+	requestDef := GenReqDefForListCdnDomainTopRefers()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListCdnDomainTopRefersResponse), nil
+	}
+}
+
+// ListCdnDomainTopRefersInvoker 查询统计TOP100 referer数据明细
+func (c *CdnClient) ListCdnDomainTopRefersInvoker(request *model.ListCdnDomainTopRefersRequest) *ListCdnDomainTopRefersInvoker {
+	requestDef := GenReqDefForListCdnDomainTopRefers()
+	return &ListCdnDomainTopRefersInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListDomains 查询加速域名
+//
+// 查询加速域名。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ListDomains(request *model.ListDomainsRequest) (*model.ListDomainsResponse, error) {
+	requestDef := GenReqDefForListDomains()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListDomainsResponse), nil
+	}
+}
+
+// ListDomainsInvoker 查询加速域名
+func (c *CdnClient) ListDomainsInvoker(request *model.ListDomainsRequest) *ListDomainsInvoker {
+	requestDef := GenReqDefForListDomains()
+	return &ListDomainsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// SetChargeModes 设置用户计费模式
+//
+// - 设置用户计费模式。
+//
+// - 服务区域仅支持mainland_china（国内）
+//
+// - 计费模式仅支持设置flux（流量），v2及以上客户支持bw（带宽）
+//
+// - 加速类型仅支持base（基础加速）
+//
+// - 单租户调用频率：10次/min。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) SetChargeModes(request *model.SetChargeModesRequest) (*model.SetChargeModesResponse, error) {
+	requestDef := GenReqDefForSetChargeModes()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.SetChargeModesResponse), nil
+	}
+}
+
+// SetChargeModesInvoker 设置用户计费模式
+func (c *CdnClient) SetChargeModesInvoker(request *model.SetChargeModesRequest) *SetChargeModesInvoker {
+	requestDef := GenReqDefForSetChargeModes()
+	return &SetChargeModesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+// ShowBandwidthCalc 查询域名带宽峰值类数据
+//
+// - 查询域名带宽峰值类数据。
+//
+// - 支持查询90天内的数据。
+//
+// - 查询时间跨度不能超过31天。
+//
+// - 起始时间和结束时间，左闭右开。如查询2022-10-24 00:00:00 到 2022-10-25 00:00:00 的数据，表示取 [2022-10-24 00:00:00, 2022-10-25 00:00:00)的统计数据。
+//
+// - 起始时间、结束时间必须传毫秒级时间戳，起始时间和结束时间必须同时指定。
+//
+// - 流量类指标单位统一为Byte（字节）、带宽类指标单位统一为bit/s（比特/秒）、峰值类指标单位统一为bps（比特率），请求数类和状态码类指标单位统一为次数。用于查询指定域名、指定统计指标的明细数据。
+//
+// - 单租户调用频率：2次/s。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowBandwidthCalc(request *model.ShowBandwidthCalcRequest) (*model.ShowBandwidthCalcResponse, error) {
+	requestDef := GenReqDefForShowBandwidthCalc()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowBandwidthCalcResponse), nil
+	}
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+// ShowBandwidthCalcInvoker 查询域名带宽峰值类数据
+func (c *CdnClient) ShowBandwidthCalcInvoker(request *model.ShowBandwidthCalcRequest) *ShowBandwidthCalcInvoker {
+	requestDef := GenReqDefForShowBandwidthCalc()
+	return &ShowBandwidthCalcInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowCertificatesHttpsInfo 查询所有绑定HTTPS证书的域名信息
+//
+// 查询所有绑定HTTPS证书的域名信息
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowCertificatesHttpsInfo(request *model.ShowCertificatesHttpsInfoRequest) (*model.ShowCertificatesHttpsInfoResponse, error) {
+	requestDef := GenReqDefForShowCertificatesHttpsInfo()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowCertificatesHttpsInfoResponse), nil
+	}
+}
+
+// ShowCertificatesHttpsInfoInvoker 查询所有绑定HTTPS证书的域名信息
+func (c *CdnClient) ShowCertificatesHttpsInfoInvoker(request *model.ShowCertificatesHttpsInfoRequest) *ShowCertificatesHttpsInfoInvoker {
+	requestDef := GenReqDefForShowCertificatesHttpsInfo()
+	return &ShowCertificatesHttpsInfoInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowChargeModes 查询用户计费模式
+//
+// - 查询用户计费模式。
+//
+// - 服务区域仅支持mainland_china（国内，默认）和outside_mainland_china（海外）
+//
+// - 计费模式状态支持active（已生效），upcoming（待生效）两种状态，默认为active(已生效)
+//
+// - 加速类型仅支持base（基础加速）
+//
+// - 单租户调用频率：5次/s。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowChargeModes(request *model.ShowChargeModesRequest) (*model.ShowChargeModesResponse, error) {
+	requestDef := GenReqDefForShowChargeModes()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowChargeModesResponse), nil
+	}
+}
+
+// ShowChargeModesInvoker 查询用户计费模式
+func (c *CdnClient) ShowChargeModesInvoker(request *model.ShowChargeModesRequest) *ShowChargeModesInvoker {
+	requestDef := GenReqDefForShowChargeModes()
+	return &ShowChargeModesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowDomainDetailByName 查询加速域名详情
+//
+// 加速域名详情信息接口。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowDomainDetailByName(request *model.ShowDomainDetailByNameRequest) (*model.ShowDomainDetailByNameResponse, error) {
+	requestDef := GenReqDefForShowDomainDetailByName()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowDomainDetailByNameResponse), nil
+	}
+}
+
+// ShowDomainDetailByNameInvoker 查询加速域名详情
+func (c *CdnClient) ShowDomainDetailByNameInvoker(request *model.ShowDomainDetailByNameRequest) *ShowDomainDetailByNameInvoker {
+	requestDef := GenReqDefForShowDomainDetailByName()
+	return &ShowDomainDetailByNameInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowDomainFullConfig 查询域名配置接口
+//
+// 查询域名配置接口，支持查询业务类型、服务范围、备注、IPv6开关、回源方式、回源URL改写、高级回源、Range回源、回源跟随、回源是否校验Etag、回源超时时间、回源请求头、HTTPS配置、TLS版本配置、强制跳转、HSTS、HTTP/2、OCSP Stapling、QUIC、缓存规则、状态码缓存时间、防盗链、IP黑白名单、 Use-Agent黑白名单、URL鉴权配置、远程鉴权配置、IP访问限频、HTTP header配置、自定义错误页面配置、智能压缩、请求限速配置、WebSocket配置、视频拖拽。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowDomainFullConfig(request *model.ShowDomainFullConfigRequest) (*model.ShowDomainFullConfigResponse, error) {
+	requestDef := GenReqDefForShowDomainFullConfig()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowDomainFullConfigResponse), nil
+	}
+}
+
+// ShowDomainFullConfigInvoker 查询域名配置接口
+func (c *CdnClient) ShowDomainFullConfigInvoker(request *model.ShowDomainFullConfigRequest) *ShowDomainFullConfigInvoker {
+	requestDef := GenReqDefForShowDomainFullConfig()
+	return &ShowDomainFullConfigInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowDomainLocationStats 按区域运营商查询域名统计数据
+//
+// - 支持查询90天内的数据。
+//
+// - 支持多指标同时查询，不超过5个。
+//
+// - 最多同时指定20个域名。
+//
+// - 起始时间和结束时间需要同时指定，左闭右开，毫秒级时间戳，且时间点必须为与查询时间间隔参数匹配的整时刻点。比如查询时间间隔为5分钟时，起始时间和结束时间必须为5分钟整时刻点，如：0分、5分、10分、15分等，如果时间点与时间间隔不匹配，返回数据可能与预期不一致。统一用开始时间表示一个时间段，如：2019-01-24 20:15:00 表示取 [20:15:00, 20:20:00)的统计数据，且左闭右开。
+//
+// - action取值：location_detail,location_summary
+//
+// - 流量类指标单位统一为Byte（字节）、带宽类指标单位统一为bit/s（比特/秒）、请求数类和状态码类指标单位统一为次数。用于查询指定域名、指定统计指标的区域运营商明细数据。
+//
+// - 单租户调用频率：15次/s。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowDomainLocationStats(request *model.ShowDomainLocationStatsRequest) (*model.ShowDomainLocationStatsResponse, error) {
+	requestDef := GenReqDefForShowDomainLocationStats()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowDomainLocationStatsResponse), nil
+	}
+}
+
+// ShowDomainLocationStatsInvoker 按区域运营商查询域名统计数据
+func (c *CdnClient) ShowDomainLocationStatsInvoker(request *model.ShowDomainLocationStatsRequest) *ShowDomainLocationStatsInvoker {
+	requestDef := GenReqDefForShowDomainLocationStats()
+	return &ShowDomainLocationStatsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowDomainStats 查询域名统计数据
+//
+// - 支持查询90天内的数据。
+//
+// - 支持多指标同时查询，不超过5个。
+//
+// - 最多同时指定20个域名。
+//
+// - 起始时间和结束时间需要同时指定，左闭右开，毫秒级时间戳，且时间点必须为与查询时间间隔参数匹配的整时刻点。比如查询时间间隔为5分钟时，起始时间和结束时间必须为5分钟整时刻点，如：0分、5分、10分、15分等，如果时间点与时间间隔不匹配，返回数据可能与预期不一致。统一用开始时间表示一个时间段，如：2019-01-24 20:15:00 表示取 [20:15:00, 20:20:00)的统计数据，且左闭右开。
+//
+// - action取值：detail,summary
+//
+// - 流量类指标单位统一为Byte（字节）、带宽类指标单位统一为bit/s（比特/秒）、请求数类和状态码类指标单位统一为次数。用于查询指定域名、指定统计指标的明细数据。
+//
+// - 单租户调用频率：15次/s。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowDomainStats(request *model.ShowDomainStatsRequest) (*model.ShowDomainStatsResponse, error) {
+	requestDef := GenReqDefForShowDomainStats()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowDomainStatsResponse), nil
+	}
+}
+
+// ShowDomainStatsInvoker 查询域名统计数据
+func (c *CdnClient) ShowDomainStatsInvoker(request *model.ShowDomainStatsRequest) *ShowDomainStatsInvoker {
+	requestDef := GenReqDefForShowDomainStats()
+	return &ShowDomainStatsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowHistoryTaskDetails 查询刷新预热任务详情
+//
+// 查询刷新预热任务详情。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowHistoryTaskDetails(request *model.ShowHistoryTaskDetailsRequest) (*model.ShowHistoryTaskDetailsResponse, error) {
+	requestDef := GenReqDefForShowHistoryTaskDetails()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowHistoryTaskDetailsResponse), nil
+	}
+}
+
+// ShowHistoryTaskDetailsInvoker 查询刷新预热任务详情
+func (c *CdnClient) ShowHistoryTaskDetailsInvoker(request *model.ShowHistoryTaskDetailsRequest) *ShowHistoryTaskDetailsInvoker {
+	requestDef := GenReqDefForShowHistoryTaskDetails()
+	return &ShowHistoryTaskDetailsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowHistoryTasks 查询刷新预热任务
+//
+// 查询刷新预热任务。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowHistoryTasks(request *model.ShowHistoryTasksRequest) (*model.ShowHistoryTasksResponse, error) {
+	requestDef := GenReqDefForShowHistoryTasks()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowHistoryTasksResponse), nil
+	}
+}
+
+// ShowHistoryTasksInvoker 查询刷新预热任务
+func (c *CdnClient) ShowHistoryTasksInvoker(request *model.ShowHistoryTasksRequest) *ShowHistoryTasksInvoker {
+	requestDef := GenReqDefForShowHistoryTasks()
+	return &ShowHistoryTasksInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowIpInfo 查询IP归属信息
+//
+// 查询IP归属信息。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowIpInfo(request *model.ShowIpInfoRequest) (*model.ShowIpInfoResponse, error) {
+	requestDef := GenReqDefForShowIpInfo()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowIpInfoResponse), nil
+	}
+}
+
+// ShowIpInfoInvoker 查询IP归属信息
+func (c *CdnClient) ShowIpInfoInvoker(request *model.ShowIpInfoRequest) *ShowIpInfoInvoker {
+	requestDef := GenReqDefForShowIpInfo()
+	return &ShowIpInfoInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowLogs 日志查询
+//
+// 查询日志下载链接，支持查询30天内的日志信息。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowLogs(request *model.ShowLogsRequest) (*model.ShowLogsResponse, error) {
+	requestDef := GenReqDefForShowLogs()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowLogsResponse), nil
+	}
+}
+
+// ShowLogsInvoker 日志查询
+func (c *CdnClient) ShowLogsInvoker(request *model.ShowLogsRequest) *ShowLogsInvoker {
+	requestDef := GenReqDefForShowLogs()
+	return &ShowLogsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowTags 查询资源标签列表配置接口
+//
+// 用于查询资源标签列表。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowTags(request *model.ShowTagsRequest) (*model.ShowTagsResponse, error) {
+	requestDef := GenReqDefForShowTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowTagsResponse), nil
+	}
+}
+
+// ShowTagsInvoker 查询资源标签列表配置接口
+func (c *CdnClient) ShowTagsInvoker(request *model.ShowTagsRequest) *ShowTagsInvoker {
+	requestDef := GenReqDefForShowTags()
+	return &ShowTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+// ShowTopDomainNames 查询TOP域名
+//
+// - 查询TOP域名。
+//
+// - 支持查询90天内的数据。
+//
+// - 查询时间跨度不能超过1天。
+//
+// - 起始时间和结束时间，左闭右开，必须同时指定。如查询2022-10-24 00:00:00 到 2022-10-25 00:00:00 的数据，表示取 [2022-10-24 00:00:00, 2022-10-25 00:00:00)的统计数据。
+//
+// - 起始时间、结束时间必须传整点毫秒级时间戳。
+//
+// - 流量类指标单位统一为Byte（字节）、带宽类指标单位统一为bit/s（比特/秒）、请求数类和状态码类指标单位统一为次数。用于查询指定域名、指定统计指标的明细数据。
+//
+// - 单租户调用频率：5次/s。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowTopDomainNames(request *model.ShowTopDomainNamesRequest) (*model.ShowTopDomainNamesResponse, error) {
+	requestDef := GenReqDefForShowTopDomainNames()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowTopDomainNamesResponse), nil
+	}
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+// ShowTopDomainNamesInvoker 查询TOP域名
+func (c *CdnClient) ShowTopDomainNamesInvoker(request *model.ShowTopDomainNamesRequest) *ShowTopDomainNamesInvoker {
+	requestDef := GenReqDefForShowTopDomainNames()
+	return &ShowTopDomainNamesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowTopUrl 查询TOP100 URL明细
+//
+// - 查询TOP100 URL明细。
+//
+// - 支持查询90天内的数据。
+//
+// - 查询跨度不能超过31天。
+//
+// - 起始时间和结束时间，左闭右开，需要同时指定。如查询2021-10-24 00:00:00 到 2021-10-25 00:00:00 的数据，表示取 [2021-10-24 00:00:00, 2021-10-25 00:00:00)的统计数据。
+//
+// - 开始时间、结束时间必须传毫秒级时间戳，且必须为凌晨0点整时刻点，如果传的不是凌晨0点整时刻点，返回数据可能与预期不一致。
+//
+// - 流量类指标单位统一为Byte（字节）、请求数类指标单位统一为次数。用于查询指定域名、指定统计指标的明细数据。
+//
+// - 单租户调用频率：5次/s。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowTopUrl(request *model.ShowTopUrlRequest) (*model.ShowTopUrlResponse, error) {
+	requestDef := GenReqDefForShowTopUrl()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowTopUrlResponse), nil
+	}
+}
+
+// ShowTopUrlInvoker 查询TOP100 URL明细
+func (c *CdnClient) ShowTopUrlInvoker(request *model.ShowTopUrlRequest) *ShowTopUrlInvoker {
+	requestDef := GenReqDefForShowTopUrl()
+	return &ShowTopUrlInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowUrlTaskInfo 查询刷新预热URL记录
+//
+// 查询刷新预热URL记录。如需此接口，请提交工单开通。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowUrlTaskInfo(request *model.ShowUrlTaskInfoRequest) (*model.ShowUrlTaskInfoResponse, error) {
+	requestDef := GenReqDefForShowUrlTaskInfo()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowUrlTaskInfoResponse), nil
+	}
+}
+
+// ShowUrlTaskInfoInvoker 查询刷新预热URL记录
+func (c *CdnClient) ShowUrlTaskInfoInvoker(request *model.ShowUrlTaskInfoRequest) *ShowUrlTaskInfoInvoker {
+	requestDef := GenReqDefForShowUrlTaskInfo()
+	return &ShowUrlTaskInfoInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowVerifyDomainOwnerInfo 查询域名归属校验信息
+//
+// 用于查询域名归属校验信息
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) ShowVerifyDomainOwnerInfo(request *model.ShowVerifyDomainOwnerInfoRequest) (*model.ShowVerifyDomainOwnerInfoResponse, error) {
+	requestDef := GenReqDefForShowVerifyDomainOwnerInfo()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowVerifyDomainOwnerInfoResponse), nil
+	}
+}
+
+// ShowVerifyDomainOwnerInfoInvoker 查询域名归属校验信息
+func (c *CdnClient) ShowVerifyDomainOwnerInfoInvoker(request *model.ShowVerifyDomainOwnerInfoRequest) *ShowVerifyDomainOwnerInfoInvoker {
+	requestDef := GenReqDefForShowVerifyDomainOwnerInfo()
+	return &ShowVerifyDomainOwnerInfoInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateDomainFullConfig 修改域名全量配置接口
+//
+// 修改域名配置接口，支持修改业务类型、服务范围、备注、IPv6开关、回源方式、回源URL改写、高级回源、Range回源、回源跟随、回源是否校验Etag、回源超时时间、回源请求头、HTTPS配置、TLS版本配置、强制跳转、HSTS、HTTP/2、OCSP Stapling、QUIC、缓存规则、状态码缓存时间、防盗链、IP黑白名单、Use-Agent黑白名单、URL鉴权配置、远程鉴权配置、IP访问限频、HTTP header配置、自定义错误页面配置、智能压缩、请求限速配置、WebSocket配置、视频拖拽。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) UpdateDomainFullConfig(request *model.UpdateDomainFullConfigRequest) (*model.UpdateDomainFullConfigResponse, error) {
+	requestDef := GenReqDefForUpdateDomainFullConfig()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateDomainFullConfigResponse), nil
+	}
+}
+
+// UpdateDomainFullConfigInvoker 修改域名全量配置接口
+func (c *CdnClient) UpdateDomainFullConfigInvoker(request *model.UpdateDomainFullConfigRequest) *UpdateDomainFullConfigInvoker {
+	requestDef := GenReqDefForUpdateDomainFullConfig()
+	return &UpdateDomainFullConfigInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateDomainMultiCertificates 一个证书批量设置多个域名
+//
+// 一个证书配置多个域名，设置域名强制https回源参数。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) UpdateDomainMultiCertificates(request *model.UpdateDomainMultiCertificatesRequest) (*model.UpdateDomainMultiCertificatesResponse, error) {
+	requestDef := GenReqDefForUpdateDomainMultiCertificates()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateDomainMultiCertificatesResponse), nil
+	}
+}
+
+// UpdateDomainMultiCertificatesInvoker 一个证书批量设置多个域名
+func (c *CdnClient) UpdateDomainMultiCertificatesInvoker(request *model.UpdateDomainMultiCertificatesRequest) *UpdateDomainMultiCertificatesInvoker {
+	requestDef := GenReqDefForUpdateDomainMultiCertificates()
+	return &UpdateDomainMultiCertificatesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdatePrivateBucketAccess 修改私有桶开启关闭状态
+//
+// 修改私有桶开启关闭状态。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) UpdatePrivateBucketAccess(request *model.UpdatePrivateBucketAccessRequest) (*model.UpdatePrivateBucketAccessResponse, error) {
+	requestDef := GenReqDefForUpdatePrivateBucketAccess()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdatePrivateBucketAccessResponse), nil
+	}
+}
+
+// UpdatePrivateBucketAccessInvoker 修改私有桶开启关闭状态
+func (c *CdnClient) UpdatePrivateBucketAccessInvoker(request *model.UpdatePrivateBucketAccessRequest) *UpdatePrivateBucketAccessInvoker {
+	requestDef := GenReqDefForUpdatePrivateBucketAccess()
+	return &UpdatePrivateBucketAccessInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// VerifyDomainOwner 域名归属校验
+//
+// 用于域名归属校验
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *CdnClient) VerifyDomainOwner(request *model.VerifyDomainOwnerRequest) (*model.VerifyDomainOwnerResponse, error) {
+	requestDef := GenReqDefForVerifyDomainOwner()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.VerifyDomainOwnerResponse), nil
+	}
+}
+
+// VerifyDomainOwnerInvoker 域名归属校验
+func (c *CdnClient) VerifyDomainOwnerInvoker(request *model.VerifyDomainOwnerRequest) *VerifyDomainOwnerInvoker {
+	requestDef := GenReqDefForVerifyDomainOwner()
+	return &VerifyDomainOwnerInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/cdn_invoker.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/cdn_invoker.go
@@ -1,0 +1,418 @@
+package v2
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/invoker"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model"
+)
+
+type BatchCopyDomainInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *BatchCopyDomainInvoker) Invoke() (*model.BatchCopyDomainResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.BatchCopyDomainResponse), nil
+	}
+}
+
+type BatchDeleteTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *BatchDeleteTagsInvoker) Invoke() (*model.BatchDeleteTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.BatchDeleteTagsResponse), nil
+	}
+}
+
+type CreateDomainInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreateDomainInvoker) Invoke() (*model.CreateDomainResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreateDomainResponse), nil
+	}
+}
+
+type CreatePreheatingTasksInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreatePreheatingTasksInvoker) Invoke() (*model.CreatePreheatingTasksResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreatePreheatingTasksResponse), nil
+	}
+}
+
+type CreateRefreshTasksInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreateRefreshTasksInvoker) Invoke() (*model.CreateRefreshTasksResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreateRefreshTasksResponse), nil
+	}
+}
+
+type CreateTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreateTagsInvoker) Invoke() (*model.CreateTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreateTagsResponse), nil
+	}
+}
+
+type DeleteDomainInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *DeleteDomainInvoker) Invoke() (*model.DeleteDomainResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DeleteDomainResponse), nil
+	}
+}
+
+type DisableDomainInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *DisableDomainInvoker) Invoke() (*model.DisableDomainResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DisableDomainResponse), nil
+	}
+}
+
+type DownloadRegionCarrierExcelInvoker struct {
+	*invoker.BaseInvoker
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+func (i *DownloadRegionCarrierExcelInvoker) Invoke() (*model.DownloadRegionCarrierExcelResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DownloadRegionCarrierExcelResponse), nil
+	}
+}
+
+type DownloadStatisticsExcelInvoker struct {
+	*invoker.BaseInvoker
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+func (i *DownloadStatisticsExcelInvoker) Invoke() (*model.DownloadStatisticsExcelResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DownloadStatisticsExcelResponse), nil
+	}
+}
+
+type EnableDomainInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *EnableDomainInvoker) Invoke() (*model.EnableDomainResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.EnableDomainResponse), nil
+	}
+}
+
+type ListCdnDomainTopRefersInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListCdnDomainTopRefersInvoker) Invoke() (*model.ListCdnDomainTopRefersResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListCdnDomainTopRefersResponse), nil
+	}
+}
+
+type ListDomainsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListDomainsInvoker) Invoke() (*model.ListDomainsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListDomainsResponse), nil
+	}
+}
+
+type SetChargeModesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *SetChargeModesInvoker) Invoke() (*model.SetChargeModesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.SetChargeModesResponse), nil
+	}
+}
+
+type ShowBandwidthCalcInvoker struct {
+	*invoker.BaseInvoker
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+func (i *ShowBandwidthCalcInvoker) Invoke() (*model.ShowBandwidthCalcResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowBandwidthCalcResponse), nil
+	}
+}
+
+type ShowCertificatesHttpsInfoInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowCertificatesHttpsInfoInvoker) Invoke() (*model.ShowCertificatesHttpsInfoResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowCertificatesHttpsInfoResponse), nil
+	}
+}
+
+type ShowChargeModesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowChargeModesInvoker) Invoke() (*model.ShowChargeModesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowChargeModesResponse), nil
+	}
+}
+
+type ShowDomainDetailByNameInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowDomainDetailByNameInvoker) Invoke() (*model.ShowDomainDetailByNameResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowDomainDetailByNameResponse), nil
+	}
+}
+
+type ShowDomainFullConfigInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowDomainFullConfigInvoker) Invoke() (*model.ShowDomainFullConfigResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowDomainFullConfigResponse), nil
+	}
+}
+
+type ShowDomainLocationStatsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowDomainLocationStatsInvoker) Invoke() (*model.ShowDomainLocationStatsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowDomainLocationStatsResponse), nil
+	}
+}
+
+type ShowDomainStatsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowDomainStatsInvoker) Invoke() (*model.ShowDomainStatsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowDomainStatsResponse), nil
+	}
+}
+
+type ShowHistoryTaskDetailsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowHistoryTaskDetailsInvoker) Invoke() (*model.ShowHistoryTaskDetailsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowHistoryTaskDetailsResponse), nil
+	}
+}
+
+type ShowHistoryTasksInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowHistoryTasksInvoker) Invoke() (*model.ShowHistoryTasksResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowHistoryTasksResponse), nil
+	}
+}
+
+type ShowIpInfoInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowIpInfoInvoker) Invoke() (*model.ShowIpInfoResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowIpInfoResponse), nil
+	}
+}
+
+type ShowLogsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowLogsInvoker) Invoke() (*model.ShowLogsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowLogsResponse), nil
+	}
+}
+
+type ShowTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowTagsInvoker) Invoke() (*model.ShowTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowTagsResponse), nil
+	}
+}
+
+type ShowTopDomainNamesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+// Deprecated: This function is deprecated and will be removed in the future versions.
+func (i *ShowTopDomainNamesInvoker) Invoke() (*model.ShowTopDomainNamesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowTopDomainNamesResponse), nil
+	}
+}
+
+type ShowTopUrlInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowTopUrlInvoker) Invoke() (*model.ShowTopUrlResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowTopUrlResponse), nil
+	}
+}
+
+type ShowUrlTaskInfoInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowUrlTaskInfoInvoker) Invoke() (*model.ShowUrlTaskInfoResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowUrlTaskInfoResponse), nil
+	}
+}
+
+type ShowVerifyDomainOwnerInfoInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowVerifyDomainOwnerInfoInvoker) Invoke() (*model.ShowVerifyDomainOwnerInfoResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowVerifyDomainOwnerInfoResponse), nil
+	}
+}
+
+type UpdateDomainFullConfigInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateDomainFullConfigInvoker) Invoke() (*model.UpdateDomainFullConfigResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateDomainFullConfigResponse), nil
+	}
+}
+
+type UpdateDomainMultiCertificatesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateDomainMultiCertificatesInvoker) Invoke() (*model.UpdateDomainMultiCertificatesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateDomainMultiCertificatesResponse), nil
+	}
+}
+
+type UpdatePrivateBucketAccessInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdatePrivateBucketAccessInvoker) Invoke() (*model.UpdatePrivateBucketAccessResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdatePrivateBucketAccessResponse), nil
+	}
+}
+
+type VerifyDomainOwnerInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *VerifyDomainOwnerInvoker) Invoke() (*model.VerifyDomainOwnerResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.VerifyDomainOwnerResponse), nil
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/cdn_meta.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/cdn_meta.go
@@ -1,0 +1,1137 @@
+package v2
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/def"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model"
+	"net/http"
+)
+
+func GenReqDefForBatchCopyDomain() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1.0/cdn/configuration/domains/batch-copy").
+		WithResponse(new(model.BatchCopyDomainResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForBatchDeleteTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1.0/cdn/configuration/tags/batch-delete").
+		WithResponse(new(model.BatchDeleteTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateDomain() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1.0/cdn/domains").
+		WithResponse(new(model.CreateDomainResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreatePreheatingTasks() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1.0/cdn/content/preheating-tasks").
+		WithResponse(new(model.CreatePreheatingTasksResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateRefreshTasks() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1.0/cdn/content/refresh-tasks").
+		WithResponse(new(model.CreateRefreshTasksResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1.0/cdn/configuration/tags").
+		WithResponse(new(model.CreateTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteDomain() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v1.0/cdn/domains/{domain_id}").
+		WithResponse(new(model.DeleteDomainResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainId").
+		WithJsonTag("domain_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDisableDomain() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v1.0/cdn/domains/{domain_id}/disable").
+		WithResponse(new(model.DisableDomainResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainId").
+		WithJsonTag("domain_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDownloadRegionCarrierExcel() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/statistics/region-carrier-excel").
+		WithResponse(new(model.DownloadRegionCarrierExcelResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Interval").
+		WithJsonTag("interval").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Country").
+		WithJsonTag("country").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ExcelLanguage").
+		WithJsonTag("excel_language").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ExcelType").
+		WithJsonTag("excel_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Region").
+		WithJsonTag("region").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Carrier").
+		WithJsonTag("carrier").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDownloadStatisticsExcel() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/statistics/statistics-excel").
+		WithResponse(new(model.DownloadStatisticsExcelResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ExcelLanguage").
+		WithJsonTag("excel_language").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ServiceArea").
+		WithJsonTag("service_area").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Interval").
+		WithJsonTag("interval").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ExcelType").
+		WithJsonTag("excel_type").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForEnableDomain() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v1.0/cdn/domains/{domain_id}/enable").
+		WithResponse(new(model.EnableDomainResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainId").
+		WithJsonTag("domain_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListCdnDomainTopRefers() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/statistics/top-refers").
+		WithResponse(new(model.ListCdnDomainTopRefersResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StatType").
+		WithJsonTag("stat_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ServiceArea").
+		WithJsonTag("service_area").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("IncludeRatio").
+		WithJsonTag("include_ratio").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListDomains() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/domains").
+		WithResponse(new(model.ListDomainsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("BusinessType").
+		WithJsonTag("business_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainStatus").
+		WithJsonTag("domain_status").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ServiceArea").
+		WithJsonTag("service_area").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageSize").
+		WithJsonTag("page_size").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageNumber").
+		WithJsonTag("page_number").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ShowTags").
+		WithJsonTag("show_tags").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ExactMatch").
+		WithJsonTag("exact_match").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForSetChargeModes() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v1.0/cdn/charge/charge-modes").
+		WithResponse(new(model.SetChargeModesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowBandwidthCalc() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/statistics/bandwidth-calc").
+		WithResponse(new(model.ShowBandwidthCalcResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ServiceArea").
+		WithJsonTag("service_area").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("CalcType").
+		WithJsonTag("calc_type").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowCertificatesHttpsInfo() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/domains/https-certificate-info").
+		WithResponse(new(model.ShowCertificatesHttpsInfoResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageSize").
+		WithJsonTag("page_size").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageNumber").
+		WithJsonTag("page_number").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("UserDomainId").
+		WithJsonTag("user_domain_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowChargeModes() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/charge/charge-modes").
+		WithResponse(new(model.ShowChargeModesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ProductType").
+		WithJsonTag("product_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Status").
+		WithJsonTag("status").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ServiceArea").
+		WithJsonTag("service_area").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowDomainDetailByName() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/configuration/domains/{domain_name}").
+		WithResponse(new(model.ShowDomainDetailByNameResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowDomainFullConfig() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.1/cdn/configuration/domains/{domain_name}/configs").
+		WithResponse(new(model.ShowDomainFullConfigResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ShowSpecialConfigs").
+		WithJsonTag("show_special_configs").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowDomainLocationStats() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/statistics/domain-location-stats").
+		WithResponse(new(model.ShowDomainLocationStatsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Action").
+		WithJsonTag("action").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StatType").
+		WithJsonTag("stat_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Interval").
+		WithJsonTag("interval").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Country").
+		WithJsonTag("country").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Province").
+		WithJsonTag("province").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Isp").
+		WithJsonTag("isp").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("GroupBy").
+		WithJsonTag("group_by").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowDomainStats() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/statistics/domain-stats").
+		WithResponse(new(model.ShowDomainStatsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Action").
+		WithJsonTag("action").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StatType").
+		WithJsonTag("stat_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Interval").
+		WithJsonTag("interval").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("GroupBy").
+		WithJsonTag("group_by").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ServiceArea").
+		WithJsonTag("service_area").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowHistoryTaskDetails() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/historytasks/{history_tasks_id}/detail").
+		WithResponse(new(model.ShowHistoryTaskDetailsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("HistoryTasksId").
+		WithJsonTag("history_tasks_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageSize").
+		WithJsonTag("page_size").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageNumber").
+		WithJsonTag("page_number").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Status").
+		WithJsonTag("status").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Url").
+		WithJsonTag("url").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("CreateTime").
+		WithJsonTag("create_time").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowHistoryTasks() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/historytasks").
+		WithResponse(new(model.ShowHistoryTasksResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageSize").
+		WithJsonTag("page_size").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageNumber").
+		WithJsonTag("page_number").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Status").
+		WithJsonTag("status").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartDate").
+		WithJsonTag("start_date").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndDate").
+		WithJsonTag("end_date").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("OrderField").
+		WithJsonTag("order_field").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("OrderType").
+		WithJsonTag("order_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("FileType").
+		WithJsonTag("file_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("TaskType").
+		WithJsonTag("task_type").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowIpInfo() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/ip-info").
+		WithResponse(new(model.ShowIpInfoResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Ips").
+		WithJsonTag("ips").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowLogs() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/logs").
+		WithResponse(new(model.ShowLogsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageSize").
+		WithJsonTag("page_size").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("PageNumber").
+		WithJsonTag("page_number").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/configuration/tags").
+		WithResponse(new(model.ShowTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ResourceId").
+		WithJsonTag("resource_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowTopDomainNames() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1/cdn/statistics/top-domain-names").
+		WithResponse(new(model.ShowTopDomainNamesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StatType").
+		WithJsonTag("stat_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ServiceArea").
+		WithJsonTag("service_area").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowTopUrl() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/statistics/top-url").
+		WithResponse(new(model.ShowTopUrlResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StatType").
+		WithJsonTag("stat_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ServiceArea").
+		WithJsonTag("service_area").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowUrlTaskInfo() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/contentgateway/url-tasks").
+		WithResponse(new(model.ShowUrlTaskInfoResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("StartTime").
+		WithJsonTag("start_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EndTime").
+		WithJsonTag("end_time").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Url").
+		WithJsonTag("url").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("TaskType").
+		WithJsonTag("task_type").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Status").
+		WithJsonTag("status").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("FileType").
+		WithJsonTag("file_type").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-request-id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowVerifyDomainOwnerInfo() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v1.0/cdn/configuration/domains/{domain_name}/domain-verifies").
+		WithResponse(new(model.ShowVerifyDomainOwnerInfoResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateDomainFullConfig() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v1.1/cdn/configuration/domains/{domain_name}/configs").
+		WithResponse(new(model.UpdateDomainFullConfigResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateDomainMultiCertificates() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v1.0/cdn/domains/config-https-info").
+		WithResponse(new(model.UpdateDomainMultiCertificatesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdatePrivateBucketAccess() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v1.0/cdn/domains/{domain_id}/private-bucket-access").
+		WithResponse(new(model.UpdatePrivateBucketAccessResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainId").
+		WithJsonTag("domain_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("EnterpriseProjectId").
+		WithJsonTag("enterprise_project_id").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForVerifyDomainOwner() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v1.0/cdn/configuration/domains/{domain_name}/verify-owner").
+		WithResponse(new(model.VerifyDomainOwnerResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DomainName").
+		WithJsonTag("domain_name").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("XRequestId").
+		WithJsonTag("X-Request-Id").
+		WithKindName("string").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_back_sources.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_back_sources.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BackSources 高级回源信息源站配置。
+type BackSources struct {
+
+	// 源站类型, ipaddr：源站IP，domain：源站域名，obs_bucket：OBS桶域名。
+	SourcesType string `json:"sources_type"`
+
+	// 源站IP或者域名。
+	IpOrDomain string `json:"ip_or_domain"`
+
+	// OBS桶类型： - “private”， 私有桶： - “public”，公有桶。
+	ObsBucketType *string `json:"obs_bucket_type,omitempty"`
+
+	// HTTP端口，取值范围：1-65535。
+	HttpPort *int32 `json:"http_port,omitempty"`
+
+	// HTTPS端口，取值范围：1-65535。
+	HttpsPort *int32 `json:"https_port,omitempty"`
+}
+
+func (o BackSources) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BackSources struct{}"
+	}
+
+	return strings.Join([]string{"BackSources", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_configs.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_configs.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchCopyConfigs 需要复制的原域名配置。
+type BatchCopyConfigs struct {
+
+	// 目标域名列表,多个域名以逗号（半角）分隔,域名数最大10个。
+	TargetDomain string `json:"target_domain"`
+
+	// 原域名。
+	SourceDomain string `json:"source_domain"`
+
+	// 需要复制的域名配置项,多个配置项以逗号（半角）分隔，支持复制的配置项： - originRequestHeader（回源请求头） - httpResponseHeader（HTTP header配置） - cacheUrlParamsConfig（URL参数） - urlAuth（URL鉴权配置） - userAgentBlackAndWhiteList（User-Agent黑白名单） - ipv6Accelerate（IPv6开关） - rangeStatus（Range回源） - cacheRules（缓存规则） - followOrigin（缓存遵循源站） - privateBucketRetrieval（私有桶回源） - follow302Status（回源跟随） - sources（源站配置） - compress（智能压缩） - referer（防盗链） - ipBlackAndWhiteList（IP黑白名单）
+	ConfigList []string `json:"config_list"`
+}
+
+func (o BatchCopyConfigs) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCopyConfigs struct{}"
+	}
+
+	return strings.Join([]string{"BatchCopyConfigs", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_d_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_d_request_body.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchCopyDRequestBody 域名复制请求体。
+type BatchCopyDRequestBody struct {
+	Configs *BatchCopyConfigs `json:"configs"`
+}
+
+func (o BatchCopyDRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCopyDRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"BatchCopyDRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_domain_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_domain_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchCopyDomainRequest Request Object
+type BatchCopyDomainRequest struct {
+	Body *BatchCopyDRequestBody `json:"body,omitempty"`
+}
+
+func (o BatchCopyDomainRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCopyDomainRequest struct{}"
+	}
+
+	return strings.Join([]string{"BatchCopyDomainRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_domain_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_domain_response.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchCopyDomainResponse Response Object
+type BatchCopyDomainResponse struct {
+
+	// 复制配置结果。
+	Result *[]BatchCopyResultVo `json:"result,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o BatchCopyDomainResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCopyDomainResponse struct{}"
+	}
+
+	return strings.Join([]string{"BatchCopyDomainResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_error_rsp.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_error_rsp.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchCopyErrorRsp 原域名所有配置
+type BatchCopyErrorRsp struct {
+	Error *BatchCopyErrorRspError `json:"error,omitempty"`
+}
+
+func (o BatchCopyErrorRsp) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCopyErrorRsp struct{}"
+	}
+
+	return strings.Join([]string{"BatchCopyErrorRsp", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_error_rsp_error.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_error_rsp_error.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchCopyErrorRspError 错误体
+type BatchCopyErrorRspError struct {
+
+	// 错误码
+	ErrorCode *string `json:"error_code,omitempty"`
+
+	// 错误描述
+	ErrorMsg *string `json:"error_msg,omitempty"`
+}
+
+func (o BatchCopyErrorRspError) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCopyErrorRspError struct{}"
+	}
+
+	return strings.Join([]string{"BatchCopyErrorRspError", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_result_vo.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_copy_result_vo.go
@@ -1,0 +1,79 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// BatchCopyResultVo 成功响应详细内容。
+type BatchCopyResultVo struct {
+
+	// 失败原因,成功时没有该字段
+	Reason *string `json:"reason,omitempty"`
+
+	// 批量操作结果。
+	Status BatchCopyResultVoStatus `json:"status"`
+
+	// 域名。
+	DomainName string `json:"domain_name"`
+}
+
+func (o BatchCopyResultVo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCopyResultVo struct{}"
+	}
+
+	return strings.Join([]string{"BatchCopyResultVo", string(data)}, " ")
+}
+
+type BatchCopyResultVoStatus struct {
+	value string
+}
+
+type BatchCopyResultVoStatusEnum struct {
+	SUCCESS BatchCopyResultVoStatus
+	FAIL    BatchCopyResultVoStatus
+}
+
+func GetBatchCopyResultVoStatusEnum() BatchCopyResultVoStatusEnum {
+	return BatchCopyResultVoStatusEnum{
+		SUCCESS: BatchCopyResultVoStatus{
+			value: "success",
+		},
+		FAIL: BatchCopyResultVoStatus{
+			value: "fail",
+		},
+	}
+}
+
+func (c BatchCopyResultVoStatus) Value() string {
+	return c.value
+}
+
+func (c BatchCopyResultVoStatus) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *BatchCopyResultVoStatus) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_delete_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_delete_tags_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchDeleteTagsRequest Request Object
+type BatchDeleteTagsRequest struct {
+	Body *DeleteTagsRequestBody `json:"body,omitempty"`
+}
+
+func (o BatchDeleteTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_delete_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_batch_delete_tags_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchDeleteTagsResponse Response Object
+type BatchDeleteTagsResponse struct {
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o BatchDeleteTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_cache_rules.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_cache_rules.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type CacheRules struct {
+
+	// 匹配类型: - all：匹配所有文件， - file_extension：按文件后缀匹配， - catalog：按目录匹配， - full_path：全路径匹配， - home_page：按首页匹配。   > 配置单条缓存规则时，可不传，默认为all。   > 配置多条缓存规则时，此参数必传。
+	MatchType *string `json:"match_type,omitempty"`
+
+	// 缓存匹配设置， 当match_type为all时，为空。当match_type为file_extension时，为文件后缀，输入首字符为“.”，以“,”进行分隔， 如.jpg,.zip,.exe，并且输入的文 件名后缀总数不超过20个。 当match_type为catalog时，为目录，输入要求以“/”作为首字符， 以“,”进行分隔，如/test/folder01,/test/folder02，并且输入的目录路径总数不超过20个。  当match_type为full_path时，为全路径，输入要求以“/”作为首字符，支持匹配指定目录下的具体文件，或者带通配符“\\*”的文件， 如/test/index.html,/test/\\*.jpg。 当match_type为home_page时，为空。
+	MatchValue *string `json:"match_value,omitempty"`
+
+	// 缓存过期时间，最大支持365天。  > 默认值为0。
+	Ttl *int32 `json:"ttl,omitempty"`
+
+	// 缓存过期时间单位，s：秒；m：分；h：小时；d：天。
+	TtlUnit string `json:"ttl_unit"`
+
+	// 此条缓存规则的优先级, 默认值1，数值越大，优先级越高，取值范围为1-100，优先级不能相同。
+	Priority int32 `json:"priority"`
+
+	// 缓存遵循源站开关，on：打开，off：关闭。  > 默认值为off。
+	FollowOrigin *string `json:"follow_origin,omitempty"`
+
+	// URL参数： - del_params：忽略指定URL参数， - reserve_params：保留指定URL参数， - ignore_url_params：忽略全部URL参数， - full_url：使用完整URL参数。   > 不传此参数时，默认为full_url。
+	UrlParameterType *string `json:"url_parameter_type,omitempty"`
+
+	// URL参数值，最多设置10条，以\",\"分隔。  > 当url_parameter_type为del_params或reserve_params时必填。
+	UrlParameterValue *string `json:"url_parameter_value,omitempty"`
+}
+
+func (o CacheRules) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CacheRules struct{}"
+	}
+
+	return strings.Join([]string{"CacheRules", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_cache_url_parameter_filter.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_cache_url_parameter_filter.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CacheUrlParameterFilter 缓存url参数配置。  > 此参数作为旧参数，将于近期下线，建议使用CacheRules设置URL参数。
+type CacheUrlParameterFilter struct {
+
+	// 缓存URL参数操作类型： - full_url：缓存所有参数； - ignore_url_params：忽略所有参数； - del_params：忽略指定URL参数； - reserve_params：保留指定URL参数。   > 本接口参数有调整，参数替换如下：   > - del_params替代del_args。   > - reserve_params替代reserve_args。
+	Type *string `json:"type,omitempty"`
+
+	// 参数值，多个参数使用分号分隔。
+	Value *string `json:"value,omitempty"`
+}
+
+func (o CacheUrlParameterFilter) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CacheUrlParameterFilter struct{}"
+	}
+
+	return strings.Join([]string{"CacheUrlParameterFilter", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_cache_url_parameter_filter_get_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_cache_url_parameter_filter_get_body.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CacheUrlParameterFilterGetBody 缓存url参数配置查询响应体， >  此参数作为旧参数，将于近期下线。
+type CacheUrlParameterFilterGetBody struct {
+
+	// 缓存URL参数操作类型： - full_url：缓存所有参数； - ignore_url_params：忽略所有参数； - del_params：忽略指定URL参数； - reserve_params：保留指定URL参数。   > 本接口参数有调整，参数替换如下：   > - del_params替代del_args。   > - reserve_params替代reserve_args。
+	Type *string `json:"type,omitempty"`
+
+	// 参数值。
+	Value *string `json:"value,omitempty"`
+}
+
+func (o CacheUrlParameterFilterGetBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CacheUrlParameterFilterGetBody struct{}"
+	}
+
+	return strings.Join([]string{"CacheUrlParameterFilterGetBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_cdn_ips.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_cdn_ips.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type CdnIps struct {
+
+	// 需查询的IP地址。
+	Ip *string `json:"ip,omitempty"`
+
+	// 是否是华为云CDN节点。（true:是华为云CDN节点，false:不是华为云CDN节点）
+	Belongs *bool `json:"belongs,omitempty"`
+
+	// IP归属地省份。（Unknown:表示未知归属地）
+	Region *string `json:"region,omitempty"`
+
+	// 运营商名称。如果IP归属地未知，该字段返回null。
+	Isp *string `json:"isp,omitempty"`
+
+	// 平台。如果IP归属地未知，该字段返回null。
+	Platform *string `json:"platform,omitempty"`
+}
+
+func (o CdnIps) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CdnIps struct{}"
+	}
+
+	return strings.Join([]string{"CdnIps", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_common_remote_auth.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_common_remote_auth.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CommonRemoteAuth 远程鉴权配置。
+type CommonRemoteAuth struct {
+
+	// 是否开启远程鉴权(on：开启，off：关闭)。
+	RemoteAuthentication string `json:"remote_authentication"`
+
+	RemoteAuthRules *RemoteAuthRuleVo `json:"remote_auth_rules"`
+}
+
+func (o CommonRemoteAuth) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CommonRemoteAuth struct{}"
+	}
+
+	return strings.Join([]string{"CommonRemoteAuth", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_compress.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_compress.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Compress 智能压缩。
+type Compress struct {
+
+	// 智能压缩开关（on：开启，off：关闭）。
+	Status string `json:"status"`
+
+	// 智能压缩类型（gzip：gzip压缩，brotli：brotli压缩）。
+	Type *string `json:"type,omitempty"`
+
+	// 压缩格式，内容总长度不可超过200个字符，  多种格式用“,”分割，每组内容不可超过50个字符， 开启状态下，首次传空时默认值为.js,.html,.css,.xml,.json,.shtml,.htm，否则为上次设置的结果。
+	FileType *string `json:"file_type,omitempty"`
+}
+
+func (o Compress) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Compress struct{}"
+	}
+
+	return strings.Join([]string{"Compress", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_configs.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_configs.go
@@ -1,0 +1,102 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Configs 配置项。
+type Configs struct {
+
+	// 业务类型： - web：网站加速； - download：文件下载加速； - video：点播加速。  > 暂不支持“全站加速”变更为其它业务类型。
+	BusinessType *string `json:"business_type,omitempty"`
+
+	// 服务区域： - mainland_china：中国大陆； - global：全球； - outside_mainland_china：中国大陆境外。  > 暂不支持“中国大陆”与“中国大陆境外”互相直接切换。
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 给域名添加备注，字符长度范围0-200。
+	Remark *string `json:"remark,omitempty"`
+
+	// 回源请求头改写 该功能将覆盖原有配置（清空之前的配置），在使用此接口时，请上传全量头部信息。
+	OriginRequestHeader *[]OriginRequestHeader `json:"origin_request_header,omitempty"`
+
+	// http header配置 该功能将覆盖原有配置（清空之前的配置），在使用此接口时，请上传全量头部信息。
+	HttpResponseHeader *[]HttpResponseHeader `json:"http_response_header,omitempty"`
+
+	UrlAuth *UrlAuth `json:"url_auth,omitempty"`
+
+	Https *HttpPutBody `json:"https,omitempty"`
+
+	// 源站配置。
+	Sources *[]SourcesConfig `json:"sources,omitempty"`
+
+	// 回源协议，follow：协议跟随回源，http：HTTP回源(默认)，https：https回源。
+	OriginProtocol *string `json:"origin_protocol,omitempty"`
+
+	// 回源跟随，on：开启，off：关闭。
+	OriginFollow302Status *string `json:"origin_follow302_status,omitempty"`
+
+	// 缓存规则。
+	CacheRules *[]CacheRules `json:"cache_rules,omitempty"`
+
+	IpFilter *IpFilter `json:"ip_filter,omitempty"`
+
+	Referer *RefererConfig `json:"referer,omitempty"`
+
+	ForceRedirect *ForceRedirectConfig `json:"force_redirect,omitempty"`
+
+	Compress *Compress `json:"compress,omitempty"`
+
+	CacheUrlParameterFilter *CacheUrlParameterFilter `json:"cache_url_parameter_filter,omitempty"`
+
+	// ipv6设置，1：打开；0：关闭。
+	Ipv6Accelerate *int32 `json:"ipv6_accelerate,omitempty"`
+
+	// 状态码缓存时间。
+	ErrorCodeCache *[]ErrorCodeCache `json:"error_code_cache,omitempty"`
+
+	// Range回源，即分片回源，开启: on，关闭: off。  > 开启Range回源的前提是您的源站支持Range请求，即HTTP请求头中包含Range字段，否则可能导致回源失败。
+	OriginRangeStatus *string `json:"origin_range_status,omitempty"`
+
+	UserAgentFilter *UserAgentFilter `json:"user_agent_filter,omitempty"`
+
+	// 改写回源URL，最多配置20条。
+	OriginRequestUrlRewrite *[]OriginRequestUrlRewrite `json:"origin_request_url_rewrite,omitempty"`
+
+	// 高级回源，最多配置20条。
+	FlexibleOrigin *[]FlexibleOrigins `json:"flexible_origin,omitempty"`
+
+	// 回源是否校验ETag，on：开启，off：关闭。
+	SliceEtagStatus *string `json:"slice_etag_status,omitempty"`
+
+	// 回源超时时间，范围:5-60，单位：秒。
+	OriginReceiveTimeout *int32 `json:"origin_receive_timeout,omitempty"`
+
+	RemoteAuth *CommonRemoteAuth `json:"remote_auth,omitempty"`
+
+	Websocket *WebSocketSeek `json:"websocket,omitempty"`
+
+	VideoSeek *VideoSeek `json:"video_seek,omitempty"`
+
+	// 请求限速配置。
+	RequestLimitRules *[]RequestLimitRules `json:"request_limit_rules,omitempty"`
+
+	IpFrequencyLimit *IpFrequencyLimit `json:"ip_frequency_limit,omitempty"`
+
+	Hsts *Hsts `json:"hsts,omitempty"`
+
+	Quic *Quic `json:"quic,omitempty"`
+
+	// 自定义错误页面。
+	ErrorCodeRedirectRules *[]ErrorCodeRedirectRules `json:"error_code_redirect_rules,omitempty"`
+}
+
+func (o Configs) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Configs struct{}"
+	}
+
+	return strings.Join([]string{"Configs", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_configs_get_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_configs_get_body.go
@@ -1,0 +1,102 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ConfigsGetBody 配置项。
+type ConfigsGetBody struct {
+
+	// 业务类型： - web：网站加速； - download：文件下载加速； - video：点播加速； - wholesite：全站加速。
+	BusinessType *string `json:"business_type,omitempty"`
+
+	// 服务区域： - mainland_china：中国大陆； - global：全球； - outside_mainland_china：中国大陆境外。
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 域名备注。
+	Remark *string `json:"remark,omitempty"`
+
+	// 回源请求头配置
+	OriginRequestHeader *[]OriginRequestHeader `json:"origin_request_header,omitempty"`
+
+	// http header配置
+	HttpResponseHeader *[]HttpResponseHeader `json:"http_response_header,omitempty"`
+
+	UrlAuth *UrlAuthGetBody `json:"url_auth,omitempty"`
+
+	Https *HttpGetBody `json:"https,omitempty"`
+
+	// 源站配置。
+	Sources *[]SourcesConfig `json:"sources,omitempty"`
+
+	// 回源协议，follow：协议跟随回源，http：HTTP回源(默认)，https：https回源。
+	OriginProtocol *string `json:"origin_protocol,omitempty"`
+
+	// 回源跟随，on：开启，off：关闭。
+	OriginFollow302Status *string `json:"origin_follow302_status,omitempty"`
+
+	// 缓存规则。
+	CacheRules *[]CacheRules `json:"cache_rules,omitempty"`
+
+	IpFilter *IpFilter `json:"ip_filter,omitempty"`
+
+	Referer *RefererConfig `json:"referer,omitempty"`
+
+	ForceRedirect *ForceRedirectConfig `json:"force_redirect,omitempty"`
+
+	Compress *Compress `json:"compress,omitempty"`
+
+	CacheUrlParameterFilter *CacheUrlParameterFilterGetBody `json:"cache_url_parameter_filter,omitempty"`
+
+	// ipv6设置，1：打开；0：关闭。
+	Ipv6Accelerate *int32 `json:"ipv6_accelerate,omitempty"`
+
+	// 状态码缓存时间。
+	ErrorCodeCache *[]ErrorCodeCache `json:"error_code_cache,omitempty"`
+
+	// Range回源，开启: on，off:关闭。
+	OriginRangeStatus *string `json:"origin_range_status,omitempty"`
+
+	UserAgentFilter *UserAgentFilter `json:"user_agent_filter,omitempty"`
+
+	// 改写回源URL。
+	OriginRequestUrlRewrite *[]OriginRequestUrlRewrite `json:"origin_request_url_rewrite,omitempty"`
+
+	// 高级回源。
+	FlexibleOrigin *[]FlexibleOrigins `json:"flexible_origin,omitempty"`
+
+	// 回源是否校验ETag，on：开启，off：关闭。
+	SliceEtagStatus *string `json:"slice_etag_status,omitempty"`
+
+	// 回源超时时间，单位：秒。
+	OriginReceiveTimeout *int32 `json:"origin_receive_timeout,omitempty"`
+
+	RemoteAuth *CommonRemoteAuth `json:"remote_auth,omitempty"`
+
+	Websocket *WebSocketSeek `json:"websocket,omitempty"`
+
+	VideoSeek *VideoSeek `json:"video_seek,omitempty"`
+
+	// 请求限速。
+	RequestLimitRules *[]RequestLimitRules `json:"request_limit_rules,omitempty"`
+
+	IpFrequencyLimit *IpFrequencyLimitQuery `json:"ip_frequency_limit,omitempty"`
+
+	Hsts *HstsQuery `json:"hsts,omitempty"`
+
+	Quic *Quic `json:"quic,omitempty"`
+
+	// 自定义错误页面
+	ErrorCodeRedirectRules *[]ErrorCodeRedirectRules `json:"error_code_redirect_rules,omitempty"`
+}
+
+func (o ConfigsGetBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ConfigsGetBody struct{}"
+	}
+
+	return strings.Join([]string{"ConfigsGetBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_domain_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_domain_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateDomainRequest Request Object
+type CreateDomainRequest struct {
+	Body *CreateDomainRequestBody `json:"body,omitempty"`
+}
+
+func (o CreateDomainRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateDomainRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateDomainRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_domain_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_domain_request_body.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateDomainRequestBody 域名对象
+type CreateDomainRequestBody struct {
+	Domain *DomainBody `json:"domain"`
+}
+
+func (o CreateDomainRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateDomainRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"CreateDomainRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_domain_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_domain_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateDomainResponse Response Object
+type CreateDomainResponse struct {
+	Domain *CreateDomainResponseBodyContent `json:"domain,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateDomainResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateDomainResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateDomainResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_domain_response_body_content.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_domain_response_body_content.go
@@ -1,0 +1,73 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateDomainResponseBodyContent 创建域名返回信息。
+type CreateDomainResponseBodyContent struct {
+
+	// 加速域名ID。
+	Id *string `json:"id,omitempty"`
+
+	// 加速域名。
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// 域名业务类型： - web:网站加速； - download:文件下载加速； - video:点播加速； - wholeSite:全站加速。
+	BusinessType *string `json:"business_type,omitempty"`
+
+	// 域名服务范围，若为mainland_china，则表示服务范围为中国大陆；若为outside_mainland_china，则表示服务范围为中国大陆境外；若为global，则表示服务范围为全球。
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 域名所属用户的domain_id。
+	UserDomainId *string `json:"user_domain_id,omitempty"`
+
+	// 加速域名状态。取值意义： - online表示“已开启” - offline表示“已停用” - configuring表示“配置中” - configure_failed表示“配置失败” - checking表示“审核中” - check_failed表示“审核未通过” - deleting表示“删除中”。
+	DomainStatus *string `json:"domain_status,omitempty"`
+
+	// 加速域名对应的CNAME。
+	Cname *string `json:"cname,omitempty"`
+
+	// 源站信息。
+	Sources *[]Sources `json:"sources,omitempty"`
+
+	DomainOriginHost *DomainOriginHost `json:"domain_origin_host,omitempty"`
+
+	// 是否开启HTTPS加速。
+	HttpsStatus *int32 `json:"https_status,omitempty"`
+
+	// 域名创建时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 域名修改时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	ModifyTime *int64 `json:"modify_time,omitempty"`
+
+	// 封禁状态（0代表未禁用；1代表禁用）。
+	Disabled *int32 `json:"disabled,omitempty"`
+
+	// 锁定状态（0代表未锁定；1代表锁定）。
+	Locked *int32 `json:"locked,omitempty"`
+
+	// range状态，off：关闭，on：开启。
+	RangeStatus *string `json:"range_status,omitempty"`
+
+	// follow302状态，off：关闭，on：开启。
+	FollowStatus *string `json:"follow_status,omitempty"`
+
+	// 是否暂停源站回源（off代表关闭 on代表开启）。
+	OriginStatus *string `json:"origin_status,omitempty"`
+
+	// 自动刷新预热（0代表关闭；1代表打开）。
+	AutoRefreshPreheat *int32 `json:"auto_refresh_preheat,omitempty"`
+}
+
+func (o CreateDomainResponseBodyContent) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateDomainResponseBodyContent struct{}"
+	}
+
+	return strings.Join([]string{"CreateDomainResponseBodyContent", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_preheating_tasks_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_preheating_tasks_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreatePreheatingTasksRequest Request Object
+type CreatePreheatingTasksRequest struct {
+
+	// 当用户开启企业项目功能时，该参数生效，表示在当前企业项目下添加缓存预热任务，\"all\"代表所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	Body *PreheatingTaskRequest `json:"body,omitempty"`
+}
+
+func (o CreatePreheatingTasksRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePreheatingTasksRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreatePreheatingTasksRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_preheating_tasks_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_preheating_tasks_response.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreatePreheatingTasksResponse Response Object
+type CreatePreheatingTasksResponse struct {
+
+	// 任务ID。
+	PreheatingTask *string `json:"preheating_task,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreatePreheatingTasksResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreatePreheatingTasksResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreatePreheatingTasksResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_refresh_tasks_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_refresh_tasks_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateRefreshTasksRequest Request Object
+type CreateRefreshTasksRequest struct {
+
+	// 当用户开启企业项目功能时，该参数生效，表示在当前企业项目下添加缓存刷新任务，\"all\"代表所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	Body *RefreshTaskRequest `json:"body,omitempty"`
+}
+
+func (o CreateRefreshTasksRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateRefreshTasksRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateRefreshTasksRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_refresh_tasks_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_refresh_tasks_response.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateRefreshTasksResponse Response Object
+type CreateRefreshTasksResponse struct {
+
+	// 任务ID。
+	RefreshTask *string `json:"refresh_task,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateRefreshTasksResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateRefreshTasksResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateRefreshTasksResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_tags_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateTagsRequest Request Object
+type CreateTagsRequest struct {
+	Body *CreateTagsRequestBody `json:"body,omitempty"`
+}
+
+func (o CreateTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_tags_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_tags_request_body.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateTagsRequestBody CreateTagsRequestBody
+type CreateTagsRequestBody struct {
+
+	// 资源id。  > 域名ID
+	ResourceId string `json:"resource_id"`
+
+	// 标签列表。
+	Tags []TagMap `json:"tags"`
+}
+
+func (o CreateTagsRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateTagsRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"CreateTagsRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_create_tags_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateTagsResponse Response Object
+type CreateTagsResponse struct {
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o CreateTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_custom_args.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_custom_args.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CustomArgs 鉴权参数
+type CustomArgs struct {
+
+	// 参数类型，custom_var：自定义，nginx_preset_var：预置的变量。
+	Type string `json:"type"`
+
+	// 参数,长度支持1-256，由数字0-9、字符a-z、A-Z，及特殊字符._-*#%|+^@?=组成。
+	Key string `json:"key"`
+
+	// 取值,长度支持1-256，由数字0-9、字符a-z、A-Z，及特殊字符._-*#%|+^@?=组成。
+	Value string `json:"value"`
+}
+
+func (o CustomArgs) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CustomArgs struct{}"
+	}
+
+	return strings.Join([]string{"CustomArgs", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_delete_domain_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_delete_domain_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DeleteDomainRequest Request Object
+type DeleteDomainRequest struct {
+
+	// 加速域名ID。
+	DomainId string `json:"domain_id"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示修改当前企业项目下加速域名的配置，\"all\"代表所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o DeleteDomainRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteDomainRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteDomainRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_delete_domain_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_delete_domain_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DeleteDomainResponse Response Object
+type DeleteDomainResponse struct {
+	Domain *DomainsWithPort `json:"domain,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o DeleteDomainResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteDomainResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteDomainResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_delete_tags_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_delete_tags_request_body.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DeleteTagsRequestBody DeleteTagsRequestBody
+type DeleteTagsRequestBody struct {
+
+	// 资源id。  > 域名ID
+	ResourceId string `json:"resource_id"`
+
+	// 键列表
+	Tags []string `json:"tags"`
+}
+
+func (o DeleteTagsRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteTagsRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"DeleteTagsRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_disable_domain_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_disable_domain_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DisableDomainRequest Request Object
+type DisableDomainRequest struct {
+
+	// 加速域名ID。
+	DomainId string `json:"domain_id"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示修改当前企业项目下加速域名的配置，\"all\"代表所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o DisableDomainRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DisableDomainRequest struct{}"
+	}
+
+	return strings.Join([]string{"DisableDomainRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_disable_domain_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_disable_domain_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DisableDomainResponse Response Object
+type DisableDomainResponse struct {
+	Domain *DomainsWithPort `json:"domain,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o DisableDomainResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DisableDomainResponse struct{}"
+	}
+
+	return strings.Join([]string{"DisableDomainResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domain_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domain_body.go
@@ -1,0 +1,144 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// DomainBody 创建域名Body
+type DomainBody struct {
+
+	// 加速域名。（ 由字母（A-Z，a-z，大小写等价）、数字（0-9）和连接符（-）组成，各级域名之间用（.）连接，域名长度不超过75个字符。连接符（-）不能作为域名的开头或结尾字符。）
+	DomainName string `json:"domain_name"`
+
+	// 域名业务类型，若为web，则表示类型为网页加速；若为download，则表示业务类型为文件下载加速；若为video，则表示业务类型为点播加速；若为wholeSite，则表示业务类型为全站加速。
+	BusinessType DomainBodyBusinessType `json:"business_type"`
+
+	// 源站配置。
+	Sources []Sources `json:"sources"`
+
+	// 域名服务范围，若为mainland_china，则表示服务范围为中国大陆；若为outside_mainland_china，则表示服务范围为中国大陆境外；若为global，则表示服务范围为全球。
+	ServiceArea DomainBodyServiceArea `json:"service_area"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示添加加速域名到该企业项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o DomainBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DomainBody struct{}"
+	}
+
+	return strings.Join([]string{"DomainBody", string(data)}, " ")
+}
+
+type DomainBodyBusinessType struct {
+	value string
+}
+
+type DomainBodyBusinessTypeEnum struct {
+	WEB        DomainBodyBusinessType
+	DOWNLOAD   DomainBodyBusinessType
+	VIDEO      DomainBodyBusinessType
+	WHOLE_SITE DomainBodyBusinessType
+}
+
+func GetDomainBodyBusinessTypeEnum() DomainBodyBusinessTypeEnum {
+	return DomainBodyBusinessTypeEnum{
+		WEB: DomainBodyBusinessType{
+			value: "web",
+		},
+		DOWNLOAD: DomainBodyBusinessType{
+			value: "download",
+		},
+		VIDEO: DomainBodyBusinessType{
+			value: "video",
+		},
+		WHOLE_SITE: DomainBodyBusinessType{
+			value: "wholeSite",
+		},
+	}
+}
+
+func (c DomainBodyBusinessType) Value() string {
+	return c.value
+}
+
+func (c DomainBodyBusinessType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *DomainBodyBusinessType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type DomainBodyServiceArea struct {
+	value string
+}
+
+type DomainBodyServiceAreaEnum struct {
+	MAINLAND_CHINA         DomainBodyServiceArea
+	OUTSIDE_MAINLAND_CHINA DomainBodyServiceArea
+	GLOBAL                 DomainBodyServiceArea
+}
+
+func GetDomainBodyServiceAreaEnum() DomainBodyServiceAreaEnum {
+	return DomainBodyServiceAreaEnum{
+		MAINLAND_CHINA: DomainBodyServiceArea{
+			value: "mainland_china",
+		},
+		OUTSIDE_MAINLAND_CHINA: DomainBodyServiceArea{
+			value: "outside_mainland_china",
+		},
+		GLOBAL: DomainBodyServiceArea{
+			value: "global",
+		},
+	}
+}
+
+func (c DomainBodyServiceArea) Value() string {
+	return c.value
+}
+
+func (c DomainBodyServiceArea) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *DomainBodyServiceArea) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domain_origin_host.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domain_origin_host.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DomainOriginHost 域名回源HOST配置。
+type DomainOriginHost struct {
+
+	// 域名ID。
+	DomainId *string `json:"domain_id,omitempty"`
+
+	// 回源host的类型,accelerate：选择加速域名作为回源host域名， customize：使用自定义的域名作为回源host域名。
+	OriginHostType string `json:"origin_host_type"`
+
+	// 自定义回源host域名。
+	CustomizeDomain *string `json:"customize_domain,omitempty"`
+}
+
+func (o DomainOriginHost) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DomainOriginHost struct{}"
+	}
+
+	return strings.Join([]string{"DomainOriginHost", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domains.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domains.go
@@ -1,0 +1,136 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// Domains 域名信息
+type Domains struct {
+
+	// 加速域名ID。
+	Id *string `json:"id,omitempty"`
+
+	// 加速域名。
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// 域名业务类型，若为web，则表示类型为网站加速；若为download，则表示业务类型为文件下载加速；若为video，则表示业务类型为点播加速；若为wholeSite，则表示类型为全站加速。
+	BusinessType *string `json:"business_type,omitempty"`
+
+	// 加速域名状态。取值意义： - online表示“已开启” - offline表示“已停用” - configuring表示“配置中” - configure_failed表示“配置失败” - checking表示“审核中” - check_failed表示“审核未通过” - deleting表示“删除中”。
+	DomainStatus *string `json:"domain_status,omitempty"`
+
+	// 加速域名对应的CNAME。
+	Cname *string `json:"cname,omitempty"`
+
+	// 源站配置。
+	Sources *[]Sources `json:"sources,omitempty"`
+
+	DomainOriginHost *DomainOriginHost `json:"domain_origin_host,omitempty"`
+
+	// 是否开启HTTPS加速。
+	HttpsStatus *int32 `json:"https_status,omitempty"`
+
+	// 域名创建时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 域名修改时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	ModifyTime *int64 `json:"modify_time,omitempty"`
+
+	// 封禁状态（0代表未禁用；1代表禁用）。
+	Disabled *int32 `json:"disabled,omitempty"`
+
+	// 锁定状态（0代表未锁定；1代表锁定）。
+	Locked *int32 `json:"locked,omitempty"`
+
+	// 自动刷新预热（0代表关闭；1代表打开）。
+	AutoRefreshPreheat *int32 `json:"auto_refresh_preheat,omitempty"`
+
+	// 华为云CDN提供的加速服务范围，包含：mainland_china中国大陆、outside_mainland_china中国大陆境外、global全球。
+	ServiceArea *DomainsServiceArea `json:"service_area,omitempty"`
+
+	// Range回源状态。
+	RangeStatus *string `json:"range_status,omitempty"`
+
+	// 回源跟随状态。
+	FollowStatus *string `json:"follow_status,omitempty"`
+
+	// 是否暂停源站回源（off代表关闭 on代表开启）。
+	OriginStatus *string `json:"origin_status,omitempty"`
+
+	// 域名禁用原因。
+	BannedReason *string `json:"banned_reason,omitempty"`
+
+	// 域名锁定原因。
+	LockedReason *string `json:"locked_reason,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，不传表示查询默认项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 标签信息。
+	Tags *[]EpResourceTag `json:"tags,omitempty"`
+}
+
+func (o Domains) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Domains struct{}"
+	}
+
+	return strings.Join([]string{"Domains", string(data)}, " ")
+}
+
+type DomainsServiceArea struct {
+	value string
+}
+
+type DomainsServiceAreaEnum struct {
+	MAINLAND_CHINA         DomainsServiceArea
+	OUTSIDE_MAINLAND_CHINA DomainsServiceArea
+	GLOBAL                 DomainsServiceArea
+}
+
+func GetDomainsServiceAreaEnum() DomainsServiceAreaEnum {
+	return DomainsServiceAreaEnum{
+		MAINLAND_CHINA: DomainsServiceArea{
+			value: "mainland_china",
+		},
+		OUTSIDE_MAINLAND_CHINA: DomainsServiceArea{
+			value: "outside_mainland_china",
+		},
+		GLOBAL: DomainsServiceArea{
+			value: "global",
+		},
+	}
+}
+
+func (c DomainsServiceArea) Value() string {
+	return c.value
+}
+
+func (c DomainsServiceArea) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *DomainsServiceArea) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domains_detail.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domains_detail.go
@@ -1,0 +1,110 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// DomainsDetail 域名信息。
+type DomainsDetail struct {
+
+	// 加速域名ID。
+	Id *string `json:"id,omitempty"`
+
+	// 加速域名。
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// 域名业务类型，若为web，则表示类型为网站加速；若为download，则表示业务类型为文件下载加速；若为video，则表示业务类型为点播加速；若为wholeSite，则表示类型为全站加速。
+	BusinessType *string `json:"business_type,omitempty"`
+
+	// 加速域名状态。取值意义： - online表示“已开启” - offline表示“已停用” - configuring表示“配置中” - configure_failed表示“配置失败” - checking表示“审核中” - check_failed表示“审核未通过” - deleting表示“删除中”。
+	DomainStatus *string `json:"domain_status,omitempty"`
+
+	// 加速域名对应的CNAME。
+	Cname *string `json:"cname,omitempty"`
+
+	// 源站配置。
+	Sources *[]SourcesDomainConfig `json:"sources,omitempty"`
+
+	// 是否开启HTTPS加速。 0：代表未开启HTTPS加速； 1：代表开启HTTPS加速，且回源方式为协议跟随； 2：代表开启HTTPS加速，且回源方式为HTTP； 3：代表开启HTTPS加速，且回源方式为HTTPS。
+	HttpsStatus *int32 `json:"https_status,omitempty"`
+
+	// 域名创建时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 域名修改时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	UpdateTime *int64 `json:"update_time,omitempty"`
+
+	// 封禁状态（0代表未禁用；1代表禁用）。
+	Disabled *int32 `json:"disabled,omitempty"`
+
+	// 锁定状态（0代表未锁定；1代表锁定）。
+	Locked *int32 `json:"locked,omitempty"`
+
+	// 华为云CDN提供的加速服务范围，包含：mainland_china中国大陆、outside_mainland_china中国大陆境外、global全球。
+	ServiceArea *DomainsDetailServiceArea `json:"service_area,omitempty"`
+}
+
+func (o DomainsDetail) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DomainsDetail struct{}"
+	}
+
+	return strings.Join([]string{"DomainsDetail", string(data)}, " ")
+}
+
+type DomainsDetailServiceArea struct {
+	value string
+}
+
+type DomainsDetailServiceAreaEnum struct {
+	MAINLAND_CHINA         DomainsDetailServiceArea
+	OUTSIDE_MAINLAND_CHINA DomainsDetailServiceArea
+	GLOBAL                 DomainsDetailServiceArea
+}
+
+func GetDomainsDetailServiceAreaEnum() DomainsDetailServiceAreaEnum {
+	return DomainsDetailServiceAreaEnum{
+		MAINLAND_CHINA: DomainsDetailServiceArea{
+			value: "mainland_china",
+		},
+		OUTSIDE_MAINLAND_CHINA: DomainsDetailServiceArea{
+			value: "outside_mainland_china",
+		},
+		GLOBAL: DomainsDetailServiceArea{
+			value: "global",
+		},
+	}
+}
+
+func (c DomainsDetailServiceArea) Value() string {
+	return c.value
+}
+
+func (c DomainsDetailServiceArea) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *DomainsDetailServiceArea) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domains_with_port.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domains_with_port.go
@@ -1,0 +1,136 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// DomainsWithPort 域名信息。
+type DomainsWithPort struct {
+
+	// 加速域名ID。
+	Id *string `json:"id,omitempty"`
+
+	// 加速域名。
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// 域名业务类型，若为web，则表示类型为网站加速；若为download，则表示业务类型为文件下载加速；若为video，则表示业务类型为点播加速；若为wholeSite，则表示类型为全站加速。
+	BusinessType *string `json:"business_type,omitempty"`
+
+	// 域名所属用户的domain_id。
+	UserDomainId *string `json:"user_domain_id,omitempty"`
+
+	// 加速域名状态。取值意义： - online表示“已开启” - offline表示“已停用” - configuring表示“配置中” - configure_failed表示“配置失败” - checking表示“审核中” - check_failed表示“审核未通过” - deleting表示“删除中”。
+	DomainStatus *string `json:"domain_status,omitempty"`
+
+	// 加速域名对应的CNAME。
+	Cname *string `json:"cname,omitempty"`
+
+	// 源站配置。
+	Sources *[]SourceWithPort `json:"sources,omitempty"`
+
+	DomainOriginHost *DomainOriginHost `json:"domain_origin_host,omitempty"`
+
+	// 是否开启HTTPS加速。 0：代表未开启HTTPS加速； 1：代表开启HTTPS加速，且回源方式为协议跟随； 2：代表开启HTTPS加速，且回源方式为HTTP； 3：代表开启HTTPS加速，且回源方式为HTTPS。
+	HttpsStatus *int32 `json:"https_status,omitempty"`
+
+	// 域名创建时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 域名修改时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	ModifyTime *int64 `json:"modify_time,omitempty"`
+
+	// 封禁状态（0代表未禁用；1代表禁用）。
+	Disabled *int32 `json:"disabled,omitempty"`
+
+	// 锁定状态（0代表未锁定；1代表锁定）。
+	Locked *int32 `json:"locked,omitempty"`
+
+	// 自动刷新预热（0代表关闭；1代表打开）。
+	AutoRefreshPreheat *int32 `json:"auto_refresh_preheat,omitempty"`
+
+	// 华为云CDN提供的加速服务范围，包含：mainland_china中国大陆、outside_mainland_china中国大陆境外、global全球。
+	ServiceArea *DomainsWithPortServiceArea `json:"service_area,omitempty"`
+
+	// Range回源状态（off代表关闭 on代表开启）。
+	RangeStatus *string `json:"range_status,omitempty"`
+
+	// 回源跟随状态（off代表关闭 on代表开启）。
+	FollowStatus *string `json:"follow_status,omitempty"`
+
+	// 是否暂停源站回源（off代表关闭 on代表开启）。
+	OriginStatus *string `json:"origin_status,omitempty"`
+
+	// 域名禁用原因。 1：该域名涉嫌违规内容（涉黄/涉赌/涉毒/涉政）已被禁用； 2：该域名因备案失效已被禁用； 3：该域名遭受攻击，已被禁用； 150：该域名涉嫌违规内容涉黄已被禁用； 151：该域名涉嫌违规内容涉政已被禁用； 152：该域名涉嫌违规内容涉暴已被禁用； 153：该域名涉嫌违规内容涉赌已被禁用。
+	BannedReason *string `json:"banned_reason,omitempty"`
+
+	// 域名锁定原因（Changing the config, please wait）。
+	LockedReason *string `json:"locked_reason,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，不传表示查询默认项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o DomainsWithPort) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DomainsWithPort struct{}"
+	}
+
+	return strings.Join([]string{"DomainsWithPort", string(data)}, " ")
+}
+
+type DomainsWithPortServiceArea struct {
+	value string
+}
+
+type DomainsWithPortServiceAreaEnum struct {
+	MAINLAND_CHINA         DomainsWithPortServiceArea
+	OUTSIDE_MAINLAND_CHINA DomainsWithPortServiceArea
+	GLOBAL                 DomainsWithPortServiceArea
+}
+
+func GetDomainsWithPortServiceAreaEnum() DomainsWithPortServiceAreaEnum {
+	return DomainsWithPortServiceAreaEnum{
+		MAINLAND_CHINA: DomainsWithPortServiceArea{
+			value: "mainland_china",
+		},
+		OUTSIDE_MAINLAND_CHINA: DomainsWithPortServiceArea{
+			value: "outside_mainland_china",
+		},
+		GLOBAL: DomainsWithPortServiceArea{
+			value: "global",
+		},
+	}
+}
+
+func (c DomainsWithPortServiceArea) Value() string {
+	return c.value
+}
+
+func (c DomainsWithPortServiceArea) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *DomainsWithPortServiceArea) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_download_region_carrier_excel_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_download_region_carrier_excel_request.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DownloadRegionCarrierExcelRequest Request Object
+type DownloadRegionCarrierExcelRequest struct {
+
+	// 查询起始时间戳，需与结束时间戳同时指定，左闭右开，设置方式如下： - interval为300时，start_time设置为整5分钟时刻点，如：1631240100000(对应2021-09-10 10:15:00) - interval为3600时，start_time设置为整小时时刻点，如：1631239200000(对应2021-09-10 10:00:00) - interval为86400时，start_time设置为东8区零点时刻点，如：1631203200000(对应2021-09-10 00:00:00)
+	StartTime int64 `json:"start_time"`
+
+	// 查询结束时间戳，需与开始时间戳同时指定，左闭右开，设置方式如下： - interval为300时，end_time设置为整5分钟时刻点，如：1631243700000(对应2021-09-10 11:15:00) - interval为3600时，end_time设置为整小时时刻点，如：1631325600000(对应2021-09-11 10:00:00) - interval为86400时，end_time设置为东8区零点时刻点，如：1631376000000(对应2021-09-12 00:00:00)
+	EndTime int64 `json:"end_time"`
+
+	// 域名列表，多个域名以逗号（半角）分隔，如：www.test1.com,www.test2.com all表示查询名下全部域名。如果域名在查询时间段内无数据，结果将不返回该域名的信息。
+	DomainName string `json:"domain_name"`
+
+	// - 查询时间间隔，单位：秒，取值说明： - 300(5分钟)：最大查询跨度2天 - 3600(1小时)：最大查询跨度7天 - 86400(1天)：最大查询跨度31天 - 如果不传，默认取对应时间跨度的最小间隔。
+	Interval *int64 `json:"interval,omitempty"`
+
+	// - 国家&地区编码，多个以英文逗号分隔，all表示全部，取值见附录 - 访问运营商统计数据时不能填写 - 访问top_url数据时不能填写 - 访问区域情况数据时只能填写cn(中国)
+	Country *string `json:"country,omitempty"`
+
+	// 创建表格语言，支持zh(中文)，en(英文)两种，如果不传默认为zh
+	ExcelLanguage *string `json:"excel_language,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子账号调用接口时，该参数必传。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 统计数据表格类型,目前支持 - 区域用量统计数据(excel_type_usage) - 区域访问情况统计数据(excel_type_access) - 区域情况统计数据（excel_type_region） - 区域运营商情况统计数据(excel_type_carrier) - 国家情况统计数据(excel_type_country) - top_url统计数据(excel_type_top_url)
+	ExcelType string `json:"excel_type"`
+
+	// - 地区区域,当country为cn（中国）时有效 - 访问运营商统计数据时不能填写 - 访问国家统计数据时不能填写 - 访问top_url数据时不能填写
+	Region *string `json:"region,omitempty"`
+
+	// - 运营商编码 - 访问区域统计数据时不能填写 - 访问国家统计数据时不能填写 - 访问top_url数据时不能填写
+	Carrier *string `json:"carrier,omitempty"`
+}
+
+func (o DownloadRegionCarrierExcelRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DownloadRegionCarrierExcelRequest struct{}"
+	}
+
+	return strings.Join([]string{"DownloadRegionCarrierExcelRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_download_region_carrier_excel_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_download_region_carrier_excel_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DownloadRegionCarrierExcelResponse Response Object
+type DownloadRegionCarrierExcelResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o DownloadRegionCarrierExcelResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DownloadRegionCarrierExcelResponse struct{}"
+	}
+
+	return strings.Join([]string{"DownloadRegionCarrierExcelResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_download_statistics_excel_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_download_statistics_excel_request.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DownloadStatisticsExcelRequest Request Object
+type DownloadStatisticsExcelRequest struct {
+
+	// 查询起始时间戳，需与结束时间戳同时指定，左闭右开，设置方式如下： - interval为300时，start_time设置为整5分钟时刻点，如：1631240100000(对应2021-09-10 10:15:00) - interval为3600时，start_time设置为整小时时刻点，如：1631239200000(对应2021-09-10 10:00:00) - interval为86400时，start_time设置为东8区零点时刻点，如：1631203200000(对应2021-09-10 00:00:00)
+	StartTime int64 `json:"start_time"`
+
+	// 查询结束时间戳，需与开始时间戳同时指定，左闭右开，设置方式如下： - interval为300时，end_time设置为整5分钟时刻点，如：1631243700000(对应2021-09-10 11:15:00) - interval为3600时，end_time设置为整小时时刻点，如：1631325600000(对应2021-09-11 10:00:00) - interval为86400时，end_time设置为东8区零点时刻点，如：1631376000000(对应2021-09-12 00:00:00)
+	EndTime int64 `json:"end_time"`
+
+	// 域名列表，多个域名以逗号（半角）分隔，如：www.test1.com,www.test2.com all表示查询名下全部域名。如果域名在查询时间段内无数据，结果将不返回该域名的信息。
+	DomainName string `json:"domain_name"`
+
+	// 创建表格语言，支持zh(中文)，en(英文)两种，如果不传默认为zh
+	ExcelLanguage *string `json:"excel_language,omitempty"`
+
+	// 服务区域：mainland_china(中国大陆)，outside_mainland_china(中国大陆境外)，默认为mainland_china，当查询回源类指标时该参数无效。
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// - 查询时间间隔，单位：秒，取值说明： - 300(5分钟)：最大查询跨度2天 - 3600(1小时)：最大查询跨度7天 - 86400(1天)：最大查询跨度31天 - 如果不传，默认取对应时间跨度的最小间隔。
+	Interval *int64 `json:"interval,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子账号调用接口时，该参数必传。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 统计数据表格类型,目前支持 - 用量统计数据(excel_type_usage) - 访问情况统计数据(excel_type_access) - 回源情况统计数据（excel_type_origin） - http_code统计数据(excel_type_http_code)
+	ExcelType string `json:"excel_type"`
+}
+
+func (o DownloadStatisticsExcelRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DownloadStatisticsExcelRequest struct{}"
+	}
+
+	return strings.Join([]string{"DownloadStatisticsExcelRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_download_statistics_excel_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_download_statistics_excel_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DownloadStatisticsExcelResponse Response Object
+type DownloadStatisticsExcelResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o DownloadStatisticsExcelResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DownloadStatisticsExcelResponse struct{}"
+	}
+
+	return strings.Join([]string{"DownloadStatisticsExcelResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_enable_domain_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_enable_domain_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// EnableDomainRequest Request Object
+type EnableDomainRequest struct {
+
+	// 加速域名ID。
+	DomainId string `json:"domain_id"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o EnableDomainRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "EnableDomainRequest struct{}"
+	}
+
+	return strings.Join([]string{"EnableDomainRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_enable_domain_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_enable_domain_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// EnableDomainResponse Response Object
+type EnableDomainResponse struct {
+	Domain *DomainsWithPort `json:"domain,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o EnableDomainResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "EnableDomainResponse struct{}"
+	}
+
+	return strings.Join([]string{"EnableDomainResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_ep_resource_tag.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_ep_resource_tag.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// EpResourceTag 标签信息。
+type EpResourceTag struct {
+
+	// 资源标签key。
+	Key string `json:"key"`
+
+	// 资源标签value值。
+	Value string `json:"value"`
+}
+
+func (o EpResourceTag) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "EpResourceTag struct{}"
+	}
+
+	return strings.Join([]string{"EpResourceTag", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_err_msg.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_err_msg.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ErrMsg 用于返回具体的错误码和错误消息
+type ErrMsg struct {
+
+	// 错误码
+	ErrorCode string `json:"error_code"`
+
+	// 错误描述
+	ErrorMsg string `json:"error_msg"`
+}
+
+func (o ErrMsg) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ErrMsg struct{}"
+	}
+
+	return strings.Join([]string{"ErrMsg", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_err_rsp.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_err_rsp.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ErrRsp 当北向接口报错时，按此格式返回到body体中
+type ErrRsp struct {
+	Error *ErrMsg `json:"error"`
+}
+
+func (o ErrRsp) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ErrRsp struct{}"
+	}
+
+	return strings.Join([]string{"ErrRsp", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_error_code_cache.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_error_code_cache.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ErrorCodeCache CDN状态码缓存时间。
+type ErrorCodeCache struct {
+
+	// 允许配置的错误码: 400, 403, 404, 405, 414, 500, 501, 502, 503, 504
+	Code *int32 `json:"code,omitempty"`
+
+	// 错误码缓存时间，单位为秒，范围0-31,536,000(一年默认为365天)。
+	Ttl *int32 `json:"ttl,omitempty"`
+}
+
+func (o ErrorCodeCache) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ErrorCodeCache struct{}"
+	}
+
+	return strings.Join([]string{"ErrorCodeCache", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_error_code_redirect_rules.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_error_code_redirect_rules.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ErrorCodeRedirectRules 自定义错误页面。
+type ErrorCodeRedirectRules struct {
+
+	// 重定向的错误码，当前支持以下状态码 4xx:400, 403, 404, 405, 414, 416, 451 5xx:500, 501, 502, 503, 504
+	ErrorCode int32 `json:"error_code"`
+
+	// 重定向状态码，取值为301或302
+	TargetCode int32 `json:"target_code"`
+
+	// 重定向的目标链接
+	TargetLink string `json:"target_link"`
+}
+
+func (o ErrorCodeRedirectRules) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ErrorCodeRedirectRules struct{}"
+	}
+
+	return strings.Join([]string{"ErrorCodeRedirectRules", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_flexible_origins.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_flexible_origins.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// FlexibleOrigins 灵活回源信息,最多20条。
+type FlexibleOrigins struct {
+
+	// URI的匹配方式，支持文件后缀（file_extension）和路径前缀（file_path）。
+	MatchType string `json:"match_type"`
+
+	// file_extension（文件后缀）： 支持所有格式的文件类型。 输入首字符为“.”，以“;”进行分隔。 输入的文件后缀名总数不能超过20个。 file_path（目录路径）：输入要求以“/”作为首字符，以“;”进行分隔，输入的目录路径总数不能超过20个。
+	MatchPattern string `json:"match_pattern"`
+
+	// 优先级取值范围为1-100，数值越大优先级越高。
+	Priority int32 `json:"priority"`
+
+	// 回源信息。  > 每个目录的回源源站数量不超过1个。
+	BackSources []BackSources `json:"back_sources"`
+}
+
+func (o FlexibleOrigins) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "FlexibleOrigins struct{}"
+	}
+
+	return strings.Join([]string{"FlexibleOrigins", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_force_redirect.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_force_redirect.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ForceRedirect 强制跳转。
+type ForceRedirect struct {
+
+	// 强制跳转开关。1打开。0关闭。
+	Switch int32 `json:"switch"`
+
+	// 强制跳转类型。http：强制跳转HTTP。https：强制跳转HTTPS。
+	RedirectType *string `json:"redirect_type,omitempty"`
+}
+
+func (o ForceRedirect) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ForceRedirect struct{}"
+	}
+
+	return strings.Join([]string{"ForceRedirect", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_force_redirect_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_force_redirect_config.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ForceRedirectConfig 强制跳转。
+type ForceRedirectConfig struct {
+
+	// 强制跳转开关（on：打开，off：关闭）。
+	Status string `json:"status"`
+
+	// 强制跳转类型（http：强制跳转HTTP，https：强制跳转HTTPS）。
+	Type *string `json:"type,omitempty"`
+
+	// 重定向跳转码301,302。
+	RedirectCode *int32 `json:"redirect_code,omitempty"`
+}
+
+func (o ForceRedirectConfig) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ForceRedirectConfig struct{}"
+	}
+
+	return strings.Join([]string{"ForceRedirectConfig", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_hsts.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_hsts.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Hsts HSTS：配置HSTS后，将强制客户端（如浏览器）使用 HTTPS 协议访问服务器，提升访问安全性。
+type Hsts struct {
+
+	// 状态，on：打开，off：关闭。
+	Status string `json:"status"`
+
+	// 过期时间,即：响应头“Strict-Transport-Security”在客户端的缓存时间。单位:秒,取值范围:0-63072000。  > status参数为on时，必传。
+	MaxAge *int32 `json:"max_age,omitempty"`
+
+	// 包含子域名，on：包含，off：不包含。   > status参数为on时，必传。
+	IncludeSubdomains *string `json:"include_subdomains,omitempty"`
+}
+
+func (o Hsts) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Hsts struct{}"
+	}
+
+	return strings.Join([]string{"Hsts", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_hsts_query.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_hsts_query.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// HstsQuery HSTS：配置HSTS后，将强制客户端（如浏览器）使用 HTTPS 协议访问服务器，提升访问安全性。
+type HstsQuery struct {
+
+	// 状态，on：打开，off：关闭。
+	Status string `json:"status"`
+
+	// 过期时间,即：响应头“Strict-Transport-Security”在客户端的缓存时间。单位:秒。
+	MaxAge *int32 `json:"max_age,omitempty"`
+
+	// 包含子域名，on：包含，off：不包含。
+	IncludeSubdomains *string `json:"include_subdomains,omitempty"`
+}
+
+func (o HstsQuery) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "HstsQuery struct{}"
+	}
+
+	return strings.Join([]string{"HstsQuery", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_get_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_get_body.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// HttpGetBody 证书配置查询响应体。
+type HttpGetBody struct {
+
+	// HTTPS证书是否启用，on：开启，off：关闭。
+	HttpsStatus *string `json:"https_status,omitempty"`
+
+	// 证书名字。
+	CertificateName *string `json:"certificate_name,omitempty"`
+
+	// HTTPS协议使用的证书内容，PEM编码格式。
+	CertificateValue *string `json:"certificate_value,omitempty"`
+
+	// 证书过期时间。  > UTC时间。
+	ExpireTime *int64 `json:"expire_time,omitempty"`
+
+	// 证书来源,1：华为云托管证书,0：自有证书。
+	CertificateSource *int32 `json:"certificate_source,omitempty"`
+
+	// 证书类型。server：国际证书；server_sm：国密证书。
+	CertificateType *string `json:"certificate_type,omitempty"`
+
+	// 是否使用HTTP2.0，on：是，off：否。
+	Http2Status *string `json:"http2_status,omitempty"`
+
+	// 传输层安全性协议。
+	TlsVersion *string `json:"tls_version,omitempty"`
+
+	// 是否开启ocsp stapling,on：是，off：否。
+	OcspStaplingStatus *string `json:"ocsp_stapling_status,omitempty"`
+}
+
+func (o HttpGetBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "HttpGetBody struct{}"
+	}
+
+	return strings.Join([]string{"HttpGetBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_put_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_put_body.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// HttpPutBody 证书设置
+type HttpPutBody struct {
+
+	// HTTPS证书是否启用，on：开启，off：关闭。
+	HttpsStatus *string `json:"https_status,omitempty"`
+
+	// 证书名字，长度限制为3-64字符。  > 当证书开启时必传。
+	CertificateName *string `json:"certificate_name,omitempty"`
+
+	// HTTPS协议使用的证书内容，当证书开启时必传。  > PEM编码格式。
+	CertificateValue *string `json:"certificate_value,omitempty"`
+
+	// HTTPS协议使用的私钥，当证书开启时必传。  > PEM编码格式。
+	PrivateKey *string `json:"private_key,omitempty"`
+
+	// 证书来源,1：华为云托管证书,0：自有证书, 默认值0。  > 证书开启时必传
+	CertificateSource *int32 `json:"certificate_source,omitempty"`
+
+	// 证书类型，server：国际证书；server_sm：国密证书。
+	CertificateType *string `json:"certificate_type,omitempty"`
+
+	// 是否使用HTTP2.0，on：是，off：否。  > 默认关闭，https_status=off时，该值不生效。
+	Http2Status *string `json:"http2_status,omitempty"`
+
+	// 传输层安全性协议， 目前支持TLSv1.0/1.1/1.2/1.3四个版本的协议，CDN默认开启TLS1.1/1.2/1.3，不可全部关闭。  > 1.需开启连续或单个版本号，例：不可仅开启TLS1.0/1.2而关闭TLS1.1。  > 2.多版本开启时，使用逗号拼接传输，例：TLSv1.1,TLSv1.2。
+	TlsVersion *string `json:"tls_version,omitempty"`
+
+	// 是否开启ocsp stapling,on：是，off：否。
+	OcspStaplingStatus *string `json:"ocsp_stapling_status,omitempty"`
+}
+
+func (o HttpPutBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "HttpPutBody struct{}"
+	}
+
+	return strings.Join([]string{"HttpPutBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_response_header.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_response_header.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// HttpResponseHeader http响应头设置
+type HttpResponseHeader struct {
+
+	// 设置HTTP响应头参数。取值：\"Content-Disposition\", \"Content-Language\", \"Access-Control-Allow-Origin\",\"Access-Control-Allow-Methods\", \"Access-Control-Max-Age\", \"Access-Control-Expose-Headers\"或自定义头部。格式要求：长度1-100，以字母开头，可以使用字母、数字和短横杠。
+	Name string `json:"name"`
+
+	// 设置HTTP响应头参数的值。自定义HTTP响应头参数长度范围1-256，支持字母、数字和特定字符（.-_*#!&+|^~'\"/:;,=@?<>）。
+	Value *string `json:"value,omitempty"`
+
+	// 设置http响应头操作类型，取值“set/delete”。set代表设置，delete代表删除。
+	Action string `json:"action"`
+}
+
+func (o HttpResponseHeader) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "HttpResponseHeader struct{}"
+	}
+
+	return strings.Join([]string{"HttpResponseHeader", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_https_detail.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_https_detail.go
@@ -1,0 +1,51 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type HttpsDetail struct {
+
+	// 域名id。
+	DomainId *string `json:"domain_id,omitempty"`
+
+	// 绑定该证书的域名。
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// 证书名字。
+	CertName *string `json:"cert_name,omitempty"`
+
+	// 证书内容。
+	Certificate *string `json:"certificate,omitempty"`
+
+	// 私钥内容。
+	PrivateKey *string `json:"private_key,omitempty"`
+
+	// 0：自有证书  1：云托管证书。
+	CertificateType *int32 `json:"certificate_type,omitempty"`
+
+	// 证书过期时间。
+	ExpirationTime *int64 `json:"expiration_time,omitempty"`
+
+	// HTTPS证书是否启用，取值0：不启用；1：启用HTTPS加速并协议跟随回源；2：启用HTTPS加速并HTTP回源。
+	HttpsStatus *int32 `json:"https_status,omitempty"`
+
+	// 客户端请求是否强制重定向。1是，0否。（如果为2，表示强制跳转HTTP）
+	ForceRedirectHttps *int32 `json:"force_redirect_https,omitempty"`
+
+	ForceRedirectConfig *ForceRedirect `json:"force_redirect_config,omitempty"`
+
+	// 是否使用HTTP2.0。（1是，0否。）
+	Http2 *int32 `json:"http2,omitempty"`
+}
+
+func (o HttpsDetail) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "HttpsDetail struct{}"
+	}
+
+	return strings.Join([]string{"HttpsDetail", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_inherit_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_inherit_config.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// InheritConfig 鉴权继承，为M3U8/MPD索引文件下的TS/MP4文件添加鉴权参数，解决因鉴权不通过导致的TS/MP4文件无法播放的问题。
+type InheritConfig struct {
+
+	// 是否开启鉴权继承，on：开启,off：关闭。
+	Status string `json:"status"`
+
+	// 鉴权继承配置， m3u8：M3U8,mpd：MPD,输入多个时用“,”分开，例如“m3u8,mpd”  > 开启鉴权继承时，该参数必填。
+	InheritType *string `json:"inherit_type,omitempty"`
+
+	// 鉴权继承的文件类型时间, sys_time：当前系统时间，parent_url_time：与m3u8和mpd访问链接保持一致。  > 开启鉴权继承时，该参数必填。
+	InheritTimeType *string `json:"inherit_time_type,omitempty"`
+}
+
+func (o InheritConfig) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "InheritConfig struct{}"
+	}
+
+	return strings.Join([]string{"InheritConfig", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_inherit_config_query.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_inherit_config_query.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// InheritConfigQuery 鉴权继承，为M3U8/MPD索引文件下的TS/MP4文件添加鉴权参数，解决因鉴权不通过导致的TS/MP4文件无法播放的问题。
+type InheritConfigQuery struct {
+
+	// 是否开启鉴权继承，on：开启,off：关闭。
+	Status string `json:"status"`
+
+	// 鉴权继承配置， m3u8：M3U8,mpd：MPD,“m3u8,mpd”。
+	InheritType *string `json:"inherit_type,omitempty"`
+
+	// 鉴权继承的文件类型时间, sys_time：当前系统时间，parent_url_time：与m3u8和mpd访问链接保持一致。
+	InheritTimeType *string `json:"inherit_time_type,omitempty"`
+}
+
+func (o InheritConfigQuery) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "InheritConfigQuery struct{}"
+	}
+
+	return strings.Join([]string{"InheritConfigQuery", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_ip_filter.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_ip_filter.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// IpFilter IP黑白名单。
+type IpFilter struct {
+
+	// IP黑白名单类型，off：关闭IP黑白名单，black：IP黑名单，white：IP白名单。
+	Type string `json:"type"`
+
+	// 配置IP黑白名单，当type=off时，非必传， 支持IPv6,支持配置IP地址和IP&掩码格式的网段, 多条规则用“,”分割,最多支持配置150个, 多个完全重复的IP/IP段将合并为一个,不支持带通配符的地址，如192.168.0.*。
+	Value *string `json:"value,omitempty"`
+}
+
+func (o IpFilter) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "IpFilter struct{}"
+	}
+
+	return strings.Join([]string{"IpFilter", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_ip_frequency_limit.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_ip_frequency_limit.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// IpFrequencyLimit IP访问限频，通过对单IP每秒访问单个节点的次数限制，实现CC攻击防御及恶意盗刷防护。
+type IpFrequencyLimit struct {
+
+	// 状态，on：打开，off：关闭。
+	Status string `json:"status"`
+
+	// 访问阈值,单位：次/秒，取值范围：1-100000。   > 当开启ip限频时，访问阈值必填。
+	Qps *int32 `json:"qps,omitempty"`
+}
+
+func (o IpFrequencyLimit) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "IpFrequencyLimit struct{}"
+	}
+
+	return strings.Join([]string{"IpFrequencyLimit", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_ip_frequency_limit_query.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_ip_frequency_limit_query.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// IpFrequencyLimitQuery Ip访问限频。
+type IpFrequencyLimitQuery struct {
+
+	// 状态，on：打开，off：关闭。
+	Status string `json:"status"`
+
+	// 访问阈值，单位：次/秒。
+	Qps *int32 `json:"qps,omitempty"`
+}
+
+func (o IpFrequencyLimitQuery) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "IpFrequencyLimitQuery struct{}"
+	}
+
+	return strings.Join([]string{"IpFrequencyLimitQuery", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_list_cdn_domain_top_refers_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_list_cdn_domain_top_refers_request.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListCdnDomainTopRefersRequest Request Object
+type ListCdnDomainTopRefersRequest struct {
+
+	// 查询起始时间戳，需与结束时间戳同时指定，左闭右开，设置方式如下： - interval为300时，start_time设置为整5分钟时刻点，如：1631240100000(对应2021-09-10 10:15:00) - interval为3600时，start_time设置为整小时时刻点，如：1631239200000(对应2021-09-10 10:00:00) - interval为86400时，start_time设置为东8区零点时刻点，如：1631203200000(对应2021-09-10 00:00:00)
+	StartTime int64 `json:"start_time"`
+
+	// 查询结束时间戳，需与开始时间戳同时指定，左闭右开，设置方式如下： - interval为300时，end_time设置为整5分钟时刻点，如：1631243700000(对应2021-09-10 11:15:00) - interval为3600时，end_time设置为整小时时刻点，如：1631325600000(对应2021-09-11 10:00:00) - interval为86400时，end_time设置为东8区零点时刻点，如：1631376000000(对应2021-09-12 00:00:00)
+	EndTime int64 `json:"end_time"`
+
+	// 域名列表，多个域名以逗号（半角）分隔，如：www.test1.com,www.test2.com all表示查询名下全部域名。如果域名在查询时间段内无数据，结果将不返回该域名的信息。
+	DomainName string `json:"domain_name"`
+
+	// - 统计指标类型 - 目前只支持flux（流量），req_num（请求数）
+	StatType string `json:"stat_type"`
+
+	// 服务区域：mainland_china(大陆)，outside_mainland_china(海外)，默认为global(全球)
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子账号调用接口时，该参数必传。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 是否包含百分比数据，默认false
+	IncludeRatio *bool `json:"include_ratio,omitempty"`
+}
+
+func (o ListCdnDomainTopRefersRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListCdnDomainTopRefersRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListCdnDomainTopRefersRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_list_cdn_domain_top_refers_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_list_cdn_domain_top_refers_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListCdnDomainTopRefersResponse Response Object
+type ListCdnDomainTopRefersResponse struct {
+
+	// 详情数据对象。
+	TopReferSummary *[]TopReferSummary `json:"top_refer_summary,omitempty"`
+	HttpStatusCode  int                `json:"-"`
+}
+
+func (o ListCdnDomainTopRefersResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListCdnDomainTopRefersResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListCdnDomainTopRefersResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_list_domains_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_list_domains_request.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListDomainsRequest Request Object
+type ListDomainsRequest struct {
+
+	// 加速域名，采用模糊匹配的方式。（长度限制为1-255字符）。
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// 加速域名的业务类型。取值： - web（网站加速） - download（文件下载加速） - video（点播加速） - wholeSite（全站加速）
+	BusinessType *string `json:"business_type,omitempty"`
+
+	// 加速域名状态。取值意义： - online表示“已开启” - offline表示“已停用” - configuring表示“配置中” - configure_failed表示“配置失败” - checking表示“审核中” - check_failed表示“审核未通过” - deleting表示“删除中”。
+	DomainStatus *string `json:"domain_status,omitempty"`
+
+	// 华为云CDN提供的加速服务范围，包含： - mainland_china 中国大陆 - outside_mainland_china 中国大陆境外 - global 全球。
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 每页加速域名的数量，取值范围1-10000，默认值为30。
+	PageSize *int32 `json:"page_size,omitempty"`
+
+	// 查询的页码，即：从哪一页开始查询，取值范围1-65535，默认值为1。
+	PageNumber *int32 `json:"page_number,omitempty"`
+
+	// 展示标签标识 true：不展示 false：展示。
+	ShowTags *bool `json:"show_tags,omitempty"`
+
+	// 精准匹配 true：开启 false：关闭。
+	ExactMatch *bool `json:"exact_match,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o ListDomainsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListDomainsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListDomainsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_list_domains_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_list_domains_response.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListDomainsResponse Response Object
+type ListDomainsResponse struct {
+
+	// 总条数。
+	Total *int32 `json:"total,omitempty"`
+
+	// 域名信息。
+	Domains *[]Domains `json:"domains,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ListDomainsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListDomainsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListDomainsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_log_object.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_log_object.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type LogObject struct {
+
+	// 域名名称。
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// 查询起始时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	StartTime *int64 `json:"start_time,omitempty"`
+
+	// 查询结束时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	EndTime *int64 `json:"end_time,omitempty"`
+
+	// 日志文件名字。
+	Name *string `json:"name,omitempty"`
+
+	// 文件大小(Byte)。
+	Size *int64 `json:"size,omitempty"`
+
+	// 下载链接。
+	Link *string `json:"link,omitempty"`
+}
+
+func (o LogObject) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "LogObject struct{}"
+	}
+
+	return strings.Join([]string{"LogObject", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_modify_domain_config_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_modify_domain_config_request_body.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ModifyDomainConfigRequestBody struct {
+	Configs *Configs `json:"configs,omitempty"`
+}
+
+func (o ModifyDomainConfigRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ModifyDomainConfigRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"ModifyDomainConfigRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_origin_request_header.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_origin_request_header.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// OriginRequestHeader 回源请求头
+type OriginRequestHeader struct {
+
+	// 设置回源请求头参数。格式要求：由数字，大小写字母，中划线组成，只能以字母开头。
+	Name string `json:"name"`
+
+	// 设置回源请求头参数的值。当为删除动作时，可不填。格式要求：长度1-512。不支持中文，不支持变量配置，如：$client_ip,$remote_port等。
+	Value *string `json:"value,omitempty"`
+
+	// 回源请求头设置类型。delete：删除，set：设置。同一个请求头字段只允许删除或者设置。设置：若原始回源请求中不存在该字段，先执行新增再执行设置。
+	Action string `json:"action"`
+}
+
+func (o OriginRequestHeader) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "OriginRequestHeader struct{}"
+	}
+
+	return strings.Join([]string{"OriginRequestHeader", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_origin_request_url_rewrite.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_origin_request_url_rewrite.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// OriginRequestUrlRewrite 改写回源URL，最多配置20条。
+type OriginRequestUrlRewrite struct {
+
+	// 回源URL改写规则的优先级。 优先级设置具有唯一性，不支持多条回源URL改写规则设置同一优先级，且优先级不能输入为空。 多条规则下，不同规则中的相同资源内容，CDN按照优先级高的规则执行URL改写。 取值为1-100之间的整数，数值越大优先级越高。
+	Priority int32 `json:"priority"`
+
+	// 匹配类型， all：所有文件， file_path：URL路径， wildcard：通配符， full_path: 全路径。
+	MatchType string `json:"match_type"`
+
+	// 需要替换的URI。 改写后的URI以正斜线（/）开头的URI，不含http(s)://头及域名。 长度不超过512个字符。 支持通配符\\*匹配，如：/test/\\*_/\\*.mp4。 匹配方式为“所有文件”时，不支持配置参数。
+	SourceUrl *string `json:"source_url,omitempty"`
+
+	// 以正斜线（/）开头的URI，不含http(s)://头及域名。 长度不超过256个字符。 通配符 * 可通过$n捕获（n=1,2,3...，例如：/newtest/$1/$2.jpg）。
+	TargetUrl string `json:"target_url"`
+}
+
+func (o OriginRequestUrlRewrite) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "OriginRequestUrlRewrite struct{}"
+	}
+
+	return strings.Join([]string{"OriginRequestUrlRewrite", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_preheating_task_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_preheating_task_request.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type PreheatingTaskRequest struct {
+	PreheatingTask *PreheatingTaskRequestBody `json:"preheating_task"`
+}
+
+func (o PreheatingTaskRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "PreheatingTaskRequest struct{}"
+	}
+
+	return strings.Join([]string{"PreheatingTaskRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_preheating_task_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_preheating_task_request_body.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type PreheatingTaskRequestBody struct {
+
+	// 是否对url中的中文字符进行编码后预热，false代表不开启，true代表开启，开启后仅预热转码后的URL。
+	ZhUrlEncode *bool `json:"zh_url_encode,omitempty"`
+
+	// 需要预热的URL必须带有“http://”或“https://”，多个URL用逗号分隔，目前不支持对目录的预热，单个url的长度限制为4096字符,单次最多输入1000个url。
+	Urls []string `json:"urls"`
+}
+
+func (o PreheatingTaskRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "PreheatingTaskRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"PreheatingTaskRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_quic.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_quic.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Quic QUIC协议。
+type Quic struct {
+
+	// 状态，on：打开，off：关闭。
+	Status string `json:"status"`
+}
+
+func (o Quic) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Quic struct{}"
+	}
+
+	return strings.Join([]string{"Quic", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_referer_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_referer_config.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// RefererConfig 防盗链。
+type RefererConfig struct {
+
+	// Referer黑白名单类型，off：关闭Referer黑白名单，black：Referer黑名单，white：Referer白名单。
+	Type string `json:"type"`
+
+	// 域名或IP地址，以“,”进行分割，域名、IP地址可以混合输入，支持泛域名和带端口的域名。域名、IP地址总数不超过400个，端口取值范围1-65535。
+	Value *string `json:"value,omitempty"`
+
+	// 是否包含空Referer，如果是黑名单并开启该选项，则表示无referer不允许访问，如果是白名单并开启该选项，则表示无referer允许访问，true:包含空，false：不包含空，默认值false。
+	IncludeEmpty *bool `json:"include_empty,omitempty"`
+}
+
+func (o RefererConfig) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "RefererConfig struct{}"
+	}
+
+	return strings.Join([]string{"RefererConfig", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_refresh_task_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_refresh_task_request.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type RefreshTaskRequest struct {
+	RefreshTask *RefreshTaskRequestBody `json:"refresh_task"`
+}
+
+func (o RefreshTaskRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "RefreshTaskRequest struct{}"
+	}
+
+	return strings.Join([]string{"RefreshTaskRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_refresh_task_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_refresh_task_request_body.go
@@ -1,0 +1,128 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type RefreshTaskRequestBody struct {
+
+	// 刷新的类型，其值可以为file：文件，或directory：目录，默认为file。
+	Type *RefreshTaskRequestBodyType `json:"type,omitempty"`
+
+	// 目录刷新方式，all：刷新目录下全部资源；detect_modify_refresh：刷新目录下已变更的资源，默认值为all。
+	Mode *RefreshTaskRequestBodyMode `json:"mode,omitempty"`
+
+	// 是否对url中的中文字符进行编码后刷新，false代表不开启，true代表开启，开启后仅刷新转码后的URL。
+	ZhUrlEncode *bool `json:"zh_url_encode,omitempty"`
+
+	// 需要刷新的URL必须带有“http://”或“https://”，多个URL用逗号分隔，单个url的长度限制为4096字符，单次最多输入1000个url，如果输入的是目录，支持100个目录刷新。  >   如果您需要刷新的URL中有中文，请同时刷新中文URL和转码后的URL。
+	Urls []string `json:"urls"`
+}
+
+func (o RefreshTaskRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "RefreshTaskRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"RefreshTaskRequestBody", string(data)}, " ")
+}
+
+type RefreshTaskRequestBodyType struct {
+	value string
+}
+
+type RefreshTaskRequestBodyTypeEnum struct {
+	FILE      RefreshTaskRequestBodyType
+	DIRECTORY RefreshTaskRequestBodyType
+}
+
+func GetRefreshTaskRequestBodyTypeEnum() RefreshTaskRequestBodyTypeEnum {
+	return RefreshTaskRequestBodyTypeEnum{
+		FILE: RefreshTaskRequestBodyType{
+			value: "file",
+		},
+		DIRECTORY: RefreshTaskRequestBodyType{
+			value: "directory",
+		},
+	}
+}
+
+func (c RefreshTaskRequestBodyType) Value() string {
+	return c.value
+}
+
+func (c RefreshTaskRequestBodyType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *RefreshTaskRequestBodyType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type RefreshTaskRequestBodyMode struct {
+	value string
+}
+
+type RefreshTaskRequestBodyModeEnum struct {
+	ALL                   RefreshTaskRequestBodyMode
+	DETECT_MODIFY_REFRESH RefreshTaskRequestBodyMode
+}
+
+func GetRefreshTaskRequestBodyModeEnum() RefreshTaskRequestBodyModeEnum {
+	return RefreshTaskRequestBodyModeEnum{
+		ALL: RefreshTaskRequestBodyMode{
+			value: "all",
+		},
+		DETECT_MODIFY_REFRESH: RefreshTaskRequestBodyMode{
+			value: "detect_modify_refresh",
+		},
+	}
+}
+
+func (c RefreshTaskRequestBodyMode) Value() string {
+	return c.value
+}
+
+func (c RefreshTaskRequestBodyMode) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *RefreshTaskRequestBodyMode) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_remote_auth_rule_vo.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_remote_auth_rule_vo.go
@@ -1,0 +1,65 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// RemoteAuthRuleVo 远程鉴权配置。
+type RemoteAuthRuleVo struct {
+
+	// 可访问的鉴权服务器地址。 输入的URL必须有“http”或“https”。不能是localhost或127.0.0.1这类本地地址。 不能是CDN的加速域名。
+	AuthServer string `json:"auth_server"`
+
+	// 鉴权服务器支持的请求方法，支持GET、POST、HEAD。
+	RequestMethod string `json:"request_method"`
+
+	// all（所有文件类型）：所有文件均参与鉴权。 specific_file（指定文件类型）：指定类型的文件参与鉴权。示例：jpg|MP4。 文件类型不区分大小写，即：jpg和JPG代表同一种文件类型，多个文件类型用“|”分割。
+	FileTypeSetting string `json:"file_type_setting"`
+
+	// 字符总数不能超过512,当file_type_setting等于specific_file时为必选，其余情况为空， 由大小写字母和数字构成，文件类型用竖线分隔，例如jpg|mp4，只有在必选情况下才会对该字段做校验。
+	SpecifiedFileType *string `json:"specified_file_type,omitempty"`
+
+	// 设置用户请求中需要参与鉴权的参数，可选reserve_all_args（保留所有URL参数）、reserve_specific_args（保留指定URL参数）、ignore_all_args（忽略所有URL参数）。
+	ReserveArgsSetting string `json:"reserve_args_setting"`
+
+	// 当reserve_args_setting等于reserve_specific_args时为必选，其余情况为空，要保留的参数，多个参数用竖线分隔：key1|key2。
+	ReserveArgs *string `json:"reserve_args,omitempty"`
+
+	// URL鉴权参数
+	AddCustomArgsRules *[]CustomArgs `json:"add_custom_args_rules,omitempty"`
+
+	// 设置用户请求中参与鉴权请求头，可选reserve_all_headers（保留所有请求头参数）、reserve_specific_headers（保留指定请求头参数）、ignore_all_headers（忽略所有请求头参数）。
+	ReserveHeadersSetting string `json:"reserve_headers_setting"`
+
+	// 请求头鉴权参数
+	AddCustomHeadersRules *[]CustomArgs `json:"add_custom_headers_rules,omitempty"`
+
+	// 设置鉴权成功时远程鉴权服务器返回给CDN节点的状态码。取值范围：2xx/3xx。
+	AuthSuccessStatus string `json:"auth_success_status"`
+
+	// 设置鉴权失败时远程鉴权服务器返回给CDN节点的状态码。取值范围：4xx/5xx。
+	AuthFailedStatus string `json:"auth_failed_status"`
+
+	// 设置鉴权失败时CDN节点返回给用户的状态码。取值范围：2xx/3xx/4xx/5xx。
+	ResponseStatus string `json:"response_status"`
+
+	// 设置鉴权超时时间，即从CDN转发鉴权请求开始，到CDN节点收到远程鉴权服务器返回的结果的时间。单位为毫秒，值为0或50-3000。
+	Timeout int32 `json:"timeout"`
+
+	// 设置鉴权超时后，CDN节点如何处理用户请求。 pass(鉴权失败放过)：鉴权超时后允许用户请求，返回对应的资源。 forbid(鉴权失败拒绝)：鉴权超时后拒绝用户请求，返回配置的响应自定义状态码给用户。
+	TimeoutAction string `json:"timeout_action"`
+
+	// 当reserve_headers_setting等于reserve_specific_headers时为必选，其余情况为空，要保留的请求头，多个请求头用竖线分隔：key1|key2。
+	ReserveHeaders *string `json:"reserve_headers,omitempty"`
+}
+
+func (o RemoteAuthRuleVo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "RemoteAuthRuleVo struct{}"
+	}
+
+	return strings.Join([]string{"RemoteAuthRuleVo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_request_limit_rules.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_request_limit_rules.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// RequestLimitRules 请求限速配置。
+type RequestLimitRules struct {
+
+	// status只支持on，off无效。  > request_limit_rules字段置空时代表关闭请求限速功能。  > 旧接口中的参数，后续将下线。
+	Status *string `json:"status,omitempty"`
+
+	// 优先级，值越大，优先级越高,取值范围：1-100。
+	Priority int32 `json:"priority"`
+
+	// 匹配类型，all：所有文件，catalog：目录。
+	MatchType string `json:"match_type"`
+
+	// 匹配类型值。 当match_type为all时传空值，例如：\"\"； 当match_type为catalog时传目录地址，以“/”作为首字符,例如：\"/test\"。  > 值为catalog的时候必填
+	MatchValue *string `json:"match_value,omitempty"`
+
+	// 限速方式，当前仅支持按流量大小限速，取值为size。
+	Type string `json:"type"`
+
+	// 限速条件,type=size,limit_rate_after=50表示从传输表示传输50个字节后开始限速且限速值为limit_rate_value， 单位byte，取值范围：0-1073741824。
+	LimitRateAfter int64 `json:"limit_rate_after"`
+
+	// 限速值,单位Bps，取值范围 0-104857600。
+	LimitRateValue int32 `json:"limit_rate_value"`
+}
+
+func (o RequestLimitRules) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "RequestLimitRules struct{}"
+	}
+
+	return strings.Join([]string{"RequestLimitRules", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_set_charge_modes_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_set_charge_modes_body.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// SetChargeModesBody 设置计费模式请求体
+type SetChargeModesBody struct {
+
+	// 计费模式，支持flux（流量），v2及以上客户支持bw（带宽）
+	ChargeMode string `json:"charge_mode"`
+
+	// 产品模式，仅支持base（基础加速）
+	ProductType string `json:"product_type"`
+
+	// 服务区域，仅支持mainland_china（国内）
+	ServiceArea string `json:"service_area"`
+}
+
+func (o SetChargeModesBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SetChargeModesBody struct{}"
+	}
+
+	return strings.Join([]string{"SetChargeModesBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_set_charge_modes_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_set_charge_modes_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// SetChargeModesRequest Request Object
+type SetChargeModesRequest struct {
+	Body *SetChargeModesBody `json:"body,omitempty"`
+}
+
+func (o SetChargeModesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SetChargeModesRequest struct{}"
+	}
+
+	return strings.Join([]string{"SetChargeModesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_set_charge_modes_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_set_charge_modes_response.go
@@ -1,0 +1,39 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// SetChargeModesResponse Response Object
+type SetChargeModesResponse struct {
+
+	// 账号的计费模式
+	ChargeMode *string `json:"charge_mode,omitempty"`
+
+	// 加速类型
+	ProductType *string `json:"product_type,omitempty"`
+
+	// 该模式生效时间
+	EffectiveTime *int64 `json:"effective_time,omitempty"`
+
+	// 创建时间
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 该模式的区域
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 状态,首次开通状态为active,之后修改为upcoming
+	Status         *string `json:"status,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o SetChargeModesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SetChargeModesResponse struct{}"
+	}
+
+	return strings.Join([]string{"SetChargeModesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_bandwidth_calc_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_bandwidth_calc_request.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowBandwidthCalcRequest Request Object
+type ShowBandwidthCalcRequest struct {
+
+	// 查询起始时间戳，需与结束时间戳同时指定，左闭右开，设置方式如下： - interval为300时，start_time设置为整5分钟时刻点，如：1631240100000(对应2021-09-10 10:15:00) - interval为3600时，start_time设置为整小时时刻点，如：1631239200000(对应2021-09-10 10:00:00) - interval为86400时，start_time设置为东8区零点时刻点，如：1631203200000(对应2021-09-10 00:00:00)
+	StartTime int64 `json:"start_time"`
+
+	// 查询结束时间戳，需与开始时间戳同时指定，左闭右开，设置方式如下： - interval为300时，end_time设置为整5分钟时刻点，如：1631243700000(对应2021-09-10 11:15:00) - interval为3600时，end_time设置为整小时时刻点，如：1631325600000(对应2021-09-11 10:00:00) - interval为86400时，end_time设置为东8区零点时刻点，如：1631376000000(对应2021-09-12 00:00:00)
+	EndTime int64 `json:"end_time"`
+
+	// 域名列表，多个域名以逗号（半角）分隔，如：www.test1.com,www.test2.com all表示查询名下全部域名。如果域名在查询时间段内无数据，结果将不返回该域名的信息。
+	DomainName string `json:"domain_name"`
+
+	// 服务区域：mainland_china(中国大陆)，outside_mainland_china(中国大陆境外)，默认为mainland_china，当查询回源类指标时该参数无效。
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子账号调用接口时，该参数必传。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 查询类别，目前支持bw_95（95峰值带宽），bw_peak（日峰值月平均带宽），bw_95_average(95月平均带宽)
+	CalcType string `json:"calc_type"`
+}
+
+func (o ShowBandwidthCalcRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowBandwidthCalcRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowBandwidthCalcRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_bandwidth_calc_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_bandwidth_calc_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowBandwidthCalcResponse Response Object
+type ShowBandwidthCalcResponse struct {
+
+	// 95峰值，日峰值月平均线信息
+	BandwidthCalc  map[string]interface{} `json:"bandwidth_calc,omitempty"`
+	HttpStatusCode int                    `json:"-"`
+}
+
+func (o ShowBandwidthCalcResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowBandwidthCalcResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowBandwidthCalcResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_certificates_https_info_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_certificates_https_info_request.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowCertificatesHttpsInfoRequest Request Object
+type ShowCertificatesHttpsInfoRequest struct {
+
+	// 每页的数量，取值范围1-10000，不设值时默认值为30。
+	PageSize *int32 `json:"page_size,omitempty"`
+
+	// 查询的页码。取值范围1-65535，不设值时默认值为1。
+	PageNumber *int32 `json:"page_number,omitempty"`
+
+	// 加速域名。
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// 域名所属用户的domain_id。
+	UserDomainId *string `json:"user_domain_id,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子帐号调用接口时，该参数必传。 您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o ShowCertificatesHttpsInfoRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCertificatesHttpsInfoRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowCertificatesHttpsInfoRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_certificates_https_info_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_certificates_https_info_response.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowCertificatesHttpsInfoResponse Response Object
+type ShowCertificatesHttpsInfoResponse struct {
+
+	// 查询结果总数
+	Total *int32 `json:"total,omitempty"`
+
+	// https配置。
+	Https *[]HttpsDetail `json:"https,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowCertificatesHttpsInfoResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowCertificatesHttpsInfoResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowCertificatesHttpsInfoResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_charge_modes_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_charge_modes_request.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowChargeModesRequest Request Object
+type ShowChargeModesRequest struct {
+
+	// 加速类型，base（基础加速）
+	ProductType string `json:"product_type"`
+
+	// 查询计费模式状态，active（已生效），upcoming（待生效），不传默认为active(已生效)
+	Status *string `json:"status,omitempty"`
+
+	// 服务区域，mainland_china（国内），outside_mainland_china（海外），不传默认为mainland_china(国内)
+	ServiceArea *string `json:"service_area,omitempty"`
+}
+
+func (o ShowChargeModesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowChargeModesRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowChargeModesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_charge_modes_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_charge_modes_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowChargeModesResponse Response Object
+type ShowChargeModesResponse struct {
+
+	// 计费模式查询结果
+	Result         *[]map[string]interface{} `json:"result,omitempty"`
+	HttpStatusCode int                       `json:"-"`
+}
+
+func (o ShowChargeModesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowChargeModesResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowChargeModesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_detail_by_name_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_detail_by_name_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowDomainDetailByNameRequest Request Object
+type ShowDomainDetailByNameRequest struct {
+
+	// 加速域名名称。
+	DomainName string `json:"domain_name"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o ShowDomainDetailByNameRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowDomainDetailByNameRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowDomainDetailByNameRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_detail_by_name_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_detail_by_name_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowDomainDetailByNameResponse Response Object
+type ShowDomainDetailByNameResponse struct {
+	Domain *DomainsDetail `json:"domain,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowDomainDetailByNameResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowDomainDetailByNameResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowDomainDetailByNameResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_full_config_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_full_config_request.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowDomainFullConfigRequest Request Object
+type ShowDomainFullConfigRequest struct {
+
+	// 加速域名。
+	DomainName string `json:"domain_name"`
+
+	// 企业项目ID， all：所有项目。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 取值为auth_key，用来查询鉴权KEY和鉴权备KEY的值。
+	ShowSpecialConfigs *string `json:"show_special_configs,omitempty"`
+}
+
+func (o ShowDomainFullConfigRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowDomainFullConfigRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowDomainFullConfigRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_full_config_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_full_config_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowDomainFullConfigResponse Response Object
+type ShowDomainFullConfigResponse struct {
+	Configs *ConfigsGetBody `json:"configs,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowDomainFullConfigResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowDomainFullConfigResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowDomainFullConfigResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_location_stats_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_location_stats_request.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowDomainLocationStatsRequest Request Object
+type ShowDomainLocationStatsRequest struct {
+
+	// 动作名称，可选location_summary、location_detail。 - location_summary：查询汇总数据 - location_detail：查询数据详情。
+	Action string `json:"action"`
+
+	// 查询起始时间戳，需与结束时间戳同时指定，左闭右开，设置方式如下： - interval为300时，start_time设置为整5分钟时刻点，如：1631240100000(对应2021-09-10 10:15:00) - interval为3600时，start_time设置为整小时时刻点，如：1631239200000(对应2021-09-10 10:00:00) - interval为86400时，start_time设置为东8区零点时刻点，如：1631203200000(对应2021-09-10 00:00:00)
+	StartTime int64 `json:"start_time"`
+
+	// 查询结束时间戳，需与开始时间戳同时指定，左闭右开，设置方式如下： - interval为300时，end_time设置为整5分钟时刻点，如：1631243700000(对应2021-09-10 11:15:00) - interval为3600时，end_time设置为整小时时刻点，如：1631325600000(对应2021-09-11 10:00:00) - interval为86400时，end_time设置为东8区零点时刻点，如：1631376000000(对应2021-09-12 00:00:00)
+	EndTime int64 `json:"end_time"`
+
+	// 域名列表，多个域名以逗号（半角）分隔，如：www.test1.com,www.test2.com all表示查询名下全部域名。如果域名在查询时间段内无数据，结果将不返回该域名的信息。
+	DomainName string `json:"domain_name"`
+
+	// - 网络资源消耗   - bw（带宽）   - flux（流量） - 访问情况   - req_num（请求总数） - HTTP状态码（组合指标）   - http_code_2xx(状态码汇总2xx)   - http_code_3xx(状态码汇总3xx)   - http_code_4xx(状态码汇总4xx)   - http_code_5xx(状态码汇总5xx)   - status_code_2xx(状态码详情2xx)   - status_code_3xx(状态码详情3xx)   - status_code_4xx(状态码详情4xx)   - status_code_5xx(状态码详情5xx)
+	StatType string `json:"stat_type"`
+
+	// 查询时间间隔，单位：秒，取值说明： - 300(5分钟)：最大查询跨度2天 - 3600(1小时)：最大查询跨度7天 - 86400(1天)：最大查询跨度31天 - 如果不传，默认取对应时间跨度的最小间隔。
+	Interval *int64 `json:"interval,omitempty"`
+
+	// - 国家&地区编码，多个以英文逗号分隔，all表示全部，取值见附录 - 访问运营商统计数据时不能填写 - 访问top_url数据时不能填写 - 访问区域情况数据时只能填写cn(中国)
+	Country *string `json:"country,omitempty"`
+
+	// 省份编码，当country为cn（中国）时有效，多个以英文逗号分隔，all表示全部，取值见附录
+	Province *string `json:"province,omitempty"`
+
+	// 运营商编码，多个以英文逗号分隔，all表示全部，取值见附录
+	Isp *string `json:"isp,omitempty"`
+
+	// 数据分组方式，多个以英文逗号分隔，可选domain（域名）、country（国家）、province（省份，仅国家为中国时有效）、isp（区域运营商），默认不分组
+	GroupBy *string `json:"group_by,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子账号调用接口时，该参数必传。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o ShowDomainLocationStatsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowDomainLocationStatsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowDomainLocationStatsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_location_stats_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_location_stats_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowDomainLocationStatsResponse Response Object
+type ShowDomainLocationStatsResponse struct {
+
+	// 数据分组方式
+	GroupBy *string `json:"group_by,omitempty"`
+
+	// 按指定的分组方式组织的数据
+	Result         map[string]interface{} `json:"result,omitempty"`
+	HttpStatusCode int                    `json:"-"`
+}
+
+func (o ShowDomainLocationStatsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowDomainLocationStatsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowDomainLocationStatsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_stats_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_stats_request.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowDomainStatsRequest Request Object
+type ShowDomainStatsRequest struct {
+
+	// 动作名称，可选summary、detail。 - summary：查询汇总数据 - detail：查询数据详情。
+	Action string `json:"action"`
+
+	// 查询起始时间戳，需与结束时间戳同时指定，左闭右开，设置方式如下： - interval为300时，start_time设置为整5分钟时刻点，如：1631240100000(对应2021-09-10 10:15:00) - interval为3600时，start_time设置为整小时时刻点，如：1631239200000(对应2021-09-10 10:00:00) - interval为86400时，start_time设置为东8区零点时刻点，如：1631203200000(对应2021-09-10 00:00:00)
+	StartTime int64 `json:"start_time"`
+
+	// 查询结束时间戳，需与开始时间戳同时指定，左闭右开，设置方式如下： - interval为300时，end_time设置为整5分钟时刻点，如：1631243700000(对应2021-09-10 11:15:00) - interval为3600时，end_time设置为整小时时刻点，如：1631325600000(对应2021-09-11 10:00:00) - interval为86400时，end_time设置为东8区零点时刻点，如：1631376000000(对应2021-09-12 00:00:00)
+	EndTime int64 `json:"end_time"`
+
+	// 域名列表，多个域名以逗号（半角）分隔，如：www.test1.com,www.test2.com all表示查询名下全部域名。如果域名在查询时间段内无数据，结果将不返回该域名的信息。
+	DomainName string `json:"domain_name"`
+
+	// - 网络资源消耗：   - bw（带宽）   - flux（流量）   - bs_bw（回源带宽）   - bs_flux（回源流量） - 访问情况   - req_num（请求总数）   - hit_num（请求命中次数）   - bs_num（回源总数）   - bs_fail_num（回源失败数）   - hit_flux（命中流量） - HTTP状态码（组合指标）   - http_code_2xx（状态码汇总2xx）   - http_code_3xx（状态码汇总3xx）   - http_code_4xx（状态码汇总4xx）   - http_code_5xx（状态码汇总5xx）   - bs_http_code_2xx（回源状态码汇总2xx）   - bs_http_code_3xx（回源状态码汇总3xx）   - bs_http_code_4xx（回源状态码汇总4xx）   - bs_http_code_5xx（回源状态码汇总5xx）   - status_code_2xx（状态码详情2xx）   - status_code_3xx（状态码详情3xx）   - status_code_4xx（状态码详情4xx）   - status_code_5xx（状态码详情5xx）   - bs_status_code_2xx（回源状态码详情2xx）   - bs_status_code_3xx（回源状态码详情3xx）   - bs_status_code_4xx（回源状态码详情4xx）   - bs_status_code_5xx（回源状态码详情5xx）   - status_code和bs_status_code不能一起查询
+	StatType string `json:"stat_type"`
+
+	// 查询时间间隔，单位：秒，取值说明： - 300(5分钟)：最大查询跨度2天 - 3600(1小时)：最大查询跨度7天 - 86400(1天)：最大查询跨度31天 - 如果不传，默认取对应时间跨度的最小间隔。
+	Interval *int64 `json:"interval,omitempty"`
+
+	// 数据分组方式，可选domain，默认不分组
+	GroupBy *string `json:"group_by,omitempty"`
+
+	// 服务区域：mainland_china(中国大陆)，outside_mainland_china(中国大陆境外)，默认为mainland_china，当查询回源类指标时该参数无效。
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子账号调用接口时，该参数必传。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o ShowDomainStatsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowDomainStatsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowDomainStatsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_stats_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_domain_stats_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowDomainStatsResponse Response Object
+type ShowDomainStatsResponse struct {
+
+	// 按指定的分组方式组织的数据
+	Result         map[string]interface{} `json:"result,omitempty"`
+	HttpStatusCode int                    `json:"-"`
+}
+
+func (o ShowDomainStatsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowDomainStatsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowDomainStatsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_history_task_details_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_history_task_details_request.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowHistoryTaskDetailsRequest Request Object
+type ShowHistoryTaskDetailsRequest struct {
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 刷新任务ID。
+	HistoryTasksId string `json:"history_tasks_id"`
+
+	// 刷新预热的urls所显示单页最大数量，取值范围为1-10000。page_size和page_number必须同时传值。默认值30。
+	PageSize *int32 `json:"page_size,omitempty"`
+
+	// 刷新预热的urls当前查询为第几页，取值范围为1-65535。默认值1。
+	PageNumber *int32 `json:"page_number,omitempty"`
+
+	// url的状态 processing 处理中，succeed 完成，failed 失败，waiting 等待，refreshing 刷新中，preheating 预热中。
+	Status *string `json:"status,omitempty"`
+
+	// url的地址。
+	Url *string `json:"url,omitempty"`
+
+	// 刷新预热任务的创建时间。不传参默认为查询7天内的任务。最长可查询15天内数据。
+	CreateTime *int64 `json:"create_time,omitempty"`
+}
+
+func (o ShowHistoryTaskDetailsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowHistoryTaskDetailsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowHistoryTaskDetailsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_history_task_details_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_history_task_details_response.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowHistoryTaskDetailsResponse Response Object
+type ShowHistoryTaskDetailsResponse struct {
+
+	// 任务id。
+	Id *string `json:"id,omitempty"`
+
+	// 任务类型，refresh：刷新任务；preheating：预热任务。
+	TaskType *string `json:"task_type,omitempty"`
+
+	// 任务执行结果,task_done:成功，task_inprocess:处理中。
+	Status *string `json:"status,omitempty"`
+
+	// 本次提交的url列表。
+	Urls *[]UrlObject `json:"urls,omitempty"`
+
+	// 创建时间。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 处理中的url个数。
+	Processing *int32 `json:"processing,omitempty"`
+
+	// 成功处理的url个数。
+	Succeed *int32 `json:"succeed,omitempty"`
+
+	// 处理失败的url个数。
+	Failed *int32 `json:"failed,omitempty"`
+
+	// 历史任务的url个数。
+	Total *int32 `json:"total,omitempty"`
+
+	// 文件类型，file：文件；directory：目录，默认是文件file。
+	FileType *string `json:"file_type,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowHistoryTaskDetailsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowHistoryTaskDetailsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowHistoryTaskDetailsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_history_tasks_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_history_tasks_request.go
@@ -1,0 +1,194 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// ShowHistoryTasksRequest Request Object
+type ShowHistoryTasksRequest struct {
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 单页最大数量，取值范围为1-10000。page_size和page_number必须同时传值。默认值30。
+	PageSize *int32 `json:"page_size,omitempty"`
+
+	// 当前查询第几页，取值范围为1-65535。默认值1。
+	PageNumber *int32 `json:"page_number,omitempty"`
+
+	// 任务状态。 task_inprocess 表示任务处理中，task_done表示任务完成。
+	Status *ShowHistoryTasksRequestStatus `json:"status,omitempty"`
+
+	// 查询起始时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	StartDate *int64 `json:"start_date,omitempty"`
+
+	// 查询结束时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	EndDate *int64 `json:"end_date,omitempty"`
+
+	// 用来排序的字段，支持的字段有“task_type”：任务的类型，“total”：url总数，“processing”：处理中的url个数， “succeed”：成功处理的url个数，“failed”：处理失败的url个数，“create_time”：任务的创建时间。order_field和order_type必须同时传值，否则使用默认值\"create_time\" 和 \"desc\"：降序。
+	OrderField *string `json:"order_field,omitempty"`
+
+	// desc：降序，或者asc：升序。默认值desc。
+	OrderType *string `json:"order_type,omitempty"`
+
+	// 默认是文件file。file：文件,directory：目录。
+	FileType *ShowHistoryTasksRequestFileType `json:"file_type,omitempty"`
+
+	// 任务类型，refresh：刷新任务；preheating：预热任务
+	TaskType *ShowHistoryTasksRequestTaskType `json:"task_type,omitempty"`
+}
+
+func (o ShowHistoryTasksRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowHistoryTasksRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowHistoryTasksRequest", string(data)}, " ")
+}
+
+type ShowHistoryTasksRequestStatus struct {
+	value string
+}
+
+type ShowHistoryTasksRequestStatusEnum struct {
+	TASK_INPROCESS ShowHistoryTasksRequestStatus
+	TASK_DONE      ShowHistoryTasksRequestStatus
+}
+
+func GetShowHistoryTasksRequestStatusEnum() ShowHistoryTasksRequestStatusEnum {
+	return ShowHistoryTasksRequestStatusEnum{
+		TASK_INPROCESS: ShowHistoryTasksRequestStatus{
+			value: "task_inprocess",
+		},
+		TASK_DONE: ShowHistoryTasksRequestStatus{
+			value: "task_done",
+		},
+	}
+}
+
+func (c ShowHistoryTasksRequestStatus) Value() string {
+	return c.value
+}
+
+func (c ShowHistoryTasksRequestStatus) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowHistoryTasksRequestStatus) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type ShowHistoryTasksRequestFileType struct {
+	value string
+}
+
+type ShowHistoryTasksRequestFileTypeEnum struct {
+	FILE      ShowHistoryTasksRequestFileType
+	DIRECTORY ShowHistoryTasksRequestFileType
+}
+
+func GetShowHistoryTasksRequestFileTypeEnum() ShowHistoryTasksRequestFileTypeEnum {
+	return ShowHistoryTasksRequestFileTypeEnum{
+		FILE: ShowHistoryTasksRequestFileType{
+			value: "file",
+		},
+		DIRECTORY: ShowHistoryTasksRequestFileType{
+			value: "directory",
+		},
+	}
+}
+
+func (c ShowHistoryTasksRequestFileType) Value() string {
+	return c.value
+}
+
+func (c ShowHistoryTasksRequestFileType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowHistoryTasksRequestFileType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type ShowHistoryTasksRequestTaskType struct {
+	value string
+}
+
+type ShowHistoryTasksRequestTaskTypeEnum struct {
+	REFRESH    ShowHistoryTasksRequestTaskType
+	PREHEATING ShowHistoryTasksRequestTaskType
+}
+
+func GetShowHistoryTasksRequestTaskTypeEnum() ShowHistoryTasksRequestTaskTypeEnum {
+	return ShowHistoryTasksRequestTaskTypeEnum{
+		REFRESH: ShowHistoryTasksRequestTaskType{
+			value: "refresh",
+		},
+		PREHEATING: ShowHistoryTasksRequestTaskType{
+			value: "preheating",
+		},
+	}
+}
+
+func (c ShowHistoryTasksRequestTaskType) Value() string {
+	return c.value
+}
+
+func (c ShowHistoryTasksRequestTaskType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *ShowHistoryTasksRequestTaskType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_history_tasks_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_history_tasks_response.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowHistoryTasksResponse Response Object
+type ShowHistoryTasksResponse struct {
+
+	// 总共的任务个数。
+	Total *int32 `json:"total,omitempty"`
+
+	// 日志列表数据
+	Tasks *[]TasksObject `json:"tasks,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowHistoryTasksResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowHistoryTasksResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowHistoryTasksResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_ip_info_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_ip_info_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowIpInfoRequest Request Object
+type ShowIpInfoRequest struct {
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// IP地址列表，以“，”分割，最多20个。
+	Ips string `json:"ips"`
+}
+
+func (o ShowIpInfoRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowIpInfoRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowIpInfoRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_ip_info_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_ip_info_response.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowIpInfoResponse Response Object
+type ShowIpInfoResponse struct {
+
+	// IP归属信息列表。
+	CdnIps *[]CdnIps `json:"cdn_ips,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowIpInfoResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowIpInfoResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowIpInfoResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_logs_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_logs_request.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowLogsRequest Request Object
+type ShowLogsRequest struct {
+
+	// 只支持单个域名，如：www.test1.com。
+	DomainName string `json:"domain_name"`
+
+	// 查询开始时间，时间格式为整点毫秒时间戳，此参数传空值时默认为当天0点。
+	StartTime *int64 `json:"start_time,omitempty"`
+
+	// 查询结束时间（不包含结束时间），时间格式为整点毫秒时间戳，与开始时间的最大跨度为30天，此参数传空值时默认为开始时间加1天。
+	EndTime *int64 `json:"end_time,omitempty"`
+
+	// 单页最大数量，取值范围为1-10000，默认值：10。
+	PageSize *int32 `json:"page_size,omitempty"`
+
+	// 当前查询第几页，取值范围为1-65535，默认值：1。
+	PageNumber *int32 `json:"page_number,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o ShowLogsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowLogsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowLogsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_logs_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_logs_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowLogsResponse Response Object
+type ShowLogsResponse struct {
+
+	// 总数。
+	Total *int32 `json:"total,omitempty"`
+
+	// 日志列表数据。
+	Logs           *[]LogObject `json:"logs,omitempty"`
+	HttpStatusCode int          `json:"-"`
+}
+
+func (o ShowLogsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowLogsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowLogsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_tags_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowTagsRequest Request Object
+type ShowTagsRequest struct {
+
+	// 资源id。  > 域名ID
+	ResourceId string `json:"resource_id"`
+}
+
+func (o ShowTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_tags_response.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowTagsResponse Response Object
+type ShowTagsResponse struct {
+
+	// 标签列表
+	Tags *[]TagMap `json:"tags,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_top_domain_names_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_top_domain_names_request.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowTopDomainNamesRequest Request Object
+type ShowTopDomainNamesRequest struct {
+
+	// - 查询起始时间戳，时间戳应设置需为整点时间戳，设置方式如下： - interval为3600时，start_time设置为整小时时刻点，如：1631239200000(对应2021-09-10 10:00:00) - interval为86400时，start_time设置为东8区零点时刻点，如：1631203200000(对应2021-09-10 00:00:00)
+	StartTime int64 `json:"start_time"`
+
+	// - 查询结束时间戳，时间戳应设置需为整点时间戳，设置方式如下： - interval为3600时，end_time设置为整小时时刻点，如：1631325600000(对应2021-09-11 10:00:00) - interval为86400时，end_time设置为东8区零点时刻点，如：1631376000000(对应2021-09-12 00:00:00)
+	EndTime int64 `json:"end_time"`
+
+	// - 统计类型 - 目前只支持bw（带宽），flux（流量），req_num（请求总数）
+	StatType string `json:"stat_type"`
+
+	// 服务区域：mainland_china(中国大陆)，outside_mainland_china(中国大陆境外)，默认为mainland_china，当查询回源类指标时该参数无效。
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// top域名查询数量,默认为20,最大为500，最小为0
+	Limit *int32 `json:"limit,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子账号调用接口时，该参数必传。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o ShowTopDomainNamesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTopDomainNamesRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowTopDomainNamesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_top_domain_names_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_top_domain_names_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowTopDomainNamesResponse Response Object
+type ShowTopDomainNamesResponse struct {
+
+	// top域名信息
+	TopDomainNames *[]map[string]interface{} `json:"top_domain_names,omitempty"`
+	HttpStatusCode int                       `json:"-"`
+}
+
+func (o ShowTopDomainNamesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTopDomainNamesResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowTopDomainNamesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_top_url_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_top_url_request.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowTopUrlRequest Request Object
+type ShowTopUrlRequest struct {
+
+	// 查询起始时间戳，只能传0点毫秒时间戳
+	StartTime int64 `json:"start_time"`
+
+	// 查询结束时间戳，只能传0点毫秒时间戳
+	EndTime int64 `json:"end_time"`
+
+	// 域名列表，多个域名以逗号（半角）分隔，如：www.test1.com,www.test2.com all表示查询名下全部域名。如果域名在查询时间段内无数据，结果将不返回该域名的信息。
+	DomainName string `json:"domain_name"`
+
+	// - 参数类型支持：flux(流量),req_num(请求数)
+	StatType string `json:"stat_type"`
+
+	// 服务区域：mainland_china(大陆)，outside_mainland_china(海外)，默认为global(全球)
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示查询资源所属项目，\"all\"表示所有项目。注意：当使用子账号调用接口时，该参数必传。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+}
+
+func (o ShowTopUrlRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTopUrlRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowTopUrlRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_top_url_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_top_url_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowTopUrlResponse Response Object
+type ShowTopUrlResponse struct {
+
+	// 服务区域：mainland_china(中国大陆)，outside_mainland_china(中国大陆境外)，默认为mainland_china。
+	ServiceArea *string `json:"service_area,omitempty"`
+
+	// 详情数据对象。
+	TopUrlSummary  *[]TopUrlSummary `json:"top_url_summary,omitempty"`
+	HttpStatusCode int              `json:"-"`
+}
+
+func (o ShowTopUrlResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowTopUrlResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowTopUrlResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_url_task_info_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_url_task_info_request.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowUrlTaskInfoRequest Request Object
+type ShowUrlTaskInfoRequest struct {
+
+	// 起始时间戳（毫秒），默认当天00:00。
+	StartTime *int64 `json:"start_time,omitempty"`
+
+	// 结束时间戳（毫秒），默认次日00:00。
+	EndTime *int64 `json:"end_time,omitempty"`
+
+	// 偏移量：特定数据字段与起始数据字段位置的距离。
+	Offset *int32 `json:"offset,omitempty"`
+
+	// 单次查询数据条数，上限为100。
+	Limit *int32 `json:"limit,omitempty"`
+
+	// 刷新预热url。
+	Url *string `json:"url,omitempty"`
+
+	// 任务类型，REFRESH：刷新任务；PREHEATING：预热任务。
+	TaskType *string `json:"task_type,omitempty"`
+
+	// url状态，状态类型：processing：处理中；succeed：完成；failed：失败；waiting：等待；refreshing：刷新中; preheating : 预热中。
+	Status *string `json:"status,omitempty"`
+
+	// 文件类型，file:文件;directory:目录。
+	FileType *string `json:"file_type,omitempty"`
+}
+
+func (o ShowUrlTaskInfoRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowUrlTaskInfoRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowUrlTaskInfoRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_url_task_info_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_url_task_info_response.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowUrlTaskInfoResponse Response Object
+type ShowUrlTaskInfoResponse struct {
+
+	// 查询结果总数。
+	Total *int32 `json:"total,omitempty"`
+
+	// 当前查询到的总页数。
+	Count *int32 `json:"count,omitempty"`
+
+	// url信息。
+	Result *[]Urls `json:"result,omitempty"`
+
+	XRequestId     *string `json:"X-request-id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowUrlTaskInfoResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowUrlTaskInfoResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowUrlTaskInfoResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_verify_domain_owner_info_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_verify_domain_owner_info_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowVerifyDomainOwnerInfoRequest Request Object
+type ShowVerifyDomainOwnerInfoRequest struct {
+
+	// 域名
+	DomainName string `json:"domain_name"`
+}
+
+func (o ShowVerifyDomainOwnerInfoRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowVerifyDomainOwnerInfoRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowVerifyDomainOwnerInfoRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_verify_domain_owner_info_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_verify_domain_owner_info_response.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowVerifyDomainOwnerInfoResponse Response Object
+type ShowVerifyDomainOwnerInfoResponse struct {
+
+	// DNS探测类型
+	DnsVerifyType *string `json:"dns_verify_type,omitempty"`
+
+	// DNS记录名称
+	DnsVerifyName *string `json:"dns_verify_name,omitempty"`
+
+	// 文件探测地址
+	FileVerifyUrl *string `json:"file_verify_url,omitempty"`
+
+	// 域名
+	DomainName *string `json:"domain_name,omitempty"`
+
+	// 探测域名
+	VerifyDomainName *string `json:"verify_domain_name,omitempty"`
+
+	// 探测文件名
+	FileVerifyFilename *string `json:"file_verify_filename,omitempty"`
+
+	// 探测内容，DNS值或者文件内容，时间加uuid
+	VerifyContent *string `json:"verify_content,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ShowVerifyDomainOwnerInfoResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowVerifyDomainOwnerInfoResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowVerifyDomainOwnerInfoResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_source_with_port.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_source_with_port.go
@@ -1,0 +1,95 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// SourceWithPort 域名信息。
+type SourceWithPort struct {
+
+	// 加速域名id。
+	DomainId *string `json:"domain_id,omitempty"`
+
+	// 源站IP（非内网IP）或者域名。
+	IpOrDomain string `json:"ip_or_domain"`
+
+	// 源站类型，ipaddr：源站IP、 domain：源站域名、obs_bucket：OBS桶域名。
+	OriginType SourceWithPortOriginType `json:"origin_type"`
+
+	// 主备状态（1代表主源站；0代表备源站）。
+	ActiveStandby int32 `json:"active_standby"`
+
+	// 是否开OBS托管(0表示关闭,1表示则为开启)，源站类型为obs_bucket时传递。
+	EnableObsWebHosting *int32 `json:"enable_obs_web_hosting,omitempty"`
+
+	// HTTP端口，默认80
+	HttpPort *int32 `json:"http_port,omitempty"`
+
+	// HTTPS端口，默认443
+	HttpsPort *int32 `json:"https_port,omitempty"`
+}
+
+func (o SourceWithPort) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SourceWithPort struct{}"
+	}
+
+	return strings.Join([]string{"SourceWithPort", string(data)}, " ")
+}
+
+type SourceWithPortOriginType struct {
+	value string
+}
+
+type SourceWithPortOriginTypeEnum struct {
+	IPADDR     SourceWithPortOriginType
+	DOMAIN     SourceWithPortOriginType
+	OBS_BUCKET SourceWithPortOriginType
+}
+
+func GetSourceWithPortOriginTypeEnum() SourceWithPortOriginTypeEnum {
+	return SourceWithPortOriginTypeEnum{
+		IPADDR: SourceWithPortOriginType{
+			value: "ipaddr",
+		},
+		DOMAIN: SourceWithPortOriginType{
+			value: "domain",
+		},
+		OBS_BUCKET: SourceWithPortOriginType{
+			value: "obs_bucket",
+		},
+	}
+}
+
+func (c SourceWithPortOriginType) Value() string {
+	return c.value
+}
+
+func (c SourceWithPortOriginType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *SourceWithPortOriginType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources.go
@@ -1,0 +1,89 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// Sources 源站信息。
+type Sources struct {
+
+	// 加速域名id。
+	DomainId *string `json:"domain_id,omitempty"`
+
+	// 源站IP（非内网IP）或者域名。
+	IpOrDomain string `json:"ip_or_domain"`
+
+	// 源站类型取值：ipaddr：源站IP、 domain：源站域名、obs_bucket：OBS桶域名。
+	OriginType SourcesOriginType `json:"origin_type"`
+
+	// 主备状态，1代表主源站，0代表备源站。
+	ActiveStandby int32 `json:"active_standby"`
+
+	// 是否开启OBS静态网站托管(0表示关闭,1表示则为开启)，源站类型为obs_bucket时传递。
+	EnableObsWebHosting *int32 `json:"enable_obs_web_hosting,omitempty"`
+}
+
+func (o Sources) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Sources struct{}"
+	}
+
+	return strings.Join([]string{"Sources", string(data)}, " ")
+}
+
+type SourcesOriginType struct {
+	value string
+}
+
+type SourcesOriginTypeEnum struct {
+	IPADDR     SourcesOriginType
+	DOMAIN     SourcesOriginType
+	OBS_BUCKET SourcesOriginType
+}
+
+func GetSourcesOriginTypeEnum() SourcesOriginTypeEnum {
+	return SourcesOriginTypeEnum{
+		IPADDR: SourcesOriginType{
+			value: "ipaddr",
+		},
+		DOMAIN: SourcesOriginType{
+			value: "domain",
+		},
+		OBS_BUCKET: SourcesOriginType{
+			value: "obs_bucket",
+		},
+	}
+}
+
+func (c SourcesOriginType) Value() string {
+	return c.value
+}
+
+func (c SourcesOriginType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *SourcesOriginType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_config.go
@@ -1,0 +1,59 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// SourcesConfig 源站配置。
+type SourcesConfig struct {
+
+	// 源站类型， - ipaddr：源站IP； - domain：源站域名； - obs_bucket：OBS桶域名； - third_bucket：第三方桶。
+	OriginType string `json:"origin_type"`
+
+	// 源站IP或者域名。
+	OriginAddr string `json:"origin_addr"`
+
+	// 源站优先级，70：主，30：备。
+	Priority int32 `json:"priority"`
+
+	// 权重，取值范围1-100。
+	Weight *int32 `json:"weight,omitempty"`
+
+	// 是否开启OBS静态网站托管，源站类型为obs_bucket时传递，off：关闭，on：开启。
+	ObsWebHostingStatus *string `json:"obs_web_hosting_status,omitempty"`
+
+	// HTTP端口，默认80,端口取值取值范围1-65535。
+	HttpPort *int32 `json:"http_port,omitempty"`
+
+	// HTTPS端口，默认443,端口取值取值范围1-65535。
+	HttpsPort *int32 `json:"https_port,omitempty"`
+
+	// 回源HOST，默认加速域名。
+	HostName *string `json:"host_name,omitempty"`
+
+	// OBS桶源站类型： - “private” 私有桶； - “public” 公有桶，默认为公有桶。
+	ObsBucketType *string `json:"obs_bucket_type,omitempty"`
+
+	// 第三方对象存储访问密钥。  > 源站类型为第三方桶时必填
+	BucketAccessKey *string `json:"bucket_access_key,omitempty"`
+
+	// 第三方对象存储密钥。  > 源站类型为第三方桶时必填
+	BucketSecretKey *string `json:"bucket_secret_key,omitempty"`
+
+	// 第三方对象存储区域。  > 源站类型为第三方桶时必填
+	BucketRegion *string `json:"bucket_region,omitempty"`
+
+	// 第三方对象存储名称。  > 源站类型为第三方桶时必填
+	BucketName *string `json:"bucket_name,omitempty"`
+}
+
+func (o SourcesConfig) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SourcesConfig struct{}"
+	}
+
+	return strings.Join([]string{"SourcesConfig", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_domain_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_domain_config.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// SourcesDomainConfig 源站配置。
+type SourcesDomainConfig struct {
+
+	// 源站类型。 - ipaddr：源站IP； - domain：源站域名； - obs_bucket：OBS桶域名； - third_bucket：第三方桶。
+	OriginType string `json:"origin_type"`
+
+	// 源站IP或者域名。
+	OriginAddr string `json:"origin_addr"`
+
+	// 源站优先级，70：主，30：备。
+	Priority int32 `json:"priority"`
+
+	// 是否开启OBS静态网站托管，源站类型为obs_bucket时传递，off：关闭，on：开启。
+	ObsWebHostingStatus *string `json:"obs_web_hosting_status,omitempty"`
+
+	// HTTP端口，默认80,端口取值取值范围1-65535。
+	HttpPort *int32 `json:"http_port,omitempty"`
+
+	// HTTPS端口，默认443,端口取值取值范围1-65535。
+	HttpsPort *int32 `json:"https_port,omitempty"`
+
+	// 回源HOST，默认加速域名。
+	HostName *string `json:"host_name,omitempty"`
+
+	// OBS桶源站类型： - “private” 私有桶； - “public” 公有桶，默认为公有桶。
+	ObsBucketType *string `json:"obs_bucket_type,omitempty"`
+}
+
+func (o SourcesDomainConfig) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SourcesDomainConfig struct{}"
+	}
+
+	return strings.Join([]string{"SourcesDomainConfig", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_tag_map.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_tag_map.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type TagMap struct {
+
+	// 标签键。长度1-128个字符, 可用 UTF-8 格式表示的字母(包含中文)、数字和空格，以及以下字符： _ . : = + - @
+	Key string `json:"key"`
+
+	// 标签值。长度0-255个字符,  可用 UTF-8 格式表示的字母(包含中文)、数字和空格，以及以下字符： _ . : / = + - @
+	Value *string `json:"value,omitempty"`
+}
+
+func (o TagMap) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TagMap struct{}"
+	}
+
+	return strings.Join([]string{"TagMap", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_tasks_object.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_tasks_object.go
@@ -1,0 +1,143 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+type TasksObject struct {
+
+	// 任务id。
+	Id *string `json:"id,omitempty"`
+
+	// 任务的类型， 其值可以为refresh：刷新任务，或preheating：预热任务。
+	TaskType *TasksObjectTaskType `json:"task_type,omitempty"`
+
+	// 刷新结果。task_done表示刷新成功  ，task_inprocess表示刷新中。
+	Status *string `json:"status,omitempty"`
+
+	// 处理中的url个数。
+	Processing *int32 `json:"processing,omitempty"`
+
+	// 成功处理的url个数。
+	Succeed *int32 `json:"succeed,omitempty"`
+
+	// 处理失败的url个数。
+	Failed *int32 `json:"failed,omitempty"`
+
+	// url总数。
+	Total *int32 `json:"total,omitempty"`
+
+	// 任务的创建时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 默认是文件file。file：文件,directory：目录。
+	FileType *TasksObjectFileType `json:"file_type,omitempty"`
+}
+
+func (o TasksObject) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TasksObject struct{}"
+	}
+
+	return strings.Join([]string{"TasksObject", string(data)}, " ")
+}
+
+type TasksObjectTaskType struct {
+	value string
+}
+
+type TasksObjectTaskTypeEnum struct {
+	REFRESH    TasksObjectTaskType
+	PREHEATING TasksObjectTaskType
+}
+
+func GetTasksObjectTaskTypeEnum() TasksObjectTaskTypeEnum {
+	return TasksObjectTaskTypeEnum{
+		REFRESH: TasksObjectTaskType{
+			value: "refresh",
+		},
+		PREHEATING: TasksObjectTaskType{
+			value: "preheating",
+		},
+	}
+}
+
+func (c TasksObjectTaskType) Value() string {
+	return c.value
+}
+
+func (c TasksObjectTaskType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *TasksObjectTaskType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type TasksObjectFileType struct {
+	value string
+}
+
+type TasksObjectFileTypeEnum struct {
+	FILE      TasksObjectFileType
+	DIRECTORY TasksObjectFileType
+}
+
+func GetTasksObjectFileTypeEnum() TasksObjectFileTypeEnum {
+	return TasksObjectFileTypeEnum{
+		FILE: TasksObjectFileType{
+			value: "file",
+		},
+		DIRECTORY: TasksObjectFileType{
+			value: "directory",
+		},
+	}
+}
+
+func (c TasksObjectFileType) Value() string {
+	return c.value
+}
+
+func (c TasksObjectFileType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *TasksObjectFileType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_top_refer_summary.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_top_refer_summary.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// TopReferSummary TOP100 Referer数据明细
+type TopReferSummary struct {
+
+	// referer值。
+	Refer *string `json:"refer,omitempty"`
+
+	// 对应查询类型的值。（流量单位：Byte）
+	Value *int64 `json:"value,omitempty"`
+
+	// 该referer的流量(或请求数)占当前查询条件下总流量(或请求数)的比例。保留4位小数
+	Ratio *float64 `json:"ratio,omitempty"`
+}
+
+func (o TopReferSummary) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TopReferSummary struct{}"
+	}
+
+	return strings.Join([]string{"TopReferSummary", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_top_url_summary.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_top_url_summary.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// TopUrlSummary top url 详情数据
+type TopUrlSummary struct {
+
+	// URL名称。
+	Url *string `json:"url,omitempty"`
+
+	// 对应查询类型的值。（流量单位：Byte）
+	Value *int64 `json:"value,omitempty"`
+
+	// 查询起始时间戳。
+	StartTime *int64 `json:"start_time,omitempty"`
+
+	// 查询结束时间戳
+	EndTime *int64 `json:"end_time,omitempty"`
+
+	// 参数类型支持：flux(流量)，req_num(请求总数)。
+	StatType *string `json:"stat_type,omitempty"`
+}
+
+func (o TopUrlSummary) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TopUrlSummary struct{}"
+	}
+
+	return strings.Join([]string{"TopUrlSummary", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_full_config_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_full_config_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateDomainFullConfigRequest Request Object
+type UpdateDomainFullConfigRequest struct {
+
+	// 加速域名。
+	DomainName string `json:"domain_name"`
+
+	// 当用户开启企业项目功能时，该参数生效，表示修改当前企业项目下加速域名的配置，\"all\"代表所有项目。  > 当使用子帐号调用接口时，该参数必传。 您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	Body *ModifyDomainConfigRequestBody `json:"body,omitempty"`
+}
+
+func (o UpdateDomainFullConfigRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateDomainFullConfigRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateDomainFullConfigRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_full_config_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_full_config_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateDomainFullConfigResponse Response Object
+type UpdateDomainFullConfigResponse struct {
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o UpdateDomainFullConfigResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateDomainFullConfigResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateDomainFullConfigResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateDomainMultiCertificatesRequest Request Object
+type UpdateDomainMultiCertificatesRequest struct {
+
+	// 当用户开启企业项目功能时，该参数生效，表示修改当前企业项目下加速域名的配置，\"all\"代表所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	Body *UpdateDomainMultiCertificatesRequestBody `json:"body,omitempty"`
+}
+
+func (o UpdateDomainMultiCertificatesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateDomainMultiCertificatesRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateDomainMultiCertificatesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_request_body.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type UpdateDomainMultiCertificatesRequestBody struct {
+	Https *UpdateDomainMultiCertificatesRequestBodyContent `json:"https,omitempty"`
+}
+
+func (o UpdateDomainMultiCertificatesRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateDomainMultiCertificatesRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"UpdateDomainMultiCertificatesRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_request_body_content.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_request_body_content.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateDomainMultiCertificatesRequestBodyContent https配置。
+type UpdateDomainMultiCertificatesRequestBodyContent struct {
+
+	// 域名列表,逗号分割，上限50个域名
+	DomainName string `json:"domain_name"`
+
+	// https开关（0：\"关闭\"；1：\"设置证书\" https_switch为1时，证书参数不能为空）
+	HttpsSwitch int32 `json:"https_switch"`
+
+	// 回源方式:1：\"回源跟随\"；2：\"http\"(默认)，3：\"https\"  为空值时默认设置为http
+	AccessOriginWay *int32 `json:"access_origin_way,omitempty"`
+
+	// 强制跳转HTTPS（0：不强制；1：强制） 为空值时默认设置为关闭。（此参数即将下线，建议使用force_redirect_config修改配置）
+	ForceRedirectHttps *int32 `json:"force_redirect_https,omitempty"`
+
+	ForceRedirectConfig *ForceRedirect `json:"force_redirect_config,omitempty"`
+
+	// http2.0（0：关闭；1：开启） 为空值时默认设置为关闭
+	Http2 *int32 `json:"http2,omitempty"`
+
+	// 证书名称（设置证书必填）（长度限制为3-64字符）。
+	CertName *string `json:"cert_name,omitempty"`
+
+	// HTTPS协议使用的SSL证书内容，仅支持PEM编码格式。不启用证书则无需输入。初次配置证书时必传。
+	Certificate *string `json:"certificate,omitempty"`
+
+	// HTTPS协议使用的SSL证书私钥内容，仅支持PEM编码格式。不启用证书则无需输入。初次配置证书时必传。
+	PrivateKey *string `json:"private_key,omitempty"`
+
+	// 证书类型（0为自有证书 ；1为托管证书，此时不必不传入证书内容和私钥，自动根据证书名称匹配；不传默认为自有证书）
+	CertificateType *int32 `json:"certificate_type,omitempty"`
+}
+
+func (o UpdateDomainMultiCertificatesRequestBodyContent) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateDomainMultiCertificatesRequestBodyContent struct{}"
+	}
+
+	return strings.Join([]string{"UpdateDomainMultiCertificatesRequestBodyContent", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateDomainMultiCertificatesResponse Response Object
+type UpdateDomainMultiCertificatesResponse struct {
+	Https *UpdateDomainMultiCertificatesResponseBodyContent `json:"https,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o UpdateDomainMultiCertificatesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateDomainMultiCertificatesResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateDomainMultiCertificatesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_response_body_content.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_domain_multi_certificates_response_body_content.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateDomainMultiCertificatesResponseBodyContent https配置。
+type UpdateDomainMultiCertificatesResponseBodyContent struct {
+
+	// 域名列表。
+	DomainName string `json:"domain_name"`
+
+	// https开关(0：\"关闭\"；1：\"设置证书\")。
+	HttpsSwitch *int32 `json:"https_switch,omitempty"`
+
+	// 回源方式:1：\"回源跟随\"；2：\"HTTP\"(默认)，3：https（自建）。
+	AccessOriginWay *int32 `json:"access_origin_way,omitempty"`
+
+	// 强制跳转HTTPS（0：不强制；1：强制） 。
+	ForceRedirectHttps *int32 `json:"force_redirect_https,omitempty"`
+
+	ForceRedirectConfig *ForceRedirect `json:"force_redirect_config,omitempty"`
+
+	// http2.0（0：关闭；1：开启）
+	Http2 *int32 `json:"http2,omitempty"`
+
+	// 证书名称。
+	CertName *string `json:"cert_name,omitempty"`
+
+	// 证书内容。
+	Certificate *string `json:"certificate,omitempty"`
+
+	// 证书类型（0为自有证书 ， 1为托管证书）。
+	CertificateType *int32 `json:"certificate_type,omitempty"`
+
+	// 证书过期时间。
+	ExpirationTime *int64 `json:"expiration_time,omitempty"`
+}
+
+func (o UpdateDomainMultiCertificatesResponseBodyContent) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateDomainMultiCertificatesResponseBodyContent struct{}"
+	}
+
+	return strings.Join([]string{"UpdateDomainMultiCertificatesResponseBodyContent", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_private_bucket_access_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_private_bucket_access_body.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdatePrivateBucketAccessBody 修改私有桶开启关闭状态
+type UpdatePrivateBucketAccessBody struct {
+
+	// 桶开启关闭状态（true：开启；false：关闭）
+	Status *bool `json:"status,omitempty"`
+}
+
+func (o UpdatePrivateBucketAccessBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdatePrivateBucketAccessBody struct{}"
+	}
+
+	return strings.Join([]string{"UpdatePrivateBucketAccessBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_private_bucket_access_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_private_bucket_access_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdatePrivateBucketAccessRequest Request Object
+type UpdatePrivateBucketAccessRequest struct {
+
+	// 当用户开启企业项目功能时，该参数生效，表示修改当前企业项目下加速域名的配置，\"all\"代表所有项目。注意：当使用子帐号调用接口时，该参数必传。  您可以通过调用企业项目管理服务（EPS）的查询企业项目列表接口（ListEnterpriseProject）查询企业项目id。
+	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 加速域名id。
+	DomainId string `json:"domain_id"`
+
+	Body *UpdatePrivateBucketAccessBody `json:"body,omitempty"`
+}
+
+func (o UpdatePrivateBucketAccessRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdatePrivateBucketAccessRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdatePrivateBucketAccessRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_private_bucket_access_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_update_private_bucket_access_response.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdatePrivateBucketAccessResponse Response Object
+type UpdatePrivateBucketAccessResponse struct {
+
+	// 桶开启关闭状态（true：开启；false：关闭）
+	Status *bool `json:"status,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o UpdatePrivateBucketAccessResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdatePrivateBucketAccessResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdatePrivateBucketAccessResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_url_auth.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_url_auth.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UrlAuth URL鉴权。
+type UrlAuth struct {
+
+	// 是否开启URL鉴权，on：开启,off：关闭。
+	Status string `json:"status"`
+
+	// 鉴权方式 type_a：鉴权方式A type_b：鉴权方式B type_c1：鉴权方式C1 type_c2：鉴权方式C2
+	Type *string `json:"type,omitempty"`
+
+	// 过期时间：范围：0-31536000单位为秒。
+	ExpireTime *int32 `json:"expire_time,omitempty"`
+
+	// 加密的算法 可选择md5或sha256。
+	SignMethod *string `json:"sign_method,omitempty"`
+
+	// 鉴权范围，目前仅支持配置所有文件参与鉴权，all：所有文件。
+	MatchType *string `json:"match_type,omitempty"`
+
+	InheritConfig *InheritConfig `json:"inherit_config,omitempty"`
+
+	// 鉴权KEY 由6-32位大小写字母、数字构成。
+	Key *string `json:"key,omitempty"`
+
+	// 鉴权KEY（备） 由6-32位大小写字母、数字构成。
+	BackupKey *string `json:"backup_key,omitempty"`
+
+	// 鉴权参数：1-100位可以由大小写字母、数字、下划线构成（不能以数字开头）。
+	SignArg *string `json:"sign_arg,omitempty"`
+
+	// 时间格式 dec：十进制 hex：十六进制 鉴权方式A：只支持十进制 鉴权方式B：只支持十进制 鉴权方式C1：只支持十六进制鉴权方式 鉴权方式C2：支持十进制/十六进制
+	TimeFormat *string `json:"time_format,omitempty"`
+}
+
+func (o UrlAuth) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UrlAuth struct{}"
+	}
+
+	return strings.Join([]string{"UrlAuth", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_url_auth_get_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_url_auth_get_body.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UrlAuthGetBody URL鉴权查询响应体。
+type UrlAuthGetBody struct {
+
+	// 是否开启URL鉴权，on：开启,off：关闭。
+	Status string `json:"status"`
+
+	// 鉴权方式， type_a：鉴权方式A， type_b：鉴权方式B， type_c1：鉴权方式C1， type_c2：鉴权方式C2。
+	Type *string `json:"type,omitempty"`
+
+	// 过期时间，单位：秒。
+	ExpireTime *int32 `json:"expire_time,omitempty"`
+
+	// 加密算法。
+	SignMethod *string `json:"sign_method,omitempty"`
+
+	// 鉴权范围。
+	MatchType *string `json:"match_type,omitempty"`
+
+	InheritConfig *InheritConfigQuery `json:"inherit_config,omitempty"`
+
+	// 鉴权KEY。
+	Key *string `json:"key,omitempty"`
+
+	// 鉴权KEY（备）。
+	BackupKey *string `json:"backup_key,omitempty"`
+
+	// 鉴权参数。
+	SignArg *string `json:"sign_arg,omitempty"`
+
+	// 时间格式， dec：十进制, hex：十六进制。
+	TimeFormat *string `json:"time_format,omitempty"`
+}
+
+func (o UrlAuthGetBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UrlAuthGetBody struct{}"
+	}
+
+	return strings.Join([]string{"UrlAuthGetBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_url_object.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_url_object.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type UrlObject struct {
+
+	// url的id
+	Id *string `json:"id,omitempty"`
+
+	// url的地址。
+	Url *string `json:"url,omitempty"`
+
+	// url的状态 processing 处理中，succeed 完成，failed 失败，waiting 等待，refreshing 刷新中，preheating 预热中。
+	Status *string `json:"status,omitempty"`
+
+	// url创建时间，相对于UTC 1970-01-01到当前时间相隔的毫秒数。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 任务id。
+	TaskId *string `json:"task_id,omitempty"`
+
+	// 任务的类型， 其值可以为REFRESH：刷新任务、PREHEATING：预热任务、REFRESH_AFTER_PREHEATING：预热后刷新
+	TaskType *string `json:"task_type,omitempty"`
+}
+
+func (o UrlObject) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UrlObject struct{}"
+	}
+
+	return strings.Join([]string{"UrlObject", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_urls.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_urls.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// Urls 具体url信息。
+type Urls struct {
+
+	// url id。
+	Id *int64 `json:"id,omitempty"`
+
+	// url具体值。
+	Url *string `json:"url,omitempty"`
+
+	// url状态，状态类型：processing：处理中；succeed：完成；failed：失败；waiting：等待；refreshing：刷新中; preheating : 预热中。
+	Status *string `json:"status,omitempty"`
+
+	// 任务类型，REFRESH：刷新任务；PREHEATING：预热任务。
+	Type *string `json:"type,omitempty"`
+
+	// 任务id。
+	TaskId *int64 `json:"task_id,omitempty"`
+
+	// 修改时间戳（毫秒）。
+	ModifyTime *int64 `json:"modify_time,omitempty"`
+
+	// 创建时间戳（毫秒）。
+	CreateTime *int64 `json:"create_time,omitempty"`
+
+	// 文件类型，directory：目录，或file：文件。
+	FileType *string `json:"file_type,omitempty"`
+
+	// 目录刷新方式，all：刷新目录下全部资源；detect_modify_refresh：刷新目录下已变更的资源，默认值为all。
+	Mode *string `json:"mode,omitempty"`
+}
+
+func (o Urls) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "Urls struct{}"
+	}
+
+	return strings.Join([]string{"Urls", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_user_agent_filter.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_user_agent_filter.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UserAgentFilter UA黑白名单设置。
+type UserAgentFilter struct {
+
+	// UA黑白名单类型 off：关闭UA黑白名单; black：UA黑名单; white：UA白名单;
+	Type string `json:"type"`
+
+	// 配置UA黑白名单，当type=off时，非必传。最多配置10条规则，单条规则不超过100个字符，多条规则用“,”分割。
+	Value *string `json:"value,omitempty"`
+
+	// 配置UA黑白名单，当type=off时，非必传。最多配置10条规则，单条规则不超过100个字符,同时配置value和ua_list时，ua_list生效。
+	UaList *[]string `json:"ua_list,omitempty"`
+}
+
+func (o UserAgentFilter) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UserAgentFilter struct{}"
+	}
+
+	return strings.Join([]string{"UserAgentFilter", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_verify_domain_owner_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_verify_domain_owner_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// VerifyDomainOwnerRequest Request Object
+type VerifyDomainOwnerRequest struct {
+
+	// 域名
+	DomainName string `json:"domain_name"`
+
+	Body *VerifyDomainOwnerRequestBody `json:"body,omitempty"`
+}
+
+func (o VerifyDomainOwnerRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "VerifyDomainOwnerRequest struct{}"
+	}
+
+	return strings.Join([]string{"VerifyDomainOwnerRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_verify_domain_owner_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_verify_domain_owner_request_body.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// VerifyDomainOwnerRequestBody 域名归属校验请求体
+type VerifyDomainOwnerRequestBody struct {
+
+	// 校验类型： - dns：DNS解析校验； - file：文件校验； - all：dns、file均校验，默认为all。
+	VerifyType *string `json:"verify_type,omitempty"`
+}
+
+func (o VerifyDomainOwnerRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "VerifyDomainOwnerRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"VerifyDomainOwnerRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_verify_domain_owner_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_verify_domain_owner_response.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// VerifyDomainOwnerResponse Response Object
+type VerifyDomainOwnerResponse struct {
+
+	// 验证是否通过，true:通过，false:不通过
+	Result *bool `json:"result,omitempty"`
+
+	XRequestId     *string `json:"X-Request-Id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o VerifyDomainOwnerResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "VerifyDomainOwnerResponse struct{}"
+	}
+
+	return strings.Join([]string{"VerifyDomainOwnerResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_video_seek.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_video_seek.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// VideoSeek 视频拖拽配置。 > 1. 需同步开启FLV、MP4格式文件的URL参数功能，并选择“忽略参数”。 > 2. 关闭视频拖拽功能时，FLV时间拖拽功能失效。
+type VideoSeek struct {
+
+	// 视频拖拽开关， true：开启，false：关闭  > 当本字段设置为“false”时，查询域名配置接口将不会返回视频拖拽配置信息。
+	EnableVideoSeek bool `json:"enable_video_seek"`
+
+	// flv时间拖拽开关， true：开启，false：关闭。
+	EnableFlvByTimeSeek *bool `json:"enable_flv_by_time_seek,omitempty"`
+
+	// 自定义用户请求URL中视频播放的开始参数，支持使用数字0-9、字符a-z、A-Z，及\"_\"，长度≤64个字符。
+	StartParameter *string `json:"start_parameter,omitempty"`
+
+	// 自定义用户请求URL中视频播放的结束参数，支持使用数字0-9、字符a-z、A-Z，及\"_\"，长度≤64个字符。
+	EndParameter *string `json:"end_parameter,omitempty"`
+}
+
+func (o VideoSeek) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "VideoSeek struct{}"
+	}
+
+	return strings.Join([]string{"VideoSeek", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_web_socket_seek.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_web_socket_seek.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// WebSocketSeek webSocket配置。  > 只有全站加速的域名支持该配置。
+type WebSocketSeek struct {
+
+	// 开关， on 开启，off 关闭。
+	Status string `json:"status"`
+
+	// 请求建立连接后，会话的保持时间：范围：1-300，单位：秒。
+	Timeout int32 `json:"timeout"`
+}
+
+func (o WebSocketSeek) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "WebSocketSeek struct{}"
+	}
+
+	return strings.Join([]string{"WebSocketSeek", string(data)}, " ")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -541,6 +541,8 @@ github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cce/v3
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cce/v3/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v1
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v1/model
+github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2
+github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cpts/v1
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cpts/v1/model
 github.com/huaweicloud/huaweicloud-sdk-go-v3/services/css/v1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Uniformly use the V2 version of the client.
- Replace CDN domain expired detail API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- When reviewing the code, please check according to the commit.
- The newly replaced details API can only be queried based on `name`, so the implementation of import has been modified.
- When the resource does not exist in the cloud, executing `terraform plan` will get the following information.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/3da34192-d42c-42ce-abb5-88ca248970ad)



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (386.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       386.067s
```
