### PR TITLE
fix(DDS): fix dds instance backup strategy period

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -328,6 +328,8 @@ var (
 
 	HW_HSS_HOST_PROTECTION_HOST_ID  = os.Getenv("HW_HSS_HOST_PROTECTION_HOST_ID")
 	HW_HSS_HOST_PROTECTION_QUOTA_ID = os.Getenv("HW_HSS_HOST_PROTECTION_QUOTA_ID")
+
+	HW_DDS_SECOND_LEVEL_MONITORING_ENABLED = os.Getenv("HW_DDS_SECOND_LEVEL_MONITORING_ENABLED")
 )
 
 // TestAccProviders is a static map containing only the main provider instance.
@@ -1530,5 +1532,12 @@ func TestAccPreCheckHSSHostProtectionHostId(t *testing.T) {
 func TestAccPreCheckHSSHostProtectionQuotaId(t *testing.T) {
 	if HW_HSS_HOST_PROTECTION_QUOTA_ID == "" {
 		t.Skip("HW_HSS_HOST_PROTECTION_QUOTA_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDDSSecondLevelMonitoringEnabled(t *testing.T) {
+	if HW_DDS_SECOND_LEVEL_MONITORING_ENABLED == "" {
+		t.Skip("HW_DDS_SECOND_LEVEL_MONITORING_ENABLED must be set for the acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -290,6 +290,7 @@ func TestAccDDSV3Instance_withSecondLevelMonitoring(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDDSSecondLevelMonitoringEnabled(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_instance_v3.go
@@ -343,7 +343,9 @@ func resourceDdsBackupStrategy(d *schema.ResourceData) instances.BackupStrategy 
 	if len(backupStrategyRaw) == 1 {
 		startTime = backupStrategyRaw[0].(map[string]interface{})["start_time"].(string)
 		keepDays = backupStrategyRaw[0].(map[string]interface{})["keep_days"].(int)
-		period = backupStrategyRaw[0].(map[string]interface{})["period"].(string)
+		if periodRaw := backupStrategyRaw[0].(map[string]interface{})["period"].(string); periodRaw != "" {
+			period = periodRaw
+		}
 	}
 	backupStrategy.KeepDays = &keepDays
 	backupStrategy.StartTime = startTime
@@ -498,7 +500,7 @@ func resourceDdsInstanceV3Create(ctx context.Context, d *schema.ResourceData, me
 	backupStrategyRaw := d.Get("backup_strategy").([]interface{})
 	if len(backupStrategyRaw) == 1 {
 		period := backupStrategyRaw[0].(map[string]interface{})["period"].(string)
-		if !isEqualPeriod(period, "1,2,3,4,5,6,7") {
+		if period != "" && !isEqualPeriod(period, "1,2,3,4,5,6,7") {
 			_, err = instances.CreateBackupPolicy(client, instance.Id, resourceDdsBackupStrategy(d))
 			if err != nil {
 				return diag.Errorf("error creating backup strategy of the DDS instance %s: %s", instance.Id, err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dds instance backup strategy period
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dds instance backup strategy period
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dds/ TESTARGS='-run TestAccDDSV3Instance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds/ -v -run TestAccDDSV3Instance_ -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_basic
=== PAUSE TestAccDDSV3Instance_basic
=== RUN   TestAccDDSV3Instance_withEpsId
=== PAUSE TestAccDDSV3Instance_withEpsId
=== RUN   TestAccDDSV3Instance_prePaid
=== PAUSE TestAccDDSV3Instance_prePaid
=== RUN   TestAccDDSV3Instance_withConfigurationSharding
=== PAUSE TestAccDDSV3Instance_withConfigurationSharding
=== RUN   TestAccDDSV3Instance_withConfigurationReplicaSet
=== PAUSE TestAccDDSV3Instance_withConfigurationReplicaSet
=== RUN   TestAccDDSV3Instance_withSecondLevelMonitoring
=== PAUSE TestAccDDSV3Instance_withSecondLevelMonitoring
=== CONT  TestAccDDSV3Instance_basic
=== CONT  TestAccDDSV3Instance_withConfigurationSharding
=== CONT  TestAccDDSV3Instance_withSecondLevelMonitoring
=== CONT  TestAccDDSV3Instance_prePaid
=== CONT  TestAccDDSV3Instance_withSecondLevelMonitoring
    acceptance.go:1541: HW_DDS_SECOND_LEVEL_MONITORING_ENABLED must be set for the acceptance test
--- SKIP: TestAccDDSV3Instance_withSecondLevelMonitoring (0.00s)
=== CONT  TestAccDDSV3Instance_withEpsId
--- PASS: TestAccDDSV3Instance_withConfigurationSharding (936.36s)
=== CONT  TestAccDDSV3Instance_withConfigurationReplicaSet
--- PASS: TestAccDDSV3Instance_withEpsId (953.49s)
--- PASS: TestAccDDSV3Instance_withConfigurationReplicaSet (769.20s)
--- PASS: TestAccDDSV3Instance_prePaid (1894.91s)
--- PASS: TestAccDDSV3Instance_basic (2820.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       2820.262s
```
