### PR TITLE
fix(iotda/device): remove the default value of the secure_access parameter from the device resource

### DIFF
--- a/docs/resources/iotda_device.md
+++ b/docs/resources/iotda_device.md
@@ -97,9 +97,9 @@ which is a 40-digit or 64-digit hexadecimal string. For more detail, please see
   fields and `fingerprint`, `secondary_fingerprint` fields cannot be set simultaneously.
 
 * `secure_access` - (Optional, Bool) Specifies whether the device is connected through a secure protocol.
-  The default value is **true**. If specified as **false**, this means accessing via an insecure protocol, and the
-  device accessed through insecure methods are susceptible to security risks such as counterfeiting.
-  Please use with caution.
+  This parameter is only valid when `secret` or `fingerprint` is specified, and suggest setting it to **true**.
+  If ignored, it means accessing through insecure protocols, and the device is susceptible to security risks such as
+  counterfeiting, please be cautious with this configuration.
 
 * `force_disconnect` - (Optional, Bool) Specifies whether to force device disconnection when resetting secrets or
   fingerprints, currently, only long connections are allowed. The default value is **false**.

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_test.go
@@ -49,7 +49,7 @@ func TestAccDevice_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "secret", "1234567890"),
 					resource.TestCheckResourceAttr(rName, "secondary_secret", "test123456"),
-					resource.TestCheckResourceAttr(rName, "secure_access", "false"),
+					resource.TestCheckResourceAttr(rName, "secure_access", "true"),
 					resource.TestCheckResourceAttr(rName, "description", "demo"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "status", "INACTIVE"),
@@ -70,7 +70,7 @@ func TestAccDevice_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "fingerprint", "1234567890123456789012345678901234567890"),
 					resource.TestCheckResourceAttr(rName, "secondary_fingerprint", "dc0f1016f495157344ac5f1296335cff725ef22f"),
-					resource.TestCheckResourceAttr(rName, "secure_access", "true"),
+					resource.TestCheckResourceAttr(rName, "secure_access", "false"),
 					resource.TestCheckResourceAttr(rName, "description", "demo_update"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar_update"),
 					resource.TestCheckResourceAttr(rName, "status", "FROZEN"),
@@ -126,7 +126,7 @@ func TestAccDevice_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "secret", "1234567890"),
 					resource.TestCheckResourceAttr(rName, "secondary_secret", "test123456"),
-					resource.TestCheckResourceAttr(rName, "secure_access", "false"),
+					resource.TestCheckResourceAttr(rName, "secure_access", "true"),
 					resource.TestCheckResourceAttr(rName, "description", "demo"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "status", "INACTIVE"),
@@ -147,7 +147,7 @@ func TestAccDevice_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "node_id", nodeId),
 					resource.TestCheckResourceAttr(rName, "fingerprint", "1234567890123456789012345678901234567890"),
 					resource.TestCheckResourceAttr(rName, "secondary_fingerprint", "dc0f1016f495157344ac5f1296335cff725ef22f"),
-					resource.TestCheckResourceAttr(rName, "secure_access", "true"),
+					resource.TestCheckResourceAttr(rName, "secure_access", "false"),
 					resource.TestCheckResourceAttr(rName, "description", "demo_update"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar_update"),
 					resource.TestCheckResourceAttr(rName, "status", "FROZEN"),
@@ -185,7 +185,7 @@ resource "huaweicloud_iotda_device" "test" {
   product_id       = huaweicloud_iotda_product.test.id
   secret           = "1234567890"
   secondary_secret = "test123456"
-  secure_access    = false
+  secure_access    = true
   force_disconnect = true
   description      = "demo"
 
@@ -217,6 +217,7 @@ resource "huaweicloud_iotda_device" "test" {
   product_id            = huaweicloud_iotda_product.test.id
   fingerprint           = "1234567890123456789012345678901234567890"
   secondary_fingerprint = "dc0f1016f495157344ac5f1296335cff725ef22f"
+  secure_access         = false
   description           = "demo_update"
   frozen                = true
 

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device.go
@@ -124,7 +124,7 @@ func ResourceDevice() *schema.Resource {
 			"secure_access": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Computed: true,
 			},
 			"force_disconnect": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

An error was found in the acc test of the BatchTask resource: if the `secret` or `fingerprint` is not set when creating the device, the API will return **false** for the `secure_access` field, which is inconsistent with the default value of **true** defined in the schema and generates an error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

1. Remove the setting of default value in the schema. Add a description in the document and suggest that users set it to **true** when using it.
2. With this change, the acc test in BatchTask resource can be executed successfully.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

## Device Resource
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDevice_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDevice_basic -timeout 360m -parallel 4
=== RUN   TestAccDevice_basic
--- PASS: TestAccDevice_basic (16.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     16.104s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDevice_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDevice_derived -timeout 360m -parallel 4
=== RUN   TestAccDevice_derived
    acceptance.go:1385: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccDevice_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.035s


$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e33xxxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDevice_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDevice_derived -timeout 360m -parallel 4
=== RUN   TestAccDevice_derived
--- PASS: TestAccDevice_derived (30.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     30.269s

```

## BatchTask Resource
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_basic -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_basic
--- PASS: TestAccBatchTask_basic (19.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     19.214s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_derived -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_derived
    acceptance.go:1385: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccBatchTask_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.062s


$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e33xxxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccBatchTask_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_derived -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_derived
--- PASS: TestAccBatchTask_derived (23.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     23.441s

```
