### PR TITLE
feat(lb): add attrs for member

### DIFF
--- a/docs/resources/lb_member.md
+++ b/docs/resources/lb_member.md
@@ -49,6 +49,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the member.
 
+* `backend_server_status` - Indicates the administrative status of the backend server.
+
+* `operating_status` - Indicates the health check result of the backend server.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_member_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_member_test.go
@@ -50,26 +50,25 @@ func TestAccLBV2Member_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckLBV2MemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccLBV2MemberConfig_basic(rName),
-				ExpectNonEmptyPlan: true, // Because admin_state_up remains false.
+				Config: testAccLBV2MemberConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc1.CheckResourceExists(),
 					rc2.CheckResourceExists(),
 				),
 			},
 			{
-				Config:             testAccLBV2MemberConfig_update(rName),
-				ExpectNonEmptyPlan: true, // Because admin_state_up remains false.
+				Config: testAccLBV2MemberConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("huaweicloud_lb_member.member_1", "weight", "10"),
 					resource.TestCheckResourceAttr("huaweicloud_lb_member.member_2", "weight", "15"),
 				),
 			},
 			{
-				ResourceName:      "huaweicloud_lb_member.member_1",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccLBMemberImportStateIdFunc(),
+				ResourceName:            "huaweicloud_lb_member.member_1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"admin_state_up"},
+				ImportStateIdFunc:       testAccLBMemberImportStateIdFunc(),
 			},
 		},
 	})
@@ -197,7 +196,6 @@ resource "huaweicloud_lb_member" "member_1" {
   address        = "192.168.0.10"
   protocol_port  = 8080
   weight         = 10
-  admin_state_up = "true"
   pool_id        = huaweicloud_lb_pool.pool_1.id
   subnet_id      = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 
@@ -212,7 +210,6 @@ resource "huaweicloud_lb_member" "member_2" {
   address        = "192.168.0.11"
   protocol_port  = 8080
   weight         = 15
-  admin_state_up = "true"
   pool_id        = huaweicloud_lb_pool.pool_1.id
   subnet_id      = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
 

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_member.go
@@ -95,16 +95,28 @@ func ResourceMemberV2() *schema.Resource {
 				Description: "the IPv4 subnet ID of the subnet in which to access the member",
 			},
 
-			"admin_state_up": {
-				Type:     schema.TypeBool,
-				Default:  true,
-				Optional: true,
-			},
-
 			"pool_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+
+			"backend_server_status": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"operating_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			// deprecated
+			"admin_state_up": {
+				Type:        schema.TypeBool,
+				Default:     true,
+				Optional:    true,
+				Description: "schema: Deprecated",
 			},
 		},
 	}
@@ -175,11 +187,12 @@ func resourceMemberV2Read(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("region", config.GetRegion(d)),
 		d.Set("name", member.Name),
 		d.Set("weight", member.Weight),
-		d.Set("admin_state_up", member.AdminStateUp),
 		d.Set("tenant_id", member.TenantID),
 		d.Set("subnet_id", member.SubnetID),
 		d.Set("address", member.Address),
 		d.Set("protocol_port", member.ProtocolPort),
+		d.Set("operating_status", member.OperatingStatus),
+		d.Set("backend_server_status", member.AdminStateUp),
 	)
 
 	if err = mErr.ErrorOrNil(); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add attrs for `huaweicloud_lb_member`, including `operating_status`

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/lb" TESTARGS="-run TestAccLBV2Member_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb -v -run TestAccLBV2Member_basic -timeout 360m -parallel 4
=== RUN   TestAccLBV2Member_basic
=== PAUSE TestAccLBV2Member_basic
=== CONT  TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (176.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        176.172s
```
