### PR TITLE
feat(er): add new datasource to get the list of associations

### DIFF
--- a/docs/data-sources/er_associations.md
+++ b/docs/data-sources/er_associations.md
@@ -1,0 +1,69 @@
+---
+subcategory: "Enterprise Router (ER)"
+---
+
+# huaweicloud_er_associations
+
+Use this data source to get the list of associations.
+
+## Example Usage
+
+```hcl
+variable instance_id {}
+variable route_table_id {}
+
+data "huaweicloud_er_associations" "test" {
+  instance_id     = var.instance_id
+  route_table_id  = var.route_table_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ER instance ID to which the association belongs.
+
+* `route_table_id` - (Required, String) Specifies the route table ID to which the association belongs.
+
+* `attachment_id` - (Optional, String) Specifies the attachment ID corresponding to the association.  
+
+* `attachment_type` - (Optional, String) Specifies the attachment type corresponding to the association.  
+
+* `status` - (Optional, String) Specifies the status of the association. Default value is `available`.
+  The valid values are as follows:
+  + **available**
+  + **failed**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `associations` - All associations that match the filter parameters.
+  The [associations](#route_associations) structure is documented below.
+
+<a name="route_associations"></a>
+The `associations` block supports:
+
+* `id` - The association ID.
+
+* `route_table_id` -The route table ID corresponding to the association.
+
+* `attachment_id` -The attachment ID corresponding to the association.
+
+* `attachment_type` -The type of the attachment corresponding to the association.
+
+* `resource_id` - The resource ID of the attachment corresponding to the association.
+
+* `route_policy_id` - The route policy ID of the egress IPv4 protocol.
+
+* `status` - The current status of the association.
+
+* `created_at` - The creation time.
+
+* `updated_at` - The latest update time.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -507,6 +507,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_enterprise_project":  eps.DataSourceEnterpriseProject(),
 			"huaweicloud_enterprise_projects": eps.DataSourceEnterpriseProjects(),
 
+			"huaweicloud_er_associations":       er.DataSourceAssociations(),
 			"huaweicloud_er_attachments":        er.DataSourceAttachments(),
 			"huaweicloud_er_flow_logs":          er.DataSourceFlowLogs(),
 			"huaweicloud_er_instances":          er.DataSourceInstances(),

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_associations_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_associations_test.go
@@ -1,0 +1,190 @@
+package er
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAssociations_basic(t *testing.T) {
+	var (
+		dcName   = "data.huaweicloud_er_associations.test"
+		name     = acceptance.RandomAccResourceName()
+		dc       = acceptance.InitDataSourceCheck(dcName)
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+
+		byInstanceId   = "data.huaweicloud_er_associations.not_found_instance_id"
+		dcByInstanceId = acceptance.InitDataSourceCheck(byInstanceId)
+
+		byRouteTableId   = "data.huaweicloud_er_associations.not_found_route_table_id"
+		dcByRouteTableId = acceptance.InitDataSourceCheck(byRouteTableId)
+
+		byAttachmentId   = "data.huaweicloud_er_associations.filter_by_attachment_id"
+		dcByAttachmentId = acceptance.InitDataSourceCheck(byAttachmentId)
+
+		byAttachmentType   = "data.huaweicloud_er_associations.filter_by_attachment_type"
+		dcByAttachmentType = acceptance.InitDataSourceCheck(byAttachmentType)
+
+		byStatus   = "data.huaweicloud_er_associations.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceAssociations_basic(name, bgpAsNum),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dcName, "associations.#"),
+					resource.TestCheckResourceAttrSet(dcName, "associations.0.resource_id"),
+					resource.TestCheckResourceAttrSet(dcName, "associations.0.created_at"),
+					resource.TestCheckResourceAttrSet(dcName, "associations.0.updated_at"),
+
+					dcByInstanceId.CheckResourceExists(),
+					resource.TestCheckOutput("instance_id_not_found", "true"),
+
+					dcByRouteTableId.CheckResourceExists(),
+					resource.TestCheckOutput("route_table_id_not_found", "true"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+
+					dcByAttachmentId.CheckResourceExists(),
+					resource.TestCheckOutput("is_attachment_id_filter_useful", "true"),
+
+					dcByAttachmentType.CheckResourceExists(),
+					resource.TestCheckOutput("is_attachment_type_filter_useful", "true"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceAssociations_basic(name string, bgpAsNum int) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_associations" "not_found_instance_id" {
+  depends_on = [
+    huaweicloud_er_association.test,
+  ]
+
+  instance_id    = "%[2]s"
+  route_table_id = huaweicloud_er_route_table.test.id
+}
+  
+output "instance_id_not_found" {
+  value = length(data.huaweicloud_er_associations.not_found_instance_id.associations) == 0
+}
+  
+data "huaweicloud_er_associations" "not_found_route_table_id" {
+  depends_on = [
+    huaweicloud_er_association.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = "%[2]s"
+}
+  
+output "route_table_id_not_found" {
+  value = length(data.huaweicloud_er_associations.not_found_route_table_id.associations) == 0
+}
+
+data "huaweicloud_er_associations" "test" {
+  depends_on = [
+    huaweicloud_er_association.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+}
+
+locals {
+  attachment_id = data.huaweicloud_er_associations.test.associations[0].attachment_id
+}
+
+data "huaweicloud_er_associations" "filter_by_attachment_id" {
+  depends_on = [
+    huaweicloud_er_association.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  attachment_id  = local.attachment_id
+}
+
+locals {
+ attachment_id_filter_result = [
+    for v in data.huaweicloud_er_associations.filter_by_attachment_id.associations[*].attachment_id : 
+    v == local.attachment_id
+  ]
+}
+
+output "is_attachment_id_filter_useful" {
+  value = alltrue(local.attachment_id_filter_result) && length(local.attachment_id_filter_result) > 0
+}
+
+locals {
+  attachment_type = data.huaweicloud_er_associations.test.associations[0].attachment_type
+}
+
+data "huaweicloud_er_associations" "filter_by_attachment_type" {
+  depends_on = [
+    huaweicloud_er_association.test,
+  ]
+
+  instance_id     = huaweicloud_er_instance.test.id
+  route_table_id  = huaweicloud_er_route_table.test.id
+  attachment_type = local.attachment_type
+}
+
+locals {
+  attachment_type_filter_result = [
+    for v in data.huaweicloud_er_associations.filter_by_attachment_type.associations[*].attachment_type : 
+    v == local.attachment_type
+  ]
+}
+   
+output "is_attachment_type_filter_useful" {
+  value = alltrue(local.attachment_type_filter_result) && length(local.attachment_type_filter_result) > 0
+}
+
+locals {
+  status = data.huaweicloud_er_associations.test.associations[0].status
+}
+  
+data "huaweicloud_er_associations" "filter_by_status" {
+  depends_on = [
+    huaweicloud_er_association.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  status         = local.status
+}
+  
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_er_associations.filter_by_status.associations[*].status : v == local.status
+  ]
+}
+   
+output "is_status_filter_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+`, testAccAssociation_basic(name, bgpAsNum), randUUID)
+}

