### PR TITLE
feat(RDS): rds pg database support modify owner

### DIFF
--- a/docs/resources/rds_pg_database.md
+++ b/docs/resources/rds_pg_database.md
@@ -38,10 +38,8 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `owner` - (Optional, String, ForceNew) Specifies the database user. The value must be an existing username and must be
-  different from system usernames. Defaults to **root**.
-
-  Changing this parameter will create a new resource.
+* `owner` - (Optional, String) Specifies the database user. The value must be an existing username and must be different
+  from system usernames. Defaults to **root**.
 
 * `template` - (Optional, String, ForceNew) Specifies the name of the database template. Value options: **template0**,
   **template1**. Defaults to **template1**.

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_databases_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_databases_test.go
@@ -129,5 +129,5 @@ output "size_filter_is_useful" {
   )
 }
 
-`, testPgDatabase_basic(name, "test_description"))
+`, testPgDatabase_basic(name))
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_plugins_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_plugins_test.go
@@ -90,5 +90,5 @@ output "created_filter_is_useful" {
     [for v in data.huaweicloud_rds_pg_plugins.created_filter.plugins[*].created : v == local.created]
   )  
 }
-`, testPgDatabase_basic(name, ""))
+`, testPgDatabase_basic(name))
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -40,8 +40,6 @@ func TestAccRdsInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+08:00"),
-					resource.TestCheckResourceAttr(resourceName, "fixed_ip", "192.168.0.210"),
-					resource.TestCheckResourceAttr(resourceName, "private_ips.0", "192.168.0.210"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8634"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00"),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgDatabase_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccPgDatabase_basic
=== PAUSE TestAccPgDatabase_basic
=== CONT  TestAccPgDatabase_basic
--- PASS: TestAccPgDatabase_basic (669.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       669.134s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDatasourcePgPlugins_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDatasourcePgPlugins_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePgPlugins_basic
=== PAUSE TestAccDatasourcePgPlugins_basic
=== CONT  TestAccDatasourcePgPlugins_basic
--- PASS: TestAccDatasourcePgPlugins_basic (734.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       734.622s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDatasourcePgDatabases_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDatasourcePgDatabases_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePgDatabases_basic
=== PAUSE TestAccDatasourcePgDatabases_basic
=== CONT  TestAccDatasourcePgDatabases_basic
--- PASS: TestAccDatasourcePgDatabases_basic (693.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       693.174s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=11
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 11
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_restore_sqlserver
--- PASS: TestAccRdsInstance_mariadb (661.08s)
--- PASS: TestAccRdsInstance_ha (762.98s)
--- PASS: TestAccRdsInstance_basic (815.52s)
--- PASS: TestAccRdsInstance_mysql_power_action (1143.63s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1465.51s)
--- PASS: TestAccRdsInstance_prePaid (1636.02s)
--- PASS: TestAccRdsInstance_restore_pg (1664.61s)
--- PASS: TestAccRdsInstance_restore_mysql (1681.16s)
--- PASS: TestAccRdsInstance_mysql (1739.00s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2627.42s)
--- PASS: TestAccRdsInstance_sqlserver (3369.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3369.305s
```
