### PR TITLE
fix(RDS): fix some rds instance sdk response to job response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240327094536-5c1c4556890e
+	github.com/chnsz/golangsdk v0.0.0-20240328033637-1dc9ef2bda5e
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240327094536-5c1c4556890e h1:zH9k6zhwm8vCuaYb8M6iszh2aciduo0fAty+YZX77SA=
-github.com/chnsz/golangsdk v0.0.0-20240327094536-5c1c4556890e/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240328033637-1dc9ef2bda5e h1:jKM8DBhAdzqQuKUS002VBh5YR6P2Qp0fsYd7oww3+lQ=
+github.com/chnsz/golangsdk v0.0.0-20240328033637-1dc9ef2bda5e/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
@@ -1731,7 +1731,7 @@ func updateMsdtcHosts(ctx context.Context, d *schema.ResourceData, client *golan
 		if err != nil {
 			return fmt.Errorf("error modify RDS instance (%s) MSDTC hosts: %s", instanceID, err)
 		}
-		job := res.(*instances.MsdtcHosts)
+		job := res.(*instances.JobResponse)
 
 		if err = checkRDSInstanceJobFinish(client, job.JobId, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return fmt.Errorf("error waiting for RDS instance (%s) update msdtc hosts completed: %s", instanceID, err)
@@ -2018,7 +2018,7 @@ func updateRdsInstanceCollation(ctx context.Context, d *schema.ResourceData, cli
 	if err != nil {
 		return fmt.Errorf("error modify RDS instance (%s) collation: %s", instanceID, err)
 	}
-	job := res.(*instances.Collation)
+	job := res.(*instances.JobResponse)
 
 	if err = checkRDSInstanceJobFinish(client, job.JobId, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return fmt.Errorf("error waiting for RDS instance (%s) update collation completed: %s", instanceID, err)

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -157,7 +157,7 @@ func (opts DeleteOpts) ToInstancesDeleteMap() (map[string]interface{}, error) {
 	return b, nil
 }
 
-func Delete(client *golangsdk.ServiceClient, instanceId string) (r DeleteResult) {
+func Delete(client *golangsdk.ServiceClient, instanceId string) (r JobResult) {
 
 	url := deleteURL(client, instanceId)
 
@@ -231,7 +231,7 @@ func (opts RestartInstanceOpts) ToActionInstanceMap() (map[string]interface{}, e
 	return toActionInstanceMap(opts)
 }
 
-func Restart(client *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r RestartResult) {
+func Restart(client *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r JobResult) {
 	b, err := opts.ToActionInstanceMap()
 	if err != nil {
 		r.Err = err
@@ -277,7 +277,7 @@ func (opts SingleToHaRdsOpts) ToActionInstanceMap() (map[string]interface{}, err
 	return toActionInstanceMap(opts)
 }
 
-func SingleToHa(client *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r SingleToHaResult) {
+func SingleToHa(client *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r JobResult) {
 	b, err := opts.ToActionInstanceMap()
 	if err != nil {
 		r.Err = err
@@ -519,7 +519,7 @@ func GetConfigurations(c *golangsdk.ServiceClient, instanceID string) (r GetConf
 	return
 }
 
-func RebootInstance(c *golangsdk.ServiceClient, instanceID string) (r RebootResult) {
+func RebootInstance(c *golangsdk.ServiceClient, instanceID string) (r JobResult) {
 	b, err := golangsdk.BuildRequestBody(struct{}{}, "restart")
 	if err != nil {
 		r.Err = err
@@ -708,7 +708,7 @@ func (opts ModifyCollationOpts) ToActionInstanceMap() (map[string]interface{}, e
 }
 
 // ModifyCollation is a method used to modify collation.
-func ModifyCollation(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r ModifyCollationResult) {
+func ModifyCollation(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r JobResult) {
 	b, err := opts.ToActionInstanceMap()
 	if err != nil {
 		r.Err = err
@@ -727,7 +727,7 @@ func (opts ModifyBinlogRetentionHoursOpts) ToActionInstanceMap() (map[string]int
 }
 
 // ModifyBinlogRetentionHours is a method used to modify binlog retention hours.
-func ModifyBinlogRetentionHours(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r ModifyCollationResult) {
+func ModifyBinlogRetentionHours(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r JobResult) {
 	b, err := opts.ToActionInstanceMap()
 	if err != nil {
 		r.Err = err
@@ -759,7 +759,7 @@ func (opts ModifyMsdtcHostsOpts) ToActionInstanceMap() (map[string]interface{}, 
 }
 
 // ModifyMsdtcHosts is a method used to modify msdtc hosts.
-func ModifyMsdtcHosts(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r ModifyMsdtcHostsResult) {
+func ModifyMsdtcHosts(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r JobResult) {
 	b, err := opts.ToActionInstanceMap()
 	if err != nil {
 		r.Err = err
@@ -784,4 +784,14 @@ func GetMsdtcHosts(c *golangsdk.ServiceClient, instanceId string) ([]RdsMsdtcHos
 		return nil, err
 	}
 	return res.Hosts, err
+}
+
+func Startup(client *golangsdk.ServiceClient, instanceId string) (r JobResult) {
+	_, r.Err = client.Post(updateURL(client, instanceId, "action/startup"), nil, &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+func Shutdown(client *golangsdk.ServiceClient, instanceId string) (r JobResult) {
+	_, r.Err = client.Post(updateURL(client, instanceId, "action/shutdown"), nil, &r.Body, &golangsdk.RequestOpts{})
+	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -14,14 +14,6 @@ type CreateResult struct {
 	commonResult
 }
 
-type DeleteResult struct {
-	commonResult
-}
-
-type RestartResult struct {
-	commonResult
-}
-
 type RenameResult struct {
 	commonResult
 }
@@ -38,23 +30,11 @@ type ModifyReplicationModeResult struct {
 	commonResult
 }
 
-type ModifyCollationResult struct {
-	commonResult
-}
-
-type ModifyMsdtcHostsResult struct {
-	commonResult
-}
-
 type ModifyBinlogRetentionHoursResult struct {
 	commonResult
 }
 
 type ModifySwitchStrategyResult struct {
-	commonResult
-}
-
-type SingleToHaResult struct {
 	commonResult
 }
 
@@ -82,7 +62,7 @@ type GetBinlogRetentionHoursResult struct {
 	commonResult
 }
 
-type RebootResult struct {
+type JobResult struct {
 	commonResult
 }
 
@@ -123,32 +103,12 @@ func (r CreateResult) Extract() (*CreateResponse, error) {
 	return &response, err
 }
 
-type DeleteResponse struct {
+type JobResponse struct {
 	JobId string `json:"job_id"`
 }
 
-func (r DeleteResult) Extract() (*DeleteResponse, error) {
-	var response DeleteResponse
-	err := r.ExtractInto(&response)
-	return &response, err
-}
-
-type RestartResponse struct {
-	JobId string `json:"job_id"`
-}
-
-func (r RestartResult) Extract() (*RestartResponse, error) {
-	var response RestartResponse
-	err := r.ExtractInto(&response)
-	return &response, err
-}
-
-type SingleToHaResponse struct {
-	JobId string `json:"job_id"`
-}
-
-func (r SingleToHaResult) Extract() (*SingleToHaResponse, error) {
-	var response SingleToHaResponse
+func (r JobResult) Extract() (*JobResponse, error) {
+	var response JobResponse
 	err := r.ExtractInto(&response)
 	return &response, err
 }
@@ -195,16 +155,6 @@ type ModifyConfigurationResp struct {
 
 func (r ModifyConfigurationResult) Extract() (*ModifyConfigurationResp, error) {
 	var response ModifyConfigurationResp
-	err := r.ExtractInto(&response)
-	return &response, err
-}
-
-type RebootResp struct {
-	JobId string `json:"job_id"`
-}
-
-func (r RebootResult) Extract() (*RebootResp, error) {
-	var response RebootResp
 	err := r.ExtractInto(&response)
 	return &response, err
 }
@@ -280,26 +230,6 @@ type ReplicationMode struct {
 
 func (r ModifyReplicationModeResult) Extract() (*ReplicationMode, error) {
 	var response ReplicationMode
-	err := r.ExtractInto(&response)
-	return &response, err
-}
-
-type Collation struct {
-	JobId string `json:"job_id"`
-}
-
-func (r ModifyCollationResult) Extract() (*Collation, error) {
-	var response Collation
-	err := r.ExtractInto(&response)
-	return &response, err
-}
-
-type MsdtcHosts struct {
-	JobId string `json:"job_id"`
-}
-
-func (r ModifyMsdtcHostsResult) Extract() (*MsdtcHosts, error) {
-	var response MsdtcHosts
 	err := r.ExtractInto(&response)
 	return &response, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240327094536-5c1c4556890e
+# github.com/chnsz/golangsdk v0.0.0-20240328033637-1dc9ef2bda5e
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix some rds instance sdk response to job response
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix some rds instance sdk response to job response
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 10
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_restore_pg
--- PASS: TestAccRdsInstance_mariadb (453.93s)
--- PASS: TestAccRdsInstance_ha (562.68s)
--- PASS: TestAccRdsInstance_basic (566.46s)
--- PASS: TestAccRdsInstance_prePaid (1214.88s)
--- PASS: TestAccRdsInstance_mysql (1333.92s)
--- PASS: TestAccRdsInstance_restore_pg (1400.75s)
--- PASS: TestAccRdsInstance_restore_mysql (1465.71s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1474.79s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2050.60s)
--- PASS: TestAccRdsInstance_sqlserver (2994.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2994.355s
```
