### PR TITLE
feat(lb): support new params in pool

### DIFF
--- a/docs/resources/lb_certificate.md
+++ b/docs/resources/lb_certificate.md
@@ -104,6 +104,7 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Specifies a resource ID in UUID format.
 * `update_time` - Indicates the update time.
 * `create_time` - Indicates the creation time.
+* `expire_time` - Indicates the expire time.
 
 ## Timeouts
 

--- a/docs/resources/lb_pool.md
+++ b/docs/resources/lb_pool.md
@@ -48,18 +48,27 @@ The following arguments are supported:
 * `lb_method` - (Required, String) The load balancing algorithm to distribute traffic to the pool's members. Must be one
   of ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
 
-* `persistence` - (Optional, List, ForceNew) Omit this field to prevent session persistence. Indicates whether
-  connections in the same session will be processed by the same Pool member or not. Changing this creates a new pool.
+* `protection_status` - (Optional, String) The protection status for update. Value options:
+  + **nonProtection**: No protection.
+  + **consoleProtection**: Console modification protection.
+
+  Defaults to **nonProtection**.
+
+* `protection_reason` - (Optional, String) The reason for update protection. Only valid when `protection_status` is
+  **consoleProtection**.
+
+* `persistence` - (Optional, List) Omit this field to prevent session persistence. Indicates whether
+  connections in the same session will be processed by the same Pool member or not.
 
 The `persistence` argument supports:
 
-* `type` - (Required, String, ForceNew) The type of persistence mode. The current specification supports SOURCE_IP,
+* `type` - (Required, String) The type of persistence mode. The current specification supports SOURCE_IP,
   HTTP_COOKIE, and APP_COOKIE.
 
-* `cookie_name` - (Optional, String, ForceNew) The name of the cookie if persistence mode is set appropriately. Required
+* `cookie_name` - (Optional, String) The name of the cookie if persistence mode is set appropriately. Required
   if `type = APP_COOKIE`.
 
-* `timeout` - (Optional, Int, ForceNew) Specifies the sticky session timeout duration in minutes. This parameter is
+* `timeout` - (Optional, Int) Specifies the sticky session timeout duration in minutes. This parameter is
   invalid when type is set to APP_COOKIE. The value range varies depending on the protocol of the backend server group:
   + When the protocol of the backend server group is TCP or UDP, the value ranges from 1 to 60.
   + When the protocol of the backend server group is HTTP or HTTPS, the value ranges from 1 to 1440.
