### PR TITLE
feat(iotda): add derived auth documents and tests for resources under the IoTDA pckage

### DIFF
--- a/docs/resources/iotda_amqp.md
+++ b/docs/resources/iotda_amqp.md
@@ -6,6 +6,21 @@ subcategory: "IoT Device Access (IoTDA)"
 
 Manages an IoTDA AMQP queue within HuaweiCloud.
 
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+endpoint in `provider` block.
+You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+to view the HTTPS application access address. An example of the access address might be
+**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+`provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/iotda_dataforwarding_rule.md
+++ b/docs/resources/iotda_dataforwarding_rule.md
@@ -6,6 +6,21 @@ subcategory: "IoT Device Access (IoTDA)"
 
 Manages an IoTDA data forwarding rule within HuaweiCloud.
 
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+endpoint in `provider` block.
+You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+to view the HTTPS application access address. An example of the access address might be
+**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+`provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/iotda_device.md
+++ b/docs/resources/iotda_device.md
@@ -6,6 +6,21 @@ subcategory: "IoT Device Access (IoTDA)"
 
 Manages an IoTDA device within HuaweiCloud.
 
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+endpoint in `provider` block.
+You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+to view the HTTPS application access address. An example of the access address might be
+**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+`provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
 ## Example Usage
 
 ### Create a directly connected device and an indirectly connected device

--- a/docs/resources/iotda_device_certificate.md
+++ b/docs/resources/iotda_device_certificate.md
@@ -6,6 +6,21 @@ subcategory: "IoT Device Access (IoTDA)"
 
 Manages an IoTDA device CA certificate within HuaweiCloud.
 
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+endpoint in `provider` block.
+You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+to view the HTTPS application access address. An example of the access address might be
+**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+`provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/iotda_device_group.md
+++ b/docs/resources/iotda_device_group.md
@@ -6,6 +6,21 @@ subcategory: "IoT Device Access (IoTDA)"
 
 Manages an IoTDA device group within HuaweiCloud.
 
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+endpoint in `provider` block.
+You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+to view the HTTPS application access address. An example of the access address might be
+**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+`provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/iotda_device_linkage_rule.md
+++ b/docs/resources/iotda_device_linkage_rule.md
@@ -6,6 +6,21 @@ subcategory: "IoT Device Access (IoTDA)"
 
 Manages an IoTDA device linkage rule within HuaweiCloud.
 
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+endpoint in `provider` block.
+You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+to view the HTTPS application access address. An example of the access address might be
+**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+`provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/iotda_product.md
+++ b/docs/resources/iotda_product.md
@@ -6,6 +6,21 @@ subcategory: "IoT Device Access (IoTDA)"
 
 Manages an IoTDA product within HuaweiCloud.
 
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+endpoint in `provider` block.
+You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+to view the HTTPS application access address. An example of the access address might be
+**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+`provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/iotda_upgrade_package.md
+++ b/docs/resources/iotda_upgrade_package.md
@@ -6,6 +6,21 @@ subcategory: "IoT Device Access (IoTDA)"
 
 Manages an IoTDA OTA upgrade package within HuaweiCloud.
 
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+endpoint in `provider` block.
+You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+to view the HTTPS application access address. An example of the access address might be
+**9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+`provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
 ## Example Usage
 
 ```hcl

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_amqp_test.go
@@ -61,10 +61,48 @@ func TestAccAmqp_basic(t *testing.T) {
 	})
 }
 
+func TestAccAmqp_derived(t *testing.T) {
+	var obj model.ShowQueueResponse
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_iotda_amqp.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAmqpResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAmqp_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAmqp_basic(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_iotda_amqp" "test" {
-  name = "%s"
+  name = "%[2]s"
 }
-`, name)
+`, buildIoTDAEndpoint(), name)
 }

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
@@ -75,10 +75,68 @@ func TestAccDataForwardingRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataForwardingRule_derived(t *testing.T) {
+	var obj model.ShowRoutingRuleResponse
+
+	name := acceptance.RandomAccResourceNameWithDash()
+	updateName := acceptance.RandomAccResourceNameWithDash()
+	rName := "huaweicloud_iotda_dataforwarding_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDataForwardingRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDataForwardingRule_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "trigger", "product:delete"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(rName, "targets.0.type", "HTTP_FORWARDING"),
+					resource.TestCheckResourceAttr(rName, "targets.0.http_forwarding.0.url", "http://www.exampletest.com"),
+					resource.TestCheckResourceAttrSet(rName, "targets.0.id"),
+				),
+			},
+			{
+				Config: testDataForwardingRule_dis(updateName, acceptance.HW_REGION_NAME),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "trigger", "product:delete"),
+					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(rName, "targets.0.type", "DIS_FORWARDING"),
+					resource.TestCheckResourceAttrSet(rName, "targets.0.id"),
+					resource.TestCheckResourceAttrPair(rName, "targets.0.dis_forwarding.0.stream_id",
+						"huaweicloud_dis_stream.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testDataForwardingRule_basic(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_iotda_dataforwarding_rule" "test" {
-  name    = "%s"
+  name    = "%[2]s"
   trigger = "product:delete"
   enabled = true
   
@@ -91,28 +149,30 @@ resource "huaweicloud_iotda_dataforwarding_rule" "test" {
 
 
 }
-`, name)
+`, buildIoTDAEndpoint(), name)
 }
 
 func testDataForwardingRule_dis(name, region string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_dis_stream" "test" {
-  stream_name     = "%s"
+  stream_name     = "%[2]s"
   partition_count = 1
 }
 
 resource "huaweicloud_iotda_dataforwarding_rule" "test" {
-  name    = "%s"
+  name    = "%[3]s"
   trigger = "product:delete"
   enabled = false
 
   targets {
     type = "DIS_FORWARDING"
     dis_forwarding {
-      region    = "%s"
+      region    = "%[4]s"
       stream_id = huaweicloud_dis_stream.test.id
     }
   }
 }
-`, name, name, region)
+`, buildIoTDAEndpoint(), name, name, region)
 }

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_certificate_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_certificate_test.go
@@ -37,7 +37,7 @@ func TestAccDeviceCertificate_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testDeviceCertificate_basic,
+				Config: testDeviceCertificate_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "cn", "huaweiIoT"),
@@ -58,7 +58,49 @@ func TestAccDeviceCertificate_basic(t *testing.T) {
 	})
 }
 
-const testDeviceCertificate_basic = `
+func TestAccDeviceCertificate_derived(t *testing.T) {
+	var obj model.CertificatesRspDto
+	rName := "huaweicloud_iotda_device_certificate.test"
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceCertificateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeviceCertificate_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cn", "huaweiIoT"),
+					resource.TestCheckResourceAttr(rName, "status", "Unverified"),
+					resource.TestCheckResourceAttrSet(rName, "verify_code"),
+					resource.TestCheckResourceAttrSet(rName, "effective_date"),
+					resource.TestCheckResourceAttrSet(rName, "expiry_date"),
+					resource.TestCheckResourceAttrSet(rName, "owner"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"content"},
+			},
+		},
+	})
+}
+
+func testDeviceCertificate_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_iotda_device_certificate" "test" {
   content  = <<EOT
 -----BEGIN CERTIFICATE-----
