### PR TITLE
feat(RDS): rds instance support power action

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -297,6 +297,11 @@ The `db` block supports:
   + The MariaDB database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are occupied by the RDS system
       and cannot be used). The default value is 3306.
 
+* `power_action` - (Optional, String) Specifies the power action to be done for the instance.
+  Value options: **ON**, **OFF** and **REBOOT**.
+
+  -> **NOTE:** The `power_action` is a one-time action.
+
 The `volume` block supports:
 
 * `size` - (Required, Int) Specifies the volume size. Its value range is from 40 GB to 4000 GB. The value must be a

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240328033637-1dc9ef2bda5e
+	github.com/chnsz/golangsdk v0.0.0-20240330094231-c23394e5a4a4
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240328033637-1dc9ef2bda5e h1:jKM8DBhAdzqQuKUS002VBh5YR6P2Qp0fsYd7oww3+lQ=
-github.com/chnsz/golangsdk v0.0.0-20240328033637-1dc9ef2bda5e/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240330094231-c23394e5a4a4 h1:9PA9mfTpZnIU9PrIDURwMf8BVjoj3duvkyiZA/fUfj4=
+github.com/chnsz/golangsdk v0.0.0-20240330094231-c23394e5a4a4/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/requests.go
@@ -98,10 +98,10 @@ type CreateOpts struct {
 	QuicConfig *QuicConfig `json:"quic_config,omitempty"`
 
 	// Security Policy ID
-	SecurityPolicyId *string `json:"security_policy_id,omitempty"`
+	SecurityPolicyId string `json:"security_policy_id,omitempty"`
 
 	// The SNI certificates used by the listener.
-	SniMatchAlgo *string `json:"sni_match_algo,omitempty"`
+	SniMatchAlgo string `json:"sni_match_algo,omitempty"`
 
 	// Protection status
 	ProtectionStatus string `json:"protection_status,omitempty"`
@@ -131,6 +131,9 @@ type InsertHeaders struct {
 	ForwardedPort    *bool `json:"X-Forwarded-Port,omitempty"`
 	ForwardedForPort *bool `json:"X-Forwarded-For-Port,omitempty"`
 	ForwardedHost    *bool `json:"X-Forwarded-Host,omitempty"`
+	ForwardedProto   *bool `json:"X-Forwarded-Proto,omitempty"`
+	RealIP           *bool `json:"X-Real-IP,omitempty"`
+	ForwardedELBID   *bool `json:"X-Forwarded-ELB-ID,omitempty"`
 }
 
 // ToListenerCreateMap builds a request body from CreateOpts.
@@ -233,10 +236,10 @@ type UpdateOpts struct {
 	QuicConfig *QuicConfig `json:"quic_config,omitempty"`
 
 	// Security Policy ID
-	SecurityPolicyId *string `json:"security_policy_id,omitempty"`
+	SecurityPolicyId string `json:"security_policy_id,omitempty"`
 
 	// The SNI certificates used by the listener.
-	SniMatchAlgo *string `json:"sni_match_algo,omitempty"`
+	SniMatchAlgo string `json:"sni_match_algo,omitempty"`
 
 	// Update protection status
 	ProtectionStatus string `json:"protection_status,omitempty"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/results.go
@@ -80,6 +80,9 @@ type Listener struct {
 	// The creation time of the current listener
 	CreatedAt string `json:"created_at"`
 
+	// The update time of the current listener
+	UpdatedAt string `json:"updated_at"`
+
 	// The port range of the current listener
 	PortRanges []PortRange `json:"port_ranges"`
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -787,11 +787,15 @@ func GetMsdtcHosts(c *golangsdk.ServiceClient, instanceId string) ([]RdsMsdtcHos
 }
 
 func Startup(client *golangsdk.ServiceClient, instanceId string) (r JobResult) {
-	_, r.Err = client.Post(updateURL(client, instanceId, "action/startup"), nil, &r.Body, &golangsdk.RequestOpts{})
+	_, r.Err = client.Post(updateURL(client, instanceId, "action/startup"), nil, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
 	return
 }
 
 func Shutdown(client *golangsdk.ServiceClient, instanceId string) (r JobResult) {
-	_, r.Err = client.Post(updateURL(client, instanceId, "action/shutdown"), nil, &r.Body, &golangsdk.RequestOpts{})
+	_, r.Err = client.Post(updateURL(client, instanceId, "action/shutdown"), nil, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+	})
 	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -104,13 +104,21 @@ func (r CreateResult) Extract() (*CreateResponse, error) {
 }
 
 type JobResponse struct {
-	JobId string `json:"job_id"`
+	JobId     string `json:"job_id"`
+	HumpJobId string `json:"jobId"`
 }
 
 func (r JobResult) Extract() (*JobResponse, error) {
 	var response JobResponse
 	err := r.ExtractInto(&response)
 	return &response, err
+}
+
+func (job JobResponse) GetJobId() string {
+	if job.JobId != "" {
+		return job.JobId
+	}
+	return job.HumpJobId
 }
 
 type ResizeFlavor struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240328033637-1dc9ef2bda5e
+# github.com/chnsz/golangsdk v0.0.0-20240330094231-c23394e5a4a4
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support power action
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support power action
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=11
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 11
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_restore_sqlserver
--- PASS: TestAccRdsInstance_mariadb (456.51s)
--- PASS: TestAccRdsInstance_basic (520.47s)
--- PASS: TestAccRdsInstance_ha (544.94s)
--- PASS: TestAccRdsInstance_mysql_power_action (861.13s)
--- PASS: TestAccRdsInstance_prePaid (1190.10s)
--- PASS: TestAccRdsInstance_restore_pg (1395.04s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1462.80s)
--- PASS: TestAccRdsInstance_mysql (1485.36s)
--- PASS: TestAccRdsInstance_restore_mysql (1594.95s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2075.55s)
--- PASS: TestAccRdsInstance_sqlserver (2873.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2873.368s
```
