### PR TITLE
chore(cae): fix the issue of the component resource acceptance test

### DIFF
--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -277,10 +277,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version: "v1",
 		Product: "SFSTurbo",
 	},
-	"cae": {
-		Name:    "cae",
-		Product: "CAE",
-	},
 	"cbh": {
 		Name:    "cbh",
 		Version: "v1",
@@ -627,6 +623,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	},
 
 	// catalog for Enterprise Intelligence
+	"cae": {
+		Name:    "cae",
+		Product: "CAE",
+	},
 	"mrs": {
 		Name:    "mrs",
 		Version: "v1.1",

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -389,7 +389,7 @@ func TestAccPreCheckCaeApplication(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckCAEComponent(t *testing.T) {
+func TestAccPreCheckCaeComponent(t *testing.T) {
 	if HW_CAE_CODE_URL == "" || HW_CAE_CODE_AUTH_NAME == "" || HW_CAE_CODE_BRANCH == "" || HW_CAE_CODE_NAMESPACE == "" ||
 		HW_CAE_ARTIFACT_NAMESPACE == "" || HW_CAE_BUILD_BASE_IMAGE == "" || HW_CAE_IMAGE_URL == "" {
 		t.Skip("Skip the CAE acceptance tests.")

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_test.go
@@ -1,4 +1,4 @@
-package cbh
+package cae
 
 import (
 	"fmt"
@@ -14,8 +14,8 @@ import (
 
 func getComponentFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	environmentId := state.Primary.Attributes["environment_id"]
-	resp, err := cae.GetComponentById(cfg, acceptance.HW_REGION_NAME, environmentId, state.Primary.Attributes["application_id"], state.Primary.ID)
-	return resp, err
+	applicationId := state.Primary.Attributes["application_id"]
+	return cae.GetComponentById(cfg, acceptance.HW_REGION_NAME, environmentId, applicationId, state.Primary.ID)
 }
 
 func TestAccComponent_basic(t *testing.T) {
@@ -36,7 +36,7 @@ func TestAccComponent_basic(t *testing.T) {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckCaeEnvironment(t)
 			acceptance.TestAccPreCheckCaeApplication(t)
-			acceptance.TestAccPreCheckCAEComponent(t)
+			acceptance.TestAccPreCheckCaeComponent(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -63,7 +63,6 @@ func TestAccComponent_basic(t *testing.T) {
 				Config: testAccComponent_step2(updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-
 					resource.TestCheckResourceAttr(rName, "metadata.0.name", updateName),
 					resource.TestCheckResourceAttr(rName, "spec.0.replica", "1"),
 					resource.TestCheckResourceAttr(rName, "spec.0.%", "5"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Fix the issue of the component resource acceptance test package name.
2. Modify `TestAccPreCheckCAEComponent` to `TestAccPreCheckCaeComponent`.
3. Move the CAE definition location in the endponit file.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/cae TESTARGS='-run TestAccComponent_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cae -v -run TestAccComponent_basic -timeout 360m -parallel 4
=== RUN   TestAccComponent_basic
=== PAUSE TestAccComponent_basic
=== CONT  TestAccComponent_basic
--- PASS: TestAccComponent_basic (36.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       36.929s```
