### PR TITLE
feat(CDN): CDN domain support new fields `configs.0.description`,  `configs.0.slice_etag_status`, and  `configs.0.origin_receive_timeout`

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -256,6 +256,13 @@ The `configs` block support:
 
 * `description` - (Optional, String) Specifies the description of the domain. The value contains up to `200` characters.
 
+* `slice_etag_status` - (Optional, String) Specifies whether ETag is verified during origin pull.
+  Valid values are as follows:
+  + **on**: Enable.
+  + **off**: Disable.
+
+  Defaults to **on**.
+
 * `https_settings` - (Optional, List) Specifies the certificate configuration. The [https_settings](#https_settings_object)
   structure is documented below.
 

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -263,6 +263,9 @@ The `configs` block support:
 
   Defaults to **on**.
 
+* `origin_receive_timeout` - (Optional, Int) Specifies the origin response timeout.
+  The value ranges from **5** to **60**, in seconds. Defaults to **30**.
+
 * `https_settings` - (Optional, List) Specifies the certificate configuration. The [https_settings](#https_settings_object)
   structure is documented below.
 

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -82,6 +82,7 @@ resource "huaweicloud_cdn_domain" "domain_1" {
     origin_protocol               = "http"
     ipv6_enable                   = true
     range_based_retrieval_enabled = true
+    description                   = "test description"
 
     https_settings {
       certificate_name     = "terraform-test"
@@ -252,6 +253,8 @@ The `configs` block support:
 
   -> The prerequisite for enabling range-based retrieval is that your origin site supports Range requests, that is, the
   HTTP request header contains the Range field. Otherwise, the back-to-origin may fail.
+
+* `description` - (Optional, String) Specifies the description of the domain. The value contains up to `200` characters.
 
 * `https_settings` - (Optional, List) Specifies the certificate configuration. The [https_settings](#https_settings_object)
   structure is documented below.

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -454,6 +454,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ipv6_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.range_based_retrieval_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.type", "ignore_url_params"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
@@ -509,6 +510,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ipv6_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.range_based_retrieval_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "update description"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.type", "del_params"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.value", "test_value"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name-update"),
@@ -571,6 +573,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
@@ -735,6 +738,7 @@ resource "huaweicloud_cdn_domain" "test" {
     ipv6_enable                   = false
     range_based_retrieval_enabled = false
     description                   = "update description"
+    slice_etag_status             = "off"
 
     cache_url_parameter_filter {
       type  = "del_params"
@@ -826,6 +830,7 @@ resource "huaweicloud_cdn_domain" "test" {
     origin_protocol               = "follow"
     ipv6_enable                   = false
     range_based_retrieval_enabled = false
+    slice_etag_status             = "on"
 
     remote_auth {
       enabled = false

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -455,6 +455,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.range_based_retrieval_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "60"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.type", "ignore_url_params"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
@@ -511,6 +512,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.range_based_retrieval_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "update description"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "30"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.type", "del_params"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.value", "test_value"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name-update"),
@@ -574,6 +576,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", ""),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "5"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
@@ -614,6 +617,7 @@ resource "huaweicloud_cdn_domain" "test" {
     ipv6_enable                   = true
     range_based_retrieval_enabled = true
     description                   = "test description"
+    origin_receive_timeout        = "60"
 
     cache_url_parameter_filter {
       type = "ignore_url_params"
@@ -739,6 +743,7 @@ resource "huaweicloud_cdn_domain" "test" {
     range_based_retrieval_enabled = false
     description                   = "update description"
     slice_etag_status             = "off"
+    origin_receive_timeout        = "30"
 
     cache_url_parameter_filter {
       type  = "del_params"
@@ -831,6 +836,7 @@ resource "huaweicloud_cdn_domain" "test" {
     ipv6_enable                   = false
     range_based_retrieval_enabled = false
     slice_etag_status             = "on"
+    origin_receive_timeout        = "5"
 
     remote_auth {
       enabled = false

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -453,6 +453,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_protocol", "http"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ipv6_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.range_based_retrieval_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.type", "ignore_url_params"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
@@ -507,6 +508,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_protocol", "follow"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ipv6_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.range_based_retrieval_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "update description"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.type", "del_params"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.value", "test_value"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name-update"),
@@ -568,6 +570,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.description", ""),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
@@ -607,6 +610,7 @@ resource "huaweicloud_cdn_domain" "test" {
     origin_protocol               = "http"
     ipv6_enable                   = true
     range_based_retrieval_enabled = true
+    description                   = "test description"
 
     cache_url_parameter_filter {
       type = "ignore_url_params"
@@ -730,6 +734,7 @@ resource "huaweicloud_cdn_domain" "test" {
     origin_protocol               = "follow"
     ipv6_enable                   = false
     range_based_retrieval_enabled = false
+    description                   = "update description"
 
     cache_url_parameter_filter {
       type  = "del_params"

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -517,6 +517,12 @@ func ResourceCdnDomain() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						// Cloud will configure this field to `on` by default
+						"slice_etag_status": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 						"https_settings":             &httpsConfig,
 						"retrieval_request_header":   &requestAndResponseHeader,
 						"http_response_header":       &requestAndResponseHeader,
@@ -977,6 +983,9 @@ func buildUpdateDomainFullConfigsOpts(configsOpts *model.Configs, configs map[st
 	}
 	if d.HasChange("configs.0.description") {
 		configsOpts.Remark = utils.String(configs["description"].(string))
+	}
+	if d.HasChange("configs.0.slice_etag_status") {
+		configsOpts.SliceEtagStatus = utils.StringIgnoreEmpty(configs["slice_etag_status"].(string))
 	}
 	if d.HasChange("configs.0.https_settings") {
 		configsOpts.Https = buildHTTPSOpts(configs["https_settings"].([]interface{}))
@@ -1442,6 +1451,7 @@ func flattenConfigAttrs(configsResp *model.ConfigsGetBody, d *schema.ResourceDat
 		"ipv6_enable":                   configsResp.Ipv6Accelerate != nil && *configsResp.Ipv6Accelerate == 1,
 		"range_based_retrieval_enabled": analyseFunctionEnabledStatusPtr(configsResp.OriginRangeStatus),
 		"description":                   configsResp.Remark,
+		"slice_etag_status":             configsResp.SliceEtagStatus,
 	}
 	return []map[string]interface{}{configsAttrs}
 }

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -523,6 +523,12 @@ func ResourceCdnDomain() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						// Cloud will configure this field to `30` by default
+						"origin_receive_timeout": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
 						"https_settings":             &httpsConfig,
 						"retrieval_request_header":   &requestAndResponseHeader,
 						"http_response_header":       &requestAndResponseHeader,
@@ -986,6 +992,9 @@ func buildUpdateDomainFullConfigsOpts(configsOpts *model.Configs, configs map[st
 	}
 	if d.HasChange("configs.0.slice_etag_status") {
 		configsOpts.SliceEtagStatus = utils.StringIgnoreEmpty(configs["slice_etag_status"].(string))
+	}
+	if d.HasChange("configs.0.origin_receive_timeout") {
+		configsOpts.OriginReceiveTimeout = utils.Int32IgnoreEmpty(int32(configs["origin_receive_timeout"].(int)))
 	}
 	if d.HasChange("configs.0.https_settings") {
 		configsOpts.Https = buildHTTPSOpts(configs["https_settings"].([]interface{}))
@@ -1452,6 +1461,7 @@ func flattenConfigAttrs(configsResp *model.ConfigsGetBody, d *schema.ResourceDat
 		"range_based_retrieval_enabled": analyseFunctionEnabledStatusPtr(configsResp.OriginRangeStatus),
 		"description":                   configsResp.Remark,
 		"slice_etag_status":             configsResp.SliceEtagStatus,
+		"origin_receive_timeout":        configsResp.OriginReceiveTimeout,
 	}
 	return []map[string]interface{}{configsAttrs}
 }

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -513,6 +513,10 @@ func ResourceCdnDomain() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"https_settings":             &httpsConfig,
 						"retrieval_request_header":   &requestAndResponseHeader,
 						"http_response_header":       &requestAndResponseHeader,
@@ -970,6 +974,9 @@ func buildUpdateDomainFullConfigsOpts(configsOpts *model.Configs, configs map[st
 	if d.HasChange("configs.0.range_based_retrieval_enabled") {
 		retrievalEnabled := configs["range_based_retrieval_enabled"].(bool)
 		configsOpts.OriginRangeStatus = utils.String(parseFunctionEnabledStatus(retrievalEnabled))
+	}
+	if d.HasChange("configs.0.description") {
+		configsOpts.Remark = utils.String(configs["description"].(string))
 	}
 	if d.HasChange("configs.0.https_settings") {
 		configsOpts.Https = buildHTTPSOpts(configs["https_settings"].([]interface{}))
@@ -1434,6 +1441,7 @@ func flattenConfigAttrs(configsResp *model.ConfigsGetBody, d *schema.ResourceDat
 		"remote_auth":                   flattenRemoteAuthAttrs(configsResp.RemoteAuth),
 		"ipv6_enable":                   configsResp.Ipv6Accelerate != nil && *configsResp.Ipv6Accelerate == 1,
 		"range_based_retrieval_enabled": analyseFunctionEnabledStatusPtr(configsResp.OriginRangeStatus),
+		"description":                   configsResp.Remark,
 	}
 	return []map[string]interface{}{configsAttrs}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN domain support new fields `configs.0.description`,  `configs.0.slice_etag_status`, and  `configs.0.origin_receive_timeout`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (751.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       751.253s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (627.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       627.309s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (585.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       585.050s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (745.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       745.505s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_epsID_migrate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_epsID_migrate -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_epsID_migrate (426.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       426.934s
```