### PR TITLE
feat(RDS): rds instance support msdtc hosts

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -270,6 +270,11 @@ The following arguments are supported:
 * `binlog_retention_hours` - (Optional, Int) Specify the binlog retention period in hours. This parameter applies only to
   MySQL Server databases. Value range: **0** to **168 (7x24)**.
 
+* `msdtc_hosts` - (Optional, List) Specify the host information for MSDTC.
+  The [msdtc_hosts](#RdsInstance_MsdtcHosts) structure is documented below.
+
+  -> **NOTE:** Only adding MSDTC hosts is supported, deletion is not allowed.
+
 The `db` block supports:
 
 * `type` - (Required, String, ForceNew) Specifies the DB engine. Available value are **MySQL**, **PostgreSQL**,
@@ -356,6 +361,13 @@ The `parameters` block supports:
 
 * `value` - (Required, String) Specifies the parameter value.
 
+<a name="RdsInstance_MsdtcHosts"></a>
+The `msdtc_hosts` block supports:
+
+* `ip` - (Required, String) Specifies the host IP address.
+
+* `host_name` - (Required, String) Specifies the host name.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -374,6 +386,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `public_ips` - Indicates the public IP address list.
 
+* `msdtc_hosts` - Indicates the host information for MSDTC.
+  The [msdtc_hosts](#RdsInstance_MsdtcHostsResp) structure is documented below.
+
 The `nodes` block contains:
 
 * `availability_zone` - Indicates the AZ.
@@ -386,6 +401,11 @@ The `nodes` block contains:
   respectively.
 
 * `status` - Indicates the node status.
+
+<a name="RdsInstance_MsdtcHostsResp"></a>
+The `msdtc_hosts` block supports:
+
+* `id` - Indicates the host ID.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support msdtc hosts
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support msdtc hosts
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 10
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_ha
--- PASS: TestAccRdsInstance_mariadb (448.78s)
--- PASS: TestAccRdsInstance_ha (557.19s)
--- PASS: TestAccRdsInstance_basic (599.84s)
--- PASS: TestAccRdsInstance_prePaid (1194.39s)
--- PASS: TestAccRdsInstance_restore_pg (1355.03s)
--- PASS: TestAccRdsInstance_mysql (1370.75s)
--- PASS: TestAccRdsInstance_restore_mysql (1432.17s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2013.68s)
--- PASS: TestAccRdsInstance_sqlserver (2952.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2952.525s
```
