### PR TITLE
feat(iotda): add a datasource to get the list of device linkage rules

### DIFF
--- a/docs/data-sources/iotda_device_linkage_rules.md
+++ b/docs/data-sources/iotda_device_linkage_rules.md
@@ -1,0 +1,237 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+---
+
+# huaweicloud_iotda_device_linkage_rules
+
+Use this data source to get the list of IoTDA device linkage rules.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "rule_id" {}
+
+data "huaweicloud_iotda_device_linkage_rules" "test" {
+  rule_id = var.rule_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the device linkage rules.
+  If omitted, the provider-level region will be used.
+
+* `rule_id` - (Optional, String) Specifies the ID of the device linkage rule.
+
+* `name` - (Optional, String) Specifies the name of the device linkage rule.
+
+* `type` - (Optional, String) Specifies the type of the device linkage rules.
+  The valid values are as follows:
+  + **DEVICE_LINKAGE**: Cloud based linkage rule.
+  + **DEVICE_SIDE**: Device side rule.
+
+* `status` - (Optional, String) Specifies the current status of the device linkage rule.
+  The valid values are as follows:
+  + **active**: The device linkage rule is active.
+  + **inactive**: The device linkage rule is not enabled.
+
+* `space_id` - (Optional, String) Specifies the ID of the resource space to which the device linkage rules belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - All rules that match the filter parameters.
+  The [rules](#iotda_linkage_rules) structure is documented below.
+
+<a name="iotda_linkage_rules"></a>
+The `rules` block supports:
+
+* `id` - The ID of the device linkage rule.
+
+* `name` - The name of the device linkage rule.
+
+* `description` - The description of the device linkage rule.
+
+* `type` - The type of the device linkage rule.
+
+* `status` - The current status of the device linkage rule.
+
+* `space_id` - The ID of the resource space to which the device linkage rule belongs.
+
+* `triggers` - The condition list of the device linkage rule.
+  The [triggers](#rule_conditions) structure is documented below.
+
+* `actions` - The action list of the device linkage rule.
+  The [actions](#rule_actions) structure is documented below.
+
+* `effective_period` - The rule condition triggered validity period of the device linkage rule.
+  The [effective_period](#rule_effective_period) structure is documented below.
+
+* `trigger_logic` - The logical relationship between multiple rule conditions of the device linkage rule.
+
+* `updated_at` - The latest update time of the device linkage rule.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.
+
+<a name="rule_conditions"></a>
+The `triggers` block supports:
+
+* `type` - The rule condition type of the device linkage rule. The valid values are as follows:
+  + **DEVICE_DATA**: Triggered upon the property of device.
+  + **SIMPLE_TIMER**: Triggered by schedule upon policy.
+  + **DAILY_TIMER**: Triggered by schedule upon period.
+  + **DEVICE_LINKAGE_STATUS**: Triggered upon the status of device.
+
+* `device_data_condition` - The rule condition triggered upon the property of device.
+  The [device_data_condition](#trigger_device_data_condition) structure is documented below.
+
+* `simple_timer_condition` - The rule condition triggered by schedule upon policy.
+  The [simple_timer_condition](#trigger_simple_timer_condition) structure is documented below.
+
+* `daily_timer_condition` - The rule condition triggered by schedule upon period.
+  The [daily_timer_condition](#trigger_daily_timer_condition) structure is documented below.
+
+* `device_linkage_status_condition` - The rule condition triggered upon the status of device.
+  The [device_linkage_status_condition](#trigger_device_linkage_status_condition) structure is documented below.
+
+<a name="trigger_device_data_condition"></a>
+The `device_data_condition` block supports:
+
+* `device_id` - The ID of the device which trigger the rule.
+
+* `product_id` - The ID of the product associated with the device.
+
+* `path` - The path of the device property.
+  The format is **service_id/DataProperty**. e.g. **DoorWindow/status**
+
+* `operator` - The data comparison operator. The valid values are: **>**, **<**,
+  **>=**, **<=**, **=**, **in**, or **between**.
+
+* `value` - The rigth value of a data comparison expression.
+
+* `trigger_strategy` - The judgment strategy triggered by rule conditions. The valid values are:
+  + **pulse**: When the data reported by the device meets the conditions, the rule can be triggered.
+  + **reverse**: When the data reported by the device last time does not meet the conditions and the
+    data reported this time meets the conditions, the rule can be triggered.
+
+* `data_validatiy_period` - The data validity period, in seconds.
+
+<a name="trigger_simple_timer_condition"></a>
+The `simple_timer_condition` block supports:
+
+* `start_time` - The start time for triggering the rule.
+  The format is **yyyyMMdd'T'HHmmss'Z'**. e.g. **20151212T121212Z**.
+
+* `repeat_interval` - The repeat time interval for triggering the rule, in minutes.
+
+* `repeat_count` - The repeat times for triggering the rule.
+  The valid value is range from `1` to `9,999`.
+
+<a name="trigger_daily_timer_condition"></a>
+The `daily_timer_condition` block supports:
+
+* `start_time` - The start time for triggering the rule.
+  The format is **HH:MM**. e.g. **10:00**.
+
+* `days_of_week` - The week list of the rule validity period, separated by commas. **1** represents Sunday,
+  **2** represents Monday, and so on.
+
+<a name="trigger_device_linkage_status_condition"></a>
+The `device_linkage_status_condition` block supports:
+
+* `device_id` - The ID of the device which trigger the rule.
+
+* `product_id` - The ID of the product associated with the device.
+
+* `status_list` - All devices status which trigger the rule. The valid values can be **ONLINE** or **OFFLINE**.
+
+* `duration` - The duration of the device status, in minutes.
+  The valid value is range from `0` to `60`.
+
+<a name="rule_actions"></a>
+The `actions` block supports:
+
+* `type` - The rule action type of the device linkage rule. The valid values are as follows:
+  + **DEVICE_CMD**: Device command deliver messages.
+  + **SMN_FORWARDING**: Send SMN messages.
+  + **DEVICE_ALARM**: Report device alarm messages.
+
+* `device_command` - The detail of device command.
+  The [device_command](#action_device_command) structure is documented below.
+
+* `smn_forwarding` - The detail of SMN notifications.
+  The [smn_forwarding](#action_smn_forwarding) structure is documented below.
+
+* `device_alarm` - The detail of device alarm.
+  The [device_alarm](#action_device_alarm) structure is documented below.
+
+<a name="action_device_command"></a>
+The `device_command` block supports:
+
+* `device_id` - The ID of the device to which the command is delivered.
+
+* `command_name` - The name of the command.
+
+* `command_body` - The command parameters.
+
+* `service_id` - The ID of the service to which the command belongs.
+
+<a name="action_smn_forwarding"></a>
+The `smn_forwarding` block supports:
+
+* `region` - The region to which the SMN service belongs.
+
+* `topic_name` - The topic name of the SMN.
+
+* `topic_urn` - The topic URN of the SMN.
+
+* `message_title` - The message title.
+
+* `message_content` - The message content.
+
+* `project_id` - The project ID to which the SMN belongs.
+
+<a name="action_device_alarm"></a>
+The `device_alarm` block supports:
+
+* `name` - The name of the alarm.
+
+* `type` - The type of the alarm. The valid values are as follows:
+  + **fault**: Report alarms.
+  + **recovery**: Restore alarms.
+
+* `severity` - The severity level of the alarm.
+  The valid values can be **warning**, **minor**, **major**, or **critical**.
+
+* `description` - The description of the alarm.
+
+<a name="rule_effective_period"></a>
+The `effective_period` block supports:
+
+* `start_time` - The start time for triggering the rule.
+  The format is **HH:MM**. e.g. **10:00**.
+
+* `end_time` - The end time for triggering the rule.
+  The format is **HH:MM**. e.g. **10:00**.
+
+* `days_of_week` - The week list of the rule validity period, separated by commas. **1** represents Sunday,
+  **2** represents Monday, and so on.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -585,6 +585,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_amqps":                iotda.DataSourceAMQPQueues(),
 			"huaweicloud_iotda_dataforwarding_rules": iotda.DataSourceDataForwardingRules(),
 			"huaweicloud_iotda_device_groups":        iotda.DataSourceDeviceGroups(),
+			"huaweicloud_iotda_device_linkage_rules": iotda.DataSourceDeviceLinkageRules(),
 			"huaweicloud_iotda_spaces":               iotda.DataSourceSpaces(),
 			"huaweicloud_iotda_products":             iotda.DataSourceProducts(),
 			"huaweicloud_iotda_devices":              iotda.DataSourceDevices(),

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_linkage_rules_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_linkage_rules_test.go
@@ -1,0 +1,178 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDeviceLinkageRules_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_device_linkage_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDeviceLinkageRules_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.space_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.triggers.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.actions.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.updated_at"),
+
+					resource.TestCheckOutput("rule_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckOutput("space_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceDeviceLinkageRules_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_device_linkage_rules.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDeviceLinkageRules_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.space_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.triggers.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.actions.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rules.0.updated_at"),
+
+					resource.TestCheckOutput("rule_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDeviceLinkageRules_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_iotda_device_linkage_rules" "test" {
+  depends_on = [
+    huaweicloud_iotda_device_linkage_rule.test
+  ]
+}
+
+locals {
+  rule_id = data.huaweicloud_iotda_device_linkage_rules.test.rules[0].id
+}
+
+data "huaweicloud_iotda_device_linkage_rules" "rule_id_filter" {
+  rule_id = local.rule_id
+}
+
+output "rule_id_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_device_linkage_rules.rule_id_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_linkage_rules.rule_id_filter.rules[*].id : v == local.rule_id]
+  )
+}
+
+locals {
+  name = data.huaweicloud_iotda_device_linkage_rules.test.rules[0].name
+}
+
+data "huaweicloud_iotda_device_linkage_rules" "name_filter" {
+  name = local.name
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_device_linkage_rules.name_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_linkage_rules.name_filter.rules[*].name : v == local.name]
+  )
+}
+
+locals {
+  type = data.huaweicloud_iotda_device_linkage_rules.test.rules[0].type
+}
+
+data "huaweicloud_iotda_device_linkage_rules" "type_filter" {
+  type = local.type
+}
+
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_device_linkage_rules.type_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_linkage_rules.type_filter.rules[*].type : v == local.type]
+  )
+}
+
+locals {
+  space_id = data.huaweicloud_iotda_device_linkage_rules.test.rules[0].space_id
+}
+
+data "huaweicloud_iotda_device_linkage_rules" "space_id_filter" {
+  space_id = local.space_id
+}
+
+output "space_id_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_device_linkage_rules.space_id_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_linkage_rules.space_id_filter.rules[*].space_id : v == local.space_id]
+  )
+}
+
+locals {
+  status = data.huaweicloud_iotda_device_linkage_rules.test.rules[0].status
+}
+
+data "huaweicloud_iotda_device_linkage_rules" "status_filter" {
+  status = local.status
+}
+
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_device_linkage_rules.status_filter.rules) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_linkage_rules.status_filter.rules[*].status : v == local.status]
+  )
+}
+
+data "huaweicloud_iotda_device_linkage_rules" "not_found" {
+  name = "not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_device_linkage_rules.not_found.rules) == 0
+}
+`, testDeviceLinkageRule_basic(name))
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_linkage_rules.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_linkage_rules.go
@@ -1,0 +1,459 @@
+package iotda
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/rules
+func DataSourceDeviceLinkageRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceeDeviceLinkageRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"rule_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"space_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"triggers": {
+							Type:     schema.TypeList,
+							Elem:     ruleConditionSchema(),
+							Computed: true,
+						},
+						"actions": {
+							Type:     schema.TypeList,
+							Elem:     ruleActionSchema(),
+							Computed: true,
+						},
+						"effective_period": {
+							Type:     schema.TypeList,
+							Elem:     ruleTimeRangeSchema(),
+							Computed: true,
+						},
+						"trigger_logic": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func ruleConditionSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"device_data_condition": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"device_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"operator": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"trigger_strategy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_validatiy_period": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"simple_timer_condition": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"repeat_interval": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"repeat_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"daily_timer_condition": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"days_of_week": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"device_linkage_status_condition": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"device_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status_list": {
+							Type:     schema.TypeList,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
+						"duration": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	return &sc
+}
+
+func ruleActionSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"device_command": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"device_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"command_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"command_body": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"smn_forwarding": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"topic_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"topic_urn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"message_title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"message_content": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"device_alarm": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"severity": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	return &sc
+}
+
+func ruleTimeRangeSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"days_of_week": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceeDeviceLinkageRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := WithDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allRules []model.RuleResponse
+		limit    = int32(50)
+		offset   int32
+	)
+
+	for {
+		listOpts := model.ListRulesRequest{
+			AppId:    utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+			RuleType: utils.StringIgnoreEmpty(d.Get("type").(string)),
+			Limit:    utils.Int32(limit),
+			Offset:   &offset,
+		}
+
+		listResp, listErr := client.ListRules(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error querying IoTDA device linkage rules: %s", listErr)
+		}
+
+		if len(*listResp.Rules) == 0 {
+			break
+		}
+
+		allRules = append(allRules, *listResp.Rules...)
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuId)
+
+	targetRules := filterListeDeviceLinkageRules(allRules, d)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rules", flatteneDeviceLinkageRules(targetRules)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterListeDeviceLinkageRules(rules []model.RuleResponse, d *schema.ResourceData) []model.RuleResponse {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	rst := make([]model.RuleResponse, 0, len(rules))
+	for _, v := range rules {
+		if ruleId, ok := d.GetOk("rule_id"); ok &&
+			fmt.Sprint(ruleId) != utils.StringValue(v.RuleId) {
+			continue
+		}
+
+		if ruleName, ok := d.GetOk("name"); ok &&
+			fmt.Sprint(ruleName) != v.Name {
+			continue
+		}
+
+		if status, ok := d.GetOk("status"); ok &&
+			fmt.Sprint(status) != utils.StringValue(v.Status) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func flatteneDeviceLinkageRules(rules []model.RuleResponse) []interface{} {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(rules))
+	for _, v := range rules {
+		rst = append(rst, map[string]interface{}{
+			"id":               v.RuleId,
+			"name":             v.Name,
+			"description":      v.Description,
+			"type":             v.RuleType,
+			"status":           v.Status,
+			"space_id":         v.AppId,
+			"triggers":         flattenRuleConditions(v.ConditionGroup),
+			"actions":          flattenRuleActions(v.Actions),
+			"effective_period": flattenLinkageEffectivePeriod(v.ConditionGroup),
+			"trigger_logic":    v.ConditionGroup.Logic,
+			"updated_at":       v.LastUpdateTime,
+		})
+	}
+
+	return rst
+}
+
+func flattenRuleConditions(conditionGroup *model.ConditionGroup) []interface{} {
+	rst := flattenLinkageTriggers(conditionGroup)
+	for _, v := range *conditionGroup.Conditions {
+		if v.DeviceLinkageStatusCondition == nil {
+			return rst
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"type": v.Type,
+			"device_linkage_status_condition": []interface{}{
+				map[string]interface{}{
+					"device_id":   v.DeviceLinkageStatusCondition.DeviceId,
+					"product_id":  v.DeviceLinkageStatusCondition.ProductId,
+					"duration":    v.DeviceLinkageStatusCondition.Duration,
+					"status_list": v.DeviceLinkageStatusCondition.StatusList,
+				},
+			},
+		})
+	}
+
+	return rst
+}
+
+func flattenRuleActions(actions []model.RuleAction) []interface{} {
+	return flattenLinkageActions(&actions)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a datasource to get the list of device linkage rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new datasource to get the list of the device linkage rules.
2.support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed
## Basic
```
$ export HW_REGION_NAME=cn-north-4 
$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceLinkageRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceLinkageRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceLinkageRules_basic
=== PAUSE TestAccDataSourceDeviceLinkageRules_basic
=== CONT  TestAccDataSourceDeviceLinkageRules_basic
--- PASS: TestAccDataSourceDeviceLinkageRules_basic (122.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     122.828s
```
## Skip
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceLinkageRules_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceLinkageRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceLinkageRules_derived
=== PAUSE TestAccDataSourceDeviceLinkageRules_derived
=== CONT  TestAccDataSourceDeviceLinkageRules_derived
    acceptance.go:1414: HW_IOTDA_ACCESS_ADDRESS must be set for the acceptance test
--- SKIP: TestAccDataSourceDeviceLinkageRules_derived (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     0.041s
```
## Derived
```
$ export HW_REGION_NAME=cn-south-1
$ export HW_IOTDA_ACCESS_ADDRESS=e333xxxxxx.st1.iotda-app.cn-south-1.myhuaweicloud.com
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceLinkageRules_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceLinkageRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceLinkageRules_derived
=== PAUSE TestAccDataSourceDeviceLinkageRules_derived
=== CONT  TestAccDataSourceDeviceLinkageRules_derived
--- PASS: TestAccDataSourceDeviceLinkageRules_derived (100.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     100.953s
```