### PR TITLE
feat(lb): support new params for load balancer

### DIFF
--- a/docs/resources/lb_loadbalancer.md
+++ b/docs/resources/lb_loadbalancer.md
@@ -59,6 +59,32 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the loadbalancer. Changing this
   creates a new loadbalancer.
 
+* `protection_status` - (Optional, String) Specifies whether modification protection is enabled. Value options:
+  + **nonProtection**: No protection.
+  + **consoleProtection**: Console modification protection.
+
+  Defaults to **nonProtection**.
+
+* `protection_reason` - (Optional, String) Specifies the reason to enable modification protection. Only valid when
+  `protection_status` is **consoleProtection**.
+
+* `charging_mode` - (Optional, String) Specifies the charging mode of the loadbalancer.  
+  The valid values are **prePaid** and **postPaid**, defaults to **postPaid**.
+
+* `period_unit` - (Optional, String) Specifies the charging period unit of the loadbalancer.  
+  Valid values are **month** and **year**. This parameter is mandatory if `charging_mode` is set to **prePaid**.
+
+* `period` - (Optional, Int) Specifies the charging period of the loadbalancer.
+  + If `period_unit` is set to **month**, the value ranges from `1` to `9`.
+  + If `period_unit` is set to **year**, the value ranges from `1` to `3`.
+
+  This parameter is mandatory if `charging_mode` is set to **prePaid**.
+
+* `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.  
+  Valid values are **true** and **false**. Defaults to **false**.
+
+-> **NOTE:** `period_unit`, `period` and `auto_renew` can only be updated when changing to **prePaid** billing mode.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -66,6 +92,14 @@ In addition to all arguments above, the following attributes are exported:
 * `vip_port_id` - The Port ID of the Load Balancer IP.
 
 * `public_ip` - The EIP address that is associated to the Load Balancer instance.
+
+* `charge_mode` - Indicates how the load balancer will be billed.
+
+* `frozen_scene` - Indicates the scenario where the load balancer is frozen.
+
+* `created_at` - The create time of the load balancer.
+
+* `updated_at` - The update time of the load balancer.
 
 ## Timeouts
 
@@ -81,4 +115,22 @@ Load balancers can be imported using the `id`, e.g.
 
 ```
 $ terraform import huaweicloud_lb_loadbalancer.test 3e3632db-36c6-4b28-a92e-e72e6562daa6
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `period_unit`, `period`, `auto_renew`.
+It is generally recommended running `terraform plan` after importing a loadbalancer.
+You can then decide if changes should be applied to the loadbalancer, or the resource definition should be updated to
+align with the loadbalancer. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_lb_loadbalancer" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      period_unit, period, auto_renew,
+    ]
+  }
+}
 ```

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
@@ -262,6 +262,9 @@ func resourceMemberV2Delete(ctx context.Context, d *schema.ResourceData, meta in
 		}
 		return nil
 	})
+	if err != nil {
+		return diag.Errorf("error deleting member: %s", err)
+	}
 
 	// Wait for LB to become ACTIVE
 	err = waitForLBV2viaPool(ctx, lbClient, poolID, "ACTIVE", timeout)

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_pool.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_pool.go
@@ -385,6 +385,9 @@ func resourcePoolV2Delete(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 		return nil
 	})
+	if err != nil {
+		return diag.Errorf("error deleting pool: %s", err)
+	}
 
 	if lbID != "" {
 		err = waitForLBV2LoadBalancer(ctx, lbClient, lbID, "ACTIVE", nil, timeout)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new params for `huaweicloud_lb_loadbalancer`, including `protection_status`, `protection_reason`, `charging_mode`, `period_unit`, `period`, `auto_renew` and new atts `charge_mode`, `frozen_scene`, `created_at`, `updated_at`.

Fix the error return for `huaweicloud_lb_pool` and `huaweicloud_lb_member`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/lb" TESTARGS="-run TestAccLBV2LoadBalancer_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run TestAccLBV2LoadBalancer_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (115.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        115.042s

make testacc TEST="./huaweicloud/services/acceptance/lb" TESTARGS="-run TestAccLBV2LoadBalancer_changeToPrePaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run TestAccLBV2LoadBalancer_changeToPrePaid -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_changeToPrePaid
=== PAUSE TestAccLBV2LoadBalancer_changeToPrePaid
=== CONT  TestAccLBV2LoadBalancer_changeToPrePaid
--- PASS: TestAccLBV2LoadBalancer_changeToPrePaid (134.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        134.806s
```
