### PR TITLE
feat(dds): support updating configuration ID in instance

### DIFF
--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -206,8 +206,9 @@ The `configuration` block supports:
   + For a Community Edition single node instance, the value is **single**.
     Changing this creates a new instance.
 
-* `id` - (Required, String, ForceNew) Specifies the ID of the template.
-  Changing this creates a new instance.
+* `id` - (Required, String) Specifies the ID of the template.
+
+  -> Atfer updating the `configuration.id`, please check whether the instance needs to be restarted.
 
 The `flavor` block supports:
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support updating `configuration.id` in `huaweiclou_dds_instance`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_withConfigurationSharding"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withConfigurationSharding -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withConfigurationSharding
=== PAUSE TestAccDDSV3Instance_withConfigurationSharding
=== CONT  TestAccDDSV3Instance_withConfigurationSharding
--- PASS: TestAccDDSV3Instance_withConfigurationSharding (1438.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       1438.820s

make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_withConfigurationReplicaSet"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withConfigurationReplicaSet -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withConfigurationReplicaSet
=== PAUSE TestAccDDSV3Instance_withConfigurationReplicaSet
=== CONT  TestAccDDSV3Instance_withConfigurationReplicaSet
--- PASS: TestAccDDSV3Instance_withConfigurationReplicaSet (1049.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       1049.423s
```
