### PR TITLE
feat(CC): add a datasource to get the list of CC bandwidth packages

### DIFF
--- a/docs/data-sources/cc_bandwidth_packages.md
+++ b/docs/data-sources/cc_bandwidth_packages.md
@@ -1,0 +1,105 @@
+---
+subcategory: "Cloud Connect (CC)"
+---
+
+# huaweicloud_cc_bandwidth_packages
+
+Use this data source to get the list of CC bandwidth packages.
+
+## Example Usage
+
+```hcl
+variable "bandwidth_package_id" {}
+
+data "huaweicloud_cc_bandwidth_packages" "test" {
+  bandwidth_package_id = var.bandwidth_package_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `bandwidth_package_id` - (Optional, String) Specifies the bandwidth package ID.
+
+* `name` - (Optional, String) Specifies the bandwidth package name.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project that the bandwidth package
+  belongs to.
+
+* `status` - (Optional, String) Specifies the bandwidth package status.
+  The valid value is as follows:
+  + **ACTIVE**: Bandwidth packages are available.
+
+* `billing_mode` - (Optional, String) Specifies the billing mode of the bandwidth package.
+  The options are as follows:
+  + **1**：pay by period for the Chinese Mainland website.
+  + **2**: pay by period for the International website.
+  + **3**: pay-per-use for the Chinese Mainland website.
+  + **4**: pay-per-use for the International website.
+  + **5**: 95th percentile bandwidth billing for the Chinese Mainland website.
+  + **6**: 95th percentile bandwidth billing for the International website.
+
+* `resource_id` - (Optional, String) Specifies the ID of the resource that the bandwidth package is bound to.
+
+* `bandwidth` - (Optional, Int) Specifies the bandwidth range specified for the bandwidth package.
+
+* `tags` - (Optional, Map) Specifies the bandwidth package tags.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `bandwidth_packages` - Bandwidth package list.
+
+  The [bandwidth_packages](#bandwidth_packages_struct) structure is documented below.
+
+<a name="bandwidth_packages_struct"></a>
+The `bandwidth_packages` block supports:
+
+* `id` - The bandwidth package ID.
+
+* `name` - The bandwidth package name.
+
+* `description` - The bandwidth package description.
+
+* `domain_id` - The ID of the account that the bandwidth package belongs to.
+
+* `enterprise_project_id` - The ID of the enterprise project that the bandwidth package belongs to.
+
+* `project_id` - Project ID of the bandwidth package.
+
+* `created_at` - Time when the resource was created.
+
+* `updated_at` - Time when the resource was updated.
+
+* `resource_id` - The ID of the resource that the bandwidth package is bound to.
+
+* `resource_type` - Type of the resource that the bandwidth package is bound to.
+
+* `local_area_id` - The ID of a local access point.
+
+* `remote_area_id` - The ID of a remote access point.
+
+* `spec_code` - Specification code of the bandwidth package.
+
+* `billing_mode` - Billing mode of the bandwidth package.
+
+* `tags` - The bandwidth package tags.
+
+* `status` - Status of the bandwidth package.
+
+* `order_id` - Order ID of the bandwidth package.
+
+* `product_id` - Product ID of the bandwidth package.
+
+* `charge_mode` - Billing option.
+
+* `bandwidth` - Bandwidth range specified for the bandwidth package.
+
+* `interflow_mode` - Interflow mode of the bandwidth package.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -416,6 +416,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbh_instances": cbh.DataSourceCbhInstances(),
 			"huaweicloud_cbh_flavors":   cbh.DataSourceCbhFlavors(),
 
+			"huaweicloud_cc_bandwidth_packages":           cc.DataSourceCcBandwidthPackages(),
 			"huaweicloud_cc_central_networks":             cc.DataSourceCcCentralNetworks(),
 			"huaweicloud_cc_central_network_connections":  cc.DataSourceCcCentralNetworkConnections(),
 			"huaweicloud_cc_connections":                  cc.DataSourceCloudConnections(),

--- a/huaweicloud/services/acceptance/cc/data_source_huaweicloud_cc_bandwidth_packages_test.go
+++ b/huaweicloud/services/acceptance/cc/data_source_huaweicloud_cc_bandwidth_packages_test.go
@@ -1,0 +1,164 @@
+package cc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCcBandwidthPackages_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cc_bandwidth_packages.filter_by_id"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+	baseConfig := testDataSourceCcBandwidthPackages_base(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCcBandwidthPackages_basic(baseConfig, rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_packages.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_packages.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_packages.0.status"),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_packages.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_packages.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSource, "bandwidth_packages.0.updated_at"),
+					resource.TestCheckOutput("is_id_useful", "true"),
+					resource.TestCheckOutput("is_bandwidth_filter_useful", "true"),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_and_tags_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCcBandwidthPackages_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cc_bandwidth_package" "test1" {
+  name           = "%[1]s1"
+  local_area_id  = "Chinese-Mainland"
+  remote_area_id = "Chinese-Mainland"
+  charge_mode    = "bandwidth"
+  billing_mode   = 3
+  bandwidth      = 6
+  description    = "desc 1"
+	  
+  tags = {
+    foo   = "bar"
+    owner = "terraform_test"
+  }
+}
+
+resource "huaweicloud_cc_bandwidth_package" "test2" {
+  name           = "%[1]s2"
+  local_area_id  = "Chinese-Mainland"
+  remote_area_id = "Chinese-Mainland"
+  charge_mode    = "bandwidth"
+  billing_mode   = 3
+  bandwidth      = 12
+  description    = "desc 2"
+		
+  tags = {
+    foo = "bar"
+  }
+}
+`, name)
+}
+
+func testDataSourceCcBandwidthPackages_basic(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  id = huaweicloud_cc_bandwidth_package.test1.id
+}
+  
+data "huaweicloud_cc_bandwidth_packages" "filter_by_id" {
+  bandwidth_package_id = local.id
+	  
+  depends_on = [
+    huaweicloud_cc_bandwidth_package.test1,
+    huaweicloud_cc_bandwidth_package.test2,
+  ]
+}
+	
+output "is_id_useful" {
+  value = length(data.huaweicloud_cc_bandwidth_packages.filter_by_id.bandwidth_packages) >= 1 && alltrue(
+    [for v in data.huaweicloud_cc_bandwidth_packages.filter_by_id.bandwidth_packages[*].id : v == local.id]
+  )
+}
+	
+locals {
+  bandwidth = huaweicloud_cc_bandwidth_package.test1.bandwidth
+}
+	  
+data "huaweicloud_cc_bandwidth_packages" "filter_by_bandwidth" {
+  bandwidth = local.bandwidth
+	
+  depends_on = [
+    huaweicloud_cc_bandwidth_package.test1,
+    huaweicloud_cc_bandwidth_package.test2,
+  ]
+}
+		
+output "is_bandwidth_filter_useful" {
+  value = length(data.huaweicloud_cc_bandwidth_packages.filter_by_bandwidth.bandwidth_packages) >= 1 && alltrue([
+    for v in data.huaweicloud_cc_bandwidth_packages.filter_by_bandwidth.bandwidth_packages[*].bandwidth : 
+      v == local.bandwidth
+  ])
+}
+	
+locals {
+  tags = huaweicloud_cc_bandwidth_package.test1.tags
+}
+	  
+data "huaweicloud_cc_bandwidth_packages" "filter_by_tags" {
+  tags = local.tags
+	
+  depends_on = [
+    huaweicloud_cc_bandwidth_package.test1,
+    huaweicloud_cc_bandwidth_package.test2,
+  ]
+}
+		
+output "is_tags_filter_useful" {
+  value = length(data.huaweicloud_cc_bandwidth_packages.filter_by_tags.bandwidth_packages) >= 1 && alltrue([
+    for bp in data.huaweicloud_cc_bandwidth_packages.filter_by_tags.bandwidth_packages : alltrue([
+      for k, v in local.tags : bp.tags[k] == v
+    ])
+  ])
+}
+
+locals {
+  tags2 = huaweicloud_cc_bandwidth_package.test2.tags
+  name  = huaweicloud_cc_bandwidth_package.test2.name
+}
+		
+data "huaweicloud_cc_bandwidth_packages" "filter_by_name_and_tags" {
+  tags = local.tags2
+  name = local.name
+	  
+  depends_on = [
+    huaweicloud_cc_bandwidth_package.test1,
+    huaweicloud_cc_bandwidth_package.test2,
+  ]
+}
+		  
+output "is_name_and_tags_filter_useful" {
+  value = length(data.huaweicloud_cc_bandwidth_packages.filter_by_name_and_tags.bandwidth_packages) >= 1 && alltrue([
+    for bp in data.huaweicloud_cc_bandwidth_packages.filter_by_name_and_tags.bandwidth_packages : alltrue([
+      for k, v in local.tags2 : bp.tags[k] == v
+    ]) && bp.name == local.name
+  ])
+}
+`, baseConfig, name)
+}

--- a/huaweicloud/services/cc/data_source_huaweicloud_cc_bandwidth_packages.go
+++ b/huaweicloud/services/cc/data_source_huaweicloud_cc_bandwidth_packages.go
@@ -1,0 +1,386 @@
+package cc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceCcBandwidthPackages() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCcBandwidthPackagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"bandwidth_package_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the bandwidth package ID.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the bandwidth package name.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the enterprise project that the bandwidth package belongs to.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the bandwidth package status.`,
+			},
+			"billing_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the billing mode of the bandwidth package.`,
+			},
+			"resource_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the resource that the bandwidth package is bound to.`,
+			},
+			"bandwidth": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies Bandwidth range specified for the bandwidth package.`,
+			},
+			"tags": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the tags of the bandwidth package.`,
+			},
+			"bandwidth_packages": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Bandwidth package list.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The bandwidth package ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The bandwidth package name.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The bandwidth package description.`,
+						},
+						"domain_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the account that the bandwidth package belongs to.`,
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the enterprise project that the bandwidth package belongs to.`,
+						},
+						"project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Project ID of the bandwidth package.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Time when the resource was created.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Time when the resource was updated.`,
+						},
+						"resource_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the resource that the bandwidth package is bound to.`,
+						},
+						"resource_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Type of the resource that the bandwidth package is bound to.`,
+						},
+						"local_area_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of a local access point.`,
+						},
+						"remote_area_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of a remote access point.`,
+						},
+						"spec_code": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Specification code of the bandwidth package.`,
+						},
+						"billing_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Billing mode of the bandwidth package.`,
+						},
+						"tags": common.TagsComputedSchema(),
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Status of the bandwidth package.`,
+						},
+						"order_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Order ID of the bandwidth package.`,
+						},
+						"product_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Product ID of the bandwidth package.`,
+						},
+						"charge_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Billing option.`,
+						},
+						"bandwidth": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `Bandwidth range specified for the bandwidth package.`,
+						},
+						"interflow_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Interflow mode of the bandwidth package.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// @API CC GET /v3/{domain_id}/ccaas/bandwidth-packages
+// @API CC POST /v3/{domain_id}/ccaas/bandwidth-packages/filter
+func dataSourceCcBandwidthPackagesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cc", region)
+
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	result, err := getBandwidthPackages(client, cfg, d)
+	if err != nil {
+		return diag.Errorf("error retrieving bandwidth packages: %s", err)
+	}
+
+	if tags, ok := d.GetOk("tags"); ok {
+		resourceIDs, err := filterBandwidthPackageByTags(tags.(map[string]interface{}), client, cfg.DomainID)
+		if err != nil {
+			return diag.Errorf("error filtering bandwidth packages by tags: %s", err)
+		}
+
+		result = filter(result, resourceIDs)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("bandwidth_packages", flattenListBandwidthPackageResponseBody(result)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getBandwidthPackages(client *golangsdk.ServiceClient, cfg *config.Config, d *schema.ResourceData) ([]interface{}, error) {
+	httpUrl := "v3/{domain_id}/ccaas/bandwidth-packages"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{domain_id}", cfg.DomainID)
+
+	params := buildBandwidthPackagesQueryParams(d, cfg)
+	path += params
+
+	resp, err := pagination.ListAllItems(
+		client,
+		"marker",
+		path,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return nil, err
+	}
+
+	respJson, err := json.Marshal(resp)
+	if err != nil {
+		return nil, err
+	}
+	var respBody interface{}
+	err = json.Unmarshal(respJson, &respBody)
+	if err != nil {
+		return nil, err
+	}
+
+	curJson := utils.PathSearch("bandwidth_packages", respBody, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+
+	rst := make([]interface{}, 0, len(curArray))
+
+	if bandwidthFilter, ok := d.GetOk("bandwidth"); ok {
+		for _, item := range curArray {
+			itemMap := item.(map[string]interface{})
+			if int(itemMap["bandwidth"].(float64)) == bandwidthFilter {
+				rst = append(rst, item)
+			}
+		}
+	} else {
+		rst = append(rst, curArray...)
+	}
+
+	return rst, nil
+}
+
+func flattenListBandwidthPackageResponseBody(resp []interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(resp))
+	for _, v := range resp {
+		rst = append(rst, map[string]interface{}{
+			"id":                    utils.PathSearch("id", v, nil),
+			"name":                  utils.PathSearch("name", v, nil),
+			"description":           utils.PathSearch("description", v, nil),
+			"domain_id":             utils.PathSearch("domain_id", v, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", v, nil),
+			"project_id":            utils.PathSearch("project_id", v, nil),
+			"created_at":            utils.PathSearch("created_at", v, nil),
+			"updated_at":            utils.PathSearch("updated_at", v, nil),
+			"resource_id":           utils.PathSearch("resource_id", v, nil),
+			"resource_type":         utils.PathSearch("resource_type", v, nil),
+			"local_area_id":         utils.PathSearch("local_area_id", v, nil),
+			"remote_area_id":        utils.PathSearch("remote_area_id", v, nil),
+			"spec_code":             utils.PathSearch("spec_code", v, nil),
+			"billing_mode":          utils.PathSearch("billing_mode", v, nil),
+			"tags":                  utils.FlattenTagsToMap(utils.PathSearch("tags", v, nil)),
+			"status":                utils.PathSearch("status", v, nil),
+			"order_id":              utils.PathSearch("order_id", v, nil),
+			"product_id":            utils.PathSearch("product_id", v, nil),
+			"charge_mode":           utils.PathSearch("charge_mode", v, nil),
+			"bandwidth":             utils.PathSearch("bandwidth", v, nil),
+			"interflow_mode":        utils.PathSearch("interflow_mode", v, nil),
+		})
+	}
+	return rst
+}
+
+func filterBandwidthPackageByTags(tags map[string]interface{}, client *golangsdk.ServiceClient, domainID string) ([]string, error) {
+	var resourceIDs []string
+	httpUrl := "v3/{domain_id}/ccaas/bandwidth-packages/filter"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{domain_id}", domainID)
+
+	if len(tags) < 1 {
+		return nil, nil
+	}
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildFilterBandwidthPackageByTagsOpts(tags),
+	}
+
+	resp, err := client.Request("POST", path, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	curJson := utils.PathSearch("bandwidth_packages[*].id", respBody, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+
+	for _, item := range curArray {
+		resourceIDs = append(resourceIDs, item.(string))
+	}
+
+	return resourceIDs, nil
+}
+
+func buildFilterBandwidthPackageByTagsOpts(tagmap map[string]interface{}) map[string]interface{} {
+	taglist := make([]interface{}, 0, len(tagmap))
+
+	for k, v := range tagmap {
+		taglist = append(taglist, map[string]interface{}{
+			"key":    k,
+			"values": []string{v.(string)},
+		})
+	}
+
+	return map[string]interface{}{
+		"tags": taglist,
+	}
+}
+
+func buildBandwidthPackagesQueryParams(d *schema.ResourceData, cfg *config.Config) string {
+	res := ""
+	epsID := cfg.GetEnterpriseProjectID(d)
+
+	if v, ok := d.GetOk("bandwidth_package_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("status"); ok {
+		res = fmt.Sprintf("%s&status=%v", res, v)
+	}
+	if v, ok := d.GetOk("billing_mode"); ok {
+		res = fmt.Sprintf("%s&billing_mode=%v", res, v)
+	}
+	if v, ok := d.GetOk("resource_id"); ok {
+		res = fmt.Sprintf("%s&resource_id=%v", res, v)
+	}
+	if epsID != "" {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsID)
+	}
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a datasource to get the list of CC bandwidth packages
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a datasource to get the list of CC bandwidth packages
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccDataSourceCcBandwidthPackages_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccDataSourceCcBandwidthPackages_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCcBandwidthPackages_basic
=== PAUSE TestAccDataSourceCcBandwidthPackages_basic
=== CONT  TestAccDataSourceCcBandwidthPackages_basic
--- PASS: TestAccDataSourceCcBandwidthPackages_basic (53.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        53.641s

```
