### PR TITLE
feat(dds): support replica set name in instance

### DIFF
--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -153,6 +153,10 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the DDS instance.
 
+* `replica_set_name` - (Optional, String) Specifies the name of the replica set in the connection address.
+  It must be `3` to `128` characters long and start with a letter. It is case-sensitive and can contain only letters,
+  digits, and underscores (_). Default is **replica**.
+
 * `ssl` - (Optional, Bool) Specifies whether to enable or disable SSL. Defaults to true.
 
 **NOTE:** The instance will be restarted in the background when switching SSL. Please operate with caution.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240422111604-27d1f9a6f456
+	github.com/chnsz/golangsdk v0.0.0-20240424032404-7e0bce05ac1a
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240422111604-27d1f9a6f456 h1:v+GvJez+slXIh5Fbt5T8NTVUG++7rZP5tSW3zC2FCnM=
-github.com/chnsz/golangsdk v0.0.0-20240422111604-27d1f9a6f456/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240424032404-7e0bce05ac1a h1:Qfcn91dn22UP5AxYMBnWeBXYyjiZnifgDOodqEyT8CM=
+github.com/chnsz/golangsdk v0.0.0-20240424032404-7e0bce05ac1a/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -270,6 +270,7 @@ func TestAccDDSV3Instance_withConfigurationReplicaSet(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.start_time", "08:00-09:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "8"),
+					resource.TestCheckResourceAttr(resourceName, "replica_set_name", "replicaName"),
 				),
 			},
 		},
@@ -980,6 +981,8 @@ resource "huaweicloud_dds_instance" "instance" {
   password          = "Terraform@123"
   mode              = "ReplicaSet"
   port              = %[3]d
+  replica_set_name  = "replicaName"
+
   datastore {
     type           = "DDS-Community"
     version        = "3.4"

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
@@ -283,6 +283,15 @@ func GetSecondsLevelMonitoring(c *golangsdk.ServiceClient, instanceId string) (*
 	return &r, err
 }
 
+// GetReplicaSetName is a method to get the replica set name.
+func GetReplicaSetName(c *golangsdk.ServiceClient, instanceId string) (*ReplicaSetNameOpts, error) {
+	var r ReplicaSetNameOpts
+	_, err := c.Get(replicaSetNameURL(c, instanceId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
 // CreateBackupPolicy is a method to create the backup policy.
 func CreateBackupPolicy(c *golangsdk.ServiceClient, instanceId string, backPolicy BackupStrategy) (*BackupPolicyResp, error) {
 	opts := BackupPolicyOpts{
@@ -309,12 +318,30 @@ func GetBackupPolicy(c *golangsdk.ServiceClient, instanceId string) (*BackupPoli
 	return &r, err
 }
 
+type ReplicaSetNameOpts struct {
+	Name string `json:"name" required:"true"`
+}
+
 type AvailabilityZoneOpts struct {
 	TargetAzs string `json:"target_azs" required:"true"`
 }
 
 type RemarkOpts struct {
 	Remark string `json:"remark"`
+}
+
+// UpdateReplicaSetName is a method to update the replica set name.
+func UpdateReplicaSetName(c *golangsdk.ServiceClient, instanceId string, opts ReplicaSetNameOpts) (*CommonResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r CommonResp
+	_, err = c.Put(replicaSetNameURL(c, instanceId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
 }
 
 // UpdateAvailabilityZone is a method to update the AvailabilityZone.

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/results.go
@@ -181,6 +181,11 @@ type AvailabilityZoneResp struct {
 	JobId string `json:"job_id"`
 }
 
+type CommonResp struct {
+	// Job ID.
+	JobId string `json:"job_id"`
+}
+
 type SlowLogStatusResp struct {
 	// Status.
 	Status string `json:"status"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/urls.go
@@ -38,6 +38,10 @@ func remarkURL(c *golangsdk.ServiceClient, instanceId string) string {
 	return c.ServiceURL("instances", instanceId, "remark")
 }
 
+func replicaSetNameURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "replica-set/name")
+}
+
 func slowLogStatusURL(c *golangsdk.ServiceClient, instanceId string, status string) string {
 	return c.ServiceURL("instances", instanceId, "slowlog-desensitization", status)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240422111604-27d1f9a6f456
+# github.com/chnsz/golangsdk v0.0.0-20240424032404-7e0bce05ac1a
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support `replica_set_name` in `hauweicloud_dds_instance`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds  TESTARGS="-run TestAccDDSV3Instance_withConfigurationReplicaSet"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withConfigurationReplicaSet -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withConfigurationReplicaSet
=== PAUSE TestAccDDSV3Instance_withConfigurationReplicaSet
=== CONT  TestAccDDSV3Instance_withConfigurationReplicaSet
--- PASS: TestAccDDSV3Instance_withConfigurationReplicaSet (964.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       964.943s
```