@@ -85,4 +127,5 @@ RQocSUkUw0EW
 -----END CERTIFICATE-----
 EOT
 }
-`
+`, buildIoTDAEndpoint())
+}

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
@@ -72,6 +72,59 @@ func TestAccDeviceGroup_basic(t *testing.T) {
 	})
 }
 
+func TestAccDeviceGroup_derived(t *testing.T) {
+	var obj model.ShowDeviceGroupResponse
+
+	deviceName := acceptance.RandomAccResourceName()
+	name := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_iotda_device_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceGroupResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeviceGroup_basic(name, deviceName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", name),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "device_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(rName, "device_ids.0", "huaweicloud_iotda_device.test", "id"),
+				),
+			},
+			{
+				Config: testDeviceGroup_basic_update(updateName, deviceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", updateName),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "device_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(rName, "device_ids.0", "huaweicloud_iotda_device.test2", "id"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"space_id"},
+			},
+		},
+	})
+}
+
 func testDeviceGroup_basic(name, deviceName string) string {
 	baseConfig := testDevice_basic(deviceName, deviceName)
 	return fmt.Sprintf(`

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_linkage_rule_test.go
@@ -123,6 +123,110 @@ func TestAccDeviceLinkageRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccDeviceLinkageRule_derived(t *testing.T) {
+	var obj model.ShowRuleResponse
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_iotda_device_linkage_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceLinkageRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeviceLinkageRule_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DEVICE_DATA"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.path", "service_1/p_1"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.operator", "="),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.value", "4"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.trigger_strategy", "pulse"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.device_data_condition.0.data_validatiy_period",
+						"300"),
+					resource.TestCheckResourceAttrPair(rName, "triggers.0.device_data_condition.0.product_id",
+						"huaweicloud_iotda_product.test", "id"),
+					resource.TestCheckResourceAttr(rName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(rName, "actions.0.type", "SMN_FORWARDING"),
+					resource.TestCheckResourceAttr(rName, "actions.0.smn_forwarding.0.message_title", "title"),
+					resource.TestCheckResourceAttr(rName, "actions.0.smn_forwarding.0.message_content", "content"),
+					resource.TestCheckResourceAttrPair(rName, "actions.0.smn_forwarding.0.topic_name",
+						"huaweicloud_smn_topic.topic", "name"),
+					resource.TestCheckResourceAttrPair(rName, "actions.0.smn_forwarding.0.topic_urn",
+						"huaweicloud_smn_topic.topic", "topic_urn"),
+				),
+			},
+			{
+				Config: testDeviceLinkageRule_timer(name + "_update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
+					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.type", "SIMPLE_TIMER"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.simple_timer_condition.0.start_time", "20220622T160000Z"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.simple_timer_condition.0.repeat_interval", "2"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.simple_timer_condition.0.repeat_count", "2"),
+					resource.TestCheckResourceAttr(rName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(rName, "actions.0.type", "SMN_FORWARDING"),
+					resource.TestCheckResourceAttr(rName, "actions.0.smn_forwarding.0.message_title", "title"),
+					resource.TestCheckResourceAttr(rName, "actions.0.smn_forwarding.0.message_content", "content"),
+					resource.TestCheckResourceAttrPair(rName, "actions.0.smn_forwarding.0.topic_name",
+						"huaweicloud_smn_topic.topic", "name"),
+					resource.TestCheckResourceAttrPair(rName, "actions.0.smn_forwarding.0.topic_urn",
+						"huaweicloud_smn_topic.topic", "topic_urn"),
+				),
+			},
+			{
+				Config: testDeviceLinkageRule_daily(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "trigger_logic", "and"),
+					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+					resource.TestCheckResourceAttr(rName, "triggers.#", "1"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.type", "DAILY_TIMER"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.daily_timer_condition.0.start_time", "19:02"),
+					resource.TestCheckResourceAttr(rName, "triggers.0.daily_timer_condition.0.days_of_week",
+						"1,2,3,4,5,6,7"),
+					resource.TestCheckResourceAttr(rName, "actions.#", "1"),
+					resource.TestCheckResourceAttr(rName, "actions.0.type", "DEVICE_CMD"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.service_id", "service_1"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.command_name", "cmd_1"),
+					resource.TestCheckResourceAttr(rName, "actions.0.device_command.0.command_body",
+						"{\"cmd_p_1\":\"3\"}"),
+					resource.TestCheckResourceAttrPair(rName, "actions.0.device_command.0.device_id",
+						"huaweicloud_iotda_device.test", "id"),
+					resource.TestCheckResourceAttr(rName, "effective_period.0.start_time", "00:00"),
+					resource.TestCheckResourceAttr(rName, "effective_period.0.end_time", "23:59"),
+					resource.TestCheckResourceAttr(rName, "effective_period.0.days_of_week", "1,2,3,4,5,6"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testDeviceLinkageRule_basic(name string) string {
 	deviceConfig := testDevice_basic(name, name)
 	return fmt.Sprintf(`

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
@@ -96,6 +96,83 @@ func TestAccDevice_basic(t *testing.T) {
 	})
 }
 
