### PR TITLE
fix(CDN): fix CDN domain `https_settings` several issues

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -281,7 +281,7 @@ The `https_settings` block support:
   When `https_enabled` is set to **false**, this parameter does not take effect.
 
 * `tls_version` - (Optional, String) Specifies the transport Layer Security (TLS). Currently, **TLSv1.0**,
-  **TLSv1.1**, **TLSv1.2**, and **TLSv1.3** are supported. By default, **TLS 1.1**, **TLS 1.2**, and **TLS 1.3** are
+  **TLSv1.1**, **TLSv1.2**, and **TLSv1.3** are supported. By default, **TLSv1.1**, **TLSv1.2**, and **TLSv1.3** are
   enabled. You can enable a single version or consecutive versions. To enable multiple versions, use commas (,) to
   separate versions, for example, **TLSv1.1,TLSv1.2**.
 

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -271,11 +271,8 @@ The `https_settings` block support:
 * `private_key` - (Optional, String) Specifies the private key used by the HTTPS protocol. This parameter is mandatory
   when a certificate is configured. The value is in PEM format.
 
-* `certificate_source` - (Optional, Int) Specifies the certificate type. Possible values are:
-  + **1**: Huawei-managed certificate.
-  + **0**: Your own certificate.
-  
-  Defaults to **0**.
+* `certificate_source` - (Optional, Int) Specifies the certificate type. Currently, only **0** is supported, which means
+  your own certificate. Defaults to **0**.
 
 * `http2_enabled` - (Optional, Bool) Specifies whether HTTP/2 is used. Defaults to **false**.
   When `https_enabled` is set to **false**, this parameter does not take effect.

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -249,11 +249,12 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ipv6_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.range_based_retrieval_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.certificate_name", "terraform-test"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.certificate_source", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "on"),
-					testAccCheckTlsVersion(resourceName, "TLSv1.1,TLSv1.2"),
+					testAccCheckTLSVersion(resourceName, "TLSv1.1,TLSv1.2"),
 
 					resource.TestCheckResourceAttrSet(resourceName, "configs.0.https_settings.0.certificate_body"),
 					resource.TestCheckResourceAttrSet(resourceName, "configs.0.https_settings.0.private_key"),
@@ -265,7 +266,12 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.certificate_name", "terraform-update"),
-					testAccCheckTlsVersion(resourceName, "TLSv1.1,TLSv1.2,TLSv1.3"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.certificate_source", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "off"),
+					testAccCheckTLSVersion(resourceName, "TLSv1.1,TLSv1.2,TLSv1.3"),
 				),
 			},
 			{
@@ -273,7 +279,10 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.tls_version", "TLSv1.2"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "off"),
 				),
 			},
 		},
@@ -282,7 +291,7 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 
 // The response value order of field `tls_version` will be modified.
 // For example `TLSv1.1,TLSv1.2` will be modified to `TLSv1.2,TLSv1.1`.
-func testAccCheckTlsVersion(n string, tlsVersion string) resource.TestCheckFunc {
+func testAccCheckTLSVersion(n string, tlsVersion string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -325,12 +334,13 @@ resource "huaweicloud_cdn_domain" "test" {
     range_based_retrieval_enabled = "true"
 
     https_settings {
-      certificate_name = "terraform-test"
-      certificate_body = file("%s")
-      http2_enabled    = true
-      https_enabled    = true
-      private_key      = file("%s")
-      tls_version      = "TLSv1.1,TLSv1.2"
+      certificate_name   = "terraform-test"
+      certificate_body   = file("%s")
+      http2_enabled      = true
+      https_enabled      = true
+      private_key        = file("%s")
+      tls_version        = "TLSv1.1,TLSv1.2"
+      certificate_source = 0
     }
   }
 }
@@ -355,12 +365,13 @@ resource "huaweicloud_cdn_domain" "test" {
     range_based_retrieval_enabled = "true"
 
     https_settings {
-      certificate_name = "terraform-update"
-      certificate_body = file("%s")
-      http2_enabled    = true
-      https_enabled    = true
-      private_key      = file("%s")
-      tls_version      = "TLSv1.1,TLSv1.2,TLSv1.3"
+      certificate_name   = "terraform-update"
+      certificate_body   = file("%s")
+      http2_enabled      = false
+      https_enabled      = true
+      private_key        = file("%s")
+      tls_version        = "TLSv1.1,TLSv1.2,TLSv1.3"
+      certificate_source = 0
     }
   }
 }
@@ -385,16 +396,11 @@ resource "huaweicloud_cdn_domain" "test" {
     range_based_retrieval_enabled = "true"
 
     https_settings {
-      certificate_name = "terraform-update"
-      certificate_body = file("%s")
-      http2_enabled    = true
-      https_enabled    = true
-      private_key      = file("%s")
-      tls_version      = "TLSv1.2"
+      https_enabled = false
     }
   }
 }
