### PR TITLE
feat(cdn): CDN domain support new fields

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -111,9 +111,19 @@ resource "huaweicloud_cdn_domain" "domain_1" {
     url_signing {
       enabled     = true
       type        = "type_a"
+      sign_method = "md5"
+      match_type  = "all"
+      sign_arg    = "Psd_123"
       key         = "A27jtfSTy13q7A0UnTA9vpxYXEb"
+      backup_key  = "S36klgTFa60q3V8DmSK2hwfBOYp"
       time_format = "dec"
       expire_time = 30
+
+      inherit_config {
+        enabled           = true
+        inherit_type      = "m3u8"
+        inherit_time_type = "sys_time"
+      }
     }
 
     flexible_origin {
@@ -373,13 +383,51 @@ The `url_signing` block support:
   **type_c1**: Method C1.
   **type_c2**: Method C2.
 
-* `key` - (Optional, String) Specifies the authentication key contains `6` to `32` characters, including letters and digits.
+* `sign_method` - (Optional, String) Specifies the encryption algorithm type for URL authentication.
+  The valid values are as following:
+  + **md5**
+  + **sha256**
+
+* `match_type` - (Optional, String) Specifies the authentication scope.
+  Currently, only spuuort value is **all**, indicates that all files are involved in authentication.
+
+* `sign_arg` - (Optional, String) Specifies the authentication parameters.
+  The valid length is limited from `1` to `100` characters, only letters, digits, and underscores (_) are allowed.
+  The value cang not start with a digit.
+
+* `inherit_config` - (Optional, List) Specifies the details of the authentication inheritance.
+  The [inherit_config](#inherit_config_object) structure is documented below.
+
+* `key` - (Optional, String) Specifies the authentication key contains `16` to `32` characters, including letters and digits.
+
+* `backup_key` - (Optional, String) Specifies the standby authentication key contains `16` to `32` characters,
+  including letters and digits.
 
 * `time_format` - (Optional, String) Specifies the time format. Possible values are:
   **dec**: Decimal, can be used in Method A, Method B and Method C2.
   **hex**: Hexadecimal, can be used in Method C1 and Method C2.
 
 * `expire_time` - (Optional, Int) Specifies the expiration time. The value ranges from `0` to `31536000`, in seconds.
+
+<a name="inherit_config_object"></a>
+The `inherit_config` blocks support:
+
+* `enabled` - (Required, Bool) Specifies whether to enable authentication inheritance.
+
+* `inherit_type` - (Optional, String) Specifies the authentication inheritance configuration.
+  The valid values are as follows:
+  + **m3u8**
+  + **mpd**
+
+-> Separate multiple values with commas (,). e.g. **m3u8,mpd**.
+-> This parameter is mandatory when authentication inheritance is enabled.
+
+* `inherit_time_type` - (Optional, String) Specifies the start time of authentication inheritance.
+  The valid values are as follows:
+  + **sys_time**: The current system time.
+  + **parent_url_time**: The time consistent with the M3U8 and MPD access links.
+
+  -> This parameter is mandatory when authentication inheritance is enabled.
 
 <a name="force_redirect_object"></a>
 The `force_redirect` blocks support:
@@ -614,6 +662,9 @@ In addition to all arguments above, the following attributes are exported:
 * `configs/https_settings/http2_status` - The status of the http 2.0. The available values are 'on' and 'off'.
 
 * `configs/url_signing/status` - The status of the url_signing. The available values are 'on' and 'off'.
+
+* `configs/url_signing/inherit_config/status` - The status of the authentication inheritance.
+  The valid values are **on** and **off**.
 
 * `configs/force_redirect/status` - The status of the force redirect. The available values are 'on' and 'off'.
 

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -457,10 +457,18 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.type", "type_a"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.sign_method", "md5"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.match_type", "all"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.sign_arg", "Psd_123"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.key", "A27jtfSTy13q7A0UnTA9vpxYXEb"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.backup_key", "S36klgTFa60q3V8DmSK2hwfBOYp"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.time_format", "dec"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.expire_time", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_type", "m3u8"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_time_type", "sys_time"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "on"),
 
@@ -514,10 +522,18 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.action", "set"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.type", "type_c2"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.sign_method", "sha256"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.match_type", "all"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.sign_arg", "Dma_001"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.key", "3P7k9s4r0aey9CB1mvvDHG2"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.backup_key", "5F8a6c3r1xgp7DL0jkeBYZ4"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.time_format", "hex"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.expire_time", "31536000"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_type", "mpd"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_time_type", "parent_url_time"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.status", "on"),
 
@@ -572,6 +588,21 @@ func TestAccCdnDomain_configs(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "off"),
+				),
+			},
+			{
+				Config: testAccCdnDomain_configsUpdate3,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "off"),
 				),
@@ -582,8 +613,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testCDNDomainImportState(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"enterprise_project_id", "configs.0.url_signing.0.key", "configs.0.https_settings.0.certificate_body",
-					"configs.0.https_settings.0.private_key", "cache_settings",
+					"enterprise_project_id", "configs.0.url_signing.0.key", "configs.0.url_signing.0.backup_key",
+					"configs.0.https_settings.0.certificate_body", "configs.0.https_settings.0.private_key", "cache_settings",
 				},
 			},
 		},
