### PR TITLE
feat(hss): add host protection resource support

### DIFF
--- a/docs/resources/hss_host_protection.md
+++ b/docs/resources/hss_host_protection.md
@@ -1,0 +1,106 @@
+---
+subcategory: "Host Security Service (HSS)"
+---
+
+# huaweicloud_hss_host_protection
+
+Manages an HSS host protection resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "host_id" {}
+variable "version" {}
+variable "charging_mode" {}
+
+resource "huaweicloud_hss_host_protection" "test" {
+  host_id       = var.host_id
+  version       = var.version
+  charging_mode = var.charging_mode
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region to which the HSS host protection resource belongs.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `host_id` - (Required, String, ForceNew) Specifies the host ID for the host protection.
+  Changing this parameter will create a new resource.
+
+  -> Before using host protection, it is necessary to ensure that the agent status of the host is **online**.
+
+* `version` - (Required, String) Specifies the protection version enabled by the host.  
+  The valid values are as follows:
+  + **hss.version.basic**: Basic version.
+  + **hss.version.advanced**: Professional version.
+  + **hss.version.enterprise**: Enterprise version.
+  + **hss.version.premium**: Ultimate version.
+
+* `charging_mode` - (Required, String) Specifies the charging mode for host protection.  
+  The valid values are as follows:
+  + **prePaid**: The yearly/monthly billing mode.
+  + **postPaid**: The pay-per-use billing mode.
+
+* `quota_id` - (Optional, String) Specifies quota ID for host protection.
+  If omitted, randomly select quota for the corresponding version.
+  This field is valid only when `charging_mode` is set to **prePaid**.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the host
+  protection belongs. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID same as `host_id`.
+
+* `host_name` - The host name.
+
+* `host_status` - The host status. The value can be **ACTIVE**, **SHUTOFF**, **BUILDING**, or **ERROR**.
+
+* `private_ip` - The private IP address of the host.
+
+* `agent_id` - The agent ID installed on the host.
+
+* `agent_status` - The agent status of the host. The value can be **installed**, **not_installed**, **online**,
+  **offline**, **install_failed**, or **installing**.
+
+* `os_type` - The operating system type of the host. The value can be **Linux** or **Windows**.
+
+* `status` - The protection status of the host. The value can be **closed** or **opened**.
+
+* `detect_result` - The security detection result of the host. The value can be **undetected**, **clean**, **risk**,
+  or **scanning**.
+
+* `asset_value` - The asset importance. The value can be **important**, **common**, or **test**.
+
+* `open_time` - The time to enable host protection.
+
+## Import
+
+The host protection can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_hss_host_protection.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `quota_id`.
+It is generally recommended running `terraform plan` after importing a resource.
+You can then decide if changes should be applied to the resource, or the resource definition
+should be updated to align with the resource. Also, you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_hss_host_protection" "test" { 
+  ...
+  
+  lifecycle {
+    ignore_changes = [
+      quota_id,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1112,7 +1112,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_ges_metadata": ges.ResourceGesMetadata(),
 			"huaweicloud_ges_backup":   ges.ResourceGesBackup(),
 
-			"huaweicloud_hss_host_group": hss.ResourceHostGroup(),
+			"huaweicloud_hss_host_group":      hss.ResourceHostGroup(),
+			"huaweicloud_hss_host_protection": hss.ResourceHostProtection(),
 
 			"huaweicloud_identity_access_key":            iam.ResourceIdentityKey(),
 			"huaweicloud_identity_acl":                   iam.ResourceIdentityACL(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -307,6 +307,9 @@ var (
 	HW_LTS_AGENCY_NAME        = os.Getenv("HW_LTS_AGENCY_NAME")
 
 	HW_VPCEP_SERVICE_ID = os.Getenv("HW_VPCEP_SERVICE_ID")
+
+	HW_HSS_HOST_PROTECTION_HOST_ID  = os.Getenv("HW_HSS_HOST_PROTECTION_HOST_ID")
+	HW_HSS_HOST_PROTECTION_QUOTA_ID = os.Getenv("HW_HSS_HOST_PROTECTION_QUOTA_ID")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -1446,5 +1449,19 @@ func TestAccPreCheckCCMPushWAFInstance(t *testing.T) {
 func TestAccPreCheckVPCEPServiceId(t *testing.T) {
 	if HW_VPCEP_SERVICE_ID == "" {
 		t.Skip("HW_VPCEP_SERVICE_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckHSSHostProtectionHostId(t *testing.T) {
+	if HW_HSS_HOST_PROTECTION_HOST_ID == "" {
+		t.Skip("HW_HSS_HOST_PROTECTION_HOST_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckHSSHostProtectionQuotaId(t *testing.T) {
+	if HW_HSS_HOST_PROTECTION_QUOTA_ID == "" {
+		t.Skip("HW_HSS_HOST_PROTECTION_QUOTA_ID must be set for the acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_protection_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_protection_test.go
@@ -1,0 +1,155 @@
+package hss
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	hssv5model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/hss/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/hss"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getHostProtectionFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcHssV5Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HSS v5 client: %s", err)
+	}
+
+	var (
+		epsId = acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
+		id    = state.Primary.ID
+	)
+
+	// If the enterprise project ID is not set during query, query all enterprise projects.
+	if epsId == "" {
+		epsId = hss.QueryAllEpsValue
+	}
+	listHostOpts := hssv5model.ListHostStatusRequest{
+		Region:              &acceptance.HW_REGION_NAME,
+		EnterpriseProjectId: utils.String(epsId),
+		HostId:              utils.String(id),
+	}
+
+	resp, err := client.ListHostStatus(&listHostOpts)
+	if err != nil {
+		return nil, fmt.Errorf("error querying HSS hosts: %s", err)
+	}
+
+	if resp == nil || resp.DataList == nil {
+		return nil, fmt.Errorf("the host (%s) for HSS host protection does not exist", id)
+	}
+
+	hostList := *resp.DataList
+	if len(hostList) == 0 || utils.StringValue(hostList[0].ProtectStatus) == string(hss.ProtectStatusClosed) {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return hostList[0], nil
+}
+
+func TestAccHostProtection_basic(t *testing.T) {
+	var (
+		host  *hssv5model.Host
+		rName = "huaweicloud_hss_host_protection.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&host,
+		getHostProtectionFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+			acceptance.TestAccPreCheckHSSHostProtectionQuotaId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostProtection_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "host_id", acceptance.HW_HSS_HOST_PROTECTION_HOST_ID),
+					resource.TestCheckResourceAttr(rName, "version", "hss.version.basic"),
+					resource.TestCheckResourceAttr(rName, "charging_mode", "prePaid"),
+					resource.TestCheckResourceAttr(rName, "quota_id", acceptance.HW_HSS_HOST_PROTECTION_QUOTA_ID),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(rName, "host_name"),
+					resource.TestCheckResourceAttrSet(rName, "host_status"),
+					resource.TestCheckResourceAttrSet(rName, "private_ip"),
+					resource.TestCheckResourceAttrSet(rName, "agent_id"),
+					resource.TestCheckResourceAttrSet(rName, "agent_status"),
+					resource.TestCheckResourceAttrSet(rName, "os_type"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "detect_result"),
+					resource.TestCheckResourceAttrSet(rName, "asset_value"),
+					resource.TestCheckResourceAttrSet(rName, "open_time"),
+				),
+			},
+			{
+				Config: testAccHostProtection_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "host_id", acceptance.HW_HSS_HOST_PROTECTION_HOST_ID),
+					resource.TestCheckResourceAttr(rName, "version", "hss.version.enterprise"),
+					resource.TestCheckResourceAttr(rName, "charging_mode", "postPaid"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(rName, "host_name"),
+					resource.TestCheckResourceAttrSet(rName, "host_status"),
+					resource.TestCheckResourceAttrSet(rName, "private_ip"),
+					resource.TestCheckResourceAttrSet(rName, "agent_id"),
+					resource.TestCheckResourceAttrSet(rName, "agent_status"),
+					resource.TestCheckResourceAttrSet(rName, "os_type"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "detect_result"),
+					resource.TestCheckResourceAttrSet(rName, "asset_value"),
+					resource.TestCheckResourceAttrSet(rName, "open_time"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"quota_id",
+				},
+			},
+		},
+	})
+}
+
+func testAccHostProtection_basic() string {
+	return fmt.Sprintf(`
+
+resource "huaweicloud_hss_host_protection" "test" {
+  host_id               = "%[1]s"
+  version               = "hss.version.basic"
+  charging_mode         = "prePaid"
+  quota_id              = "%[2]s"
+  enterprise_project_id = "%[3]s"
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID, acceptance.HW_HSS_HOST_PROTECTION_QUOTA_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccHostProtection_update() string {
+	return fmt.Sprintf(`
+
+resource "huaweicloud_hss_host_protection" "test" {
+  host_id               = "%[1]s"
+  version               = "hss.version.enterprise"
+  charging_mode         = "postPaid"
+  enterprise_project_id = "%[2]s"
+}
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_host_protection.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_host_protection.go
@@ -1,0 +1,358 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	hssv5 "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/hss/v5"
+	hssv5model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/hss/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	QueryAllEpsValue        string = "all_granted_eps"
+	protectionVersionNull   string = "hss.version.null"
+	hostAgentStatusOnline   string = "online"
+	chargingModePacketCycle string = "packet_cycle"
+	chargingModeOnDemand    string = "on_demand"
+	chargingModePrePaid     string = "prePaid"
+	chargingModePostPaid    string = "postPaid"
+)
+
+// @API HSS GET /v5/{project_id}/host-management/hosts
+// @API HSS POST /v5/{project_id}/host-management/protection
+func ResourceHostProtection() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceHostProtectionCreate,
+		ReadContext:   resourceHostProtectionRead,
+		UpdateContext: resourceHostProtectionUpdate,
+		DeleteContext: resourceHostProtectionDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceHostProtectionImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"charging_mode": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"quota_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			// Attributes
+			"host_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"host_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agent_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"agent_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"detect_result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"asset_value": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"open_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func checkHostAvailable(client *hssv5.HssClient, region, epsId, hostId string) error {
+	request := hssv5model.ListHostStatusRequest{
+		Region:              &region,
+		EnterpriseProjectId: utils.StringIgnoreEmpty(epsId),
+		HostId:              utils.String(hostId),
+	}
+
+	resp, err := client.ListHostStatus(&request)
+	if err != nil {
+		return fmt.Errorf("error querying HSS hosts: %s", err)
+	}
+
+	if resp == nil || resp.DataList == nil {
+		return fmt.Errorf("the host (%s) for HSS host protection does not exist", hostId)
+	}
+
+	hostList := *resp.DataList
+	if len(hostList) == 0 {
+		return fmt.Errorf("the host (%s) does not exist", hostId)
+	}
+
+	agentStatus := *hostList[0].AgentStatus
+	if agentStatus != hostAgentStatusOnline {
+		return fmt.Errorf("the host anget status for HSS protection must be: %s,"+
+			" but the current host (%s) agent status is: %s ", hostAgentStatusOnline, hostId, agentStatus)
+	}
+
+	return nil
+}
+
+func switchHostsProtectStatus(client *hssv5.HssClient, region, epsId, hostId string, d *schema.ResourceData) error {
+	var (
+		version      = d.Get("version").(string)
+		chargingMode = d.Get("charging_mode").(string)
+		quotaId      = d.Get("quota_id").(string)
+	)
+
+	if chargingMode == chargingModePrePaid {
+		chargingMode = chargingModePacketCycle
+	}
+	if chargingMode == chargingModePostPaid {
+		chargingMode = chargingModeOnDemand
+	}
+
+	switchOpts := hssv5model.SwitchHostsProtectStatusRequest{
+		Region:              region,
+		EnterpriseProjectId: utils.StringIgnoreEmpty(epsId),
+		Body: &hssv5model.SwitchHostsProtectStatusRequestInfo{
+			Version:      version,
+			ChargingMode: utils.String(chargingMode),
+			ResourceId:   utils.StringIgnoreEmpty(quotaId),
+			HostIdList:   []string{hostId},
+		},
+	}
+
+	_, err := client.SwitchHostsProtectStatus(&switchOpts)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceHostProtectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		epsId  = cfg.GetEnterpriseProjectID(d)
+		hostId = d.Get("host_id").(string)
+	)
+
+	client, err := cfg.HcHssV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating HSS v5 client: %s", err)
+	}
+
+	checkHostAvailableErr := checkHostAvailable(client, region, epsId, hostId)
+	if checkHostAvailableErr != nil {
+		return diag.FromErr(checkHostAvailableErr)
+	}
+
+	err = switchHostsProtectStatus(client, region, epsId, hostId, d)
+	if err != nil {
+		return diag.Errorf("error opening HSS host (%s) protection: %s", hostId, err)
+	}
+
+	d.SetId(hostId)
+
+	return resourceHostProtectionRead(ctx, d, meta)
+}
+
+func resourceHostProtectionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		id     = d.Id()
+		epsId  = cfg.GetEnterpriseProjectID(d)
+	)
+
+	client, err := cfg.HcHssV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating HSS v5 client: %s", err)
+	}
+
+	// If the enterprise project ID is not set during query, query all enterprise projects.
+	if epsId == "" {
+		epsId = QueryAllEpsValue
+	}
+	listHostOpts := hssv5model.ListHostStatusRequest{
+		Region:              &region,
+		EnterpriseProjectId: utils.String(epsId),
+		HostId:              utils.String(id),
+	}
+
+	resp, err := client.ListHostStatus(&listHostOpts)
+	if err != nil {
+		return diag.Errorf("error querying HSS hosts: %s", err)
+	}
+
+	if resp == nil || resp.DataList == nil {
+		return diag.Errorf("the host (%s) for HSS host protection does not exist", id)
+	}
+
+	hostList := *resp.DataList
+	if len(hostList) == 0 || utils.StringValue(hostList[0].ProtectStatus) == string(ProtectStatusClosed) {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "HSS host protection")
+	}
+
+	host := hostList[0]
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("host_id", host.HostId),
+		d.Set("version", host.Version),
+		d.Set("charging_mode", convertChargingMode(host.ChargingMode)),
+		d.Set("enterprise_project_id", host.EnterpriseProjectId),
+		d.Set("host_name", host.HostName),
+		d.Set("host_status", host.HostStatus),
+		d.Set("private_ip", host.PrivateIp),
+		d.Set("agent_id", host.AgentId),
+		d.Set("agent_status", host.AgentStatus),
+		d.Set("os_type", host.OsType),
+		d.Set("status", host.ProtectStatus),
+		d.Set("detect_result", host.DetectResult),
+		d.Set("asset_value", host.AssetValue),
+		d.Set("open_time", convertOpenTime(host.OpenTime)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func convertChargingMode(chargingMode *string) string {
+	if utils.StringValue(chargingMode) == chargingModePacketCycle {
+		return chargingModePrePaid
+	}
+
+	return chargingModePostPaid
+}
+
+func convertOpenTime(openTime *int64) string {
+	if openTime == nil {
+		return ""
+	}
+
+	return utils.FormatTimeStampRFC3339(*openTime/1000, false)
+}
+
+func resourceHostProtectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		epsId  = cfg.GetEnterpriseProjectID(d)
+		id     = d.Id()
+	)
+
+	client, err := cfg.HcHssV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating HSS v5 client: %s", err)
+	}
+
+	checkHostAvailableErr := checkHostAvailable(client, region, epsId, id)
+	if checkHostAvailableErr != nil {
+		return diag.FromErr(checkHostAvailableErr)
+	}
+
+	if d.HasChanges("version", "charging_mode", "quota_id") {
+		err = switchHostsProtectStatus(client, region, epsId, id, d)
+		if err != nil {
+			return diag.Errorf("error updating HSS host (%s) protection: %s", id, err)
+		}
+	}
+
+	return resourceHostProtectionRead(ctx, d, meta)
+}
+
+func resourceHostProtectionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		epsId  = cfg.GetEnterpriseProjectID(d)
+		id     = d.Id()
+	)
+
+	client, err := cfg.HcHssV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating HSS v5 client: %s", err)
+	}
+
+	closeOpts := hssv5model.SwitchHostsProtectStatusRequest{
+		Region:              region,
+		EnterpriseProjectId: utils.StringIgnoreEmpty(epsId),
+		Body: &hssv5model.SwitchHostsProtectStatusRequestInfo{
+			Version:    protectionVersionNull,
+			HostIdList: []string{id},
+		},
+	}
+
+	_, err = client.SwitchHostsProtectStatus(&closeOpts)
+	if err != nil {
+		return diag.Errorf("error closing HSS host (%s) protection: %s", id, err)
+	}
+
+	return nil
+}
+
+func resourceHostProtectionImportState(_ context.Context, d *schema.ResourceData, meta interface{}) (
+	[]*schema.ResourceData, error) {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		id     = d.Id()
+	)
+
+	client, err := cfg.HcHssV5Client(region)
+	if err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error creating HSS v5 client: %s", err)
+	}
+
+	checkHostAvailableErr := checkHostAvailable(client, region, QueryAllEpsValue, id)
+
+	return []*schema.ResourceData{d}, checkHostAvailableErr
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. add host protection resource support
2. use environment variables to set the host ID and quota ID, as it is not possible to create a host for installing the agent through a script, and unable to create protection quota through script.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
1. add host protection resource support
2. set host ID and quota ID using environment variables for testing
3. when the resource does not exist, execute `terraform plan` and the program output is as follows:
    
