### PR TITLE
feat(cbh/instance): support new fields `attach_disk_size`, `enterprise_project_id`, `data_disk_size`

### DIFF
--- a/docs/resources/cbh_instance.md
+++ b/docs/resources/cbh_instance.md
@@ -42,9 +42,11 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `flavor_id` - (Required, String, ForceNew) Specifies the product ID of the CBH server.
+* `flavor_id` - (Required, String) Specifies the product ID of the CBH server. When updating the flavor, it can only be
+  changed to a higher flavor.
 
-  Changing this parameter will create a new resource.
+  -> 1. The flavor change is a high-risk operation, with a certain risk of failure.
+  <br/>2. Flavor change failing may impact the usability of the instance. Please be sure to back up your data.
 
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC.
 
@@ -97,6 +99,16 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
+* `attach_disk_size` - (Optional, Int) Specifies the size of the additional data disk for the CBH instance.
+  The unit is TB. It refers to the additional disk size added on top of the existing disk. And the sum of the built-in
+  disk of the instance flavor and the additional disk cannot exceed **300TB**.
+
+  -> 1. Storage expansion is a high-risk operation, with a certain risk of failure.
+  <br/>2. Expansion failure may affect the usability of the instance. Please ensure to back up your data.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the CBH instance
+  belongs. For enterprise users, if omitted, default enterprise project will be used.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -111,11 +123,15 @@ In addition to all arguments above, the following attributes are exported:
 
 * `version` - Indicates the current version of the instance image.
 
+* `data_disk_size` - Indicates the data disk size of the instance. The unit is TB. It represents the sum of the disks
+  that come with the flavor and the disks that have already been expanded.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
 
 * `create` - Default is 60 minutes.
+* `update` - Default is 60 minutes.
 * `delete` - Default is 30 minutes.
 
 ## Import
@@ -128,7 +144,7 @@ $ terraform import huaweicloud_cbh_instance.test <id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `charging_mode`, `period`, `period_unit`,
-`auto_renew`, `password`, `ipv6_enable`.
+`auto_renew`, `password`, `ipv6_enable`, `attach_disk_size`.
 It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated
 to align with the instance. Also, you can ignore changes as below.
@@ -139,7 +155,7 @@ resource "huaweicloud_cbh_instance" "test" {
 
   lifecycle {
     ignore_changes = [
-      charging_mode, period, period_unit, auto_renew, password, ipv6_enable,
+      charging_mode, period, period_unit, auto_renew, password, ipv6_enable, attach_disk_size,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
@@ -81,6 +81,9 @@ func TestAccCBHInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "subnet_address", "192.168.0.154"),
 					resource.TestCheckResourceAttr(rName, "public_ip_id", ""),
 					resource.TestCheckResourceAttr(rName, "public_ip", ""),
+					// The built-in disk for this flavor instance is **0.2TB**, increase disk size by **1TB** through
+					// the `attach_disk_size` parameter.
+					resource.TestCheckResourceAttr(rName, "data_disk_size", "1.2"),
 
 					resource.TestCheckResourceAttrPair(rName, "vpc_id",
 						"huaweicloud_vpc.test", "id"),
@@ -93,6 +96,7 @@ func TestAccCBHInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "private_ip"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
 					resource.TestCheckResourceAttrSet(rName, "version"),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 				),
 			},
 			{
@@ -100,7 +104,9 @@ func TestAccCBHInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "password", "test_147258"),
+					resource.TestCheckResourceAttr(rName, "flavor_id", "cbh.basic.20"),
 					resource.TestCheckResourceAttr(rName, "auto_renew", "true"),
+					resource.TestCheckResourceAttr(rName, "data_disk_size", "3.2"),
 					resource.TestCheckResourceAttrPair(rName, "security_group_id",
 						"huaweicloud_networking_secgroup.test", "id"),
 				),
@@ -116,6 +122,7 @@ func TestAccCBHInstance_basic(t *testing.T) {
 					"period_unit",
 					"auto_renew",
 					"ipv6_enable",
+					"attach_disk_size",
 				},
 			},
 		},
