### PR TITLE
feat(RDS): add sql audit operations data source

### DIFF
--- a/docs/data-sources/rds_sql_audit_operations.md
+++ b/docs/data-sources/rds_sql_audit_operations.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# huaweicloud_rds_sql_audit_operations
+
+Use this data source to get the list of RDS SQL audit operations.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_rds_sql_audit_operations" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the RDS instance.
+
+* `operation_types` - (Optional, List) Specifies the list of the operation type. Value options: **DDL**, **DCL**,
+  **DML**, **OTHER**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `operations` - Indicates the list of audit operations.
+
+  The [operations](#operations_struct) structure is documented below.
+
+<a name="operations_struct"></a>
+The `operations` block supports:
+
+* `type` - Indicates the type of the operation.
+
+* `actions` - Indicates the list of the operation actions.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -768,8 +768,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_key_v1":      dew.DataSourceKmsKey(),
 			"huaweicloud_kms_data_key_v1": dew.DataSourceKmsDataKeyV1(),
 
-			"huaweicloud_rds_flavors_v3":     rds.DataSourceRdsFlavor(),
-			"huaweicloud_sfs_file_system_v2": sfs.DataSourceSFSFileSystemV2(),
+			"huaweicloud_rds_flavors_v3":           rds.DataSourceRdsFlavor(),
+			"huaweicloud_sfs_file_system_v2":       sfs.DataSourceSFSFileSystemV2(),
+			"huaweicloud_rds_sql_audit_operations": rds.DataSourceRdsSqlAuditTypes(),
 
 			"huaweicloud_vpc_v1":                    vpc.DataSourceVpcV1(),
 			"huaweicloud_vpc_ids_v1":                vpc.DataSourceVpcIdsV1(),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sql_audit_operations_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sql_audit_operations_test.go
@@ -1,0 +1,57 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceRdsSqlAuditTypes_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_rds_sql_audit_operations.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDataSourceRdsSqlAuditOperations_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "operations.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "operations.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "operations.0.actions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "operations.0.actions.0"),
+
+					resource.TestCheckOutput("operation_types_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDataSourceRdsSqlAuditOperations_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_rds_sql_audit_operations" "test" {
+  instance_id = huaweicloud_rds_instance.test.id
+}
+
+data "huaweicloud_rds_sql_audit_operations" "operation_types_filter" {
+  instance_id     = huaweicloud_rds_instance.test.id
+  operation_types = ["DDL", "DML"]
+}
+output "operation_types_filter_is_useful" {
+  value = length(data.huaweicloud_rds_sql_audit_operations.operation_types_filter.operations) > 0 && alltrue(
+  [for v in data.huaweicloud_rds_sql_audit_operations.operation_types_filter.operations[*].type : contains(["DDL", "DML"], v)]
+  )
+}
+`, testAccRdsInstance_mysql_step1(name))
+}

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_sql_audit_operations.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_sql_audit_operations.go
@@ -1,0 +1,145 @@
+package rds
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RDS GET /v3/{project_id}/instances/{instance_id}/auditlog-policy
+func DataSourceRdsSqlAuditTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceRdsSqlAuditTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the RDS instance.`,
+			},
+			"operation_types": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: `Specifies the list of the operation type.`,
+			},
+			"operations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the list of the audit operations.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the type of the operation.`,
+						},
+						"actions": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: `Indicates the list of the operation actions.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceRdsSqlAuditTypesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/auditlog-policy"
+		product = "rds"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS Client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", d.Get("instance_id").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	getResp, err := client.Request("GET", getPath, &getOpt)
+
+	if err != nil {
+		return diag.Errorf("error retrieving RDS SQL audit operations: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	operations, err := flattenAuditOperationsBody(d, getRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	mErr := multierror.Append(
+		d.Set("region", cfg.GetRegion(d)),
+		d.Set("operations", operations),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAuditOperationsBody(d *schema.ResourceData, resp interface{}) ([]interface{}, error) {
+	if resp == nil {
+		return nil, nil
+	}
+	allAuditLogAction := utils.PathSearch("all_audit_log_action", resp, nil)
+	if allAuditLogAction == nil {
+		return nil, fmt.Errorf("unable to find the all_audit_log_action from the response")
+	}
+	var auditTypes interface{}
+	err := json.Unmarshal([]byte(allAuditLogAction.(string)), &auditTypes)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling RDS SQL audit types: %s", err)
+	}
+	operationsTypes := d.Get("operation_types").([]interface{})
+	operationsTypeMap := make(map[string]bool)
+	for _, operationsType := range operationsTypes {
+		operationsTypeMap[operationsType.(string)] = true
+	}
+	rst := make([]interface{}, 0)
+	for k, v := range auditTypes.(map[string]interface{}) {
+		if len(operationsTypes) > 0 && !operationsTypeMap[k] {
+			continue
+		}
+		rst = append(rst, map[string]interface{}{
+			"type":    k,
+			"actions": strings.Split(v.(string), ","),
+		})
+	}
+	return rst, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add sql audit operations data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add sql audit operations data source
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsSqlAuditTypes_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsSqlAuditTypes_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsSqlAuditTypes_basic
=== PAUSE TestAccDataSourceRdsSqlAuditTypes_basic
=== CONT  TestAccDataSourceRdsSqlAuditTypes_basic
--- PASS: TestAccDataSourceRdsSqlAuditTypes_basic (549.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       549.855s
```
