### PR TITLE
feat(cbh/instance): support update security group

### DIFF
--- a/docs/resources/cbh_instance.md
+++ b/docs/resources/cbh_instance.md
@@ -54,9 +54,8 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `security_group_id` - (Required, String, ForceNew) Specifies the ID of the security group.
-
-  Changing this parameter will create a new resource.
+* `security_group_id` - (Required, String) Specifies the IDs of the security group. Multiple security group IDs are
+  separated by commas (,) without spaces.
 
 * `availability_zone` - (Required, String, ForceNew) Specifies the availability zone name.
 

--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
@@ -86,11 +86,10 @@ func TestAccCBHInstance_basic(t *testing.T) {
 						"huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttrPair(rName, "subnet_id",
 						"huaweicloud_vpc_subnet.test", "id"),
-					resource.TestCheckResourceAttrPair(rName, "security_group_id",
-						"huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttrPair(rName, "availability_zone",
 						"data.huaweicloud_availability_zones.test", "names.0"),
 
+					resource.TestCheckResourceAttrSet(rName, "security_group_id"),
 					resource.TestCheckResourceAttrSet(rName, "private_ip"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
 					resource.TestCheckResourceAttrSet(rName, "version"),
@@ -102,6 +101,8 @@ func TestAccCBHInstance_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "password", "test_147258"),
 					resource.TestCheckResourceAttr(rName, "auto_renew", "true"),
+					resource.TestCheckResourceAttrPair(rName, "security_group_id",
+						"huaweicloud_networking_secgroup.test", "id"),
 				),
 			},
 			{
@@ -123,10 +124,15 @@ func TestAccCBHInstance_basic(t *testing.T) {
 
 func testCBHInstance_base(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
+
+resource "huaweicloud_networking_secgroup" "test2" {
+  name                 = "%[2]s_2"
+  delete_default_rules = true
+}
 
 data "huaweicloud_availability_zones" "test" {}
-`, common.TestBaseNetwork(name))
+`, common.TestBaseNetwork(name), name)
 }
 
 func testCBHInstance_basic(name string) string {
@@ -139,7 +145,7 @@ resource "huaweicloud_cbh_instance" "test" {
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
   subnet_address    = "192.168.0.154"
-  security_group_id = huaweicloud_networking_secgroup.test.id
+  security_group_id = join(",", [huaweicloud_networking_secgroup.test.id, huaweicloud_networking_secgroup.test2.id])
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   password          = "test_123456"
   charging_mode     = "prePaid"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
cbh instance support update  security group
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
1. `security_group_id` field support update.
2. Due to API limitations, only one security group ID can be specified when creating an instance.
3. When querying, the format returned by the API is "security_group_id": "xxx, xxx".

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_basic
=== PAUSE TestAccCBHInstance_basic
=== CONT  TestAccCBHInstance_basic
--- PASS: TestAccCBHInstance_basic (1104.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1104.583s

```
