### PR TITLE
feat(dds): support restart for instance

### DIFF
--- a/docs/resources/dds_instance_restart.md
+++ b/docs/resources/dds_instance_restart.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_instance_restart"
+description: |-
+  Manages a DDS instance restart resource within HuaweiCloud.
+---
+
+# huaweicloud_dds_instance_restart
+
+Manages a DDS instance restart resource within HuaweiCloud.
+
+## Example Usage
+
+### Restart insatnce
+
+```hcl
+variable instance_id {}
+
+resource "huaweicloud_dds_instance_restart" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Restart insatnce's mongos node
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+resource "huaweicloud_dds_instance_restart" "test" {
+  instance_id = var.instance_id
+  target_type = "mongos"
+  target_id   = var.node_id
+}
+```
+
+### Restart insatnce's shard group
+
+```hcl
+variable "instance_id" {}
+variable "group_id" {}
+
+resource "huaweicloud_dds_instance_restart" "test" {
+  instance_id = var.instance_id
+  target_type = "shard"
+  target_id   = var.group_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of a DDS instance.
+  Changing this creates a new resource.
+
+* `target_type` - (Optional, String, ForceNew) Specifies the type of the object to restart. Valid values are **mongos**,
+  **shard**, **config**. It's required with `target_id`. Changing this creates a new resource.
+
+* `target_id` - (Optional, String, ForceNew) Specifies the ID of the object to be restarted. When you restart a node in
+  a cluster instance, the value is the mongos node ID for a mongos node, and shard or config group ID for a shard or
+  config group. It's required with `target_type`.
+  Changing this creates a new resource.
+
+-> If you want to restart instance, set both `target_type` and `target_id` empty.
+
+## Attribute Reference
+
+* `id` - Indicates the resource ID. It's same as the instance ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240424032404-7e0bce05ac1a
+	github.com/chnsz/golangsdk v0.0.0-20240425061404-47aa27c2676d
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240424032404-7e0bce05ac1a h1:Qfcn91dn22UP5AxYMBnWeBXYyjiZnifgDOodqEyT8CM=
-github.com/chnsz/golangsdk v0.0.0-20240424032404-7e0bce05ac1a/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240425061404-47aa27c2676d h1:xBEJ3XB395b38XO6tF64pFc+/+RRgo1R6043O5CmBGQ=
+github.com/chnsz/golangsdk v0.0.0-20240425061404-47aa27c2676d/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1044,6 +1044,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_parameter_template": dds.ResourceDdsParameterTemplate(),
 			"huaweicloud_dds_audit_log_policy":   dds.ResourceDdsAuditLogPolicy(),
 			"huaweicloud_dds_lts_log":            dds.ResourceDdsLtsLog(),
+			"huaweicloud_dds_instance_restart":   dds.ResourceDDSInstanceRestart(),
 
 			"huaweicloud_ddm_instance":               ddm.ResourceDdmInstance(),
 			"huaweicloud_ddm_schema":                 ddm.ResourceDdmSchema(),

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_restart_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_restart_test.go
@@ -1,0 +1,49 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/dds/v3/instances"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDDSV3InstanceRestart_basic(t *testing.T) {
+	var instance instances.InstanceResponse
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_dds_instance_restart.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&instance,
+		getDdsResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDDSInstanceV3Config_restart(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccDDSInstanceV3Config_restart(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dds_instance_restart" "test" {
+  depends_on = [huaweicloud_dds_instance.instance]
+  
+  instance_id = huaweicloud_dds_instance.instance.id
+}`, testAccDDSInstanceV3Config_basic(rName, 8800))
+}

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_instance_restart.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_instance_restart.go
@@ -1,0 +1,136 @@
+package dds
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dds/v3/instances"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API DDS POST /v3/{project_id}/instances/{instance_id}/restart
+// @API DDS GET /v3/{project_id}/instances
+// @API DDS GET /v3/{project_id}/jobs
+func ResourceDDSInstanceRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDDSInstanceRestartCreate,
+		ReadContext:   resourceDDSInstanceRestartRead,
+		DeleteContext: resourceDDSInstanceRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"target_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"target_id"},
+			},
+			"target_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"target_type"},
+			},
+		},
+	}
+}
+
+func resourceDDSInstanceRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	client, err := conf.DdsV3Client(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s ", err)
+	}
+	instId := d.Get("instance_id").(string)
+
+	restartOpts := instances.RestartOpts{
+		TargetId: instId,
+	}
+	if v, ok := d.GetOk("target_id"); ok {
+		restartOpts.TargetType = d.Get("target_type").(string)
+		restartOpts.TargetId = v.(string)
+	}
+
+	// restart instance
+	err = restartInstance(ctx, client, d.Timeout(schema.TimeoutCreate), instId, restartOpts)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(instId)
+
+	return nil
+}
+
+func resourceDDSInstanceRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDDSInstanceRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restart resource is not supported. The restart resource is only removed from the state," +
+		" the instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func restartInstance(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration, instId string,
+	restartOpts instances.RestartOpts) error {
+	retryFunc := func() (interface{}, bool, error) {
+		resp, err := instances.RestartInstance(client, instId, restartOpts)
+		retry, err := handleMultiOperationsError(err)
+		return resp, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     ddsInstanceStateRefreshFunc(client, instId),
+		WaitTarget:   []string{"normal"},
+		Timeout:      timeout,
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("error restarting instance: %s", err)
+	}
+	resp := r.(*instances.CommonResp)
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"Running"},
+		Target:       []string{"Completed"},
+		Refresh:      JobStateRefreshFunc(client, resp.JobId),
+		Timeout:      timeout,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for the job (%s) completed: %s ", resp.JobId, err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
@@ -322,6 +322,11 @@ type ReplicaSetNameOpts struct {
 	Name string `json:"name" required:"true"`
 }
 
+type RestartOpts struct {
+	TargetType string `json:"target_type,omitempty"`
+	TargetId   string `json:"target_id" required:"true"`
+}
+
 type AvailabilityZoneOpts struct {
 	TargetAzs string `json:"target_azs" required:"true"`
 }
@@ -383,6 +388,19 @@ func UpdateSlowLogStatus(c *golangsdk.ServiceClient, instanceId string, slowLogS
 func GetSlowLogStatus(c *golangsdk.ServiceClient, instanceId string) (*SlowLogStatusResp, error) {
 	var r SlowLogStatusResp
 	_, err := c.Get(slowLogStatusURL(c, instanceId, "status"), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+func RestartInstance(c *golangsdk.ServiceClient, instanceId string, opts RestartOpts) (*CommonResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r CommonResp
+	_, err = c.Post(restartURL(c, instanceId), b, &r, &golangsdk.RequestOpts{
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
 	return &r, err

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/urls.go
@@ -45,3 +45,7 @@ func replicaSetNameURL(c *golangsdk.ServiceClient, instanceId string) string {
 func slowLogStatusURL(c *golangsdk.ServiceClient, instanceId string, status string) string {
 	return c.ServiceURL("instances", instanceId, "slowlog-desensitization", status)
 }
+
+func restartURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "restart")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240424032404-7e0bce05ac1a
+# github.com/chnsz/golangsdk v0.0.0-20240425061404-47aa27c2676d
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new resource `huaweicloud_dds_instance_restart` to support restarting instance.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3InstanceRestart_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3InstanceRestart_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSV3InstanceRestart_basic
=== PAUSE TestAccDDSV3InstanceRestart_basic
=== CONT  TestAccDDSV3InstanceRestart_basic
--- PASS: TestAccDDSV3InstanceRestart_basic (923.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       923.545s
```
