### PR TITLE
test(iotda): fix the issue of acceptance test failure

### DIFF
--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_amqps_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_amqps_test.go
@@ -76,7 +76,6 @@ func TestAccDataSourceAMQPQueues_derived(t *testing.T) {
 func testAccDataSourceAMQPQueues_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-%[2]s
 
 data "huaweicloud_iotda_amqps" "test" {
   depends_on = [
@@ -119,5 +118,5 @@ data "huaweicloud_iotda_amqps" "not_found" {
 output "not_found_validation_pass" {
   value = length(data.huaweicloud_iotda_amqps.not_found.queues) == 0
 }
-`, testAmqp_basic(name), buildIoTDAEndpoint())
+`, testAmqp_basic(name))
 }

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_dataforwarding_rules_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_dataforwarding_rules_test.go
@@ -85,7 +85,6 @@ func TestAccDataSourceDataForwardingRules_derived(t *testing.T) {
 func testAccDataSourceDataForwardingRules_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-%[2]s
 
 data "huaweicloud_iotda_dataforwarding_rules" "test" {
   depends_on = [
@@ -177,5 +176,5 @@ data "huaweicloud_iotda_dataforwarding_rules" "not_found" {
 output "not_found_validation_pass" {
   value = length(data.huaweicloud_iotda_dataforwarding_rules.not_found.rules) == 0
 }
-`, testDataForwardingRule_basic(name), buildIoTDAEndpoint())
+`, testDataForwardingRule_basic(name))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the issue of acceptance test failure.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the datasource (iotda_amqps/iotda_dataforwarding_rules) issue of acceptance test failure
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
## Basic
```
$ export HW_REGION_NAME=cn-north-4 
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceAMQPQueues_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceAMQPQueues_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAMQPQueues_basic
=== PAUSE TestAccDataSourceAMQPQueues_basic
=== CONT  TestAccDataSourceAMQPQueues_basic
--- PASS: TestAccDataSourceAMQPQueues_basic (33.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     33.110s
```
```
$ export HW_REGION_NAME=cn-north-4 
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDataForwardingRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataForwardingRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataForwardingRules_basic
=== PAUSE TestAccDataSourceDataForwardingRules_basic
=== CONT  TestAccDataSourceDataForwardingRules_basic
--- PASS: TestAccDataSourceDataForwardingRules_basic (54.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     54.067s
```
## Skip
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceAMQPQueues_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceAMQPQueues_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAMQPQueues_derived
=== PAUSE TestAccDataSourceAMQPQueues_derived
=== CONT  TestAccDataSourceAMQPQueues_derived
    acceptance.go:1385: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccDataSourceAMQPQueues_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.042s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDataForwardingRules_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataForwardingRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataForwardingRules_derived
=== PAUSE TestAccDataSourceDataForwardingRules_derived
=== CONT  TestAccDataSourceDataForwardingRules_derived
    acceptance.go:1385: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccDataSourceDataForwardingRules_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.078s
```
## Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceAMQPQueues_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceAMQPQueues_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAMQPQueues_derived
=== PAUSE TestAccDataSourceAMQPQueues_derived
=== CONT  TestAccDataSourceAMQPQueues_derived
--- PASS: TestAccDataSourceAMQPQueues_derived (38.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     38.991s
```
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDataForwardingRules_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataForwardingRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataForwardingRules_derived
=== PAUSE TestAccDataSourceDataForwardingRules_derived
=== CONT  TestAccDataSourceDataForwardingRules_derived
--- PASS: TestAccDataSourceDataForwardingRules_derived (59.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     59.841s
```