### PR TITLE
feat(RDS): rds parametergroup add attributes created_at and updated_at

### DIFF
--- a/docs/resources/rds_parametergroup.md
+++ b/docs/resources/rds_parametergroup.md
@@ -70,6 +70,10 @@ In addition to all arguments above, the following attributes are exported:
   + `type` - Indicates the parameter type.
   + `description` - Indicates the parameter description.
 
+* `created_at` - The creation time, in UTC format.
+
+* `updated_at` - The last update time, in UTC format.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240325022336-b8d28279d50c
+	github.com/chnsz/golangsdk v0.0.0-20240326122909-40f5d835cc07
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240325022336-b8d28279d50c h1:dtMqsGyhcQi9nYUF+9lCNRN21zxdfYpVb3N0ogMasnY=
-github.com/chnsz/golangsdk v0.0.0-20240325022336-b8d28279d50c/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240326122909-40f5d835cc07 h1:yAz0lYNK/H42slriQICfP5dc1oaIm4Jnl8MMpIWPkYk=
+github.com/chnsz/golangsdk v0.0.0-20240326122909-40f5d835cc07/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_parametergroup_test.go
@@ -30,6 +30,10 @@ func TestAccRdsConfiguration_basic(t *testing.T) {
 					testAccCheckRdsConfigExists(resourceName, &config),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "description_1"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.type", "mysql"),
+					resource.TestCheckResourceAttr(resourceName, "datastore.0.version", "8.0"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 				),
 			},
 			{

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_parametergroup.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_parametergroup.go
@@ -109,6 +109,14 @@ func ResourceRdsConfiguration() *schema.Resource {
 					},
 				},
 			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -175,6 +183,8 @@ func resourceRdsConfigurationRead(ctx context.Context, d *schema.ResourceData, m
 	d.SetId(n.Id)
 	d.Set("name", n.Name)
 	d.Set("description", n.Description)
+	d.Set("created_at", n.Created)
+	d.Set("updated_at", n.Updated)
 
 	datastore := []map[string]string{
 		{

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/requests.go
@@ -82,6 +82,12 @@ type CreateOpts struct {
 
 	// Protection reason
 	ProtectionReason string `json:"protection_reason,omitempty"`
+
+	// Waf failure action
+	WafFailureAction string `json:"waf_failure_action,omitempty"`
+
+	// IpV6 Vip Address
+	Ipv6VipAddress string `json:"ipv6_vip_address,omitempty"`
 }
 
 // BandwidthRef
@@ -239,6 +245,12 @@ type UpdateOpts struct {
 
 	// Update protection reason
 	ProtectionReason *string `json:"protection_reason,omitempty"`
+
+	// Waf failure action
+	WafFailureAction string `json:"waf_failure_action,omitempty"`
+
+	// IpV6 Vip Address
+	Ipv6VipAddress string `json:"ipv6_vip_address,omitempty"`
 }
 
 // ToLoadBalancerUpdateMap builds a request body from UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/results.go
@@ -121,6 +121,18 @@ type LoadBalancer struct {
 
 	// Autoscaling configuration
 	AutoScaling AutoScaling `json:"autoscaling"`
+
+	// Waf failure action
+	WafFailureAction string `json:"waf_failure_action"`
+
+	// Charge Mode
+	ChargeMode string `json:"charge_mode"`
+
+	// Creation time
+	CreatedAt string `json:"created_at"`
+
+	// Update time
+	UpdatedAt string `json:"updated_at"`
 }
 
 // EipInfo

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/configurations/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/configurations/results.go
@@ -30,6 +30,10 @@ type Configuration struct {
 	Description string `json:"description"`
 	//Configuration Parameters
 	Parameters []Parameter `json:"configuration_parameters"`
+	//Create time
+	Created string `json:"created"`
+	//Last update time
+	Updated string `json:"updated"`
 }
 
 type Parameter struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -42,6 +42,10 @@ type ModifyCollationResult struct {
 	commonResult
 }
 
+type ModifyMsdtcHostsResult struct {
+	commonResult
+}
+
 type ModifyBinlogRetentionHoursResult struct {
 	commonResult
 }
@@ -238,6 +242,36 @@ func (r GetBinlogRetentionHoursResult) Extract() (*GetBinlogRetentionHoursResp, 
 	return &response, err
 }
 
+type ListMsdtcHostsResponse struct {
+	Hosts      []RdsMsdtcHosts `json:"hosts"`
+	TotalCount int             `json:"total_count"`
+}
+
+type RdsMsdtcHosts struct {
+	Id       string `json:"id"`
+	Host     string `json:"host"`
+	HostName string `json:"host_name"`
+}
+
+type MsdtcHostsPage struct {
+	pagination.OffsetPageBase
+}
+
+func (r MsdtcHostsPage) IsEmpty() (bool, error) {
+	data, err := ExtractRdsMsdtcHosts(r)
+	if err != nil {
+		return false, err
+	}
+	return len(data.Hosts) == 0, err
+}
+
+// ExtractRdsMsdtcHosts is a function that takes a ListResult and returns the msdct hosts' information.
+func ExtractRdsMsdtcHosts(r pagination.Page) (ListMsdtcHostsResponse, error) {
+	var s ListMsdtcHostsResponse
+	err := (r.(MsdtcHostsPage)).ExtractInto(&s)
+	return s, err
+}
+
 type ReplicationMode struct {
 	WorkflowId      string `json:"workflowId"`
 	InstanceId      string `json:"instanceId"`
@@ -256,6 +290,16 @@ type Collation struct {
 
 func (r ModifyCollationResult) Extract() (*Collation, error) {
 	var response Collation
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type MsdtcHosts struct {
+	JobId string `json:"job_id"`
+}
+
+func (r ModifyMsdtcHostsResult) Extract() (*MsdtcHosts, error) {
+	var response MsdtcHosts
 	err := r.ExtractInto(&response)
 	return &response, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
@@ -49,3 +49,7 @@ func autoExpandURL(c *golangsdk.ServiceClient, instancesId string) string {
 func binlogRetentionHoursURL(c *golangsdk.ServiceClient, instancesId string) string {
 	return c.ServiceURL("instances", instancesId, "binlog/clear-policy")
 }
+
+func msdtcHostsURL(c *golangsdk.ServiceClient, instancesId string) string {
+	return c.ServiceURL("instances", instancesId, "msdtc/hosts")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240325022336-b8d28279d50c
+# github.com/chnsz/golangsdk v0.0.0-20240326122909-40f5d835cc07
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds parametergroup add attributes created_at and updated_at
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds parametergroup add attributes created_at and updated_at
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsConfiguration_basic
=== PAUSE TestAccRdsConfiguration_basic
=== CONT  TestAccRdsConfiguration_basic
--- PASS: TestAccRdsConfiguration_basic (18.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       18.999s
```
