### PR TITLE
feat(drs): support charging mode in job

### DIFF
--- a/docs/resources/drs_job.md
+++ b/docs/resources/drs_job.md
@@ -299,6 +299,23 @@ The following arguments are supported:
   <br/>4. It's only for synchronization from **MySQL** to **MySQL**, migration from **Redis** to **GeminiDB Redis**,
        migration from cluster **Redis** to **GeminiDB Redis**, and synchronization from **Oracle** to **GaussDB Distributed**.
 
+* `charging_mode` - (Optional, String, ForceNew) Specifies the billing mode of the job.
+  The valid values are **prePaid** and **postPaid**. Defaults to **postPaid**.
+  When `type` is **sync** or **cloudDataGuard**, **prePaid** is valid.
+  Changing this will create a new resource.
+
+* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the job.
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this will create a new resource.
+
+* `period` - (Optional, Int, ForceNew) Specifies the charging period of the job.
+  If `period_unit` is set to **month**, the value ranges from 1 to 9.
+  If `period_unit` is set to **year**, the value ranges from 1 to 3.
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.
+  Changing this will create a new resource.
+
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled. Valid values are **true** and **false**.
+
 <a name="block--db_info"></a>
 The `db_info` block supports:
 
@@ -368,6 +385,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in UUID format.
 
+* `order_id` - The order ID which will return if `charging_mode` is **prePaid**.
+
 * `created_at` - Create time. The format is ISO8601:YYYY-MM-DDThh:mm:ssZ
 
 * `status` - Status.
@@ -396,9 +415,10 @@ $ terraform import huaweicloud_drs_job.test <id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `enterprise_project_id`, `force_destroy`,
-`source_db.0.password` and `destination_db.0.password`, `action`, `is_sync_re_edit`, `pause_mode`. It is generally
-recommended running **terraform plan** after importing a job. You can then decide if changes should be applied to the
-job, or the resource definition should be updated to align with the job. Also you can ignore changes as below.
+`source_db.0.password` and `destination_db.0.password`, `action`, `is_sync_re_edit`, `pause_mode`, `auto_renew`.
+It is generally recommended running **terraform plan** after importing a job. You can then decide if changes should be
+applied to the job, or the resource definition should be updated to align with the job. Also you can ignore changes as
+below.
 
 ```
 resource "huaweicloud_drs_job" "test" {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240319093124-b9198aba9864
+	github.com/chnsz/golangsdk v0.0.0-20240319123712-e3b56146a035
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240319093124-b9198aba9864 h1:DNDhvqDaw/qZbiqt/TL+zshYQykjS2IebtFnRpmeimA=
-github.com/chnsz/golangsdk v0.0.0-20240319093124-b9198aba9864/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240319123712-e3b56146a035 h1:MjoiBaun+T+lmgCHww1OVFkXdIigSjO0BmnUVGLbbAA=
+github.com/chnsz/golangsdk v0.0.0-20240319123712-e3b56146a035/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/common/common.go
+++ b/huaweicloud/common/common.go
@@ -374,3 +374,20 @@ func GetEipsbyAddresses(client *golangsdk.ServiceClient, addresses []string, eps
 	}
 	return allEips, nil
 }
+
+// GetResourceIDsByOrder returns resource IDs from an order.
+func GetResourceIDsByOrder(client *golangsdk.ServiceClient, orderId string, onlyMainResource int) ([]string, error) {
+	listOpts := resources.ListOpts{
+		OrderId:          orderId,
+		OnlyMainResource: onlyMainResource,
+	}
+	resp, err := resources.List(client, listOpts)
+	if err != nil || resp == nil || resp.TotalCount < 1 {
+		return nil, fmt.Errorf("error getting order (%s) details: %s", orderId, err)
+	}
+	rst := make([]string, len(resp.Resources))
+	for i, v := range resp.Resources {
+		rst[i] = v.ResourceId
+	}
+	return rst, nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/drs/v3/jobs/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/drs/v3/jobs/requests.go
@@ -35,6 +35,8 @@ type CreateJobReq struct {
 	MultiWrite       *bool              `json:"multi_write,omitempty"`
 	Tags             []tags.ResourceTag `json:"tags,omitempty"`
 	SysTags          []tags.ResourceTag `json:"sys_tags,omitempty"`
+	ChargingMode     string             `json:"charging_mode,omitempty"`
+	PeriodOrder      *PeriodOrder       `json:"period_order,omitempty"`
 }
 
 type Endpoint struct {
@@ -64,6 +66,12 @@ type Endpoint struct {
 	MongoHaMode string `json:"mongo_ha_mode,omitempty"`
 	Topic       string `json:"topic,omitempty"`
 	ClusterMode string `json:"cluster_mode,omitempty"`
+}
+
+type PeriodOrder struct {
+	PeriodType  int `json:"period_type,omitempty"`
+	PeriodNum   int `json:"period_num,omitempty"`
+	IsAutoRenew int `json:"is_auto_renew,omitempty"`
 }
 
 type QueryJobReq struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/drs/v3/jobs/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/drs/v3/jobs/results.go
@@ -84,6 +84,7 @@ type JobDetail struct {
 	AlarmNotify              string             `json:"alarm_notify"`
 	IncreStartPosition       string             `json:"incre_start_position"`
 	Tags                     []tags.ResourceTag `json:"tags"`
+	PeriodOrder              OrderInfo          `json:"period_order"`
 }
 
 type InstInfo struct {
@@ -107,6 +108,17 @@ type ObjectInfo struct {
 type DefaultRootDb struct {
 	DbName     string `json:"db_name"`
 	DbEncoding string `json:"db_encoding"`
+}
+
+type OrderInfo struct {
+	Status       string `json:"status"`
+	OrderId      string `json:"order_id"`
+	ChargingMode int    `json:"charging_mode"`
+	PeriodType   int    `json:"period_type"`
+	PeriodNum    int    `json:"period_num"`
+	IsAutoRenew  int    `json:"is_auto_renew"`
+	EffTime      string `json:"eff_time"`
+	ExpTime      string `json:"exp_time"`
 }
 
 type ActionResp struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240319093124-b9198aba9864
+# github.com/chnsz/golangsdk v0.0.0-20240319123712-e3b56146a035
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support `charging_mode` in `huaweicloud_drs_job`, and fix the `created_at` which is time stamp in API returns.

**Which issue this PR fixes**:
fixes #4414 

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccResourceDrsJob_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccResourceDrsJob_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_basic
=== PAUSE TestAccResourceDrsJob_basic
=== CONT  TestAccResourceDrsJob_basic
--- PASS: TestAccResourceDrsJob_basic (1483.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       1483.181s

make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccResourceDrsJob_sync"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccResourceDrsJob_sync -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_sync
=== PAUSE TestAccResourceDrsJob_sync
=== CONT  TestAccResourceDrsJob_sync
--- PASS: TestAccResourceDrsJob_sync (1273.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       1273.092s
```
