### PR TITLE
feat(RDS): rds instance support read write permissions

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -317,6 +317,10 @@ The `db` block supports:
   -> **NOTE:** `rotate_day`, `secret_id`, `secret_name` and `secret_version` will only take effect when `tde_enabled`
   is **true**.
 
+* `read_write_permissions` - (Optional, String) Specifies the read write permissions of the instance. Valid values:
+  + **readwrite**: read write permissions.
+  + **readonly**: readonly permissions.
+
 The `volume` block supports:
 
 * `size` - (Required, Int) Specifies the volume size. Its value range is from 40 GB to 4000 GB. The value must be a

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240419031333-15c783d48321
+	github.com/chnsz/golangsdk v0.0.0-20240422111604-27d1f9a6f456
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240419031333-15c783d48321 h1:rQJdMQnC22uJ6vnw5Du/TiU63Eh7vXjjvgXTaTZFA98=
-github.com/chnsz/golangsdk v0.0.0-20240419031333-15c783d48321/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240422111604-27d1f9a6f456 h1:v+GvJez+slXIh5Fbt5T8NTVUG++7rZP5tSW3zC2FCnM=
+github.com/chnsz/golangsdk v0.0.0-20240422111604-27d1f9a6f456/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -677,6 +677,7 @@ resource "huaweicloud_rds_instance" "test" {
   availability_zone      = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
   ssl_enable             = true  
   binlog_retention_hours = "12"
+  read_write_permissions = "readonly"
 
   db {
     type     = "MySQL"
@@ -728,6 +729,7 @@ resource "huaweicloud_rds_instance" "test" {
   ssl_enable             = false
   param_group_id         = huaweicloud_rds_parametergroup.pg_1.id
   binlog_retention_hours = "0"
+  read_write_permissions = "readwrite"
 
   db {
     password = "Huangwei!120521"
@@ -780,6 +782,7 @@ resource "huaweicloud_rds_instance" "test" {
   ssl_enable             = false
   param_group_id         = huaweicloud_rds_parametergroup.pg_1.id
   binlog_retention_hours = "6"
+  read_write_permissions = "readwrite"
 
   db {
     password = "Huangwei!120521"

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/loadbalancers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/loadbalancers/requests.go
@@ -108,6 +108,12 @@ type CreateOpts struct {
 
 	// Enterprise project ID
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
+
+	// Protection status
+	ProtectionStatus string `json:"protection_status,omitempty"`
+
+	// Protection reason
+	ProtectionReason string `json:"protection_reason,omitempty"`
 }
 
 // ToLoadBalancerCreateMap builds a request body from CreateOpts.
@@ -153,6 +159,12 @@ type UpdateOpts struct {
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Update protection status
+	ProtectionStatus string `json:"protection_status,omitempty"`
+
+	// Update protection reason
+	ProtectionReason *string `json:"protection_reason,omitempty"`
 }
 
 // ToLoadBalancerUpdateMap builds a request body from UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/loadbalancers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v2/loadbalancers/results.go
@@ -61,6 +61,27 @@ type LoadBalancer struct {
 
 	// The public ip of the loadbalancer.
 	PublicIps []PublicIp `json:"publicips"`
+
+	// Update protection status
+	ProtectionStatus string `json:"protection_status"`
+
+	// Update protection reason
+	ProtectionReason string `json:"protection_reason"`
+
+	// Billing info
+	BillingInfo string `json:"billing_info"`
+
+	// Charge mode
+	ChargeMode string `json:"charge_mode"`
+
+	// Frozen scene
+	FrozenScene string `json:"frozen_scene"`
+
+	// The create time.
+	CreatedAt string `json:"created_at"`
+
+	// The update time.
+	UpdatedAt string `json:"updated_at"`
 }
 
 type PublicIp struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/requests.go
@@ -326,3 +326,29 @@ func RemoveAvailabilityZone(c *golangsdk.ServiceClient, id string, opts Availabi
 	_, r.Err = c.Post(updateAvailabilityZoneURL(c, id, "batch-remove"), b, &r.Body, &golangsdk.RequestOpts{})
 	return
 }
+
+// Charging info.
+type ChangeChargingModeOpts struct {
+	LoadBalancerIds []string       `json:"loadbalancer_ids" required:"true"`
+	ChargingMode    string         `json:"charge_mode" required:"true"`
+	PrepaidOptions  PrepaidOptions `json:"prepaid_options,omitempty"`
+}
+
+type PrepaidOptions struct {
+	IncludePublicIp *bool  `json:"include_publicip,omitempty"`
+	PeriodType      string `json:"period_type" required:"true"`
+	PeriodNum       int    `json:"period_num,omitempty"`
+	AutoRenew       string `json:"auto_renew,omitempty"`
+	AutoPay         bool   `json:"auto_pay,omitempty"`
+}
+
+// ChangeChargingMode will change the charging mode of the loadbalancer
+func ChangeChargingMode(c *golangsdk.ServiceClient, opts ChangeChargingModeOpts) (r ChangeResult) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(changeChargingModeURL(c), b, &r.Body, &golangsdk.RequestOpts{})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/results.go
@@ -212,6 +212,23 @@ func (r GetStatusesResult) Extract() (*StatusTree, error) {
 	return s.Statuses, err
 }
 
+// ChangeResult represents the result of a ChangeChargingMode operation.
+// Call its Extract method to get the order ID.
+type ChangeResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts the order ID.
+func (r ChangeResult) Extract() (string, error) {
+	var s struct {
+		LoadBalancerIdList []string `json:"loadbalancer_id_list"`
+		EipIdList          []string `json:"eip_id_list"`
+		OrderId            string   `json:"order_id"`
+	}
+	err := r.ExtractInto(&s)
+	return s.OrderId, err
+}
+
 // CreateResult represents the result of a create operation. Call its Extract
 // method to interpret it as a LoadBalancer.
 type CreateResult struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers/urls.go
@@ -29,3 +29,7 @@ func resourceForceDeleteURL(c *golangsdk.ServiceClient, id string) string {
 func updateAvailabilityZoneURL(c *golangsdk.ServiceClient, id string, action string) string {
 	return c.ServiceURL(rootPath, resourcePath, id, azPath, action)
 }
+
+func changeChargingModeURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath, "change-charge-mode")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -829,3 +829,22 @@ func GetTdeStatus(c *golangsdk.ServiceClient, instanceId string) (r GetTdeStatus
 	})
 	return
 }
+
+type ModifyReadWritePermissionsOpts struct {
+	Readonly bool `json:"readonly"`
+}
+
+func (opts ModifyReadWritePermissionsOpts) ToActionInstanceMap() (map[string]interface{}, error) {
+	return toActionInstanceMap(opts)
+}
+
+// ModifyReadWritePermissions is a method used to modify the read write permissions of the instance.
+func ModifyReadWritePermissions(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r JobResult) {
+	b, err := opts.ToActionInstanceMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, instanceId, "readonly-status"), b, &r.Body, &golangsdk.RequestOpts{})
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240419031333-15c783d48321
+# github.com/chnsz/golangsdk v0.0.0-20240422111604-27d1f9a6f456
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support read write permissions
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support read write permissions
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=11
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 11
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_ha
--- PASS: TestAccRdsInstance_mariadb (675.24s)
--- PASS: TestAccRdsInstance_ha (768.05s)
--- PASS: TestAccRdsInstance_basic (802.25s)
--- PASS: TestAccRdsInstance_mysql_power_action (1122.30s)
--- PASS: TestAccRdsInstance_restore_pg (1653.43s)
--- PASS: TestAccRdsInstance_prePaid (1656.06s)
--- PASS: TestAccRdsInstance_restore_mysql (1735.21s)
--- PASS: TestAccRdsInstance_mysql (1808.75s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (2128.97s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2724.68s)
--- PASS: TestAccRdsInstance_sqlserver (3347.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3347.517s
```
