### PR TITLE
feat(ecs): add the extend_param parameter to bandwidth

### DIFF
--- a/docs/resources/compute_instance.md
+++ b/docs/resources/compute_instance.md
@@ -460,6 +460,13 @@ The `bandwidth` block supports:
 * `charge_mode` - (Optional, String, ForceNew) Specifies the bandwidth billing mode. The value can be *traffic* or *bandwidth*.
   Changing this creates a new instance.
 
+* `extend_param` - (Optional, Map, ForceNew) Specifies the additional EIP information.
+  Changing this creates a new instance.
+
+  -> Currently, only the `charging_mode` key is supported and the value can be *prePaid* or *postPaid*.
+  This parameter is **mandatory** when the created ECS is billed in yearly/monthly payments and
+  bound with a pay-per-use EIP. In such a case, `charging_mode` must be set to *postPaid*.
+
 The `scheduler_hints` block supports:
 
 * `group` - (Optional, String, ForceNew) Specifies a UUID of a Server Group.

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -410,6 +410,12 @@ func ResourceComputeInstance() *schema.Resource {
 							ForceNew:     true,
 							RequiredWith: []string{"bandwidth.0.size"},
 						},
+						"extend_param": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},
@@ -1524,10 +1530,19 @@ func buildInstancePublicIPRequest(d *schema.ResourceData) *cloudservers.PublicIp
 		Size:       bandWidth["size"].(int),
 	}
 
+	var eipExtendOpts *cloudservers.EipExtendParam
+	extendParam := bandWidth["extend_param"].(map[string]interface{})
+	if v, ok := extendParam["charging_mode"]; ok {
+		eipExtendOpts = &cloudservers.EipExtendParam{
+			ChargingMode: v.(string),
+		}
+	}
+
 	return &cloudservers.PublicIp{
 		Eip: &cloudservers.Eip{
-			IpType:    d.Get("eip_type").(string),
-			BandWidth: &bwOpts,
+			IpType:      d.Get("eip_type").(string),
+			BandWidth:   &bwOpts,
+			ExtendParam: eipExtendOpts,
 		},
 		DeleteOnTermination: d.Get("delete_eip_on_termination").(bool),
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

Add the `extend_param` parameter to bandwidth
Currently, only the `charging_mode` key is supported and the value can be *prePaid* or *postPaid*.
  This parameter is **mandatory** when the created ECS is billed in yearly/monthly payments and
  bound with a pay-per-use EIP. In such a case, `charging_mode` must be set to *postPaid*.

https://support.huaweicloud.com/api-ecs/zh-cn_topic_0167957246.html#ZH-CN_TOPIC_0167957246__section1840318312449

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/ecs" TESTARGS="-run TestAccComputeInstance_prePaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ecs -v -run TestAccComputeInstance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccComputeInstance_prePaid
=== PAUSE TestAccComputeInstance_prePaid
=== CONT  TestAccComputeInstance_prePaid
--- PASS: TestAccComputeInstance_prePaid (209.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       209.451s
```