@@ -69,6 +78,8 @@ The `persistence` argument supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the pool.
+
+* `monitor_id` - The ID of the health check configured for the backend server group.
 
 ## Timeouts
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240411063334-847704c1242c
+	github.com/chnsz/golangsdk v0.0.0-20240416091815-0328dbf056fd
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240411063334-847704c1242c h1:qTPIxPSQpDkCLEqHJGx9HjQOWAboakny8BHQ4Mv37ek=
-github.com/chnsz/golangsdk v0.0.0-20240411063334-847704c1242c/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240416091815-0328dbf056fd h1:wvojLYFrrd59VPr0ZQ59NJ7kxhXhG8VhGQHEIKi2xNU=
+github.com/chnsz/golangsdk v0.0.0-20240416091815-0328dbf056fd/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_pool_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_pool_test.go
@@ -48,6 +48,8 @@ func TestAccLBV2Pool_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "lb_method", "ROUND_ROBIN"),
+					resource.TestCheckResourceAttr(resourceName, "persistence.0.type", "APP_COOKIE"),
+					resource.TestCheckResourceAttr(resourceName, "persistence.0.cookie_name", "testCookie"),
 				),
 			},
 			{
@@ -55,6 +57,8 @@ func TestAccLBV2Pool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
 					resource.TestCheckResourceAttr(resourceName, "lb_method", "LEAST_CONNECTIONS"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status", "consoleProtection"),
+					resource.TestCheckResourceAttr(resourceName, "protection_reason", "test protection reason"),
 				),
 			},
 			{
@@ -90,6 +94,11 @@ resource "huaweicloud_lb_pool" "pool_1" {
   lb_method   = "ROUND_ROBIN"
   listener_id = huaweicloud_lb_listener.listener_1.id
 
+  persistence {
+    type        = "APP_COOKIE"
+    cookie_name = "testCookie"
+  }
+
   timeouts {
     create = "5m"
     update = "5m"
@@ -118,11 +127,12 @@ resource "huaweicloud_lb_listener" "listener_1" {
 }
 
 resource "huaweicloud_lb_pool" "pool_1" {
-  name           = "%s"
-  protocol       = "HTTP"
-  lb_method      = "LEAST_CONNECTIONS"
-  admin_state_up = "true"
-  listener_id    = huaweicloud_lb_listener.listener_1.id
+  name              = "%s"
+  protocol          = "HTTP"
+  lb_method         = "LEAST_CONNECTIONS"
+  listener_id       = huaweicloud_lb_listener.listener_1.id
+  protection_status = "consoleProtection"
+  protection_reason = "test protection reason"
 
   timeouts {
     create = "5m"

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_certificate.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_certificate.go
@@ -102,6 +102,11 @@ func ResourceCertificateV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"expire_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -161,6 +166,7 @@ func resourceCertificateV2Read(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("private_key", c.PrivateKey),
 		d.Set("create_time", c.CreateTime),
 		d.Set("update_time", c.UpdateTime),
+		d.Set("expire_time", c.ExpireTime),
 	)
 	if err = mErr.ErrorOrNil(); err != nil {
 		return fmtp.DiagErrorf("Error setting certificate fields: %s", err)

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/pools/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/pools/requests.go
@@ -122,6 +122,12 @@ type CreateOpts struct {
 	// Omit this field to prevent session persistence.
 	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
 
+	// Protection status
+	ProtectionStatus string `json:"protection_status,omitempty"`
+
+	// Protection reason
+	ProtectionReason string `json:"protection_reason,omitempty"`
+
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
@@ -177,6 +183,12 @@ type UpdateOpts struct {
 	// Persistence is the session persistence of the pool.
 	// Omit this field to prevent session persistence.
 	Persistence *SessionPersistence `json:"session_persistence,omitempty"`
+
+	// Update protection status
+	ProtectionStatus string `json:"protection_status,omitempty"`
+
+	// Update protection reason
+	ProtectionReason *string `json:"protection_reason,omitempty"`
 }
 
 // ToPoolUpdateMap builds a request body from UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/pools/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/pools/results.go
@@ -12,18 +12,20 @@ import (
 // types of persistence are supported:
 //
 // SOURCE_IP:   With this mode, all connections originating from the same source
-//              IP address, will be handled by the same Member of the Pool.
+// IP address, will be handled by the same Member of the Pool.
+//
 // HTTP_COOKIE: With this persistence mode, the load balancing function will
-//              create a cookie on the first request from a client. Subsequent
-//              requests containing the same cookie value will be handled by
-//              the same Member of the Pool.
+// create a cookie on the first request from a client. Subsequent
+// requests containing the same cookie value will be handled by
+// the same Member of the Pool.
+//
 // APP_COOKIE:  With this persistence mode, the load balancing function will
-//              rely on a cookie established by the backend application. All
-//              requests carrying the same cookie value will be handled by the
-//              same Member of the Pool.
+// rely on a cookie established by the backend application. All
+// requests carrying the same cookie value will be handled by the
+// same Member of the Pool.
 type SessionPersistence struct {
 	// The type of persistence mode.
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 
 	// Name of cookie if persistence mode is set appropriately.
 	CookieName string `json:"cookie_name,omitempty"`
@@ -104,6 +106,12 @@ type Pool struct {
 	// The provisioning status of the pool.
 	// This value is ACTIVE, PENDING_* or ERROR.
 	ProvisioningStatus string `json:"provisioning_status"`
+
+	// Update protection status
+	ProtectionStatus string `json:"protection_status"`
+
+	// Update protection reason
+	ProtectionReason string `json:"protection_reason"`
 }
 
 // PoolPage is the page returned by a pager when traversing over a

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240411063334-847704c1242c
+# github.com/chnsz/golangsdk v0.0.0-20240416091815-0328dbf056fd
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new params in `huaweicloud_lb_pool`, including `protection_status`, `protection_reason`.
Suppor updating `persistence`, and add attr `monitor_id` in `huaweicloud_lb_pool`.
And add attrs `expire_time` in `huaweicloud_lb_certificate`.


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/lb" TESTARGS="-run TestAccLBV2Pool_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run TestAccLBV2Pool_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Pool_basic
=== PAUSE TestAccLBV2Pool_basic
=== CONT  TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (127.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        127.522s
```
