### PR TITLE
chore(cse): resource supports create the nacos engines

### DIFF
--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -8,20 +8,40 @@ Manages a dedicated microservice engine (2.0+) resource within HuaweiCloud.
 
 ## Example Usage
 
+### Create an engine for the default type CSE
+
 ```hcl
 variable "engine_name" {}
 variable "network_id" {}
-variable "az1" {}
+variable "floating_ip_id" {}
+variable "availability_zones" {
+  type = list(string)
+}
+variable "manager_password" {}
+
+resource "huaweicloud_cse_microservice_engine" "test" {
+  name               = var.engine_name
+  flavor             = "cse.s1.small2"
+  network_id         = var.network_id
+  eip_id             = var.floating_ip_id
+  availability_zones = var.availability_zones
+  auth_type          = "RBAC"
+  admin_pass         = var.manager_password
+}
+```
+
+### Create an engine for the type Nacos
+
+```hcl
+variable "engine_name" {}
+variable "network_id" {}
 
 resource "huaweicloud_cse_microservice_engine" "test" {
   name       = var.engine_name
-  flavor     = "cse.s1.small2"
+  flavor     = "cse.nacos2.c1.large.10"
   network_id = var.network_id
   auth_type  = "NONE"
-
-  availability_zones = [
-    var.az1,
-  ]
+  version    = "Nacos2"
 }
 ```
 
@@ -40,7 +60,8 @@ The following arguments are supported:
 * `flavor` - (Required, String, ForceNew) Specifies the flavor of the dedicated microservice engine.
   Changing this will create a new engine.
 
-* `availability_zones` - (Required, List, ForceNew) Specifies the list of availability zone.
+* `availability_zones` - (Optional, List, ForceNew) Specifies the list of availability zones.  
+  Required if the `version` is **CSE2**.  
   Changing this will create a new engine.
 
 * `network_id` - (Required, String, ForceNew) Specifies the network ID of the subnet to which the dedicated microservice
@@ -56,8 +77,14 @@ The following arguments are supported:
     After security authentication is disabled, all users who use the engine can use the engine without using the account
     and password, and have the same operation permissions on all services.
 
-* `version` - (Optional, String, ForceNew) Specifies the version of the dedicated microservice engine. The value can be:
-  **CSE2**. Defaults to: **CSE2**. Changing this will create a new engine.
+  -> **NONE** is required for the nacos engine.
+
+* `version` - (Optional, String, ForceNew) Specifies the version of the dedicated microservice engine.  
+  The valid values are as follows:
+  + **CSE2**
+  + **Nacos2**
+
+  Defaults to **CSE2**. Changing this will create a new engine.
 
 * `admin_pass` - (Optional, String, ForceNew) Specifies the account password. The corresponding account name is **root**.
   Required if `auth_type` is **RBAC**. Changing this will create a new engine.
@@ -68,8 +95,9 @@ The following arguments are supported:
   + Cannot be the account name or account name spelled backwards.
   + The password can only start with a letter.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id. Changing this will create
