### PR TITLE
feat(dataarts): add new resource support permission set privileges

### DIFF
--- a/docs/resources/dataarts_security_permission_set_privilege.md
+++ b/docs/resources/dataarts_security_permission_set_privilege.md
@@ -1,0 +1,145 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_permission_set_privilege"
+description: |-
+  Use this resource to assign data source permissions to workspace permission set or permission set within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_security_permission_set_privilege
+
+Use this resource to assign data source permissions to workspace permission set or permission set within HuaweiCloud.
+
+-> If you are assigning privileges to permission set, you can only select permission types included in the parent
+   permission set.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "permission_set_id" {}
+variable "permission_actions" {
+  type = list(string)
+}
+variable "database_name" {}
+variable "table_name" {}
+variable "connection_id" {}
+
+resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
+  workspace_id      = var.workspace_id
+  permission_set_id = var.permission_set_id
+  datasource_type   = "DLI"
+  type              = "ALLOW"
+  actions           = var.permission_actions
+  cluster_name      = "*"
+  database_name     = var.database_name
+  table_name        = var.table_name
+  connection_id     = var.connection_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the ID of the workspace to which the permission set belongs.
+  Changing this creates a new resource.
+
+* `permission_set_id` - (Required, String, ForceNew) Specifies the ID of the permission set to be granted.
+  Changing this creates a new resource.
+
+* `datasource_type` - (Required, String, ForceNew) Specifies the type of granted data source.
+  The valid values are **HIVE**, **DWS** and **DLI**.
+  Changing this creates a new resource.
+  
+* `type` - (Required, String, ForceNew) Specifies the type of permission to be configured.
+  Currently, only **ALLOW** is supported.
+  Changing this creates a new resource.
+
+* `actions` - (Required, List) Specifies the list of granted permissions. The valid length is limited from `1` to `32`,
+  The valid [permissions](#permissions_for_permission_set) are documented below.
+
+* `cluster_name` - (Required, String, ForceNew) Specifies the cluster name corresponding to the granted data source.
+  The valid ranges from `1` to `128`.
+  Changing this creates a new resource.
+  If `datasource_type` is set to `DLI`, the parameter is set to `*`.
+
+* `cluster_id` - (Optional, String, ForceNew) Specifies the cluster ID corresponding to the granted data source.
+  It is required when `datasource_type` is `HIVE` or `DWS`.
+  Changing this creates a new resource.
+
+* `connection_id` - (Optional, String) Specifies the data connection ID corresponding to the granted data source.
+
+* `database_url` - (Optional, String, ForceNew) Specifies the URL of the database corresponding to the granted data source.
+  Changing this creates a new resource.
+  This parameter is only valid when `datasource_type` is set to `HIVE`.
+  This parameter is conflict with `database_name`, `table_name` and `column_name`.
+
+* `database_name` - (Optional, String, ForceNew) Specifies the name of the database corresponding to the granted data source.
+  Changing this creates a new resource.
+  It is required when `datasource_type` is `DWS` or `DLI`.
+
+* `table_name` - (Optional, String, ForceNew) Specifies the name of the data table corresponding to the granted data source.
+  Changing this creates a new resource.
+
+* `column_name` - (Optional, String, ForceNew) Specifies the name of column corresponding to the granted data source.
+  Changing this creates a new resource.
+
+  -> 1. For `database_name`, `table_name` and `column_name` parameters, the valid length is limited from `1` to `128`,
+     only letters, digits, underscores (_) and asterisk (*) are allowed.<br/>2. The permissions of databases, tables,
+     and columns are managed by layer.
+     For example, a user who has been granted database permissions does not have the permissions of tables and columns.
+     Table and column permissions must be granted separately.
+  
+* `schema_name` - (Optional, String, ForceNew) Specifies the schema name corresponding to the DWS data source.
+  Changing this creates a new resource.
+  This parameter is only valid when `datasource_type` is set to `DWS`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `name` - The resource ID.
+
+* `status` - The current synchronization status of the resource.
+  The valid values are **UNKNOWN**, **NOT_SYNC**, **SYNC_SUCCESS** and **SYNC_FAIL**.
+
+* `sync_msg` - The status information of the resource.
+
+## Import
+
+The resource can be imported using `workspace_id`, `permission_set_id` and `id`, separated by slashes (/), e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_security_permission_set_privilege.test <workspace_id>/<permission_set_id>/<id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `connection_id`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      connection_id,
+    ]
+  }
+}
+```
+
+## Appendix
+
+<a name="permissions_for_permission_set"></a>
+| Type | HIVE | DWS | DLI |
+| ---- | ---- | --- | --- |
+| Permissions | ALL<br>SELECT<br>UPDATE<br>CREATE<br>DROP<br>ALTER<br>INDEX<br>READ<br>WRITE<br> | ALL<br>SELECT<br>UPDATE<br>DROP<br>ALTER<br>INSERT<br>CREATE_TABLE<br>DELETE<br>CREATE_SCHEMA<br> | SELECT<br>DROP<br>ALTER<br>INSERT<br>CREATE_TABLE |

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1327,9 +1327,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_job":      dataarts.ResourceFactoryJob(),
 			"huaweicloud_dataarts_factory_script":   dataarts.ResourceDataArtsFactoryScript(),
 			// DataArts Security
-			"huaweicloud_dataarts_security_data_recognition_rule": dataarts.ResourceSecurityRule(),
-			"huaweicloud_dataarts_security_permission_set":        dataarts.ResourceSecurityPermissionSet(),
-			"huaweicloud_dataarts_security_permission_set_member": dataarts.ResourceSecurityPermissionSetMember(),
+			"huaweicloud_dataarts_security_data_recognition_rule":    dataarts.ResourceSecurityRule(),
+			"huaweicloud_dataarts_security_permission_set":           dataarts.ResourceSecurityPermissionSet(),
+			"huaweicloud_dataarts_security_permission_set_member":    dataarts.ResourceSecurityPermissionSetMember(),
+			"huaweicloud_dataarts_security_permission_set_privilege": dataarts.ResourceSecurityPermissionSetPrivilege(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_app":     dataarts.ResourceDataServiceApp(),
 			"huaweicloud_dataarts_dataservice_catalog": dataarts.ResourceDatatServiceCatalog(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege_test.go
@@ -1,0 +1,149 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dataarts"
+)
+
+func getSecurityPermissionSetPrivilegeFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+	workspaceId := state.Primary.Attributes["workspace_id"]
+	permissionSetId := state.Primary.Attributes["permission_set_id"]
+	return dataarts.GetPrivilegeById(client, workspaceId, permissionSetId, state.Primary.ID)
+}
+
+func TestAccResourceSecurityPermissionSetPrivilege_basic(t *testing.T) {
+	var privliegeInfo interface{}
+	resourceName := "huaweicloud_dataarts_security_permission_set_privilege.test"
+	name := acceptance.RandomAccResourceName()
+	rc := acceptance.InitResourceCheck(resourceName, &privliegeInfo, getSecurityPermissionSetPrivilegeFunc)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsManagerID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceSecurityPermissionSetPrivilege_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "workspace_id", acceptance.HW_DATAARTS_WORKSPACE_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "permission_set_id", "huaweicloud_dataarts_security_permission_set.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "datasource_type", "DLI"),
+					resource.TestCheckResourceAttr(resourceName, "type", "ALLOW"),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_name", "*"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", "DLI"),
+					resource.TestCheckResourceAttr(resourceName, "database_name", name),
+					resource.TestCheckResourceAttr(resourceName, "table_name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+			{
+				Config: testAccResourceSecurityPermissionSetPrivilege_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       testAccSecurityPermissionSetPrivilegeImportFunc(resourceName),
+				ImportStateVerifyIgnore: []string{"connection_id"},
+			},
+		},
+	})
+}
+
+func testAccSecurityPermissionSetPrivilegeImportFunc(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", n, rs)
+		}
+		workspaceId := rs.Primary.Attributes["workspace_id"]
+		permissionSetId := rs.Primary.Attributes["permission_set_id"]
+		privilegeId := rs.Primary.ID
+		if workspaceId == "" || permissionSetId == "" || privilegeId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<workspace_id>/<permission_set_id>/<id>', but got '%s/%s/%s'",
+				workspaceId, permissionSetId, privilegeId)
+		}
+		return fmt.Sprintf("%s/%s/%s", workspaceId, permissionSetId, privilegeId), nil
+	}
+}
+
+func testAccResourceSecurityPermissionSetPrivilege_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_dli_database" "test" {
+  name                  = "%[3]s"
+  enterprise_project_id = "0"
+}
+  
+resource "huaweicloud_dli_table" "test" {
+  database_name = huaweicloud_dli_database.test.name
+  name          = "%[3]s"
+  data_location = "DLI"
+
+  columns {
+    name        = "name"
+    type        = "string"
+    description = "person name"
+  }
+}
+`, testAccDataConnection_basic(name), testAccSecurityPermissionSet_basic(name), name, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testAccResourceSecurityPermissionSetPrivilege_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+  
+resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
+  workspace_id      = "%[3]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  datasource_type   = "DLI"
+  type              = "ALLOW"
+  actions           = ["SELECT", "INSERT", "ALTER"]
+  cluster_name      = "*"
+  database_name     = huaweicloud_dli_database.test.name
+  table_name        = huaweicloud_dli_table.test.name
+  connection_id     = huaweicloud_dataarts_studio_data_connection.test.id
+}
+`, testAccResourceSecurityPermissionSetPrivilege_base(name), name, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testAccResourceSecurityPermissionSetPrivilege_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+  
+resource "huaweicloud_dataarts_security_permission_set_privilege" "test" {
+  workspace_id      = "%[3]s"
+  permission_set_id = huaweicloud_dataarts_security_permission_set.test.id
+  datasource_type   = "DLI"
+  type              = "ALLOW"
+  actions           = ["SELECT", "DROP"]
+  cluster_name      = "*"
+  database_name     = huaweicloud_dli_database.test.name
+  table_name        = huaweicloud_dli_table.test.name
+  connection_id     = huaweicloud_dataarts_studio_data_connection.test.id
+}
+`, testAccResourceSecurityPermissionSetPrivilege_base(name), name, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/common.go
+++ b/huaweicloud/services/dataarts/common.go
@@ -17,6 +17,7 @@ import (
 //
 // + Data Service:
 //   - DLM.4205: catalog does not found.
+//   - DLM.3027: Permission set does not found.
 func ParseQueryError400(err error, specErrors []string) error {
 	var err400 golangsdk.ErrDefault400
 	if errors.As(err, &err400) {

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
@@ -1,0 +1,341 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var PermissionSetPrivilegeResourceNotFoundCodes = []string{
+	"DLS.6036",
+	"DLS.3027",
+}
+
+// @API DataArtsStudio POST /v1/{project_id}/security/permission-sets/{permission_set_id}/permissions
+// @API DataArtsStudio GET /v1/{project_id}/security/permission-sets/{permission_set_id}/permissions
+// @API DataArtsStudio PUT /v1/{project_id}/security/permission-sets/{permission_set_id}/permissions/{permission_id}
+// @API DataArtsStudio POST /v1/{project_id}/security/permission-sets/{permission_set_id}/permissions/batch-delete
+func ResourceSecurityPermissionSetPrivilege() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecurityPermissionSetPrivilegeCreate,
+		ReadContext:   resourceSecurityPermissionSetPrivilegeRead,
+		UpdateContext: resourceSecurityPermissionSetPrivilegeUpdate,
+		DeleteContext: resourceSecurityPermissionSetPrivilegeDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceSecurityPermissionSetPrivilegeImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"permission_set_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"datasource_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"actions": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"connection_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"database_url": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"database_name", "table_name", "column_name"},
+			},
+			"database_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"database_url"},
+			},
+			"table_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"database_url"},
+			},
+			"column_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"database_url"},
+			},
+			"schema_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sync_msg": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSecurityPermissionSetPrivilegeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	creatPath := client.Endpoint + httpUrl
+	creatPath = strings.ReplaceAll(creatPath, "{project_id}", client.ProjectID)
+	creatPath = strings.ReplaceAll(creatPath, "{permission_set_id}", d.Get("permission_set_id").(string))
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody:         utils.RemoveNil(buildCreatePermissionSetPrivilegeBodyParams(d)),
+	}
+	resp, err := client.Request("POST", creatPath, &opts)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Security permission set privilege: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("id", respBody)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Security permission set privilege: ID is not found in API response")
+	}
+
+	d.SetId(id.(string))
+	return resourceSecurityPermissionSetPrivilegeRead(ctx, d, meta)
+}
+
+func buildCreatePermissionSetPrivilegeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"datasource_type":    d.Get("datasource_type"),
+		"permission_type":    d.Get("type"),
+		"permission_actions": utils.ExpandToStringList(d.Get("actions").(*schema.Set).List()),
+		"cluster_name":       d.Get("cluster_name"),
+		"cluster_id":         utils.ValueIngoreEmpty(d.Get("cluster_id")),
+		"dw_id":              utils.ValueIngoreEmpty(d.Get("connection_id")),
+		"url":                utils.ValueIngoreEmpty(d.Get("database_url")),
+		"database_name":      utils.ValueIngoreEmpty(d.Get("database_name")),
+		"table_name":         utils.ValueIngoreEmpty(d.Get("table_name")),
+		"column_name":        utils.ValueIngoreEmpty(d.Get("column_name")),
+		"schema_name":        utils.ValueIngoreEmpty(d.Get("schema_name")),
+	}
+	return bodyParams
+}
+
+// GetPrivilegeById is a method used to query permission configuration using a specified ID.
+func GetPrivilegeById(client *golangsdk.ServiceClient, workspaceId, permissionSetId, id string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions?limit=100"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{permission_set_id}", permissionSetId)
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": workspaceId},
+	}
+
+	var currentTotal int
+	for {
+		path := fmt.Sprintf("%s&offset=%v", getPath, currentTotal)
+		resp, err := client.Request("GET", path, &opts)
+		if err != nil {
+			return nil, ParseQueryError400(err, PermissionSetPrivilegeResourceNotFoundCodes)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		totalNum := utils.PathSearch("total", respBody, 0)
+		if privilegeInfo := utils.PathSearch(fmt.Sprintf("permissions|[?id=='%s']|[0]", id), respBody, nil); privilegeInfo != nil {
+			return privilegeInfo, nil
+		}
+
+		privileges := utils.PathSearch("permissions", respBody, make([]interface{}, 0)).([]interface{})
+		currentTotal += len(privileges)
+		// The type of `total` is float64.
+		if float64(currentTotal) == totalNum {
+			break
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func resourceSecurityPermissionSetPrivilegeRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	respBody, err := GetPrivilegeById(client, d.Get("workspace_id").(string), d.Get("permission_set_id").(string), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, ParseQueryError400(err, PermissionSetPrivilegeResourceNotFoundCodes),
+			"DataArts Security permission set privilege")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("datasource_type", utils.PathSearch("datasource_type", respBody, nil)),
+		d.Set("type", utils.PathSearch("permission_type", respBody, nil)),
+		d.Set("actions", utils.PathSearch("permission_actions", respBody, nil)),
+		d.Set("cluster_name", utils.PathSearch("cluster_name", respBody, nil)),
+		d.Set("cluster_id", utils.PathSearch("cluster_id", respBody, nil)),
+		d.Set("database_url", utils.PathSearch("url", respBody, nil)),
+		d.Set("database_name", utils.PathSearch("database_name", respBody, nil)),
+		d.Set("table_name", utils.PathSearch("table_name", respBody, nil)),
+		d.Set("column_name", utils.PathSearch("column_name", respBody, nil)),
+		d.Set("schema_name", utils.PathSearch("schema_name", respBody, nil)),
+		d.Set("status", utils.PathSearch("sync_status", respBody, nil)),
+		d.Set("sync_msg", utils.PathSearch("sync_msg", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceSecurityPermissionSetPrivilegeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	httpUrl := "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions/{permission_id}"
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{permission_set_id}", d.Get("permission_set_id").(string))
+	updatePath = strings.ReplaceAll(updatePath, "{permission_id}", d.Id())
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody:         utils.RemoveNil(buildUpdatePermissionSetPrivilegeBodyParams(d)),
+	}
+
+	_, err = client.Request("PUT", updatePath, &opts)
+	if err != nil {
+		return diag.Errorf("error updating DataArts Security permission set privilege: %s", err)
+	}
+
+	return resourceSecurityPermissionSetPrivilegeRead(ctx, d, meta)
+}
+
+func buildUpdatePermissionSetPrivilegeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"dw_id":              utils.ValueIngoreEmpty(d.Get("connection_id")),
+		"permission_actions": utils.ExpandToStringList(d.Get("actions").(*schema.Set).List()),
+	}
+	return bodyParams
+}
+
+func resourceSecurityPermissionSetPrivilegeDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/security/permission-sets/{permission_set_id}/permissions/batch-delete"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{permission_set_id}", d.Get("permission_set_id").(string))
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody: map[string]interface{}{
+			"ids": []string{d.Id()},
+		},
+		OkCodes: []int{204},
+	}
+
+	_, err = client.Request("POST", deletePath, &opts)
+	if err != nil {
+		return diag.Errorf("error deleting DataArts Security permission set privilege: %s", err)
+	}
+
+	return nil
+}
+
+func resourceSecurityPermissionSetPrivilegeImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<permission_set_id>/<id>', but got '%s'",
+			importedId)
+	}
+
+	mErr := multierror.Append(
+		d.Set("workspace_id", parts[0]),
+		d.Set("permission_set_id", parts[1]),
+	)
+	d.SetId(parts[2])
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource supports assigning data source privileges to workspace permission set or permission set.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

1. add new resource permission set privilege.
2. add corresponding documentation and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dataarts TESTARGS='-run TestAccResourceSecurityPermissionSetPrivilege_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceSecurityPermissionSetPrivilege_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceSecurityPermissionSetPrivilege_basic
=== PAUSE TestAccResourceSecurityPermissionSetPrivilege_basic
=== CONT  TestAccResourceSecurityPermissionSetPrivilege_basic
--- PASS: TestAccResourceSecurityPermissionSetPrivilege_basic (73.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  73.263s
```
