### PR TITLE
feat(dli): add new resource to manage permissions for database and data table

### DIFF
--- a/docs/resources/dli_database_privilege.md
+++ b/docs/resources/dli_database_privilege.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# huaweicloud_dli_database_privilege
+
+Using this resource to manage the privileges for the DLI database or data table within HuaweiCloud.
+
+## Example Usage
+
+### Grant permissions of database to a specific user
+
+```hcl
+variable "authorized_iam_user_name" {}
+variable "database_name" {}
+
+resource "huaweicloud_dli_database_privilege" "test" {
+  user_name = var.authorized_iam_user_name
+  object    = format("databases.%s", var.database_name)
+
+  privileges = [
+    "CREATE_TABLE",
+    "CREATE_VIEW",
+    "DISPLAY_ALL_TABLES",
+    "SELECT",
+    "DESCRIBE_TABLE",
+    "SHOW_CREATE_TABLE",
+  ]
+}
+```
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `user_name` - (Required, String, ForceNew) Specifies the name of the authorized (IAM) user.  
+  The valid length is limited from `1` to `32`, only letters, digits, hyphens (-), underscores (_), dots (.) and spaces
+  are allowed. The name cannot contain start with a digit.
+  Changing this parameter will create a new resource.
+
+* `object` - (Required, String, ForceNew) Specifies the authorization object definition.
+  + If it's authorized to the database, the format is **databases.{database_name}**.
+  + If it's authorized to the data table, the format is **databases.{database_name}.tables.{data_table_name}**.
+
+  Changing this parameter will create a new resource.
+
+* `privileges` - (Optional, List) Specifies the list of permissions granted to the database or data table.  
+  The valid [permissions](#permissions_for_database_and_table) are documented below.
+  Currently, only **SELECT** is supported and is the default value.  
+  If you want to grant all permissions, please configure **ALL**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, consisting of `object` and `user_name`, the format is `<object>/<user_name>`.
+
+## Import
+
+The resource can be imported using the `object` and `user_name`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dli_database_privilege.test <object>/<user_name>
+```
+
+## Appendix
+
+<a name="permissions_for_database_and_table"></a>
+| Number | Permissions for database | Permissions for data table |
+| ------ | ------------------------ | -------------------------- |
+| Non-inherited permissions | DISPLAY_ALL_TABLES<br>DISPLAY_DATABASE<br>DROP_DATABASE<br>CREATE_TABLE<br>CREATE_VIEW<br>EXPLAIN<br>CREATE_ROLE<br>DROP_ROLE<br>SHOW_ROLES<br>GRANT_ROLE<br>REVOKE_ROLE<br>SHOW_USERS<br>CREATE_FUNCTION<br>DROP_FUNCTION<br>SHOW_FUNCTIONS<br>DESCRIBE_FUNCTION<br> | DISPLAY_TABLE<br>SELECT<br>DESCRIBE_TABLE<br>SHOW_CREATE_TABLE<br>DROP_TABLE<br>TRUNCATE_TABLE<br>ALTER_TABLE_RENAME<br>INSERT_INTO_TABLE<br>INSERT_OVERWRITE_TABLE<br>ALTER_TABLE_ADD_COLUMNS<br>SPARK_APP_ACCESS_META<br>SHOW_PRIVILEGES<br>GRANT_PRIVILEGE<br>REVOKE_PRIVILEGE |
+| Inherited permissions | SELECT<br>DESCRIBE_TABLE<br>SHOW_CREATE_TABLE<br>DROP_TABLE<br>TRUNCATE_TABLE<br>ALTER_TABLE_RENAME<br>INSERT_INTO_TABLE<br>INSERT_OVERWRITE_TABLE<br>ALTER_TABLE_ADD_COLUMNS<br>SPARK_APP_ACCESS_META<br>SHOW_PRIVILEGES<br>GRANT_PRIVILEGE<br>REVOKE_PRIVILEGE<br>ALTER_TABLE_ADD_PARTITION<br>ALTER_TABLE_DROP_PARTITION<br>ALTER_TABLE_SET_LOCATION<br>ALTER_TABLE_RENAME_PARTITION<br>ALTER_TABLE_RECOVER_PARTITION<br>SHOW_PARTITIONS |  |

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1015,6 +1015,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dis_stream": dis.ResourceDisStream(),
 
 			"huaweicloud_dli_database":                        dli.ResourceDliSqlDatabaseV1(),
+			"huaweicloud_dli_database_privilege":              dli.ResourceDatabasePrivilege(),
 			"huaweicloud_dli_elastic_resource_pool":           dli.ResourceElasticResourcePool(),
 			"huaweicloud_dli_package":                         dli.ResourceDliPackageV2(),
 			"huaweicloud_dli_queue":                           dli.ResourceDliQueue(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -99,6 +99,7 @@ var (
 	HW_DMS_ENVIRONMENT              = os.Getenv("HW_DMS_ENVIRONMENT")
 	HW_SMS_SOURCE_SERVER            = os.Getenv("HW_SMS_SOURCE_SERVER")
 
+	HW_DLI_AUTHORIZED_USER_NAME         = os.Getenv("HW_DLI_AUTHORIZED_USER_NAME")
 	HW_DLI_FLINK_JAR_OBS_PATH           = os.Getenv("HW_DLI_FLINK_JAR_OBS_PATH")
 	HW_DLI_DS_AUTH_CSS_OBS_PATH         = os.Getenv("HW_DLI_DS_AUTH_CSS_OBS_PATH")
 	HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH = os.Getenv("HW_DLI_DS_AUTH_KAFKA_TRUST_OBS_PATH")
@@ -778,6 +779,15 @@ func TestAccPreCheckRAMSharedPrincipalsQueryFields(t *testing.T) {
 func TestAccPreCheckDms(t *testing.T) {
 	if HW_DMS_ENVIRONMENT == "" {
 		t.Skip("This environment does not support DMS tests")
+	}
+}
+
+// DLI authorization operations require that the object has administrative rights to the DLI service and has logged in
+// to the DLI console.
+// lintignore:AT003
+func TestAccPreCheckDliAuthorizedUserConfigured(t *testing.T) {
+	if HW_DLI_AUTHORIZED_USER_NAME == "" {
+		t.Skip("HW_DLI_AUTHORIZED_USER_NAME must be set for DLI privilege acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_privilege_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_privilege_test.go
@@ -1,0 +1,116 @@
+package dli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
+)
+
+func getDatabasePrivilegeResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dli", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DLI client: %s", err)
+	}
+
+	return dli.GetObjectPrivilegesForSpecifiedUser(client, state.Primary.Attributes["object"],
+		state.Primary.Attributes["user_name"])
+}
+
+func TestAccDatabasePrivilege_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		name        = acceptance.RandomAccResourceName()
+		rNameToUser = "huaweicloud_dli_database_privilege.grant_user"
+
+		rcToUser = acceptance.InitResourceCheck(rNameToUser, &obj, getDatabasePrivilegeResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliAuthorizedUserConfigured(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rcToUser.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDatabasePrivilege_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Resource that authorized IAM user.
+					rcToUser.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameToUser, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
+					resource.TestCheckResourceAttr(rNameToUser, "privileges.#", "1"),
+					resource.TestCheckResourceAttr(rNameToUser, "privileges.0", "SELECT"),
+				),
+			},
+			{
+				Config: testDatabasePrivilege_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcToUser.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameToUser, "privileges.#", "3"),
+				),
+			},
+			{
+				ResourceName:      rNameToUser,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDatabasePrivilege_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_database" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_dli_table" "test" {
+  database_name = huaweicloud_dli_database.test.name
+  name          = "%[1]s"
+  data_location = "DLI"
+
+  columns {
+    name = "user_name"
+    type = "string"
+  }
+  columns {
+    name = "age"
+    type = "int"
+  }
+}
+`, name)
+}
+
+func testDatabasePrivilege_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dli_database_privilege" "grant_user" {
+  object    = format("databases.%%s.tables.%%s", huaweicloud_dli_database.test.name, huaweicloud_dli_table.test.name)
+  user_name = "%[2]s" # Make sure the user has correct permissions and has logged in to the DLI console.
+}
+`, testDatabasePrivilege_base(name), acceptance.HW_DLI_AUTHORIZED_USER_NAME)
+}
+
+func testDatabasePrivilege_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dli_database_privilege" "grant_user" {
+  object    = format("databases.%%s.tables.%%s", huaweicloud_dli_database.test.name, huaweicloud_dli_table.test.name)
+  user_name = "%[2]s" # Make sure the user has correct permissions and has logged in to the DLI console.
+
+  privileges = [
+    "SELECT", "DESCRIBE_TABLE", "DISPLAY_TABLE"
+  ]
+}
+`, testDatabasePrivilege_base(name), acceptance.HW_DLI_AUTHORIZED_USER_NAME)
+}

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_connection_privilege_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_connection_privilege_test.go
@@ -39,7 +39,7 @@ func getDatasourceConnectionPrivilegeResourceFunc(cfg *config.Config, state *ter
 	}
 	requestResp, err := client.Request("GET", getPath, &getOpts)
 	if err != nil {
-		return nil, dli.ParsePrivilegesQueryError(err)
+		return nil, dli.ParsePrivilegesQueryError(err, dli.ErrCodeConnNotFound)
 	}
 	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_database_privilege.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_database_privilege.go