-  a new engine.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.  
+  If omitted and the version is **Nacos2**, the default enterprise project will be used.  
+  Changing this will create a new engine.
 
 * `description` - (Optional, String, ForceNew) Specifies the description of the dedicated microservice engine.
   The description can contain a maximum of `255` characters.

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
@@ -72,7 +72,8 @@ func ResourceMicroserviceEngine() *schema.Resource {
 			},
 			"availability_zones": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -104,6 +105,7 @@ func ResourceMicroserviceEngine() *schema.Resource {
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"description": {

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine.go
@@ -219,9 +219,9 @@ func resourceMicroserviceEngineCreate(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[DEBUG] Waiting for the Microservice engine to become running, the engine ID is %s.", d.Id())
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"Init", "Executing"},
-		Target:       []string{"Finished"},
-		Refresh:      MicroserviceJobRefreshFunc(client, d.Id(), strconv.Itoa(resp.JobId), epsId),
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      MicroserviceJobRefreshFunc(client, d.Id(), strconv.Itoa(resp.JobId), epsId, []string{"Finished"}),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        180 * time.Second,
 		PollInterval: 15 * time.Second,
@@ -346,9 +346,9 @@ func resourceMicroserviceEngineDelete(ctx context.Context, d *schema.ResourceDat
 
 	log.Printf("[DEBUG] Waiting for the Microservice engine delete complete, the engine ID is %s.", d.Id())
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"Init", "Executing"},
-		Target:       []string{"Deleted"},
-		Refresh:      MicroserviceJobRefreshFunc(client, d.Id(), strconv.Itoa(resp.JobId), epsId),
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      MicroserviceJobRefreshFunc(client, d.Id(), strconv.Itoa(resp.JobId), epsId, nil),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        120 * time.Second,
 		PollInterval: 15 * time.Second,
@@ -388,16 +388,25 @@ func parseEngineJobError(respErr error) error {
 	return respErr
 }
 
-func MicroserviceJobRefreshFunc(c *golangsdk.ServiceClient, engineId, jobId, epsId string) resource.StateRefreshFunc {
+func MicroserviceJobRefreshFunc(client *golangsdk.ServiceClient, engineId, jobId, epsId string,
+	targets []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		resp, err := engines.GetJob(c, engineId, jobId, epsId)
+		resp, err := engines.GetJob(client, engineId, jobId, epsId)
 		if newErr := parseEngineJobError(err); newErr != nil {
-			if _, ok := newErr.(golangsdk.ErrDefault404); ok {
-				return resp, "Deleted", nil
+			if _, ok := newErr.(golangsdk.ErrDefault404); ok && len(targets) < 1 {
+				return resp, "COMPLETED", nil
 			}
-			return resp, "ERROR", newErr
+			return resp, "ERROR", err
 		}
-		return resp, resp.Status, nil
+
+		if utils.StrSliceContains([]string{"CreateFail", "DeleteFailed", "UpgradeFailed", "ModifyFailed"}, resp.Status) {
+			return resp, "ERROR", fmt.Errorf("unexpect status (%s)", resp.Status)
+		}
+
+		if utils.StrSliceContains(targets, resp.Status) {
+			return resp, "COMPLETED", nil
+		}
+		return resp, "PENDING", nil
 	}
 }
 
@@ -413,6 +422,6 @@ func resourceEngineImportState(_ context.Context, d *schema.ResourceData,
 		d.SetId(parts[0])
 		return []*schema.ResourceData{d}, d.Set("enterprise_project_id", parts[1])
 	}
-	return nil, fmt.Errorf("The imported ID specifies an invalid format: want '<id>' or "+
+	return nil, fmt.Errorf("the imported ID specifies an invalid format: want '<id>' or "+
 		"'<id>/<enterprise_project_id>', but '%s'", importedId)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The API supports nacos engine creation and the resource needs to support it.
There are some problems for engine resource that it used to create the Nacos engine:
- The availability zones can be omitted.
- The default enterprise project used for the Nacos engines even if the parameter `enterprise_project_id` is not set.
- The refresh function can not cover the status `PreInit`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. refactor refresh function to allow more pending statuses.
2. resource supports create the nacos engines.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cse' TESTARGS='-run=TestAccMicroserviceEngine_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cse -v -run=TestAccMicroserviceEngine_basic -timeout 360m -parallel 4
=== RUN   TestAccMicroserviceEngine_basic
=== PAUSE TestAccMicroserviceEngine_basic
=== CONT  TestAccMicroserviceEngine_basic
--- PASS: TestAccMicroserviceEngine_basic (1180.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       1180.912s
```
```
make testacc TEST='./huaweicloud/services/acceptance/cse' TESTARGS='-run=TestAccMicroserviceEngine_nacos'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cse -v -run=TestAccMicroserviceEngine_nacos -timeout 360m -parallel 4
=== RUN   TestAccMicroserviceEngine_nacos
=== PAUSE TestAccMicroserviceEngine_nacos
=== CONT  TestAccMicroserviceEngine_nacos
--- PASS: TestAccMicroserviceEngine_nacos (495.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       495.517s
```
