### PR TITLE
feat(dataarts): add new resource to manage catalogs

### DIFF
--- a/docs/resources/dataarts_dataservice_catalog.md
+++ b/docs/resources/dataarts_dataservice_catalog.md
@@ -1,0 +1,133 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_dataservice_catalog"
+description: |-
+  Use this resource to manage a shared or exclusive catalog within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_catalog
+
+Use this resource to manage a shared or exclusive catalog within HuaweiCloud.
+
+## Example Usage
+
+### Create a catalog under the ROOT path
+
+```hcl
+variable "workspace_id" {}
+variable "catalog_name" {}
+
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  workspace_id = var.workspace_id
+  dlm_type     = "EXCLUSIVE"
+  name         = var.catalog_name
+}
+```
+
+### Create a catalog under the specified catalog
+
+```hcl
+variable "workspace_id" {}
+variable "parent_catalog_id" {}
+variable "catalog_name" {}
+
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  workspace_id = var.workspace_id
+  parent_id    = var.parent_catalog_id
+  dlm_type     = "EXCLUSIVE"
+  name         = var.catalog_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the catalog is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the ID of the workspace to which the catalog belongs.  
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the catalog.  
+  The valid length is limited from `1` to `64`, only Chinese and English characters, digits and hyphens (-) are
+  allowed.  
+  The name must start with a Chinese or English character or a digit, and the Chinese characters must be in **UTF-8** or
+  **Unicode** format.
+
+* `description` - (Optional, String) Specifies the description of the catalog.  
+  Maximum of `255` characters are allowed.
+
+* `dlm_type` - (Optional, String, ForceNew) Specifies the type of DLM engine.  
+  The valid values are as follows:
+  + **SHARED**: Shared data service.
+  + **EXCLUSIVE**: The exclusive data service.
+
+  Defaults to **SHARED**. Changing this parameter will create a new resource.
+
+  -> The value of `dlm_type` for all catalogs under this directory must be consistent with this resource.
+
+* `parent_id` - (Optional, String) Specifies the ID of the parent catalog for current catalog.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `path` - The path of current catalog.
+
+* `catalog_total` - The total number of sub-catalogs in the current catalog.
+
+-> The newly added sub-catalogs needs to wait until the next time `terraform refresh` command is executed that the value
+   can be refreshed.
+
+* `api_total` - The total number of APIs in the current catalog.
+
+-> The newly added APIs needs to wait until the next time `terraform refresh` command is executed before that value
+   can be refreshed.
+
+* `created_at` - The creation time of the catalog.
+
+* `updated_at` - The latest update time of the catalog.
+
+* `create_user` - The creator of the catalog.
+
+* `update_user` - The user who latest updated the catalog.
+
+## Import
+
+The catalog can be imported using `workspace_id`, `dlm_type` and `id` separated by slashes, e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_dataservice_catalog.test <workspace_id>/<dlm_type>/<id>
+```
+
+Also, you can omit `dlm_type` and provide just `workspace_id` and `id`, separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_dataservice_catalog.test <workspace_id>/<id>
+```
+
+~> This way only supports importing the catalog of the **SHARED** type, but does not support the catalog imported for
+   **EXCLUSIVE** type. If an error is reported, please carefully check the `dlm_type` value to which imported catalog
+   you want.
+
+Note that the imported state may not be identical to your resource definition, because the attributes are missing in the
+API response. The missing attributes include: `parent_id`.
+It is generally recommended running `terraform plan` after importing an resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      parent_id,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1311,7 +1311,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_security_permission_set":        dataarts.ResourceSecurityPermissionSet(),
 			"huaweicloud_dataarts_security_data_recognition_rule": dataarts.ResourceSecurityRule(),
 			// DataArts DataService
-			"huaweicloud_dataarts_dataservice_app": dataarts.ResourceDataServiceApp(),
+			"huaweicloud_dataarts_dataservice_app":     dataarts.ResourceDataServiceApp(),
+			"huaweicloud_dataarts_dataservice_catalog": dataarts.ResourceDatatServiceCatalog(),
 
 			"huaweicloud_mpc_transcoding_template":       mpc.ResourceTranscodingTemplate(),
 			"huaweicloud_mpc_transcoding_template_group": mpc.ResourceTranscodingTemplateGroup(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_catalog_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_catalog_test.go
@@ -1,0 +1,227 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dataarts"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDataServiceCatalogResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	httpUrl := "v1/{project_id}/service/servicecatalogs/{catalog_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{catalog_id}", state.Primary.ID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    state.Primary.Attributes["workspace_id"],
+			"Dlm-Type":     state.Primary.Attributes["dlm_type"],
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, dataarts.ParseQueryError400(err, dataarts.CatalogResourceNotFoundCodes)
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func TestAccDataServiceCatalog_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		rName       = "huaweicloud_dataarts_dataservice_catalog.test"
+		name        = acceptance.RandomAccResourceName()
+		updateName  = acceptance.RandomAccResourceName()
+		basicConfig = testDataServiceCatalog_base()
+
+		rc = acceptance.InitResourceCheck(rName, &obj, getDataServiceCatalogResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDataServiceCatalog_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "parent_id", "0"),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(rName, "catalog_total", "0"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+			{
+				Config: testDataServiceCatalog_basic_step2(basicConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				// Refresh all resources and update the value of parameter 'catalog_total'.
+				Config: testDataServiceCatalog_basic_step2(basicConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(rName, "parent_id",
+						"huaweicloud_dataarts_dataservice_catalog.sub_path.0", "id"),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(rName, "catalog_total", "2"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				Config: testDataServiceCatalog_basic_step3(basicConfig, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				// Refresh all resources and update the value of parameter 'catalog_total'.
+				Config: testDataServiceCatalog_basic_step3(basicConfig, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "parent_id",
+						"huaweicloud_dataarts_dataservice_catalog.sub_path.1", "id"),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(rName, "catalog_total", "3"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDataServiceCatalogImportState(rName),
+				ImportStateVerifyIgnore: []string{
+					"parent_id",
+				},
+			},
+		},
+	})
+}
+
+func testDataServiceCatalogImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var workspaceId, dlmType, resourceId string
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+
+		workspaceId = rs.Primary.Attributes["workspace_id"]
+		dlmType = rs.Primary.Attributes["dlm_type"]
+		resourceId = rs.Primary.ID
+		if rs.Primary.Attributes["workspace_id"] == "" || rs.Primary.ID == "" {
+			return "", fmt.Errorf("attribute 'workspace_id' or resource ID is missing")
+		}
+		if rs.Primary.Attributes["dlm_type"] != "" {
+			return fmt.Sprintf("%s/%s/%s", workspaceId, dlmType, resourceId), nil
+		}
+		return fmt.Sprintf("%s/%s", workspaceId, resourceId), nil
+	}
+}
+
+func testDataServiceCatalog_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+// Under root path.
+resource "huaweicloud_dataarts_dataservice_catalog" "sub_path" {
+  count = 2
+
+  workspace_id = "%[1]s"
+  dlm_type     = "SHARED"
+  name         = format("%[2]s_parent_%%d", count.index)
+}
+
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testDataServiceCatalog_basic_step1(name string) string {
+	return fmt.Sprintf(`
+// Under root path.
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  workspace_id = "%[1]s"
+  dlm_type     = "SHARED"
+  name         = "%[2]s"
+  description  = "Created by terraform script"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testDataServiceCatalog_basic_step2(basicConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  parent_id    = huaweicloud_dataarts_dataservice_catalog.sub_path[0].id
+  workspace_id = "%[2]s"
+  dlm_type     = "SHARED"
+  name         = "%[3]s"
+  description  = "Created by terraform script"
+}
+
+resource "huaweicloud_dataarts_dataservice_catalog" "child" {
+  count = 2
+
+  parent_id    = huaweicloud_dataarts_dataservice_catalog.test.id
+  workspace_id = "%[2]s"
+  dlm_type     = "SHARED"
+  name         = format("%[3]s_child_%%d", count.index)
+}
+`, basicConfig, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testDataServiceCatalog_basic_step3(basicConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  parent_id = huaweicloud_dataarts_dataservice_catalog.sub_path[1].id
+
+  workspace_id = "%[2]s"
+  dlm_type     = "SHARED"
+  name         = "%[3]s"
+  description  = "Updated by terraform script"
+}
+
+resource "huaweicloud_dataarts_dataservice_catalog" "child" {
+  count = 3
+
+  parent_id    = huaweicloud_dataarts_dataservice_catalog.test.id
+  workspace_id = "%[2]s"
+  dlm_type     = "SHARED"
+  name         = format("%[3]s_child_%%d", count.index)
+}
+`, basicConfig, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/common.go
+++ b/huaweicloud/services/dataarts/common.go
@@ -1,0 +1,39 @@
+package dataarts
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// ParseQueryError400 is a method used to parse whether a 404 error message means the resources not found.
+// For the DataArts Studio service, there are some known 404 error codes:
+// + Workspace:
+//   - DLM.4001: Instance or workspace does not exist.
+//
+// + Data Service:
+//   - DLM.4205: catalog does not found.
+func ParseQueryError400(err error, specErrors []string) error {
+	var err400 golangsdk.ErrDefault400
+	if errors.As(err, &err400) {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(err400.Body, &apiError); jsonErr != nil {
+			return err
+		}
+
+		errCode, searchErr := jmespath.Search("error_code", apiError)
+		if searchErr != nil {
+			return err
+		}
+
+		for _, v := range specErrors {
+			if errCode == v {
+				return golangsdk.ErrDefault404{}
+			}
+		}
+	}
+	return err
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_catalog.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_catalog.go
@@ -1,0 +1,365 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var CatalogResourceNotFoundCodes = []string{
+	"DLM.4001", // Instance or workspace does not exist.
+	"DLM.4205", // Catalog does not exist
+}
+
+// @API DataArtsStudio POST /v1/{project_id}/service/servicecatalogs
+// @API DataArtsStudio GET /v1/{project_id}/service/servicecatalogs/{catalog_id}
+// @API DataArtsStudio PUT /v1/{project_id}/service/servicecatalogs/{catalog_id}
+// @API DataArtsStudio POST /v1/{project_id}/service/servicecatalogs/{catalog_id}/move
+// @API DataArtsStudio DELETE /v1/{project_id}/service/servicecatalogs/{catalog_id}
+func ResourceDatatServiceCatalog() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDatatServiceCatalogCreate,
+		ReadContext:   resourceDatatServiceCatalogRead,
+		UpdateContext: resourceDatatServiceCatalogUpdate,
+		DeleteContext: resourceDatatServiceCatalogDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDataServiceCatalogImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the catalog is located.`,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the workspace to which the catalog belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the catalog.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the catalog.`,
+			},
+			"dlm_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The type of DLM engine.`,
+			},
+			"parent_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "0", // Root path.
+				Description: `The ID of the parent catalog for current catalog.`,
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The path of current catalog.`,
+			},
+			"catalog_total": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total number of sub-catalogs in the current catalog.`,
+			},
+			"api_total": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total number of APIs in the current catalog.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the catalog.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the catalog.`,
+			},
+			"create_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator of the catalog.`,
+			},
+			"update_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The user who latest updated the catalog.`,
+			},
+		},
+	}
+}
+
+func buildCreateDatatServiceCatalogBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+		"pid":         utils.ValueIngoreEmpty(d.Get("parent_id")),
+	}
+	return bodyParams
+}
+
+func resourceDatatServiceCatalogCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/service/servicecatalogs"
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    d.Get("workspace_id").(string),
+			"Dlm-Type":     d.Get("dlm_type").(string),
+		},
+		JSONBody: utils.RemoveNil(buildCreateDatatServiceCatalogBodyParams(d)),
+	}
+
+	createAppResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating catalog: %s", err)
+	}
+
+	createAppRespBody, err := utils.FlattenResponse(createAppResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	catalogId, err := jmespath.Search("catalog_id", createAppRespBody)
+	if err != nil {
+		return diag.Errorf("catalog ID does not found in API response")
+	}
+	d.SetId(catalogId.(string))
+
+	return resourceDatatServiceCatalogRead(ctx, d, meta)
+}
+
+func resourceDatatServiceCatalogRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/service/servicecatalogs/{catalog_id}"
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{catalog_id}", d.Id())
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    d.Get("workspace_id").(string),
+			"Dlm-Type":     d.Get("dlm_type").(string),
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, ParseQueryError400(err, CatalogResourceNotFoundCodes), "error retrieving catalog")
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("path", utils.PathSearch("path", respBody, nil)),
+		d.Set("catalog_total", utils.PathSearch("catalog_total", respBody, nil)),
+		d.Set("api_total", utils.PathSearch("api_total", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", respBody, 0).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", respBody, 0).(float64))/1000, false)),
+		d.Set("create_user", utils.PathSearch("create_user", respBody, nil)),
+		d.Set("update_user", utils.PathSearch("update_user", respBody, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildUpdateDatatServiceCatalogBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": d.Get("description"),
+	}
+	return bodyParams
+}
+
+func updateCatalogBasicConfigs(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl   = "v1/{project_id}/service/servicecatalogs/{catalog_id}"
+		catalogId = d.Id()
+	)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{catalog_id}", catalogId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    d.Get("workspace_id").(string),
+			"Dlm-Type":     d.Get("dlm_type").(string),
+		},
+		JSONBody: buildUpdateDatatServiceCatalogBodyParams(d),
+	}
+
+	_, err := client.Request("PUT", createPath, &opt)
+	if err != nil {
+		return fmt.Errorf("error updating catalog (%s): %s", catalogId, err)
+	}
+	return nil
+}
+
+func updateCatalogParentId(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl   = "v1/{project_id}/service/servicecatalogs/{catalog_id}/move"
+		catalogId = d.Id()
+	)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{catalog_id}", catalogId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{204},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    d.Get("workspace_id").(string),
+			"Dlm-Type":     d.Get("dlm_type").(string),
+		},
+		JSONBody: map[string]interface{}{
+			"target_pid": d.Get("parent_id"),
+		},
+	}
+
+	_, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return fmt.Errorf("error moving current catalog to a new path: %s", err)
+	}
+	return nil
+}
+
+func resourceDatatServiceCatalogUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	if d.HasChanges("name", "description") {
+		err = updateCatalogBasicConfigs(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("parent_id") {
+		err = updateCatalogParentId(client, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceDatatServiceCatalogRead(ctx, d, meta)
+}
+
+func resourceDatatServiceCatalogDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v1/{project_id}/service/servicecatalogs/batch-delete"
+		workspaceId = d.Get("workspace_id").(string)
+		catalogId   = d.Id()
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	// Due to the lack of an interface for deleting a single directory, the corresponding function can only be
+	// implemented through the batch deletion interface, and the batch deletion API cannot be sent to the server
+	// at the same time, which will cause an error to be returned.
+	config.MutexKV.Lock(workspaceId)
+	defer config.MutexKV.Unlock(workspaceId)
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{204},
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    workspaceId,
+			"Dlm-Type":     d.Get("dlm_type").(string),
+		},
+		JSONBody: map[string]interface{}{
+			"ids": []string{catalogId},
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error deleting catalog (%s): %s", catalogId, err)
+	}
+	return nil
+}
+
+func resourceDataServiceCatalogImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 && len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import ID, must be '<workspace_id>/<dlm_type>/<id>' or "+
+			"'<workspace_id>/<id>', but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(nil, d.Set("workspace_id", parts[0]))
+	if len(parts) == 2 {
+		d.SetId(parts[1])
+	}
+	if len(parts) == 3 {
+		mErr = multierror.Append(mErr, d.Set("dlm_type", parts[1]))
+		d.SetId(parts[2])
+	}
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to manage catalogs for DataArts Data Service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support new resource.
2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dataarts' TESTARGS='-run=TestAccDataServiceCatalog_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run=TestAccDataServiceCatalog_basic -timeout 360m -parallel 4
=== RUN   TestAccDataServiceCatalog_basic
=== PAUSE TestAccDataServiceCatalog_basic
=== CONT  TestAccDataServiceCatalog_basic
--- PASS: TestAccDataServiceCatalog_basic (76.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  76.468s
```
