### PR TITLE
feat(cfw): firewall resource support to update tags

### DIFF
--- a/docs/resources/cfw_firewall.md
+++ b/docs/resources/cfw_firewall.md
@@ -107,10 +107,6 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
   The [flavor](#Firewall_Flavor) structure is documented below.
 
-* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the firewall.
-
-  Changing this parameter will create a new resource.
-
 * `east_west_firewall_inspection_cidr` - (Optional, String, ForceNew) Specifies the inspection cidr of the east-west firewall.
 
   Changing this parameter will create a new resource.
@@ -163,6 +159,8 @@ The following arguments are supported:
   + **1**: Strict Mode.
   + **2**: Medium Mode.
   + **3**: Loose Mode.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the firewall.
 
 <a name="Firewall_Flavor"></a>
 The `flavor` block supports:

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_firewall_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_firewall_test.go
@@ -124,12 +124,23 @@ func TestAccFirewall_prePaid(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "charging_mode", "prePaid"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttrSet(rName, "engine_type"),
 					resource.TestCheckResourceAttrSet(rName, "ha_type"),
 					resource.TestCheckResourceAttrSet(rName, "protect_objects.#"),
 					resource.TestCheckResourceAttrSet(rName, "service_type"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
 					resource.TestCheckResourceAttrSet(rName, "support_ipv6"),
+				),
+			},
+			{
+				Config: testFirewall_prePaid_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "tags.k1", "v1"),
+					resource.TestCheckResourceAttr(rName, "tags.k2", "v2"),
 				),
 			},
 			{
@@ -396,6 +407,28 @@ resource "huaweicloud_cfw_firewall" "test" {
   tags = {
     key = "value"
     foo = "bar"
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = false
+}
+`, name)
+}
+
+func testFirewall_prePaid_update(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cfw_firewall" "test" {
+  name = "%s"
+
+  flavor {
+    version = "Professional"
+  }
+
+  tags = {
+    k1 = "v1"
+    k2 = "v2"
   }
 
   charging_mode = "prePaid"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
firewall resource support to update tags
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. firewall resource support to update tags
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccFirewall_ips"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccFirewall_ips -timeout 360m -parallel 4
=== RUN   TestAccFirewall_ips
=== PAUSE TestAccFirewall_ips
=== CONT  TestAccFirewall_ips
--- PASS: TestAccFirewall_ips (549.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       549.093s

make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccFirewall_prePaid"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccFirewall_prePaid -timeout 360m -parallel 4
=== RUN   TestAccFirewall_prePaid
=== PAUSE TestAccFirewall_prePaid
=== CONT  TestAccFirewall_prePaid
--- PASS: TestAccFirewall_prePaid (549.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       549.296s

```
