### PR TITLE
chore(apig): when type is elb, supports ingerss_address attribute

### DIFF
--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -265,6 +265,7 @@ func TestAccInstance_ingress(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "14:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_address", ""),
 				),
 			},
 			{
@@ -275,6 +276,7 @@ func TestAccInstance_ingress(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
 					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_size", "5"),
 					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_charging_mode", "bandwidth"),
+					resource.TestCheckResourceAttrSet(resourceName, "ingress_address"),
 				),
 			},
 			{
@@ -292,6 +294,7 @@ func TestAccInstance_ingress(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "ingress_address", ""),
 				),
 			},
 			{

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -482,7 +482,6 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("ingress_bandwidth_charging_mode", resp.IngressBandwidthChargingMode),
 		// Attributes
 		d.Set("maintain_end", resp.MaintainEnd),
-		d.Set("ingress_address", resp.Ipv4IngressEipAddress),
 		d.Set("vpc_ingress_address", resp.Ipv4VpcIngressAddress),
 		d.Set("egress_address", resp.Ipv4EgressAddress),
 		d.Set("supported_features", resp.SupportedFeatures),
@@ -505,12 +504,20 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 		)
 	}
 
-	ingressBandwidthSize := 0
+	var (
+		ingressBandwidthSize int
+		ingressPublicIp      string
+	)
 	if len(resp.PublicIps) > 0 {
 		ingressBandwidthSize = resp.PublicIps[0].BandwidthSize
+		ingressPublicIp = resp.PublicIps[0].IpAddress
+	} else {
+		ingressPublicIp = resp.Ipv4IngressEipAddress
 	}
+
 	mErr = multierror.Append(mErr,
 		d.Set("ingress_bandwidth_size", ingressBandwidthSize),
+		d.Set("ingress_address", ingressPublicIp),
 	)
 
 	if tagList, err := instances.GetTags(client, instanceId); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 
when instance type is `elb`, the resource supports  `ingerss_address` attribute.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

 Query instance details [API document](https://support.huaweicloud.com/api-apig/ShowDetailsOfInstanceV2.html).
1. The ingress EIP address fields corresponding to the two types are as follows:
When the instance type is `elb`, the corresponding field is `publicips[0].ip_address`;
When the instance type is `lvs`, the corresponding field is `eip_address`;
2. The egress EIP address corresponding to both types are `nat_eip_address`.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccInstance_ingress'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccInstance_ingress -timeout 360m -parallel 4
=== RUN   TestAccInstance_ingress
=== PAUSE TestAccInstance_ingress
=== CONT  TestAccInstance_ingress
--- PASS: TestAccInstance_ingress (723.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      723.543s
```
