### PR TITLE
feat(CDN): cdn domain support new field `configs.0.video_seek`

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -330,6 +330,13 @@ The `configs` block support:
 
   -> You can define referer whitelists and blacklists to control who can access specific domain names.
 
+* `video_seek` - (Optional, List) Specifies the video seek settings. The [video_seek](#video_seek_object) structure
+  is documented below.
+
+  -> 1. You need to configure a cache rule for `FLV` and `MP4` files and ignored all URL parameters in `cache_settings`.
+  <br/>2. Video seek is valid only when your origin server supports range requests.
+  <br/>3. Only `MP4` and `FLV` videos are supported.
+
 <a name="https_settings_object"></a>
 The `https_settings` block support:
 
@@ -644,6 +651,20 @@ The `referer` block support:
   A referer whitelist including blank `referers` indicates that requests without any `referers` are allowed to access.
 
   Defaults to **false**.
+
+<a name="video_seek_object"></a>
+The `video_seek` block support:
+
+* `enable_video_seek` - (Required, Bool) Specifies the video seek status. **true**: enabled; **false**: disabled.
+
+* `enable_flv_by_time_seek` - (Optional, Bool) Specifies the time-based `FLV` seek status.
+  **true**: enabled; **false**: disabled. Defaults to **false**.
+
+* `start_parameter` - (Optional, String) Specifies the video playback start parameter in user request URLs.
+  The value contains up to `64` characters. Only letters, digits, and underscores (_) are allowed.
+
+* `end_parameter` - (Optional, String) Specifies the video playback end parameter in user request URLs.
+  The value contains up to `64` characters. Only letters, digits, and underscores (_) are allowed.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -493,6 +493,11 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.type", "white"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.include_empty", "false"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.enable_video_seek", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.enable_flv_by_time_seek", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.start_parameter", "test-start"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.end_parameter", "test-end"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "2"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
@@ -565,6 +570,11 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.type", "black"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.referer.0.include_empty", "true"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.enable_video_seek", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.enable_flv_by_time_seek", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.start_parameter", "test-startUpdate"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.end_parameter", ""),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.match_type", "file_path"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.match_pattern", "/test/folder01;/test/folder02"),
@@ -623,6 +633,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "off"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.enable_video_seek", "false"),
 				),
 			},
 			{
@@ -721,6 +733,13 @@ resource "huaweicloud_cdn_domain" "test" {
       type          = "white"
       value         = "*.common.com,192.187.2.43,www.test.top:4990"
       include_empty = false
+    }
+
+    video_seek {
+      enable_video_seek       = true
+      enable_flv_by_time_seek = true
+      start_parameter         = "test-start"
+      end_parameter           = "test-end"
     }
 
     flexible_origin {
@@ -862,6 +881,12 @@ resource "huaweicloud_cdn_domain" "test" {
       include_empty = true
     }
 
+    video_seek {
+      enable_video_seek       = true
+      enable_flv_by_time_seek = false
+      start_parameter         = "test-startUpdate"
+    }
+
     flexible_origin {
       match_type    = "file_path"
       match_pattern = "/test/folder01;/test/folder02"
@@ -939,6 +964,10 @@ resource "huaweicloud_cdn_domain" "test" {
       inherit_config {
         enabled = false
       }
+    }
+
+    video_seek {
+      enable_video_seek = false
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

cdn domain support new field `configs.0.video_seek`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (653.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       653.099s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (654.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       654.345s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (444.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       444.342s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_epsID_migrate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_epsID_migrate -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_epsID_migrate (327.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       327.554s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (666.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       666.128s
```