### PR TITLE
test(RDS): fix rds test

### DIFF
--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_backup_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_backup_test.go
@@ -193,7 +193,7 @@ resource "huaweicloud_rds_instance" "test" {
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
   availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   time_zone         = "UTC+08:00"
@@ -224,13 +224,22 @@ resource "huaweicloud_rds_backup" "test" {
   name        = "%[2]s"
   instance_id = huaweicloud_rds_instance.test.id
 }
-`, testAccRdsInstance_base(), name)
+`, testAccRdsInstance_base(name), name)
 }
 
 // disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
 func testBackup_sqlserver_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
+
+resource "huaweicloud_networking_secgroup_rule" "ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  ports             = 8634
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = huaweicloud_networking_secgroup.test.id
+}
 
 data "huaweicloud_rds_flavors" "test" {
   db_type       = "SQLServer"
@@ -241,10 +250,11 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
+  depends_on        = [huaweicloud_networking_secgroup_rule.ingress]
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
   availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   time_zone         = "UTC+08:00"
@@ -275,7 +285,7 @@ resource "huaweicloud_rds_backup" "test" {
   name        = "%[2]s"
   instance_id = huaweicloud_rds_instance.test.id
 }
-`, testAccRdsInstance_base(), name)
+`, testAccRdsInstance_base(name), name)
 }
 
 // disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
@@ -295,7 +305,7 @@ resource "huaweicloud_rds_instance" "test" {
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
   availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   time_zone         = "UTC+08:00"
@@ -326,7 +336,7 @@ resource "huaweicloud_rds_backup" "test" {
   name        = "%[2]s"
   instance_id = huaweicloud_rds_instance.test.id
 }
-`, testAccRdsInstance_base(), name)
+`, testAccRdsInstance_base(name), name)
 }
 
 func testAccBackupImportStateFunc(name string) resource.ImportStateIdFunc {

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -515,8 +515,10 @@ func testAccCheckRdsInstanceExists(name string, instance *instances.RdsInstanceR
 	}
 }
 
-func testAccRdsInstance_base() string {
-	return `
+func testAccRdsInstance_base(name string) string {
+	return fmt.Sprintf(`
+%s
+
 data "huaweicloud_availability_zones" "test" {}
 
 data "huaweicloud_vpc" "test" {
@@ -526,10 +528,7 @@ data "huaweicloud_vpc" "test" {
 data "huaweicloud_vpc_subnet" "test" {
   name = "subnet-default"
 }
-
-data "huaweicloud_networking_secgroup" "test" {
-  name = "default"
-}`
+`, common.TestSecGroup(name))
 }
 
 func testAccRdsInstance_basic(name string) string {
@@ -541,7 +540,7 @@ resource "huaweicloud_rds_instance" "test" {
   description       = "test_description"
   flavor            = "rds.pg.n1.large.2"
   availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   time_zone         = "UTC+08:00"
@@ -568,7 +567,7 @@ resource "huaweicloud_rds_instance" "test" {
     foo = "bar"
   }
 }
-`, testAccRdsInstance_base(), name)
+`, testAccRdsInstance_base(name), name)
 }
 
 // name, volume.size, backup_strategy, flavor, tags and password will be updated
@@ -580,7 +579,7 @@ resource "huaweicloud_rds_instance" "test" {
   name                  = "%[2]s-update"
   flavor                = "rds.pg.n1.large.2"
   availability_zone     = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id     = data.huaweicloud_networking_secgroup.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
   subnet_id             = data.huaweicloud_vpc_subnet.test.id
   vpc_id                = data.huaweicloud_vpc.test.id
   enterprise_project_id = "%[3]s"
@@ -609,7 +608,7 @@ resource "huaweicloud_rds_instance" "test" {
     foo  = "bar_updated"
   }
 }
