### PR TITLE
feat(elb): add params and atrrs for elb

### DIFF
--- a/docs/resources/elb_active_standby_pool.md
+++ b/docs/resources/elb_active_standby_pool.md
@@ -74,6 +74,9 @@ The following arguments are supported:
   -> **NOTE:** If this parameter is not passed, any type of active-standby pool can be added and will return an empty string.
   This parameter can be updated only when it is left blank.
 
+* `ip_version` - (Optional, String, ForceNew) Specifies the IP address version supported by active-standby pool.
+  The value can be **dualstack**, **v6**, or **v4**. Changing this parameter will create a new resource.
+
 * `loadbalancer_id` - (Optional, String, ForceNew) Specifies the ID of the load balancer with which the active-standby
   pool is associated. Changing this parameter will create a new resource.
 
@@ -201,13 +204,17 @@ The `healthmonitor` block supports:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The unique ID for the active-standby pool.
+* `id` - The unique ID of the active-standby pool.
 
 * `members` - The backend servers in the active-standby pool.
   The [members](#ELB_membersResp) structure is documented below.
 
 * `healthmonitor` - The health check configured for the active-standby pool.
   The [healthmonitor](#ELB_healthmonitorResp) structure is documented below.
+
+* `created_at` - The create time of the active-standby pool.
+
+* `updated_at` - The update time of the active-standby pool.
 
 <a name="ELB_membersResp"></a>
 The `members` block supports:

--- a/docs/resources/elb_ipgroup.md
+++ b/docs/resources/elb_ipgroup.md
@@ -49,6 +49,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The uuid of the ip group.
 
+* `listener_ids` - The listener IDs which the ip group associated with.
+
+* `created_at` - The create time of the ip group.
+
+* `updated_at` - The update time of the ip group.
+
 ELB IP group can be imported using the IP group ID, e.g.
 
 ```

--- a/docs/resources/elb_l7policy.md
+++ b/docs/resources/elb_l7policy.md
@@ -210,7 +210,13 @@ The `fixed_response_config` block supports:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The unique ID for the L7 policy.
+* `id` - The unique ID of the L7 policy.
+
+* `provisioning_status` - The provisioning status of the forwarding policy.
+
+* `created_at` - The create time of the L7 policy.
+
+* `updated_at` - The update time of the L7 policy.
 
 ## Timeouts
 

--- a/docs/resources/elb_l7rule.md
+++ b/docs/resources/elb_l7rule.md
@@ -161,7 +161,11 @@ The `condition` block supports:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The unique ID for the L7 Rule.
+* `id` - The unique ID of the L7 Rule.
+
+* `created_at` - The create time of the L7 Rule.
+
+* `updated_at` - The update time of the L7 Rule.
 
 ## Timeouts
 

--- a/docs/resources/elb_security_policy.md
+++ b/docs/resources/elb_security_policy.md
@@ -57,6 +57,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
 
+* `created_at` - The create time of the security policy.
+
+* `updated_at` - The update time of the security policy.
+
 * `listeners` - The listener which the security policy associated with.
   The [ListenerRef](#SecurityPoliciesV3_ListenerRef) structure is documented below.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240416091815-0328dbf056fd
+	github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240416091815-0328dbf056fd h1:wvojLYFrrd59VPr0ZQ59NJ7kxhXhG8VhGQHEIKi2xNU=
-github.com/chnsz/golangsdk v0.0.0-20240416091815-0328dbf056fd/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762 h1:yEkY1dexnt7HdLdoyuJ98Y+VHBlWAJm4tWmP8e+ft38=
+github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_active_standby_pool_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_active_standby_pool_test.go
@@ -70,6 +70,7 @@ func TestAccElbActiveStandbyPool_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
 						"huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "any_port_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "dualstack"),
 					resource.TestCheckResourceAttr(resourceName, "members.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "healthmonitor.0.delay", "5"),
 					resource.TestCheckResourceAttr(resourceName, "healthmonitor.0.expected_codes", "200"),
@@ -82,6 +83,8 @@ func TestAccElbActiveStandbyPool_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "members.0.operating_status"),
 					resource.TestCheckResourceAttrSet(resourceName, "members.0.ip_version"),
 					resource.TestCheckResourceAttrSet(resourceName, "healthmonitor.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
 				),
 			},
 			{
@@ -104,6 +107,7 @@ resource "huaweicloud_elb_active_standby_pool" "test" {
   vpc_id          = huaweicloud_vpc.test.id
   type            = "instance"
   any_port_enable = false
+  ip_version      = "dualstack"
 
   members {
     address       = "192.168.0.1"

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_active_standby_pool.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_active_standby_pool.go
@@ -107,6 +107,16 @@ func ResourceActiveStandbyPool() *schema.Resource {
 			},
 			"ip_version": {
 				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
@@ -325,6 +335,9 @@ func resourceActiveStandbyPoolRead(_ context.Context, d *schema.ResourceData, me
 		d.Set("vpc_id", utils.PathSearch("pool.vpc_id", getActiveStandbyPoolBody, nil)),
 		d.Set("members", flattenActiveStandbyPoolMembers(getActiveStandbyPoolBody)),
 		d.Set("healthmonitor", flattenActiveStandbyPoolHealthMonitor(getActiveStandbyPoolBody)),
+		d.Set("ip_version", utils.PathSearch("pool.ip_version", getActiveStandbyPoolBody, nil)),
+		d.Set("created_at", utils.PathSearch("pool.created_at", getActiveStandbyPoolBody, nil)),
+		d.Set("updated_at", utils.PathSearch("pool.updated_at", getActiveStandbyPoolBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -483,6 +496,7 @@ func buildCreateActiveStandbyPoolBodyParams(d *schema.ResourceData) map[string]i
 		"any_port_enable": utils.ValueIngoreEmpty(d.Get("any_port_enable")),
 		"vpc_id":          utils.ValueIngoreEmpty(d.Get("vpc_id")),
 		"description":     utils.ValueIngoreEmpty(d.Get("description")),
+		"ip_version":      utils.ValueIngoreEmpty(d.Get("ip_version")),
 		"members":         buildActiveStandbyPoolMembers(d.Get("members").(*schema.Set).List()),
 		"healthmonitor":   buildActiveStandbyPoolHealthMonitor(d.Get("healthmonitor")),
 	}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_ipgroup.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_ipgroup.go
@@ -69,6 +69,19 @@ func ResourceIpGroupV3() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"listener_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -137,11 +150,19 @@ func resourceIpGroupV3Read(_ context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 
+	listenerIDs := make([]string, 0)
+	for _, listener := range ipGroup.Listeners {
+		listenerIDs = append(listenerIDs, listener.ID)
+	}
+
 	mErr := multierror.Append(nil,
 		d.Set("name", ipGroup.Name),
 		d.Set("description", ipGroup.Description),
 		d.Set("region", cfg.GetRegion(d)),
 		d.Set("ip_list", ipList),
+		d.Set("listener_ids", listenerIDs),
+		d.Set("created_at", ipGroup.CreatedAt),
+		d.Set("updated_at", ipGroup.UpdatedAt),
 	)
 
 	if err := mErr.ErrorOrNil(); err != nil {

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_l7policy.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_l7policy.go
@@ -103,6 +103,18 @@ func ResourceL7PolicyV3() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"provisioning_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -346,6 +358,9 @@ func resourceL7PolicyV3Read(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("redirect_url_config", flattenRedirectUrlConfig(l7Policy)),
 		d.Set("fixed_response_config", flattenFixedResponseConfig(l7Policy)),
 		d.Set("region", cfg.GetRegion(d)),
+		d.Set("created_at", l7Policy.CreatedAt),
+		d.Set("updated_at", l7Policy.UpdatedAt),
+		d.Set("provisioning_status", l7Policy.ProvisioningStatus),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error setting Dedicated ELB l7policy fields: %s", err)

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_l7rule.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_l7rule.go
@@ -71,6 +71,14 @@ func ResourceL7RuleV3() *schema.Resource {
 				Computed: true,
 				Elem:     l7RuleConditionSchema(),
 			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -164,6 +172,8 @@ func resourceL7RuleV3Read(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("type", l7Rule.RuleType),
 		d.Set("compare_type", l7Rule.CompareType),
 		d.Set("value", l7Rule.Value),
+		d.Set("created_at", l7Rule.CreatedAt),
+		d.Set("updated_at", l7Rule.UpdatedAt),
 	)
 
 	var conditions []map[string]interface{}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_security_policy.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_security_policy.go
@@ -86,6 +86,14 @@ func ResourceSecurityPolicy() *schema.Resource {
 				Computed:    true,
 				Description: `The listener which the security policy associated with.`,
 			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -237,6 +245,8 @@ func resourceSecurityPoliciesV3Read(_ context.Context, d *schema.ResourceData, m
 		d.Set("protocols", utils.PathSearch("security_policy.protocols", getSecurityPolicyRespBody, nil)),
 		d.Set("ciphers", utils.PathSearch("security_policy.ciphers", getSecurityPolicyRespBody, nil)),
 		d.Set("listeners", flattenGetSecurityPolicyResponseBodyListenerRef(getSecurityPolicyRespBody)),
+		d.Set("created_at", utils.PathSearch("security_policy.created_at", getSecurityPolicyRespBody, nil)),
+		d.Set("updated_at", utils.PathSearch("security_policy.updated_at", getSecurityPolicyRespBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/ipgroups/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/ipgroups/results.go
@@ -26,6 +26,12 @@ type IpGroup struct {
 
 	// A list of IP addresses.
 	IpList []IpListOpt `json:"ip_list"`
+
+	// The create time.
+	CreatedAt string `json:"created_at"`
+
+	// The update time.
+	UpdatedAt string `json:"updated_at"`
 }
 
 type commonResult struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/l7policies/results.go
@@ -69,6 +69,12 @@ type L7Policy struct {
 
 	// Rules are List of associated L7 rule IDs.
 	Rules []Rule `json:"rules"`
+
+	// The create time.
+	CreatedAt string `json:"created_at"`
+
+	// The update time.
+	UpdatedAt string `json:"updated_at"`
 }
 
 // Rule represents layer 7 load balancing rule.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240416091815-0328dbf056fd
+# github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add params and atrrs for elb:
`huaweicloud_elb_active_standby_pool`: supporting new param `ip_version` and attrs `created_at`, `updated_at`.
`huaweicloud_elb_ipgroup`: supporting attrs `created_at`, `updated_at`, `listener_ids`.
`huaweicloud_elb_l7policy`: supporting attrs `created_at`, `updated_at`, `provisioning_status`.
`huaweicloud_elb_l7rule`, `huaweicloud_elb_security_policy`: supporting attrs `created_at`, `updated_at`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/elb" TESTARGS="-run TestAccElbActiveStandbyPool_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb -v -run TestAccElbActiveStandbyPool_basic -timeout 360m -parallel 4
=== RUN   TestAccElbActiveStandbyPool_basic
=== PAUSE TestAccElbActiveStandbyPool_basic
=== CONT  TestAccElbActiveStandbyPool_basic
--- PASS: TestAccElbActiveStandbyPool_basic (65.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       65.730s
```
