### PR TITLE
fix(drs): add param vpc id for net type vpc

### DIFF
--- a/docs/resources/drs_job.md
+++ b/docs/resources/drs_job.md
@@ -60,7 +60,7 @@ resource "huaweicloud_drs_job" "test" {
 }
 ```
 
-### Create a DRS job to synchronize database level data to the HuaweiCloud RDS database
+### Create a DRS job to synchronize database level data to the HuaweiCloud RDS database and net type is VPC
 
 ```hcl
 variable "name" {}
@@ -71,6 +71,8 @@ variable "source_db_password" {}
 variable "source_db_port" {}
 variable "destination_db_password" {}
 variable "database_name" {}
+variable "source_db_vpc_id" {}
+variable "source_db_subnet_id" {}
 
 resource "huaweicloud_rds_instance" "mysql" {
   ...
@@ -81,7 +83,7 @@ resource "huaweicloud_drs_job" "test" {
   type           = "sync"
   engine_type    = "mysql"
   direction      = "up"
-  net_type       = "eip"
+  net_type       = "vpc"
   migration_type = "FULL_INCR_TRANS"
   description    = "terraform demo"
 
@@ -92,6 +94,8 @@ resource "huaweicloud_drs_job" "test" {
     user        = var.source_db_user
     password    = var.source_db_password
     ssl_link    = false
+    vpc_id      = var.source_db_vpc_id
+    subnet_id   = var.source_db_subnet_id
   }
 
   destination_db {
@@ -335,8 +339,14 @@ The `db_info` block supports:
 * `instance_id` - (Optional, String, ForceNew) Specifies the instance id of database when it is a RDS database.
  Changing this parameter will create a new resource.
 
+* `vpc_id` - (Optional, String, ForceNew) Specifies vpc ID of database.
+ Changing this parameter will create a new resource.
+
 * `subnet_id` - (Optional, String, ForceNew) Specifies subnet ID of database when it is a RDS database.
  It is mandatory when `direction` is **down**. Changing this parameter will create a new resource.
+
+ -> When `net_type` is **vpc**, if `direction` is **up**, `source_db.vpc_id` and `source_db.subnet_id` is mandatory, if
+ `direction` is **down**, `destination_db.vpc_id` and `destination_db.subnet_id` is mandatory.
 
 * `region` - (Optional, String, ForceNew) Specifies the region which the database belongs when it is a RDS database.
  Changing this parameter will create a new resource.

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_job_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_job_test.go
@@ -270,7 +270,7 @@ func TestAccResourceDrsJob_sync(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", "sync"),
 					resource.TestCheckResourceAttr(resourceName, "direction", "up"),
-					resource.TestCheckResourceAttr(resourceName, "net_type", "eip"),
+					resource.TestCheckResourceAttr(resourceName, "net_type", "vpc"),
 					resource.TestCheckResourceAttr(resourceName, "destination_db_readnoly", "true"),
 					resource.TestCheckResourceAttr(resourceName, "migration_type", "FULL_INCR_TRANS"),
 					resource.TestCheckResourceAttr(resourceName, "description", name),
@@ -278,6 +278,10 @@ func TestAccResourceDrsJob_sync(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "source_db.0.ip", "192.168.0.58"),
 					resource.TestCheckResourceAttr(resourceName, "source_db.0.port", "3306"),
 					resource.TestCheckResourceAttr(resourceName, "source_db.0.user", "root"),
+					resource.TestCheckResourceAttrPair(resourceName, "source_db.0.vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "source_db.0.subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "destination_db.0.engine_type", "mysql"),
 					resource.TestCheckResourceAttr(resourceName, "destination_db.0.ip", "192.168.0.59"),
 					resource.TestCheckResourceAttr(resourceName, "destination_db.0.port", "3306"),
@@ -289,7 +293,6 @@ func TestAccResourceDrsJob_sync(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "destination_db.0.region",
 						"huaweicloud_rds_instance.test2", "region"),
 					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
 					resource.TestCheckResourceAttr(resourceName, "period_unit", "month"),
@@ -348,7 +351,7 @@ resource "huaweicloud_drs_job" "test" {
   type           = "sync"
   engine_type    = "mysql"
   direction      = "up"
-  net_type       = "eip"
+  net_type       = "vpc"
   migration_type = "FULL_INCR_TRANS"
   description    = "%s"
   force_destroy  = true
@@ -359,6 +362,8 @@ resource "huaweicloud_drs_job" "test" {
     port        = 3306
     user        = "root"
     password    = "%s"
+    vpc_id      = huaweicloud_rds_instance.test1.vpc_id
+    subnet_id   = huaweicloud_rds_instance.test1.subnet_id
   }
 
   destination_db {

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -338,6 +338,13 @@ func dbInfoSchemaResource() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -1151,6 +1158,7 @@ func buildDbConfigParamter(d *schema.ResourceData, dbType, projectId string) (*j
 		DbPort:          golangsdk.IntToPointer(configRaw["port"].(int)),
 		InstanceId:      configRaw["instance_id"].(string),
 		Region:          configRaw["region"].(string),
+		VpcId:           configRaw["vpc_id"].(string),
 		SubnetId:        configRaw["subnet_id"].(string),
 		ProjectId:       projectId,
 		SslCertPassword: configRaw["ssl_cert_password"].(string),
@@ -1186,6 +1194,7 @@ func setDbInfoToState(d *schema.ResourceData, endpoint jobs.Endpoint, fieldName 
 		"instance_id":        endpoint.InstanceId,
 		"name":               endpoint.InstanceName,
 		"region":             endpoint.Region,
+		"vpc_id":             endpoint.VpcId,
 		"subnet_id":          endpoint.SubnetId,
 		"ssl_cert_password":  endpoint.SslCertPassword,
 		"ssl_cert_check_sum": endpoint.SslCertCheckSum,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add param `destination_db.vpc_id` and `source_db.vpc_id` in `huaweicloud_drs_job`.
When `net_type` is `vpc`, one of them is required, please refer to the `Example Usage`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/drs" TESTARGS="-run TestAccResourceDrsJob_sync"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccResourceDrsJob_sync -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_sync
=== PAUSE TestAccResourceDrsJob_sync
=== CONT  TestAccResourceDrsJob_sync
--- PASS: TestAccResourceDrsJob_sync (1293.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       1293.476s
```