### PR TITLE
fix(GaussDB): fix gaussdb opengauss instance data source and test

### DIFF
--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_opengauss_instance_test.go
@@ -346,6 +346,11 @@ func testAccOpenGaussInstance_basic(rName, password string, replicaNum int) stri
 %[1]s
 
 resource "huaweicloud_gaussdb_opengauss_instance" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss,
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss_egress
+  ]
+
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -379,6 +384,11 @@ func testAccOpenGaussInstance_update(rName, password string, replicaNum int) str
 %[1]s
 
 resource "huaweicloud_gaussdb_opengauss_instance" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss,
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss_egress
+  ]
+
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -417,6 +427,11 @@ func testAccOpenGaussInstance_prepaid(rName, password string) string {
 %[1]s
 
 resource "huaweicloud_gaussdb_opengauss_instance" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss,
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss_egress
+  ]
+
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -458,6 +473,11 @@ func testAccOpenGaussInstance_prepaidUpdate(rName, password string) string {
 %[1]s
 
 resource "huaweicloud_gaussdb_opengauss_instance" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss,
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss_egress
+  ]
+
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -504,6 +524,10 @@ func testAccOpenGaussInstance_haModeCentralized(rName, password string) string {
 %[1]s
 
 resource "huaweicloud_gaussdb_opengauss_instance" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss,
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss_egress
+  ]
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -535,6 +559,11 @@ func testAccOpenGaussInstance_haModeCentralizedUpdate(rName, password string) st
 %[1]s
 
 resource "huaweicloud_gaussdb_opengauss_instance" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss,
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss_egress
+  ]
+
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id
@@ -571,6 +600,11 @@ func testAccOpenGaussInstance_withEpsId(rName, password string, replicaNum int, 
 %[1]s
 
 resource "huaweicloud_gaussdb_opengauss_instance" "test" {
+  depends_on = [
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss,
+    huaweicloud_networking_secgroup_rule.in_v4_tcp_opengauss_egress
+  ]
+
   vpc_id                = huaweicloud_vpc.test.id
   subnet_id             = huaweicloud_vpc_subnet.test.id
   security_group_id     = huaweicloud_networking_secgroup.test.id

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instance.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instance.go
@@ -303,7 +303,7 @@ func dataSourceOpenGaussInstanceRead(_ context.Context, d *schema.ResourceData, 
 	}
 
 	if shardingNum > 0 && coordinatorNum > 0 {
-		dnNum = shardingNum / 3
+		dnNum = shardingNum / instance.ReplicaNum
 		d.Set("nodes", nodesList)
 		d.Set("sharding_num", dnNum)
 		d.Set("coordinator_num", coordinatorNum)

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_opengauss_instances.go
@@ -321,7 +321,7 @@ func dataSourceOpenGaussInstancesRead(_ context.Context, d *schema.ResourceData,
 		}
 
 		if shardingNum > 0 && coordinatorNum > 0 {
-			dnNum = shardingNum / 3
+			dnNum = shardingNum / instanceInAll.ReplicaNum
 			instanceToSet["nodes"] = nodesList
 			instanceToSet["coordinator_num"] = coordinatorNum
 			instanceToSet["sharding_num"] = dnNum


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix gaussdb opengauss instance data source and test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix gaussdb opengauss instance data source and test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccOpenGaussInstanceDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccOpenGaussInstanceDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstanceDataSource_basic
=== PAUSE TestAccOpenGaussInstanceDataSource_basic
=== RUN   TestAccOpenGaussInstanceDataSource_haModeCentralized
=== PAUSE TestAccOpenGaussInstanceDataSource_haModeCentralized
=== CONT  TestAccOpenGaussInstanceDataSource_basic
=== CONT  TestAccOpenGaussInstanceDataSource_haModeCentralized
--- PASS: TestAccOpenGaussInstanceDataSource_haModeCentralized (1725.89s)
--- PASS: TestAccOpenGaussInstanceDataSource_basic (1732.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1732.335s

make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccOpenGaussInstancesDataSource_'        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccOpenGaussInstancesDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstancesDataSource_basic
=== PAUSE TestAccOpenGaussInstancesDataSource_basic
=== RUN   TestAccOpenGaussInstancesDataSource_haModeCentralized
=== PAUSE TestAccOpenGaussInstancesDataSource_haModeCentralized
=== CONT  TestAccOpenGaussInstancesDataSource_basic
=== CONT  TestAccOpenGaussInstancesDataSource_haModeCentralized
--- PASS: TestAccOpenGaussInstancesDataSource_haModeCentralized (1737.73s)
--- PASS: TestAccOpenGaussInstancesDataSource_basic (1933.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1933.139s
```
