### PR TITLE
feat(dli): the queue resource supports setting properties

### DIFF
--- a/docs/resources/dli_queue.md
+++ b/docs/resources/dli_queue.md
@@ -105,6 +105,10 @@ The following arguments are supported:
      For the default scaling policy, except for the `impact_start_time` and `impact_stop_time`, which are not allowed to
      be modified, other values can be modified according to the actual situation.
 
+* `spark_driver` - (Optional, List) Specifies spark driver configuration of the queue.
+  This parameter is only available if `queue_type` is set to `sql`.
+  The [spark_driver](#queue_spark_driver) structure is documented below.
+
 <a name="queue_scaling_policies"></a>
 The `scaling_policies` block supports:
 
@@ -129,6 +133,24 @@ The `scaling_policies` block supports:
   The number must be a multiple of `4`.
   
   -> The maximum CUs of any queue in an elastic resource pool cannot be more than the maximum CUs of the pool.
+
+<a name="queue_spark_driver"></a>
+The `spark_driver` block supports:
+
+* `max_instance` - (Optional, Int) Specifies the maximum number of spark drivers that can be started on the queue.
+  If the `cu_count` is `16`, the value can only be `2`.
+  If The `cu_count` is greater than `16`, the minimum value is `2`, the maximum value is the number of queue CUs
+  divided by `16`.
+
+* `max_concurrent` - (Optional, Int) Specifies the maximum number of tasks that can be concurrently executed by a spark driver.
+  The valid value ranges from `1` to `32`.
+
+* `max_prefetch_instance` - (Optional, String) Specifies the maximum number of spark drivers to be pre-started on the queue.
+  The minimum value is `0`. If the `cu_count` is less than `32`, the maximum value is `1`.
+  If the `cu_count` is greater than or equal to `32`, the maximum value is the number of queue CUs divided by `16`.
+
+  -> If the minimum CUs of the queue is less than `16` CUs, the `max_instance` and `max_prefetch_instance` parameters
+     does not take effect.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762
+	github.com/chnsz/golangsdk v0.0.0-20240418022603-d3c99f628233
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762 h1:yEkY1dexnt7HdLdoyuJ98Y+VHBlWAJm4tWmP8e+ft38=
-github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240418022603-d3c99f628233 h1:pZtrA6aLmmeXyKn5ny083jUIknHa9woSylP+GqGS/zk=
+github.com/chnsz/golangsdk v0.0.0-20240418022603-d3c99f628233/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/queues/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/queues/requests.go
@@ -1,0 +1,71 @@
+package queues
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListQueuePropertyOpts is the structure that used to query the list of the queue properties.
+type ListQueuePropertyOpts struct {
+	// The queue name.
+	QueueName string `json:"-" required:"true"`
+	// The offset number.
+	Offset int `q:"offset"`
+	// Number of records to be queried.
+	Limit int `q:"limit"`
+}
+
+// ListQueueProperty is the method that used to query list of the queue properties using given parameters.
+func ListQueueProperty(c *golangsdk.ServiceClient, opts ListQueuePropertyOpts) ([]PropertyResp, error) {
+	url := propertyURL(c, opts.QueueName)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	url += query.String()
+	pager := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := QueuePropertyPage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	})
+
+	pages, err := pager.AllPages()
+	if err != nil {
+		return nil, err
+	}
+	return ExtractProperties(pages)
+}
+
+// Property is the structure that used to update the property of the queue.
+type Property struct {
+	// Maximum number of Spark drivers can be started on this queue.
+	MaxInstance int `json:"computeEngine.maxInstance,omitempty"`
+	// Maximum number of tasks can be concurrently executed by a Spark driver.
+	MaxConcurrent int `json:"job.maxConcurrent,omitempty"`
+	// Maximum number of Spark drivers can be pre-started on this queue.
+	MaxPrefetchInstance *int `json:"computeEngine.maxPrefetchInstance,omitempty"`
+	// The cidr of the queue.
+	Cidr string `json:"network.cidrInVpc,omitempty"`
+}
+
+// UpdateQueueProperty is the method that used to update property of the queue using given parameters.
+func UpdateQueueProperty(c *golangsdk.ServiceClient, queueName string, opts Property) (*QueuePropertyResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "properties")
+	if err != nil {
+		return nil, err
+	}
+	var r QueuePropertyResp
+	_, err = c.Put(propertyURL(c, queueName), b, &r, &golangsdk.RequestOpts{})
+	return &r, err
+}
+
+// DeleteQueueProperties is the method that used to delete properties of the queue.
+func DeleteQueueProperties(c *golangsdk.ServiceClient, queueName string, opts []string) (*QueuePropertyResp, error) {
+	var r QueuePropertyResp
+	_, err := c.DeleteWithResponse(propertyURL(c, queueName), &r, &golangsdk.RequestOpts{
+		JSONBody: map[string]interface{}{
+			"keys": opts,
+		},
+	})
+	return &r, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/queues/result.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/queues/result.go
@@ -1,0 +1,34 @@
+package queues
+
+import "github.com/chnsz/golangsdk/pagination"
+
+// PropertyResp is the structure that represents property detail of the queue.
+type PropertyResp struct {
+	// The valid values are as follows:
+	// + computeEngine.maxInstances: Maximum number of Spark drivers can be started on this queue.
+	// + computeEngine.maxPrefetchInstan: Maximum number of Spark drivers can be pre-started on this queue.
+	// + job.maxConcurrent: Maximum number of tasks can be concurrently executed by a Spark driver.
+	// + multipleSc.support: Whether multiple spark drivers can be configured.
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// QueuePropertyPage is a single page maximum result representing a query by offset page.
+type QueuePropertyPage struct {
+	pagination.OffsetPageBase
+}
+
+// ExtractProperties is a method to extract the list of properties.
+func ExtractProperties(r pagination.Page) ([]PropertyResp, error) {
+	var s []PropertyResp
+	err := r.(QueuePropertyPage).Result.ExtractIntoSlicePtr(&s, "properties")
+	return s, err
+}
+
+// QueuePropertyResp is the structure that represents response of UpdateQueueProperty or DeleteQueueProperties method.
+type QueuePropertyResp struct {
+	// Whether the request is successfully executed. Value true indicates that the request is successfully executed.
+	IsSuccess bool `json:"is_success"`
+	// System prompt. If execution succeeds, the parameter setting may be left blank.
+	Message string `json:"message"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/queues/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v3/queues/urls.go
@@ -1,0 +1,7 @@
+package queues
+
+import "github.com/chnsz/golangsdk"
+
+func propertyURL(c *golangsdk.ServiceClient, queueName string) string {
+	return c.ServiceURL("queues", queueName, "properties")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240418020440-443cc893b762
+# github.com/chnsz/golangsdk v0.0.0-20240418022603-d3c99f628233
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -130,6 +130,7 @@ github.com/chnsz/golangsdk/openstack/dli/v2/batches
 github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources
 github.com/chnsz/golangsdk/openstack/dli/v3/elasticresourcepool
 github.com/chnsz/golangsdk/openstack/dli/v3/flinkjob
+github.com/chnsz/golangsdk/openstack/dli/v3/queues
 github.com/chnsz/golangsdk/openstack/dli/v3/tags
 github.com/chnsz/golangsdk/openstack/dms/v1/groups
 github.com/chnsz/golangsdk/openstack/dms/v1/instances


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The queue resource supports configuration properities.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dli TESTARGS='-run TestAccDliQueue_sparkDriver'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDliQueue_sparkDriver -timeout 360m -parallel 4
=== RUN   TestAccDliQueue_sparkDriver
=== PAUSE TestAccDliQueue_sparkDriver
=== CONT  TestAccDliQueue_sparkDriver
--- PASS: TestAccDliQueue_sparkDriver (289.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       289.997s
```