--- a/huaweicloud/services/er/data_source_huaweicloud_er_associations.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_associations.go
@@ -1,0 +1,163 @@
+package er
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/er/v3/associations"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations
+func DataSourceAssociations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAssociationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"attachment_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"associations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     associationsSchema(),
+			},
+		},
+	}
+}
+
+func associationsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"attachment_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"route_policy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildAssociationsistOpts(d *schema.ResourceData) associations.ListOpts {
+	opts := associations.ListOpts{}
+	if attachmentId, ok := d.GetOk("attachment_id"); ok {
+		opts.AttachmentIds = []string{attachmentId.(string)}
+	}
+
+	if attachmentType, ok := d.GetOk("attachment_type"); ok {
+		opts.ResourceTypes = []string{attachmentType.(string)}
+	}
+
+	if status, ok := d.GetOk("status"); ok {
+		opts.Statuses = []string{status.(string)}
+	}
+
+	return opts
+}
+
+func flattenAssociations(all []associations.Association) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(all))
+	for i, propagation := range all {
+		result[i] = map[string]interface{}{
+			"id":              propagation.ID,
+			"route_table_id":  propagation.RouteTableId,
+			"attachment_id":   propagation.AttachmentId,
+			"attachment_type": propagation.ResourceType,
+			"resource_id":     propagation.ResourceId,
+			"route_policy_id": propagation.RoutePolicy.ExportPoilicyId,
+			"status":          propagation.Status,
+			"created_at":      propagation.CreatedAt,
+			"updated_at":      propagation.UpdatedAt,
+		}
+	}
+	return result
+}
+
+func dataSourceAssociationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.ErV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating ER v3 client: %s", err)
+	}
+
+	opts := buildAssociationsistOpts(d)
+	resp, err := associations.List(client, d.Get("instance_id").(string), d.Get("route_table_id").(string), opts)
+	if err != nil {
+		return diag.Errorf("error retrieving associations: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("associations", flattenAssociations(resp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource to get the list of associations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support a new data source to get the list of associations.
2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/er TESTARGS='-run TestAccDataSourceAssociations_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run TestAccDataSourceAssociations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAssociations_basic
--- PASS: TestAccDataSourceAssociations_basic (178.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        178.315s
```
