### PR TITLE
feat(cae/component): add resource to manage develop configurations

### DIFF
--- a/docs/resources/cae_component_configurations.md
+++ b/docs/resources/cae_component_configurations.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Cloud Application Engine (CAE)"
+---
+
+# huaweicloud_cae_component_configurations
+
+Using this resource to manage develop configurations for a component within HuaweiCloud.
+
+-> A component can only have one resource.
+
+## Example Usage
+
+```hcl
+variable "environment_id" {}
+variable "application_id" {}
+variable "component_id" {}
+
+resource "huaweicloud_cae_component_configurations" "test" {
+  environment_id = var.environment_id
+  application_id = var.application_id
+  component_id   = var.component_id
+
+  items {
+    type = "lifecycle"
+    data = jsonencode({
+      "spec": {
+        "postStart": {
+          "exec": {
+            "command": [
+              "/bin/bash",
+              "-c",
+              "sleep",
+              "10",
+              "done",
+            ]
+          }
+        }
+      }
+    })
+  }
+  items {
+    type = "env"
+    data = jsonencode({
+      "spec": {
+        "envs": {
+            "key": "value",
+            "foo": "bar"
+        }
+      }
+    })
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `environment_id` - (Required, String, ForceNew) Specifies the ID of the develop environment where the applications
+  and components are located.  
+  Changing this parameter will create a new resource.
+
+* `application_id` - (Required, String, ForceNew) Specifies the ID of the application where the components are
+  located.  
+  Changing this parameter will create a new resource.
+
+* `component_id` - (Required, String, ForceNew) Specifies the ID of the component to which the configurations belong.  
+  Changing this parameter will create a new resource.
+
+* `items` - (Required, List, ForceNew) Specifies the list of configurations for component.  
+  The [items](#component_configuration_items) structure is documented below.  
+  Changing this parameter will create a new resource.
+
+<a name="component_configuration_items"></a>
+The `items` block supports:
+
+* `type` - (Required, String, ForceNew) Specifies the type of the configuration.  
+  Please following [reference documentation](https://support.huaweicloud.com/api-cae/CreateComponentConfiguration.html#CreateComponentConfiguration__request_ConfigurationItem).
+
+* `data` - (Required, String, ForceNew) Specifies the configuration detail, in JSON format.  
+  Please following [reference documentation](https://support.huaweicloud.com/api-cae/CreateComponentConfiguration.html#CreateComponentConfiguration__request_ConfigurationData).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also component ID), in UUID format.
+
+## Import
+
+The resource can be imported using `environment_id`, `application_id` and `component_id`, e.g.
+
+```bash
+$ terraform import huaweicloud_cae_component_configurations.test <environment_id>/<application_id>/<component_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -876,7 +876,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_instance": bms.ResourceBmsInstance(),
 			"huaweicloud_bcs_instance": bcs.ResourceInstance(),
 