-`, testAccRdsInstance_base(), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccRdsInstance_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
 
 func testAccRdsInstance_ha(name, replicationMode, switchStrategy string) string {
@@ -619,7 +618,7 @@ func testAccRdsInstance_ha(name, replicationMode, switchStrategy string) string 
 resource "huaweicloud_rds_instance" "test" {
   name                = "%[2]s"
   flavor              = "rds.pg.n1.large.2.ha"
-  security_group_id   = data.huaweicloud_networking_secgroup.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
   subnet_id           = data.huaweicloud_vpc_subnet.test.id
   vpc_id              = data.huaweicloud_vpc.test.id
   time_zone           = "UTC+08:00"
@@ -650,7 +649,7 @@ resource "huaweicloud_rds_instance" "test" {
     foo = "bar"
   }
 }
-`, testAccRdsInstance_base(), name, replicationMode, switchStrategy)
+`, testAccRdsInstance_base(name), name, replicationMode, switchStrategy)
 }
 
 // if the instance flavor has been changed, then a temp instance will be kept for 12 hours,
@@ -671,7 +670,7 @@ data "huaweicloud_rds_flavors" "test" {
 resource "huaweicloud_rds_instance" "test" {
   name                   = "%[2]s"
   flavor                 = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id      = data.huaweicloud_networking_secgroup.test.id
+  security_group_id      = huaweicloud_networking_secgroup.test.id
   subnet_id              = data.huaweicloud_vpc_subnet.test.id
   vpc_id                 = data.huaweicloud_vpc.test.id
   availability_zone      = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
@@ -702,7 +701,7 @@ resource "huaweicloud_rds_instance" "test" {
     value = "12"
   }
 }
-`, testAccRdsInstance_base(), name)
+`, testAccRdsInstance_base(name), name)
 }
 
 func testAccRdsInstance_mysql_step2(name string) string {
@@ -721,7 +720,7 @@ data "huaweicloud_rds_flavors" "test" {
 resource "huaweicloud_rds_instance" "test" {
   name                   = "%[3]s"
   flavor                 = data.huaweicloud_rds_flavors.test.flavors[1].name
-  security_group_id      = data.huaweicloud_networking_secgroup.test.id
+  security_group_id      = huaweicloud_networking_secgroup.test.id
   subnet_id              = data.huaweicloud_vpc_subnet.test.id
   vpc_id                 = data.huaweicloud_vpc.test.id
   availability_zone      = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
@@ -754,7 +753,7 @@ resource "huaweicloud_rds_instance" "test" {
     value = "14"
   }
 }
-`, testAccRdsInstance_base(), testAccRdsConfig_basic(name), name)
+`, testAccRdsInstance_base(name), testAccRdsConfig_basic(name), name)
 }
 
 func testAccRdsInstance_mysql_step3(name string) string {
@@ -773,7 +772,7 @@ data "huaweicloud_rds_flavors" "test" {
 resource "huaweicloud_rds_instance" "test" {
   name                   = "%[3]s"
   flavor                 = data.huaweicloud_rds_flavors.test.flavors[1].name
-  security_group_id      = data.huaweicloud_networking_secgroup.test.id
+  security_group_id      = huaweicloud_networking_secgroup.test.id
   subnet_id              = data.huaweicloud_vpc_subnet.test.id
   vpc_id                 = data.huaweicloud_vpc.test.id
   availability_zone      = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
@@ -798,7 +797,7 @@ resource "huaweicloud_rds_instance" "test" {
     value = "14"
   }
 }
-`, testAccRdsInstance_base(), testAccRdsConfig_basic(name), name)
+`, testAccRdsInstance_base(name), testAccRdsConfig_basic(name), name)
 }
 
 func testAccRdsInstance_mysql_power_action(name, action string, status []string) string {
@@ -815,7 +814,7 @@ data "huaweicloud_rds_flavors" "test" {
 resource "huaweicloud_rds_instance" "test" {
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
@@ -835,14 +834,12 @@ resource "huaweicloud_rds_instance" "test" {
 output "instance_status_contains" {
   value = contains(split(",", "%[4]s"), huaweicloud_rds_instance.test.status)
 }
-`, testAccRdsInstance_base(), name, action, strings.Join(status, ","))
+`, testAccRdsInstance_base(name), name, action, strings.Join(status, ","))
 }
 
 func testAccRdsInstance_sqlserver(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-
-data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_networking_secgroup_rule" "ingress" {
   direction         = "ingress"
@@ -862,11 +859,12 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
+  depends_on        = [huaweicloud_networking_secgroup_rule.ingress]
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
   security_group_id = huaweicloud_networking_secgroup.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
   collation         = "Chinese_PRC_CI_AS"
 
   availability_zone = [
@@ -885,14 +883,12 @@ resource "huaweicloud_rds_instance" "test" {
     size = 40
   }
 }
-`, common.TestBaseNetwork(name), name)
+`, testAccRdsInstance_base(name), name)
 }
 
 func testAccRdsInstance_sqlserver_update(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-
-data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_networking_secgroup_rule" "ingress" {
   direction         = "ingress"
@@ -912,11 +908,12 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
+  depends_on        = [huaweicloud_networking_secgroup_rule.ingress]
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
   security_group_id = huaweicloud_networking_secgroup.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
   collation         = "Chinese_PRC_CI_AI"
 
   availability_zone = [
@@ -935,14 +932,12 @@ resource "huaweicloud_rds_instance" "test" {
     size = 40
   }
 }
-`, common.TestBaseNetwork(name), name)
+`, testAccRdsInstance_base(name), name)
 }
 
 func testAccRdsInstance_sqlserver_msdtcHosts_base(name string) string {
 	return fmt.Sprintf(`
 %[1]s
