### PR TITLE
chore(dli): fix the issue of the flink sql job acceptance test failure

### DIFF
--- a/docs/resources/dli_flinksql_job.md
+++ b/docs/resources/dli_flinksql_job.md
@@ -46,6 +46,7 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies job description. Length range: 1 to 512 characters.
 
 * `queue_name` - (Optional, String) Specifies name of a queue.
+  If you want to use the parameters, the `run_mode` parameter must be set to `exclusive_cluster`.
 
 * `sql` - (Optional, String) Specifies stream SQL statement, which includes at least the following
  three parts: source, query, and sink. Length range: 1024x1024 characters.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In the test case, the test case fails because the general queue is not bound, so specifies the `queue_name` parameter for the fink sql job (binding the queue is only supported when the `run_mode` parameter is `exclusive_cluster`).
The error message before repair is as follows:
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/5c36c075-8df7-4223-bb91-097882680315)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the issue of the flink sql job acceptance test failure.
2. add constraint description for queue_name parameter.

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST=./huaweicloud/services/acceptance/dli TESTARGS='-run TestAccResourceDliFlinkJob_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccResourceDliFlinkJob_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDliFlinkJob_basic
=== PAUSE TestAccResourceDliFlinkJob_basic
=== CONT  TestAccResourceDliFlinkJob_basic
--- PASS: TestAccResourceDliFlinkJob_basic (355.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       355.842s
```
