### PR TITLE
feat(iotda): add devices datasource support

### DIFF
--- a/docs/data-sources/iotda_devices.md
+++ b/docs/data-sources/iotda_devices.md
@@ -1,0 +1,122 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_devices
+
+Use this data source to get the list of IoTDA devices within HuaweiCloud.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "device_id" {}
+
+data "huaweicloud_iotda_devices" "test" {
+  device_id = var.device_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the devices.
+  If omitted, the provider-level region will be used.
+
+* `space_id` - (Optional, String) Specifies the space ID of the devices to be queried.
+  If omitted, query the devices in all spaces under the current instance.
+
+* `product_id` - (Optional, String) Specifies the ID of the product to be queried.
+  If omitted, query the devices in all products under the current instance.
+
+* `gateway_id` - (Optional, String) Specifies the gateway ID of the devices to be queried;
+  The `gateway_id` is the ID of the parent device to which the devices belong.
+
+* `is_cascade` - (Optional, Bool) Specifies whether to cascade queries, this parameter only takes effect when
+  carrying `gateway_id` simultaneously. The default value is **false**.  
+  The valid values are as follows:
+  + **true**: Represents querying all levels of sub devices under a device with a device ID equal to gateway ID.
+  + **false**: Represents the first level child devices under the device with the query device ID equal to gateway ID.
+  
+* `node_id` - (Optional, String) Specifies the node ID of the device to be queried.
+
+* `node_type` - (Optional, String) Specifies the node type of the devices to be queried.  
+  The valid values are as follows:
+  + **ENDPOINT**: Non-directly connected devices.
+  + **GATEWAY**: Directly connected devices or gateways.
+  + **UNKNOWN**: Unknown.
+
+* `status` - (Optional, String) Specifies the status of the devices to be queried.  
+  The valid values are as follows:
+  + **ONLINE**: Device is online.
+  + **OFFLINE**: Device is offline.
+  + **ABNORMAL**: Device is abnormal.
+  + **INACTIVE**: Device is inactive.
+  + **FROZEN**: Device is frozen.
+
+* `device_id` - (Optional, String) Specifies the ID of the device to be queried.
+
+* `name` - (Optional, String) Specifies the name of the device to be queried.
+
+* `start_time` - (Optional, String) Specifies the start time to be queried. The query result shows devices created after
+  this time (including devices created at this time). The format is **yyyyMMdd'T'HHmmss'Z**. e.g. **20190528T153000Z**.
+
+* `end_time` - (Optional, String) Specifies the end time to be queried. The query result is for devices created before
+  this time (excluding devices created at this time). The format is **yyyyMMdd'T'HHmmss'Z**. e.g. **20190528T153000Z**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `devices` - All devices that match the filter parameters.
+  The [devices](#iotda_devices) structure is documented below.
+
+<a name="iotda_devices"></a>
+The `devices` block supports:
+
+* `space_id` - The space ID to which the device belongs.
+
+* `space_name` - The space name to which the device belongs.
+
+* `product_id` - The product ID to which the device belongs.
+
+* `product_name` - The product name to which the device belongs.
+
+* `gateway_id` - The ID of the parent device to which the device belongs
+
+* `id` - The device ID.
+
+* `name` - The device name.
+
+* `node_id` - The node ID of the device.
+
+* `node_type` - The node type of the device.
+
+* `description` - The description of the device.
+
+* `status` - The status of the device.
+
+* `fw_version` - The firmware version of the device.
+
+* `sw_version` - The software version of the device.
+
+* `sdk_version` - The SDK information of the device.
+
+* `tags` - The tags of the device, key/value pair format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -581,6 +581,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_dataforwarding_rules": iotda.DataSourceDataForwardingRules(),
 			"huaweicloud_iotda_spaces":               iotda.DataSourceSpaces(),
 			"huaweicloud_iotda_products":             iotda.DataSourceProducts(),
+			"huaweicloud_iotda_devices":              iotda.DataSourceDevices(),
 
 			"huaweicloud_koogallery_assets": koogallery.DataSourceKooGalleryAssets(),
 

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_devices_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_devices_test.go
@@ -1,0 +1,184 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDevices_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_devices.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDevices_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.space_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.space_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.product_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.product_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.node_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.node_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.status"),
+
+					resource.TestCheckOutput("is_product_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_node_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_device_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDevices_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_devices.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDevices_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.space_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.space_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.product_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.product_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.node_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.node_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "devices.0.status"),
+
+					resource.TestCheckOutput("is_product_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_node_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_device_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDevices_base() string {
+	name := acceptance.RandomAccResourceName()
+	productBasic := testProduct_basic(name)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_device" "test" {
+  node_id    = "%[2]s"
+  name       = "%[2]s"
+  space_id   = huaweicloud_iotda_space.test.id
+  product_id = huaweicloud_iotda_product.test.id
+}
+`, productBasic, name)
+}
+
+func testAccDataSourceDevices_basic() string {
+	deviceBasic := testDataSourceDevices_base()
+
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_iotda_devices" "test" {
+  depends_on = [huaweicloud_iotda_device.test]
+}
+
+# Filter using product ID.
+locals {
+  product_id = data.huaweicloud_iotda_devices.test.devices[0].product_id
+}
+
+data "huaweicloud_iotda_devices" "product_id_filter" {
+  product_id = local.product_id
+}
+
+output "is_product_id_filter_useful" {
+  value = length(data.huaweicloud_iotda_devices.product_id_filter.devices) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_devices.product_id_filter.devices[*].product_id : v == local.product_id]
+  )
+}
+
+# Filter using node ID.
+locals {
+  node_id = data.huaweicloud_iotda_devices.test.devices[0].node_id
+}
+
+data "huaweicloud_iotda_devices" "node_id_filter" {
+  node_id = local.node_id
+}
+
+output "is_node_id_filter_useful" {
+  value = length(data.huaweicloud_iotda_devices.node_id_filter.devices) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_devices.node_id_filter.devices[*].node_id : v == local.node_id]
+  )
+}
+
+# Filter using device ID.
+locals {
+  device_id = data.huaweicloud_iotda_devices.test.devices[0].id
+}
+
+data "huaweicloud_iotda_devices" "device_id_filter" {
+  device_id = local.device_id
+}
+
+output "is_device_id_filter_useful" {
+  value = length(data.huaweicloud_iotda_devices.device_id_filter.devices) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_devices.device_id_filter.devices[*].id : v == local.device_id]
+  )
+}
+
+# Filter using device name.
+locals {
+  name = data.huaweicloud_iotda_devices.test.devices[0].name
+}
+
+data "huaweicloud_iotda_devices" "name_filter" {
+  name = local.name
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_iotda_devices.name_filter.devices) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_devices.name_filter.devices[*].name : v == local.name]
+  )
+}
+
+# Filter using non existent device name.
+data "huaweicloud_iotda_devices" "not_found" {
+  name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_devices.not_found.devices) == 0
+}
+`, deviceBasic)
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_devices.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_devices.go
@@ -1,0 +1,243 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/devices
+func DataSourceDevices() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDevicesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"is_cascade": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"device_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"devices": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"space_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"space_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"node_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"node_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fw_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sw_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sdk_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDevicesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	isDerived := WithDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allDevices []model.QueryDeviceSimplify
+		limit      = int32(50)
+		offset     int32
+	)
+
+	for {
+		listOpts := model.ListDevicesRequest{
+			AppId:          utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+			ProductId:      utils.StringIgnoreEmpty(d.Get("product_id").(string)),
+			GatewayId:      utils.StringIgnoreEmpty(d.Get("gateway_id").(string)),
+			IsCascadeQuery: utils.Bool(d.Get("is_cascade").(bool)),
+			NodeId:         utils.StringIgnoreEmpty(d.Get("node_id").(string)),
+			DeviceName:     utils.StringIgnoreEmpty(d.Get("name").(string)),
+			StartTime:      utils.StringIgnoreEmpty(d.Get("start_time").(string)),
+			EndTime:        utils.StringIgnoreEmpty(d.Get("end_time").(string)),
+			Limit:          utils.Int32(limit),
+			Offset:         &offset,
+		}
+
+		listResp, listErr := client.ListDevices(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error querying IoTDA devices: %s", listErr)
+		}
+
+		if len(*listResp.Devices) == 0 {
+			break
+		}
+
+		allDevices = append(allDevices, *listResp.Devices...)
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuId)
+
+	targetDevices := filterListDevices(allDevices, d)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("devices", flattenDevices(targetDevices)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterListDevices(devices []model.QueryDeviceSimplify, d *schema.ResourceData) []model.QueryDeviceSimplify {
+	if len(devices) == 0 {
+		return nil
+	}
+
+	rst := make([]model.QueryDeviceSimplify, 0, len(devices))
+	for _, v := range devices {
+		if deviceID, ok := d.GetOk("device_id"); ok &&
+			fmt.Sprint(deviceID) != utils.StringValue(v.DeviceId) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func flattenDevices(devices []model.QueryDeviceSimplify) []interface{} {
+	if len(devices) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(devices))
+	for _, v := range devices {
+		rst = append(rst, map[string]interface{}{
+			"space_id":     v.AppId,
+			"space_name":   v.AppName,
+			"product_id":   v.ProductId,
+			"product_name": v.ProductName,
+			"gateway_id":   v.GatewayId,
+			"id":           v.DeviceId,
+			"name":         v.DeviceName,
+			"node_id":      v.NodeId,
+			"node_type":    v.NodeType,
+			"description":  v.Description,
+			"status":       v.Status,
+			"fw_version":   v.FwVersion,
+			"sw_version":   v.SwVersion,
+			"sdk_version":  v.DeviceSdkVersion,
+			"tags":         flattenTags(v.Tags),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add devices datasource support
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add devices datasource support
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

## Basic
```
$ export HW_REGION_NAME=cn-north-4
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDevices_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDevices_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDevices_basic
=== PAUSE TestAccDataSourceDevices_basic
=== CONT  TestAccDataSourceDevices_basic
--- PASS: TestAccDataSourceDevices_basic (8.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     8.598s

```

## Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDevices_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDevices_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDevices_derived
=== PAUSE TestAccDataSourceDevices_derived
=== CONT  TestAccDataSourceDevices_derived
--- PASS: TestAccDataSourceDevices_derived (16.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     16.721s

```
