### PR TITLE
feat(ram): add a datasource to get the list of RAM resource share invitations

### DIFF
--- a/docs/data-sources/ram_resource_share_invitations.md
+++ b/docs/data-sources/ram_resource_share_invitations.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Resource Access Manager (RAM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ram_resource_share_invitations"
+description: |-
+  Use this data source to get the list of RAM resource share invitations.
+---
+
+# huaweicloud_ram_resource_share_invitations
+
+Use this data source to get the list of resource share invitations.
+
+## Example Usage
+
+```hcl
+var "status" {}
+
+data "huaweicloud_ram_resource_share_invitations" "test" {
+  status = var.status
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `resource_share_ids` - (Optional, List) Specifies the list of the resource share IDs.
+
+* `resource_share_invitation_ids` - (Optional, List) Specifies the list of the resource share invitation IDs.
+
+* `status` - (Optional, String) Specifies the status of the resource share invitation.
+  The valid values are **pending**, **accepted** and **rejected**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `resource_share_invitations` - The list of shared resources.
+  The [resource_share_invitations](#ram_resource_share_invitations) structure is documented below.
+
+<a name="ram_resource_share_invitations"></a>
+The `resource_share_invitations` block supports:
+
+* `id` - The ID of the resource share invitation.
+
+* `resource_share_id` - The ID of the resource share.
+
+* `resource_share_name` - The name of the resource share.
+
+* `receiver_account_id` - The ID of the account that receives the resource share invitation.
+
+* `sender_account_id` - The ID of the account that sends the resource share invitation.
+
+* `status` - The status of the resource share invitation.
+
+* `created_at` - The creation time of the resource share invitation.
+
+* `updated_at` - The latest update time of the resource share invitation.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -687,9 +687,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_obs_buckets":       obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
 
-			"huaweicloud_ram_resource_permissions": ram.DataSourceRAMPermissions(),
-			"huaweicloud_ram_shared_resources":     ram.DataSourceRAMSharedResources(),
-			"huaweicloud_ram_shared_principals":    ram.DataSourceRAMSharedPrincipals(),
+			"huaweicloud_ram_resource_permissions":       ram.DataSourceRAMPermissions(),
+			"huaweicloud_ram_resource_share_invitations": ram.DataSourceResourceShareInvitations(),
+			"huaweicloud_ram_shared_resources":           ram.DataSourceRAMSharedResources(),
+			"huaweicloud_ram_shared_principals":          ram.DataSourceRAMSharedPrincipals(),
 
 			"huaweicloud_rds_flavors":                       rds.DataSourceRdsFlavor(),
 			"huaweicloud_rds_engine_versions":               rds.DataSourceRdsEngineVersionsV3(),

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_resource_share_invitations_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_resource_share_invitations_test.go
@@ -1,0 +1,65 @@
+package ram
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceResourceShareInvitations_basic(t *testing.T) {
+	dName := "data.huaweicloud_ram_resource_share_invitations.test"
+	dc := acceptance.InitDataSourceCheck(dName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRAMShareInvitationId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceResourceShareInvitations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dName, "resource_share_invitations.0.id"),
+					resource.TestCheckResourceAttrSet(dName, "resource_share_invitations.0.resource_share_id"),
+					resource.TestCheckResourceAttrSet(dName, "resource_share_invitations.0.resource_share_name"),
+					resource.TestCheckResourceAttrSet(dName, "resource_share_invitations.0.receiver_account_id"),
+					resource.TestCheckResourceAttrSet(dName, "resource_share_invitations.0.sender_account_id"),
+					resource.TestCheckResourceAttrSet(dName, "resource_share_invitations.0.status"),
+					resource.TestCheckResourceAttrSet(dName, "resource_share_invitations.0.created_at"),
+					resource.TestCheckResourceAttrSet(dName, "resource_share_invitations.0.updated_at"),
+
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceResourceShareInvitations_basic() string {
+	return (`
+data "huaweicloud_ram_resource_share_invitations" "test" {}
+
+locals {
+  status = data.huaweicloud_ram_resource_share_invitations.test.resource_share_invitations[0].status
+}
+
+data "huaweicloud_ram_resource_share_invitations" "filter_by_status" {
+  status = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_ram_resource_share_invitations.filter_by_status.resource_share_invitations[*].status : 
+    v == local.status
+  ]
+}
+
+output "status_filter_is_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+`)
+}

