### PR TITLE
feat(RDS): rds instance support tde

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -302,6 +302,21 @@ The `db` block supports:
 
   -> **NOTE:** The `power_action` is a one-time action.
 
+* `tde_enabled` - (Optional, Bool) Specifies whether enable TDE for the instance.
+
+  -> **NOTE:** TDE cannot be disabled after being enabled.
+
+* `rotate_day` - (Optional, Int) Specifies the rotation days of TDE rotation.
+
+* `secret_id` - (Optional, String) Specifies the key ID of TDE rotation.
+
+* `secret_name` - (Optional, String) Specifies the key name of TDE rotation.
+
+* `secret_version` - (Optional, String) Specifies the key version of TDE rotation.
+
+  -> **NOTE:** `rotate_day`, `secret_id`, `secret_name` and `secret_version` will only take effect when `tde_enabled`
+  is **true**.
+
 The `volume` block supports:
 
 * `size` - (Required, Int) Specifies the volume size. Its value range is from 40 GB to 4000 GB. The value must be a

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762
+	github.com/chnsz/golangsdk v0.0.0-20240418022603-d3c99f628233
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762 h1:yEkY1dexnt7HdLdoyuJ98Y+VHBlWAJm4tWmP8e+ft38=
-github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240418022603-d3c99f628233 h1:pZtrA6aLmmeXyKn5ny083jUIknHa9woSylP+GqGS/zk=
+github.com/chnsz/golangsdk v0.0.0-20240418022603-d3c99f628233/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -258,6 +258,7 @@ func TestAccRdsInstance_sqlserver(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "collation", "Chinese_PRC_CI_AS"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "40"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8634"),
+					resource.TestCheckResourceAttr(resourceName, "tde_enabled", "true"),
 				),
 			},
 			{
@@ -866,6 +867,7 @@ resource "huaweicloud_rds_instance" "test" {
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
   collation         = "Chinese_PRC_CI_AS"
+  tde_enabled       = true
 
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0],

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -62,6 +62,10 @@ type GetBinlogRetentionHoursResult struct {
 	commonResult
 }
 
+type GetTdeStatusResult struct {
+	commonResult
+}
+
 type JobResult struct {
 	commonResult
 }
@@ -185,6 +189,17 @@ type GetConfigurationResp struct {
 
 func (r GetConfigurationResult) Extract() (*GetConfigurationResp, error) {
 	var response GetConfigurationResp
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type GetTdeStatusResp struct {
+	InstanceId string `json:"instance_id"`
+	TdeStatus  string `json:"tde_status"`
+}
+
+func (r GetTdeStatusResult) Extract() (*GetTdeStatusResp, error) {
+	var response GetTdeStatusResp
 	err := r.ExtractInto(&response)
 	return &response, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
@@ -14,42 +14,22 @@ func listURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("instances")
 }
 
-func updateURL(c *golangsdk.ServiceClient, instancesId string, update string) string {
-	return c.ServiceURL("instances", instancesId, update)
+func updateURL(c *golangsdk.ServiceClient, instanceId string, update string) string {
+	return c.ServiceURL("instances", instanceId, update)
 }
 
 func jobURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("jobs")
 }
 
+func getURL(c *golangsdk.ServiceClient, instanceId, getContent string) string {
+	return c.ServiceURL("instances", instanceId, getContent)
+}
+
 func engineURL(c *golangsdk.ServiceClient, dbName string) string {
 	return c.ServiceURL("datastores", dbName)
 }
 
-func resetRootPasswordURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "password")
-}
-
 func applyConfigurationURL(c *golangsdk.ServiceClient, configId string) string {
 	return c.ServiceURL("configurations", configId, "apply")
-}
-
-func configurationsURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "configurations")
-}
-
-func actionURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "action")
-}
-
-func autoExpandURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "disk-auto-expansion")
-}
-
-func binlogRetentionHoursURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "binlog/clear-policy")
-}
-
-func msdtcHostsURL(c *golangsdk.ServiceClient, instancesId string) string {
-	return c.ServiceURL("instances", instancesId, "msdtc/hosts")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762
+# github.com/chnsz/golangsdk v0.0.0-20240418022603-d3c99f628233
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support tde
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support tde
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=11
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 11
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_mysql
--- PASS: TestAccRdsInstance_mariadb (659.97s)
--- PASS: TestAccRdsInstance_ha (727.64s)
--- PASS: TestAccRdsInstance_basic (823.68s)
--- PASS: TestAccRdsInstance_mysql_power_action (1152.53s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1563.01s)
--- PASS: TestAccRdsInstance_prePaid (1599.37s)
--- PASS: TestAccRdsInstance_restore_mysql (1652.64s)
--- PASS: TestAccRdsInstance_restore_pg (1725.65s)
--- PASS: TestAccRdsInstance_mysql (1849.58s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2767.54s)
--- PASS: TestAccRdsInstance_sqlserver (3298.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3298.482s
```
