### PR TITLE
feat(CDN): CDN domain resource support new fields

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -150,6 +150,13 @@ resource "huaweicloud_cdn_domain" "domain_1" {
       ttl  = 70
     }
 
+    origin_request_url_rewrite {
+      match_type = "file_path"
+      priority   = 10
+      source_url = "/tt/abc.txt"
+      target_url = "/new/$1/$2.html"
+    }
+
     remote_auth {
       enabled = true
 
@@ -366,6 +373,11 @@ The `configs` block support:
 
 * `ip_filter` - (Optional, List) Specifies the IP address blacklist or whitelist.
   The [ip_filter](#ip_filter_object) structure is documented below.
+
+* `origin_request_url_rewrite` - (Optional, List) Specifies the rules of rewriting origin request URLs.
+  The [origin_request_url_rewrite](#origin_request_url_rewrite_object) structure is documented below.
+
+  -> Up to 20 rules can be configured.
 
 <a name="https_settings_object"></a>
 The `https_settings` block support:
@@ -744,6 +756,27 @@ The `ip_filter` block support:
   set to **black** or **white**. A list contains up to `500` IP addresses and IP address segments, which are separated
   by commas (,). IPv6 addresses are supported. Duplicate IP addresses and IP address segments will be removed.
   Addresses with wildcard characters are not supported, for example, `192.168.0.*`.
+
+<a name="origin_request_url_rewrite_object"></a>
+The `origin_request_url_rewrite` block support:
+
+* `priority` - (Required, Int) Specifies the priority of a URL rewrite rule. The priority of a rule is mandatory and
+  must be unique. The rule with the highest priority will be used for matching first. The value ranges from **1** to
+  **100**.
+
+* `match_type` - (Required, String) Specifies the match type. Valid values are:
+  + **all**: All files.
+  + **file_path**: URI path.
+  + **wildcard**: Wildcard.
+  + **full_path**: Full path.
+
+* `target_url` - (Required, String) Specifies a URI starts with a slash (/) and does not contain `http://`, `https://`,
+  or the domain name. The value contains up to `256` characters. The nth wildcard (*) field can be substituted with
+  `$n`, where n = 1, 2, 3..., for example, `/newtest/$1/$2.jpg`.
+
+* `source_url` - (Optional, String) Specifies the URI to be rewritten. The URI starts with a slash (/) and does not
+  contain `http://`, `https://`, or the domain name. The value contains up to `512` characters.
+  Wildcards (*) are supported, for example, `/test/*/*.mp4`. This field is invalid when `match_type` is set to **all**.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -379,6 +379,9 @@ The `configs` block support:
 
   -> Up to 20 rules can be configured.
 
+* `user_agent_filter` - (Optional, List) Specifies the User-Agent blacklist or whitelist settings.
+  The [user_agent_filter](#user_agent_filter_object) structure is documented below.
+
 <a name="https_settings_object"></a>
 The `https_settings` block support:
 
@@ -762,7 +765,7 @@ The `origin_request_url_rewrite` block support:
 
 * `priority` - (Required, Int) Specifies the priority of a URL rewrite rule. The priority of a rule is mandatory and
   must be unique. The rule with the highest priority will be used for matching first. The value ranges from **1** to
-  **100**.
+  **100**. A greater number indicates a higher priority.
 
 * `match_type` - (Required, String) Specifies the match type. Valid values are:
   + **all**: All files.
@@ -777,6 +780,17 @@ The `origin_request_url_rewrite` block support:
 * `source_url` - (Optional, String) Specifies the URI to be rewritten. The URI starts with a slash (/) and does not
   contain `http://`, `https://`, or the domain name. The value contains up to `512` characters.
   Wildcards (*) are supported, for example, `/test/*/*.mp4`. This field is invalid when `match_type` is set to **all**.
+
+<a name="user_agent_filter_object"></a>
+The `user_agent_filter` block support:
+
+* `type` - (Required, String) Specifies the User-Agent blacklist or whitelist type. Valid values are:
+  + **off**: The User-Agent blacklist/whitelist is disabled.
+  + **black**: The User-Agent blacklist.
+  + **white**: The User-Agent whitelist.
+
+* `ua_list` - (Optional, List) Specifies the User-Agent blacklist or whitelist. This parameter is required when `type`
+  is set to **black** or **white**. Up to `10` rules can be configured. A rule contains up to `100` characters.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -510,6 +510,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.type", "black"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.value", "5.12.3.65,35.2.65.21"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.#", "2"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "403"),
@@ -612,6 +614,12 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.type", "white"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.value", "5.12.3.66"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.0.match_type", "file_path"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.0.priority", "10"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.0.source_url", "/tt/abc.txt"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.0.target_url", "/new/$1/$2.html"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "503"),
@@ -657,6 +665,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.type", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
@@ -834,6 +843,19 @@ resource "huaweicloud_cdn_domain" "test" {
       value = "5.12.3.65,35.2.65.21"
     }
 
+    origin_request_url_rewrite {
+      match_type = "all"
+      priority   = 2
+      target_url = "/nn.tx"
+    }
+
+    origin_request_url_rewrite {
+      match_type = "file_path"
+      priority   = 5
+      source_url = "/tt/ab.txt"
+      target_url = "/new/$1/$2.html"
+    }
+
     remote_auth {
       enabled = true
 
@@ -986,6 +1008,13 @@ resource "huaweicloud_cdn_domain" "test" {
     ip_filter {
       type  = "white"
       value = "5.12.3.66"
+    }
+
+    origin_request_url_rewrite {
+      match_type = "file_path"
+      priority   = 10
+      source_url = "/tt/abc.txt"
+      target_url = "/new/$1/$2.html"
     }
 
     remote_auth {

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -512,6 +512,9 @@ func TestAccCdnDomain_configs(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.#", "2"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.type", "white"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.ua_list.#", "3"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "403"),
@@ -620,6 +623,9 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.0.source_url", "/tt/abc.txt"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.0.target_url", "/new/$1/$2.html"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.type", "black"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.ua_list.0", "t1*"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "503"),
@@ -666,6 +672,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.ip_filter.0.type", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.type", "off"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
@@ -856,6 +864,15 @@ resource "huaweicloud_cdn_domain" "test" {
       target_url = "/new/$1/$2.html"
     }
 
+    user_agent_filter {
+      type    = "white"
+      ua_list = [
+        "t1",
+        "t2",
+        "t3*",
+      ]
+    }
+
     remote_auth {
       enabled = true
 
@@ -1017,6 +1034,13 @@ resource "huaweicloud_cdn_domain" "test" {
       target_url = "/new/$1/$2.html"
     }
 
+    user_agent_filter {
+      type    = "black"
+      ua_list = [
+        "t1*",
+      ]
+    }
+
     remote_auth {
       enabled = true
 
@@ -1092,6 +1116,10 @@ resource "huaweicloud_cdn_domain" "test" {
     }
 
     ip_filter {
+      type = "off"
+    }
+
+    user_agent_filter {
       type = "off"
     }
   }

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -625,6 +625,32 @@ var ipFilter = schema.Schema{
 	},
 }
 
+var originRequestUrlRewrite = schema.Schema{
+	Type:     schema.TypeSet,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"priority": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"match_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target_url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"source_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	},
+}
+
 // @API CDN POST /v1.0/cdn/domains
 // @API CDN GET /v1.0/cdn/configuration/domains/{domain_name}
 // @API CDN PUT /v1.0/cdn/domains/{domainId}/disable
@@ -772,6 +798,7 @@ func ResourceCdnDomain() *schema.Resource {
 						"request_limit_rules":        &requestLimitRules,
 						"error_code_cache":           &errorCodeCache,
 						"ip_filter":                  &ipFilter,
+						"origin_request_url_rewrite": &originRequestUrlRewrite,
 					},
 				},
 			},
@@ -1263,6 +1290,27 @@ func buildIpFilterOpts(rawIpFilter []interface{}) *model.IpFilter {
 	return &ipFilterOpts
 }
 
+func buildOriginRequestUrlRewriteOpts(rawOriginRequestUrlRewrite []interface{}) *[]model.OriginRequestUrlRewrite {
+	if len(rawOriginRequestUrlRewrite) < 1 {
+		// Define an empty array to clear all origin request url rewrite
+		rst := make([]model.OriginRequestUrlRewrite, 0)
+		return &rst
+	}
+
+	originRequestUrlRewriteOpts := make([]model.OriginRequestUrlRewrite, len(rawOriginRequestUrlRewrite))
+	for i, v := range rawOriginRequestUrlRewrite {
+		urlMap := v.(map[string]interface{})
+		urlOpt := model.OriginRequestUrlRewrite{
+			Priority:  int32(urlMap["priority"].(int)),
+			MatchType: urlMap["match_type"].(string),
+			TargetUrl: urlMap["target_url"].(string),
+			SourceUrl: utils.StringIgnoreEmpty(urlMap["source_url"].(string)),
+		}
+		originRequestUrlRewriteOpts[i] = urlOpt
+	}
+	return &originRequestUrlRewriteOpts
+}
+
 func buildSourcesOpts(rawSources []interface{}) *[]model.SourcesConfig {
 	if len(rawSources) < 1 {
 		return nil
@@ -1413,6 +1461,10 @@ func buildUpdateDomainFullConfigsOpts(configsOpts *model.Configs, configs map[st
 	}
 	if d.HasChange("configs.0.ip_filter") {
 		configsOpts.IpFilter = buildIpFilterOpts(configs["ip_filter"].([]interface{}))
+	}
+	if d.HasChange("configs.0.origin_request_url_rewrite") {
+		originRequestUrlRewrites := configs["origin_request_url_rewrite"].(*schema.Set).List()
+		configsOpts.OriginRequestUrlRewrite = buildOriginRequestUrlRewriteOpts(originRequestUrlRewrites)
 	}
 }
 
@@ -1907,6 +1959,23 @@ func flattenIpFilterAttrs(ipFilter *model.IpFilter) []map[string]interface{} {
 	return []map[string]interface{}{ipFilterAttrs}
 }
 
+func flattenOriginRequestUrlRewriteAttrs(originRequestUrlRewrite *[]model.OriginRequestUrlRewrite) []map[string]interface{} {
+	if originRequestUrlRewrite == nil || len(*originRequestUrlRewrite) == 0 {
+		return nil
+	}
+
+	originRequestUrlRewriteAttrs := make([]map[string]interface{}, len(*originRequestUrlRewrite))
+	for i, v := range *originRequestUrlRewrite {
+		originRequestUrlRewriteAttrs[i] = map[string]interface{}{
+			"priority":   v.Priority,
+			"match_type": v.MatchType,
+			"target_url": v.TargetUrl,
+			"source_url": v.SourceUrl,
+		}
+	}
+	return originRequestUrlRewriteAttrs
+}
+
 func flattenSourcesAttrs(sources *[]model.SourcesConfig) []map[string]interface{} {
 	if sources == nil || len(*sources) == 0 {
 		return nil
@@ -1962,6 +2031,7 @@ func flattenConfigAttrs(configsResp *model.ConfigsGetBody, d *schema.ResourceDat
 		"request_limit_rules":           flattenRequestLimitRulesAttrs(configsResp.RequestLimitRules),
 		"error_code_cache":              flattenErrorCodeCacheAttrs(configsResp.ErrorCodeCache),
 		"ip_filter":                     flattenIpFilterAttrs(configsResp.IpFilter),
+		"origin_request_url_rewrite":    flattenOriginRequestUrlRewriteAttrs(configsResp.OriginRequestUrlRewrite),
 	}
 	return []map[string]interface{}{configsAttrs}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN domain resource support new fields
- commit1: CDN domain support new field `configs.0.origin_request_url_rewrite`.
- commit2: CDN domain support new field `configs.0.user_agent_filter`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (689.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       689.674s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (739.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       739.245s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (428.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       428.610s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_epsID_migrate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_epsID_migrate -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_epsID_migrate (328.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       328.252s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (648.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       648.261s
```
