### PR TITLE
fix(cae/deploy): remove the hard coding for resource ids

### DIFF
--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_deployment_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_deployment_test.go
@@ -65,8 +65,8 @@ resource "huaweicloud_cae_component_configurations" "test" {
 }
 
 resource "huaweicloud_cae_component_deployment" "test" {
-  environment_id = "ae22f51f-39fa-4252-beb5-fb3e508c78b7"
-  application_id = "9db0d7ad-e9a5-4447-b351-04a7a9d7af02"
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
   component_id   = huaweicloud_cae_component.test.id
 
   metadata {
@@ -123,8 +123,8 @@ resource "huaweicloud_cae_component_configurations" "test" {
 }
 
 resource "huaweicloud_cae_component_deployment" "test" {
-  environment_id = "ae22f51f-39fa-4252-beb5-fb3e508c78b7"
-  application_id = "9db0d7ad-e9a5-4447-b351-04a7a9d7af02"
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
   component_id   = huaweicloud_cae_component.test.id
 
   metadata {
@@ -181,8 +181,8 @@ resource "huaweicloud_cae_component_configurations" "test" {
 }
 
 resource "huaweicloud_cae_component_deployment" "test" {
-  environment_id = "ae22f51f-39fa-4252-beb5-fb3e508c78b7"
-  application_id = "9db0d7ad-e9a5-4447-b351-04a7a9d7af02"
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
   component_id   = huaweicloud_cae_component.test.id
 
   metadata {
@@ -239,8 +239,8 @@ resource "huaweicloud_cae_component_configurations" "test" {
 }
 
 resource "huaweicloud_cae_component_deployment" "test" {
-  environment_id = "ae22f51f-39fa-4252-beb5-fb3e508c78b7"
-  application_id = "9db0d7ad-e9a5-4447-b351-04a7a9d7af02"
+  environment_id = "%[2]s"
+  application_id = "%[3]s"
   component_id   = huaweicloud_cae_component.test.id
 
   metadata {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some references of the resource IDs are hard coding, we need to remove them.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cae' TESTARGS='-run=TestAccComponentDeployment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cae -v -run=TestAccComponentDeployment_basic -timeout 360m -parallel 4
=== RUN   TestAccComponentDeployment_basic
=== PAUSE TestAccComponentDeployment_basic
=== CONT  TestAccComponentDeployment_basic
--- PASS: TestAccComponentDeployment_basic (702.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cae       703.283s
```
