### PR TITLE
feat(iotda): add a datasource to get the list of AMQP queues

### DIFF
--- a/docs/data-sources/iotda_amqps.md
+++ b/docs/data-sources/iotda_amqps.md
@@ -1,0 +1,64 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_amqps
+
+Use this data source to get the list of the IoTDA AMQP queues.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify
+  the IoTDA service endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  *9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com*, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "queue_name" {}
+data "huaweicloud_iotda_amqps" "test" {
+  name = var.queue_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the AMQP queues.
+  If omitted, the provider-level region will be used.
+
+* `queue_id` - (Optional, String) Specifies the ID of the AMQP queue.
+
+* `name` - (Optional, String) Specifies the name of the AMQP queue.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `queues` - The list of the AMQP queues.
+  The [queues](#iotda_queues) structure is documented below.
+
+<a name="iotda_queues"></a>
+The `queues` block supports:
+
+* `id` - The ID of the AMQP queue.
+
+* `name` - The name of the AMQP queue.
+
+* `created_at` - The creation time of the AMQP queue.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.
+
+* `updated_at` - The latest update time of the AMQP queue.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -574,6 +574,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_data_key": dew.DataSourceKmsDataKeyV1(),
 			"huaweicloud_kps_keypairs": dew.DataSourceKeypairs(),
 
+			"huaweicloud_iotda_amqps":                iotda.DataSourceAMQPQueues(),
 			"huaweicloud_iotda_dataforwarding_rules": iotda.DataSourceDataForwardingRules(),
 			"huaweicloud_iotda_spaces":               iotda.DataSourceSpaces(),
 			"huaweicloud_iotda_products":             iotda.DataSourceProducts(),

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_amqps_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_amqps_test.go
@@ -1,0 +1,123 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAMQPQueues_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_amqps.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAMQPQueues_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.0.updated_at"),
+
+					resource.TestCheckOutput("queue_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAMQPQueues_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_amqps.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAMQPQueues_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "queues.0.updated_at"),
+
+					resource.TestCheckOutput("queue_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAMQPQueues_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+data "huaweicloud_iotda_amqps" "test" {
+  depends_on = [
+    huaweicloud_iotda_amqp.test
+  ]
+}
+
+locals {
+  queue_id = data.huaweicloud_iotda_amqps.test.queues[0].id
+}
+
+data "huaweicloud_iotda_amqps" "queue_id_filter" {
+  queue_id = local.queue_id
+}
+
+output "queue_id_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_amqps.queue_id_filter.queues) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_amqps.queue_id_filter.queues[*].id : v == local.queue_id]
+  )
+}
+
+locals {
+  name = data.huaweicloud_iotda_amqps.test.queues[0].name
+}
+
+data "huaweicloud_iotda_amqps" "name_filter" {
+  name = local.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_amqps.name_filter.queues) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_amqps.name_filter.queues[*].name : v == local.name]
+  )
+}
+
+data "huaweicloud_iotda_amqps" "not_found" {
+  name = "not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_amqps.not_found.queues) == 0
+}
+`, testAmqp_basic(name), buildIoTDAEndpoint())
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_amqps.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_amqps.go
@@ -1,0 +1,149 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/amqp-queues
+func DataSourceAMQPQueues() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAMQPQueuesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"queue_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"queues": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAMQPQueuesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := WithDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allQueues []model.QueryQueueBase
+		limit     = int32(50)
+		offset    int32
+	)
+
+	for {
+		listOpts := model.BatchShowQueueRequest{
+			QueueName: utils.StringIgnoreEmpty(d.Get("name").(string)),
+			Limit:     utils.Int32(limit),
+			Offset:    &offset,
+		}
+
+		listResp, listErr := client.BatchShowQueue(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error querying IoTDA AMQP queues: %s", listErr)
+		}
+
+		if len(*listResp.Queues) == 0 {
+			break
+		}
+
+		allQueues = append(allQueues, *listResp.Queues...)
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuId)
+
+	targetQueues := filterListQueues(allQueues, d)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("queues", flattenAMQPQueues(targetQueues)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterListQueues(queues []model.QueryQueueBase, d *schema.ResourceData) []model.QueryQueueBase {
+	if len(queues) == 0 {
+		return nil
+	}
+
+	rst := make([]model.QueryQueueBase, 0, len(queues))
+	for _, v := range queues {
+		if queueId, ok := d.GetOk("queue_id"); ok &&
+			fmt.Sprint(queueId) != utils.StringValue(v.QueueId) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func flattenAMQPQueues(queues []model.QueryQueueBase) []interface{} {
+	if len(queues) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(queues))
+	for _, v := range queues {
+		rst = append(rst, map[string]interface{}{
+			"id":         v.QueueId,
+			"name":       v.QueueName,
+			"created_at": v.CreateTime,
+			"updated_at": v.LastModifyTime,
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a datasource to get the list of AMQP queues.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new datasource to get the list of the AMQP queues.
2.support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

## Basic
```
$ export HW_REGION_NAME=cn-north-4 
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceAMQPQueues_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceAMQPQueues_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAMQPQueues_basic
=== PAUSE TestAccDataSourceAMQPQueues_basic
=== CONT  TestAccDataSourceAMQPQueues_basic
--- PASS: TestAccDataSourceAMQPQueues_basic (31.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     31.777s
```
## Skip
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceAMQPQueues_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceAMQPQueues_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAMQPQueues_derived
=== PAUSE TestAccDataSourceAMQPQueues_derived
=== CONT  TestAccDataSourceAMQPQueues_derived
    acceptance.go:1373: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccDataSourceAMQPQueues_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.040s
```
## Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceAMQPQueues_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceAMQPQueues_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAMQPQueues_derived
=== PAUSE TestAccDataSourceAMQPQueues_derived
=== CONT  TestAccDataSourceAMQPQueues_derived
--- PASS: TestAccDataSourceAMQPQueues_derived (33.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     33.189s
```