### PR TITLE
feat(lts): add new resource to enable log receiving status

### DIFF
--- a/docs/resources/lts_log_converge_switch.md
+++ b/docs/resources/lts_log_converge_switch.md
@@ -1,0 +1,29 @@
+---
+subcategory: "Log Tank Service (LTS)"
+---
+
+# huaweicloud_lts_log_converge_switch
+
+Using this resource to enable the LTS log receiving status within HuaweiCloud.
+
+~> Deleting this resource means disable the LTS log receiving status.
+
+## Example Usage
+
+```hcl
+# Create a resource to enable the LTS log receiving status.
+resource "huaweicloud_lts_log_converge_switch" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the configurations of log converge are located.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1244,6 +1244,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lts_group":                            lts.ResourceLTSGroup(),
 			"huaweicloud_lts_host_group":                       lts.ResourceHostGroup(),
 			"huaweicloud_lts_host_access":                      lts.ResourceHostAccessConfig(),
+			"huaweicloud_lts_log_converge_switch":              lts.ResourceLogConvergeSwitch(),
 			"huaweicloud_lts_stream":                           lts.ResourceLTSStream(),
 			"huaweicloud_lts_structuring_configuration":        lts.ResourceStructConfig(),
 			"huaweicloud_lts_structuring_custom_configuration": lts.ResourceStructCustomConfig(),

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_log_converge_switch_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_log_converge_switch_test.go
@@ -1,0 +1,50 @@
+package lts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lts"
+)
+
+func getLogConvergeSwitchResourceFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("lts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating LTS client: %s", err)
+	}
+
+	return lts.GetLogConvergeSwitchEnabled(client)
+}
+
+func TestAccLogConvergeSwitch_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_lts_log_converge_switch.test"
+		rc    = acceptance.InitResourceCheck(rName, &obj, getLogConvergeSwitchResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testLogConvergeSwitch_basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+const testLogConvergeSwitch_basic string = `
+resource "huaweicloud_lts_log_converge_switch" "test" {}
+`

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_log_converge_switch.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_log_converge_switch.go
@@ -1,0 +1,154 @@
+package lts
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LTS PUT /v1/{project_id}/lts/log-converge-config/switch
+// @API LTS GET /v1/{project_id}/lts/log-converge-config/switch
+func ResourceLogConvergeSwitch() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceLogConvergeSwitchCreate,
+		ReadContext:   resourceLogConvergeSwitchRead,
+		DeleteContext: resourceLogConvergeSwitchDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func modifyLogConvergeConfigsMessageSwitch(client *golangsdk.ServiceClient, switchTarget bool) error {
+	httpUrl := "v1/{project_id}/lts/log-converge-config/switch?log_converge_switch={log_converge_switch}"
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{log_converge_switch}", strconv.FormatBool(switchTarget))
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	requestResp, err := client.Request("PUT", getPath, &opts)
+	if err != nil {
+		return fmt.Errorf("failed to enable log receiving status (target: %v): %#v", switchTarget, err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return fmt.Errorf("error retrieving API response body: %#v", err)
+	}
+	requestResult := utils.PathSearch("result", respBody, nil)
+	if requestResult != "success" {
+		return fmt.Errorf("failed to enable log receiving status (target: %v), but the result of API request is: %#v",
+			switchTarget, requestResult)
+	}
+	return nil
+}
+
+func resourceLogConvergeSwitchCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	if err = modifyLogConvergeConfigsMessageSwitch(client, true); err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	return resourceLogConvergeSwitchRead(ctx, d, meta)
+}
+
+func GetLogConvergeSwitchEnabled(client *golangsdk.ServiceClient) (bool, error) {
+	httpUrl := "v1/{project_id}/lts/log-converge-config/switch"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+
+	getOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	requestResp, err := client.Request("GET", getPath, &getOpts)
+	if err != nil {
+		return false, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return false, err
+	}
+	switchEnabled := utils.PathSearch("log_converge_switch", respBody, false).(bool)
+	if !switchEnabled {
+		return switchEnabled, golangsdk.ErrDefault404{}
+	}
+	return switchEnabled, nil
+}
+
+func resourceLogConvergeSwitchRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	_, err = GetLogConvergeSwitchEnabled(client)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "LTS log converge switch")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceLogConvergeSwitchDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	if err = modifyLogConvergeConfigsMessageSwitch(client, false); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to enable log receiving status.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run=TestAccLogConvergeSwitch_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run=TestAccLogConvergeSwitch_basic -timeout 360m -parallel 4
=== RUN   TestAccLogConvergeSwitch_basic
=== PAUSE TestAccLogConvergeSwitch_basic
=== CONT  TestAccLogConvergeSwitch_basic
--- PASS: TestAccLogConvergeSwitch_basic (14.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       14.828s
```
