### PR TITLE
feat(dds): change new api for data source flavors

### DIFF
--- a/docs/data-sources/dds_flavors.md
+++ b/docs/data-sources/dds_flavors.md
@@ -25,8 +25,10 @@ data "huaweicloud_dds_flavors" "flavor" {
 
 * `engine_name` - (Required, String) Specifies the engine name. Value options: **DDS-Community** and **DDS-Enhanced**.
 
+* `engine_version` - (Optional, String) Specifies the DB version number. Value options: **3.4**, **4.0**, **4.2** and **4.4**.
+
 * `type` - (Optional, String) Specifies the type of the flavor. Value options: **mongos**, **shard**, **config**,
-  **replica** and **single**.
+  **replica**, **single** and **readonly**.
 
 * `vcpus` - (Optional, String) Specifies the number of vCPUs.
 
@@ -46,6 +48,8 @@ In addition to all arguments above, the following attributes are exported:
 The `flavors` block supports:
 
 * `engine_name` - Indicates the engine name.
+
+* `engine_versions` - Indicates the database versions.
 
 * `spec_code` - Indicates the resource specification code.
 

--- a/huaweicloud/config/endpoints.go
+++ b/huaweicloud/config/endpoints.go
@@ -29,6 +29,7 @@ var multiCatalogKeys = map[string][]string{
 	"vpc":          {"networkv2", "vpcv3", "fwv2"},
 	"elb":          {"elbv2", "elbv3"},
 	"dns":          {"dns_region", "dnsv21"},
+	"dds":          {"ddsv31"},
 	"kms":          {"kmsv1", "kmsv3"},
 	"mrs":          {"mrsv2"},
 	"nat":          {"natv3"},
@@ -450,6 +451,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"dds": {
 		Name:    "dds",
 		Version: "v3",
+		Product: "DDS",
+	},
+	"ddsv31": {
+		Name:    "dds",
+		Version: "v3.1",
 		Product: "DDS",
 	},
 	"geminidb": {

--- a/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_flavors_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_flavors_v3_test.go
@@ -20,6 +20,7 @@ func TestAccDDSFlavorV3DataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.engine_name", "DDS-Community"),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.engine_versions.0", "3.4"),
 					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.vcpus", "2"),
 					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.memory", "4"),
 					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.type", "mongos"),
@@ -34,9 +35,10 @@ func TestAccDDSFlavorV3DataSource_basic(t *testing.T) {
 
 var testAccDDSFlavorV3DataSource_basic = `
 data "huaweicloud_dds_flavors" "flavor" {
-  engine_name = "DDS-Community"
-  vcpus       = 2
-  memory      = 4
-  type        = "mongos"
+  engine_name    = "DDS-Community"
+  engine_version = "3.4"
+  vcpus          = 2
+  memory         = 4
+  type           = "mongos"
 }
 `


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Change new api for `data.huaweicloud_dds_flavors`


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSFlavorV3DataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSFlavorV3DataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSFlavorV3DataSource_basic
=== PAUSE TestAccDDSFlavorV3DataSource_basic
=== CONT  TestAccDDSFlavorV3DataSource_basic
--- PASS: TestAccDDSFlavorV3DataSource_basic (21.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       21.286s
```
