### PR TITLE
feat(DEW): kms grant resource support retiring_principal parameter

### DIFF
--- a/docs/resources/kms_grant.md
+++ b/docs/resources/kms_grant.md
@@ -13,12 +13,14 @@ and a maximum of 100 authorizations can be created under one master key.
 ```HCL
 variable "key_id" {}
 variable "user_id" {}
+variable "retiring_principal" {}
 
 resource "huaweicloud_kms_grant" "test" {
-  key_id            = var.key_id
-  type              = "user"
-  grantee_principal = var.user_id
-  operations        = ["create-datakey", "encrypt-datakey"]
+  key_id             = var.key_id
+  type               = "user"
+  grantee_principal  = var.user_id
+  operations         = ["create-datakey", "encrypt-datakey"]
+  retiring_principal = var.retiring_principal
 }
 ```
 
@@ -30,30 +32,28 @@ The following arguments are supported:
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
 * `key_id` - (Required, String, ForceNew) Key ID.
-
   Changing this parameter will create a new resource.
 
 * `grantee_principal` - (Required, String, ForceNew) The ID of the authorized user or account.  
-
   Changing this parameter will create a new resource.
 
 * `operations` - (Required, List, ForceNew) List of granted operations.
   The options are: **create-datakey**, **create-datakey-without-plaintext**, **encrypt-datakey**,
   **decrypt-datakey**, **describe-key**, **create-grant**, **retire-grant**, **encrypt-data**, **decrypt-data**
   A value containing only **create-grant** is invalid.
-
   Changing this parameter will create a new resource.
 
 * `name` - (Optional, String, ForceNew) Grant name.  
   It must be 1 to 255 characters long, start with a letter, and contain only letters (case-sensitive),
   digits, hyphens (-), underscores (_), and slash(/).
-
   Changing this parameter will create a new resource.
 
 * `type` - (Optional, String, ForceNew) Authorization type.
-  The options are: **user**, **domain**. The default value is **user**.  
-
+  The options are: **user**, **domain**. The default value is **user**.
   Changing this parameter will create a new resource.
+
+* `retiring_principal` - (Optional, String, ForceNew) Specifies the ID of the retiring user who has the
+  authority to retire the authorization. Changing this parameter will create a new resource.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_grant_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_grant_test.go
@@ -88,6 +88,7 @@ func TestAccKmsGrant_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(rName, "key_id", "huaweicloud_kms_key.test", "id"),
 					resource.TestCheckResourceAttrPair(rName, "grantee_principal", "huaweicloud_identity_user.test", "id"),
 					resource.TestCheckResourceAttrSet(rName, "creator"),
+					resource.TestCheckResourceAttrPair(rName, "retiring_principal", "huaweicloud_identity_user.test", "id"),
 				),
 			},
 			{
@@ -116,11 +117,11 @@ resource "huaweicloud_identity_user" "test" {
 }
 
 resource "huaweicloud_kms_grant" "test" {
-  key_id            = huaweicloud_kms_key.test.id
-  grantee_principal = huaweicloud_identity_user.test.id
-  operations        = ["create-datakey", "encrypt-datakey"]
+  key_id             = huaweicloud_kms_key.test.id
+  grantee_principal  = huaweicloud_identity_user.test.id
+  operations         = ["create-datakey", "encrypt-datakey"]
+  retiring_principal = huaweicloud_identity_user.test.id
 }
-
 `, name, name)
 }
 

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_grant.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_grant.go
@@ -85,6 +85,13 @@ func ResourceKmsGrant() *schema.Resource {
 					"user", "domain",
 				}, false),
 			},
+			"retiring_principal": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The ID of the retiring user.`,
+			},
 			"creator": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -144,6 +151,7 @@ func buildCreateGrantBodyParams(d *schema.ResourceData, _ *config.Config) map[st
 		"grantee_principal_type": utils.ValueIngoreEmpty(d.Get("type")),
 		"grantee_principal":      utils.ValueIngoreEmpty(d.Get("grantee_principal")),
 		"operations":             utils.ValueIngoreEmpty(d.Get("operations")),
+		"retiring_principal":     utils.ValueIngoreEmpty(d.Get("retiring_principal")),
 	}
 	return bodyParams
 }
@@ -213,6 +221,7 @@ func resourceKmsGrantRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("grantee_principal", utils.PathSearch("grantee_principal", grantDetail, nil)),
 		d.Set("operations", utils.PathSearch("operations", grantDetail, nil)),
 		d.Set("creator", utils.PathSearch("issuing_principal", grantDetail, nil)),
+		d.Set("retiring_principal", utils.PathSearch("retiring_principal", grantDetail, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
kms grant resource support retiring_principal parameter
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dew TESTARGS='-run TestAccKmsGrant_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKmsGrant_basic -timeout 360m -parallel 4
=== RUN   TestAccKmsGrant_basic
=== PAUSE TestAccKmsGrant_basic
=== CONT  TestAccKmsGrant_basic
--- PASS: TestAccKmsGrant_basic (43.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       43.512s

```
