### PR TITLE
fix(vpc): fix destroy problem in network acl

### DIFF
--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_network_acl.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_network_acl.go
@@ -614,9 +614,11 @@ func resourceNetworkAclDelete(_ context.Context, d *schema.ResourceData, meta in
 	}
 
 	// the associated subnets need to be removed before deleting the ACL
-	err = networkAclDisassociatSubnets(client, d.Get("associated_subnets").(*schema.Set).List(), id)
-	if err != nil {
-		return diag.FromErr(err)
+	if d.Get("associated_subnets").(*schema.Set).Len() > 0 {
+		err = networkAclDisassociatSubnets(client, d.Get("associated_subnets").(*schema.Set).List(), id)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	deleteNetworkAclHttpUrl := "v3/{project_id}/vpc/firewalls/" + id


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

check whether associated subnet list is empty bofore call the disassociate them
this will avoid error when no subnet is associated

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccNetworkAcl_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccNetworkAcl_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkAcl_basic
=== PAUSE TestAccNetworkAcl_basic
=== CONT  TestAccNetworkAcl_basic
--- PASS: TestAccNetworkAcl_basic (118.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       118.297s
```
