### PR TITLE
feat(cc): add datasource to get the list of central network capabilities

### DIFF
--- a/docs/data-sources/cc_central_network_capabilities.md
+++ b/docs/data-sources/cc_central_network_capabilities.md
@@ -1,0 +1,65 @@
+---
+subcategory: "Cloud Connect (CC)"
+---
+
+# huaweicloud_cc_central_network_capabilities
+
+Use this data source to get the list of CC central network capabilities.
+
+## Example Usage
+
+```hcl
+variable "capability" {}
+
+data "huaweicloud_cc_central_network_capabilities" "test" {
+  capability = var.capability
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `capability` - (Optional, String) Specifies the capability of the central network.
+  The valid values are as follows:
+  + **central-network.is-support**: Whether the central network is supported.
+  + **central-network.is-support-enterprise-project**: Whether the central network supports enterprise projects.
+  + **central-network.is-support-tag**: Whether the central network supports tags.
+  + **connection-bandwidth.size-range**: The bandwidth range for a cross-site connection.
+  + **connection-bandwidth.charge-mode**: The Billing mode of the global private bandwidth for assigning cross-site
+  connection bandwidths.
+  + **er-instance.support-regions**: The list of the regions where Enterprise Router is available.
+  + **er-instance.support-ipv6-regions**: The list of the regions where Enterprise Router supports IPv6.
+  + **er-instance.support-dscp-regions**: The list of the regions that support gold, silver, and bronze global private
+  bandwidths.
+  + **er-instance.support-sites**: The list of the sites where Enterprise Router is available.
+  + **gdgw-attachment.is-support**: Whether global DC gateways as attachments are supported.
+  + **gdgw-attachment.support-regions**: The list of the regions where global DC gateways are available.
+  + **gdgw-attachment.support-sites**: The list of the sites where global DC gateways are available.
+  + **er-route-table-attachment.is-support**: Whether The enterprise router route tables as attachments are supported.
+  + **er-route-table-attachment.support-regions**: The list of regions where enterprise router route tables can be added
+  as attachments.
+  + **er-route-table-attachment.support-sites**: The list of sites where enterprise router route tables can be added as
+  attachments.
+  + **cloud-alliance.support-regions**: The list of regions that support Cloud Alliance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `capabilities` - Central network capability list.
+  The [capabilities](#Capabilities) structure is documented below.
+
+<a name="Capabilities"></a>
+The `capabilities` block supports:
+
+* `capability` - The capability of the central network.
+
+* `domain_id` - The ID of the account that the central network belongs to.
+
+* `specifications` - The specifications of the central network capability.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -418,6 +418,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cc_bandwidth_packages":           cc.DataSourceCcBandwidthPackages(),
 			"huaweicloud_cc_central_networks":             cc.DataSourceCcCentralNetworks(),
+			"huaweicloud_cc_central_network_capabilities": cc.DataSourceCcCentralNetworkCapabilities(),
 			"huaweicloud_cc_central_network_connections":  cc.DataSourceCcCentralNetworkConnections(),
 			"huaweicloud_cc_connections":                  cc.DataSourceCloudConnections(),
 			"huaweicloud_cc_global_connection_bandwidths": cc.DataSourceCcGlobalConnectionBandwidths(),

--- a/huaweicloud/services/acceptance/cc/data_source_huaweicloud_cc_central_network_capabilities_test.go
+++ b/huaweicloud/services/acceptance/cc/data_source_huaweicloud_cc_central_network_capabilities_test.go
@@ -1,0 +1,53 @@
+package cc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCcCentralNetworkCapabilities_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_cc_central_network_capabilities.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCcCentralNetworkCapabilities_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "capabilities.0.domain_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "capabilities.0.capability"),
+					resource.TestCheckResourceAttrSet(dataSource, "capabilities.0.specifications"),
+				),
+			},
+			{
+				Config: testDataSourceCcCentralNetworkCapabilities_useFilter(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSource, "capabilities.0.capability", "central-network.is-support"),
+					resource.TestCheckResourceAttrSet(dataSource, "capabilities.0.domain_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "capabilities.0.specifications"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCcCentralNetworkCapabilities_basic() string {
+	return `data "huaweicloud_cc_central_network_capabilities" "test" {}`
+}
+
+func testDataSourceCcCentralNetworkCapabilities_useFilter() string {
+	return `
+data "huaweicloud_cc_central_network_capabilities" "test" {
+  capability = "central-network.is-support"
+}
+`
+}

--- a/huaweicloud/services/cc/data_source_huaweicloud_cc_central_network_capabilities.go
+++ b/huaweicloud/services/cc/data_source_huaweicloud_cc_central_network_capabilities.go
@@ -1,0 +1,145 @@
+package cc
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CC GET /v3/{domain_id}/gcn/capabilities
+func DataSourceCcCentralNetworkCapabilities() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCcCentralNetworkCapabilitiesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"capability": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the capability of the central network.`,
+			},
+			"capabilities": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Central network capability list.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the account that the central network belongs to.`,
+						},
+						"capability": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The capability of the central network.`,
+						},
+						"specifications": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The specifications of the central network capability.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCcCentralNetworkCapabilitiesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("cc", region)
+
+	if err != nil {
+		return diag.Errorf("error creating CC client: %s", err)
+	}
+
+	httpUrl := "v3/{domain_id}/gcn/capabilities"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{domain_id}", cfg.DomainID)
+
+	params := buildCentralNetworkCapabilitiesQueryParams(d)
+	path += params
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	resp, err := client.Request("GET", path, &opt)
+	if err != nil {
+		return diag.Errorf("error retrieving central network capabilities: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	rawCapabilities := utils.PathSearch("capabilities", respBody, make([]interface{}, 0))
+	capabilities, err := flattenCentralNetworkCapabilities(rawCapabilities.([]interface{}))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("capabilities", capabilities),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildCentralNetworkCapabilitiesQueryParams(d *schema.ResourceData) string {
+	var params string
+	if capability, ok := d.GetOk("capability"); ok {
+		params += "?capability=" + capability.(string)
+	}
+	return params
+}
+
+func flattenCentralNetworkCapabilities(capabilities []interface{}) ([]interface{}, error) {
+	if capabilities == nil {
+		return nil, nil
+	}
+
+	rst := make([]interface{}, 0, len(capabilities))
+
+	for _, v := range capabilities {
+		specifications := utils.PathSearch("specifications", v, nil)
+
+		specJson, err := json.Marshal(specifications)
+		if err != nil {
+			return nil, err
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"domain_id":      utils.PathSearch("domain_id", v, nil),
+			"capability":     utils.PathSearch("capability", v, nil),
+			"specifications": string(specJson),
+		})
+	}
+
+	return rst, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add datasource to get the list of central network capabilities
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add datasource to get the list of central network capabilities
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccDataSourceCcCentralNetworkCapabilities_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccDataSourceCcCentralNetworkCapabilities_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCcCentralNetworkCapabilities_basic
=== PAUSE TestAccDataSourceCcCentralNetworkCapabilities_basic
=== CONT  TestAccDataSourceCcCentralNetworkCapabilities_basic
--- PASS: TestAccDataSourceCcCentralNetworkCapabilities_basic (22.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        22.677s
```
