### PR TITLE
fix(CDN): fix CDN domain int-value field error and add test cases

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -515,7 +515,8 @@ The `cache_settings` block support:
 The `rules` block support:
 
 * `rule_type` - (Required, String) Specifies the rule type. Possible value are:
-  + **all**: All types of files are matched. It is the default value.
+  + **all**: All types of files are matched. It is the default value. The cloud will create a cache rule with **all**
+    rule type by default.
   + **file_extension**: Files are matched based on their suffixes.
   + **catalog**: Files are matched based on their directories.
   + **full_path**: Files are matched based on their full paths.
@@ -581,7 +582,9 @@ $ terraform import huaweicloud_cdn_domain.test <name>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `enterprise_project_id`.
+API response, security or some other reason. The missing attributes include: `enterprise_project_id`,
+`configs.0.url_signing.0.key`, `configs.0.https_settings.0.certificate_body`, `configs.0.https_settings.0.private_key`,
+and `cache_settings`.
 It is generally recommended running `terraform plan` after importing a resource.
 You can then decide if changes should be applied to the resource, or the resource definition should be updated to align
 with the resource. Also, you can ignore changes as below.
@@ -592,8 +595,9 @@ resource "huaweicloud_cdn_domain" "test" {
   
   lifecycle {
     ignore_changes = [
-      enterprise_project_id,
+      enterprise_project_id, configs.0.url_signing.0.key, configs.0.https_settings.0.certificate_body,
+      configs.0.https_settings.0.private_key, cache_settings,
     ]
   }
 }
-```**
+```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There has somthing wrong with CDN domain resource.
- Fileds `cache_settings.0.rules.0.ttl` and `configs.0.url_signing.0.expire_time` should be supported to set to zero.
- Missing test cases for fields `cache settings.0.rules.0.ttl` and `configs.0.url_signing.0.expire_time`.
- Field `cache_settings` need to be ignored when querying.
- Several fields need to be ignored when importing.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed
```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (557.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       557.371s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (377.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       377.818s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (395.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       395.388s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (730.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       730.176s
```
