### PR TITLE
feat(elb): add params and attrs for monitor

### DIFF
--- a/docs/resources/elb_monitor.md
+++ b/docs/resources/elb_monitor.md
@@ -50,7 +50,12 @@ The following arguments are supported:
   parameter `interval`.
 
 * `max_retries` - (Required, Int) Specifies the number of consecutive health checks when the health check result of
-  a backend server changes from OFFLINE to ONLINE. Value ranges from **1** to **50**.
+  a backend server changes from OFFLINE to ONLINE. Value ranges from **1** to **10**.
+
+* `max_retries_down` - (Optional, Int) Specifies the number of consecutive health checks when the health check result of
+  a backend server changes from ONLINE to OFFLINE. The value ranges from **1** to **10**, and the default value is **3**.
+
+* `name` - (Optional, String) Specifies the health check name.
 
 * `domain_name` - (Optional, String) Specifies the domain name that HTTP requests are sent to during the health check.
   The domain name consists of 1 to 100 characters, can contain only digits, letters, hyphens (-), and periods (.) and
@@ -78,7 +83,11 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The unique ID for the monitor.
+* `id` - The unique ID of the monitor.
+
+* `created_at` - The create time of the monitor.
+
+* `updated_at` - The update time of the monitor.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_monitor_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_monitor_test.go
@@ -46,6 +46,8 @@ func TestAccElbV3Monitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interval", "20"),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "10"),
 					resource.TestCheckResourceAttr(resourceName, "max_retries", "5"),
+					resource.TestCheckResourceAttr(resourceName, "max_retries_down", "5"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "url_path", "/aa"),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", "www.aa.com"),
 					resource.TestCheckResourceAttr(resourceName, "port", "8000"),
@@ -60,6 +62,8 @@ func TestAccElbV3Monitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "interval", "30"),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "20"),
 					resource.TestCheckResourceAttr(resourceName, "max_retries", "8"),
+					resource.TestCheckResourceAttr(resourceName, "max_retries_down", "8"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
 					resource.TestCheckResourceAttr(resourceName, "url_path", "/bb"),
 					resource.TestCheckResourceAttr(resourceName, "domain_name", "www.bb.com"),
 					resource.TestCheckResourceAttr(resourceName, "port", "8888"),
@@ -80,17 +84,19 @@ func testAccElbV3MonitorConfig_basic(rName string) string {
 %s
 
 resource "huaweicloud_elb_monitor" "monitor_1" {
-  pool_id     = huaweicloud_elb_pool.test.id
-  protocol    = "HTTP"
-  interval    = 20
-  timeout     = 10
-  max_retries = 5
-  url_path    = "/aa"
-  domain_name = "www.aa.com"
-  port        = "8000"
-  status_code = "200,401-500,502"
+  pool_id          = huaweicloud_elb_pool.test.id
+  name             = "%s"
+  protocol         = "HTTP"
+  interval         = 20
+  timeout          = 10
+  max_retries      = 5
+  max_retries_down = 5
+  url_path         = "/aa"
+  domain_name      = "www.aa.com"
+  port             = "8000"
+  status_code      = "200,401-500,502"
 }
-`, testAccElbV3PoolConfig_basic(rName))
+`, testAccElbV3PoolConfig_basic(rName), rName)
 }
 
 func testAccElbV3MonitorConfig_update(rName string) string {
@@ -98,15 +104,17 @@ func testAccElbV3MonitorConfig_update(rName string) string {
 %s
 
 resource "huaweicloud_elb_monitor" "monitor_1" {
-  pool_id     = huaweicloud_elb_pool.test.id
-  protocol    = "HTTPS"
-  interval    = 30
-  timeout     = 20
-  max_retries = 8
-  url_path    = "/bb"
-  domain_name = "www.bb.com"
-  port        = 8888
-  status_code = "200,301,404-500,504"
+  pool_id          = huaweicloud_elb_pool.test.id
+  name             = "%s-update"
+  protocol         = "HTTPS"
+  interval         = 30
+  timeout          = 20
+  max_retries      = 8
+  max_retries_down = 8
+  url_path         = "/bb"
+  domain_name      = "www.bb.com"
+  port             = 8888
+  status_code      = "200,301,404-500,504"
 }
-`, testAccElbV3PoolConfig_basic(rName))
+`, testAccElbV3PoolConfig_basic(rName), rName)
 }

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_monitor.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_monitor.go
@@ -56,6 +56,15 @@ func ResourceMonitorV3() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
+			"max_retries_down": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"domain_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -76,6 +85,14 @@ func ResourceMonitorV3() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -88,15 +105,17 @@ func resourceMonitorV3Create(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	createOpts := monitors.CreateOpts{
-		PoolID:        d.Get("pool_id").(string),
-		Type:          d.Get("protocol").(string),
-		Delay:         d.Get("interval").(int),
-		Timeout:       d.Get("timeout").(int),
-		MaxRetries:    d.Get("max_retries").(int),
-		URLPath:       d.Get("url_path").(string),
-		DomainName:    d.Get("domain_name").(string),
-		MonitorPort:   d.Get("port").(int),
-		ExpectedCodes: d.Get("status_code").(string),
+		PoolID:         d.Get("pool_id").(string),
+		Type:           d.Get("protocol").(string),
+		Delay:          d.Get("interval").(int),
+		Timeout:        d.Get("timeout").(int),
+		MaxRetries:     d.Get("max_retries").(int),
+		MaxRetriesDown: d.Get("max_retries_down").(int),
+		Name:           d.Get("name").(string),
+		URLPath:        d.Get("url_path").(string),
+		DomainName:     d.Get("domain_name").(string),
+		MonitorPort:    d.Get("port").(int),
+		ExpectedCodes:  d.Get("status_code").(string),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -133,6 +152,10 @@ func resourceMonitorV3Read(_ context.Context, d *schema.ResourceData, meta inter
 		d.Set("url_path", monitor.URLPath),
 		d.Set("domain_name", monitor.DomainName),
 		d.Set("status_code", monitor.ExpectedCodes),
+		d.Set("name", monitor.Name),
+		d.Set("max_retries_down", monitor.MaxRetriesDown),
+		d.Set("created_at", monitor.CreatedAt),
+		d.Set("updated_at", monitor.UpdatedAt),
 	)
 
 	if len(monitor.Pools) != 0 {
@@ -181,6 +204,12 @@ func resourceMonitorV3Update(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	if d.HasChange("protocol") {
 		updateOpts.Type = d.Get("protocol").(string)
+	}
+	if d.HasChange("name") {
+		updateOpts.Name = d.Get("name").(string)
+	}
+	if d.HasChange("max_retries_down") {
+		updateOpts.MaxRetriesDown = d.Get("max_retries_down").(int)
 	}
 
 	log.Printf("[DEBUG] Updating monitor %s with options: %#v", d.Id(), updateOpts)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add params and attrs for `huaweicloud_elb_monitor`
params: `name` 、`max_retries_down`
attrs:   `created_at`、`updated_at`

Fix the statements of `max_retries` in docs.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/elb" TESTARGS="-run TestAccElbV3Monitor_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccElbV3Monitor_basic -timeout 360m -parallel 4
=== RUN   TestAccElbV3Monitor_basic
=== PAUSE TestAccElbV3Monitor_basic
=== CONT  TestAccElbV3Monitor_basic
--- PASS: TestAccElbV3Monitor_basic (87.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       87.930s
```
