### PR TITLE
feat(CDN): CDN domain resource support new field `configs.0.flexible_origin`

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -230,13 +230,20 @@ The `configs` block support:
   The [ip_frequency_limit](#ip_frequency_limit_object) structure is documented below.
 
   -> Restricting the IP access frequency can effectively defend against CC attacks, but it may affect normal access.
-  Please set access thresholds carefully.
+  Please set access thresholds carefully. After creating the domain name, please wait a few minutes before configuring
+  this field, otherwise the configuration may fail.
 
 * `websocket` - (Optional, List) Specifies the websocket settings. This field can only be configured if `type` is
   set to **wholeSite**. The [websocket](#websocket_object) structure is documented below.
 
   -> Websocket and HTTP/2 are incompatible and cannot be both enabled. Websocket will not take effect when
   origin cache control is enabled in the cache configuration.
+
+* `flexible_origin` - (Optional, List) Specifies the advanced origin rules.
+  The [flexible_origin](#flexible_origin_object) structure is documented below.
+
+  -> Up to 20 advanced origin rules can be configured. When `type` is configured as **wholeSite**, configuring this
+  field is not supported.
 
 <a name="https_settings_object"></a>
 The `https_settings` block support:
@@ -353,6 +360,50 @@ The `websocket` block support:
 
 * `timeout` - (Optional, Int) Specifies the duration for keeping a connection open, in seconds. The value ranges
   from **1** to **300**. This field is required when enable websocket settings.
+
+<a name="flexible_origin_object"></a>
+The `flexible_origin` block support:
+
+* `match_type` - (Required, String) Specifies the URI match mode. Valid values are as follows:
+  + **all**: All files.
+  + **file_extension**: File name extension.
+  + **file_path**: Directory.
+
+* `priority` - (Required, Int) Specifies the priority. The value of this field must be unique. Value ranges from **1**
+  to **100**. A greater number indicates a higher priority.
+
+* `back_sources` - (Required, List) Specifies the back source information. The length of this array field cannot exceed 1.
+  The [back_sources](#flexible_origin_back_sources_object) structure is documented below.
+
+* `match_pattern` - (Optional, String) Specifies the URI match rule. The usage rules are as follows:
+  + When `match_type` is set to **all**, set this field to empty.
+  + When `match_type` is set to **file_extension**, the value of this field should start with a period (.).
+    Enter up to 20 file name extensions and use semicolons (;) to separate them. Example: **.jpg;.zip;.exe**.
+  + When `match_type` is set to **file_path**, the value of this field should start with a slash (/).
+    Enter up to 20 paths and use semicolons (;) to separate them. Example: **/test/folder01;/test/folder02**.
+
+<a name="flexible_origin_back_sources_object"></a>
+The `back_sources` block support:
+
+* `sources_type` - (Required, String) Specifies the origin server type. Valid values are as follows:
+  + **ipaddr**: IP address.
+  + **domain**: Domain name.
+  + **obs_bucket**: OBS bucket.
+
+* `ip_or_domain` - (Required, String) Specifies the IP address or domain name of the origin server.
+  + When `sources_type` is set to **ipaddr**, the value of this field can only be set to a valid IPv4 or Ipv6 address.
+  + When `sources_type` is set to **domain**, the value of this field can only be set to a domain name.
+  + When `sources_type` is set to **obs_bucket**, the value of this field can only be set to an OBS bucket access
+    domain name.
+
+* `obs_bucket_type` - (Optional, String) Specifies the OBS bucket type. Valid values are **private** and **public**.
+  This field is required when `sources_type` is set to **obs_bucket**.
+
+* `http_port` - (Optional, Int) Specifies the HTTP port, ranging from **1** to **65535**. Defaults to **80**.
+
+* `https_port` - (Optional, Int) Specifies the HTTPS port, ranging from **1** to **65535**. Defaults to **443**.
+
+-> Fields `http_port` and `https_port` do not support editing when `sources_type` is set to **obs_bucket**.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -209,6 +209,8 @@ resource "huaweicloud_cdn_domain" "test" {
 `, acceptance.HW_CDN_DOMAIN_NAME)
 
 // Prepare the HTTPS certificate before running this test case
+// All configuration item modifications may trigger `CDN.0163`. This is a problem that we have no way to solve.
+// When a `CDN.0163` error occurs, you can avoid this error by adjusting the test case configuration items.
 func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 	var (
 		obj          interface{}
@@ -309,6 +311,8 @@ resource "huaweicloud_cdn_domain" "test" {
 }
 `, acceptance.HW_CDN_DOMAIN_NAME, acceptance.HW_CDN_CERT_PATH, acceptance.HW_CDN_PRIVATE_KEY_PATH)
 
+// All configuration item modifications may trigger `CDN.0163`. This is a problem that we have no way to solve.
+// When a `CDN.0163` error occurs, you can avoid this error by adjusting the test case configuration items.
 func TestAccCdnDomain_configs(t *testing.T) {
 	var (
 		obj          interface{}
@@ -341,8 +345,21 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "on"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_frequency_limit.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_frequency_limit.0.qps", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.match_type", "all"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.http_port", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.https_port", "65535"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.ip_or_domain", "165.132.12.2"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.sources_type", "ipaddr"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.match_type", "file_extension"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.match_pattern", ".jpg;.zip;.exe"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.priority", "2"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.back_sources.0.http_port", "65535"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.back_sources.0.https_port", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.back_sources.0.ip_or_domain", "165.5.1.4"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.back_sources.0.sources_type", "ipaddr"),
 				),
 			},
 			{
@@ -361,8 +378,15 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "on"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_frequency_limit.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_frequency_limit.0.qps", "100000"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.match_type", "file_path"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.match_pattern", "/test/folder01;/test/folder02"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.priority", "3"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.http_port", "83"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.https_port", "470"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.ip_or_domain", "www.hshs.cdd"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.sources_type", "domain"),
 				),
 			},
 			{
@@ -370,7 +394,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_frequency_limit.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
 				),
 			},
 			{
@@ -433,9 +457,29 @@ resource "huaweicloud_cdn_domain" "test" {
       type    = "http"
     }
 
-    ip_frequency_limit {
-      enabled = true
-      qps     = 1
+    flexible_origin {
+      match_type = "all"
+      priority   = 1
+
+      back_sources {
+        http_port    = 1
+        https_port   = 65535
+        ip_or_domain = "165.132.12.2"
+        sources_type = "ipaddr"
+      }
+    }
+
+    flexible_origin {
+      match_type    = "file_extension"
+      match_pattern = ".jpg;.zip;.exe"
+      priority      = 2
+
+      back_sources {
+        http_port    = 65535
+        https_port   = 1
+        ip_or_domain = "165.5.1.4"
+        sources_type = "ipaddr"
+      }
     }
   }
 }
@@ -489,9 +533,17 @@ resource "huaweicloud_cdn_domain" "test" {
       type    = "http"
     }
 
-    ip_frequency_limit {
-      enabled = true
-      qps     = 100000
+    flexible_origin {
+      match_type    = "file_path"
+      match_pattern = "/test/folder01;/test/folder02"
+      priority      = 3
+
+      back_sources {
+        http_port    = 83
+        https_port   = 470
+        ip_or_domain = "www.hshs.cdd"
+        sources_type = "domain"
+      }
     }
   }
 }
@@ -514,15 +566,12 @@ resource "huaweicloud_cdn_domain" "test" {
     origin_protocol               = "follow"
     ipv6_enable                   = false
     range_based_retrieval_enabled = false
-
-    ip_frequency_limit {
-      enabled = false
-    }
   }
 }
 `, acceptance.HW_CDN_DOMAIN_NAME)
 
-// This case is used to test fields that are only valid in the `wholeSite` scenario.
+// All configuration item modifications may trigger `CDN.0163`. This is a problem that we have no way to solve.
+// When a `CDN.0163` error occurs, you can avoid this error by adjusting the test case configuration items.
 func TestAccCdnDomain_configTypeWholeSite(t *testing.T) {
 	var (
 		obj          interface{}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Complete the CDN domain resource field.



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Add new field `configs.0.flexible_origin` to resource CDN domain.
- Remove field `ip_frequency_limit` in domain test case, cause the test conditions are insufficient.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (386.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       386.227s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (418.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       418.456s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (384.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       384.289s
```