### PR TITLE
feat(hss): add hosts datasource support

### DIFF
--- a/docs/data-sources/hss_hosts.md
+++ b/docs/data-sources/hss_hosts.md
@@ -1,0 +1,143 @@
+---
+subcategory: "Host Security Service (HSS)"
+---
+
+# huaweicloud_hss_hosts
+
+Use this data source to get the list of HSS hosts within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable host_id {}
+
+data "hss_hosts" "test" {
+  host_id = var.host_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the HSS hosts.
+  If omitted, the provider-level region will be used.
+
+* `host_id` - (Optional, String) Specifies the ID of the host to be queried.
+
+* `name` - (Optional, String) Specifies the name of the host to be queried.
+  This field will undergo a fuzzy matching query, the query result is for all hosts whose names contain this value.
+
+* `status` - (Optional, String) Specifies the status of the hosts to be queried.  
+  The valid values are as follows:
+  + **ACTIVE**
+  + **SHUTOFF**
+  + **ERROR**
+
+* `os_type` - (Optional, String) Specifies the operating system type of the hosts to be queried.  
+  The valid values are as follows:
+  + **Linux**
+  + **Windows**
+
+* `agent_status` - (Optional, String) Specifies the agent status of the hosts to be queried.  
+  The valid values are as follows:
+  + **installed**
+  + **not_installed**
+  + **online**
+  + **offline**
+  + **install_failed**
+
+* `protect_status` - (Optional, String) Specifies the protection status of the hosts to be queried.  
+  The valid values are as follows:
+  + **closed**
+  + **opened**
+
+* `protect_version` - (Optional, String) Specifies the protection version enabled by the hosts to be queried.  
+  The valid values are as follows:
+  + **hss.version.basic**
+  + **hss.version.advanced**
+  + **hss.version.enterprise**
+  + **hss.version.premium**
+  + **hss.version.wtp**
+  + **hss.version.container.enterprise**
+
+* `protect_charging_mode` - (Optional, String) Specifies the charging mode for the hosts protection quota to be queried.
+  
+  The valid values are as follows:
+  + **prePaid**
+  + **postPaid**
+
+* `detect_result` - (Optional, String) Specifies the security detection result of the hosts to be queried.  
+  The valid values are as follows:
+  + **undetected**
+  + **clean**
+  + **risk**
+
+* `group_id` - (Optional, String) Specifies the host group ID of the hosts to be queried.
+
+* `policy_group_id` - (Optional, String) Specifies the policy group ID of the hosts to be queried.
+
+* `asset_value` - (Optional, String) Specifies the asset importance of the hosts to be queried.  
+  The valid values are as follows:
+  + **important**
+  + **common**
+  + **test**
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the hosts belong.
+  If omitted, will query the hosts under all enterprise projects.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `hosts` - All hosts that match the filter parameters.  
+  The [hosts](#hss_hosts) structure is documented below.
+
+<a name="hss_hosts"></a>
+The `hosts` block supports:
+
+* `id` - The ID of the host.
+
+* `name` - The name of the host.
+
+* `status` - The status of the host.
+
+* `os_type` - The operating system type of the host.
+
+* `agent_id` - The agent ID installed on the host.
+
+* `agent_status` - The agent status of the host.
+
+* `protect_status` - The protection status of the host.
+
+* `protect_version` - The protection version enabled by the host.
+
+* `protect_charging_mode` - The charging mode for the host protection quota.
+
+* `quota_id` - The protection quota ID of the host.
+
+* `detect_result` - The security detection result of the host.
+
+* `group_id` - The host group ID to which the host belongs.
+
+* `policy_group_id` - The policy group ID to which the host belongs.
+
+* `asset_value` - The asset importance of the host.
+
+* `open_time` - The time to enable host protection.
+
+* `private_ip` - The private IP address of the host.
+
+* `public_ip` - The elastic public IP address of the host.
+
+* `asset_risk_num` - The number of asset risks in the host
+
+* `vulnerability_risk_num` - The number of vulnerability risks in the host.
+
+* `baseline_risk_num` - The number of baseline risks in the host.
+
+* `intrusion_risk_num` - The number of intrusion risks in the host.
+
+* `enterprise_project_id` - The ID of the enterprise project to which the host belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -562,6 +562,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_restore_time_ranges":    gaussdb.DataSourceGaussdbMysqlRestoreTimeRanges(),
 
 			"huaweicloud_hss_host_groups": hss.DataSourceHostGroups(),
+			"huaweicloud_hss_hosts":       hss.DataSourceHosts(),
 
 			"huaweicloud_identity_permissions": iam.DataSourceIdentityPermissions(),
 			"huaweicloud_identity_role":        iam.DataSourceIdentityRole(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_hosts_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_hosts_test.go
@@ -1,0 +1,129 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceHosts_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_hss_hosts.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceHosts_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.os_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.agent_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.agent_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.protect_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.protect_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.protect_charging_mode"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.quota_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.detect_result"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.policy_group_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.asset_value"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.open_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.private_ip"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.enterprise_project_id"),
+
+					resource.TestCheckOutput("is_host_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_agent_status_filter_useful", "true"),
+					resource.TestCheckOutput("is_protect_version_filter_useful", "true"),
+					resource.TestCheckOutput("is_protect_charging_mode_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceHosts_basic() string {
+	return `
+
+data "huaweicloud_hss_hosts" "test" {}
+
+# Filter using host ID.
+locals {
+  host_id = data.huaweicloud_hss_hosts.test.hosts[0].id
+}
+
+data "huaweicloud_hss_hosts" "host_id_filter" {
+  host_id = local.host_id
+}
+
+output "is_host_id_filter_useful" {
+  value = length(data.huaweicloud_hss_hosts.host_id_filter.hosts) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_hosts.host_id_filter.hosts[*].id : v == local.host_id]
+  )
+}
+
+# Filter using agent_status
+locals {
+  agent_status = data.huaweicloud_hss_hosts.test.hosts[0].agent_status
+}
+
+data "huaweicloud_hss_hosts" "agent_status_filter" {
+  agent_status = local.agent_status
+}
+
+output "is_agent_status_filter_useful" {
+  value = length(data.huaweicloud_hss_hosts.agent_status_filter.hosts) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_hosts.agent_status_filter.hosts[*].agent_status : v == local.agent_status]
+  )
+}
+
+# Filter using protect_version
+locals {
+  protect_version = data.huaweicloud_hss_hosts.test.hosts[0].protect_version
+}
+
+data "huaweicloud_hss_hosts" "protect_version_filter" {
+  protect_version = local.protect_version
+}
+
+output "is_protect_version_filter_useful" {
+  value = length(data.huaweicloud_hss_hosts.protect_version_filter.hosts) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_hosts.protect_version_filter.hosts[*].protect_version : v == local.protect_version]
+  )
+}
+
+# Filter using protect_charging_mode
+locals {
+  protect_charging_mode = data.huaweicloud_hss_hosts.test.hosts[0].protect_charging_mode
+}
+
+data "huaweicloud_hss_hosts" "protect_charging_mode_filter" {
+  protect_charging_mode = local.protect_charging_mode
+}
+
+output "is_protect_charging_mode_filter_useful" {
+  value = length(data.huaweicloud_hss_hosts.protect_charging_mode_filter.hosts) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_hosts.protect_charging_mode_filter.hosts[*].protect_charging_mode : v == local.protect_charging_mode]
+  )
+}
+
+# Filter using non existent name.
+data "huaweicloud_hss_hosts" "not_found" {
+  name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_hss_hosts.not_found.hosts) == 0
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_hosts.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_hosts.go
@@ -1,0 +1,280 @@
+package hss
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	hssv5model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/hss/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/host-management/hosts
+func DataSourceHosts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHostsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"agent_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protect_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protect_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protect_charging_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"detect_result": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"asset_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"hosts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"os_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"agent_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"agent_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protect_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protect_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protect_charging_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"quota_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"detect_result": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"asset_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"open_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"asset_risk_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"vulnerability_risk_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"baseline_risk_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"intrusion_risk_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceHostsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		epsId    = cfg.DataGetEnterpriseProjectID(d)
+		limit    = int32(20)
+		offset   int32
+		allHosts []hssv5model.Host
+	)
+
+	client, err := cfg.HcHssV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating HSS v5 client: %s", err)
+	}
+
+	for {
+		request := hssv5model.ListHostStatusRequest{
+			Region:              &region,
+			Limit:               utils.Int32(limit),
+			Offset:              utils.Int32(offset),
+			HostId:              utils.StringIgnoreEmpty(d.Get("host_id").(string)),
+			HostName:            utils.StringIgnoreEmpty(d.Get("name").(string)),
+			HostStatus:          utils.StringIgnoreEmpty(d.Get("status").(string)),
+			OsType:              utils.StringIgnoreEmpty(d.Get("os_type").(string)),
+			AgentStatus:         utils.StringIgnoreEmpty(d.Get("agent_status").(string)),
+			ProtectStatus:       utils.StringIgnoreEmpty(d.Get("protect_status").(string)),
+			Version:             utils.StringIgnoreEmpty(d.Get("protect_version").(string)),
+			ChargingMode:        utils.StringIgnoreEmpty(convertChargingModeRequest(d.Get("protect_charging_mode").(string))),
+			DetectResult:        utils.StringIgnoreEmpty(d.Get("detect_result").(string)),
+			GroupId:             utils.StringIgnoreEmpty(d.Get("group_id").(string)),
+			PolicyGroupId:       utils.StringIgnoreEmpty(d.Get("policy_group_id").(string)),
+			AssetValue:          utils.StringIgnoreEmpty(d.Get("asset_value").(string)),
+			EnterpriseProjectId: utils.String(epsId),
+		}
+
+		listResp, listErr := client.ListHostStatus(&request)
+		if listErr != nil {
+			return diag.Errorf("error querying HSS hosts: %s", listErr)
+		}
+
+		if listResp == nil || listResp.DataList == nil {
+			break
+		}
+		if len(*listResp.DataList) == 0 {
+			break
+		}
+
+		allHosts = append(allHosts, *listResp.DataList...)
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("hosts", flattenHosts(allHosts)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenHosts(hosts []hssv5model.Host) []interface{} {
+	if len(hosts) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(hosts))
+	for _, v := range hosts {
+		rst = append(rst, map[string]interface{}{
+			"id":                     v.HostId,
+			"name":                   v.HostName,
+			"status":                 v.HostStatus,
+			"os_type":                v.OsType,
+			"agent_id":               v.AgentId,
+			"agent_status":           v.AgentStatus,
+			"protect_status":         v.ProtectStatus,
+			"protect_version":        v.Version,
+			"protect_charging_mode":  convertChargingMode(v.ChargingMode),
+			"quota_id":               v.ResourceId,
+			"detect_result":          v.DetectResult,
+			"group_id":               v.GroupId,
+			"policy_group_id":        v.PolicyGroupId,
+			"asset_value":            v.AssetValue,
+			"open_time":              convertOpenTime(v.OpenTime),
+			"private_ip":             v.PrivateIp,
+			"public_ip":              v.PublicIp,
+			"asset_risk_num":         v.Asset,
+			"vulnerability_risk_num": v.Vulnerability,
+			"baseline_risk_num":      v.Baseline,
+			"intrusion_risk_num":     v.Intrusion,
+			"enterprise_project_id":  v.EnterpriseProjectId,
+		})
+	}
+
+	return rst
+}

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_host_protection.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_host_protection.go
@@ -145,6 +145,17 @@ func checkHostAvailable(client *hssv5.HssClient, region, epsId, hostId string) e
 	return nil
 }
 
+func convertChargingModeRequest(chargingMode string) string {
+	switch chargingMode {
+	case chargingModePrePaid:
+		return chargingModePacketCycle
+	case chargingModePostPaid:
+		return chargingModeOnDemand
+	default:
+		return chargingMode
+	}
+}
+
 func switchHostsProtectStatus(client *hssv5.HssClient, region, epsId, hostId string, d *schema.ResourceData) error {
 	var (
 		version      = d.Get("version").(string)
@@ -152,19 +163,12 @@ func switchHostsProtectStatus(client *hssv5.HssClient, region, epsId, hostId str
 		quotaId      = d.Get("quota_id").(string)
 	)
 
-	if chargingMode == chargingModePrePaid {
-		chargingMode = chargingModePacketCycle
-	}
-	if chargingMode == chargingModePostPaid {
-		chargingMode = chargingModeOnDemand
-	}
-
 	switchOpts := hssv5model.SwitchHostsProtectStatusRequest{
 		Region:              region,
 		EnterpriseProjectId: utils.StringIgnoreEmpty(epsId),
 		Body: &hssv5model.SwitchHostsProtectStatusRequestInfo{
 			Version:      version,
-			ChargingMode: utils.String(chargingMode),
+			ChargingMode: utils.String(convertChargingModeRequest(chargingMode)),
 			ResourceId:   utils.StringIgnoreEmpty(quotaId),
 			HostIdList:   []string{hostId},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add hosts datasource support
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Add hosts datasource support.
2.Extract the conversion of the `charging_mode` field value when requesting an API as a common function.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

## Basic
```
$ export HW_HSS_HOST_PROTECTION_HOST_ID=xxxxxxxxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceHosts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceHosts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceHosts_basic
=== PAUSE TestAccDataSourceHosts_basic
=== CONT  TestAccDataSourceHosts_basic
--- PASS: TestAccDataSourceHosts_basic (15.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       15.166s

```

## Skip
```
$ unset HW_HSS_HOST_PROTECTION_HOST_ID
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceHosts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceHosts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceHosts_basic
=== PAUSE TestAccDataSourceHosts_basic
=== CONT  TestAccDataSourceHosts_basic
    acceptance.go:1535: HW_HSS_HOST_PROTECTION_HOST_ID must be set for the acceptance test
--- SKIP: TestAccDataSourceHosts_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       0.044s

```

## host_protection resource
```
$ export HW_HSS_HOST_PROTECTION_HOST_ID=xxxxxxxxxxxxxxxxxx
$ export HW_HSS_HOST_PROTECTION_QUOTA_ID=xxxxxxxxxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccHostProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccHostProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccHostProtection_basic
=== PAUSE TestAccHostProtection_basic
=== CONT  TestAccHostProtection_basic
--- PASS: TestAccHostProtection_basic (24.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       24.763s

```