@@ -627,9 +658,19 @@ resource "huaweicloud_cdn_domain" "test" {
     url_signing {
       enabled     = true
       type        = "type_a"
+      sign_method = "md5"
+      match_type  = "all"
+      sign_arg    = "Psd_123"
       key         = "A27jtfSTy13q7A0UnTA9vpxYXEb"
+      backup_key  = "S36klgTFa60q3V8DmSK2hwfBOYp"
       time_format = "dec"
       expire_time = 0
+
+      inherit_config {
+        enabled           = true
+        inherit_type      = "m3u8"
+        inherit_time_type = "sys_time"
+      }
     }
 
     compress {
@@ -751,9 +792,19 @@ resource "huaweicloud_cdn_domain" "test" {
     url_signing {
       enabled     = true
       type        = "type_c2"
+      sign_method = "sha256"
+      match_type  = "all"
+      sign_arg    = "Dma_001"
       key         = "3P7k9s4r0aey9CB1mvvDHG2"
+      backup_key  = "5F8a6c3r1xgp7DL0jkeBYZ4"
       time_format = "hex"
       expire_time = 31536000
+
+      inherit_config {
+        enabled           = true
+        inherit_type      = "mpd"
+        inherit_time_type = "parent_url_time"
+      }
     }
 
     compress {
@@ -805,6 +856,47 @@ resource "huaweicloud_cdn_domain" "test" {
 `, acceptance.HW_CDN_DOMAIN_NAME)
 
 var testAccCdnDomain_configsUpdate2 = fmt.Sprintf(`
+resource "huaweicloud_cdn_domain" "test" {
+  name                  = "%s"
+  type                  = "web"
+  service_area          = "outside_mainland_china"
+  enterprise_project_id = 0
+
+  sources {
+    active      = 1
+    origin      = "100.254.53.75"
+    origin_type = "ipaddr"
+  }
+
+  configs {
+    origin_protocol               = "follow"
+    ipv6_enable                   = false
+    range_based_retrieval_enabled = false
+
+    remote_auth {
+      enabled = false
+    }
+
+    url_signing {
+      enabled     = true
+      type        = "type_c2"
+      sign_method = "sha256"
+      match_type  = "all"
+      sign_arg    = "web506"
+      key         = "3P7k9s4r0aey9CB1mvvDHG2"
+      backup_key  = "5F8a6c3r1xgp7DL0jkeBYZ4"
+      time_format = "hex"
+      expire_time = 31536000
+
+      inherit_config {
+        enabled = false
+      }
+    }
+  }
+}
+`, acceptance.HW_CDN_DOMAIN_NAME)
+
+var testAccCdnDomain_configsUpdate3 = fmt.Sprintf(`
 resource "huaweicloud_cdn_domain" "test" {
   name                  = "%s"
   type                  = "web"

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -136,10 +136,60 @@ var authOpts = schema.Schema{
 					"type_a", "type_b", "type_c1", "type_c2",
 				}, false),
 			},
-			"key": {
+			"sign_method": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+			"match_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"inherit_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"inherit_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"inherit_time_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"sign_arg": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				Computed:  true,
+			},
+			"backup_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				Computed:  true,
 			},
 			"time_format": {
 				Type:     schema.TypeString,
@@ -709,14 +759,34 @@ func buildUrlAuthOpts(rawUrlAuth []interface{}) *model.UrlAuth {
 
 	urlAuth := rawUrlAuth[0].(map[string]interface{})
 	urlAuthOpts := model.UrlAuth{
-		Status:     parseFunctionEnabledStatus(urlAuth["enabled"].(bool)),
-		Type:       utils.StringIgnoreEmpty(urlAuth["type"].(string)),
-		Key:        utils.StringIgnoreEmpty(urlAuth["key"].(string)),
-		TimeFormat: utils.StringIgnoreEmpty(urlAuth["time_format"].(string)),
-		ExpireTime: utils.Int32(int32(urlAuth["expire_time"].(int))),
+		Status:        parseFunctionEnabledStatus(urlAuth["enabled"].(bool)),
+		Type:          utils.StringIgnoreEmpty(urlAuth["type"].(string)),
+		SignMethod:    utils.StringIgnoreEmpty(urlAuth["sign_method"].(string)),
+		MatchType:     utils.StringIgnoreEmpty(urlAuth["match_type"].(string)),
+		InheritConfig: buildInheritConfigOpts(urlAuth["inherit_config"].([]interface{})),
+		SignArg:       utils.StringIgnoreEmpty(urlAuth["sign_arg"].(string)),
+		Key:           utils.StringIgnoreEmpty(urlAuth["key"].(string)),
+		BackupKey:     utils.StringIgnoreEmpty(urlAuth["backup_key"].(string)),
+		TimeFormat:    utils.StringIgnoreEmpty(urlAuth["time_format"].(string)),
+		ExpireTime:    utils.Int32(int32(urlAuth["expire_time"].(int))),
 	}
 
 	return &urlAuthOpts
+}
+
+func buildInheritConfigOpts(rwaInheritConfig []interface{}) *model.InheritConfig {
+	if len(rwaInheritConfig) != 1 {
+		return nil
+	}
+
+	inheritConfig := rwaInheritConfig[0].(map[string]interface{})
+	inheritConfigOpts := model.InheritConfig{
+		Status:          parseFunctionEnabledStatus(inheritConfig["enabled"].(bool)),
+		InheritType:     utils.StringIgnoreEmpty(inheritConfig["inherit_type"].(string)),
+		InheritTimeType: utils.StringIgnoreEmpty(inheritConfig["inherit_time_type"].(string)),
+	}
+
+	return &inheritConfigOpts
 }
 
 func buildForceRedirectOpts(rawForceRedirect []interface{}) *model.ForceRedirectConfig {
@@ -1217,21 +1287,41 @@ func flattenHttpResponseHeaderAttrs(httpResponseHeader *[]model.HttpResponseHead
 	return httpResponseHeaderAttrs
 }
 
-func flattenUrlAuthAttrs(urlAuth *model.UrlAuthGetBody, urlAuthKey string) []map[string]interface{} {
+func flattenUrlAuthAttrs(urlAuth *model.UrlAuthGetBody, urlAuthKey, urlAuthBackupKey string) []map[string]interface{} {
 	if urlAuth == nil {
 		return nil
 	}
 
 	urlAuthAttrs := map[string]interface{}{
-		"enabled":     analyseFunctionEnabledStatus(urlAuth.Status),
-		"status":      urlAuth.Status,
-		"type":        urlAuth.Type,
-		"key":         urlAuthKey,
-		"time_format": urlAuth.TimeFormat,
-		"expire_time": urlAuth.ExpireTime,
+		"enabled":        analyseFunctionEnabledStatus(urlAuth.Status),
+		"status":         urlAuth.Status,
+		"type":           urlAuth.Type,
+		"sign_method":    urlAuth.SignMethod,
+		"match_type":     urlAuth.MatchType,
+		"inherit_config": flattenInheritConfigAttrs(urlAuth.InheritConfig),
+		"sign_arg":       urlAuth.SignArg,
+		"key":            urlAuthKey,
+		"backup_key":     urlAuthBackupKey,
+		"time_format":    urlAuth.TimeFormat,
+		"expire_time":    urlAuth.ExpireTime,
 	}
 
 	return []map[string]interface{}{urlAuthAttrs}
+}
+
+func flattenInheritConfigAttrs(inheritConfig *model.InheritConfigQuery) []map[string]interface{} {
+	if inheritConfig == nil {
+		return nil
+	}
+
+	inheritConfigAttrs := map[string]interface{}{
+		"enabled":           analyseFunctionEnabledStatus(inheritConfig.Status),
+		"status":            inheritConfig.Status,
+		"inherit_type":      inheritConfig.InheritType,
+		"inherit_time_type": inheritConfig.InheritTimeType,
+	}
+
+	return []map[string]interface{}{inheritConfigAttrs}
 }
 
 func flattenForceRedirectAttrs(forceRedirect *model.ForceRedirectConfig) []map[string]interface{} {
@@ -1418,12 +1508,13 @@ func flattenConfigAttrs(configsResp *model.ConfigsGetBody, d *schema.ResourceDat
 	privateKey := d.Get("configs.0.https_settings.0.private_key").(string)
 	certificateBody := d.Get("configs.0.https_settings.0.certificate_body").(string)
 	urlAuthKey := d.Get("configs.0.url_signing.0.key").(string)
+	urlAuthBackupKey := d.Get("configs.0.url_signing.0.backup_key").(string)
 
 	configsAttrs := map[string]interface{}{
 		"https_settings":                flattenHTTPSAttrs(configsResp.Https, privateKey, certificateBody),
 		"retrieval_request_header":      flattenOriginRequestHeaderAttrs(configsResp.OriginRequestHeader),
 		"http_response_header":          flattenHttpResponseHeaderAttrs(configsResp.HttpResponseHeader),
-		"url_signing":                   flattenUrlAuthAttrs(configsResp.UrlAuth, urlAuthKey),
+		"url_signing":                   flattenUrlAuthAttrs(configsResp.UrlAuth, urlAuthKey, urlAuthBackupKey),
 		"origin_protocol":               configsResp.OriginProtocol,
 		"force_redirect":                flattenForceRedirectAttrs(configsResp.ForceRedirect),
 		"compress":                      flattenCompressAttrs(configsResp.Compress),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The resource of CDN domain support new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Support new fields contain url_signing.0.sign_method, url_signing.0.match_type, url_signing.0.backup_key,
url_signing.0.sign_arg, url_signing.0.inherit_config.0.inherit_type, url_signing.0.inherit_config.0.inherit_time_type,
url_signing.0.inherit_config.0.status
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccCdnDomain_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (830.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       830.155s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccCdnDomain_configs"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (836.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       836.789s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccCdnDomain_configTypeWholeSite"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (580.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       580.173s
```