-			"huaweicloud_cae_component": cae.ResourceComponent(),
+			"huaweicloud_cae_component":                cae.ResourceComponent(),
+			"huaweicloud_cae_component_configurations": cae.ResourceComponentConfigurations(),
 
 			"huaweicloud_cbr_backup_share_accepter": cbr.ResourceBackupShareAccepter(),
 			"huaweicloud_cbr_backup_share":          cbr.ResourceBackupShare(),

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_configurations_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_configurations_test.go
@@ -1,0 +1,183 @@
+package cae
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cae"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getComponentConfigurationsFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		httpUrl     = "v1/{project_id}/cae/applications/{application_id}/components/{component_id}/configurations"
+		componentId = state.Primary.Attributes["component_id"]
+	)
+	client, err := cfg.NewServiceClient("cae", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CAE client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{application_id}", state.Primary.Attributes["application_id"])
+	getPath = strings.ReplaceAll(getPath, "{component_id}", componentId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-ID": state.Primary.Attributes["environment_id"],
+		},
+	}
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, cae.ParseQueryError400(err, cae.ConfigRelatedResourcesNotFoundCodes)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving configurations of the specified component (%s): %s", componentId, err)
+	}
+	items := cae.FilterActivatedConfigurations(utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}))
+	if len(items) < 1 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return items, nil
+}
+
+func TestAccComponentConfigurations_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_cae_component_configurations.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getComponentConfigurationsFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCaeEnvironment(t)
+			acceptance.TestAccPreCheckCaeApplication(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponentConfiguration_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "component_id",
+						"huaweicloud_cae_component.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccComponentConfigurationsFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccComponentConfigurationsFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var environmentId, applicaitonId, componentId string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		environmentId = rs.Primary.Attributes["environment_id"]
+		applicaitonId = rs.Primary.Attributes["application_id"]
+		componentId = rs.Primary.ID
+		if environmentId == "" || applicaitonId == "" || componentId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<environment_id>/<application_id>/<component_id>', "+
+				"but got '%s/%s/%s'", environmentId, applicaitonId, componentId)
+		}
+		return fmt.Sprintf("%s/%s/%s", environmentId, applicaitonId, componentId), nil
+	}
+}
+
+func testAccComponentConfiguration_base() string {
+	name := acceptance.RandomAccResourceNameWithDash()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_cae_component" "test" {
+  environment_id = "%[1]s"
+  application_id = "%[2]s"
+
+  metadata {
+    name = "%[3]s"
+
+    annotations = {
+      version = "1.0.0"
+    }
+  }
+
+  spec {
+    replica = 1
+    runtime = "Docker"
+
+    source {
+      type = "image"
+      url  = "nginx:alpine-perl"
+    }
+
+    resource_limit {
+      cpu    = "500m"
+      memory = "1Gi"
+    }
+  }
+}
+`, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID, name)
+}
+
+func testAccComponentConfiguration_basic_step1() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_component_configurations" "test" {
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+  component_id   = huaweicloud_cae_component.test.id
+
+  items {
+    type = "lifecycle"
+    data = jsonencode({
+      "spec": {
+        "postStart": {
+          "exec": {
+            "command": [
+              "/bin/bash",
+              "-c",
+              "sleep",
+              "10",
+              "done",
+            ]
+          }
+        }
+      }
+    })
+  }
+  items {
+    type = "env"
+    data = jsonencode({
+      "spec": {
+        "envs": {
+            "key": "value",
+            "foo": "bar"
+        }
+      }
+    })
+  }
+}
+`, testAccComponentConfiguration_base(),
+		acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
+}

--- a/huaweicloud/services/cae/common.go
+++ b/huaweicloud/services/cae/common.go
@@ -3,6 +3,7 @@ package cae
 import (
 	"encoding/json"
 	"errors"
+	"log"
 
 	"github.com/jmespath/go-jmespath"
 
@@ -33,4 +34,22 @@ func ParseQueryError400(err error, specErrors []string) error {
 		}
 	}
 	return err
