### PR TITLE
feat(cdn): CDN domain support new fields

### DIFF
--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -470,10 +470,18 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.type", "type_a"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.sign_method", "md5"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.match_type", "all"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.sign_arg", "Psd_123"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.key", "A27jtfSTy13q7A0UnTA9vpxYXEb"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.backup_key", "S36klgTFa60q3V8DmSK2hwfBOYp"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.time_format", "dec"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.expire_time", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_type", "m3u8,mpd"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_time_type", "sys_time"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.type", "http"),
@@ -536,10 +544,18 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.action", "set"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.type", "type_c2"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.sign_method", "sha256"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.match_type", "all"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.sign_arg", "Dma_001"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.key", "3P7k9s4r0aey9CB1mvvDHG2"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.backup_key", "5F8a6c3r1xgp7DL0jkeBYZ4"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.time_format", "hex"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.expire_time", "31536000"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_type", "mpd"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_time_type", "parent_url_time"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.type", "http"),
@@ -603,6 +619,21 @@ func TestAccCdnDomain_configs(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "off"),
+				),
+			},
+			{
+				Config: testAccCdnDomain_configsUpdate3,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", acceptance.HW_CDN_DOMAIN_NAME),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "off"),
 
@@ -618,8 +649,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testCDNDomainImportState(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"enterprise_project_id", "configs.0.url_signing.0.key", "configs.0.https_settings.0.certificate_body",
-					"configs.0.https_settings.0.private_key", "cache_settings",
+					"enterprise_project_id", "configs.0.url_signing.0.key", "configs.0.url_signing.0.backup_key",
+					"configs.0.https_settings.0.certificate_body", "configs.0.https_settings.0.private_key", "cache_settings",
 				},
 			},
 		},
@@ -665,9 +696,19 @@ resource "huaweicloud_cdn_domain" "test" {
     url_signing {
       enabled     = true
       type        = "type_a"
+      sign_method = "md5"
+      match_type  = "all"
+      sign_arg    = "Psd_123"
       key         = "A27jtfSTy13q7A0UnTA9vpxYXEb"
+      backup_key  = "S36klgTFa60q3V8DmSK2hwfBOYp"
       time_format = "dec"
       expire_time = 0
+
+      inherit_config {
+        enabled           = true
+        inherit_type      = "m3u8,mpd"
+        inherit_time_type = "sys_time"
+      }
     }
 
     compress {
@@ -799,9 +840,19 @@ resource "huaweicloud_cdn_domain" "test" {
     url_signing {
       enabled     = true
       type        = "type_c2"
+      sign_method = "sha256"
+      match_type  = "all"
+      sign_arg    = "Dma_001"
       key         = "3P7k9s4r0aey9CB1mvvDHG2"
+      backup_key  = "5F8a6c3r1xgp7DL0jkeBYZ4"
       time_format = "hex"
       expire_time = 31536000
+
+      inherit_config {
+        enabled           = true
+        inherit_type      = "mpd"
+        inherit_time_type = "parent_url_time"
+      }
     }
 
     compress {
@@ -878,6 +929,47 @@ resource "huaweicloud_cdn_domain" "test" {
     range_based_retrieval_enabled = false
     slice_etag_status             = "on"
     origin_receive_timeout        = "5"
+
+    remote_auth {
+      enabled = false
+    }
+
+    url_signing {
+      enabled     = true
+      type        = "type_c2"
+      sign_method = "sha256"
+      match_type  = "all"
+      sign_arg    = "web506"
+      key         = "3P7k9s4r0aey9CB1mvvDHG2"
+      backup_key  = "5F8a6c3r1xgp7DL0jkeBYZ4"
+      time_format = "hex"
+      expire_time = 31536000
+
+      inherit_config {
+        enabled = false
+      }
+    }
+  }
+}
+`, acceptance.HW_CDN_DOMAIN_NAME)
+
+var testAccCdnDomain_configsUpdate3 = fmt.Sprintf(`
+resource "huaweicloud_cdn_domain" "test" {
+  name                  = "%s"
+  type                  = "web"
+  service_area          = "outside_mainland_china"
+  enterprise_project_id = 0
+
+  sources {
+    active      = 1
+    origin      = "100.254.53.75"
+    origin_type = "ipaddr"
+  }
+
+  configs {
+    origin_protocol               = "follow"
+    ipv6_enable                   = false
+    range_based_retrieval_enabled = false
 
     remote_auth {
       enabled = false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The resource of CDN domain support new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Support new fields contain url_signing.0.sign_method, url_signing.0.match_type, url_signing.0.backup_key,
url_signing.0.sign_arg, url_signing.0.inherit_config.0.inherit_type, url_signing.0.inherit_config.0.inherit_time_type,
url_signing.0.inherit_config.0.status
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccCdnDomain_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (833.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       833.716s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccCdnDomain_configTypeWholeSite"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (543.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       543.800s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/cdn" TESTARGS="-run TestAccCdnDomain_configs"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (983.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       983.338s
```