### PR TITLE
feat(cae/deploy): support new resource to deploy component

### DIFF
--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -888,6 +888,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cae_component":                cae.ResourceComponent(),
 			"huaweicloud_cae_component_configurations": cae.ResourceComponentConfigurations(),
+			"huaweicloud_cae_component_deployment":     cae.ResourceComponentDeployment(),
 
 			"huaweicloud_cbr_backup_share_accepter": cbr.ResourceBackupShareAccepter(),
 			"huaweicloud_cbr_backup_share":          cbr.ResourceBackupShare(),

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_deployment_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_deployment_test.go
@@ -1,0 +1,257 @@
+package cae
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccComponentDeployment_basic(t *testing.T) {
+	baseConfig := testAccComponentConfiguration_base()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCaeEnvironment(t)
+			acceptance.TestAccPreCheckCaeApplication(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComponentDeployment_basic_step1(baseConfig),
+			},
+			{
+				Config: testAccComponentDeployment_basic_step2(baseConfig),
+			},
+			{
+				Config: testAccComponentDeployment_basic_step3(baseConfig),
+			},
+			{
+				Config: testAccComponentDeployment_basic_step4(baseConfig),
+			},
+		},
+	})
+}
+
+func testAccComponentDeployment_basic_step1(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_component_configurations" "test" {
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+  component_id   = huaweicloud_cae_component.test.id
+
+  items {
+    type = "lifecycle"
+    data = jsonencode({
+      "spec": {
+        "postStart": {
+          "exec": {
+            "command": [
+              "/bin/bash",
+              "-c",
+              "sleep",
+              "10",
+              "done",
+            ]
+          }
+        }
+      }
+    })
+  }
+}
+
+resource "huaweicloud_cae_component_deployment" "test" {
+  environment_id = "ae22f51f-39fa-4252-beb5-fb3e508c78b7"
+  application_id = "9db0d7ad-e9a5-4447-b351-04a7a9d7af02"
+  component_id   = huaweicloud_cae_component.test.id
+
+  metadata {
+    name = "deploy"
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      huaweicloud_cae_component_configurations.test.items
+    ]
+  }
+}
+`, baseConfig, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
+}
+
+func testAccComponentDeployment_basic_step2(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_component_configurations" "test" {
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+  component_id   = huaweicloud_cae_component.test.id
+
+  items {
+    type = "lifecycle"
+    data = jsonencode({
+      "spec": {
+        "postStart": {
+          "exec": {
+            "command": [
+              "/bin/bash",
+              "-c",
+              "sleep",
+              "10",
+              "done",
+            ]
+          }
+        }
+      }
+    })
+  }
+  items {
+    type = "env"
+    data = jsonencode({
+      "spec": {
+        "envs": {
+            "key": "value",
+            "foo": "bar"
+        }
+      }
+    })
+  }
+}
+
+resource "huaweicloud_cae_component_deployment" "test" {
+  environment_id = "ae22f51f-39fa-4252-beb5-fb3e508c78b7"
+  application_id = "9db0d7ad-e9a5-4447-b351-04a7a9d7af02"
+  component_id   = huaweicloud_cae_component.test.id
+
+  metadata {
+    name = "configure"
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      huaweicloud_cae_component_configurations.test.items
+    ]
+  }
+}
+`, baseConfig, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
+}
+
+func testAccComponentDeployment_basic_step3(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_component_configurations" "test" {
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+  component_id   = huaweicloud_cae_component.test.id
+
+  items {
+    type = "lifecycle"
+    data = jsonencode({
+      "spec": {
+        "postStart": {
+          "exec": {
+            "command": [
+              "/bin/bash",
+              "-c",
+              "sleep",
+              "10",
+              "done",
+            ]
+          }
+        }
+      }
+    })
+  }
+  items {
+    type = "env"
+    data = jsonencode({
+      "spec": {
+        "envs": {
+            "key": "value",
+            "foo": "baar"
+        }
+      }
+    })
+  }
+}
+
+resource "huaweicloud_cae_component_deployment" "test" {
+  environment_id = "ae22f51f-39fa-4252-beb5-fb3e508c78b7"
+  application_id = "9db0d7ad-e9a5-4447-b351-04a7a9d7af02"
+  component_id   = huaweicloud_cae_component.test.id
+
+  metadata {
+    name = "configure"
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      huaweicloud_cae_component_configurations.test.items
+    ]
+  }
+}
+`, baseConfig, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
+}
+
+func testAccComponentDeployment_basic_step4(baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cae_component_configurations" "test" {
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
+  component_id   = huaweicloud_cae_component.test.id
+
+  items {
+    type = "lifecycle"
+    data = jsonencode({
+      "spec": {
+        "postStart": {
+          "exec": {
+            "command": [
+              "/bin/bash",
+              "-c",
+              "sleep",
+              "10",
+              "done",
+            ]
+          }
+        }
+      }
+    })
+  }
+  items {
+    type = "env"
+    data = jsonencode({
+      "spec": {
+        "envs": {
+            "key": "value",
+            "foo": "baar"
+        }
+      }
+    })
+  }
+}
+
+resource "huaweicloud_cae_component_deployment" "test" {
+  environment_id = "ae22f51f-39fa-4252-beb5-fb3e508c78b7"
+  application_id = "9db0d7ad-e9a5-4447-b351-04a7a9d7af02"
+  component_id   = huaweicloud_cae_component.test.id
+
+  metadata {
+    name = "stop"
+  }
+
+  lifecycle {
+    replace_triggered_by = [
+      huaweicloud_cae_component_configurations.test.items
+    ]
+  }
+}
+`, baseConfig, acceptance.HW_CAE_ENVIRONMENT_ID, acceptance.HW_CAE_APPLICATION_ID)
+}

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_component_deployment.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_component_deployment.go
@@ -1,0 +1,230 @@
+package cae
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CAE POST /v1/{project_id}/cae/applications/{application_id}/components/{component_id}/action
+// @API CAE GET /v1/{project_id}/cae/jobs/{job_id}
+func ResourceComponentDeployment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceComponentDeploymentCreate,
+		ReadContext:   resourceComponentDeploymentRead,
+		UpdateContext: resourceComponentDeploymentUpdate,
+		DeleteContext: resourceComponentDeploymentDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region in which to create the resource.`,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the environment where the application is located.`,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the application where the component is located.`,
+			},
+			"component_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the component to which the configurations belong.`,
+			},
+			"metadata": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"annotations": {
+							Type:        schema.TypeMap,
+							Optional:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The resource configurations.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The action name.`,
+						},
+					},
+				},
+				Description: `The metadata of this action request.`,
+			},
+			"spec": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsJSON,
+				Description:  `The specification detail of the action.`,
+			},
+		},
+	}
+}
+
+func buildCreateComponentDeploymentBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"api_version": "v1",
+		"kind":        "Action",
+		"metadata": map[string]interface{}{
+			"annotations": d.Get("metadata.0.annotations"),
+			"name":        d.Get("metadata.0.name"),
+		},
+		"spec": utils.ValueIngoreEmpty(unmarshalJsonFormatParamster("Specification detail", d.Get("spec").(string))),
+	}
+}
+
+func deployComponent(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData, timeout time.Duration) error {
+	var (
+		httpUrl       = "v1/{project_id}/cae/applications/{application_id}/components/{component_id}/action"
+		applicationId = d.Get("application_id").(string)
+		componentId   = d.Get("component_id").(string)
+		environmentId = d.Get("environment_id").(string)
+	)
+
+	modifyPath := client.Endpoint + httpUrl
+	modifyPath = strings.ReplaceAll(modifyPath, "{project_id}", client.ProjectID)
+	modifyPath = strings.ReplaceAll(modifyPath, "{application_id}", applicationId)
+	modifyPath = strings.ReplaceAll(modifyPath, "{component_id}", componentId)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-ID": environmentId,
+		},
+		JSONBody: utils.RemoveNil(buildCreateComponentDeploymentBodyParams(d)),
+	}
+	requestResp, err := client.Request("POST", modifyPath, &opts)
+	if err != nil {
+		return fmt.Errorf("error operating the component (%s): %s", componentId, err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return fmt.Errorf("error retrieving API response of the deployment for the component configuration (%s): %s", componentId, err)
+	}
+	jobId := utils.PathSearch("job_id", respBody, "null").(string)
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      deployJobRefreshFunc(client, environmentId, jobId, []string{"success"}),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        20 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for the deploy job (%s) success: %s", jobId, err)
+	}
+	return nil
+}
+
+func getDeployJobDetail(client *golangsdk.ServiceClient, environmentId, jobId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/cae/jobs/{job_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{job_id}", jobId)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"X-Environment-ID": environmentId,
+		},
+	}
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error querying deploy job detail by its ID (%s): %s", jobId, err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving deploy job (%s) detail: %s", jobId, err)
+	}
+	return respBody, nil
+}
+
+func deployJobRefreshFunc(client *golangsdk.ServiceClient, environmentId, jobId string, targets []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := getDeployJobDetail(client, environmentId, jobId)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		status := utils.PathSearch("spec.status", resp, "null").(string)
+
+		if utils.StrSliceContains(targets, status) {
+			return resp, "COMPLETED", nil
+		}
+		return resp, "PENDING", nil
+	}
+}
+
+func resourceComponentDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		componentId = d.Get("component_id").(string)
+	)
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	err = deployComponent(ctx, client, d, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(componentId)
+
+	return resourceComponentDeploymentRead(ctx, d, meta)
+}
+
+func resourceComponentDeploymentRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceComponentDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("cae", region)
+	if err != nil {
+		return diag.Errorf("error creating CAE client: %s", err)
+	}
+
+	err = deployComponent(ctx, client, d, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceComponentDeploymentRead(ctx, d, meta)
+}
+
+func resourceComponentDeploymentDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New resource support that used to manage the deployment status of the component.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to deploy, configure or stop the component.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cae' TESTARGS='-run=TestAccComponentDeployment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cae -v -run=TestAccComponentDeployment_basic -timeout 360m -parallel 4
=== RUN   TestAccComponentDeployment_basic
=== PAUSE TestAccComponentDeployment_basic
=== CONT  TestAccComponentDeployment_basic
--- PASS: TestAccComponentDeployment_basic (698.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       699.027s
```