+}
+
+func unmarshalJsonFormatParamster(paramName, paramVal string) map[string]interface{} {
+	parseResult := make(map[string]interface{})
+	err := json.Unmarshal([]byte(paramVal), &parseResult)
+	if err != nil {
+		log.Printf("[ERROR] Invalid type of the %s, it's not JSON format", paramName)
+	}
+	return parseResult
+}
+
+func marshalJsonFormatParamster(paramName, paramVal interface{}) interface{} {
+	jsonDetail, err := json.Marshal(paramVal)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert the %s, it's not JSON format", paramName)
+		return nil
+	}
+	return string(jsonDetail)
 }

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_component_configurations.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_component_configurations.go
@@ -1,0 +1,330 @@
+package cae
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var ConfigRelatedResourcesNotFoundCodes = []string{
+	"CAE.01500208",
+	"CAE.01500404",
+}
+
+// ListNode is the structure of linked list node.
+type ListNode struct {
+	Timestamp int64
+	Val       interface{} // The stored data for node.
+	Next      *ListNode   // Pointer to next node.
+}
+
+// LinkedList is the structure of Singly Linked linked list.
+type LinkedList struct {
+	head *ListNode // Head node of linked list.
+	size int       // Size of linked list.
+}
+
+// @API CAE POST /v1/{project_id}/cae/applications/{application_id}/components/{component_id}/configurations
+// @API CAE GET /v1/{project_id}/cae/applications/{application_id}/components/{component_id}/configurations
+// @API CAE DELETE /v1/{project_id}/cae/applications/{application_id}/components/{component_id}/configurations
+func ResourceComponentConfigurations() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceComponentConfigurationsCreate,
+		ReadContext:   resourceComponentConfigurationsRead,
+		DeleteContext: resourceComponentConfigurationsDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceComponentConfigurationsImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region in which to create the resource.`,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the environment where the application is located.`,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the application where the component is located.`,
+			},
+			"component_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the component to which the configurations belong.`,
+			},
+			"items": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							ForceNew:    true,
+							Description: `The type of the configuration.`,
+						},
+						"data": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringIsJSON,
+							Description:  `The configuration detail.`,
+						},
+					},
+				},
+				Description: `The list of configurations for component.`,
+			},
+		},
+	}
+}
+
+func buildCreateComponentConfigurationBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"api_version": "v1",
+		"kind":        "ComponentConfiguration",
+		"items":       buildConfigurationItemsBodyParams(d.Get("items").(*schema.Set)),
+	}
+}
+
+func buildConfigurationItemsBodyParams(items *schema.Set) []interface{} {
+	if items.Len() < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, items.Len())
+	for _, v := range items.List() {
+		result = append(result, map[string]interface{}{
+			"type": utils.PathSearch("type", v, nil),
+			"data": utils.ValueIngoreEmpty(unmarshalJsonFormatParamster("Component configuration",
+				utils.PathSearch("data", v, "").(string))),
+		})
+	}
+	return result
+}
+
+func resourceComponentConfigurationsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/{project_id}/cae/applications/{application_id}/components/{component_id}/configurations"
+		componentId = d.Get("component_id").(string)
+	)
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE Client: %s", err)
+	}
+
+	modifyPath := client.Endpoint + httpUrl
+	modifyPath = strings.ReplaceAll(modifyPath, "{project_id}", client.ProjectID)
+	modifyPath = strings.ReplaceAll(modifyPath, "{application_id}", d.Get("application_id").(string))
+	modifyPath = strings.ReplaceAll(modifyPath, "{component_id}", componentId)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-ID": d.Get("environment_id").(string),
+		},
+	}
+	opts.JSONBody = utils.RemoveNil(buildCreateComponentConfigurationBodyParams(d))
+	// The creation API will return an 'operation_id' field, but this field is not helpful for resource logic, so it's
+	// ignored.
+	_, err = client.Request("POST", modifyPath, &opts)
+	if err != nil {
+		return diag.Errorf("error creating (overriding) the configurations for a component (%s): %s", componentId, err)
+	}
+	d.SetId(componentId)
+
+	return resourceComponentConfigurationsRead(ctx, d, meta)
+}
+
+// NewLinkedList is a method that used to create a new linked list.
+func NewLinkedList() *LinkedList {
+	return &LinkedList{
+		head: nil,
+		size: 0,
+	}
+}
+
+// Add is a method that used to add a new node to the head of the linked list.
+func (l *LinkedList) Add(timestamp int64, value interface{}) {
+	newNode := &ListNode{
+		Timestamp: timestamp,
+		Val:       value,
+	}
+	if l.head == nil {
+		l.head = newNode
+		l.size++
+		return
+	}
+	current := l.head
+
+	for current.Next != nil {
+		current = current.Next
+	}
+
+	current.Next = newNode
+	l.size++
+}
+
+// GetLatestEditingResult is a method that used to obtain the last editing results of specified type of configuration.
+func (l *LinkedList) GetLatestEditingResult() interface{} {
+	var (
+		latestUpdateTimestamp int64
+		value                 interface{}
+	)
+	current := l.head
+	for current != nil {
+		if current.Timestamp > latestUpdateTimestamp {
+			latestUpdateTimestamp = current.Timestamp
+			value = current.Val
+		}
+		current = current.Next
+	}
+
+	return value
+}
+
+func FilterActivatedConfigurations(configurations []interface{}) map[string]*LinkedList {
+	activatedMap := make(map[string]*LinkedList)
+
+	for _, v := range configurations {
+		configDetail := utils.RemoveNil(utils.PathSearch("data", v, make(map[string]interface{})).(map[string]interface{}))
+		if configDetail == nil {
+			continue
+		}
+		configType := utils.PathSearch("type", v, "").(string)
+		_, ok := activatedMap[configType]
+		if !ok {
+			activatedMap[configType] = NewLinkedList()
+		}
+		activatedMap[configType].Add(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("operated_at", v, "").(string)),
+			marshalJsonFormatParamster("component configuration", configDetail))
+	}
+
+	return activatedMap
+}
+
+func resourceComponentConfigurationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/{project_id}/cae/applications/{application_id}/components/{component_id}/configurations"
+		componentId = d.Get("component_id").(string)
+	)
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE Client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{application_id}", d.Get("application_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{component_id}", componentId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-ID": d.Get("environment_id").(string),
+		},
+	}
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, ParseQueryError400(err, ConfigRelatedResourcesNotFoundCodes),
+			fmt.Sprintf("error querying configurations for the specified component (%s): %s", componentId, err))
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.Errorf("error retrieving configurations of the specified component (%s): %s", componentId, err)
+	}
+	items := FilterActivatedConfigurations(utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{}))
+	if len(items) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "CAE component configurations")
+	}
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("items", flattenConfigurationItems(items)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConfigurationItems(items map[string]*LinkedList) []interface{} {
+	result := make([]interface{}, 0, len(items))
+	for k, v := range items {
+		result = append(result, map[string]interface{}{
+			"type": k,
+			"data": v.GetLatestEditingResult(),
+		})
+	}
+	return result
+}
+
+func resourceComponentConfigurationsDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/{project_id}/cae/applications/{application_id}/components/{component_id}/configurations"
+		componentId = d.Get("component_id").(string)
+	)
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE Client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{application_id}", d.Get("application_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{component_id}", componentId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-ID": d.Get("environment_id").(string),
+		},
+	}
+
+	// Note: This API will delete all configurations under this component, regardless of whether it's configured
+	// through other channels.
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting configurations under the specific component (%s): %s", componentId, err)
+	}
+	return nil
+}
+
+func resourceComponentConfigurationsImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want "+
+			"'<environment_id>/<application_id>/<component_id>', but got '%s'", d.Id())
+	}
+
+	d.SetId(parts[2])
+	mErr := multierror.Append(nil,
+		d.Set("environment_id", parts[0]),
+		d.Set("application_id", parts[1]),
+		d.Set("component_id", parts[2]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}

--- a/huaweicloud/utils/times.go
+++ b/huaweicloud/utils/times.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"log"
+	"time"
+)
+
+// ConvertTimeStrToNanoTimestamp is a method that used to convert the time in RFC3339 format into the corresponding
+// timestamp (in nanosecond), e.g.
+// Before: 2007-09-02T00:00:00.00000Z
+// After:  1188691200000
+func ConvertTimeStrToNanoTimestamp(timeStr string) int64 {
+	t, err := time.Parse(time.RFC3339, timeStr)
+	if err != nil {
+		log.Printf("error parsing time string, it's not RFC3339 format: %s", err)
+	}
+
+	return t.UnixNano() / int64(time.Millisecond)
+}

