### PR TITLE
feat(CDN): CDN domain support new fields

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -364,6 +364,9 @@ The `configs` block support:
   <br/>3. By default, CDN caches status codes `400`, `404`, `416`, `500`, `502`, and `504` for `3` seconds and does not
   cache other status codes.
 
+* `ip_filter` - (Optional, List) Specifies the IP address blacklist or whitelist.
+  The [ip_filter](#ip_filter_object) structure is documented below.
+
 <a name="https_settings_object"></a>
 The `https_settings` block support:
 
@@ -726,6 +729,21 @@ The `error_code_cache` block support:
   **405**, **414**, **500**, **501**, **502**, **503**, and **504**.
 
 * `ttl` - (Required, Int) Specifies the error code cache TTL, in seconds. The value ranges from **0** to **31,536,000**.
+
+<a name="ip_filter_object"></a>
+The `ip_filter` block support:
+
+* `type` - (Required, String) Specifies the IP ACL type. Valid values are:
+  + **off**: Disable the IP ACL.
+  + **black**: IP address blacklist.
+  + **white**: IP address whitelist.
+
+  Defaults to **off**.
+
+* `value` - (Optional, String) Specifies the IP address blacklist or whitelist. This field is required when `type` is
+  set to **black** or **white**. A list contains up to `500` IP addresses and IP address segments, which are separated
+  by commas (,). IPv6 addresses are supported. Duplicate IP addresses and IP address segments will be removed.
+  Addresses with wildcard characters are not supported, for example, `192.168.0.*`.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -145,6 +145,11 @@ resource "huaweicloud_cdn_domain" "domain_1" {
       type             = "size"
     }
 
+    error_code_cache {
+      code = 403
+      ttl  = 70
+    }
+
     remote_auth {
       enabled = true
 
@@ -350,6 +355,14 @@ The `configs` block support:
   The [request_limit_rules](#request_limit_rules_object) structure is documented below.
 
   -> Up to 60 request limit rules can be configured.
+
+* `error_code_cache` - (Optional, List) Specifies the status code cache TTL.
+  The [error_code_cache](#error_code_cache_object) structure is documented below.
+
+  -> 1. The status code cache TTL cannot be configured for domain names with special configurations.
+  <br/>2. Domain names whose service type is whole site acceleration do not support configuring this field.
+  <br/>3. By default, CDN caches status codes `400`, `404`, `416`, `500`, `502`, and `504` for `3` seconds and does not
+  cache other status codes.
 
 <a name="https_settings_object"></a>
 The `https_settings` block support:
@@ -705,6 +718,14 @@ The `request_limit_rules` block support:
 
 * `match_value` - (Optional, String) Specifies the match type value. This field is required when `match_type` is
   set to **catalog**. The value is a directory address starting with a slash (/), for example, **/test**.
+
+<a name="error_code_cache_object"></a>
+The `error_code_cache` block support:
+
+* `code` - (Required, Int) Specifies the error code. Valid values are: **301**, **302**, **400**, **403**, **404**,
+  **405**, **414**, **500**, **501**, **502**, **503**, and **504**.
+
+* `ttl` - (Required, Int) Specifies the error code cache TTL, in seconds. The value ranges from **0** to **31,536,000**.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -507,6 +507,9 @@ func TestAccCdnDomain_configs(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.#", "2"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.type", "black"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.value", "5.12.3.65,35.2.65.21"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "403"),
@@ -606,6 +609,9 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.0.code", "403"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.0.ttl", "70"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.type", "white"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.value", "5.12.3.66"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "503"),
@@ -650,6 +656,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.type", "off"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
@@ -822,6 +829,11 @@ resource "huaweicloud_cdn_domain" "test" {
       ttl  = 31536000
     }
 
+    ip_filter {
+      type  = "black"
+      value = "5.12.3.65,35.2.65.21"
+    }
+
     remote_auth {
       enabled = true
 
@@ -971,6 +983,11 @@ resource "huaweicloud_cdn_domain" "test" {
       ttl  = 70
     }
 
+    ip_filter {
+      type  = "white"
+      value = "5.12.3.66"
+    }
+
     remote_auth {
       enabled = true
 
@@ -1043,6 +1060,10 @@ resource "huaweicloud_cdn_domain" "test" {
 
     video_seek {
       enable_video_seek = false
+    }
+
+    ip_filter {
+      type = "off"
     }
   }
 }

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -505,6 +505,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.#", "2"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.#", "2"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "403"),
@@ -600,6 +602,10 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.0.priority", "4"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.0.type", "size"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.0.code", "403"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.0.ttl", "70"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "503"),
@@ -643,6 +649,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "5"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
@@ -805,6 +812,16 @@ resource "huaweicloud_cdn_domain" "test" {
       type             = "size"
     }
 
+    error_code_cache {
+      code = 301
+      ttl  = 0
+    }
+
+    error_code_cache {
+      code = 500
+      ttl  = 31536000
+    }
+
     remote_auth {
       enabled = true
 
@@ -947,6 +964,11 @@ resource "huaweicloud_cdn_domain" "test" {
       match_value      = "/test/ff"
       priority         = 4
       type             = "size"
+    }
+
+    error_code_cache {
+      code = 403
+      ttl  = 70
     }
 
     remote_auth {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN domain support new fields `configs.0.error_code_cache` and `configs.0.ip_filter`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (801.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       801.389s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (717.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       717.676s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (465.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       465.366s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_epsID_migrate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_epsID_migrate -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_epsID_migrate (329.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       329.075s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (687.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       687.485s
```
