### PR TITLE
feat(DEW): kms key resource support keystore_id parameter

### DIFF
--- a/docs/resources/kms_key.md
+++ b/docs/resources/kms_key.md
@@ -58,6 +58,9 @@ The following arguments are supported:
   For key_usage selection, see the [documentation](https://support.huaweicloud.com/intl/en-us/productdesc-ram/ram_01_0007.html).
   Changing this creates a new key.
 
+* `keystore_id` - (Optional, String, ForceNew) Specifies the keystore ID of the kms key.
+  Default value is the KMS default keystore ID. Changing this creates a new key.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_key_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_key_test.go
@@ -28,6 +28,7 @@ func getKmsKeyResourceFunc(conf *config.Config, state *terraform.ResourceState) 
 	return key, err
 }
 
+// Keystore_id scenario testing is currently not supported.
 func TestAccKmsKey_Basic(t *testing.T) {
 	var keyAlias = acceptance.RandomAccResourceName()
 	var keyAliasUpdate = acceptance.RandomAccResourceName()

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_key.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_key.go
@@ -118,6 +118,12 @@ func ResourceKmsKey() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"keystore_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 
 			"key_id": {
 				Type:     schema.TypeString,
@@ -183,6 +189,7 @@ func ResourceKmsKeyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		KeySpec:             d.Get("key_algorithm").(string),
 		KeyUsage:            d.Get("key_usage").(string),
 		Origin:              d.Get("origin").(string),
+		KeyStoreID:          d.Get("keystore_id").(string),
 		EnterpriseProjectID: common.GetEnterpriseProjectID(d, cfg),
 	}
 
@@ -293,6 +300,7 @@ func ResourceKmsKeyRead(_ context.Context, d *schema.ResourceData, meta interfac
 		d.Set("origin", v.Origin),
 		d.Set("key_usage", v.KeyUsage),
 		d.Set("key_state", v.KeyState),
+		d.Set("keystore_id", v.KeyStoreID),
 		utils.SetResourceTagsToState(d, kmsKeyV1Client, "kms", d.Id()),
 	)
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/keys/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/keys/requests.go
@@ -20,6 +20,8 @@ type CreateOpts struct {
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 	// Key source, the value can be kms or external, the default value is kms.
 	Origin string `json:"origin,omitempty"`
+	// Keystore id, default value is the KMS default keystore id
+	KeyStoreID string `json:"keystore_id,omitempty"`
 }
 
 type ImportMaterialOpts struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/keys/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/keys/results.go
@@ -41,6 +41,8 @@ type Key struct {
 	EnterpriseProjectID string `json:"sys_enterprise_project_id"`
 	// Key usage
 	KeyUsage string `json:"key_usage"`
+	// Keystore ID
+	KeyStoreID string `json:"keystore_id"`
 }
 
 type ListKey struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
kms key resource support keystore_id parameter
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Add keystore_id param when create a KMS key.
2. keystore_id scenario testing is currently not supported.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```

```
