### PR TITLE
test(sfs): increase verification of environmental variable

### DIFF
--- a/huaweicloud/services/acceptance/sfs/data_source_huaweicloud_sfs_turbo_obs_targets_test.go
+++ b/huaweicloud/services/acceptance/sfs/data_source_huaweicloud_sfs_turbo_obs_targets_test.go
@@ -29,6 +29,7 @@ func TestAccDataSourceSfsTurboObsTargets_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckOBSEndpoint(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

In the test case, when creating an OBS target resource, the value of this field (endpoint) is obtained in the form of an environment variable, and corresponding validation needs to be added to ensure that the field has a value.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/sfs" TESTARGS="-run TestAccDataSourceSfsTurboObsTargets_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/sfs -v -run TestAccDataSourceSfsTurboObsTargets_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSfsTurboObsTargets_basic
=== PAUSE TestAccDataSourceSfsTurboObsTargets_basic
=== CONT  TestAccDataSourceSfsTurboObsTargets_basic
    acceptance.go:700: HW_OBS_ENDPOINT must be set for the acceptance test
--- SKIP: TestAccDataSourceSfsTurboObsTargets_basic (0.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfs       0.064s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/sfs" TESTARGS="-run TestAccDataSourceSfsTurboObsTargets_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/sfs -v -run TestAccDataSourceSfsTurboObsTargets_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceSfsTurboObsTargets_basic
=== PAUSE TestAccDataSourceSfsTurboObsTargets_basic
=== CONT  TestAccDataSourceSfsTurboObsTargets_basic
--- PASS: TestAccDataSourceSfsTurboObsTargets_basic (864.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/sfs       864.111s
```
