### PR TITLE
feat(er): add new datasource to get the list of propagations

### DIFF
--- a/docs/data-sources/er_propagations.md
+++ b/docs/data-sources/er_propagations.md
@@ -1,0 +1,81 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_propagations
+
+Use this data source to get the list of propagations.
+
+## Example Usage
+
+```hcl
+variable instance_id {}
+variable route_table_id {}
+variable attachment_id {}
+
+data "huaweicloud_er_propagations" "test" {
+  instance_id    = var.instance_id
+  route_table_id = var.route_table_id
+  attachment_id  = var.attachment_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ER instance ID to which the propagation belongs.
+
+* `route_table_id` - (Required, String) Specifies the route table ID to which the propagation belongs.
+
+* `attachment_id` - (Optional, String) Specifies the attachment ID to which the propagation belongs.
+
+* `attachment_type` - (Optional, String) Specifies the attachment type of corresponding to the propagation.  
+  The valid values are as follows:
+  + **vpc**: Virtual private cloud.
+  + **vpn**: VPN gateway.
+  + **vgw**: Virtual gateway of cloud private line.
+  + **peering**: Peering connection, through the cloud connection (CC) to load ERs in different regions to create a
+    peering connection.
+  + **enc**: Enterprise connect network in EC.
+  + **cfw**: VPC border firewall.
+
+* `status` - (Optional, String) Specifies the status of the propagation. Default value is `available`.
+  The valid values are as follows:
+  + **available**
+  + **failed**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `propagations` - All propagations that match the filter parameters.
+  The [propagations](#route_propagations) structure is documented below.
+
+<a name="route_propagations"></a>
+The `propagations` block supports:
+
+* `id` - The propagation ID.
+
+* `instance_id` - The ER instance ID to which the propagation belongs.
+
+* `route_table_id` - The route table ID of corresponding to the propagation.
+
+* `attachment_id` - The attachment ID corresponding to the propagation.
+
+* `attachment_type` - The attachment type corresponding to the propagation.
+
+* `resource_id` - The resource ID of the attachment associated with the propagation.
+
+* `route_policy_id` - The route policy ID of the ingress IPv4 protocol.
+
+* `status` - The current status of the propagation.
+
+* `created_at` - The creation time of the propagation.
+
+* `updated_at` - The latest update time of the propagation.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -510,6 +510,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_er_attachments":        er.DataSourceAttachments(),
 			"huaweicloud_er_flow_logs":          er.DataSourceFlowLogs(),
 			"huaweicloud_er_instances":          er.DataSourceInstances(),
+			"huaweicloud_er_propagations":       er.DataSourcePropagations(),
 			"huaweicloud_er_route_tables":       er.DataSourceRouteTables(),
 			"huaweicloud_er_availability_zones": er.DataSourceAvailabilityZones(),
 

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_propagations_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_propagations_test.go
@@ -1,0 +1,190 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourcePropagations_basic(t *testing.T) {
+	var (
+		dcName   = "data.huaweicloud_er_propagations.test"
+		name     = acceptance.RandomAccResourceName()
+		dc       = acceptance.InitDataSourceCheck(dcName)
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		byInstanceId   = "data.huaweicloud_er_propagations.not_found_instance_id"
+		dcByInstanceId = acceptance.InitDataSourceCheck(byInstanceId)
+
+		byRouteTableId   = "data.huaweicloud_er_propagations.not_found_route_table_id"
+		dcByRouteTableId = acceptance.InitDataSourceCheck(byRouteTableId)
+
+		byAttachmentId   = "data.huaweicloud_er_propagations.filter_by_attachment_id"
+		dcByAttachmentId = acceptance.InitDataSourceCheck(byAttachmentId)
+
+		byAttachmentType   = "data.huaweicloud_er_propagations.filter_by_attachment_type"
+		dcByAttachmentType = acceptance.InitDataSourceCheck(byAttachmentType)
+
+		byStatus   = "data.huaweicloud_er_propagations.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourcePropagations_basic(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+
+					dcByInstanceId.CheckResourceExists(),
+					resource.TestCheckOutput("instance_id_not_found", "true"),
+
+					dcByRouteTableId.CheckResourceExists(),
+					resource.TestCheckOutput("route_table_id_not_found", "true"),
+					resource.TestCheckResourceAttrSet(byAttachmentId, "propagations.#"),
+					resource.TestCheckResourceAttrSet(byAttachmentId, "propagations.0.resource_id"),
+					resource.TestCheckResourceAttrSet(byAttachmentId, "propagations.0.created_at"),
+					resource.TestCheckResourceAttrSet(byAttachmentId, "propagations.0.updated_at"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+
+					dcByAttachmentId.CheckResourceExists(),
+					resource.TestCheckOutput("is_attachment_id_filter_useful", "true"),
+
+					dcByAttachmentType.CheckResourceExists(),
+					resource.TestCheckOutput("is_attachment_type_filter_useful", "true"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourcePropagations_basic(name string, bgpAsNum int) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_propagations" "not_found_instance_id" {
+  depends_on = [
+    huaweicloud_er_propagation.test,
+  ]
+
+  instance_id    = "%[2]s"
+  route_table_id = huaweicloud_er_route_table.test.id
+}
+  
+output "instance_id_not_found" {
+  value = length(data.huaweicloud_er_propagations.not_found_instance_id.propagations) == 0
+}
+  
+data "huaweicloud_er_propagations" "not_found_route_table_id" {
+  depends_on = [
+    huaweicloud_er_propagation.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = "%[2]s"
+}
+  
+output "route_table_id_not_found" {
+  value = length(data.huaweicloud_er_propagations.not_found_route_table_id.propagations) == 0
+}
+
+data "huaweicloud_er_propagations" "test" {
+  depends_on = [
+    huaweicloud_er_propagation.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+}
+
+locals {
+  attachment_id = data.huaweicloud_er_propagations.test.propagations[0].attachment_id
+}
+
+data "huaweicloud_er_propagations" "filter_by_attachment_id" {
+  depends_on = [
+    huaweicloud_er_propagation.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  attachment_id  = local.attachment_id
+}
+
+locals {
+ attachment_id_filter_result = [
+    for v in data.huaweicloud_er_propagations.filter_by_attachment_id.propagations[*].attachment_id : 
+    v == local.attachment_id
+  ]
+}
+
+output "is_attachment_id_filter_useful" {
+  value = alltrue(local.attachment_id_filter_result) && length(local.attachment_id_filter_result) > 0
+}
+
+locals {
+  attachment_type = data.huaweicloud_er_propagations.test.propagations[0].attachment_type
+}
+
+data "huaweicloud_er_propagations" "filter_by_attachment_type" {
+  depends_on = [
+    huaweicloud_er_propagation.test,
+  ]
+
+  instance_id     = huaweicloud_er_instance.test.id
+  route_table_id  = huaweicloud_er_route_table.test.id
+  attachment_type = local.attachment_type
+}
+
+locals {
+  attachment_type_filter_result = [
+    for v in data.huaweicloud_er_propagations.filter_by_attachment_type.propagations[*].attachment_type : 
+    v == local.attachment_type
+  ]
+}
+   
+output "is_attachment_type_filter_useful" {
+  value = alltrue(local.attachment_type_filter_result) && length(local.attachment_type_filter_result) > 0
+}
+
+locals {
+  status = data.huaweicloud_er_propagations.test.propagations[0].status
+}
+  
+data "huaweicloud_er_propagations" "filter_by_status" {
+  depends_on = [
+    huaweicloud_er_propagation.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  status         = local.status
+}
+  
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_er_propagations.filter_by_status.propagations[*].status : v == local.status
+  ]
+}
+   
+output "is_status_filter_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+`, testAccPropagation_basic(name, bgpAsNum), randUUID)
+}

