### PR TITLE
feat(dli): add new datasource to get list of jar type of flink jobs

### DIFF
--- a/docs/data-sources/dli_flinkjar_jobs.md
+++ b/docs/data-sources/dli_flinkjar_jobs.md
@@ -1,0 +1,112 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dli_flinkjar_jobs"
+description: |-
+  Use this data source to get the list of the DLI flinkjar jobs.
+---
+
+# huaweicloud_dli_flinkjar_jobs
+
+Use this data source to get the list of the DLI flinkjar jobs.
+
+## Example Usage
+
+```hcl
+variable "queue_name" {}
+
+data "huaweicloud_dli_flinkjar_jobs" "test" {
+  queue_name = var.queue_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `queue_name` - (Optional, String) Specifies the name of DLI queue which this job to be queried.
+
+* `job_id` - (Optional, String) Specifies the ID of the job to be queried.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to be queried.
+
+* `manager_cu_num` - (Optional, Int) Specifies number of CUs in the job manager to be queried.
+
+* `cu_num` - (Optional, Int) Specifies number of CUs to be queried.
+
+* `parallel_num` - (Optional, Int) Specifies number of parallel to be queried.
+
+* `tm_cu_num` - (Optional, Int) Specifies number of CUs occupied by a single TM to be queried.
+
+* `tm_slot_num` - (Optional, Int) Specifies number of single TM slots to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `jobs` - All jobs that match the filter parameters.
+
+  The [jobs](#job_list_jobs_struct) structure is documented below.
+
+<a name="job_list_jobs_struct"></a>
+The `jobs` block supports:
+
+* `id` - The ID of the job.
+
+* `name` - The name of the job.
+
+* `status` - The status of the job.
+
+* `description` - The description of the job.
+
+* `queue_name` - The name of DLI queue which this job run in.
+
+* `main_class` - The jar package main class.
+
+* `entrypoint_args` - The job entry arguments.
+
+* `flink_version` - The flink version.
+
+* `obs_bucket` - The name of OBS bucket.
+
+* `log_enabled` - The whether to enable the function of uploading job logs to users' OBS buckets.
+
+* `smn_topic` - The SMN topic. If a job fails, the system will send a message to users subscribed to the SMN topic.
+
+* `manager_cu_num` - The number of CUs in the job manager selected for a job.
+
+* `cu_num` - The number of CUs selected for a job.
+
+* `parallel_num` - The number of parallel for a job.
+
+* `restart_when_exception` - The whether to enable the function of restart upon exceptions.
+
+* `entrypoint` - The JAR file where the job main class is located.
+  It is the name of the package that has been uploaded to the DLI.
+
+* `dependency_jars` - The other dependency jars. It is the name of the package that has been uploaded to the DLI.
+
+* `dependency_files` - The dependency files. It is the name of the package that has been uploaded to the DLI.
+
+* `resume_checkpoint` - The whether the abnormal restart is recovered from the checkpoint.
+
+* `runtime_config` - The customize optimization parameters during flink job runtime.
+
+* `resume_max_num` - The maximum number of retry times upon exceptions.
+
+* `checkpoint_path` - The checkpoint save path.
+
+* `tm_cu_num` - The number of CUs occupied by a single TM.
+
+* `tm_slot_num` - The number of single TM slots.
+
+* `image` - The custom image.
+
+* `feature` - The custom job features. Type of the Flink image used by a job.
+    + **basic**: indicates that the basic Flink image provided by DLI is used.
+    + **custom**: indicates that the user-defined Flink image is used.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -520,6 +520,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dli_datasource_connections": dli.DataSourceConnections(),
 			"huaweicloud_dli_elastic_resource_pools": dli.DataSourceDliElasticPools(),
 			"huaweicloud_dli_flink_templates":        dli.DataSourceDliFlinkTemplates(),
+			"huaweicloud_dli_flinkjar_jobs":          dli.DataSourceDliFlinkjarJobs(),
 			"huaweicloud_dli_quotas":                 dli.DataSourceDliQuotas(),
 			"huaweicloud_dli_spark_templates":        dli.DataSourceDliSparkTemplates(),
 			"huaweicloud_dli_sql_jobs":               dli.DataSourceDliSqlJobs(),

--- a/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_flinkjar_jobs_test.go
+++ b/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_flinkjar_jobs_test.go
@@ -1,0 +1,157 @@
+package dli
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDliFlinkjarJobs_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dli_flinkjar_jobs.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+	rName := acceptance.RandomAccResourceName()
+	bucketName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceDataSourceDliFlinkjarJobs_basic(rName, bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.queue_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.cu_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.parallel_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.manager_cu_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.tm_cu_num"),
+					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.tm_slot_num"),
+
+					resource.TestCheckOutput("job_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("queue_name_filter_is_useful", "true"),
+					resource.TestCheckOutput("cu_num_filter_is_useful", "true"),
+					resource.TestCheckOutput("parallel_num_filter_is_useful", "true"),
+					resource.TestCheckOutput("manager_cu_num_filter_is_useful", "true"),
+					resource.TestCheckOutput("tm_cu_num_filter_is_useful", "true"),
+					resource.TestCheckOutput("tm_slot_num_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDataSourceDliFlinkjarJobs_basic(name, bucketName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_dli_flinkjar_jobs" "test" {
+  depends_on = [
+    huaweicloud_dli_flinkjar_job.test
+  ]
+}
+
+data "huaweicloud_dli_flinkjar_jobs" "job_id_filter" {
+  job_id = local.job_id
+}
+  
+locals {
+  job_id = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].id
+}
+  
+output "job_id_filter_is_useful" {
+  value = length(data.huaweicloud_dli_flinkjar_jobs.job_id_filter.jobs) > 0 && alltrue(
+    [for v in data.huaweicloud_dli_flinkjar_jobs.job_id_filter.jobs[*].id : v == local.job_id]
+  )
+}
+
+data "huaweicloud_dli_flinkjar_jobs" "queue_name_filter" {
+  queue_name = local.queue_name
+}
+  
+locals {
+  queue_name = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].queue_name
+}
+  
+output "queue_name_filter_is_useful" {
+  value = length(data.huaweicloud_dli_flinkjar_jobs.queue_name_filter.jobs) > 0 && alltrue(
+    [for v in data.huaweicloud_dli_flinkjar_jobs.queue_name_filter.jobs[*].queue_name : v == local.queue_name]
+  )
+}
+
+data "huaweicloud_dli_flinkjar_jobs" "cu_num_filter" {
+  cu_num = local.cu_num
+}
+  
+locals {
+  cu_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].cu_num
+}
+  
+output "cu_num_filter_is_useful" {
+  value = length(data.huaweicloud_dli_flinkjar_jobs.cu_num_filter.jobs) > 0 && alltrue(
+    [for v in data.huaweicloud_dli_flinkjar_jobs.cu_num_filter.jobs[*].cu_num : v == local.cu_num]
+  )
+}
+
+data "huaweicloud_dli_flinkjar_jobs" "parallel_num_filter" {
+  parallel_num = local.parallel_num
+}
+  
+locals {
+  parallel_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].parallel_num
+}
+  
+output "parallel_num_filter_is_useful" {
+  value = length(data.huaweicloud_dli_flinkjar_jobs.parallel_num_filter.jobs) > 0 && alltrue(
+    [for v in data.huaweicloud_dli_flinkjar_jobs.parallel_num_filter.jobs[*].parallel_num : v == local.parallel_num]
+  )
+}
+
+data "huaweicloud_dli_flinkjar_jobs" "manager_cu_num_filter" {
+  manager_cu_num = local.manager_cu_num
+}
+  
+locals {
+  manager_cu_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].manager_cu_num
+}
+  
+output "manager_cu_num_filter_is_useful" {
+  value = length(data.huaweicloud_dli_flinkjar_jobs.manager_cu_num_filter.jobs) > 0 && alltrue(
+    [for v in data.huaweicloud_dli_flinkjar_jobs.manager_cu_num_filter.jobs[*].manager_cu_num : v == local.manager_cu_num]
+  )
+}
+
+data "huaweicloud_dli_flinkjar_jobs" "tm_cu_num_filter" {
+  tm_cu_num = local.tm_cu_num
+}
+  
+locals {
+  tm_cu_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].tm_cu_num
+}
+  
+output "tm_cu_num_filter_is_useful" {
+  value = length(data.huaweicloud_dli_flinkjar_jobs.tm_cu_num_filter.jobs) > 0 && alltrue(
+    [for v in data.huaweicloud_dli_flinkjar_jobs.tm_cu_num_filter.jobs[*].tm_cu_num: v == local.tm_cu_num]
+  )
+}
+
+data "huaweicloud_dli_flinkjar_jobs" "tm_slot_num_filter" {
+  tm_slot_num = local.tm_slot_num
+}
+  
+locals {
+  tm_slot_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].tm_slot_num
+}
+  
+output "tm_slot_num_filter_is_useful" {
+  value = length(data.huaweicloud_dli_flinkjar_jobs.tm_slot_num_filter.jobs) > 0 && alltrue(
+    [for v in data.huaweicloud_dli_flinkjar_jobs.tm_slot_num_filter.jobs[*].tm_slot_num : v == local.tm_slot_num]
+  )
+}
+`, testAccFlinkJarJobResource_basic(name, bucketName))
+}

