### PR TITLE
refactor(cdn): make ForceNew of name configurable

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -205,7 +205,7 @@ resource "huaweicloud_cdn_domain" "domain_1" {
 
 The following arguments are supported:
 
-* `name` - (Required, String) Specifies acceleration domain name. The domain name consists of one or more parts,
+* `name` - (Required, String, NonUpdatable) Specifies acceleration domain name. The domain name consists of one or more parts,
   representing domains at different levels. Domain names at all levels can only be composed of letters, digits,
   and hyphens (-), and the letters are equivalent in upper and lower case. Domain names at all levels are connected
   with (.). The domain name can contain up to `75` characters.

--- a/huaweicloud/config/config.go
+++ b/huaweicloud/config/config.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -93,6 +94,8 @@ type Config struct {
 
 	// Metadata is used for extend
 	Metadata any
+
+	EnableForceNew bool
 }
 
 func (c *Config) LoadAndValidate() error {
@@ -587,6 +590,21 @@ func CheckValueInterchange(d *schema.ResourceDiff, key1, key2 string) (isKey1New
 	isKey2NewEqualKey1Old = newKey2Value.(string) == oldKey1Value.(string)
 
 	return isKey1NewEqualKey2Old, isKey2NewEqualKey1Old
+}
+
+// GetForceNew returns the enable_force_new that was specified in the resource.
+// If it was not set, the provider-level value is checked. The provider-level value can
+// either be set by the `enable_force_new` argument or by HW_ENABLE_FORCE_NEW.
+func (c *Config) GetForceNew(d *schema.ResourceDiff) bool {
+	if v, ok := d.GetOk("enable_force_new"); ok {
+		res, err := strconv.ParseBool(v.(string))
+		if err != nil {
+			return false
+		}
+		return res
+	}
+
+	return c.EnableForceNew
 }
 
 // ********** client for Global Service **********

--- a/huaweicloud/config/force_new.go
+++ b/huaweicloud/config/force_new.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// FlexibleForceNew make the ForceNew of parameters configurable
+// this func accepts a list of non-updatable parameters
+// when non-updatable parameters are changed
+// if ForceNew is enabled, the resource will be recreated
+// if ForceNew is not enabled, an error will be raise
+func FlexibleForceNew(keys []string) schema.CustomizeDiffFunc {
+	return func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		cfg := meta.(*Config)
+		var err error
+		forceNew := cfg.GetForceNew(d)
+		keysExpand := expandKeys(keys, d)
+		if forceNew {
+			for _, k := range keysExpand {
+				if err := d.ForceNew(k); err != nil {
+					log.Printf("[WARN] unable to require attribute replacement of %s: %s", k, err)
+				}
+			}
+		} else {
+			for _, k := range keysExpand {
+				if d.Id() != "" && d.HasChange(k) {
+					err = multierror.Append(err, fmt.Errorf("%s can't be updated", k))
+				}
+			}
+		}
+
+		return err
+	}
+}
+
+func expandKeys(keys []string, d *schema.ResourceDiff) []string {
+	res := []string{}
+	for _, k := range keys {
+		if strings.Contains(k, "*") {
+			parts := strings.SplitN(k, ".*.", 2)
+			l := len(d.Get(parts[0]).([]interface{}))
+			i := 0
+			var tempKeys []string
+			for i < l {
+				tempKeys = append(tempKeys, strings.Join([]string{parts[0], parts[1]}, fmt.Sprintf(".%s.", strconv.Itoa(i))))
+				i++
+			}
+			res = append(res, expandKeys(tempKeys, d)...)
+		} else {
+			res = append(res, k)
+		}
+	}
+	return res
+}

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -400,6 +400,13 @@ func Provider() *schema.Provider {
 				Description: descriptions["max_retries"],
 				DefaultFunc: schema.EnvDefaultFunc("HW_MAX_RETRIES", 5),
 			},
+
+			"enable_force_new": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: descriptions["enable_force_new"],
+				DefaultFunc: schema.EnvDefaultFunc("HW_ENABLE_FORCE_NEW", false),
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -1955,6 +1962,8 @@ func init() {
 		"max_retries": "How many times HTTP connection should be retried until giving up.",
 
 		"enterprise_project_id": "enterprise project id",
+
+		"enable_force_new": "Whether to enable ForceNew",
 	}
 }
 
@@ -1986,6 +1995,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData, terraformVersi
 		RegionProjectIDMap:  make(map[string]string),
 		RPLock:              new(sync.Mutex),
 		SecurityKeyLock:     new(sync.Mutex),
+		EnableForceNew:      d.Get("enable_force_new").(bool),
 	}
 
 	// get assume role

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -556,11 +556,3 @@ func IsUUID(uuid string) bool {
 	match, _ := regexp.MatchString(pattern, uuid)
 	return match
 }
-
-func GetForceNew() bool {
-	forceNew, err := strconv.ParseBool(os.Getenv("HW_ENABLE_FORCE_NEW"))
-	if err != nil {
-		return false
-	}
-	return forceNew
-}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add common func FlexibleForceNew to make the ForceNew action configurable
2. use this func in cdn domain resource as an example
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (704.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       704.991s
```
