### PR TITLE
fix(dli/database): set the resource ID with name when the ID is not returned

### DIFF
--- a/docs/resources/dli_database.md
+++ b/docs/resources/dli_database.md
@@ -45,7 +45,9 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Resource ID in UUID format.
+* `id` - Resource ID.
+
+-> If the user has opened the EPS service, this value is a UUID value. If not, this value is the database name.
 
 ## Import
 

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_database.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_database.go
@@ -3,6 +3,7 @@ package dli
 import (
 	"context"
 	"fmt"
+	"log"
 	"regexp"
 
 	"github.com/hashicorp/go-multierror"
@@ -138,7 +139,15 @@ func resourceDliSQLDatabaseRead(_ context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return common.CheckDeletedDiag(d, err, "DLI database")
 	}
-	d.SetId(db.ResourceId)
+
+	if db.ResourceId == "" {
+		log.Printf("[WARN] unable to find the resource ID from the API response body during normal tenant (EPS " +
+			"service has not been activated), it maybe cause the resource ID not being effectively referenced into " +
+			"TMS tags management resource.")
+		d.SetId(dbName)
+	} else {
+		d.SetId(db.ResourceId)
+	}
 
 	mErr := multierror.Append(nil,
 		d.Set("name", db.Name),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The resource ID is not returned in the request response if the user has not opened EPS service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. set the resource ID with name when the ID is not returned.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDliDatabase_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDliDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccDliDatabase_basic
=== PAUSE TestAccDliDatabase_basic
=== CONT  TestAccDliDatabase_basic
--- PASS: TestAccDliDatabase_basic (17.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       17.551s
```
