### PR TITLE
feat(cae): add new datasource to get list of applications

### DIFF
--- a/docs/data-sources/cae_applications.md
+++ b/docs/data-sources/cae_applications.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Cloud Application Engine (CAE)"
+---
+
+# huaweicloud_cae_applications
+
+Use this data source to get the list of CAE applications.
+
+## Example Usage
+
+```hcl
+variable "environment_id" {}
+
+data "huaweicloud_cae_applications" "test" {
+  environment_id = var.environment_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the CAE application list.
+  If omitted, the provider-level region will be used.
+
+* `environment_id` - (Required, String) Specifies the ID of the environment to which the applications belong.
+
+* `application_id` - (Optional, String) Specifies the ID of the application to be queried.
+
+* `name` - (Optional, String) Specifies the name of the application to be queried.
+  The name can contain `2` to `64` characters, only lowercase letters, digits, and hyphens (-) allowed.
+  The name must start with a lowercase letter and end with lowercase letters and digits.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `applications` - All applications that match the filter parameters.
+  The [applications](#CAE_applications) structure is documented below.
+
+<a name="CAE_applications"></a>
+The `applications` block supports:
+
+* `id` - The ID of the application.
+
+* `name` - The name of the application.
+
+* `created_at` - The creation time of the application.
+
+* `updated_at` - The latest update time of the application.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -410,6 +410,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_bms_instances": bms.DataSourceBmsInstances(),
 
 			"huaweicloud_cae_environments": cae.DataSourceEnvironments(),
+			"huaweicloud_cae_applications": cae.DataSourceApplications(),
 
 			"huaweicloud_cbr_backup":   cbr.DataSourceBackup(),
 			"huaweicloud_cbr_vaults":   cbr.DataSourceVaults(),

--- a/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_applications_test.go
+++ b/huaweicloud/services/acceptance/cae/data_source_huaweicloud_cae_applications_test.go
@@ -1,0 +1,51 @@
+package cae
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceApplications_basic(t *testing.T) {
+	rName := "data.huaweicloud_cae_applications.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCaeEnvironment(t)
+			acceptance.TestAccPreCheckCaeApplication(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceApplications_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+
+					resource.TestCheckOutput("application_id_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceApplications_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cae_applications" "test" {
+  environment_id = "%[1]s"
+  application_id = "%[2]s"
+}
+
+locals {
+  application_id_filter_result = [for v in data.huaweicloud_cae_applications.test.applications : v.id == "%[2]s"]
+}
+
+output "application_id_filter_is_useful" {
+  value = alltrue(local.application_id_filter_result) && length(local.application_id_filter_result) > 0
+}
+`, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
+}

--- a/huaweicloud/services/cae/data_source_huaweicloud_cae_applications.go
+++ b/huaweicloud/services/cae/data_source_huaweicloud_cae_applications.go
@@ -1,0 +1,158 @@
+package cae
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CAE GET /v1/{project_id}/cae/applications
+func DataSourceApplications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApplicationRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"environment_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"application_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// attributes
+			"applications": {
+				Type:     schema.TypeList,
+				Elem:     dataSchemaApplications(),
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSchemaApplications() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceApplicationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	// listApplications: Query the list of CAE applications
+	var (
+		listApplicationsHttpUrl = "v1/{project_id}/cae/applications"
+		listApplicationsProduct = "cae"
+	)
+	listApplicationsClient, err := cfg.NewServiceClient(listApplicationsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	listApplicationsPath := listApplicationsClient.Endpoint + listApplicationsHttpUrl
+	listApplicationsPath = strings.ReplaceAll(listApplicationsPath, "{project_id}", listApplicationsClient.ProjectID)
+	listApplicationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"X-Environment-ID": d.Get("environment_id").(string)},
+	}
+
+	listApplicationsResp, err := listApplicationsClient.Request("GET", listApplicationsPath, &listApplicationOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CAE applications")
+	}
+
+	listApplicationsRespBody, err := utils.FlattenResponse(listApplicationsResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("applications", filterListApplicationBody(
+			flattenListApplicationsBody(listApplicationsRespBody), d)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenListApplicationsBody(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	curJson := utils.PathSearch("items", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":         utils.PathSearch("id", v, nil),
+			"name":       utils.PathSearch("name", v, nil),
+			"created_at": utils.PathSearch("created_at", v, nil),
+			"updated_at": utils.PathSearch("updated_at", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterListApplicationBody(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if applicationId, ok := d.GetOk("application_id"); ok && applicationId.(string) != utils.PathSearch("id", v, "").(string) {
+			continue
+		}
+		if name, ok := d.GetOk("name"); ok && name.(string) != utils.PathSearch("name", v, "").(string) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new datasource to get list of applications.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cae" TESTARGS="-run TestAccDatasourceApplications_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cae -v -run TestAccDatasourceApplications_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceApplications_basic
=== PAUSE TestAccDatasourceApplications_basic
=== CONT  TestAccDatasourceApplications_basic
--- PASS: TestAccDatasourceApplications_basic (18.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       18.610s
```
