### PR TITLE
feat(DEW): kps keypair resource support to manage private_key

### DIFF
--- a/docs/resources/kps_keypair.md
+++ b/docs/resources/kps_keypair.md
@@ -43,12 +43,27 @@ resource "huaweicloud_kps_keypair" "test-keypair" {
 ### Import an existing keypair
 
 ```hcl
+variable "public_key" {}
+variable "kms_key_name" {}
 variable "private_key" {}
 
 resource "huaweicloud_kps_keypair" "test-keypair" {
-  name        = "my-keypair"
-  public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAlJq5Pu+eizhou7nFFDxXofr2ySF8k/yuA9OnJdVF9Fbf85Z59CWNZBvcAT... root@terra-dev"
-  private_key = var.private_key
+  name            = "my-keypair"
+  public_key      = var.public_key
+  encryption_type = "kms"
+  kms_key_name    = var.kms_key_name
+  private_key     = var.private_key
+}
+```
+
+### Import a keypair without a platform-managed private key
+
+```hcl
+variable "public_key" {}
+
+resource "huaweicloud_kps_keypair" "test-keypair" {
+  name       = "my-keypair"
+  public_key = var.public_key
 }
 ```
 
@@ -69,22 +84,20 @@ The following arguments are supported:
   The default value is `user`.
   Changing this parameter will create a new resource.
 
-* `encryption_type` - (Optional, String, ForceNew) Specifies encryption mode if manages the private key by HuaweiCloud.
+* `encryption_type` - (Optional, String) Specifies encryption mode if manages the private key by HuaweiCloud.
   The options are as follows:
   - **default**: The default encryption mode. Applicable to sites where KMS is not deployed.
   - **kms**: KMS encryption mode.
-  Changing this parameter will create a new resource.
 
-* `kms_key_name` - (Optional, String, ForceNew) Specifies the KMS key name to encrypt private keys.
-  It's mandatory when the `encryption_type` is `kms`. Changing this parameter will create a new resource.
+* `kms_key_name` - (Optional, String) Specifies the KMS key name to encrypt private keys.
+  It's mandatory when the `encryption_type` is `kms`.
 
 * `description` - (Optional, String) Specifies the description of key pair.
 
 * `public_key` - (Optional, String, ForceNew) Specifies the imported OpenSSH-formatted public key.
-  Changing this parameter will create a new resource.
+  It is required when import keypair. Changing this parameter will create a new resource.
 
-* `private_key` - (Optional, String, ForceNew) Specifies the imported OpenSSH-formatted private key.
-  Changing this parameter will create a new resource.
+* `private_key` - (Optional, String) Specifies the imported OpenSSH-formatted private key.
 
 * `key_file` - (Optional, String, ForceNew) Specifies the path of the created private key.
   The private key file (**.pem**) is created only after the resource is created.

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kps_keypair_test.go
@@ -2,7 +2,6 @@ package dew
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -13,6 +12,13 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+const (
+	publicKeyValue = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCDXP+kuDyXeZxf3p58VY/WH8yjzMAmNHXXxQKdHsvEy" +
+		"3mU4Egb7ANhDHXHFue0aywhY0XSVULVW1O7qwEtHHcJYBnbt7pKPWrE0rzSpvpvGy9BqxRV44AsHK2VTsXoKGEbXsImwgFwt/q" +
+		"5FkAqHMzWB3HJr8tb2rPs7mKjTHs9d1lFxHGehPYgjiFtCGcEOwxJnchGRKgPPa8Tcqkdy3poJ9JrGi6IgXcKtnhS/rZQ+naEG" +
+		"VdnC3Qi1Onu0ZixApdbplNcHiw/YBovImSf3JTyCn4U32o+dSFmOuUMovTvysfqtgbouJWEqwG1bQhIzGijW93vDIjjHu/vk/aet7sD rsa-key-20240321"
 )
 
 func getKpsKeypairResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -173,8 +179,7 @@ func TestAccKpsKeypair_privateKey(t *testing.T) {
 
 	rName := acceptance.RandomAccResourceName()
 	resourceName := "huaweicloud_kps_keypair.test"
-	publicKey, privateKeyPEM, _ := acctest.RandSSHKeyPair("Generated-by-AccTest")
-	privateKey := strings.ReplaceAll(privateKeyPEM, "\n", " ")
+
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&group,
@@ -187,15 +192,33 @@ func TestAccKpsKeypair_privateKey(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeypair_privateKey(rName, publicKey, privateKey),
+				Config: testKeypair_privateKey(rName, publicKeyValue),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "scope", "user"),
-					resource.TestCheckResourceAttr(resourceName, "public_key", publicKey),
-					resource.TestCheckResourceAttr(resourceName, "is_managed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "public_key", publicKeyValue),
+					resource.TestCheckResourceAttr(resourceName, "is_managed", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "fingerprint"),
+				),
+			},
+			{
+				Config: testKeypair_updatePrivateKey1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "public_key", publicKeyValue),
+					resource.TestCheckResourceAttr(resourceName, "is_managed", "false"),
+				),
+			},
+			{
+				Config: testKeypair_updatePrivateKey2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "public_key", publicKeyValue),
+					resource.TestCheckResourceAttr(resourceName, "is_managed", "true"),
 				),
 			},
 			{
@@ -203,7 +226,7 @@ func TestAccKpsKeypair_privateKey(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"private_key",
+					"private_key", "encryption_type", "kms_key_name",
 				},
 			},
 		},
