### PR TITLE
fix(lts/stream): request body within eps id if no eps permission have

### DIFF
--- a/huaweicloud/services/eps/common.go
+++ b/huaweicloud/services/eps/common.go
@@ -1,0 +1,40 @@
+package eps
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// ParseQueryError403 is a method used to parse whether a 403 error message should be ignored.
+// For the EPS service, there are some known 403 error codes:
+// + EPS.0004: The current user lacks permission for this service.
+func ParseQueryError403(err error, specErrors []string, msg ...string) error {
+	var err403 golangsdk.ErrDefault403
+	if errors.As(err, &err403) {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(err403.Body, &apiError); jsonErr != nil {
+			return err
+		}
+
+		errCode, searchErr := jmespath.Search("error_code", apiError)
+		if searchErr != nil {
+			return err
+		}
+
+		for _, v := range specErrors {
+			if errCode == v {
+				if len(msg) > 0 {
+					// Record the custom message to the log.
+					log.Println(msg[0])
+				}
+				return nil
+			}
+		}
+	}
+	return err
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
No error returned if the user does not have the EPS permissions.
And the request body do not contain the eps ID.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. request body within enterprise project ID if no EPS permission have.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run=TestAccLtsStream_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run=TestAccLtsStream_basic -timeout 360m -parallel 4
=== RUN   TestAccLtsStream_basic
=== PAUSE TestAccLtsStream_basic
=== CONT  TestAccLtsStream_basic
--- PASS: TestAccLtsStream_basic (19.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       19.596s
```
