### PR TITLE
fix(RDS): fix rds instance power action

### DIFF
--- a/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
@@ -959,7 +959,7 @@ func resourceRdsInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	// if power_action is changed from ON to OFF/REBOOT, the instance should be close/restart at the end
-	if d.HasChanges("power_action") && powerAction == "OFF" || powerAction == "REBOOT" {
+	if d.HasChanges("power_action") && (powerAction == "OFF" || powerAction == "REBOOT") {
 		if err = updatePowerAction(ctx, d, client, powerAction); err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds instance power action
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds instance power action
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 4
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_restore_mysql
--- PASS: TestAccRdsInstance_basic (827.88s)
=== CONT  TestAccRdsInstance_prePaid
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1541.05s)
=== CONT  TestAccRdsInstance_mariadb
--- PASS: TestAccRdsInstance_restore_pg (1567.60s)
=== CONT  TestAccRdsInstance_restore_sqlserver
--- PASS: TestAccRdsInstance_restore_mysql (1755.04s)
=== CONT  TestAccRdsInstance_mysql_power_action
--- PASS: TestAccRdsInstance_mariadb (648.72s)
=== CONT  TestAccRdsInstance_sqlserver
--- PASS: TestAccRdsInstance_prePaid (1617.57s)
=== CONT  TestAccRdsInstance_mysql
--- PASS: TestAccRdsInstance_mysql_power_action (1120.52s)
=== CONT  TestAccRdsInstance_ha
--- PASS: TestAccRdsInstance_ha (717.35s)
--- PASS: TestAccRdsInstance_mysql (1709.27s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2746.65s)
--- PASS: TestAccRdsInstance_sqlserver (3434.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       5624.105s
```
