### PR TITLE
feat(ecs): add the extend_param parameter to bandwidth

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -67,10 +67,13 @@ resource "huaweicloud_vpc_eip" "myeip" {
     type = "5_bgp"
   }
   bandwidth {
-    name        = "test"
-    size        = 8
-    share_type  = "PER"
-    charge_mode = "traffic"
+    name         = "test"
+    size         = 8
+    share_type   = "PER"
+    charge_mode  = "traffic"
+    extend_param = {
+      charging_mode = "postPaid"
+    }
   }
 }
 
@@ -459,6 +462,9 @@ The `bandwidth` block supports:
 
 * `charge_mode` - (Optional, String, ForceNew) Specifies the bandwidth billing mode. The value can be *traffic* or *bandwidth*.
   Changing this creates a new instance.
+
+* `extend_param` - (Optional, Map, ForceNew) Specifies the bandwidth the billing model for public IP.
+  The value can be *prePaid* or *postPaid*. Changing this creates a new instance.
 
 The `scheduler_hints` block supports:
 

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -410,6 +410,13 @@ func ResourceComputeInstance() *schema.Resource {
 							ForceNew:     true,
 							RequiredWith: []string{"bandwidth.0.size"},
 						},
+						"extend_param": {
+							Type:         schema.TypeMap,
+							Optional:     true,
+							ForceNew:     true,
+							Elem:         &schema.Schema{Type: schema.TypeString},
+							RequiredWith: []string{"bandwidth.0.charge_mode"},
+						},
 					},
 				},
 			},
@@ -1524,10 +1531,20 @@ func buildInstancePublicIPRequest(d *schema.ResourceData) *cloudservers.PublicIp
 		Size:       bandWidth["size"].(int),
 	}
 
+	extendParam := d.Get("bandwidth.0.extend_param").(map[string]interface{})
+	if len(extendParam) != 1 {
+		extendParam["charging_mode"] = ""
+	}
+
+	epOpts := cloudservers.EipExtendParam{
+		ChargingMode: extendParam["charging_mode"].(string),
+	}
+
 	return &cloudservers.PublicIp{
 		Eip: &cloudservers.Eip{
-			IpType:    d.Get("eip_type").(string),
-			BandWidth: &bwOpts,
+			IpType:      d.Get("eip_type").(string),
+			BandWidth:   &bwOpts,
+			ExtendParam: &epOpts,
 		},
 		DeleteOnTermination: d.Get("delete_eip_on_termination").(bool),
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: add the extend_param parameter to bandwidth

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstance_traffic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_traffic -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_traffic
=== PAUSE TestAccComputeInstance_traffic
=== CONT  TestAccComputeInstance_traffic
--- PASS: TestAccComputeInstance_traffic (191.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       191.294s
```
