### PR TITLE
fix(CDN): change cdn domain resource `TypeList` to `TypeSet`

### DIFF
--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -79,6 +79,7 @@ func TestAccCdnDomain_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "sources.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "sources.0.retrieval_host", "customize.test.huaweicloud.com"),
 					resource.TestCheckResourceAttr(resourceName, "sources.0.http_port", "8001"),
 					resource.TestCheckResourceAttr(resourceName, "sources.0.https_port", "8002"),
@@ -89,12 +90,7 @@ func TestAccCdnDomain_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
-					resource.TestCheckResourceAttr(resourceName, "sources.0.active", "1"),
-					resource.TestCheckResourceAttr(resourceName, "sources.0.origin", "14.215.177.39"),
-					resource.TestCheckResourceAttr(resourceName, "sources.0.origin_type", "ipaddr"),
-					resource.TestCheckResourceAttr(resourceName, "sources.1.active", "0"),
-					resource.TestCheckResourceAttr(resourceName, "sources.1.origin", "220.181.28.52"),
-					resource.TestCheckResourceAttr(resourceName, "sources.1.origin_type", "ipaddr"),
+					resource.TestCheckResourceAttr(resourceName, "sources.#", "2"),
 				),
 			},
 			{
@@ -157,9 +153,9 @@ resource "huaweicloud_cdn_domain" "test" {
 
   cache_settings {
     rules {
-      rule_type = 0
+      rule_type = "all"
       ttl       = 180
-      ttl_type  = 4
+      ttl_type  = "d"
       priority  = 2
     }
   }
@@ -347,19 +343,6 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "on"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.match_type", "all"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.priority", "1"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.http_port", "1"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.https_port", "65535"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.ip_or_domain", "165.132.12.2"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.sources_type", "ipaddr"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.match_type", "file_extension"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.match_pattern", ".jpg;.zip;.exe"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.priority", "2"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.back_sources.0.http_port", "65535"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.back_sources.0.https_port", "1"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.back_sources.0.ip_or_domain", "165.5.1.4"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.1.back_sources.0.sources_type", "ipaddr"),
 				),
 			},
 			{

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -84,7 +84,7 @@ var httpsConfig = schema.Schema{
 }
 
 var requestAndResponseHeader = schema.Schema{
-	Type:     schema.TypeList,
+	Type:     schema.TypeSet,
 	Optional: true,
 	Computed: true,
 	Elem: &schema.Resource{
@@ -238,7 +238,7 @@ var websocket = schema.Schema{
 }
 
 var flexibleOrigin = schema.Schema{
-	Type:     schema.TypeList,
+	Type:     schema.TypeSet,
 	Optional: true,
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -330,7 +330,7 @@ func ResourceCdnDomain() *schema.Resource {
 				}, true),
 			},
 			"sources": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -433,7 +433,7 @@ func ResourceCdnDomain() *schema.Resource {
 							Optional: true,
 						},
 						"rules": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -497,7 +497,7 @@ func ResourceCdnDomain() *schema.Resource {
 func buildCreateDomainSources(d *schema.ResourceData) []domains.SourcesOpts {
 	var sourceRequests []domains.SourcesOpts
 
-	sources := d.Get("sources").([]interface{})
+	sources := d.Get("sources").(*schema.Set).List()
 	for i := range sources {
 		source := sources[i].(map[string]interface{})
 		sourceRequest := domains.SourcesOpts{
@@ -786,7 +786,7 @@ func updateDomainFullConfigs(client *cdnv2.CdnClient, cfg *config.Config, d *sch
 		ipv6Accelerate = 1
 	}
 	configsOpts := model.Configs{
-		Sources:           buildSourcesOpts(d.Get("sources").([]interface{})),
+		Sources:           buildSourcesOpts(d.Get("sources").(*schema.Set).List()),
 		Ipv6Accelerate:    utils.Int32(int32(ipv6Accelerate)),
 		OriginRangeStatus: utils.String(parseFunctionEnabledStatus(configs["range_based_retrieval_enabled"].(bool))),
 	}
@@ -794,10 +794,10 @@ func updateDomainFullConfigs(client *cdnv2.CdnClient, cfg *config.Config, d *sch
 		configsOpts.Https = buildHTTPSOpts(configs["https_settings"].([]interface{}))
 	}
 	if d.HasChange("configs.0.retrieval_request_header") {
-		configsOpts.OriginRequestHeader = buildOriginRequestHeaderOpts(configs["retrieval_request_header"].([]interface{}))
+		configsOpts.OriginRequestHeader = buildOriginRequestHeaderOpts(configs["retrieval_request_header"].(*schema.Set).List())
 	}
 	if d.HasChange("configs.0.http_response_header") {
-		configsOpts.HttpResponseHeader = buildHttpResponseHeaderOpts(configs["http_response_header"].([]interface{}))
+		configsOpts.HttpResponseHeader = buildHttpResponseHeaderOpts(configs["http_response_header"].(*schema.Set).List())
 	}
 	if d.HasChange("configs.0.url_signing") {
 		configsOpts.UrlAuth = buildUrlAuthOpts(configs["url_signing"].([]interface{}))
@@ -821,14 +821,14 @@ func updateDomainFullConfigs(client *cdnv2.CdnClient, cfg *config.Config, d *sch
 		configsOpts.Websocket = buildWebsocketOpts(configs["websocket"].([]interface{}))
 	}
 	if d.HasChange("configs.0.flexible_origin") {
-		configsOpts.FlexibleOrigin = buildFlexibleOriginOpts(configs["flexible_origin"].([]interface{}))
+		configsOpts.FlexibleOrigin = buildFlexibleOriginOpts(configs["flexible_origin"].(*schema.Set).List())
 	}
 
 	if d.HasChange("cache_settings") {
 		cacheSettings := d.Get("cache_settings").([]interface{})
 		if len(cacheSettings) > 0 {
 			cacheSetting := cacheSettings[0].(map[string]interface{})
-			configsOpts.CacheRules = buildCacheRules(cacheSetting["follow_origin"].(bool), cacheSetting["rules"].([]interface{}))
+			configsOpts.CacheRules = buildCacheRules(cacheSetting["follow_origin"].(bool), cacheSetting["rules"].(*schema.Set).List())
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN domain resources do not guarantee the order of array class fields, so we need to be changed to Set.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

change cdn domain resource `TypeList` to `TypeSet`

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (313.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       313.570s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (417.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       417.273s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (362.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       362.529s
```
