### PR TITLE
refactor: fix(lts/stream): solve the problem that eps cannot be set

### DIFF
--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_stream_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_stream_test.go
@@ -2,53 +2,64 @@ package lts
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/lts/huawei/logstreams"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func getLtsStreamResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	client, err := cfg.LtsV2Client(acceptance.HW_REGION_NAME)
+	httpUrl := "v2/{project_id}/groups/{log_group_id}/streams"
+	client, err := cfg.NewServiceClient("lts", acceptance.HW_REGION_NAME)
 	if err != nil {
 		return nil, fmt.Errorf("error creating LTS client: %s", err)
 	}
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{log_group_id}", state.Primary.Attributes["group_id"])
 
-	resourceID := state.Primary.ID
-	groupID := state.Primary.Attributes["group_id"]
-	streams, err := logstreams.List(client, groupID).Extract()
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
 	if err != nil {
 		return nil, err
 	}
-
-	for _, item := range streams.LogStreams {
-		if item.ID == resourceID {
-			return &item, nil
-		}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing the log stream: %s", err)
 	}
 
-	return nil, fmt.Errorf("the log stream %s does not exist", resourceID)
+	streamId := state.Primary.ID
+	streamResult := utils.PathSearch(fmt.Sprintf("log_streams|[?log_stream_id=='%s']|[0]", streamId), respBody, nil)
+	if streamResult == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return streamResult, nil
 }
 
 func TestAccLtsStream_basic(t *testing.T) {
-	var stream logstreams.LogStream
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_lts_stream.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&stream,
-		getLtsStreamResourceFunc,
+	var (
+		stream       interface{}
+		rName        = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_lts_stream.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &stream, getLtsStreamResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -59,7 +70,7 @@ func TestAccLtsStream_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "stream_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "filter_count", "0"),
-					resource.TestCheckResourceAttrSet(resourceName, "enterprise_project_id"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrPair(resourceName, "group_id", "huaweicloud_lts_group.test", "id"),
 				),
@@ -75,14 +86,11 @@ func TestAccLtsStream_basic(t *testing.T) {
 }
 
 func TestAccLtsStream_ttl(t *testing.T) {
-	var stream logstreams.LogStream
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_lts_stream.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&stream,
-		getLtsStreamResourceFunc,
+	var (
+		stream       interface{}
+		rName        = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_lts_stream.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &stream, getLtsStreamResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -137,10 +145,11 @@ resource "huaweicloud_lts_group" "test" {
 }
 
 resource "huaweicloud_lts_stream" "test" {
-  group_id    = huaweicloud_lts_group.test.id
-  stream_name = "%[1]s"
+  group_id              = huaweicloud_lts_group.test.id
+  stream_name           = "%[1]s"
+  enterprise_project_id = "%[2]s"
 }
-`, rName)
+`, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testAccLtsStream_ttl(rName string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Solve the problem that eps cannot be set.
The old parameter 'tags._sys_enterprise_project_id' is no longer used for stream creation, should using the new parameter 'enterprise_project_name' to instead.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. refactor the stream resource and using the auto-generator fomation.
2. abandon the useless parameter 'tags._sys_enterprise_project_id' and using the new one 'enterprise_project_name'.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run=TestAccLtsStream_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run=TestAccLtsStream_basic -timeout 360m -parallel 4
=== RUN   TestAccLtsStream_basic
=== PAUSE TestAccLtsStream_basic
=== CONT  TestAccLtsStream_basic
--- PASS: TestAccLtsStream_basic (16.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       16.543s
```
