### PR TITLE
feat(elb): support new params for pool

### DIFF
--- a/docs/resources/elb_pool.md
+++ b/docs/resources/elb_pool.md
@@ -109,7 +109,7 @@ The following arguments are supported:
   -> **NOTE:** 1. If the value is **SOURCE_IP**, the weight parameter will not take effect for backend servers.
   <br/> 2. **QUIC_CID** is supported only when the protocol of the backend server group is **QUIC**.
 
-* `persistence` - (Optional, List, ForceNew) Specifies the sticky session. Changing this creates a new pool.
+* `persistence` - (Optional, List) Specifies the sticky session.
   The [object](#persistence) structure is documented below.
 
 * `type` - (Optional, String) Specifies the type of the backend server group. Value options:
@@ -126,6 +126,16 @@ The following arguments are supported:
   associated. Changing this creates a new pool.
 
   -> **NOTE:** At least one of `loadbalancer_id`, `listener_id`, `type` must be specified.
+
+* `ip_version` - (Optional, String, ForceNew) Specifies the IP address version supported by the backend server group.
+  The value can be **dualstack**, **v6**, or **v4**. If the protocol of the backend server group is HTTP, the value is **v4**.
+  Changing this creates a new pool.
+
+* `any_port_enable` - (Optional, Bool, ForceNew) Specifies whether to enable transparent port transmission on the backend.
+  If enable, the port of the backend server will be same as the port of the listener.
+  Changing this creates a new pool.
+
+* `deletion_protection_enable` - (Optional, Bool) Specifies whether to enable deletion protection.
 
 * `name` - (Optional, String) Specifies the backend server group name.
 
@@ -161,7 +171,7 @@ The following arguments are supported:
 <a name="persistence"></a>
 The `persistence` block supports:
 
-* `type` - (Required, String, ForceNew) Specifies the sticky session type. Value options: **SOURCE_IP**,
+* `type` - (Required, String) Specifies the sticky session type. Value options: **SOURCE_IP**,
   **HTTP_COOKIE**, and **APP_COOKIE**.
 
   -> **NOTE:** 1. If the protocol of the backend server group is **TCP** or **UDP**, only **SOURCE_IP** takes effect.
@@ -169,10 +179,10 @@ The `persistence` block supports:
   <br/> 3. If the backend server group protocol is **QUIC**, sticky session must be enabled with type set to
   **SOURCE_IP**.
 
-* `cookie_name` - (Optional, String, ForceNew) Specifies the cookie name. The value can contain only letters, digits,
+* `cookie_name` - (Optional, String) Specifies the cookie name. The value can contain only letters, digits,
   hyphens (-), underscores (_), and periods (.). It is required if `type` of `persistence` is set to **APP_COOKIE**.
 
-* `timeout` - (Optional, Int, ForceNew) Specifies the sticky session timeout duration in minutes. This parameter is
+* `timeout` - (Optional, Int) Specifies the sticky session timeout duration in minutes. This parameter is
   invalid when `type` is set to **APP_COOKIE**. The value range varies depending on the protocol of the backend server
   group:
   + When the protocol of the backend server group is **TCP** or **UDP**, the value ranges from **1** to **60**, and
@@ -186,7 +196,11 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the pool.
 
-* `ip_version` - The IP address version supported by the backend server group.
+* `monitor_id` - The ID of the health check configured for the backend server group.
+
+* `created_at` - The create time of the pool.
+
+* `updated_at` - The update time of the pool.
 
 ## Timeouts
 
@@ -202,4 +216,22 @@ ELB pool can be imported using the pool `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_elb_pool.pool_1 <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `deletion_protection_enable`. It is
+generally recommended running **terraform plan** after importing a pool. You can then decide if changes should be
+applied to the pool, or the resource definition should be updated to align with the pool. Also you can ignore changes
+as below.
+
+```
+resource "huaweicloud_elb_pool" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      deletion_protection_enable,
+    ]
+  }
+}
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240408021309-2f62b894fd6a
+	github.com/chnsz/golangsdk v0.0.0-20240411063334-847704c1242c
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240408021309-2f62b894fd6a h1:1J3Axh/eQN/NHwwpNyyyt5RYkLK8IADMJ2/KdvAzAoI=
-github.com/chnsz/golangsdk v0.0.0-20240408021309-2f62b894fd6a/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240411063334-847704c1242c h1:qTPIxPSQpDkCLEqHJGx9HjQOWAboakny8BHQ4Mv37ek=
+github.com/chnsz/golangsdk v0.0.0-20240411063334-847704c1242c/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/pools/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/pools/requests.go
@@ -117,6 +117,12 @@ type CreateOpts struct {
 
 	// The ID of the VPC where the backend server group works
 	VpcId string `json:"vpc_id,omitempty"`
+
+	// The IP version
+	IpVersion string `json:"ip_version,omitempty"`
+
+	// Whether to enable deletion protection for the load balancer.
+	DeletionProtectionEnable *bool `json:"member_deletion_protection_enable,omitempty"`
 }
 
 type SlowStart struct {
@@ -192,6 +198,9 @@ type UpdateOpts struct {
 
 	// The ID of the VPC where the backend server group works
 	VpcId string `json:"vpc_id,omitempty"`
+
+	// Whether to enable deletion protection for the load balancer.
+	DeletionProtectionEnable *bool `json:"member_deletion_protection_enable,omitempty"`
 }
 
 // ToPoolUpdateMap builds a request body from UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/pools/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/pools/results.go
@@ -10,19 +10,21 @@ import (
 // session to be processed by the same member as long as it is ative. Three
 // types of persistence are supported:
 //
-// SOURCE_IP:   With this mode, all connections originating from the same source
-//              IP address, will be handled by the same Member of the Pool.
+// SOURCE_IP: With this mode, all connections originating from the same source
+// IP address, will be handled by the same Member of the Pool.
+//
 // HTTP_COOKIE: With this persistence mode, the load balancing function will
-//              create a cookie on the first request from a client. Subsequent
-//              requests containing the same cookie value will be handled by
-//              the same Member of the Pool.
-// APP_COOKIE:  With this persistence mode, the load balancing function will
-//              rely on a cookie established by the backend application. All
-//              requests carrying the same cookie value will be handled by the
-//              same Member of the Pool.
+// create a cookie on the first request from a client. Subsequent
+// requests containing the same cookie value will be handled by
+// the same Member of the Pool.
+//
+// APP_COOKIE: With this persistence mode, the load balancing function will
+// rely on a cookie established by the backend application. All
+// requests carrying the same cookie value will be handled by the
+// same Member of the Pool.
 type SessionPersistence struct {
 	// The type of persistence mode.
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 
 	// Name of cookie if persistence mode is set appropriately.
 	CookieName string `json:"cookie_name,omitempty"`
@@ -105,6 +107,9 @@ type Pool struct {
 
 	// Slow start.
 	SlowStart SlowStart `json:"slow_start"`
+
+	// Whether to enable deletion protection for the load balancer.
+	DeletionProtectionEnable bool `json:"member_deletion_protection_enable"`
 
 	// The type of the backend server group.
 	Type string `json:"type"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240408021309-2f62b894fd6a
+# github.com/chnsz/golangsdk v0.0.0-20240411063334-847704c1242c
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new params for `huaweicloud_elb_pool`, including `ip_version`, `any_port_enable`, `deletion_protection_enable`, and new attrs including `monitor_id`, `updated_at`, `created_at`.
Remove `ForceNew` from `persistence`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/elb" TESTARGS="-run TestAccElbV3Pool_basic_with_type_ip"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccElbV3Pool_basic_with_type_ip -timeout 360m -parallel 4
=== RUN   TestAccElbV3Pool_basic_with_type_ip
=== PAUSE TestAccElbV3Pool_basic_with_type_ip
=== CONT  TestAccElbV3Pool_basic_with_type_ip
--- PASS: TestAccElbV3Pool_basic_with_type_ip (42.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       42.469s

make testacc TEST="./huaweicloud/services/acceptance/elb" TESTARGS="-run TestAccElbV3Pool_basic_with_protocol_tcp"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccElbV3Pool_basic_with_protocol_tcp -timeout 360m -parallel 4
=== RUN   TestAccElbV3Pool_basic_with_protocol_tcp
=== PAUSE TestAccElbV3Pool_basic_with_protocol_tcp
=== CONT  TestAccElbV3Pool_basic_with_protocol_tcp
--- PASS: TestAccElbV3Pool_basic_with_protocol_tcp (41.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       41.684s
```
