### PR TITLE
fix(dli/table): ignore changes caused by abnormal ending character

### DIFF
--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_table_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_table_test.go
@@ -2,6 +2,7 @@ package dli
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -47,7 +48,8 @@ func TestAccResourceDliTable_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "database_name", name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "data_location", tables.TableTypeDLI),
-					resource.TestCheckResourceAttr(resourceName, "description", "dli table test"),
+					// The description returned by the API may contain extra characters "}" at the end.
+					resource.TestMatchResourceAttr(resourceName, "description", regexp.MustCompile(`^dli table test?}$`)),
 				),
 			},
 			{
@@ -115,7 +117,8 @@ func TestAccResourceDliTable_OBS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "database_name", name),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "data_location", tables.TableTypeOBS),
-					resource.TestCheckResourceAttr(resourceName, "description", "dli table test"),
+					// The description returned by the API may contain extra characters "}" at the end.
+					resource.TestMatchResourceAttr(resourceName, "description", regexp.MustCompile(`^dli table test?}$`)),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The abnormal ending character "}" returned by the API will cause resource changes, and because the current description does not support changes, the UI interface will prompt "force replacement" (ForceNew behavior).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

Acceptance check error:
```
=== CONT  TestAccResourceDliTable_basic
    resource_huaweicloud_dli_table_test.go:38: Step 1/2 error: Check failed: Check 5/5 error: huaweicloud_dli_table.test: Attribute 'description' expected "dli table test", got "dli table test}"
--- FAIL: TestAccResourceDliTable_basic (15.12s)
```
Resource force replacement:
```
# huaweicloud_dli_table.test must be replaced
        -/+ resource "huaweicloud_dli_table" "test" {
              + bucket_location    = (known after apply)
              + data_format        = (known after apply)
              + date_format        = (known after apply)
              + delimiter          = (known after apply)
              ~ description        = "dli table test}" -> "dli table test" # forces replacement
              + escape_char        = (known after apply)
              ~ id                 = "tf_test_y6ir2/tf_test_y6ir2" -> (known after apply)
                name               = "tf_test_y6ir2"
              + quote_char         = (known after apply)
              + region             = (known after apply)
              + timestamp_format   = (known after apply)
              + with_column_header = (known after apply)
                # (2 unchanged attributes hidden)
        
              ~ columns {
                  - is_partition = false -> null
                    name         = "name"
                    # (2 unchanged attributes hidden)
                }
              ~ columns {
                  - is_partition = false -> null
                    name         = "addrss"
                    # (2 unchanged attributes hidden)
                }
            }
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. ignore changes caused by abnormal ending character.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccResourceDliTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccResourceDliTable_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDliTable_basic
=== PAUSE TestAccResourceDliTable_basic
=== CONT  TestAccResourceDliTable_basic
--- PASS: TestAccResourceDliTable_basic (26.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       26.470s
```
