### PR TITLE
feat: fix(CDN): add new fields and remove expired fields

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -51,10 +51,11 @@ resource "huaweicloud_cdn_domain" "domain_1" {
 
   cache_settings {
     rules {
-      rule_type = "all"
-      ttl       = 180
-      ttl_type  = "d"
-      priority  = 2
+      rule_type          = "all"
+      ttl                = 180
+      ttl_type           = "d"
+      priority           = 2
+      url_parameter_type = "ignore_url_params"
     }
   }
 }
@@ -652,6 +653,18 @@ The `rules` block support:
     Up to 20 directories are supported.
   + If `rule_type` is set to **full_path**, the value must start with a slash (/) and cannot end with an asterisk.
     Example: `/test/index.html` or `/test/*.jpg`
+
+* `url_parameter_type` - (Optional, String) Specifies the URL parameter types. Valid values are as follows:
+  + **del_params**: Ignore specific URL parameters.
+  + **reserve_params**: Retain specific URL parameters.
+  + **ignore_url_params**: Ignore all URL parameters.
+  + **full_url**: Retain all URL parameters.
+
+  Defaults to **full_url**.
+
+* `url_parameter_value` - (Optional, String) Specifies the URL parameter values, which are separated by commas (,).
+  Up to 10 parameters can be set.
+  This parameter is mandatory when `url_parameter_type` is set to **del_params** or **reserve_params**.
 
 ## Attribute Reference
 

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -94,10 +94,6 @@ resource "huaweicloud_cdn_domain" "domain_1" {
       ocsp_stapling_status = "on"
     }
 
