### PR TITLE
feat(iotda): add a datasource to get the list of device groups

### DIFF
--- a/docs/data-sources/iotda_device_groups.md
+++ b/docs/data-sources/iotda_device_groups.md
@@ -1,0 +1,73 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_device_groups
+
+Use this data source to get the list of the IoTDA device groups.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify
+  the IoTDA service endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  *9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com*, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "device_group_id" {}
+data "huaweicloud_iotda_device_groups" "test" {
+  group_id = var.device_group_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the device groups.
+  If omitted, the provider-level region will be used.
+
+* `group_id` - (Optional, String) Specifies the ID of the device group.
+
+* `name` - (Optional, String) Specifies the name of the device group.
+
+* `type` - (Optional, String) Specifies the type of the device groups.
+  The valid values are as follows:
+  + **STATIC**: The device group is a static group.
+  + **DYNAMIC**: The device group is a dynamical group.
+
+* `parent_group_id` - (Optional, String) Specifies the ID of the parent device group to which the device group belongs.
+
+* `space_id` - (Optional, String) Specifies the ID of the resource space to which the device groups belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `groups` - The list of the device groups.
+  The [groups](#iotda_device_groups) structure is documented below.
+
+<a name="iotda_device_groups"></a>
+The `groups` block supports:
+
+* `id` - The ID of the device group.
+
+* `name` - The name of the device group.
+
+* `description` - The description of the device group.
+
+* `parent_group_id` - The ID of the parent device group to which the device group belongs.
+
+* `type` - The type of the device group.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -579,6 +579,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_iotda_amqps":                iotda.DataSourceAMQPQueues(),
 			"huaweicloud_iotda_dataforwarding_rules": iotda.DataSourceDataForwardingRules(),
+			"huaweicloud_iotda_device_groups":        iotda.DataSourceDeviceGroups(),
 			"huaweicloud_iotda_spaces":               iotda.DataSourceSpaces(),
 			"huaweicloud_iotda_products":             iotda.DataSourceProducts(),
 

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_groups_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_groups_test.go
@@ -1,0 +1,140 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDeviceGroups_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_device_groups.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		deviceName     = acceptance.RandomAccResourceName()
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDeviceGroups_basic(name, deviceName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.description"),
+
+					resource.TestCheckOutput("group_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDeviceGroups_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_device_groups.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		deviceName     = acceptance.RandomAccResourceName()
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDeviceGroups_basic(name, deviceName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.description"),
+
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDeviceGroups_basic(name, deviceName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_iotda_device_groups" "test" {
+  depends_on = [
+    huaweicloud_iotda_device_group.test
+  ]
+}
+
+locals {
+  group_id = data.huaweicloud_iotda_device_groups.test.groups[0].id
+}
+
+data "huaweicloud_iotda_device_groups" "group_id_filter" {
+  group_id = local.group_id
+}
+
+output "group_id_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_device_groups.group_id_filter.groups) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_groups.group_id_filter.groups[*].id : v == local.group_id]
+  )
+}
+
+locals {
+  name = data.huaweicloud_iotda_device_groups.test.groups[0].name
+}
+
+data "huaweicloud_iotda_device_groups" "name_filter" {
+  name = local.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_device_groups.name_filter.groups) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_groups.name_filter.groups[*].name : v == local.name]
+  )
+}
+
+locals {
+  type = data.huaweicloud_iotda_device_groups.test.groups[0].type
+}
+
+data "huaweicloud_iotda_device_groups" "type_filter" {
+  type = local.type
+}
+
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_device_groups.type_filter.groups) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_groups.type_filter.groups[*].type : v == local.type]
+  )
+}
+
+data "huaweicloud_iotda_device_groups" "not_found" {
+  name = "not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_device_groups.not_found.groups) == 0
+}
+`, testDeviceGroup_basic(name, deviceName))
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_groups.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_groups.go
@@ -1,0 +1,173 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/device-group
+func DataSourceDeviceGroups() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDeviceGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parent_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"parent_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDeviceGroupsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := WithDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allDeviceGroups []model.DeviceGroupResponseSummary
+		limit           = int32(50)
+		offset          int32
+	)
+
+	for {
+		listOpts := model.ListDeviceGroupsRequest{
+			Name:      utils.StringIgnoreEmpty(d.Get("name").(string)),
+			GroupType: utils.StringIgnoreEmpty(d.Get("type").(string)),
+			AppId:     utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+			Limit:     utils.Int32(limit),
+			Offset:    &offset,
+		}
+
+		listResp, listErr := client.ListDeviceGroups(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error querying IoTDA device groups: %s", listErr)
+		}
+
+		if len(*listResp.DeviceGroups) == 0 {
+			break
+		}
+
+		allDeviceGroups = append(allDeviceGroups, *listResp.DeviceGroups...)
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuId)
+
+	targetDeviceGroups := filterListDeviceGroups(allDeviceGroups, d)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("groups", flattenDeviceGroups(targetDeviceGroups)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterListDeviceGroups(deviceGroups []model.DeviceGroupResponseSummary, d *schema.ResourceData) []model.DeviceGroupResponseSummary {
+	if len(deviceGroups) == 0 {
+		return nil
+	}
+
+	rst := make([]model.DeviceGroupResponseSummary, 0, len(deviceGroups))
+	for _, v := range deviceGroups {
+		if deviceGroupId, ok := d.GetOk("group_id"); ok &&
+			fmt.Sprint(deviceGroupId) != utils.StringValue(v.GroupId) {
+			continue
+		}
+
+		if parentGroupId, ok := d.GetOk("parent_group_id"); ok &&
+			fmt.Sprint(parentGroupId) != utils.StringValue(v.SuperGroupId) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func flattenDeviceGroups(deviceGroups []model.DeviceGroupResponseSummary) []interface{} {
+	if len(deviceGroups) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(deviceGroups))
+	for _, v := range deviceGroups {
+		rst = append(rst, map[string]interface{}{
+			"id":              v.GroupId,
+			"name":            v.Name,
+			"description":     v.Description,
+			"parent_group_id": v.SuperGroupId,
+			"type":            v.GroupType,
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a datasource to get the list of device groups.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new datasource to get the list of the device groups.
2.support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
## Basic
```
$ export HW_REGION_NAME=cn-north-4 
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceGroups_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceGroups_basic
=== PAUSE TestAccDataSourceDeviceGroups_basic
=== CONT  TestAccDataSourceDeviceGroups_basic
--- PASS: TestAccDataSourceDeviceGroups_basic (63.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     63.652s
```
## Skip
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceGroups_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceGroups_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceGroups_derived
=== PAUSE TestAccDataSourceDeviceGroups_derived
=== CONT  TestAccDataSourceDeviceGroups_derived
    acceptance.go:1385: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccDataSourceDeviceGroups_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.042s
```
## Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceGroups_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceGroups_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceGroups_derived
=== PAUSE TestAccDataSourceDeviceGroups_derived
=== CONT  TestAccDataSourceDeviceGroups_derived
--- PASS: TestAccDataSourceDeviceGroups_derived (72.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     72.629s
```