--- a/huaweicloud/utils/times.go
+++ b/huaweicloud/utils/times.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"fmt"
 	"log"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -16,4 +19,45 @@ func ConvertTimeStrToNanoTimestamp(timeStr string) int64 {
 	}
 
 	return t.UnixNano() / int64(time.Millisecond)
+}
+
+// GetTimezoneCode calculates the time zone code and returns a signed number.
+// For example, the time zone code for 'Asia/Shanghai' is 8, and the time zone code for 'America/Alaska' is -4.
+func GetTimezoneCode() int {
+	timeStr := strings.Split(time.Now().String(), " ")[2]
+	timezoneNum, _ := strconv.Atoi(timeStr)
+	return timezoneNum / 100
+}
+
+// FormatTimeStampRFC3339 is used to unify the time format to RFC-3339 and return a time string.
+// We can use "isUTC" parameter to reset the timezone. If omitted, the method will return local time.
+// Parameter "customFormat" allows you to use a custom RFC3339 format, such as: "2006-01-02T15:04:05.000Z", this
+// parameter can be omitted.
+func FormatTimeStampRFC3339(timestamp int64, isUTC bool, customFormat ...string) string {
+	if timestamp == 0 {
+		return ""
+	}
+
+	createTime := time.Unix(timestamp, 0)
+	if isUTC {
+		createTime = createTime.UTC()
+	}
+	if len(customFormat) > 0 {
+		return createTime.Format(customFormat[0])
+	}
+	return createTime.Format(time.RFC3339)
+}
+
+// FormatTimeStampUTC is used to unify the unix second time to UTC time string, format: YYYY-MM-DD HH:MM:SS.
+func FormatTimeStampUTC(timestamp int64) string {
+	return time.Unix(timestamp, 0).UTC().Format("2006-01-02 15:04:05")
+}
+
+// FormatTimeStampUTC is used to unify the unix second time to UTC time string, format: YYYY-MM-DD HH:MM:SS.
+func FormatUTCTimeStamp(utcTime string) (int64, error) {
+	timestamp, err := time.Parse("2006-01-02 15:04:05", utcTime)
+	if err != nil {
+		return 0, fmt.Errorf("unable to prase the time: %s", utcTime)
+	}
+	return timestamp.Unix(), nil
 }

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -273,47 +272,6 @@ func IsResourceNotFound(err error) bool {
 	}
 	_, ok := err.(golangsdk.ErrDefault404)
 	return ok
