### PR TITLE
fix(RDS): fix rds instance and replica instanc ssl enable

### DIFF
--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
@@ -79,7 +79,7 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"ssl_enable", "parameters",
+					"parameters",
 				},
 			},
 		},

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_read_replica_instance.go
@@ -135,6 +135,7 @@ func ResourceRdsReadReplicaInstance() *schema.Resource {
 			"ssl_enable": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"parameters": {
 				Type: schema.TypeSet,
@@ -417,6 +418,7 @@ func resourceRdsReadReplicaInstanceRead(ctx context.Context, d *schema.ResourceD
 	d.Set("type", instance.Type)
 	d.Set("status", instance.Status)
 	d.Set("enterprise_project_id", instance.EnterpriseProjectId)
+	d.Set("ssl_enable", instance.EnableSsl)
 	d.Set("tags", utils.TagsToMap(instance.Tags))
 
 	if len(instance.PrivateIps) > 0 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds instance and replica instanc ssl enable
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds instance and replica instanc ssl enable
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccOpenGaussInstanceDataSource_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccOpenGaussInstanceDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccOpenGaussInstanceDataSource_basic
=== PAUSE TestAccOpenGaussInstanceDataSource_basic
=== RUN   TestAccOpenGaussInstanceDataSource_haModeCentralized
=== PAUSE TestAccOpenGaussInstanceDataSource_haModeCentralized
=== CONT  TestAccOpenGaussInstanceDataSource_basic
=== CONT  TestAccOpenGaussInstanceDataSource_haModeCentralized
--- PASS: TestAccOpenGaussInstanceDataSource_haModeCentralized (1725.89s)
--- PASS: TestAccOpenGaussInstanceDataSource_basic (1732.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1732.335s


make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccReadReplicaInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccReadReplicaInstance_ -timeout 360m -parallel 4
=== RUN   TestAccReadReplicaInstance_basic
=== PAUSE TestAccReadReplicaInstance_basic
=== RUN   TestAccReadReplicaInstance_withEpsId
=== PAUSE TestAccReadReplicaInstance_withEpsId
=== CONT  TestAccReadReplicaInstance_basic
=== CONT  TestAccReadReplicaInstance_withEpsId
    acceptance.go:521: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccReadReplicaInstance_withEpsId (0.01s)
--- PASS: TestAccReadReplicaInstance_basic (2364.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2364.932s
```
