### PR TITLE
fix(cae/deploy): ignore at001 lint rule for one-time action resource

### DIFF
--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_deployment_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_deployment_test.go
@@ -11,6 +11,9 @@ import (
 
 func TestAccComponentDeployment_basic(t *testing.T) {
 	baseConfig := testAccComponentConfiguration_base()
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
+	// method.
+	// lintignore:AT001
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
@@ -20,6 +23,7 @@ func TestAccComponentDeployment_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				// One-time action resource do not need to be checked and no processing is performed in the Read method.
 				Config: testAccComponentDeployment_basic_step1(baseConfig),
 			},
 			{

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_component_deployment.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_component_deployment.go
@@ -19,6 +19,7 @@ import (
 
 // @API CAE POST /v1/{project_id}/cae/applications/{application_id}/components/{component_id}/action
 // @API CAE GET /v1/{project_id}/cae/jobs/{job_id}
+// ResourceComponentDeployment is a definition of the one-time action resource that used to manage component deployment.
 func ResourceComponentDeployment() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceComponentDeploymentCreate,
@@ -204,6 +205,7 @@ func resourceComponentDeploymentCreate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceComponentDeploymentRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
 	return nil
 }
 
@@ -226,5 +228,6 @@ func resourceComponentDeploymentUpdate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceComponentDeploymentDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Delete()' method because the resource is a one-time action resource.
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Avoid CheckDestroy because this resource is a one-time action resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. ignore at001 lint rule for one-time action resource.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
