### PR TITLE
feat(iam): add resource service agency

### DIFF
--- a/docs/resources/identity_service_agency.md
+++ b/docs/resources/identity_service_agency.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# huaweicloud_identity_service_agency
+
+Manages a service agency resource within HuaweiCloud.
+
+-> **NOTE:** You *must* have admin privileges to use this resource.
+
+## Example Usage
+
+### Delegate another HUAWEI CLOUD service to perform operations on your resources
+
+```hcl
+variable "agency_name" {}
+variable "delegated_service_name" {}
+variable "policy_name" {}
+
+resource "huaweicloud_identity_service_agency" "test" {
+  name                   = var.agency_name
+  delegated_service_name = var.delegated_service_name
+  policy_names           = [var.policy_name]
+  description            = "test demo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String, ForceNew) Specifies the name of service agency. The name is a string of `1` to `64`
+  characters. Only English letters, digits, underscores (_), plus (+), equals (=), commas (,), dots (.), ats (@) and
+  hyphens (-) are allowed. Changing this will create a new service agency.
+
+* `delegated_service_name` - (Required, String, ForceNew) Specifies the name of delegated service name.
+  Prefix is `service.`. Such as **service.APIG**. Changing this will create a new service agency.
+
+* `policy_names` - (Required, List) Specifies a string list of one or more policy names that you would like to attach to
+  the service agency.
+
+* `path` - (Optional, String, ForceNew) Specifies the resource path. It is made of several strings, each containing one
+  or more English letters, digits, underscores (_), plus (+), equals (=), comma (,), dots (.), at (@) and hyphens (-),
+  and must be ended with slash (/). Such as **foo/bar/**. It's a part of the uniform resource name. Default is empty.
+  Changing this will create a new service agency.
+
+* `duration` - (Optional, Int) Specifies the validity period of a service agency.
+  Default value is **3600**. The unit is seconds.
+
+* `tags` - (Optional, Map) Specifies the tags of the service agency.
+
+* `description` - (Optional, String) Specifies the description of the service agency.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The service agency ID.
+
+* `trust_policy` - The trust policy of the service agency. It's a JSON string.
+
+* `urn` - The uniform resource name of the service agency. Format is `iam::$accountID:agency:$path$agencyName` where
+  `$accountID` is IAM account ID, `$path` is `path`, `$agencyName` is `name`.
+
+* `created_at` - The time when the service agency was created.
+
+## Import
+
+Service agencies can be imported using the `id`, e.g.
+
+```
+$ terraform import huaweicloud_identity_service_agency.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1126,6 +1126,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_identity_access_key":            iam.ResourceIdentityKey(),
 			"huaweicloud_identity_acl":                   iam.ResourceIdentityACL(),
 			"huaweicloud_identity_agency":                iam.ResourceIAMAgencyV3(),
