### PR TITLE
fix(dli): catch and handle the 408 errors

### DIFF
--- a/docs/resources/dli_database.md
+++ b/docs/resources/dli_database.md
@@ -52,6 +52,13 @@ In addition to all arguments above, the following attributes are exported:
 
 -> If the user has opened the EPS service, this value is a UUID value. If not, this value is the database name.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
 ## Import
 
 DLI SQL databases can be imported by their `name`, e.g.

--- a/docs/resources/dli_table.md
+++ b/docs/resources/dli_table.md
@@ -118,7 +118,8 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `Delete` - Default is 10 minutes.
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_table.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_table.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -29,6 +30,12 @@ func ResourceDliTable() *schema.Resource {
 		CreateContext: resourceDliTableCreate,
 		ReadContext:   resourceDliTableRead,
 		DeleteContext: resourceDliTableDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -153,10 +160,19 @@ func ResourceDliTable() *schema.Resource {
 				Computed: true,
 			},
 		},
+	}
+}
 
-		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(10 * time.Minute),
-		},
+func datatableCreateRefreshFunc(client *golangsdk.ServiceClient, dbName, tableName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		detail, queryErr := tables.Get(client, dbName, tableName)
+		if queryErr != nil {
+			if _, ok := queryErr.(golangsdk.ErrDefault404); !ok {
+				return detail, "ERROR", queryErr
+			}
+			return detail, "PENDING", nil
+		}
+		return detail, "COMPLETED", nil
 	}
 }
 
@@ -189,13 +205,27 @@ func resourceDliTableCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("[DEBUG] Creating new DLI table opts: %#v", opts)
 
-	rst, createErr := tables.Create(client, databaseName, opts)
-	if createErr != nil {
-		return diag.Errorf("error creating DLI table: %s", createErr)
-	}
+	resp, err := tables.Create(client, databaseName, opts)
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault408); !ok {
+			return diag.Errorf("error create DLI datatable (%s) to the database (%s): %s", databaseName, tableName, err)
+		}
 
-	if rst != nil && !rst.IsSuccess {
-		return diag.Errorf("error creating DLI table: %s", rst.Message)
+		// Return synchronization job result times out.
+		// At this time, the job has entered the creation phase.
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      datatableCreateRefreshFunc(client, databaseName, tableName),
+			Timeout:      d.Timeout(schema.TimeoutCreate),
+			PollInterval: 10 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error create DLI datatable (%s) to the database (%s): %s", databaseName, tableName, err)
+		}
+	} else if resp != nil && !resp.IsSuccess {
+		return diag.Errorf("the request was sent successfully, but some errors occurred: %s", resp.Message)
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s", databaseName, tableName))
@@ -296,7 +326,20 @@ func setStoragePropertiesToState(d *schema.ResourceData, storageProperties []map
 	return mErr.ErrorOrNil()
 }
 
-func resourceDliTableDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func datatableDeleteRefreshFunc(client *golangsdk.ServiceClient, dbName, tableName string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		detail, queryErr := tables.Get(client, dbName, tableName)
+		if queryErr != nil {
+			if _, ok := queryErr.(golangsdk.ErrDefault404); !ok {
+				return detail, "ERROR", queryErr
+			}
+			return detail, "COMPLETED", nil
+		}
+		return detail, "PENDING", nil
+	}
+}
+
+func resourceDliTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := cfg.DliV1Client(region)
@@ -305,16 +348,28 @@ func resourceDliTableDelete(_ context.Context, d *schema.ResourceData, meta inte
 	}
 
 	databaseName, tableName := ParseTableInfoFromId(d.Id())
+	resp, err := tables.Delete(client, databaseName, tableName, false)
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault408); !ok {
+			return diag.Errorf("error deleting DLI database: %s", err)
+		}
 
-	resp, dErr := tables.Delete(client, databaseName, tableName, false)
-	if dErr != nil {
-		return diag.Errorf("error delete DLI Table %q:%s", d.Id(), dErr)
+		// Return synchronization job result times out.
+		// At this time, the job has entered the delete phase.
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      datatableDeleteRefreshFunc(client, databaseName, tableName),
+			Timeout:      d.Timeout(schema.TimeoutDelete),
+			PollInterval: 10 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error deleting DLI datatable (%s) from the database (%s): %s", databaseName, tableName, err)
+		}
+	} else if resp != nil && !resp.IsSuccess {
+		return diag.Errorf("the request was sent successfully, but some errors occurred: %s", resp.Message)
 	}
-
-	if resp != nil && !resp.IsSuccess {
-		return diag.Errorf("error delete DLI Table: %s", resp.Message)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When resource (database or data table) create or delete by provider, due to the shared queue is their bottom layer relies resource, timeout errors (status code: 408, error code: DLI.0019) will be frequently returned when the usage is large.
```
{
 "error_code": "DLI.0019",
 "error_msg": "Get sync job result timeout with id: 5e913d04-4c23-48ea-a71f-3f6c678e7bd7"
}
```
If you try again immediately, the following error will be thrown：
```
{
 "error_code": "DLI.0005",
 "error_msg": "AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: AlreadyExistsException(message:Table tf_test_db9z6 already exists);\\nCause by: HiveException: AlreadyExistsException(message:Table tf_test_db9z6 already exists)\\nCause by: AlreadyExistsException: Table tf_test_db9z6 already exists"
}
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. catch and handle the 408 errors
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccResourceDliTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccResourceDliTable_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDliTable_basic
=== PAUSE TestAccResourceDliTable_basic
=== CONT  TestAccResourceDliTable_basic
--- PASS: TestAccResourceDliTable_basic (37.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       37.509s
```
