### PR TITLE
feat(CDN): CDN domain support new fields `certificate_type` and `ocsp_stapling_status`

### DIFF
--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -262,6 +262,8 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.certificate_source", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.certificate_type", "server"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.ocsp_stapling_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "on"),
 					testAccCheckTLSVersion(resourceName, "TLSv1.1,TLSv1.2"),
@@ -279,6 +281,8 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.certificate_source", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.certificate_type", "server"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.ocsp_stapling_status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "off"),
 					testAccCheckTLSVersion(resourceName, "TLSv1.1,TLSv1.2,TLSv1.3"),
@@ -354,13 +358,15 @@ resource "huaweicloud_cdn_domain" "test" {
     range_based_retrieval_enabled = "true"
 
     https_settings {
-      certificate_name   = "terraform-test"
-      certificate_body   = file("%s")
-      http2_enabled      = true
-      https_enabled      = true
-      private_key        = file("%s")
-      tls_version        = "TLSv1.1,TLSv1.2"
-      certificate_source = 0
+      certificate_name     = "terraform-test"
+      certificate_body     = file("%s")
+      http2_enabled        = true
+      https_enabled        = true
+      private_key          = file("%s")
+      tls_version          = "TLSv1.1,TLSv1.2"
+      certificate_source   = 0
+      certificate_type     = "server"
+      ocsp_stapling_status = "on"
     }
   }
 }
@@ -385,13 +391,14 @@ resource "huaweicloud_cdn_domain" "test" {
     range_based_retrieval_enabled = "true"
 
     https_settings {
-      certificate_name   = "terraform-update"
-      certificate_body   = file("%s")
-      http2_enabled      = false
-      https_enabled      = true
-      private_key        = file("%s")
-      tls_version        = "TLSv1.1,TLSv1.2,TLSv1.3"
-      certificate_source = 0
+      certificate_name     = "terraform-update"
+      certificate_body     = file("%s")
+      http2_enabled        = false
+      https_enabled        = true
+      private_key          = file("%s")
+      tls_version          = "TLSv1.1,TLSv1.2,TLSv1.3"
+      certificate_source   = 0
+      ocsp_stapling_status = "off"
     }
   }
 }

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -58,6 +58,11 @@ var httpsConfig = schema.Schema{
 				Optional: true,
 				Computed: true,
 			},
+			"certificate_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"http2_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -68,6 +73,11 @@ var httpsConfig = schema.Schema{
 				Optional:         true,
 				DiffSuppressFunc: utils.SuppressStringSepratedByCommaDiffs,
 				Computed:         true,
+			},
+			"ocsp_stapling_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"https_status": {
 				Type:     schema.TypeString,
@@ -622,13 +632,15 @@ func buildHTTPSOpts(rawHTTPS []interface{}) *model.HttpPutBody {
 
 	https := rawHTTPS[0].(map[string]interface{})
 	httpsOpts := model.HttpPutBody{
-		HttpsStatus:       utils.String(buildHttpStatusOpts(https["https_enabled"].(bool))),
-		CertificateName:   utils.StringIgnoreEmpty(https["certificate_name"].(string)),
-		CertificateValue:  utils.StringIgnoreEmpty(https["certificate_body"].(string)),
-		PrivateKey:        utils.StringIgnoreEmpty(https["private_key"].(string)),
-		CertificateSource: utils.Int32(int32(https["certificate_source"].(int))),
-		Http2Status:       utils.String(buildHttpStatusOpts(https["http2_enabled"].(bool))),
-		TlsVersion:        utils.StringIgnoreEmpty(https["tls_version"].(string)),
+		HttpsStatus:        utils.String(buildHttpStatusOpts(https["https_enabled"].(bool))),
+		CertificateName:    utils.StringIgnoreEmpty(https["certificate_name"].(string)),
+		CertificateValue:   utils.StringIgnoreEmpty(https["certificate_body"].(string)),
+		PrivateKey:         utils.StringIgnoreEmpty(https["private_key"].(string)),
+		CertificateSource:  utils.Int32(int32(https["certificate_source"].(int))),
+		CertificateType:    utils.StringIgnoreEmpty(https["certificate_type"].(string)),
+		Http2Status:        utils.String(buildHttpStatusOpts(https["http2_enabled"].(bool))),
+		TlsVersion:         utils.StringIgnoreEmpty(https["tls_version"].(string)),
+		OcspStaplingStatus: utils.StringIgnoreEmpty(https["ocsp_stapling_status"].(string)),
 	}
 
 	return &httpsOpts
@@ -1142,15 +1154,17 @@ func flattenHTTPSAttrs(https *model.HttpGetBody, privateKey, certificateBody str
 		return nil
 	}
 	httpsAttrs := map[string]interface{}{
-		"https_status":       https.HttpsStatus,
-		"certificate_name":   https.CertificateName,
-		"certificate_body":   certificateBody,
-		"private_key":        privateKey,
-		"certificate_source": https.CertificateSource,
-		"http2_status":       https.Http2Status,
-		"tls_version":        https.TlsVersion,
-		"https_enabled":      analyseFunctionEnabledStatusPtr(https.HttpsStatus),
-		"http2_enabled":      analyseFunctionEnabledStatusPtr(https.Http2Status),
+		"https_status":         https.HttpsStatus,
+		"certificate_name":     https.CertificateName,
+		"certificate_body":     certificateBody,
+		"private_key":          privateKey,
+		"certificate_source":   https.CertificateSource,
+		"certificate_type":     https.CertificateType,
+		"http2_status":         https.Http2Status,
+		"tls_version":          https.TlsVersion,
+		"ocsp_stapling_status": https.OcspStaplingStatus,
+		"https_enabled":        analyseFunctionEnabledStatusPtr(https.HttpsStatus),
+		"http2_enabled":        analyseFunctionEnabledStatusPtr(https.Http2Status),
 	}
 
 	return []map[string]interface{}{httpsAttrs}


### PR DESCRIPTION
…ling_status`

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN domain support new fields `certificate_type` and `ocsp_stapling_status`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (621.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       621.479s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (439.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       439.124s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (501.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       501.913s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (792.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       792.303s
```