@@ -152,6 +159,7 @@ resource "huaweicloud_cbh_instance" "test" {
   period_unit       = "month"
   auto_renew        = "false"
   period            = 1
+  attach_disk_size  = 1
 }
 `, testCBHInstance_base(name), name)
 }
@@ -161,7 +169,7 @@ func testCBHInstance_basic_update(name string) string {
 %s
 
 resource "huaweicloud_cbh_instance" "test" {
-  flavor_id         = "cbh.basic.10"
+  flavor_id         = "cbh.basic.20"
   name              = "%s"
   vpc_id            = huaweicloud_vpc.test.id
   subnet_id         = huaweicloud_vpc_subnet.test.id
@@ -173,6 +181,7 @@ resource "huaweicloud_cbh_instance" "test" {
   period_unit       = "month"
   auto_renew        = "true"
   period            = 1
+  attach_disk_size  = 2
 }
 `, testCBHInstance_base(name), name)
 }

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
@@ -28,6 +28,7 @@ import (
 // @API CBH GET /v2/{project_id}/cbs/instance/list
 // @API CBH PUT /v2/{project_id}/cbs/instance/password
 // @API CBH PUT /v2/{project_id}/cbs/instance/{server_id}/security-groups
+// @API CBH PUT /v2/{project_id}/cbs/instance
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/suscriptions/resources/query
 // @API BSS POST /v2/orders/subscriptions/resources/unsubscribe
@@ -45,6 +46,7 @@ func ResourceCBHInstance() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -64,7 +66,6 @@ func ResourceCBHInstance() *schema.Resource {
 			"flavor_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `Specifies the product ID of the CBH server.`,
 			},
 			"vpc_id": {
@@ -143,6 +144,18 @@ func ResourceCBHInstance() *schema.Resource {
 				ForceNew:    true,
 				Description: `Specifies whether the IPv6 network is enabled.`,
 			},
+			"attach_disk_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the size of the additional data disk for the CBH instance.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "Specifies the enterprise project ID to which the CBH instance belongs.",
+			},
 			"public_ip": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -163,6 +176,11 @@ func ResourceCBHInstance() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `Indicates the current version of the instance image.`,
+			},
+			"data_disk_size": {
+				Type:        schema.TypeFloat,
+				Computed:    true,
+				Description: `Indicates the data disk size of the instance.`,
 			},
 		},
 	}
@@ -237,7 +255,7 @@ func createCBHInstance(client *golangsdk.ServiceClient, d *schema.ResourceData, 
 	createInstancePath = strings.ReplaceAll(createInstancePath, "{project_id}", client.ProjectID)
 	createInstanceOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		JSONBody:         utils.RemoveNil(buildCreateCBHInstanceBodyParam(d, cfg.GetRegion(d), publicIp)),
+		JSONBody:         utils.RemoveNil(buildCreateCBHInstanceBodyParam(d, cfg.GetRegion(d), cfg.GetEnterpriseProjectID(d), publicIp)),
 	}
 
 	createInstanceResp, err := client.Request("POST", createInstancePath, &createInstanceOpt)
@@ -256,19 +274,21 @@ func createCBHInstance(client *golangsdk.ServiceClient, d *schema.ResourceData, 
 	return orderId.(string), nil
 }
 