--- a/huaweicloud/services/ram/data_source_huaweicloud_ram_resource_share_invitations.go
+++ b/huaweicloud/services/ram/data_source_huaweicloud_ram_resource_share_invitations.go
@@ -1,0 +1,176 @@
+package ram
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const pageLimitCount = 200
+
+// @API RAM POST /v1/resource-share-invitations/search
+func DataSourceResourceShareInvitations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceResourceShareInvitationssRead,
+		Schema: map[string]*schema.Schema{
+			"resource_share_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"resource_share_invitation_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_share_invitations": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     resourceShareInvitationsSchema(),
+			},
+		},
+	}
+}
+
+func resourceShareInvitationsSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_share_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_share_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"receiver_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sender_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataSourceResourceShareInvitationssRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                                = meta.(*config.Config)
+		region                             = cfg.GetRegion(d)
+		mErr                               *multierror.Error
+		getResourceShareInvitationsHttpUrl = "v1/resource-share-invitations/search"
+		getResourceShareInvitationsProduct = "ram"
+	)
+	getResourceShareInvitationsClient, err := cfg.NewServiceClient(getResourceShareInvitationsProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating RAM client: %s", err)
+	}
+
+	getResourceShareInvitationsPath := getResourceShareInvitationsClient.Endpoint + getResourceShareInvitationsHttpUrl
+	getResourceShareInvitationsOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	var nextMarker string
+	allResourceShareInvitations := make([]interface{}, 0)
+	getResourceShareInvitationsJSONBody := utils.RemoveNil(buildGetResourceShareInvitationsBodyParams(d))
+	for {
+		getResourceShareInvitationsOpt.JSONBody = getResourceShareInvitationsJSONBody
+		getResourceShareInvitationsResp, err := getResourceShareInvitationsClient.Request("POST",
+			getResourceShareInvitationsPath, &getResourceShareInvitationsOpt)
+
+		if err != nil {
+			return common.CheckDeletedDiag(d, err, "error retrieving RAM resource share invitations")
+		}
+
+		getResourceShareInvitationsRespBody, err := utils.FlattenResponse(getResourceShareInvitationsResp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		resourceShareInvitations := utils.PathSearch("resource_share_invitations", getResourceShareInvitationsRespBody,
+			make([]interface{}, 0)).([]interface{})
+
+		if len(resourceShareInvitations) > 0 {
+			allResourceShareInvitations = append(allResourceShareInvitations, resourceShareInvitations...)
+		}
+
+		nextMarker = utils.PathSearch("page_info.next_marker", getResourceShareInvitationsRespBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+		getResourceShareInvitationsJSONBody["marker"] = nextMarker
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("resource_share_invitations", flattenGetResourceShareInvitationsResponseBody(allResourceShareInvitations)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildGetResourceShareInvitationsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"resource_share_ids":            utils.ValueIngoreEmpty(d.Get("resource_share_ids")),
+		"resource_share_invitation_ids": utils.ValueIngoreEmpty(d.Get("resource_share_invitation_ids")),
+		"status":                        utils.ValueIngoreEmpty(d.Get("status")),
+		"limit":                         pageLimitCount,
+	}
+	return bodyParams
+}
+
+func flattenGetResourceShareInvitationsResponseBody(curArray []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(curArray))
+	for _, v := range curArray {
+		rst = append(rst, map[string]interface{}{
+			"id":                  utils.PathSearch("resource_share_invitation_id", v, nil),
+			"resource_share_id":   utils.PathSearch("resource_share_id", v, nil),
+			"resource_share_name": utils.PathSearch("resource_share_name", v, nil),
+			"receiver_account_id": utils.PathSearch("receiver_account_id", v, nil),
+			"sender_account_id":   utils.PathSearch("sender_account_id", v, nil),
+			"status":              utils.PathSearch("status", v, nil),
+			"created_at":          utils.PathSearch("created_at", v, nil),
+			"updated_at":          utils.PathSearch("updated_at", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Aadd a datasource to get the list of RAM resource share invitations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 1. support new datasource to get list of RAM resource share invitations.
 2. support related document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/ram" TESTARGS="-run TestAccDatasourceResourceShareAccepters_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccDatasourceResourceShareAccepters_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceResourceShareAccepters_basic
=== PAUSE TestAccDatasourceResourceShareAccepters_basic
=== CONT  TestAccDatasourceResourceShareAccepters_basic
--- PASS: TestAccDatasourceResourceShareAccepters_basic (20.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       20.718s
```