-}
-
-// GetTimezoneCode calculates the time zone code and returns a signed number.
-// For example, the time zone code for 'Asia/Shanghai' is 8, and the time zone code for 'America/Alaska' is -4.
-func GetTimezoneCode() int {
-	timeStr := strings.Split(time.Now().String(), " ")[2]
-	timezoneNum, _ := strconv.Atoi(timeStr)
-	return timezoneNum / 100
-}
-
-// FormatTimeStampRFC3339 is used to unify the time format to RFC-3339 and return a time string.
-// We can use "isUTC" parameter to reset the timezone. If omitted, the method will return local time.
-// Parameter "customFormat" allows you to use a custom RFC3339 format, such as: "2006-01-02T15:04:05.000Z", this
-// parameter can be omitted.
-func FormatTimeStampRFC3339(timestamp int64, isUTC bool, customFormat ...string) string {
-	if timestamp == 0 {
-		return ""
-	}
-
-	createTime := time.Unix(timestamp, 0)
-	if isUTC {
-		createTime = createTime.UTC()
-	}
-	if len(customFormat) > 0 {
-		return createTime.Format(customFormat[0])
-	}
-	return createTime.Format(time.RFC3339)
-}
-
-// FormatTimeStampUTC is used to unify the unix second time to UTC time string, format: YYYY-MM-DD HH:MM:SS.
-func FormatTimeStampUTC(timestamp int64) string {
-	return time.Unix(timestamp, 0).UTC().Format("2006-01-02 15:04:05")
-}
-
-// FormatTimeStampUTC is used to unify the unix second time to UTC time string, format: YYYY-MM-DD HH:MM:SS.
-func FormatUTCTimeStamp(utcTime string) (int64, error) {
-	timestamp, err := time.Parse("2006-01-02 15:04:05", utcTime)
-	if err != nil {
-		return 0, fmt.Errorf("unable to prase the time: %s", utcTime)
-	}
-	return timestamp.Unix(), nil
 }
 
 // IsIPv4Address is used to check whether the addr string is IPv4 format


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support two public (marshal and unmarshal) methods to build API requests for CAE service.
Support a new category and add a new convert method, then, unify all time-related methods into one file.
Add a new resource to manage develop configurations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support two public methods to build API requests.
2. add a new category and add a new convert method.
3. unify all time-related methods into one file.
4. add resource to manage develop configurations.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
