### PR TITLE
feat(CDN): CDN domain support new fields `configs.0.quic`, `configs.0.force_redirect`, and `configs.0.referer`

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -312,6 +312,10 @@ The `configs` block support:
   -> Configure remote authentication to allow CDN to forward user requests to an authentication server and process the
   requests based on results returned by the authentication server.
 
+* `quic` - (Optional, List) Specifies the QUIC protocol. The [quic](#quic_object) structure is documented below.
+
+  -> This field can only be used when the HTTPS certificate is enabled. Disabling the HTTPS certificate will disable QUIC.
+
 <a name="https_settings_object"></a>
 The `https_settings` block support:
 
@@ -569,6 +573,11 @@ The `add_custom_args_rules` and `add_custom_headers_rules` block support:
   + When `type` is set to **nginx_preset_var**, the value can only be **$http_host**, **$http_user_agent**,
     **$http_referer**, **$http_x_forwarded_for**, **$http_content_type**, **$remote_addr**, **$scheme**,
     **$server_protocol**, **$request_uri**, **$uri**, **$args**, or **$request_method**.
+
+<a name="quic_object"></a>
+The `quic` block support:
+
+* `enabled` - (Required, Bool) Specifies whether to enable QUIC.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -406,6 +406,9 @@ The `force_redirect` blocks support:
 * `type` - (Optional, String) Specifies the force redirect type.
   Possible values are: **http** (force redirect to HTTP) and **https** (force redirect to HTTPS).
 
+* `redirect_code` - (Optional, Int) Specifies the force redirect status code. Valid values are: **301** and **302**.
+  Defaults to **302**.
+
 <a name="compress_object"></a>
 The `compress` blocks support:
 

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -160,6 +160,12 @@ resource "huaweicloud_cdn_domain" "domain_1" {
       enabled = true
       type    = "http"
     }
+
+    referer {
+      type          = "white"
+      value         = "*.common.com,192.187.2.43,www.test.top:4990"
+      include_empty = false
+    }
   }
 }
 ```
@@ -316,6 +322,10 @@ The `configs` block support:
 
   -> This field can only be used when the HTTPS certificate is enabled. Disabling the HTTPS certificate will disable QUIC.
 
+* `referer` - (Optional, List) Specifies the referer validation. The [referer](#referer_object) structure is documented below.
+
+  -> You can define referer whitelists and blacklists to control who can access specific domain names.
+
 <a name="https_settings_object"></a>
 The `https_settings` block support:
 
@@ -405,6 +415,8 @@ The `force_redirect` blocks support:
 
 * `type` - (Optional, String) Specifies the force redirect type.
   Possible values are: **http** (force redirect to HTTP) and **https** (force redirect to HTTPS).
+
+  -> Force redirect **https** type can be set only if https is enabled.
 
 * `redirect_code` - (Optional, Int) Specifies the force redirect status code. Valid values are: **301** and **302**.
   Defaults to **302**.
@@ -581,6 +593,24 @@ The `add_custom_args_rules` and `add_custom_headers_rules` block support:
 The `quic` block support:
 
 * `enabled` - (Required, Bool) Specifies whether to enable QUIC.
+
+<a name="referer_object"></a>
+The `referer` block support:
+
+* `type` - (Required, String) Specifies the referer validation type. Valid values are as follows:
+  + **off**: Disable referer validation.
+  + **black**: Referer blacklist.
+  + **white**: Referer whitelist.
+
+* `value` - (Optional, String) Specifies the domain names or IP addresses, which are separated by commas (,).
+  Wildcard domain names and domain names with port numbers are supported. Enter up to `400` domain names and IP addresses.
+  The port number ranges from `1` to `65535`. This field is required when `type` is set to **black** or **white**.
+
+* `include_empty` - (Optional, Bool) Specifies whether blank `referers` are included.
+  A referer blacklist including blank `referers` indicates that requests without any `referers` are not allowed to access.
+  A referer whitelist including blank `referers` indicates that requests without any `referers` are allowed to access.
+
+  Defaults to **false**.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -480,6 +480,9 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.redirect_code", "301"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "on"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.type", "white"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.include_empty", "false"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "2"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
@@ -539,9 +542,12 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.type", "https"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.type", "http"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.redirect_code", "302"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "on"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.type", "black"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.include_empty", "true"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.match_type", "file_path"),
@@ -602,6 +608,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "off"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.type", "off"),
 				),
 			},
 			{
@@ -670,6 +678,12 @@ resource "huaweicloud_cdn_domain" "test" {
       enabled       = true
       type          = "http"
       redirect_code = 301
+    }
+
+    referer {
+      type          = "white"
+      value         = "*.common.com,192.187.2.43,www.test.top:4990"
+      include_empty = false
     }
 
     flexible_origin {
@@ -796,8 +810,14 @@ resource "huaweicloud_cdn_domain" "test" {
 
     force_redirect {
       enabled       = true
-      type          = "https"
+      type          = "http"
       redirect_code = 302
+    }
+
+    referer {
+      type          = "black"
+      value         = "*.common.com,192.187.2.43"
+      include_empty = true
     }
 
     flexible_origin {
@@ -869,6 +889,10 @@ resource "huaweicloud_cdn_domain" "test" {
 
     force_redirect {
       enabled = false
+    }
+
+    referer {
+      type = "off"
     }
   }
 }

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -475,6 +475,9 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.expire_time", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.type", "http"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.redirect_code", "301"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "on"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "2"),
@@ -535,6 +538,9 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.expire_time", "31536000"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.type", "https"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.redirect_code", "302"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "on"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "1"),
@@ -593,6 +599,9 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "off"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "off"),
 				),
 			},
 			{
@@ -658,8 +667,9 @@ resource "huaweicloud_cdn_domain" "test" {
     }
 
     force_redirect {
-      enabled = true
-      type    = "http"
+      enabled       = true
+      type          = "http"
+      redirect_code = 301
     }
 
     flexible_origin {
@@ -785,8 +795,9 @@ resource "huaweicloud_cdn_domain" "test" {
     }
 
     force_redirect {
-      enabled = true
-      type    = "http"
+      enabled       = true
+      type          = "https"
+      redirect_code = 302
     }
 
     flexible_origin {
@@ -853,6 +864,10 @@ resource "huaweicloud_cdn_domain" "test" {
     }
 
     url_signing {
+      enabled = false
+    }
+
+    force_redirect {
       enabled = false
     }
   }

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -261,6 +261,7 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.ocsp_stapling_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.quic.0.enabled", "true"),
 					testAccCheckTLSVersion(resourceName, "TLSv1.1,TLSv1.2"),
 
 					resource.TestCheckResourceAttrSet(resourceName, "configs.0.https_settings.0.certificate_body"),
@@ -280,6 +281,7 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.ocsp_stapling_status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.quic.0.enabled", "false"),
 					testAccCheckTLSVersion(resourceName, "TLSv1.1,TLSv1.2,TLSv1.3"),
 				),
 			},
@@ -363,6 +365,10 @@ resource "huaweicloud_cdn_domain" "test" {
       certificate_type     = "server"
       ocsp_stapling_status = "on"
     }
+
+    quic {
+      enabled = true
+    }
   }
 }
 `, acceptance.HW_CDN_DOMAIN_NAME, acceptance.HW_CDN_CERT_PATH, acceptance.HW_CDN_PRIVATE_KEY_PATH)
@@ -394,6 +400,10 @@ resource "huaweicloud_cdn_domain" "test" {
       tls_version          = "TLSv1.1,TLSv1.2,TLSv1.3"
       certificate_source   = 0
       ocsp_stapling_status = "off"
+    }
+
+    quic {
+      enabled = false
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN domain support new fields `configs.0.quic`, `configs.0.force_redirect`, and `configs.0.referer`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (649.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       649.849s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (566.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       566.541s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (424.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       424.954s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_epsID_migrate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_epsID_migrate -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_epsID_migrate (285.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       285.194s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (524.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       524.885s
```