![Screenshot_38](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/121534745/250e4c24-f3af-480f-a64b-13032ef32369)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### Basic
```
$ export HW_HSS_HOST_PROTECTION_HOST_ID=xxxxxxxxxxxxx
$ export HW_HSS_HOST_PROTECTION_QUOTA_ID=xxxxxxxxxxxxx
$ export HW_ENTERPRISE_PROJECT_ID_TEST=xxxxxxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccHostProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccHostProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccHostProtection_basic
=== PAUSE TestAccHostProtection_basic
=== CONT  TestAccHostProtection_basic
--- PASS: TestAccHostProtection_basic (14.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       14.163s
      
```

### Skip
```
$ unset HW_HSS_HOST_PROTECTION_HOST_ID
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccHostProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccHostProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccHostProtection_basic
=== PAUSE TestAccHostProtection_basic
=== CONT  TestAccHostProtection_basic
    acceptance.go:1449: HW_HSS_HOST_PROTECTION_HOST_ID must be set for the acceptance test
--- SKIP: TestAccHostProtection_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       0.034s


$ unset HW_HSS_HOST_PROTECTION_QUOTA_ID
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccHostProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccHostProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccHostProtection_basic
=== PAUSE TestAccHostProtection_basic
=== CONT  TestAccHostProtection_basic
    acceptance.go:1465: HW_HSS_HOST_PROTECTION_QUOTA_ID must be set for the acceptance test
--- SKIP: TestAccHostProtection_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       0.035s

```


### 