-
-data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_networking_secgroup_rule" "ingress" {
   direction         = "ingress"
@@ -972,7 +967,7 @@ data "huaweicloud_images_image" "test" {
   name        = "Ubuntu 18.04 server 64bit"
   most_recent = true
 }
-`, common.TestBaseNetwork(name), name)
+`, testAccRdsInstance_base(name), name)
 }
 
 func testAccRdsInstance_sqlserver_msdtcHosts(name string) string {
@@ -987,16 +982,17 @@ resource "huaweicloud_compute_instance" "ecs_1" {
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
-    uuid = huaweicloud_vpc_subnet.test.id
+    uuid = data.huaweicloud_vpc_subnet.test.id
   }
 }
 
 resource "huaweicloud_rds_instance" "test" {
+  depends_on        = [huaweicloud_networking_secgroup_rule.ingress]
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
   security_group_id = huaweicloud_networking_secgroup.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
   collation         = "Chinese_PRC_CI_AS"
 
   availability_zone = [
@@ -1035,7 +1031,7 @@ resource "huaweicloud_compute_instance" "ecs_1" {
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
-    uuid = huaweicloud_vpc_subnet.test.id
+    uuid = data.huaweicloud_vpc_subnet.test.id
   }
 }
 
@@ -1047,16 +1043,17 @@ resource "huaweicloud_compute_instance" "ecs_2" {
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
 
   network {
-    uuid = huaweicloud_vpc_subnet.test.id
+    uuid = data.huaweicloud_vpc_subnet.test.id
   }
 }
 
 resource "huaweicloud_rds_instance" "test" {
+  depends_on        = [huaweicloud_networking_secgroup_rule.ingress]
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
   security_group_id = huaweicloud_networking_secgroup.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
   collation         = "Chinese_PRC_CI_AS"
 
   availability_zone = [
@@ -1101,7 +1098,7 @@ data "huaweicloud_rds_flavors" "test" {
 resource "huaweicloud_rds_instance" "test" {
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
@@ -1118,12 +1115,21 @@ resource "huaweicloud_rds_instance" "test" {
     size = 40
   }
 }
-`, testAccRdsInstance_base(), name)
+`, testAccRdsInstance_base(name), name)
 }
 
 func testAccRdsInstance_prePaid(name string, isAutoRenew bool) string {
 	return fmt.Sprintf(`
 %[1]s
+
+resource "huaweicloud_networking_secgroup_rule" "ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  ports             = 8634
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = huaweicloud_networking_secgroup.test.id
+}
 
 data "huaweicloud_rds_flavors" "test" {
   db_type       = "SQLServer"
@@ -1134,9 +1140,10 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
+  depends_on        = [huaweicloud_networking_secgroup_rule.ingress]
   vpc_id            = data.huaweicloud_vpc.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0],
@@ -1163,7 +1170,7 @@ resource "huaweicloud_rds_instance" "test" {
   period        = 1
   auto_renew    = "%[3]v"
 }
-`, testAccRdsInstance_base(), name, isAutoRenew)
+`, testAccRdsInstance_base(name), name, isAutoRenew)
 }
 
 func testAccRdsInstance_prePaid_update(name string, isAutoRenew bool) string {
@@ -1181,7 +1188,7 @@ data "huaweicloud_rds_flavors" "test" {
 resource "huaweicloud_rds_instance" "test" {
   vpc_id            = data.huaweicloud_vpc.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0],
@@ -1208,7 +1215,7 @@ resource "huaweicloud_rds_instance" "test" {
   period        = 1
   auto_renew    = "%[3]v"
 }
-`, testAccRdsInstance_base(), name, isAutoRenew)
+`, testAccRdsInstance_base(name), name, isAutoRenew)
 }
 
 func testAccRdsInstance_restore_mysql(name string) string {
@@ -1218,7 +1225,7 @@ func testAccRdsInstance_restore_mysql(name string) string {
 resource "huaweicloud_rds_instance" "test_backup" {
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
@@ -1257,9 +1264,10 @@ func testAccRdsInstance_restore_sqlserver(name string) string {
 %[1]s
 
 resource "huaweicloud_rds_instance" "test_backup" {
+  depends_on        = [huaweicloud_networking_secgroup_rule.ingress]
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
@@ -1291,7 +1299,7 @@ func testAccRdsInstance_restore_pg(name, pwd string) string {
 resource "huaweicloud_rds_instance" "test_backup" {
   name              = "%[2]s"
   flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_binlog_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_binlog_test.go
@@ -99,7 +99,7 @@ func TestAccMysqlBinlog_basic(t *testing.T) {
 	})
 }
 
-func testAccRdsInstance_mysql(name, pwd string) string {
+func testAccRdsInstance_mysql(name, pwd string, binlogRetentionHours int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -111,13 +111,14 @@ data "huaweicloud_rds_flavors" "test" {
 }
 
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%[2]s"
-  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
-  security_group_id = data.huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
-  ssl_enable        = true
+  name                   = "%[2]s"
+  flavor                 = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id      = huaweicloud_networking_secgroup.test.id
+  subnet_id              = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                 = data.huaweicloud_vpc.test.id
+  availability_zone      = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+  ssl_enable             = true
+  binlog_retention_hours = %[4]v
 
   db {
     password = "%[3]s"
@@ -131,7 +132,7 @@ resource "huaweicloud_rds_instance" "test" {
     size = 40
   }
 }
-`, testAccRdsInstance_base(), name, pwd)
+`, testAccRdsInstance_base(name), name, pwd, binlogRetentionHours)
 }
 
 func testMysqlBinlog_basic(name, dbPwd string) string {
@@ -142,7 +143,7 @@ resource "huaweicloud_rds_mysql_binlog" "test" {
   instance_id            = huaweicloud_rds_instance.test.id
   binlog_retention_hours = 6
 }
-`, testAccRdsInstance_mysql(name, dbPwd))
+`, testAccRdsInstance_mysql(name, dbPwd, 6))
 }
 
 func testMysqlBinlog_basic_update(name, dbPwd string) string {
@@ -154,5 +155,5 @@ resource "huaweicloud_rds_mysql_binlog" "test" {
   binlog_retention_hours = 8
 }
 
-`, testAccRdsInstance_mysql(name, dbPwd))
+`, testAccRdsInstance_mysql(name, dbPwd, 8))
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
@@ -36,7 +36,7 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 						"data.huaweicloud_rds_flavors.replica", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "type", "Replica"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
-						"data.huaweicloud_networking_secgroup.test", "id"),
+						"huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8888"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
@@ -61,7 +61,7 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 						"data.huaweicloud_rds_flavors.replica", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "type", "Replica"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
-						"data.huaweicloud_networking_secgroup.test", "id"),
+						"huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8889"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
@@ -139,7 +139,7 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
   flavor              = data.huaweicloud_rds_flavors.replica.flavors[0].name
   primary_instance_id = huaweicloud_rds_instance.test.id
   availability_zone   = data.huaweicloud_availability_zones.test.names[0]
-  security_group_id   = data.huaweicloud_networking_secgroup.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
   ssl_enable          = true
 
   db {
@@ -185,7 +185,7 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
   flavor              = data.huaweicloud_rds_flavors.replica.flavors[0].name
   primary_instance_id = huaweicloud_rds_instance.test.id
   availability_zone   = data.huaweicloud_availability_zones.test.names[0]
-  security_group_id   = data.huaweicloud_networking_secgroup.test.id
+  security_group_id   = huaweicloud_networking_secgroup.test.id
   ssl_enable          = false
 
   db {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 10
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
--- PASS: TestAccRdsInstance_mariadb (679.33s)
=== CONT  TestAccRdsInstance_ha
--- PASS: TestAccRdsInstance_basic (809.86s)
--- PASS: TestAccRdsInstance_mysql_power_action (1143.02s)
--- PASS: TestAccRdsInstance_ha (736.79s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1480.37s)
--- PASS: TestAccRdsInstance_restore_mysql (1569.12s)
--- PASS: TestAccRdsInstance_restore_pg (1623.33s)
--- PASS: TestAccRdsInstance_prePaid (1656.66s)
--- PASS: TestAccRdsInstance_mysql (1741.75s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2745.40s)
--- PASS: TestAccRdsInstance_sqlserver (3211.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       6763.137s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccBackup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccBackup_ -timeout 360m -parallel 4
=== RUN   TestAccBackup_mysql_basic
=== PAUSE TestAccBackup_mysql_basic
=== RUN   TestAccBackup_sqlserver_basic
=== PAUSE TestAccBackup_sqlserver_basic
=== RUN   TestAccBackup_pg_basic
=== PAUSE TestAccBackup_pg_basic
=== CONT  TestAccBackup_mysql_basic
=== CONT  TestAccBackup_pg_basic
=== CONT  TestAccBackup_sqlserver_basic
--- PASS: TestAccBackup_pg_basic (812.03s)
--- PASS: TestAccBackup_mysql_basic (865.42s)
--- PASS: TestAccBackup_sqlserver_basic (1814.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1814.263s


make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccReadReplicaInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccReadReplicaInstance_ -timeout 360m -parallel 4
=== RUN   TestAccReadReplicaInstance_basic
=== PAUSE TestAccReadReplicaInstance_basic
=== RUN   TestAccReadReplicaInstance_withEpsId
=== PAUSE TestAccReadReplicaInstance_withEpsId
=== CONT  TestAccReadReplicaInstance_basic
=== CONT  TestAccReadReplicaInstance_withEpsId
    acceptance.go:506: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccReadReplicaInstance_withEpsId (0.01s)
--- PASS: TestAccReadReplicaInstance_basic (2333.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2333.963s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlBinlog_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlBinlog_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlBinlog_basic
--- PASS: TestAccMysqlBinlog_basic (841.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       841.608s
```