-`, acceptance.HW_CDN_DOMAIN_NAME, acceptance.HW_CDN_CERT_PATH, acceptance.HW_CDN_PRIVATE_KEY_PATH)
+`, acceptance.HW_CDN_DOMAIN_NAME)
 
 // All configuration item modifications may trigger `CDN.0163`. This is a problem that we have no way to solve.
 // When a `CDN.0163` error occurs, you can avoid this error by adjusting the test case configuration items.

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -67,9 +67,10 @@ var httpsConfig = schema.Schema{
 				Computed: true,
 			},
 			"tls_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: utils.SuppressStringSepratedByCommaDiffs,
+				Computed:         true,
 			},
 			"https_status": {
 				Type:     schema.TypeString,

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -57,9 +57,6 @@ var httpsConfig = schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: validation.IntInSlice([]int{
-					0, 1,
-				}),
 			},
 			"http2_enabled": {
 				Type:     schema.TypeBool,
@@ -610,28 +607,26 @@ func buildCreateDomainSources(d *schema.ResourceData) []domains.SourcesOpts {
 	return sourceRequests
 }
 
+func buildHttpStatusOpts(enable bool) string {
+	if enable {
+		return "on"
+	}
+	return "off"
+}
+
 func buildHTTPSOpts(rawHTTPS []interface{}) *model.HttpPutBody {
 	if len(rawHTTPS) != 1 {
 		return nil
 	}
 
 	https := rawHTTPS[0].(map[string]interface{})
-	httpsStatus := ""
-	if https["https_enabled"].(bool) {
-		httpsStatus = "on"
-	}
-	http2Status := ""
-	if https["http2_enabled"].(bool) {
-		http2Status = "on"
-	}
-
 	httpsOpts := model.HttpPutBody{
-		HttpsStatus:       utils.StringIgnoreEmpty(httpsStatus),
+		HttpsStatus:       utils.String(buildHttpStatusOpts(https["https_enabled"].(bool))),
 		CertificateName:   utils.StringIgnoreEmpty(https["certificate_name"].(string)),
 		CertificateValue:  utils.StringIgnoreEmpty(https["certificate_body"].(string)),
 		PrivateKey:        utils.StringIgnoreEmpty(https["private_key"].(string)),
-		CertificateSource: utils.Int32IgnoreEmpty(int32(https["certificate_source"].(int))),
-		Http2Status:       utils.StringIgnoreEmpty(http2Status),
+		CertificateSource: utils.Int32(int32(https["certificate_source"].(int))),
+		Http2Status:       utils.String(buildHttpStatusOpts(https["http2_enabled"].(bool))),
 		TlsVersion:        utils.StringIgnoreEmpty(https["tls_version"].(string)),
 	}
 
@@ -1139,14 +1134,16 @@ func analyseFunctionEnabledStatusPtr(enabledStatus *string) bool {
 	return enabledStatus != nil && *enabledStatus == "on"
 }
 
-func flattenHTTPSAttrs(https *model.HttpGetBody, privateKey string) []map[string]interface{} {
+// flattenHTTPSAttrs Field `privateKey` is not returned in the details interface.
+// The value of the field `certificateBody` will be modified by the cloud, resulting in inconsistency with the local value.
+func flattenHTTPSAttrs(https *model.HttpGetBody, privateKey, certificateBody string) []map[string]interface{} {
 	if https == nil {
 		return nil
 	}
 	httpsAttrs := map[string]interface{}{
 		"https_status":       https.HttpsStatus,
 		"certificate_name":   https.CertificateName,
-		"certificate_body":   https.CertificateValue,
+		"certificate_body":   certificateBody,
 		"private_key":        privateKey,
 		"certificate_source": https.CertificateSource,
 		"http2_status":       https.Http2Status,
@@ -1416,10 +1413,11 @@ func flattenCacheRulesAttrs(cacheRulesPtr *[]model.CacheRules) []map[string]inte
 
 func flattenConfigAttrs(configsResp *model.ConfigsGetBody, d *schema.ResourceData) []map[string]interface{} {
 	privateKey := d.Get("configs.0.https_settings.0.private_key").(string)
+	certificateBody := d.Get("configs.0.https_settings.0.certificate_body").(string)
 	urlAuthKey := d.Get("configs.0.url_signing.0.key").(string)
 
 	configsAttrs := map[string]interface{}{
-		"https_settings":                flattenHTTPSAttrs(configsResp.Https, privateKey),
+		"https_settings":                flattenHTTPSAttrs(configsResp.Https, privateKey, certificateBody),
 		"retrieval_request_header":      flattenOriginRequestHeaderAttrs(configsResp.OriginRequestHeader),
 		"http_response_header":          flattenHttpResponseHeaderAttrs(configsResp.HttpResponseHeader),
 		"url_signing":                   flattenUrlAuthAttrs(configsResp.UrlAuth, urlAuthKey),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The field `https_settings` has a logic problem in the resource and needs to be fixed.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- commit1: Add diff func for CDN domain resource and add test case.
- commit2: Fix CDN domain `https_settings` several issues.
  - Field `certificate_source` only support setting to **0**.
  - Fields `https_enabled` and `http2_enabled` support deiting.
  - Fillback `certificate_body` from local state in read function.
  - Add test cases for edited functions.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (498.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       498.609s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (490.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       490.279s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (630.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       630.092s
```
