### PR TITLE
fix(CDN): remove wrong validation mether and add new test case

### DIFF
--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -188,9 +188,6 @@ var cacheUrlParameterFilter = schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"full_url", "ignore_url_params", "del_args", "reserve_args",
-				}, false),
 			},
 			"value": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Removed incorrect validation check for "configs.cache_url_parameter_filter.type" field in resources.
- Add a new test case for checking parameter `configs`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- A total of two commits were submitted.
  - Remove wrong field validation method.
  - Add case to test CDN config parameter.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (391.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       391.175s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (432.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       432.287s
```