-func buildCreateCBHInstanceBodyParam(d *schema.ResourceData, region string, publicIp interface{}) map[string]interface{} {
+func buildCreateCBHInstanceBodyParam(d *schema.ResourceData, region string, epsId string, publicIp interface{}) map[string]interface{} {
 	bodyParam := map[string]interface{}{
-		"specification":     d.Get("flavor_id"),
-		"instance_name":     d.Get("name"),
-		"password":          d.Get("password"),
-		"region":            region,
-		"availability_zone": d.Get("availability_zone"),
-		"charging_mode":     buildCreateChargingModeParam(d),
-		"period_type":       buildCreatePeriodTypeParam(d),
-		"period_num":        utils.ValueIngoreEmpty(d.Get("period")),
-		"is_auto_renew":     buildCreateIsAutoRenewParam(d),
-		"is_auto_pay":       1,
-		"network":           buildCreateNetworkBodyParam(d, publicIp),
+		"specification":         d.Get("flavor_id"),
+		"instance_name":         d.Get("name"),
+		"password":              d.Get("password"),
+		"region":                region,
+		"availability_zone":     d.Get("availability_zone"),
+		"charging_mode":         buildCreateChargingModeParam(d),
+		"period_type":           buildCreatePeriodTypeParam(d),
+		"period_num":            utils.ValueIngoreEmpty(d.Get("period")),
+		"is_auto_renew":         buildCreateIsAutoRenewParam(d),
+		"is_auto_pay":           1,
+		"network":               buildCreateNetworkBodyParam(d, publicIp),
+		"attach_disk_size":      utils.ValueIngoreEmpty(d.Get("attach_disk_size")),
+		"enterprise_project_id": utils.ValueIngoreEmpty(epsId),
 	}
 	// The default value of the field `ipv6_enable` is false
 	if d.Get("ipv6_enable").(bool) {
@@ -421,6 +441,48 @@ func waitingForCBHInstanceActive(ctx context.Context, client *golangsdk.ServiceC
 	return err
 }
 
+func waitingForCBHInstanceTaskCompleted(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	timeout time.Duration) error {
+	expression := fmt.Sprintf("[?server_id == '%s']|[0]", d.Id())
+	unexpectedTaskStatus := []string{"delete_wait", "frozen", "unfrozen", "updating", "configuring-ha",
+		"data-migrating", "rollback", "traffic-switchover"}
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			instances, err := getCBHInstanceList(client)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+			instance := utils.PathSearch(expression, instances, nil)
+			if instance == nil {
+				return nil, "ERROR", golangsdk.ErrDefault404{}
+			}
+
+			taskStatus := utils.PathSearch("status_info.task_status", instance, "").(string)
+			if taskStatus == "NO_TASK" {
+				return instance, "COMPLETED", nil
+			}
+
+			if taskStatus == "" {
+				return instance, "ERROR", fmt.Errorf("the cbh instnace task_status is not found in list API response")
+			}
+
+			if utils.StrSliceContains(unexpectedTaskStatus, taskStatus) {
+				return instance, taskStatus, nil
+			}
+
+			return instance, "PENDING", nil
+		},
+		Timeout:      timeout,
+		Delay:        10 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
+}
+
 func resourceCBHInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	var (
 		cfg                      = meta.(*config.Config)
@@ -454,6 +516,59 @@ func resourceCBHInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 
+	// Due to API limitations, update `flavor_id` and `attach_disk_size` must call the API separately.
+	if d.HasChanges("flavor_id") {
+		orderId, err := updateFlavorId(client, ID, d.Get("flavor_id").(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+
+		if err := common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err := waitingForCBHInstanceActive(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.Errorf("error waiting for CBH instance (%s) update to active: %s", ID, err)
+		}
+
+		// After updating the `flavor_id` and `attach_disk_size`, the instance will automatically restart;
+		// At this point, the instance is restarting, but the value of the `status` attribute is already **active**,
+		// so we need to continue waiting for the instance's `task_status` attribute to become **NO_TASK**
+		// before we can proceed.
+		if err := waitingForCBHInstanceTaskCompleted(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.Errorf("error waiting for CBH instance (%s) update flavor to complete: %s", ID, err)
+		}
+	}
+
+	if d.HasChanges("attach_disk_size") {
+		orderId, err := updateAttachDiskSize(client, ID, int32(d.Get("attach_disk_size").(int)))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		bssClient, err := cfg.BssV2Client(cfg.GetRegion(d))
+		if err != nil {
+			return diag.Errorf("error creating BSS v2 client: %s", err)
+		}
+
+		if err := common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err := waitingForCBHInstanceActive(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.Errorf("error waiting for CBH instance (%s) update to active: %s", ID, err)
+		}
+
+		if err := waitingForCBHInstanceTaskCompleted(ctx, client, d, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return diag.Errorf("error waiting for CBH instance (%s) update additional disk to complete: %s", ID, err)
+		}
+	}
+
 	if d.HasChange("auto_renew") {
 		bssClient, err := cfg.BssV2Client(region)
 		if err != nil {
@@ -476,6 +591,64 @@ func resourceCBHInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 	}
 	return resourceCBHInstanceRead(ctx, d, meta)
+}
+
+func updateFlavorId(client *golangsdk.ServiceClient, resourceId, flavorId string) (string, error) {
+	updateFlavorIdPath := client.Endpoint + "v2/{project_id}/cbs/instance"
+	updateFlavorIdPath = strings.ReplaceAll(updateFlavorIdPath, "{project_id}", client.ProjectID)
+	updateFlavorIdOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"server_id":              resourceId,
+			"new_resource_spec_code": flavorId,
+			"is_auto_pay":            1,
+		},
+	}
+	updateInstanceResp, err := client.Request("PUT", updateFlavorIdPath, &updateFlavorIdOpt)
+	if err != nil {
+		return "", fmt.Errorf("error updating CBH instance flavor: %s", err)
+	}
+
+	updateInstanceRespBody, err := utils.FlattenResponse(updateInstanceResp)
+	if err != nil {
+		return "", err
+	}
+
+	orderId, err := jmespath.Search("order_id", updateInstanceRespBody)
+	if err != nil || orderId == nil {
+		return "", fmt.Errorf("error updating CBH instance flavor: order_id is not found in API response")
+	}
+
+	return orderId.(string), nil
+}
+
+func updateAttachDiskSize(client *golangsdk.ServiceClient, resourceId string, attachDiskSize int32) (string, error) {
+	updateAttachDiskSizePath := client.Endpoint + "v2/{project_id}/cbs/instance"
+	updateAttachDiskSizePath = strings.ReplaceAll(updateAttachDiskSizePath, "{project_id}", client.ProjectID)
+	updateAttachDiskSizeOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"server_id":        resourceId,
+			"attach_disk_size": attachDiskSize,
+			"is_auto_pay":      1,
+		},
+	}
+	updateInstanceResp, err := client.Request("PUT", updateAttachDiskSizePath, &updateAttachDiskSizeOpt)
+	if err != nil {
+		return "", fmt.Errorf("error updating CBH instance additional disk: %s", err)
+	}
+
+	updateInstanceRespBody, err := utils.FlattenResponse(updateInstanceResp)
+	if err != nil {
+		return "", err
+	}
+
+	orderId, err := jmespath.Search("order_id", updateInstanceRespBody)
+	if err != nil || orderId == nil {
+		return "", fmt.Errorf("error updating CBH instance additional disk: order_id is not found in API response")
+	}
+
+	return orderId.(string), nil
 }
 
 func updateSecurityGroup(client *golangsdk.ServiceClient, resourceId string, sgIDs []string) error {
@@ -612,8 +785,10 @@ func resourceCBHInstanceRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("subnet_id", utils.PathSearch("network.subnet_id", instance, nil)),
 		d.Set("security_group_id", utils.PathSearch("network.security_group_id", instance, nil)),
 		d.Set("flavor_id", utils.PathSearch("resource_info.specification", instance, nil)),
+		d.Set("data_disk_size", utils.PathSearch("resource_info.data_disk_size", instance, float64(0)).(float64)),
 		d.Set("availability_zone", utils.PathSearch("az_info.zone", instance, nil)),
 		d.Set("version", utils.PathSearch("bastion_version", instance, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", instance, nil)),
 	)
 	return diag.FromErr(mErr.ErrorOrNil())
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support new fields `attach_disk_size`, `enterprise_project_id`, `data_disk_size`
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Support new fields `attach_disk_size`, `enterprise_project_id`, `data_disk_size`.
2. The `flavor_id` parameter support update.
3. Update 'flavor_id' and 'attach_disk_size' using the same API, but they must be updated separately, otherwise the API will report an error.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_basic
=== PAUSE TestAccCBHInstance_basic
=== CONT  TestAccCBHInstance_basic
--- PASS: TestAccCBHInstance_basic (1951.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1951.959s

```