@@ -1,0 +1,249 @@
+package dli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// The error code corresponding to errCodeDbNotFound is an important sign that the related resource does not exist.
+// When the object is database and the database does not exist, the API return this error:
+// + {"error_code": "DLI.0002", "error_msg": "There is no database named xxx"}
+// When the object is data table and the data table (even containing the database) does not exist, the API return this error:
+// + {"error_code": "DLI.0002", "error_msg": "There is no table named named xxx"}
+const errCodeDbNotFound string = "DLI.0002"
+
+// @API DLI PUT /v1.0/{project_id}/authorization
+// @API DLI GET /v1.0/{project_id}/authorization/privileges
+func ResourceDatabasePrivilege() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDatabasePrivilegeCreate,
+		ReadContext:   resourceDatabasePrivilegeRead,
+		UpdateContext: resourceDatabasePrivilegeUpdate,
+		DeleteContext: resourceDatabasePrivilegeDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDatabasePrivilegeImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region in which to create the resource.`,
+			},
+			"object": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The authorization object definition.`,
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The name of the authorized (IAM) user.`,
+			},
+			"privileges": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of permissions granted to the database or data table.`,
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
+					if _, ok := d.GetOk("privileges"); !ok {
+						// If the value of the permission is nil, the Computed behavior will prevent changes.
+						// If the value of the permission is not nil and the length of the array is zero, need a
+						// DiffSuppress function to prevent changes.
+						return true
+					}
+					return false
+				},
+			},
+		},
+	}
+}
+
+func buildModifyDatabasePrivilegeBodyParams(d *schema.ResourceData, action string) map[string]interface{} {
+	// Default permission for database and data table.
+	privileges := []string{"SELECT"}
+	if d.Get("privileges").(*schema.Set).Len() > 0 {
+		privileges = utils.ExpandToStringListBySet(d.Get("privileges").(*schema.Set))
+	}
+
+	return map[string]interface{}{
+		"user_name": utils.ValueIngoreEmpty(d.Get("user_name")),
+		"action":    action,
+		"privileges": []map[string]interface{}{
+			{
+				"object":     d.Get("object"),
+				"privileges": privileges,
+			},
+		},
+	}
+}
+
+func modifyDatabasePrivilege(client *golangsdk.ServiceClient, d *schema.ResourceData, action string) error {
+	httpUrl := "v1.0/{project_id}/authorization"
+
+	modifyPath := client.Endpoint + httpUrl
+	modifyPath = strings.ReplaceAll(modifyPath, "{project_id}", client.ProjectID)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildModifyDatabasePrivilegeBodyParams(d, action)),
+	}
+
+	requestResp, err := client.Request("PUT", modifyPath, &opts)
+	if err != nil {
+		return err
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return err
+	}
+	if !utils.PathSearch("is_success", respBody, true).(bool) {
+		return fmt.Errorf("unable to %s the privileges: %s", action,
+			utils.PathSearch("message", respBody, "Message Not Found"))
+	}
+	return nil
+}
+
+func resourceDatabasePrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	err = modifyDatabasePrivilege(client, d, "grant")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(fmt.Sprintf("%v/%v", d.Get("object"), d.Get("user_name")))
+
+	return resourceDatabasePrivilegeRead(ctx, d, meta)
+}
+
+func GetObjectPrivilegesForSpecifiedUser(client *golangsdk.ServiceClient, object, userName string) (interface{}, error) {
+	var (
+		filterExpression string
+		httpUrl          = "v1.0/{project_id}/authorization/privileges?object={object}"
+	)
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{object}", object)
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return nil, ParsePrivilegesQueryError(err, errCodeDbNotFound)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if !utils.PathSearch("is_success", respBody, true).(bool) {
+		return nil, fmt.Errorf("unable to query the privileges: %s",
+			utils.PathSearch("message", respBody, "Message Not Found"))
+	}
+	filterExpression = fmt.Sprintf("privileges[?user_name=='%s']|[0]", userName)
+	privilege := utils.PathSearch(filterExpression, respBody, nil)
+	if privilege != nil {
+		return privilege, nil
+	}
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func resourceDatabasePrivilegeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		object   = d.Get("object").(string)
+		userName = d.Get("user_name").(string)
+	)
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	privilege, err := GetObjectPrivilegesForSpecifiedUser(client, object, userName)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving privileges")
+	}
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("object", utils.PathSearch("object", privilege, nil)),
+		d.Set("user_name", utils.PathSearch("user_name", privilege, nil)),
+		d.Set("privileges", utils.PathSearch("privileges", privilege, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDatabasePrivilegeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	err = modifyDatabasePrivilege(client, d, "update")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceDatabasePrivilegeRead(ctx, d, meta)
+}
+
+func resourceDatabasePrivilegeDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dli", region)
+	if err != nil {
+		return diag.Errorf("error creating DLI client: %s", err)
+	}
+
+	err = modifyDatabasePrivilege(client, d, "revoke")
+	return diag.FromErr(err)
+}
+
+func resourceDatabasePrivilegeImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	var (
+		importId = d.Id()
+		parts    = strings.Split(importId, "/")
+	)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid resource ID format for privilege management, want '<object>/<user_name>', "+
+			"but got '%s'", importId)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("object", parts[0]),
+		d.Set("user_name", parts[1]),
+	)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New resource is supported to manage permissions for database and data table.
We can using this resource to grant some database permissions (or data table permissions) to a IAM user.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. refactor the public function to allow more special 404 error codes.
2. add new resource to manage permissions for database and data table.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDatabasePrivilege_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDatabasePrivilege_basic -timeout 360m -parallel 4
=== RUN   TestAccDatabasePrivilege_basic
=== PAUSE TestAccDatabasePrivilege_basic
=== CONT  TestAccDatabasePrivilege_basic
--- PASS: TestAccDatabasePrivilege_basic (51.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       51.321s
```
