### PR TITLE
feat(CDN): CDN domain resource support new fields

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -480,6 +480,10 @@ The `compress` blocks support:
 * `type` - (Optional, String) Specifies the smart compression type.
   Possible values are: **gzip** (gzip) and **br** (Brotli).
 
+* `file_type` - (Optional, String) Specifies the formats of files to be compressed. Enter up to 200 characters.
+  Multiple formats are separated by commas (,). Each format contains up to 50 characters.
+  Defaults to **.js,.html,.css,.xml,.json,.shtml,.htm**.
+
 <a name="ip_frequency_limit_object"></a>
 The `ip_frequency_limit` block support:
 

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -136,6 +136,15 @@ resource "huaweicloud_cdn_domain" "domain_1" {
       }
     }
 
+    request_limit_rules {
+      limit_rate_after = 50
+      limit_rate_value = 1048576
+      match_type       = "catalog"
+      match_value      = "/test/ff"
+      priority         = 4
+      type             = "size"
+    }
+
     remote_auth {
       enabled = true
 
@@ -336,6 +345,11 @@ The `configs` block support:
   -> 1. You need to configure a cache rule for `FLV` and `MP4` files and ignored all URL parameters in `cache_settings`.
   <br/>2. Video seek is valid only when your origin server supports range requests.
   <br/>3. Only `MP4` and `FLV` videos are supported.
+
+* `request_limit_rules` - (Optional, List) Specifies the request rate limiting rules.
+  The [request_limit_rules](#request_limit_rules_object) structure is documented below.
+
+  -> Up to 60 request limit rules can be configured.
 
 <a name="https_settings_object"></a>
 The `https_settings` block support:
@@ -669,6 +683,28 @@ The `video_seek` block support:
 
 * `end_parameter` - (Optional, String) Specifies the video playback end parameter in user request URLs.
   The value contains up to `64` characters. Only letters, digits, and underscores (_) are allowed.
+
+<a name="request_limit_rules_object"></a>
+The `request_limit_rules` block support:
+
+* `priority` - (Required, Int) Specifies the unique priority. A larger value indicates a higher priority.
+  The value ranges from **1** to **100**.
+
+* `match_type` - (Required, String) Specifies the match type. The options are **all** (all files) and **catalog** (directory).
+
+* `type` - (Required, String) Specifies the rate limit mode. Currently, only rate limit by traffic is supported.
+  This parameter can only be set to **size**.
+
+* `limit_rate_after` - (Required, Int) Specifies the rate limiting condition. Unit: byte.
+  The value ranges from **0** to **1,073,741,824**.
+
+* `limit_rate_value` - (Required, Int) Specifies the rate limiting value, in bit/s.
+  The value ranges from **0** to **104,857,600**.
+
+-> The speed is limited to the value of `limit_rate_value` after `limit_rate_after` bytes are transmitted.
+
+* `match_value` - (Optional, String) Specifies the match type value. This field is required when `match_type` is
+  set to **catalog**. The value is a directory address starting with a slash (/), for example, **/test**.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -503,6 +503,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "2"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.#", "2"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "403"),
@@ -590,6 +592,14 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.ip_or_domain", "www.hshs.cdd"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.0.back_sources.0.sources_type", "domain"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.0.limit_rate_after", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.0.limit_rate_value", "104857600"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.0.match_type", "catalog"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.0.match_value", "/test/ff"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.0.priority", "4"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.0.type", "size"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "503"),
@@ -632,6 +642,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "5"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
@@ -777,6 +788,23 @@ resource "huaweicloud_cdn_domain" "test" {
       }
     }
 
+    request_limit_rules {
+      limit_rate_after = 0
+      limit_rate_value = 0
+      match_type       = "all"
+      priority         = 2
+      type             = "size"
+    }
+    
+    request_limit_rules {
+      limit_rate_after = 1073741824
+      limit_rate_value = 104857600
+      match_type       = "catalog"
+      match_value      = "/test/ff"
+      priority         = 5
+      type             = "size"
+    }
+
     remote_auth {
       enabled = true
 
@@ -910,6 +938,15 @@ resource "huaweicloud_cdn_domain" "test" {
         ip_or_domain = "www.hshs.cdd"
         sources_type = "domain"
       }
+    }
+
+    request_limit_rules {
+      limit_rate_after = 0
+      limit_rate_value = 104857600
+      match_type       = "catalog"
+      match_value      = "/test/ff"
+      priority         = 4
+      type             = "size"
     }
 
     remote_auth {

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -484,7 +484,10 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_type", "m3u8,mpd"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_time_type", "sys_time"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "on"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.type", "gzip"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.file_type", ".js,.html,.css,.xml,.json,.shtml,.htm"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.type", "http"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.redirect_code", "301"),
@@ -561,7 +564,10 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_type", "mpd"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.inherit_time_type", "parent_url_time"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "on"),
-					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.type", "br"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.file_type", ".js,.html"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.type", "http"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.force_redirect.0.redirect_code", "302"),
@@ -633,6 +639,9 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.inherit_config.0.status", "off"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.compress.0.enabled", "false"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.video_seek.0.enable_video_seek", "false"),
 				),
@@ -720,7 +729,8 @@ resource "huaweicloud_cdn_domain" "test" {
     }
 
     compress {
-      enabled = false
+      enabled = true
+      type    = "gzip"
     }
 
     force_redirect {
@@ -866,7 +876,9 @@ resource "huaweicloud_cdn_domain" "test" {
     }
 
     compress {
-      enabled = false
+      enabled   = true
+      type      = "br"
+      file_type = ".js,.html"
     }
 
     force_redirect {
@@ -964,6 +976,10 @@ resource "huaweicloud_cdn_domain" "test" {
       inherit_config {
         enabled = false
       }
+    }
+
+    compress {
+      enabled = false
     }
 
     video_seek {

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -259,6 +259,11 @@ var compress = schema.Schema{
 				Optional: true,
 				Computed: true,
 			},
+			"file_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -939,8 +944,9 @@ func buildCompressOpts(rawCompress []interface{}) *model.Compress {
 
 	compress := rawCompress[0].(map[string]interface{})
 	compressOpts := model.Compress{
-		Status: parseFunctionEnabledStatus(compress["enabled"].(bool)),
-		Type:   utils.StringIgnoreEmpty(compress["type"].(string)),
+		Status:   parseFunctionEnabledStatus(compress["enabled"].(bool)),
+		Type:     utils.StringIgnoreEmpty(compress["type"].(string)),
+		FileType: utils.StringIgnoreEmpty(compress["file_type"].(string)),
 	}
 
 	return &compressOpts
@@ -1538,9 +1544,10 @@ func flattenCompressAttrs(compress *model.Compress) []map[string]interface{} {
 	}
 
 	compressAttrs := map[string]interface{}{
-		"status":  compress.Status,
-		"type":    compress.Type,
-		"enabled": analyseFunctionEnabledStatus(compress.Status),
+		"status":    compress.Status,
+		"type":      compress.Type,
+		"file_type": compress.FileType,
+		"enabled":   analyseFunctionEnabledStatus(compress.Status),
 	}
 
 	return []map[string]interface{}{compressAttrs}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- CDN domain resource support new field `configs.0.compress.0.file_type`.
- CDN domain resource support new field `configs.0.request_limit_rules`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (809.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       809.359s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (840.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       840.920s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (488.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       488.182s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_epsID_migrate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_epsID_migrate -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_epsID_migrate (348.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       348.372s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (761.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       761.344s
```