### PR TITLE
feat(cfw): firewall resource support to import attachment_id attribute

### DIFF
--- a/docs/resources/cfw_firewall.md
+++ b/docs/resources/cfw_firewall.md
@@ -262,7 +262,7 @@ $ terraform import huaweicloud_cfw_firewall.test 6cb1ce47-9990-447e-b071-d167c53
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include:
-`period_unit`, `period`, `auto_renew` and `east_west_firewall_er_attachment_id`. It is generally
+`period_unit`, `period` and `auto_renew`. It is generally
 recommended running `terraform plan` after importing an CFW firewall. You can then decide if changes should be applied to
 the firewall, or the resource definition should be updated to align with the firewall. Also you can ignore changes as
 below.
@@ -273,7 +273,7 @@ resource "huaweicloud_cfw_firewall" "test" {
 
   lifecycle {
     ignore_changes = [
-      period_unit, period, auto_renew, east_west_firewall_er_attachment_id
+      period_unit, period, auto_renew
     ]
   }
 }

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_firewall.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_firewall.go
@@ -344,7 +344,7 @@ func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		createEastWestFirewallOpt.JSONBody = utils.RemoveNil(buildCreateEastWestFirewallBodyParams(d))
-		createEastWestFirewallResp, err := createFirewallClient.Request("POST", createEastWestFirewallPath, &createEastWestFirewallOpt)
+		_, err := createFirewallClient.Request("POST", createEastWestFirewallPath, &createEastWestFirewallOpt)
 		if err != nil {
 			return diag.Errorf("error creating east-west firewall: %s", err)
 		}
@@ -353,13 +353,6 @@ func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, meta in
 		if err != nil {
 			return diag.Errorf("error waiting for the east-west firewall (%s) creation to complete: %s", d.Id(), err)
 		}
-
-		createEastWestFirewallRespBody, err := utils.FlattenResponse(createEastWestFirewallResp)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		d.Set("east_west_firewall_er_attachment_id", utils.PathSearch("data.er.er_attach_id", createEastWestFirewallRespBody, nil))
 	}
 
 	return resourceFirewallUpdate(ctx, d, meta)
@@ -664,6 +657,7 @@ func resourceFirewallRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("east_west_firewall_mode", utils.PathSearch("data.mode", getEastWestFirewallRespBody, nil)),
 		d.Set("east_west_firewall_status", utils.PathSearch("data.status", getEastWestFirewallRespBody, nil)),
 		d.Set("east_west_firewall_inspection_vpc_id", utils.PathSearch("data.inspection_vpc.id", getEastWestFirewallRespBody, nil)),
+		d.Set("east_west_firewall_er_attachment_id", utils.PathSearch("data.er.attachment_id", getEastWestFirewallRespBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
firewall resource support to import attachment_id attribute
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. firewall resource support to import attachment_id attribute
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccFirewall_prePaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccFirewall_prePaid -timeout 360m -parallel 4
=== RUN   TestAccFirewall_prePaid
=== PAUSE TestAccFirewall_prePaid
=== CONT  TestAccFirewall_prePaid
--- PASS: TestAccFirewall_prePaid (487.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       488.017s

 make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccFirewall_attachmentID"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccFirewall_attachmentID -timeout 360m -parallel 4
=== RUN   TestAccFirewall_attachmentID
=== PAUSE TestAccFirewall_attachmentID
=== CONT  TestAccFirewall_attachmentID
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: exit status 1

        Error: error deleting Instance: Expected HTTP response code [202] when accessing [DELETE https://er.la-south-2.myhuaweicloud.com/v3/0aa551bf4c800f242f54c00397409c94/enterprise-router/instances/67ab0d5d-85cc-43c5-b77f-0f88e242f42f], but got 409 instead.
        request_id: 48b13ceceb8e52e643350ed1fef7617b, error message: {"error_code":"ER.04091002","error_msg":"enterprise router 67ab0d5d-85cc-43c5-b77f-0f88e242f42f have been used by attachment 50f3ead0-a819-4a95-a66e-207dcaf13685","request_id":"48b13ceceb8e52e643350ed1fef7617b"}

--- FAIL: TestAccFirewall_attachmentID (866.85s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       866.896s
FAIL
```
