### PR TITLE
fix(geip): fix eps id for empty condition

### DIFF
--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_eip_test.go
@@ -51,7 +51,6 @@ func TestAccGEIP_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -60,7 +59,7 @@ func TestAccGEIP_basic(t *testing.T) {
 				Config: testAccGEIP_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttrSet(rName, "isp"),
@@ -95,7 +94,6 @@ func testAccGEIP_basic(name string) string {
 
 resource "huaweicloud_global_eip" "test" {
   access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
-  enterprise_project_id = "%s"
   geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
   internet_bandwidth_id = huaweicloud_global_internet_bandwidth.test.id
   name                  = "%s"
@@ -104,7 +102,7 @@ resource "huaweicloud_global_eip" "test" {
     foo = "bar"
   }
 }
-`, testAccInternetBandwidth_basic(name), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+`, testAccInternetBandwidth_basic(name), name)
 }
 
 func testAccGEIP_update(name string) string {
@@ -113,7 +111,6 @@ func testAccGEIP_update(name string) string {
 
 resource "huaweicloud_global_eip" "test" {
   access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
-  enterprise_project_id = "%s"
   geip_pool_name        = data.huaweicloud_global_eip_pools.all.geip_pools[0].name
   internet_bandwidth_id = huaweicloud_global_internet_bandwidth.test.id
   name                  = "%s-update"
@@ -123,5 +120,5 @@ resource "huaweicloud_global_eip" "test" {
     key = "value"
   }
 }
-`, testAccInternetBandwidth_basic(name), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+`, testAccInternetBandwidth_basic(name), name)
 }

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_internet_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_internet_bandwidth_test.go
@@ -51,7 +51,6 @@ func TestAccInternetBandwidth_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -61,7 +60,7 @@ func TestAccInternetBandwidth_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "charge_mode", "95peak_guar"),
-					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(rName, "size", "300"),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
@@ -97,7 +96,6 @@ func testAccInternetBandwidth_basic(name string) string {
 resource "huaweicloud_global_internet_bandwidth" "test" {
   access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
   charge_mode           = "95peak_guar"
-  enterprise_project_id = "%s"
   size                  = 300
   isp                   = data.huaweicloud_global_eip_pools.all.geip_pools[0].isp
   name                  = "%s"
@@ -107,7 +105,7 @@ resource "huaweicloud_global_internet_bandwidth" "test" {
     foo = "bar"
   }
 }
-`, testAccGlobalEIPPoolsDataSource_basic, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+`, testAccGlobalEIPPoolsDataSource_basic, name)
 }
 
 func testAccInternetBandwidth_update(name string) string {
@@ -117,7 +115,6 @@ func testAccInternetBandwidth_update(name string) string {
 resource "huaweicloud_global_internet_bandwidth" "test" {
   access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
   charge_mode           = "95peak_guar"
-  enterprise_project_id = "%s"
   size                  = 400
   isp                   = data.huaweicloud_global_eip_pools.all.geip_pools[0].isp
   name                  = "%s-update"
@@ -128,5 +125,5 @@ resource "huaweicloud_global_internet_bandwidth" "test" {
     key = "value"
   }
 }
-`, testAccGlobalEIPPoolsDataSource_basic, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+`, testAccGlobalEIPPoolsDataSource_basic, name)
 }

--- a/huaweicloud/services/eip/resource_huaweicloud_global_eip.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_eip.go
@@ -196,7 +196,7 @@ func buildCreateGEIPBodyParams(d *schema.ResourceData, epsID string) map[string]
 		"internet_bandwidth_id": d.Get("internet_bandwidth_id"),
 		"description":           utils.ValueIngoreEmpty(d.Get("description")),
 		"name":                  utils.ValueIngoreEmpty(d.Get("name")),
-		"enterprise_project_id": epsID,
+		"enterprise_project_id": utils.ValueIngoreEmpty(epsID),
 		"tags":                  utils.ValueIngoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
 	}
 	return bodyParams

--- a/huaweicloud/services/eip/resource_huaweicloud_global_internet_bandwidth.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_internet_bandwidth.go
@@ -154,7 +154,7 @@ func buildCreateInternetBandwidthBodyParams(d *schema.ResourceData, epsID string
 		"description":           utils.ValueIngoreEmpty(d.Get("description")),
 		"name":                  utils.ValueIngoreEmpty(d.Get("name")),
 		"type":                  utils.ValueIngoreEmpty(d.Get("type")),
-		"enterprise_project_id": epsID,
+		"enterprise_project_id": utils.ValueIngoreEmpty(epsID),
 		"tags":                  utils.ValueIngoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
 	}
 	return bodyParams


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When `enterprise_project_id` is empty, it should not in request body, and it will be `0` in default.
Fix it in `huaweicloud_global_eip` and `hauweicloud_global_internet_bandwidth`, and change the acc test for it.

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccInternetBandwidth_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccInternetBandwidth_basic -timeout 360m -parallel 4
=== RUN   TestAccInternetBandwidth_basic
=== PAUSE TestAccInternetBandwidth_basic
=== CONT  TestAccInternetBandwidth_basic
--- PASS: TestAccInternetBandwidth_basic (41.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       41.440s

make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGEIP_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGEIP_basic -timeout 360m -parallel 4
=== RUN   TestAccGEIP_basic
=== PAUSE TestAccGEIP_basic
=== CONT  TestAccGEIP_basic
--- PASS: TestAccGEIP_basic (77.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       77.125s
```