@@ -228,14 +251,96 @@ resource "huaweicloud_kps_keypair" "test" {
 `, rName, key)
 }
 
-func testKeypair_privateKey(rName, publicKey, privateKey string) string {
+func testKeypair_privateKey(rName, publicKeyValue string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_kps_keypair" "test" {
-  name        = "%[1]s"
-  public_key  = "%[2]s"
-  private_key = "%[3]s"
+  name            = "%[1]s"
+  encryption_type = "default"
+  public_key      = "%[2]s"
+  
+  private_key = <<EOT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAg1z/pLg8l3mcX96efFWP1h/Mo8zAJjR118UCnR7LxMt5lOBI
+G+wDYQx1xxbntGssIWNF0lVC1VtTu6sBLRx3CWAZ27e6Sj1qxNK80qb6bxsvQasU
+VeOALBytlU7F6ChhG17CJsIBcLf6uRZAKhzM1gdxya/LW9qz7O5io0x7PXdZRcRx
+noT2II4hbQhnBDsMSZ3IRkSoDz2vE3KpHct6aCfSaxouiIF3CrZ4Uv62UPp2hBlX
+Zwt0ItTp7tGYsQKXW6ZTXB4sP2AaLyJkn9yU8gp+FN9qPnUhZjrlDKL078rH6rYG
+6LiVhKsBtW0ISMxoo1vd7wyI4x7v75P2nre7AwIDAQABAoIBAHxBcJM3riC96JuK
+cTE8ocSx6Zka6Lp6ruk9Mj66zZZFvaiECdFXis62wYVjdiJjqaefRoExIvm73FVM
+6Nzp6vMUUwFRJcZpl9+7Ut6TEZodBbNBBwhDHI8dRVhQ3cS+xTPlixKsOj6L2H5Q
+vLrY6SyeeBSF0378PWslBmpewsgdATi5hBl0j7/MoxtvHo7l8Fvyt1pMxpGBWDET
+7vXERTjmJCqN8zEejR6j6NpT+SY3DU3Xq+wj/1j3k038noBPrM90ECNkv8t9g85g
+n3VczkGBlzYkqEmk0Y1/OEJ4CrnZAQ8WlkgwIuIILz5u3vWF069fEr9LmyMQILpX
+KAqVyVECgYEA7JK3MqqJIp+5e4Jh6HlPElmekiB5DSAAWonBmMKiRDxwCHCZYD0W
+8HC5HaGl8R3opGuNVnGBJnCO3TYyuHeICI5Iv0GZA42yrGyYBmhIj2i8g5N90tAR
+Xv6bHKRiutalEgO1IRj67zHSBLBOc3UXUyYUDB8wdVn0RQAzctQ6ylsCgYEAjiaK
+x3h1pTVlr29jYByAa0NoK0MJZs0HsiFNZBTcftfkph45Vugaibf2YJWzGISmT9TK
+yIuGUP8ApFBBwkj0tBznG/3Kb9etUwRR02daUvDdL+PnAogu1D9j3OZV5w9foyUr
+Fq/FiGqH4IsrxAGjVG2jdKM+7O7xyXrifDGKInkCgYA9Rpc7AV753+M8MX5Ip7sq
+ZpojAVQ5aROOX+YMOkWrZPgjx36CpfAeISRhn3AK7xNGGzGFtWqdWUQ32gTzMMrE
+ZI5FM6l9eSNRc+NArZw1wQwrDHXnt8r4DvyAQ7fq6xPggaNVylGcyQu7+SqozyhW
+eiNxLFbx3nXdtXqeAIilxwKBgEuCg8PT5EJ/K+XWOKasXTcdVm9sq8jU7tqbwB2C
+y2IB0u6/LVxR7Q7tDs5dlwZWKHZNpe6D1zSdULz3+QZ4dKxckhOXa/qfSe3IZKL0
+ytE2K3iuCl+Y8a9DgQutu0IDM51ZOBtUAY0mcclAhF4ZNKa7mtFxihKYFw4c3cR1
+GFiZAoGAMIf+7j8AedEnJRiAzbA4ScFdFLGEcN8G0ENQ/VLe9XnwDy27mMiFsVj0
+WMzXvWX6JEkuu4bf/oZ16Uz95IkSocvURuRjSpNexC9efQPH38GUY89Rgf9fl2un
+elBITIidTQ9uv/yhqiJmEuVDNncL1W+GvHXk599FLXZpYOr24X4=
+-----END RSA PRIVATE KEY-----
+EOT
 }
-`, rName, publicKey, privateKey)
+`, rName, publicKeyValue)
+}
+
+func testKeypair_updatePrivateKey1(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kps_keypair" "test" {
+  name = "%[1]s"
+}
+`, rName)
+}
+
+func testKeypair_updatePrivateKey2(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_key" "test" {
+  key_alias    = "%s"
+  pending_days = "7"
+}
+
+resource "huaweicloud_kps_keypair" "test" {
+  name            = "%[1]s"
+  encryption_type = "kms"
+  kms_key_name    = huaweicloud_kms_key.test.key_alias
+  private_key = <<EOT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAg1z/pLg8l3mcX96efFWP1h/Mo8zAJjR118UCnR7LxMt5lOBI
+G+wDYQx1xxbntGssIWNF0lVC1VtTu6sBLRx3CWAZ27e6Sj1qxNK80qb6bxsvQasU
+VeOALBytlU7F6ChhG17CJsIBcLf6uRZAKhzM1gdxya/LW9qz7O5io0x7PXdZRcRx
+noT2II4hbQhnBDsMSZ3IRkSoDz2vE3KpHct6aCfSaxouiIF3CrZ4Uv62UPp2hBlX
+Zwt0ItTp7tGYsQKXW6ZTXB4sP2AaLyJkn9yU8gp+FN9qPnUhZjrlDKL078rH6rYG
+6LiVhKsBtW0ISMxoo1vd7wyI4x7v75P2nre7AwIDAQABAoIBAHxBcJM3riC96JuK
+cTE8ocSx6Zka6Lp6ruk9Mj66zZZFvaiECdFXis62wYVjdiJjqaefRoExIvm73FVM
+6Nzp6vMUUwFRJcZpl9+7Ut6TEZodBbNBBwhDHI8dRVhQ3cS+xTPlixKsOj6L2H5Q
+vLrY6SyeeBSF0378PWslBmpewsgdATi5hBl0j7/MoxtvHo7l8Fvyt1pMxpGBWDET
+7vXERTjmJCqN8zEejR6j6NpT+SY3DU3Xq+wj/1j3k038noBPrM90ECNkv8t9g85g
+n3VczkGBlzYkqEmk0Y1/OEJ4CrnZAQ8WlkgwIuIILz5u3vWF069fEr9LmyMQILpX
+KAqVyVECgYEA7JK3MqqJIp+5e4Jh6HlPElmekiB5DSAAWonBmMKiRDxwCHCZYD0W
+8HC5HaGl8R3opGuNVnGBJnCO3TYyuHeICI5Iv0GZA42yrGyYBmhIj2i8g5N90tAR
+Xv6bHKRiutalEgO1IRj67zHSBLBOc3UXUyYUDB8wdVn0RQAzctQ6ylsCgYEAjiaK
+x3h1pTVlr29jYByAa0NoK0MJZs0HsiFNZBTcftfkph45Vugaibf2YJWzGISmT9TK
+yIuGUP8ApFBBwkj0tBznG/3Kb9etUwRR02daUvDdL+PnAogu1D9j3OZV5w9foyUr
+Fq/FiGqH4IsrxAGjVG2jdKM+7O7xyXrifDGKInkCgYA9Rpc7AV753+M8MX5Ip7sq
+ZpojAVQ5aROOX+YMOkWrZPgjx36CpfAeISRhn3AK7xNGGzGFtWqdWUQ32gTzMMrE
+ZI5FM6l9eSNRc+NArZw1wQwrDHXnt8r4DvyAQ7fq6xPggaNVylGcyQu7+SqozyhW
+eiNxLFbx3nXdtXqeAIilxwKBgEuCg8PT5EJ/K+XWOKasXTcdVm9sq8jU7tqbwB2C
+y2IB0u6/LVxR7Q7tDs5dlwZWKHZNpe6D1zSdULz3+QZ4dKxckhOXa/qfSe3IZKL0
+ytE2K3iuCl+Y8a9DgQutu0IDM51ZOBtUAY0mcclAhF4ZNKa7mtFxihKYFw4c3cR1
+GFiZAoGAMIf+7j8AedEnJRiAzbA4ScFdFLGEcN8G0ENQ/VLe9XnwDy27mMiFsVj0
+WMzXvWX6JEkuu4bf/oZ16Uz95IkSocvURuRjSpNexC9efQPH38GUY89Rgf9fl2un
+elBITIidTQ9uv/yhqiJmEuVDNncL1W+GvHXk599FLXZpYOr24X4=
+-----END RSA PRIVATE KEY-----
+EOT
+}
+`, rName, rName)
 }
 
 func testKeypair_domain(rName string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 kps keypair resource support to manage private_key
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Remove the forceNew attribute in private_key kms_key_name and encryption_type params schema.
2.Support to update kps keypair private key.
3.Modify the test cases.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dew TESTARGS='-run TestAccKpsKeypair_privateKey'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKpsKeypair_privateKey -timeout 360m -parallel 4
=== RUN   TestAccKpsKeypair_privateKey
--- PASS: TestAccKpsKeypair_privateKey (62.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       62.046ss
```
