### PR TITLE
test(dli): fix the issue of the sql job acceptance test failure

### DIFF
--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
@@ -45,6 +45,7 @@ func TestAccResourceDliSqlJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sql", fmt.Sprint("DESC ", name)),
 					resource.TestCheckResourceAttr(resourceName, "database_name", name),
 					resource.TestCheckResourceAttr(resourceName, "job_type", "DDL"),
+					resource.TestCheckResourceAttr(resourceName, "queue_name", name),
 				),
 			},
 			{
@@ -133,11 +134,17 @@ func testAccSqlJobBaseResource_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
+resource "huaweicloud_dli_queue" "test" {
+  name     = "%s"
+  cu_count = 16
+}
+
 resource "huaweicloud_dli_sql_job" "test" {
   sql           = "DESC ${huaweicloud_dli_table.test.name}"
   database_name = huaweicloud_dli_database.test.name
+  queue_name    = huaweicloud_dli_queue.test.name
 }
-`, testAccSQLJobBaseResource(name))
+`, testAccSQLJobBaseResource(name), name)
 }
 
 func testAccSQLJobBaseResource(name string) string {
@@ -151,7 +158,6 @@ resource "huaweicloud_dli_table" "test" {
   database_name = huaweicloud_dli_database.test.name
   name          = "%s"
   data_location = "DLI"
-  description   = "dli table test"
 
   columns {
     name        = "name"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the issue of the sql job acceptance test failure.
The error message before repair is as follows:
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/5fbe6ce0-8ef3-401b-83bc-7752abc9fb4c)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
The current resource depends on the `huaweicloud_dli_table resource`. After the `huaweicloud_dli_table` resource is created, 
the `table_comment` field obtained from the [the GET API ](https://support.huaweicloud.com/api-dli/dli_02_0033.html)  will contain extra characters `}`, the corresponding field in the schema is `description`. Currently  this is a bug and is waiting for back-end personnel to fix it.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/d2882e3f-df83-47e6-91e4-132bed0977c2)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix the issue of the sql job acceptance test failure.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
 make testacc TEST=./huaweicloud/services/acceptance/dli TESTARGS='-run TestAccResourceDliSqlJob_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccResourceDliSqlJob_ -timeout 360m -parallel 4
=== RUN   TestAccResourceDliSqlJob_basic
=== PAUSE TestAccResourceDliSqlJob_basic
=== RUN   TestAccResourceDliSqlJob_query
=== PAUSE TestAccResourceDliSqlJob_query
=== RUN   TestAccResourceDliSqlJob_async
=== PAUSE TestAccResourceDliSqlJob_async
=== CONT  TestAccResourceDliSqlJob_basic
=== CONT  TestAccResourceDliSqlJob_async
=== CONT  TestAccResourceDliSqlJob_query
--- PASS: TestAccResourceDliSqlJob_query (87.88s)
--- PASS: TestAccResourceDliSqlJob_async (88.81s)
--- PASS: TestAccResourceDliSqlJob_basic (385.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       385.086s
```