+func TestAccDevice_derived(t *testing.T) {
+	var obj model.ShowDeviceResponse
+
+	nodeId := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_iotda_device.test"
+	childDeviceName := "huaweicloud_iotda_device.test2"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDevice_basic(nodeId, nodeId),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", nodeId),
+					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
+					resource.TestCheckResourceAttr(rName, "secret", "1234567890"),
+					resource.TestCheckResourceAttr(rName, "secondary_secret", "test123456"),
+					resource.TestCheckResourceAttr(rName, "secure_access", "false"),
+					resource.TestCheckResourceAttr(rName, "description", "demo"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "status", "INACTIVE"),
+					resource.TestCheckResourceAttr(rName, "auth_type", "SECRET"),
+					resource.TestCheckResourceAttr(rName, "node_type", "GATEWAY"),
+					resource.TestCheckResourceAttr(rName, "frozen", "false"),
+					resource.TestCheckResourceAttr(childDeviceName, "name", nodeId+"_2"),
+					resource.TestCheckResourceAttr(childDeviceName, "node_id", nodeId+"_2"),
+					resource.TestCheckResourceAttr(childDeviceName, "status", "INACTIVE"),
+					resource.TestCheckResourceAttr(childDeviceName, "node_type", "ENDPOINT"),
+					resource.TestCheckResourceAttrPair(rName, "id", childDeviceName, "gateway_id"),
+				),
+			},
+			{
+				Config: testDevice_basic_update(updateName, nodeId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
+					resource.TestCheckResourceAttr(rName, "fingerprint", "1234567890123456789012345678901234567890"),
+					resource.TestCheckResourceAttr(rName, "secondary_fingerprint", "dc0f1016f495157344ac5f1296335cff725ef22f"),
+					resource.TestCheckResourceAttr(rName, "secure_access", "true"),
+					resource.TestCheckResourceAttr(rName, "description", "demo_update"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(rName, "status", "FROZEN"),
+					resource.TestCheckResourceAttr(rName, "frozen", "true"),
+					resource.TestCheckResourceAttr(rName, "auth_type", "CERTIFICATES"),
+					resource.TestCheckResourceAttr(rName, "node_type", "GATEWAY"),
+					resource.TestCheckResourceAttr(childDeviceName, "name", updateName+"_2"),
+					resource.TestCheckResourceAttr(childDeviceName, "node_id", nodeId+"_2"),
+					resource.TestCheckResourceAttr(childDeviceName, "status", "INACTIVE"),
+					resource.TestCheckResourceAttr(childDeviceName, "node_type", "ENDPOINT"),
+					resource.TestCheckResourceAttrPair(rName, "id", childDeviceName, "gateway_id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"force_disconnect",
+				},
+			},
+		},
+	})
+}
+
 func testDevice_basic(name, nodeId string) string {
 	productbasic := testProduct_basic(name)
 	return fmt.Sprintf(`

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_product_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_product_test.go
@@ -120,14 +120,117 @@ func TestAccProduct_basic(t *testing.T) {
 	})
 }
 
+func TestAccProduct_derived(t *testing.T) {
+	var obj model.ShowProductResponse
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_iotda_product.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getProductResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testProduct_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "device_type", "test"),
+					resource.TestCheckResourceAttr(rName, "protocol", "MQTT"),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "data_type", "json"),
+					resource.TestCheckResourceAttr(rName, "manufacturer_name", "demo_manufacturer_name"),
+					resource.TestCheckResourceAttr(rName, "industry", "demo_industry"),
+					resource.TestCheckResourceAttr(rName, "services.0.id", "service_1"),
+					resource.TestCheckResourceAttr(rName, "services.0.type", "serv_type"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.#", "4"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.name", "p_1"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.description", "desc"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.min", "3"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.max", "666"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.method", "RW"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.1.name", "p_2"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.1.type", "string"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.1.max_length", "20"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.1.method", "R"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.2.method", "W"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.3.type", "decimal"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.3.min", "3.1"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.3.max", "666.99"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.name", "cmd_1"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.name", "cmd_p_1"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.description", "desc"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.min", "3"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.max", "33"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.name", "cmd_r_1"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.min", "1"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.max", "22"),
+				),
+			},
+			{
+				Config: testProduct_update(name + "_update"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.#", "3"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.name", "p_1"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.description", "desc_update"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.min", "4"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.max", "5"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.method", "RW"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.1.name", "p_3"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.1.type", "string"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.1.max_length", "20"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.1.method", "W"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.2.name", "p_4"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.2.type", "decimal"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.2.min", "3.2"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.2.max", "777.99"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.name", "cmd_1"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.name", "cmd_p_2"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.description", "desc"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.min", "5"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.max", "33"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.name", "cmd_r_1"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.min", "2"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.max", "33"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testProduct_basic(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_iotda_space" "test" {
-  name = "%s"
+  name = "%[2]s"
 }
 
 resource "huaweicloud_iotda_product" "test" {
-  name              = "%s"
+  name              = "%[3]s"
   device_type       = "test"
   protocol          = "MQTT"
   space_id          = huaweicloud_iotda_space.test.id
@@ -191,17 +294,19 @@ resource "huaweicloud_iotda_product" "test" {
     }
   }
 }
-`, name, name)
+`, buildIoTDAEndpoint(), name, name)
 }
 
 func testProduct_update(name string) string {
 	return fmt.Sprintf(`
+%[1]s
+
 resource "huaweicloud_iotda_space" "test" {
-  name = "%s"
+  name = "%[2]s"
 }
 
 resource "huaweicloud_iotda_product" "test" {
-  name              = "%s"
+  name              = "%[3]s"
   device_type       = "test"
   protocol          = "MQTT"
   space_id          = huaweicloud_iotda_space.test.id
@@ -257,5 +362,5 @@ resource "huaweicloud_iotda_product" "test" {
     }
   }
 }
