### PR TITLE
feat(dataarts): add new resource data secrecy level

### DIFF
--- a/docs/resources/dataarts_security_data_secrecy_level.md
+++ b/docs/resources/dataarts_security_data_secrecy_level.md
@@ -1,0 +1,65 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_security_data_secrecy_level"
+description: |-
+  Manages DataArts Security data secrecy level resource within HuaweiCloud.
+---
+
+
+# huaweicloud_dataarts_security_data_secrecy_level
+
+Manages DataArts Security data secrecy level resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "secrecy_level_name" {}
+
+resource "huaweicloud_dataarts_security_data_secrecy_level" "test" {
+  workspace_id = var.workspace_id
+  name         = var.secrecy_level_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the ID of the workspace to which the data secrecy level belongs.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the data secrecy level.
+  The valid length is limited from `1` to `128`, only Chinese and English characters, digits and underscores (_) are
+  allowed. Changing this creates a new resource.
+
+* `description` - (Optional, String) Specifies the description of the data secrecy level.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `level_number` - The security level of the data secrecy level. The larger value means the higher security level.
+
+* `created_by` - The creator of the data secrecy level.
+
+* `updated_by` - The user who latest updated the data secrecy level.
+
+* `created_at` - The creation time of the data secrecy level.
+
+* `updated_at` - The latest update time of the data secrecy level.
+
+## Import
+
+The resource can be imported using `workspace_id` and `id`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_dataarts_security_data_secrecy_level.test <workspace_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1337,6 +1337,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_factory_script":   dataarts.ResourceDataArtsFactoryScript(),
 			// DataArts Security
 			"huaweicloud_dataarts_security_data_recognition_rule":    dataarts.ResourceSecurityRule(),
+			"huaweicloud_dataarts_security_data_secrecy_level":       dataarts.ResourceSecurityDataSecrecyLevel(),
 			"huaweicloud_dataarts_security_permission_set":           dataarts.ResourceSecurityPermissionSet(),
 			"huaweicloud_dataarts_security_permission_set_member":    dataarts.ResourceSecurityPermissionSetMember(),
 			"huaweicloud_dataarts_security_permission_set_privilege": dataarts.ResourceSecurityPermissionSetPrivilege(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_data_secrecy_level_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_security_data_secrecy_level_test.go
@@ -1,0 +1,122 @@
+package dataarts
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dataarts"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSecurityDataSecrecyLevelResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("dataarts", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + "v1/{project_id}/security/data-classification/secrecy-level/{id}"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{id}", state.Primary.ID)
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": state.Primary.Attributes["workspace_id"]},
+	}
+	resp, err := client.Request("GET", getPath, &opts)
+	if err != nil {
+		return nil, dataarts.ParseQueryError400(err, dataarts.DataSecrecyLevelResourceNotFoundCodes)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func TestAccResourceSecurityDataSecrecyLevel_basic(t *testing.T) {
+	var obj interface{}
+	resourceName := "huaweicloud_dataarts_security_data_secrecy_level.test"
+	rName := acceptance.RandomAccResourceName()
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getSecurityDataSecrecyLevelResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecurityDataSecrecyLevel_basic_step1(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "level_number"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_by"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+			{
+				Config: testAccSecurityDataSecrecyLevel_basic_step2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceSecurityDataSecrecyLevelImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccResourceSecurityDataSecrecyLevelImportStateFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		workspaceId := rs.Primary.Attributes["workspace_id"]
+		secrecyLevelId := rs.Primary.ID
+		if workspaceId == "" || secrecyLevelId == "" {
+			return "", fmt.Errorf("some import IDs are missing, want '<workspace_id>/<id>', but got '%s/%s'",
+				workspaceId, secrecyLevelId)
+		}
+		return fmt.Sprintf("%s/%s", workspaceId, secrecyLevelId), nil
+	}
+}
+
+func testAccSecurityDataSecrecyLevel_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_security_data_secrecy_level" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  description  = "Created by terraform"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccSecurityDataSecrecyLevel_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_security_data_secrecy_level" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/common.go
+++ b/huaweicloud/services/dataarts/common.go
@@ -17,7 +17,10 @@ import (
 //
 // + Data Service:
 //   - DLM.4205: catalog does not found.
+//
+// + Security:
 //   - DLM.3027: Permission set does not found.
+//   - DLS.1000: Data secrecy level does not found.
 func ParseQueryError400(err error, specErrors []string) error {
 	var err400 golangsdk.ErrDefault400
 	if errors.As(err, &err400) {

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_secrecy_level.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_secrecy_level.go
@@ -1,0 +1,252 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var DataSecrecyLevelResourceNotFoundCodes = []string{
+	"DLS.6036",
+	"DLS.1000",
+}
+
+// @API DataArtsStudio POST /v1/{project_id}/security/data-classification/secrecy-level
+// @API DataArtsStudio GET /v1/{project_id}/security/data-classification/secrecy-level/{id}
+// @API DataArtsStudio PUT /v1/{project_id}/security/data-classification/secrecy-level/{id}
+// @API DataArtsStudio DELETE /v1/{project_id}/security/data-classification/secrecy-level/{id}
+func ResourceSecurityDataSecrecyLevel() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecurityDataSecrecyLevelCreate,
+		ReadContext:   resourceSecurityDataSecrecyLevelRead,
+		UpdateContext: resourceSecurityDataSecrecyLevelUpdate,
+		DeleteContext: resourceSecurityDataSecrecyLevelDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceSecurityDataSecrecyLevelImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"level_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSecurityDataSecrecyLevelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/security/data-classification/secrecy-level"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	creatPath := client.Endpoint + httpUrl
+	creatPath = strings.ReplaceAll(creatPath, "{project_id}", client.ProjectID)
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody:         utils.RemoveNil(buildCreateDataSecrecyLevelBodyParams(d)),
+	}
+	resp, err := client.Request("POST", creatPath, &opts)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error retrieving DataArts Security data secrecy level: %s", err)
+	}
+
+	id, err := jmespath.Search("secrecy_level_id", respBody)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Security data secrecy level: ID is not found in API response")
+	}
+
+	d.SetId(id.(string))
+	return resourceSecurityDataSecrecyLevelRead(ctx, d, meta)
+}
+
+func buildCreateDataSecrecyLevelBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": utils.ValueIngoreEmpty(d.Get("description")),
+	}
+}
+
+func resourceSecurityDataSecrecyLevelRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/security/data-classification/secrecy-level/{id}"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	seceryLevelId := d.Id()
+	getPath = strings.ReplaceAll(getPath, "{id}", seceryLevelId)
+	getDataSecrecyLevelOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+	resp, err := client.Request("GET", getPath, &getDataSecrecyLevelOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, ParseQueryError400(err, DataSecrecyLevelResourceNotFoundCodes),
+			"error retrieving DataArts Security data secrecy level")
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.Errorf("error retrieving DataArts Security data secrecy level (%s): %s", seceryLevelId, err)
+	}
+
+	createdAt := utils.PathSearch("created_at", respBody, float64(0)).(float64)
+	updatedAt := utils.PathSearch("updated_at", respBody, float64(0)).(float64)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("secrecy_level_name", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("level_number", utils.PathSearch("secrecy_level_number", respBody, 0)),
+		d.Set("created_by", utils.PathSearch("created_by", respBody, nil)),
+		d.Set("updated_by", utils.PathSearch("updated_by", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(createdAt)/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(updatedAt)/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceSecurityDataSecrecyLevelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/security/data-classification/secrecy-level/{id}"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	seceryLevelId := d.Id()
+	updatePath = strings.ReplaceAll(updatePath, "{id}", seceryLevelId)
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+		JSONBody: map[string]interface{}{
+			"description": d.Get("description"),
+		},
+	}
+
+	_, err = client.Request("PUT", updatePath, &opts)
+	if err != nil {
+		return diag.Errorf("error updating DataArts Security data secrecy level (%s): %s", seceryLevelId, err)
+	}
+
+	return resourceSecurityDataSecrecyLevelRead(ctx, d, meta)
+}
+
+func resourceSecurityDataSecrecyLevelDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/{project_id}/security/data-classification/secrecy-level/{id}"
+		product = "dataarts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	seceryLevelId := d.Id()
+	deletePath = strings.ReplaceAll(deletePath, "{id}", seceryLevelId)
+	deleteDataSecrecyLevelOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"workspace": d.Get("workspace_id").(string)},
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteDataSecrecyLevelOpt)
+	if err != nil {
+		return diag.Errorf("error deleting DataArts Security secrecy level (%s): %s", seceryLevelId, err)
+	}
+
+	return nil
+}
+
+func resourceSecurityDataSecrecyLevelImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,
+	error) {
+	importedId := d.Id()
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<workspace_id>/<id>', but got '%s'",
+			importedId)
+	}
+
+	mErr := multierror.Append(
+		d.Set("workspace_id", parts[0]),
+	)
+
+	d.SetId(parts[1])
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource supports data secrecy level.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource data secrecy level.
2. add corresponding documentation and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dataarts TESTARGS='-run TestAccResourceSecurityDataSecrecyLevel_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceSecurityDataSecrecyLevel_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceSecurityDataSecrecyLevel_basic
=== PAUSE TestAccResourceSecurityDataSecrecyLevel_basic
=== CONT  TestAccResourceSecurityDataSecrecyLevel_basic
--- PASS: TestAccResourceSecurityDataSecrecyLevel_basic (21.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  21.360s
```
