### PR TITLE
feat(CFW): protection rule supports to clear the rule hit count

### DIFF
--- a/docs/resources/cfw_protection_rule.md
+++ b/docs/resources/cfw_protection_rule.md
@@ -199,6 +199,9 @@ The [Rule Destination Address](#ProtectionRule_RuleDestinationAddress) structure
   + **0**: inbound;
   + **1**: outbound;
 
+* `rule_hit_count` - (Optional, String) The number of times the protection rule is hit.
+  Setting the value to **0** will clear the hit count. Value options: **0**.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the protection rule.
   Tags should have only one key/value pair.
 
@@ -339,8 +342,6 @@ The `region_list` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
-
-* `rule_hit_count` - The number of times the protection rule is hit.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_protection_rule_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_protection_rule_test.go
@@ -113,6 +113,7 @@ func TestAccProtectionRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "action_type", "1"),
 					resource.TestCheckResourceAttr(rName, "source.0.address", "2.2.2.1"),
 					resource.TestCheckResourceAttr(rName, "destination.0.address", "2.2.2.2"),
+					resource.TestCheckResourceAttr(rName, "rule_hit_count", "0"),
 				),
 			},
 			{
@@ -383,6 +384,7 @@ resource "huaweicloud_cfw_protection_rule" "test" {
   action_type         = 1
   long_connect_enable = 0
   status              = 1
+  rule_hit_count      = 0
 
   source {
     type    = 0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
protection rule supports to clear the rule hit count

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Change rule_hit_count attribute from read-only to read-write.
2. Clear function is triggered if the value of rule_hit_count is set to 0.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccProtectionRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccProtectionRule_basic -timeout 360m -parallel 4
=== RUN   TestAccProtectionRule_basic
=== PAUSE TestAccProtectionRule_basic
=== CONT  TestAccProtectionRule_basic
--- PASS: TestAccProtectionRule_basic (45.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       45.135s

make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccProtectionRule_withTag_domainSet_customService"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccProtectionRule_withTag_domainSet_customService -timeout 360m -parallel 4
=== RUN   TestAccProtectionRule_withTag_domainSet_customService
=== PAUSE TestAccProtectionRule_withTag_domainSet_customService
=== CONT  TestAccProtectionRule_withTag_domainSet_customService
--- PASS: TestAccProtectionRule_withTag_domainSet_customService (105.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       105.764s

make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccProtectionRule_withIpAddress_addressGroup_serviceGroup"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccProtectionRule_withIpAddress_addressGroup_serviceGroup -timeout 360m -parallel 4
=== RUN   TestAccProtectionRule_withIpAddress_addressGroup_serviceGroup
=== PAUSE TestAccProtectionRule_withIpAddress_addressGroup_serviceGroup
=== CONT  TestAccProtectionRule_withIpAddress_addressGroup_serviceGroup
--- PASS: TestAccProtectionRule_withIpAddress_addressGroup_serviceGroup (177.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       177.165s

```