-`, name, name)
+`, buildIoTDAEndpoint(), name, name)
 }

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_upgrade_package_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_upgrade_package_test.go
@@ -79,6 +79,54 @@ func TestAccUpgradePackage_basic(t *testing.T) {
 	})
 }
 
+func TestAccUpgradePackage_derived(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_iotda_upgrade_package.test"
+		rName        = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getUpgradePackageResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testUpgradePackage_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "product_id", "huaweicloud_iotda_product.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "type", "softwarePackage"),
+					resource.TestCheckResourceAttr(resourceName, "version", "v1.0"),
+					resource.TestCheckResourceAttr(resourceName, "file_location.0.obs_location.0.region", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttrPair(resourceName, "file_location.0.obs_location.0.bucket_name",
+						"huaweicloud_obs_bucket_object.test", "bucket"),
+					resource.TestCheckResourceAttrPair(resourceName, "file_location.0.obs_location.0.object_key",
+						"huaweicloud_obs_bucket_object.test", "key"),
+					resource.TestCheckResourceAttr(resourceName, "support_source_versions.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "description", "description test"),
+					resource.TestCheckResourceAttr(resourceName, "custom_info", "custom_info test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testUpgradePackageWithObsBucket_base() string {
 	randInt := acctest.RandInt()
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
add derived auth documents and tests for resources under the IoTDA package
**What this PR does / why we need it**:
add derived auth documents and tests for resources under the IoTDA package
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
1. the acc test for all resources has been executed locally and passed
2. provide testing steps using AMQP resource as an example

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

## Basic
```
$ export HW_REGION_NAME=cn-north-4
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccAmqp_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccAmqp_basic -timeout 360m -parallel 4
=== RUN   TestAccAmqp_basic
=== PAUSE TestAccAmqp_basic
=== CONT  TestAccAmqp_basic
--- PASS: TestAccAmqp_basic (7.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     7.279s

```

## Skip
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccAmqp_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccAmqp_derived -timeout 360m -parallel 4
=== RUN   TestAccAmqp_derived
=== PAUSE TestAccAmqp_derived
=== CONT  TestAccAmqp_derived
    acceptance.go:1382: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccAmqp_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.041s

```

## Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e33xxxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccAmqp_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccAmqp_derived -timeout 360m -parallel 4
=== RUN   TestAccAmqp_derived
=== PAUSE TestAccAmqp_derived
=== CONT  TestAccAmqp_derived
--- PASS: TestAccAmqp_derived (13.30s)
PASS

```
