### PR TITLE
feat(GaussDB): add gaussdb mysql restore resource

### DIFF
--- a/docs/resources/gaussdb_mysql_restore.md
+++ b/docs/resources/gaussdb_mysql_restore.md
@@ -1,0 +1,79 @@
+---
+subcategory: "GaussDB(for MySQL)"
+---
+
+# huaweicloud_gaussdb_mysql_restore
+
+Use this resource to restore a GaussDB MySQL instance with a backup within HuaweiCloud.
+
+-> **NOTE:** Deleting restoration record is not supported. If you destroy a resource of restoration record,
+the restoration record is only removed from the state, but it remains in the cloud. And the instance doesn't return to
+the state before restoration.
+
+## Example Usage
+
+### restore by backup_id
+
+```hcl
+variable "target_instance_id" {}
+variable "source_instance_id" {}
+variable "backup_id" {}
+
+resource "huaweicloud_gaussdb_mysql_restore" "test" {
+  target_instance_id = var.target_instance_id
+  source_instance_id = var.source_instance_id
+  type               = "backup"
+  backup_id          = var.backup_id
+}
+```
+
+### restore by timestamp
+
+```hcl
+variable "target_instance_id" {}
+variable "source_instance_id" {}
+
+resource "huaweicloud_gaussdb_mysql_restore" "test" {
+  target_instance_id = var.target_instance_id
+  source_instance_id = var.source_instance_id
+  type               = "timestamp"
+  restore_time       = 1673852043000
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the GaussDB mysql restore resource. If omitted,
+  the provider-level region will be used. Changing this creates a new resource.
+
+* `target_instance_id` - (Required, String, ForceNew) Specifies the target instance ID. Changing this creates a new
+  resource.
+
+* `source_instance_id` - (Required, String, ForceNew) Specifies the source instance ID. Changing this creates a new
+  resource.
+
+* `type` - (Required, String, ForceNew) Specifies the restoration type. Value options:
+  + **backup**: indicates restoration from backup files. In this mode, `backup_id` is mandatory.
+  + **timestamp**: indicates point-in-time restoration. In this mode, `restore_time` is mandatory.
+
+  Changing this creates a new resource.
+
+* `backup_id` - (Optional, String, ForceNew) Specifies the ID of the backup to be restored. This parameter must be
+  specified when the backup file is used for restoration. Changing this creates a new resource.
+
+* `restore_time` - (Optional, Int, ForceNew) Specifies the time point of data restoration in the UNIX timestamp format.
+  The unit is millisecond and the time zone is UTC. Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attribute is exported:
+
+* `id` - The resource ID. The value is the restore job ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1136,6 +1136,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_sql_control_rule":   gaussdb.ResourceGaussDBSqlControlRule(),
 			"huaweicloud_gaussdb_mysql_parameter_template": gaussdb.ResourceGaussDBMysqlTemplate(),
 			"huaweicloud_gaussdb_mysql_backup":             gaussdb.ResourceGaussDBMysqlBackup(),
+			"huaweicloud_gaussdb_mysql_restore":            gaussdb.ResourceGaussDBMysqlRestore(),
 
 			"huaweicloud_gaussdb_opengauss_instance": gaussdb.ResourceOpenGaussInstance(),
 

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_resotre_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_resotre_test.go
@@ -1,0 +1,104 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccGaussDBRestore_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBRestoreonfig_basic(name),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBRestore_withTimestamp(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBRestoreonfig_withTimestamp(name),
+			},
+		},
+	})
+}
+
+func testAccGaussDBRestoreonfig_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_gaussdb_mysql_instance" "instance" {
+  count                 = 2
+  name                  = "%[2]s_${count.index}"
+  password              = "Test@12345678"
+  flavor                = "gaussdb.mysql.4xlarge.x86.4"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_gaussdb_mysql_backup" "backup" {
+  instance_id = huaweicloud_gaussdb_mysql_instance.instance[0].id
+  name        = "%[2]s_backup"
+}
+
+resource "huaweicloud_gaussdb_mysql_restore" "test" {
+  target_instance_id = huaweicloud_gaussdb_mysql_instance.instance[1].id
+  source_instance_id = huaweicloud_gaussdb_mysql_instance.instance[0].id
+  type               = "backup"
+  backup_id          = huaweicloud_gaussdb_mysql_backup.backup.id
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccGaussDBRestoreonfig_withTimestamp(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_gaussdb_mysql_instance" "instance" {
+  count                 = 2
+  name                  = "%[2]s_${count.index}"
+  password              = "Test@12345678"
+  flavor                = "gaussdb.mysql.4xlarge.x86.4"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_gaussdb_mysql_backup" "backup" {
+  instance_id = huaweicloud_gaussdb_mysql_instance.instance[0].id
+  name        = "%[2]s_backup"
+}
+
+data "huaweicloud_gaussdb_mysql_restore_time_ranges" "restore_times" {
+  depends_on  = [huaweicloud_gaussdb_mysql_backup.backup]
+  instance_id = huaweicloud_gaussdb_mysql_instance.instance[0].id
+}
+
+resource "huaweicloud_gaussdb_mysql_restore" "test" {
+  target_instance_id = huaweicloud_gaussdb_mysql_instance.instance[1].id
+  source_instance_id = huaweicloud_gaussdb_mysql_instance.instance[0].id
+  type               = "timestamp"
+  restore_time       = data.huaweicloud_gaussdb_mysql_restore_time_ranges.restore_times.restore_times[0].start_time
+}
+`, common.TestBaseNetwork(name), name)
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_restore_time_ranges.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_restore_time_ranges.go
@@ -39,7 +39,7 @@ func DataSourceGaussdbMysqlRestoreTimeRanges() *schema.Resource {
 				Description: `Specifies the date to be queried.`,
 			},
 			"restore_times": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Computed:    true,
 				Description: `Indicates the list of restoration time ranges.`,
 				Elem: &schema.Resource{

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance.go
@@ -1223,6 +1223,21 @@ func switchSQLFilter(client *golangsdk.ServiceClient, instanceId string, isSQLFi
 	return nil
 }
 
+func checkGaussDBMySQLJobFinish(ctx context.Context, client *golangsdk.ServiceClient, jobID string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"Pending", "Running"},
+		Target:       []string{"Completed"},
+		Refresh:      gaussDBMysqlDatabaseStatusRefreshFunc(client, jobID),
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("error waiting for GaussDB MySQL instance job (%s) to be completed: %s ", jobID, err)
+	}
+	return nil
+}
+
 func gaussDBMysqlDatabaseStatusRefreshFunc(client *golangsdk.ServiceClient, jobId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		var (

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_restore.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_restore.go
@@ -1,0 +1,142 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforMySQL POST /v3/{project_id}/instances/restore
+// @API GaussDBforMySQL GET /v3/{project_id}/jobs
+func ResourceGaussDBMysqlRestore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGaussDBMysqlRestoreCreate,
+		ReadContext:   resourceGaussDBMysqlRestoreRead,
+		DeleteContext: resourceGaussDBMysqlRestoreDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"target_instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the target instance ID.`,
+			},
+			"source_instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the source instance ID.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the restoration type.`,
+			},
+			"backup_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the backup to be restored.`,
+			},
+			"restore_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"backup_id"},
+				Description:  `Specifies the time point of data restoration in the UNIX timestamp format.`,
+			},
+		},
+	}
+}
+
+func resourceGaussDBMysqlRestoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/restore"
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	targetInstanceId := d.Get("target_instance_id").(string)
+	backupId := d.Get("backup_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{KeepResponseBody: true}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateRestoreBodyParams(d))
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error restoring from backup(%s) to GaussDB MySQL instance (%s): %s", backupId,
+			targetInstanceId, err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, nil)
+	if jobId == nil {
+		return diag.Errorf("unable to find the job_id from the response: %s", err)
+	}
+
+	d.SetId(jobId.(string))
+
+	err = checkGaussDBMySQLJobFinish(ctx, client, jobId.(string), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for restoring from backup(%s) to GaussDB MySQL instance(%s) to complete:"+
+			" %s", backupId, targetInstanceId, err)
+	}
+
+	return nil
+}
+
+func buildCreateRestoreBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"target_instance_id": d.Get("target_instance_id"),
+		"source_instance_id": d.Get("source_instance_id"),
+		"type":               d.Get("type"),
+		"backup_id":          utils.ValueIngoreEmpty(d.Get("backup_id")),
+		"restore_time":       utils.ValueIngoreEmpty(d.Get("restore_time")),
+	}
+	return bodyParams
+}
+
+func resourceGaussDBMysqlRestoreRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGaussDBMysqlRestoreDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restoration record is not supported. The restoration record is only removed from the state," +
+		" but it remains in the cloud. And the instance doesn't return to the state before restoration."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb mysql restore resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb mysql restore resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBRestore_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBRestore_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBRestore_basic
=== PAUSE TestAccGaussDBRestore_basic
=== RUN   TestAccGaussDBRestore_withTimestamp
=== PAUSE TestAccGaussDBRestore_withTimestamp
=== CONT  TestAccGaussDBRestore_basic
=== CONT  TestAccGaussDBRestore_withTimestamp
--- PASS: TestAccGaussDBRestore_withTimestamp (1884.52s)
--- PASS: TestAccGaussDBRestore_basic (1914.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1914.178s
```