-    cache_url_parameter_filter {
-      type = "ignore_url_params"
-    }
-
     retrieval_request_header {
       name   = "test-name"
       value  = "test-val"
@@ -291,9 +287,6 @@ The `configs` block support:
 * `compress` - (Optional, List) Specifies the smart compression. The [compress](#compress_object) structure
   is documented below.
 
-* `cache_url_parameter_filter` - (Optional, List) Specifies the settings for caching URL parameters.
-  The [cache_url_parameter_filter](#cache_url_parameter_filter_object) structure is documented below.
-
 * `ip_frequency_limit` - (Optional, List) Specifies the IP access frequency limit.
   The [ip_frequency_limit](#ip_frequency_limit_object) structure is documented below.
 
@@ -429,17 +422,6 @@ The `compress` blocks support:
 
 * `type` - (Optional, String) Specifies the smart compression type.
   Possible values are: **gzip** (gzip) and **br** (Brotli).
-
-<a name="cache_url_parameter_filter_object"></a>
-The `cache_url_parameter_filter` block support:
-
-* `type` - (Optional, String) Specifies the operation type for caching URL parameters. Valid values are:
-  **full_url**: Cache all parameters
-  **ignore_url_params**: Ignore all parameters
-  **del_params**: Ignore specific URL parameters
-  **reserve_params**: Reserve specified URL parameters
-
-* `value` - (Optional, String) Specifies the parameter values. Multiple values are separated by semicolons (;).
 
 <a name="ip_frequency_limit_object"></a>
 The `ip_frequency_limit` block support:

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -469,7 +469,6 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "60"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.type", "ignore_url_params"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.type", "type_a"),
@@ -532,8 +531,6 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "update description"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "30"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.type", "del_params"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.cache_url_parameter_filter.0.value", "test_value"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name-update"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.value", "test-val-update"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.action", "set"),
@@ -648,10 +645,6 @@ resource "huaweicloud_cdn_domain" "test" {
     range_based_retrieval_enabled = true
     description                   = "test description"
     origin_receive_timeout        = "60"
-
-    cache_url_parameter_filter {
-      type = "ignore_url_params"
-    }
 
     retrieval_request_header {
       name   = "test-name"
@@ -781,11 +774,6 @@ resource "huaweicloud_cdn_domain" "test" {
     description                   = "update description"
     slice_etag_status             = "off"
     origin_receive_timeout        = "30"
-
-    cache_url_parameter_filter {
-      type  = "del_params"
-      value = "test_value"
-    }
 
     retrieval_request_header {
       name   = "test-name-update"

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -135,10 +135,12 @@ resource "huaweicloud_cdn_domain" "test" {
 
   cache_settings {
     rules {
-      rule_type = "all"
-      ttl       = 365
-      ttl_type  = "d"
-      priority  = 2
+      rule_type           = "all"
+      ttl                 = 365
+      ttl_type            = "d"
+      priority            = 2
+      url_parameter_type  = "del_params"
+      url_parameter_value = "test_value"
     }
   }
 
@@ -170,11 +172,12 @@ resource "huaweicloud_cdn_domain" "test" {
   cache_settings {
     follow_origin = true
     rules {
-      rule_type = "file_extension"
-      content   = ".jpg"
-      ttl       = 0
-      ttl_type  = "d"
-      priority  = 3
+      rule_type          = "file_extension"
+      content            = ".jpg"
+      ttl                = 0
+      ttl_type           = "d"
+      priority           = 3
+      url_parameter_type = "ignore_url_params"
     }
   }
 }

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -218,10 +218,11 @@ var compress = schema.Schema{
 }
 
 var cacheUrlParameterFilter = schema.Schema{
-	Type:     schema.TypeList,
-	Optional: true,
-	Computed: true,
-	MaxItems: 1,
+	Type:        schema.TypeList,
+	Optional:    true,
+	Computed:    true,
+	MaxItems:    1,
+	Description: "schema: Deprecated; Field `cache_url_parameter_filter` will be offline soon, use `cache_settings` instead",
 	Elem: &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"type": {

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -673,6 +673,14 @@ func ResourceCdnDomain() *schema.Resource {
 										Computed:    true,
 										Description: "schema: Required",
 									},
+									"url_parameter_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"url_parameter_value": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
 								},
 							},
 						},
@@ -1062,12 +1070,14 @@ func buildCacheRules(followOrigin bool, rules []interface{}) *[]model.CacheRules
 	for i, val := range rules {
 		rule := val.(map[string]interface{})
 		result[i] = model.CacheRules{
-			FollowOrigin: utils.StringIgnoreEmpty(parseFunctionEnabledStatus(followOrigin)),
-			MatchType:    utils.StringIgnoreEmpty(parseCacheRuleType(rule["rule_type"].(string))),
-			MatchValue:   utils.StringIgnoreEmpty(rule["content"].(string)),
-			Ttl:          utils.Int32(int32(rule["ttl"].(int))),
-			TtlUnit:      parseCacheTTLUnits(rule["ttl_type"].(string)),
-			Priority:     int32(rule["priority"].(int)),
+			FollowOrigin:      utils.StringIgnoreEmpty(parseFunctionEnabledStatus(followOrigin)),
+			MatchType:         utils.StringIgnoreEmpty(parseCacheRuleType(rule["rule_type"].(string))),
+			MatchValue:        utils.StringIgnoreEmpty(rule["content"].(string)),
+			Ttl:               utils.Int32(int32(rule["ttl"].(int))),
+			TtlUnit:           parseCacheTTLUnits(rule["ttl_type"].(string)),
+			Priority:          int32(rule["priority"].(int)),
+			UrlParameterType:  utils.StringIgnoreEmpty(rule["url_parameter_type"].(string)),
+			UrlParameterValue: utils.StringIgnoreEmpty(rule["url_parameter_value"].(string)),
 		}
 	}
 	return &result


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Add new fields: `url_parameter_type` and `url_parameter_value`.
- Remove expired fields: `cache_url_parameter_filter`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- The field `cache_url_parameter_filter` will be offline soon. An error will be reported when modifying it and `cache_settings` at the same time, so mark it `Deprecated`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (627.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       627.455s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (589.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       589.224s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (366.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       366.111s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_epsID_migrate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_epsID_migrate -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_epsID_migrate (266.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       266.229s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (584.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       584.215s
```