### PR TITLE
refactor(dli/package): the package resource reconstruction

### DIFF
--- a/docs/resources/dli_package.md
+++ b/docs/resources/dli_package.md
@@ -29,13 +29,14 @@ The following arguments are supported:
   If omitted, the provider-level region will be used.
   Changing this parameter will delete the current package and upload a new package.
 
-* `group_name` - (Required, String, ForceNew) Specifies the group name which the package belongs to.
+* `group_name` - (Optional, String, ForceNew) Specifies the group name which the package belongs to.
   Changing this parameter will delete the current package and upload a new package.
 
 * `type` - (Required, String, ForceNew) Specifies the package type.
   + **jar**: `.jar` or jar related files.
   + **pyFile**: `.py` or python related files.
   + **file**: Other user files.
+  + **modelFile**: User AI model files.
 
   Changing this parameter will delete the current package and upload a new package.
 
@@ -52,7 +53,9 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Resource ID. The ID is constructed from the `group_name` and `object_name`, separated by slash.
+* `id` - The resource ID.
+  If `group_name` is specified, the ID is constructed from the `group_name` and `object_name`,
+  the format is `<group_name>#<object_name>`, otherwise the resource ID which equals the `object_name`.
 
 * `object_name` - The package name.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240318023259-a2906a92bcce
+	github.com/chnsz/golangsdk v0.0.0-20240319093124-b9198aba9864
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240318023259-a2906a92bcce h1:4t/WALfJ4GZvt2YQiBOk9WZKujden13CniKbJ+lOxRI=
-github.com/chnsz/golangsdk v0.0.0-20240318023259-a2906a92bcce/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240319093124-b9198aba9864 h1:DNDhvqDaw/qZbiqt/TL+zshYQykjS2IebtFnRpmeimA=
+github.com/chnsz/golangsdk v0.0.0-20240319093124-b9198aba9864/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -95,6 +95,7 @@ var (
 	HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH    = os.Getenv("HW_DLI_DS_AUTH_KRB_CONF_OBS_PATH")
 	HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH     = os.Getenv("HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH")
 	HW_DLI_AGENCY_FLAG                  = os.Getenv("HW_DLI_AGENCY_FLAG")
+	HW_DLI_OWNER                        = os.Getenv("HW_DLI_OWNER")
 
 	HW_GITHUB_REPO_HOST        = os.Getenv("HW_GITHUB_REPO_HOST")        // Repository host (Github, Gitlab, Gitee)
 	HW_GITHUB_PERSONAL_TOKEN   = os.Getenv("HW_GITHUB_PERSONAL_TOKEN")   // Personal access token (Github, Gitlab, Gitee)
@@ -759,6 +760,13 @@ func TestAccPreCheckDliDsAuthKrb(t *testing.T) {
 func TestAccPreCheckDliAgency(t *testing.T) {
 	if HW_DLI_AGENCY_FLAG == "" {
 		t.Skip("HW_DLI_AGENCY_FLAG must be set for DLI datasource DLI agency acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliOwner(t *testing.T) {
+	if HW_DLI_OWNER == "" {
+		t.Skip("HW_DLI_OWNER must be set for DLI datasource DLI agency acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_spark_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_spark_job.go
@@ -20,6 +20,12 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+const (
+	jarFile    = "jar"
+	pythonFile = "pyFile"
+	userFile   = "file"
+)
+
 // @API DLI POST /v2.0/{project_id}/batches
 // @API DLI GET /v2.0/{project_id}/batches/{batch_id}
 // @API DLI GET /v2.0/{project_id}/batches/{batch_id}/state

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/requests.go
@@ -19,7 +19,7 @@ type CreateGroupAndUploadOpts struct {
 	// file to be uploaded.
 	Kind string `json:"kind" required:"true"`
 	// Name of the group to be created.
-	Group string `json:"group" required:"true"`
+	Group string `json:"group,omitempty"`
 	// Whether to upload resource packages in asynchronous mode.
 	// The default value is false, indicating that the asynchronous mode is not used.
 	// You are advised to upload resource packages in asynchronous mode.
@@ -73,7 +73,7 @@ func Upload(c *golangsdk.ServiceClient, typePath string, opts UploadOpts) (*Grou
 // ResourceLocatedOpts is a structure which specify the resource package located.
 type ResourceLocatedOpts struct {
 	// Name of the package group returned when the resource package is uploaded.
-	Group string `q:"group" required:"true"`
+	Group string `q:"group,omitempty"`
 }
 
 // Get is a method to obtain the resource (packages) from the specified group.

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources/results.go
@@ -30,6 +30,9 @@ type Group struct {
 	//   pyFile: User Python file
 	//   file: User file
 	ModuleType string `json:"module_type"`
+	// List of names of resource packages contained in the group.
+	// This field is returned only when group name is not specified.
+	ResourceNames []string `json:"resource_names"`
 }
 
 // Group is a object that represents the detail about a group resource package.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240318023259-a2906a92bcce
+# github.com/chnsz/golangsdk v0.0.0-20240319093124-b9198aba9864
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The API [document](https://support.huaweicloud.com/intl/en-us/api-dli/dli_02_0130.html ) supports no grouping and **modelFile** type features, so refactoring the package resource.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
1. the `group_name` parameter is changed is from optional to required.
2. the `type` parameter supports new type `modelFile`.
3. delete other upload interfaces and use [Uploading a Package Group](https://support.huaweicloud.com/intl/en-us/api-dli/dli_02_0130.html) interface  to upload group resource.
4. If `group_name` is specified, the ID is constructed from the `group_name` and `object_name`,
  the format is `<group_name>#<object_name>`, otherwise the resource ID which equals the `object_name`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dli TESTARGS='-run TestAccDliPackage_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDliPackage_ -timeout 360m -parallel 4
=== RUN   TestAccDliPackage_basic
=== PAUSE TestAccDliPackage_basic
=== RUN   TestAccDliPackage_not_groupName
=== PAUSE TestAccDliPackage_not_groupName
=== RUN   TestAccDliPackage_owner
=== PAUSE TestAccDliPackage_owner
=== CONT  TestAccDliPackage_basic
=== CONT  TestAccDliPackage_owner
=== CONT  TestAccDliPackage_not_groupName
--- PASS: TestAccDliPackage_not_groupName (47.71s)
--- PASS: TestAccDliPackage_basic (48.07s)
--- PASS: TestAccDliPackage_owner (48.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       48.790s
```
