### PR TITLE
feat(iotda): add a datasource to get the list of dataforwarding rules

### DIFF
--- a/docs/data-sources/iotda_dataforwarding_rules.md
+++ b/docs/data-sources/iotda_dataforwarding_rules.md
@@ -1,0 +1,117 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_dataforwarding_rules
+
+Use this data source to get the list of IoTDA dataforwarding rules.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "rule_name" {}
+
+data "huaweicloud_iotda_dataforwarding_rules" "test" {
+  name = var.rule_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the dataforwarding rules.
+  If omitted, the provider-level region will be used.
+
+* `rule_id` - (Optional, String) Specifies the ID of the dataforwarding rule.
+
+* `name` - (Optional, String) Specifies the name of the dataforwarding rule.
+
+* `resource` - (Optional, String) Specifies the data source of the dataforwarding rule.
+  This parameter must be used together with `trigger`. The valid values are as follows:
+  + **device**
+  + **device.property**
+  + **device.message**
+  + **device.message.status**
+  + **device.status**
+  + **batchtask**
+  + **product**
+  + **device.command.status**
+
+* `trigger` - (Optional, String) Specifies the triggering event of the data source corresponding to
+  the dataforwarding rule. This parameter must be used together with `resource`. The valid values are as follows:
+  + **device:create**: Device added.
+  + **device:delete**: Device deleted.
+  + **device:update**: Device updated.
+  + **device.status:update**: Device status changed.
+  + **device.property:report**: Device property reported.
+  + **device.message:report**: Device message reported.
+  + **device.message.status:update**: Device message status changed.
+  + **batchtask:update**: Batch task status changed.
+  + **product:create**: Product added.
+  + **product:delete**: Product deleted.
+  + **product:update**: Product updated.
+  + **device.command.status:update**: Device asynchronous command status updated.
+
+* `app_type` - (Optional, String) Specifies the validity scope of the dataforwarding rule.
+  The valid values are as follows:
+  + **GLOBAL**: The validity scope is tenant level.
+  + **APP**: The validity scope is resource space level.
+
+  -> If the `app_type` value is **APP**, this parameter can be used together with the `space_id` to query 
+    the dataforwarding rules in the corresponding resource space, if not associated with the `space_id`,
+    will be query the dataforwarding rules in the default resource space.
+
+* `space_id` - (Optional, String) Specifies the ID of the resource space to which the dataforwarding rule belongs.
+
+  -> If use this parameter to query, the parameter `app_type` must be set to **APP**.
+
+* `enabled` - (Optional, String) Specifies whether to enable the dataforwarding rule.
+  The value can be **true** or **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - All rules that match the filter parameters.
+  The [rules](#iotda_rules) structure is documented below.
+
+<a name="iotda_rules"></a>
+The `rules` block supports:
+
+* `id` - The ID of the dataforwarding rule.
+
+* `name` - The name of the dataforwarding rule.
+
+* `description` - The description of the dataforwarding rule.
+
+* `resource` - The data source of the dataforwarding rule.
+
+* `trigger` - The triggering event of the data source corresponding to the dataforwarding rule.
+
+* `app_type` - The validity scope of the dataforwarding rule.
+
+* `space_id` - The ID of the resource space to which the dataforwarding rule belongs.
+
+* `enabled` - Whether to enable the dataforwarding rule.
+
+* `select` - The user defined SQL **select** statement.
+
+* `where` - The user defined SQL **where** statement.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -572,8 +572,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_data_key": dew.DataSourceKmsDataKeyV1(),
 			"huaweicloud_kps_keypairs": dew.DataSourceKeypairs(),
 
-			"huaweicloud_iotda_spaces":   iotda.DataSourceSpaces(),
-			"huaweicloud_iotda_products": iotda.DataSourceProducts(),
+			"huaweicloud_iotda_dataforwarding_rules": iotda.DataSourceDataForwardingRules(),
+			"huaweicloud_iotda_spaces":               iotda.DataSourceSpaces(),
+			"huaweicloud_iotda_products":             iotda.DataSourceProducts(),
 
 			"huaweicloud_koogallery_assets": koogallery.DataSourceKooGalleryAssets(),
 

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_dataforwarding_rules_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_dataforwarding_rules_test.go
@@ -1,0 +1,181 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDataForwardingRules_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_dataforwarding_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDataForwardingRules_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.resource"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.trigger"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.app_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.enabled"),
+
+					resource.TestCheckOutput("rule_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("resource_and_trigger_filter_is_useful", "true"),
+					resource.TestCheckOutput("app_type_filter_is_useful", "true"),
+					resource.TestCheckOutput("enabled_filter_is_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDataForwardingRules_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_dataforwarding_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDataForwardingRules_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.resource"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.trigger"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.app_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.enabled"),
+
+					resource.TestCheckOutput("rule_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("app_type_filter_is_useful", "true"),
+					resource.TestCheckOutput("enabled_filter_is_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDataForwardingRules_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+data "huaweicloud_iotda_dataforwarding_rules" "test" {
+  depends_on = [
+    huaweicloud_iotda_dataforwarding_rule.test
+  ]
+}
+
+locals {
+  rule_id = data.huaweicloud_iotda_dataforwarding_rules.test.rules[0].id
+}
+
+data "huaweicloud_iotda_dataforwarding_rules" "rule_id_filter" {
+  rule_id = local.rule_id
+}
+
+output "rule_id_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_dataforwarding_rules.rule_id_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_dataforwarding_rules.rule_id_filter.rules[*].id : v == local.rule_id]
+  )
+}
+
+locals {
+  name = data.huaweicloud_iotda_dataforwarding_rules.test.rules[0].name
+}
+
+data "huaweicloud_iotda_dataforwarding_rules" "name_filter" {
+  name = local.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_dataforwarding_rules.name_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_dataforwarding_rules.name_filter.rules[*].name : v == local.name]
+  )
+}
+
+locals {
+  resource = data.huaweicloud_iotda_dataforwarding_rules.test.rules[0].resource
+  trigger  = data.huaweicloud_iotda_dataforwarding_rules.test.rules[0].trigger
+}
+
+data "huaweicloud_iotda_dataforwarding_rules" "resource_and_trigger_filter" {
+  resource = local.resource
+  trigger  = local.trigger
+}
+
+locals {
+  resource_and_trigger_filter_result = [
+    for v in data.huaweicloud_iotda_dataforwarding_rules.resource_and_trigger_filter.rules : 
+    v if(v.trigger == local.trigger && v.resource == local.resource)
+  ]
+}
+
+output "resource_and_trigger_filter_is_useful" {
+  value = length(local.resource_and_trigger_filter_result) > 0 
+}
+
+locals {
+  app_type = data.huaweicloud_iotda_dataforwarding_rules.test.rules[0].app_type
+}
+
+data "huaweicloud_iotda_dataforwarding_rules" "app_type_filter" {
+  app_type = local.app_type
+}
+
+output "app_type_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_dataforwarding_rules.app_type_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_dataforwarding_rules.app_type_filter.rules[*].app_type : v == local.app_type]
+  )
+}
+
+locals {
+  enabled = data.huaweicloud_iotda_dataforwarding_rules.test.rules[0].enabled
+}
+
+data "huaweicloud_iotda_dataforwarding_rules" "enabled_filter" {
+  enabled = local.enabled
+}
+
+output "enabled_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_dataforwarding_rules.enabled_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_dataforwarding_rules.enabled_filter.rules[*].enabled : v == local.enabled]
+  )
+}
+
+data "huaweicloud_iotda_dataforwarding_rules" "not_found" {
+  name = "not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_dataforwarding_rules.not_found.rules) == 0
+}
+`, testDataForwardingRule_basic(name), buildIoTDAEndpoint())
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_dataforwarding_rules.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_dataforwarding_rules.go
@@ -1,0 +1,208 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/routing-rule/rules
+func DataSourceDataForwardingRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDataForwardingRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"rule_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"trigger": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"app_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"trigger": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"app_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"space_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"select": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"where": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDataForwardingRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := WithDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allRoutingRules []model.RoutingRule
+		limit           = int32(50)
+		offset          int32
+	)
+
+	for {
+		listOpts := model.ListRoutingRulesRequest{
+			RuleName: utils.StringIgnoreEmpty(d.Get("name").(string)),
+			Resource: utils.StringIgnoreEmpty(d.Get("resource").(string)),
+			Event:    utils.StringIgnoreEmpty(d.Get("trigger").(string)),
+			AppType:  utils.StringIgnoreEmpty(d.Get("app_type").(string)),
+			AppId:    utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+			Limit:    utils.Int32(limit),
+			Offset:   &offset,
+		}
+
+		active, ok := d.GetOk("enabled")
+		if ok {
+			listOpts.Active = utils.StringToBool(active)
+		}
+
+		listResp, listErr := client.ListRoutingRules(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error querying IoTDA dataforwarding rules: %s", listErr)
+		}
+
+		if len(*listResp.Rules) == 0 {
+			break
+		}
+		allRoutingRules = append(allRoutingRules, *listResp.Rules...)
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuId)
+
+	targetRoutingRules := filterListDataForwardingRules(allRoutingRules, d)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rules", flattenDataForwardingRules(targetRoutingRules)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterListDataForwardingRules(routingRules []model.RoutingRule, d *schema.ResourceData) []model.RoutingRule {
+	if len(routingRules) == 0 {
+		return nil
+	}
+
+	rst := make([]model.RoutingRule, 0, len(routingRules))
+	for _, v := range routingRules {
+		if ruleId, ok := d.GetOk("rule_id"); ok &&
+			fmt.Sprint(ruleId) != utils.StringValue(v.RuleId) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func flattenDataForwardingRules(routingRules []model.RoutingRule) []interface{} {
+	if len(routingRules) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(routingRules))
+	for _, v := range routingRules {
+		rst = append(rst, map[string]interface{}{
+			"id":          v.RuleId,
+			"name":        v.RuleName,
+			"description": v.Description,
+			"resource":    v.Subject.Resource,
+			"trigger":     v.Subject.Event,
+			"app_type":    v.AppType,
+			"space_id":    v.AppId,
+			"enabled":     v.Active,
+			"select":      v.Select,
+			"where":       v.Where,
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a datasource to get the list of dataforwarding rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new datasource to get the list of the dataforwarding rules.
2.support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
## Basic
```
$ export HW_REGION_NAME=cn-north-4 
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDataForwardingRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataForwardingRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataForwardingRules_basic
=== PAUSE TestAccDataSourceDataForwardingRules_basic
=== CONT  TestAccDataSourceDataForwardingRules_basic
--- PASS: TestAccDataSourceDataForwardingRules_basic (49.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     49.854s
```
## Skip
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDataForwardingRules_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataForwardingRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataForwardingRules_derived
=== PAUSE TestAccDataSourceDataForwardingRules_derived
=== CONT  TestAccDataSourceDataForwardingRules_derived
    acceptance.go:1382: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccDataSourceDataForwardingRules_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.041s
```
## Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDataForwardingRules_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataForwardingRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataForwardingRules_derived
=== PAUSE TestAccDataSourceDataForwardingRules_derived
=== CONT  TestAccDataSourceDataForwardingRules_derived
--- PASS: TestAccDataSourceDataForwardingRules_derived (44.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     44.226s
```