+			"huaweicloud_identity_service_agency":        iam.ResourceIAMServiceAgency(),
 			"huaweicloud_identity_group":                 iam.ResourceIdentityGroup(),
 			"huaweicloud_identity_group_membership":      iam.ResourceIdentityGroupMembership(),
 			"huaweicloud_identity_group_role_assignment": iam.ResourceIdentityGroupRoleAssignment(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_service_agency_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_service_agency_test.go
@@ -1,0 +1,123 @@
+package iam
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/identity/v3/agency"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getIdentityServiceAgencyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("iam_no_version", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IAM client: %s", err)
+	}
+	getAgencyHttpUrl := "v5/agencies/{agency_id}"
+	getAgencyPath := client.Endpoint + getAgencyHttpUrl
+	getAgencyPath = strings.ReplaceAll(getAgencyPath, "{agency_id}", state.Primary.ID)
+	getAgencyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getAgencyResp, err := client.Request("GET", getAgencyPath, &getAgencyOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IAM service agency: %s", err)
+	}
+	return utils.FlattenResponse(getAgencyResp)
+}
+
+func TestAccIdentityServiceAgency_basic(t *testing.T) {
+	var object agency.Agency
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_identity_service_agency.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&object,
+		getIdentityServiceAgencyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityServiceAgency_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "delegated_service_name", "service.APIG"),
+					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "duration", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test for terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "trust_policy"),
+					resource.TestCheckResourceAttrSet(resourceName, "urn"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+				),
+			},
+			{
+				Config: testAccIdentityServiceAgency_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "policy_names.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "duration", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo1", "bar1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test for terraform update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccIdentityServiceAgency_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_service_agency" "test" {
+  name                   = "%s"
+  delegated_service_name = "service.APIG"
+  policy_names           = ["NATReadOnlyPolicy"]
+  description            = "test for terraform"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName)
+}
+
+func testAccIdentityServiceAgency_update(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_service_agency" "test" {
+  name                   = "%s"
+  delegated_service_name = "service.APIG"
+  policy_names           = ["NATReadOnlyPolicy", "RDSReadOnlyPolicy"]
+  duration               = 7200
+  description            = "test for terraform update"
+
+  tags = {
+    foo1 = "bar1"
+    key1 = "value1"
+  }
+}
+`, rName)
+}

--- a/huaweicloud/services/iam/resource_huaweicloud_identity_service_agency.go
+++ b/huaweicloud/services/iam/resource_huaweicloud_identity_service_agency.go
@@ -1,0 +1,545 @@
+package iam
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const pageLimit = 100
+
+// @API IAM POST /v5/agencies
+// @API IAM GET /v5/agencies/{agency_id}
+// @API IAM PUT /v5/agencies/{agency_id}
+// @API IAM DELETE /v5/agencies/{agency_id}
+// @API IAM GET /v5/policies
+// @API IAM POST /v5/policies/{policy_id}/attach-agency
+// @API IAM POST /v5/policies/{policy_id}/detach-agency
+// @API IAM GET /v5/agencies/{agency_id}/attached-policies
+// @API IAM POST /v5/{resource_type}/{resource_id}/tags/create
+// @API IAM POST /v5/{resource_type}/{resource_id}/tags/delete
+func ResourceIAMServiceAgency() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIAMServiceAgencyCreate,
+		ReadContext:   resourceIAMServiceAgencyRead,
+		UpdateContext: resourceIAMServiceAgencyUpdate,
+		DeleteContext: resourceIAMServiceAgencyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"delegated_service_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy_names": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"duration": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": common.TagsSchema(),
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"trust_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"urn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceIAMServiceAgencyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("iam_no_version", region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	// get policy IDs by names
+	policyIDs, err := getPolicyIDsByNames(client, d.Get("policy_names").(*schema.Set).List())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createAgencyHttpUrl := "v5/agencies"
+	createAgencyPath := client.Endpoint + createAgencyHttpUrl
+	createAgencyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateAgencyBodyParams(d)),
+	}
+	createAgencyResp, err := client.Request("POST", createAgencyPath, &createAgencyOpt)
+	if err != nil {
+		return diag.Errorf("error creating IAM service agency: %s", err)
+	}
+	createAgencyRespBody, err := utils.FlattenResponse(createAgencyResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("agency.agency_id", createAgencyRespBody)
+	if err != nil {
+		return diag.Errorf("error creating IAM service agency: agency_id is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	// attach policies by ID
+	for _, policyID := range policyIDs {
+		if err = attachPolicyByID(client, d.Id(), policyID); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// create tags
+	if err := createTags(client, d.Get("tags").(map[string]interface{}), "agency", d.Id()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceIAMServiceAgencyRead(ctx, d, meta)
+}
+
+func buildCreateAgencyBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"agency_name":          d.Get("name"),
+		"trust_policy":         buildTrustPolicy(d.Get("delegated_service_name").(string)),
+		"path":                 utils.ValueIngoreEmpty(d.Get("path")),
+		"max_session_duration": utils.ValueIngoreEmpty(d.Get("duration")),
+		"description":          utils.ValueIngoreEmpty(d.Get("description")),
+	}
+	return bodyParams
+}
+
+func buildTrustPolicy(delegatedServiceName string) string {
+	// only the delegated_service_name is variable
+	statement := make([]map[string]interface{}, 1)
+	v := map[string]interface{}{
+		"Effect": "Allow",
+		"Principal": map[string]interface{}{
+			"Service": []string{delegatedServiceName},
+		},
+		"Action": []string{"sts:agencies:assume"},
+	}
+	statement[0] = v
+	trustPolicy := map[string]interface{}{
+		"Version":   "5.0",
+		"Statement": statement,
+	}
+	s, _ := json.Marshal(trustPolicy)
+
+	return string(s)
+}
+
+func resourceIAMServiceAgencyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("iam_no_version", region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	getAgencyHttpUrl := "v5/agencies/{agency_id}"
+	getAgencyPath := client.Endpoint + getAgencyHttpUrl
+	getAgencyPath = strings.ReplaceAll(getAgencyPath, "{agency_id}", d.Id())
+	getAgencyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getAgencyResp, err := client.Request("GET", getAgencyPath, &getAgencyOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IAM service")
+	}
+	getAgencyRespBody, err := utils.FlattenResponse(getAgencyResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	agency, err := jmespath.Search("agency", getAgencyRespBody)
+	if err != nil {
+		return diag.Errorf("error getting IAM service agency: agency is not found in API response")
+	}
+
+	// extract delegated service name
+	var policy interface{}
+	trustPolicy := utils.PathSearch("trust_policy", agency, nil)
+	err = json.Unmarshal([]byte(trustPolicy.(string)), &policy)
+	if err != nil {
+		return diag.Errorf("error unmarshaling trust policy: %s", err)
+	}
+
+	// get attached policy names
+	policyNames, err := listAttachedPolicyInfo(client, d.Id(), "policy_name")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("name", utils.PathSearch("agency_name", agency, nil)),
+		d.Set("path", utils.PathSearch("path", agency, nil)),
+		d.Set("duration", utils.PathSearch("max_session_duration", agency, nil)),
+		d.Set("description", utils.PathSearch("description", agency, nil)),
+		d.Set("tags", flattenTagsToMap(utils.PathSearch("tags", agency, make([]interface{}, 0)))),
+		d.Set("urn", utils.PathSearch("urn", agency, nil)),
+		d.Set("created_at", utils.PathSearch("created_at", agency, nil)),
+		d.Set("trust_policy", utils.PathSearch("trust_policy", agency, nil)),
+		d.Set("delegated_service_name", utils.PathSearch("Statement[0].Principal.Service[0]", policy, nil)),
+		d.Set("policy_names", policyNames),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting IAM service agency fields: %s", err)
+	}
+
+	return nil
+}
+
+func flattenTagsToMap(tags interface{}) map[string]interface{} {
+	if tagArray, ok := tags.([]interface{}); ok {
+		result := make(map[string]interface{})
+		for _, val := range tagArray {
+			if t, ok := val.(map[string]interface{}); ok {
+				result[t["tag_key"].(string)] = t["tag_value"]
+			}
+		}
+		return result
+	}
+	return nil
+}
+
+func listAttachedPolicyInfo(client *golangsdk.ServiceClient, agencyID, infoType string) ([]string, error) {
+	listPolicyHttpUrl := "v5/agencies/{agency_id}/attached-policies"
+	listPolicyPath := client.Endpoint + listPolicyHttpUrl
+	listPolicyPath = strings.ReplaceAll(listPolicyPath, "{agency_id}", agencyID)
+	listPolicyPath += fmt.Sprintf("?limit=%v", pageLimit)
+	listPolicyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	path := listPolicyPath
+	rst := make([]string, 0)
+	for {
+		listPolicyResp, err := client.Request("GET", path, &listPolicyOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error getting IAM policies: %s", err)
+		}
+		listPolicyRespBody, err := utils.FlattenResponse(listPolicyResp)
+		if err != nil {
+			return nil, err
+		}
+
+		// only get policy names or policy IDs
+		jsonPath := fmt.Sprintf("attached_policies[*].%s", infoType)
+		policyInfos := utils.PathSearch(jsonPath, listPolicyRespBody, make([]interface{}, 0))
+		rst = append(rst, utils.ExpandToStringList(policyInfos.([]interface{}))...)
+
+		marker := utils.PathSearch("page_info.next_marker", listPolicyRespBody, "")
+		if marker == "" {
+			break
+		}
+		path = fmt.Sprintf("%s&marker=%s", listPolicyPath, marker)
+	}
+	return rst, nil
+}
+
+func resourceIAMServiceAgencyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("iam_no_version", region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	if d.HasChanges("duration", "description") {
+		updateAgencyHttpUrl := "v5/agencies/{agency_id}"
+		updateAgencyPath := client.Endpoint + updateAgencyHttpUrl
+		updateAgencyPath = strings.ReplaceAll(updateAgencyPath, "{agency_id}", d.Id())
+		updateAgencyOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody: map[string]interface{}{
+				"max_session_duration": d.Get("duration"),
+				"description":          d.Get("description"),
+			},
+		}
+		_, err := client.Request("PUT", updateAgencyPath, &updateAgencyOpt)
+		if err != nil {
+			return diag.Errorf("error updating IAM service agency: %s", err)
+		}
+	}
+
+	// update attached policy
+	if d.HasChange("policy_names") {
+		oRaw, nRaw := d.GetChange("policy_names")
+		oMap := oRaw.(*schema.Set)
+		nMap := nRaw.(*schema.Set)
+
+		// list policy IDs which will be detached
+		detachPolicyIDs, err := getPolicyIDsByNames(client, oMap.Difference(nMap).List())
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		// detach policy by ID
+		for _, detachPolicyID := range detachPolicyIDs {
+			if err := detachPolicyByID(client, d.Id(), detachPolicyID); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		// list policy IDs which will be attached
+		attachPolicyIDs, err := getPolicyIDsByNames(client, nMap.Difference(oMap).List())
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		// attach policy by ID
+		for _, attachPolicyID := range attachPolicyIDs {
+			if err := attachPolicyByID(client, d.Id(), attachPolicyID); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	// update tags
+	if d.HasChange("tags") {
+		oRaw, nRaw := d.GetChange("tags")
+		oMap := oRaw.(map[string]interface{})
+		nMap := nRaw.(map[string]interface{})
+
+		// remove old tags
+		if len(oMap) > 0 {
+			if err = deleteTags(client, oMap, "agency", d.Id()); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		// set new tags
+		if len(nMap) > 0 {
+			if err := createTags(client, nMap, "agency", d.Id()); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	return resourceIAMServiceAgencyRead(ctx, d, meta)
+}
+
+func getPolicyIDsByNames(client *golangsdk.ServiceClient, policyNames []interface{}) ([]string, error) {
+	listPolicyHttpUrl := "v5/policies"
+	listPolicyPath := client.Endpoint + listPolicyHttpUrl
+	listPolicyPath += fmt.Sprintf("?limit=%v", pageLimit)
+	listPolicyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	path := listPolicyPath
+	rst := make([]string, 0)
+	for {
+		listPolicyResp, err := client.Request("GET", path, &listPolicyOpt)
+		if err != nil {
+			return nil, fmt.Errorf("error getting IAM policies: %s", err)
+		}
+		listPolicyRespBody, err := utils.FlattenResponse(listPolicyResp)
+		if err != nil {
+			return nil, err
+		}
+
+		policies := utils.PathSearch("policies", listPolicyRespBody, make([]interface{}, 0))
+		for _, policy := range policies.([]interface{}) {
+			policyName := utils.PathSearch("policy_name", policy, "")
+			if policyName == "" {
+				return nil, fmt.Errorf("error getting policy name")
+			}
+			policyID := utils.PathSearch("policy_id", policy, "")
+			if policyID == "" {
+				return nil, fmt.Errorf("error getting policy ID for name(%s)", policyName)
+			}
+
+			// use policy name to filter result
+			if utils.StrSliceContains(utils.ExpandToStringList(policyNames), policyName.(string)) {
+				rst = append(rst, policyID.(string))
+			}
+		}
+
+		// break when all names were found
+		if len(rst) == len(policyNames) {
+			break
+		}
+
+		marker := utils.PathSearch("page_info.next_marker", listPolicyRespBody, "")
+		if marker == "" {
+			break
+		}
+		path = fmt.Sprintf("%s&marker=%s", listPolicyPath, marker)
+	}
+	return rst, nil
+}
+
+func attachPolicyByID(client *golangsdk.ServiceClient, agencyID, policyID string) error {
+	attachHttpUrl := "v5/policies/{policy_id}/attach-agency"
+	attachPath := client.Endpoint + attachHttpUrl
+	attachPath = strings.ReplaceAll(attachPath, "{policy_id}", policyID)
+	attachOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"agency_id": agencyID,
+		},
+	}
+	_, err := client.Request("POST", attachPath, &attachOpt)
+	if err != nil {
+		return fmt.Errorf("error attaching IAM service agency to policy(%s): %s", policyID, err)
+	}
+	return nil
+}
+
+func detachPolicyByID(client *golangsdk.ServiceClient, agencyID, policyID string) error {
+	detachHttpUrl := "v5/policies/{policy_id}/detach-agency"
+	detachPath := client.Endpoint + detachHttpUrl
+	detachPath = strings.ReplaceAll(detachPath, "{policy_id}", policyID)
+	detachOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"agency_id": agencyID,
+		},
+	}
+	_, err := client.Request("POST", detachPath, &detachOpt)
+	if err != nil {
+		return fmt.Errorf("error detaching IAM service agency to policy(%s): %s", policyID, err)
+	}
+	return nil
+}
+
+func createTags(createTagsClient *golangsdk.ServiceClient, tags map[string]interface{}, resourceType, id string) error {
+	if len(tags) > 0 {
+		createTagsHttpUrl := "v5/{resource_type}/{resource_id}/tags/create"
+		createTagsPath := createTagsClient.Endpoint + createTagsHttpUrl
+		createTagsPath = strings.ReplaceAll(createTagsPath, "{resource_type}", resourceType)
+		createTagsPath = strings.ReplaceAll(createTagsPath, "{resource_id}", id)
+		createTagsOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody: map[string]interface{}{
+				"tags": expandResourceTags(tags),
+			},
+		}
+
+		_, err := createTagsClient.Request("POST", createTagsPath, &createTagsOpt)
+		if err != nil {
+			return fmt.Errorf("error creating tags: %s", err)
+		}
+	}
+	return nil
+}
+
+func expandResourceTags(tagmap map[string]interface{}) []map[string]interface{} {
+	var taglist []map[string]interface{}
+	for k, v := range tagmap {
+		tag := map[string]interface{}{
+			"tag_key":   k,
+			"tag_value": v,
+		}
+		taglist = append(taglist, tag)
+	}
+	return taglist
+}
+
+func deleteTags(deleteTagsClient *golangsdk.ServiceClient, tags map[string]interface{}, resourceType, id string) error {
+	if len(tags) > 0 {
+		deleteTagsHttpUrl := "v5/{resource_type}/{resource_id}/tags/delete"
+		deleteTagsPath := deleteTagsClient.Endpoint + deleteTagsHttpUrl
+		deleteTagsPath = strings.ReplaceAll(deleteTagsPath, "{resource_type}", resourceType)
+		deleteTagsPath = strings.ReplaceAll(deleteTagsPath, "{resource_id}", id)
+		deleteTagsOpt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody:         expandTagsKeyToStringList(tags),
+		}
+
+		_, err := deleteTagsClient.Request("DELETE", deleteTagsPath, &deleteTagsOpt)
+		if err != nil {
+			return fmt.Errorf("error deleting tags: %s", err)
+		}
+	}
+	return nil
+}
+
+func expandTagsKeyToStringList(tagmap map[string]interface{}) []string {
+	var tagKeyList []string
+	for k := range tagmap {
+		tagKeyList = append(tagKeyList, k)
+	}
+	return tagKeyList
+}
+
+func resourceIAMServiceAgencyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("iam_no_version", region)
+	if err != nil {
+		return diag.Errorf("error creating IAM client: %s", err)
+	}
+
+	// before deleting service agency, require to detach policies first
+	// get attached policy IDs
+	policyIDs, err := listAttachedPolicyInfo(client, d.Id(), "policy_id")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// detach policy by ID
+	for _, policyID := range policyIDs {
+		if err = detachPolicyByID(client, d.Id(), policyID); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	// delete service agency
+	deleteAgencyHttpUrl := "v5/agencies/{agency_id}"
+	deleteAgencyPath := client.Endpoint + deleteAgencyHttpUrl
+	deleteAgencyPath = strings.ReplaceAll(deleteAgencyPath, "{agency_id}", d.Id())
+	deleteAgencyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deleteAgencyPath, &deleteAgencyOpt)
+	if err != nil {
+		return diag.Errorf("error deleting IAM service agency: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add `resource.huaweicloud_identity_service_agency`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/iam" TESTARGS="-run TestAccIdentityServiceAgency_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iam -v -run TestAccIdentityServiceAgency_basic -timeout 360m -parallel 4
=== RUN   TestAccIdentityServiceAgency_basic
=== PAUSE TestAccIdentityServiceAgency_basic
=== CONT  TestAccIdentityServiceAgency_basic
--- PASS: TestAccIdentityServiceAgency_basic (43.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       43.102s
```
