### PR TITLE
fix(hss/host_group): fix the error caused by the host group resource not using the enterprise project ID when checking if the host is available

### DIFF
--- a/docs/resources/hss_host_group.md
+++ b/docs/resources/hss_host_group.md
@@ -60,8 +60,8 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-Host groups instance can be imported using their `id`, e.g.
+The host group resource can be imported using `enterprise_project_id` and `id`, separated by a slash, e.g.
 
-```
-$ terraform import huaweicloud_hss_host_group.test 69daa15a-3a6b-47ae-a2be-62b488c4e099
+```bash
+$ terraform import huaweicloud_hss_host_group.test <enterprise_project_id>/<id>
 ```

--- a/docs/resources/hss_host_group.md
+++ b/docs/resources/hss_host_group.md
@@ -62,6 +62,14 @@ This resource provides the following timeouts configuration options:
 
 The host group resource can be imported using `enterprise_project_id` and `id`, separated by a slash, e.g.
 
+### Import resource under the default enterprise project
+
+```bash
+$ terraform import huaweicloud_hss_host_group.test 0/<id>
+```
+
+### Import resource from non default enterprise project
+
 ```bash
 $ terraform import huaweicloud_hss_host_group.test <enterprise_project_id>/<id>
 ```

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_group_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_group_test.go
@@ -52,6 +52,8 @@ func TestAccHostGroup_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "host_ids.#", "1"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(rName, "host_num"),
 				),
 			},
 			{
@@ -60,12 +62,18 @@ func TestAccHostGroup_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
 					resource.TestCheckResourceAttr(rName, "host_ids.#", "2"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(rName, "host_num"),
 				),
 			},
 			{
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: testAccHostGroupImportStateIDFunc(rName),
+				ImportStateVerifyIgnore: []string{
+					"unprotect_host_ids",
+				},
 			},
 		},
 	})
@@ -82,11 +90,12 @@ resource "huaweicloud_kps_keypair" "test" {
 resource "huaweicloud_compute_instance" "test" {
   count = 2
 
-  name               = "%[2]s"
-  image_id           = data.huaweicloud_images_image.test.id
-  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
-  security_groups    = [huaweicloud_networking_secgroup.test.name]
-  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  name                  = "%[2]s"
+  image_id              = data.huaweicloud_images_image.test.id
+  flavor_id             = data.huaweicloud_compute_flavors.test.ids[0]
+  security_groups       = [huaweicloud_networking_secgroup.test.name]
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  enterprise_project_id = "%[3]s"
 
   key_pair   = huaweicloud_kps_keypair.test.name
   agent_list = "hss"
@@ -95,7 +104,7 @@ resource "huaweicloud_compute_instance" "test" {
     uuid = huaweicloud_vpc_subnet.test.id
   }
 }
-`, common.TestBaseComputeResources(name), name)
+`, common.TestBaseComputeResources(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testAccHostGroup_basic(name string) string {
@@ -103,10 +112,17 @@ func testAccHostGroup_basic(name string) string {
 %[1]s
 
 resource "huaweicloud_hss_host_group" "test" {
-  name     = "%[2]s"
-  host_ids = slice(huaweicloud_compute_instance.test[*].id, 0, 1)
+  name                  = "%[2]s"
+  host_ids              = slice(huaweicloud_compute_instance.test[*].id, 0, 1)
+  enterprise_project_id = "%[3]s"
+
+  lifecycle {
+    ignore_changes = [
+      unprotect_host_ids,
+    ]
+  }
 }
-`, testAccHostGroup_base(name), name)
+`, testAccHostGroup_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testAccHostGroup_update(name string) string {
@@ -114,8 +130,33 @@ func testAccHostGroup_update(name string) string {
 %[1]s
 
 resource "huaweicloud_hss_host_group" "test" {
-  name     = "%[2]s-update"
-  host_ids = huaweicloud_compute_instance.test[*].id
+  name                  = "%[2]s-update"
+  host_ids              = huaweicloud_compute_instance.test[*].id
+  enterprise_project_id = "%[3]s"
+
+  lifecycle {
+    ignore_changes = [
+      unprotect_host_ids,
+    ]
+  }
 }
-`, testAccHostGroup_base(name), name)
+`, testAccHostGroup_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccHostGroupImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		epsId := rs.Primary.Attributes["enterprise_project_id"]
+		id := rs.Primary.ID
+		if epsId == "" || id == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want '<enterprise_project_id>/<id>', but got '%s/%s'",
+				epsId, id)
+		}
+		return fmt.Sprintf("%s/%s", epsId, id), nil
+	}
 }

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_group_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_group_test.go
@@ -42,6 +42,7 @@ func TestAccHostGroup_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_host_group.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_host_group.go
@@ -376,8 +376,7 @@ func resourceHostGroupImportState(_ context.Context, d *schema.ResourceData, _ i
 		return nil, fmt.Errorf("invalid format of import ID, must be <enterprise_project_id>/<id>")
 	}
 
-	d.Set("enterprise_project_id", parts[0])
 	d.SetId(parts[1])
 
-	return []*schema.ResourceData{d}, nil
+	return []*schema.ResourceData{d}, d.Set("enterprise_project_id", parts[0])
 }

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_host_group.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_host_group.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -48,7 +49,7 @@ func ResourceHostGroup() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceHostGroupImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -108,15 +109,15 @@ func ResourceHostGroup() *schema.Resource {
 	}
 }
 
-func checkAllHostsAvailable(ctx context.Context, client *hssv5.HssClient, hostIds []string,
+func checkAllHostsAvailable(ctx context.Context, client *hssv5.HssClient, epsId string, hostIDs []string,
 	timeout time.Duration) ([]string, error) {
 	unprotected := make([]string, 0)
-	for _, hostId := range hostIds {
+	for _, hostId := range hostIDs {
 		log.Printf("[DEBUG] Waiting for the host (%s) status to become available.", hostId)
 		stateConf := &resource.StateChangeConf{
 			Pending:      []string{"PENDING"},
 			Target:       []string{"COMPLETED"},
-			Refresh:      hostStatusRefreshFunc(client, hostId),
+			Refresh:      hostStatusRefreshFunc(client, epsId, hostId),
 			Timeout:      timeout,
 			Delay:        30 * time.Second,
 			PollInterval: 30 * time.Second,
@@ -132,12 +133,17 @@ func checkAllHostsAvailable(ctx context.Context, client *hssv5.HssClient, hostId
 	return unprotected, nil
 }
 
-func hostStatusRefreshFunc(client *hssv5.HssClient, hostId string) resource.StateRefreshFunc {
+func hostStatusRefreshFunc(client *hssv5.HssClient, epsId, hostId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		var unprotectedHostId string
+		if epsId == "" {
+			epsId = "all_granted_eps"
+		}
+
 		request := hssv5model.ListHostStatusRequest{
-			Refresh: utils.Bool(true),
-			HostId:  utils.String(hostId),
+			EnterpriseProjectId: utils.String(epsId),
+			Refresh:             utils.Bool(true),
+			HostId:              utils.String(hostId),
 		}
 		resp, err := client.ListHostStatus(&request)
 		if err != nil {
@@ -178,7 +184,7 @@ func resourceHostGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	)
 
-	unprotected, err := checkAllHostsAvailable(ctx, client, hostIds, d.Timeout(schema.TimeoutCreate))
+	unprotected, err := checkAllHostsAvailable(ctx, client, epsId, hostIds, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -321,7 +327,7 @@ func resourceHostGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	)
 
-	unprotected, err := checkAllHostsAvailable(ctx, client, hostIds, d.Timeout(schema.TimeoutUpdate))
+	unprotected, err := checkAllHostsAvailable(ctx, client, epsId, hostIds, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -361,4 +367,17 @@ func resourceHostGroupDelete(_ context.Context, d *schema.ResourceData, meta int
 	}
 
 	return nil
+}
+
+func resourceHostGroupImportState(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format of import ID, must be <enterprise_project_id>/<id>")
+	}
+
+	d.Set("enterprise_project_id", parts[0])
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For the current host group resource, the checkAllHostsAvailable function does not set the enterprise project ID, so the value always queried is under the default enterprise project. When resource use non default enterprise project ID, checkAllHostsAvailable will generate a logical error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
1. Fix the error caused by the host group resource not using the enterprise project ID when checking if the host is available.
2. Add import function, because epsId="all_grantedu_eps" does not query all values for the host group list API, the import must enter the enterprise project ID.
3. Update acc test for verifying enterprise project ID parameter.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

## Basic
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_ENTERPRISE_PROJECT_ID_TEST=xxxxxxxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccHostGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccHostGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccHostGroup_basic
=== PAUSE TestAccHostGroup_basic
=== CONT  TestAccHostGroup_basic
--- PASS: TestAccHostGroup_basic (333.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       333.263s

```

## Skip
```
$ unset HW_ENTERPRISE_PROJECT_ID_TEST  
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccHostGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccHostGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccHostGroup_basic
=== PAUSE TestAccHostGroup_basic
=== CONT  TestAccHostGroup_basic
    acceptance.go:451: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccHostGroup_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       0.039s

```