--- a/huaweicloud/services/er/data_source_huaweicloud_er_propagations.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_propagations.go
@@ -1,0 +1,171 @@
+package er
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/er/v3/propagations"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations
+func DataSourcePropagations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePropagationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"attachment_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"propagations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     propagationSchema(),
+			},
+		},
+	}
+}
+
+func propagationSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"route_policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildPropagationListOpts(d *schema.ResourceData) propagations.ListOpts {
+	opts := propagations.ListOpts{}
+	if attachmentId, ok := d.GetOk("attachment_id"); ok {
+		opts.AttachmentIds = []string{attachmentId.(string)}
+	}
+
+	if attachmentType, ok := d.GetOk("attachment_type"); ok {
+		opts.ResourceTypes = []string{attachmentType.(string)}
+	}
+
+	if status, ok := d.GetOk("status"); ok {
+		opts.Statuses = []string{status.(string)}
+	}
+
+	return opts
+}
+
+func flattenPropagations(all []propagations.Propagation) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(all))
+	for i, propagation := range all {
+		result[i] = map[string]interface{}{
+			"id":              propagation.ID,
+			"instance_id":     propagation.InstanceId,
+			"route_table_id":  propagation.RouteTableId,
+			"attachment_id":   propagation.AttachmentId,
+			"attachment_type": propagation.ResourceType,
+			"resource_id":     propagation.ResourceId,
+			"route_policy_id": propagation.RoutePolicy.ImportPoilicyId,
+			"status":          propagation.Status,
+			"created_at":      propagation.CreatedAt,
+			"updated_at":      propagation.UpdatedAt,
+		}
+	}
+	return result
+}
+
+func dataSourcePropagationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	opts := buildPropagationListOpts(d)
+	resp, err := propagations.List(client, d.Get("instance_id").(string), d.Get("route_table_id").(string), opts)
+	if err != nil {
+		return diag.Errorf("error retrieving propagations: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("propagations", flattenPropagations(resp)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error saving data source fields of ER propagations: %s", mErr)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource to get the list of propagations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new datasource to get the list of propagations.
2. support related document and acceptance test.

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/er TESTARGS='-run TestAccDataSourcePropagations_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccDataSourcePropagations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePropagations_basic
--- PASS: TestAccDataSourcePropagations_basic (196.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        196.571s
```