--- a/huaweicloud/services/dli/data_source_huaweicloud_dli_flinkjar_jobs.go
+++ b/huaweicloud/services/dli/data_source_huaweicloud_dli_flinkjar_jobs.go
@@ -1,0 +1,299 @@
+package dli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/tidwall/gjson"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/filters"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/httphelper"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/schemas"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceDliFlinkjarJobs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDliFlinkjarJobsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"queue_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": common.TagsSchema(),
+			"manager_cu_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"cu_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"parallel_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"tm_cu_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"tm_slot_num": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"jobs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"queue_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"main_class": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"entrypoint_args": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"obs_bucket": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"log_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"smn_topic": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"manager_cu_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cu_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"parallel_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"restart_when_exception": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"entrypoint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dependency_jars": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"dependency_files": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"resume_checkpoint": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"runtime_config": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"resume_max_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"checkpoint_path": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tm_cu_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"tm_slot_num": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"image": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"feature": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"flink_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type FlinkjarJobsDSWrapper struct {
+	*schemas.ResourceDataWrapper
+	Config *config.Config
+}
+
+func newFlinkjarJobsDSWrapper(d *schema.ResourceData, meta interface{}) *FlinkjarJobsDSWrapper {
+	return &FlinkjarJobsDSWrapper{
+		ResourceDataWrapper: schemas.NewSchemaWrapper(d),
+		Config:              meta.(*config.Config),
+	}
+}
+
+func dataSourceDliFlinkjarJobsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	wrapper := newFlinkjarJobsDSWrapper(d, meta)
+	lisFliJobRst, err := wrapper.ListFlinkJobs()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	err = wrapper.listFlinkJobsToSchema(lisFliJobRst)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// @API DLI GET /v1.0/{project_id}/streaming/jobs
+func (w *FlinkjarJobsDSWrapper) ListFlinkJobs() (*gjson.Result, error) {
+	client, err := w.NewClient(w.Config, "dli")
+	if err != nil {
+		return nil, err
+	}
+
+	uri := "/v1.0/{project_id}/streaming/jobs"
+	params := map[string]any{
+		"queue_name": w.Get("queue_name"),
+		"tags":       w.getTags(),
+	}
+	params = utils.RemoveNil(params)
+	return httphelper.New(client).
+		Method("GET").
+		URI(uri).
+		Query(params).
+		OffsetPager("job_list.jobs", "offset", "limit", 100).
+		Filter(
+			filters.New().From("job_list.jobs").
+				Where("job_id", "=", w.GetToInt("job_id")).
+				Where("job_config.cu_number", "=", w.Get("cu_num")).
+				Where("job_config.parallel_number", "=", w.Get("parallel_num")).
+				Where("job_config.manager_cu_number", "=", w.Get("manager_cu_num")).
+				Where("job_config.tm_cus", "=", w.Get("tm_cu_num")).
+				Where("job_config.tm_slot_num", "=", w.Get("tm_slot_num")),
+		).
+		Request().
+		Result()
+}
+
+func (w *FlinkjarJobsDSWrapper) listFlinkJobsToSchema(body *gjson.Result) error {
+	d := w.ResourceData
+	mErr := multierror.Append(nil,
+		d.Set("region", w.Config.GetRegion(w.ResourceData)),
+		d.Set("jobs", schemas.SliceToList(body.Get("job_list.jobs"),
+			func(job gjson.Result) any {
+				return map[string]any{
+					"id":                     w.setJobLisJobJobId(job),
+					"name":                   job.Get("name").Value(),
+					"status":                 job.Get("status").Value(),
+					"description":            job.Get("desc").Value(),
+					"queue_name":             job.Get("queue_name").Value(),
+					"main_class":             job.Get("main_class").Value(),
+					"entrypoint_args":        job.Get("entrypoint_args").Value(),
+					"obs_bucket":             job.Get("job_config.obs_bucket").Value(),
+					"log_enabled":            job.Get("job_config.log_enabled").Value(),
+					"smn_topic":              job.Get("job_config.smn_topic").Value(),
+					"manager_cu_num":         job.Get("job_config.manager_cu_number").Value(),
+					"cu_num":                 job.Get("job_config.cu_number").Value(),
+					"parallel_num":           job.Get("job_config.parallel_number").Value(),
+					"restart_when_exception": job.Get("job_config.restart_when_exception").Value(),
+					"entrypoint":             job.Get("job_config.entrypoint").Value(),
+					"dependency_jars":        schemas.SliceToStrList(job.Get("job_config.dependency_jars")),
+					"dependency_files":       schemas.SliceToStrList(job.Get("job_config.dependency_files")),
+					"resume_checkpoint":      job.Get("job_config.resume_checkpoint").Value(),
+					"runtime_config":         job.Get("job_config.runtime_config").Value(),
+					"resume_max_num":         job.Get("job_config.resume_max_num").Value(),
+					"checkpoint_path":        job.Get("job_config.checkpoint_path").Value(),
+					"tm_cu_num":              job.Get("job_config.tm_cus").Value(),
+					"tm_slot_num":            job.Get("job_config.tm_slot_num").Value(),
+					"image":                  job.Get("job_config.image").Value(),
+					"feature":                job.Get("job_config.feature").Value(),
+					"flink_version":          job.Get("job_config.flink_version").Value(),
+				}
+			},
+		)),
+	)
+	return mErr.ErrorOrNil()
+}
+
+func (w *FlinkjarJobsDSWrapper) getTags() string {
+	raw := w.Get("tags")
+	if raw == nil {
+		return ""
+	}
+
+	tags := raw.(map[string]interface{})
+	tagsList := make([]string, 0, len(tags))
+	for k, v := range tags {
+		tagsList = append(tagsList, k+"="+v.(string))
+	}
+	return strings.Join(tagsList, ",")
+}
+
+func (*FlinkjarJobsDSWrapper) setJobLisJobJobId(data gjson.Result) string {
+	return data.Get("job_id").String()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
   add new datasource to get list of jar type of flink jobs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dli" TESTARGS="-run TestAccDataSourceDliFlinkjarJobs_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run TestAccDataSourceDliFlinkjarJobs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDliFlinkjarJobs_basic
=== PAUSE TestAccDataSourceDliFlinkjarJobs_basic
=== CONT  TestAccDataSourceDliFlinkjarJobs_basic
--- PASS: TestAccDataSourceDliFlinkjarJobs_basic (416.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       416.988s
```
