### PR TITLE
feat(nat): the NAT gateway supports ngport_ip_address field

### DIFF
--- a/docs/resources/nat_gateway.md
+++ b/docs/resources/nat_gateway.md
@@ -49,6 +49,11 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies the description of the NAT gateway, which contain maximum of `512`
   characters, and angle brackets (<) and (>) are not allowed.
 
+* `ngport_ip_address` - (Optional, String, ForceNew) Specifies the private IP address of the NAT gateway.
+  The IP address must be one of the IP addresses of the VPC subnet associated with the NAT gateway.
+  If not spacified, it will be automatically allocated.
+  Changing this will creates a new resource.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of the NAT gateway.  
   Changing this will create a new resource.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240426063406-bcdd82442b07
+	github.com/chnsz/golangsdk v0.0.0-20240429035359-1f8f46a24417
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240426063406-bcdd82442b07 h1:O9IeTMkaTR2M7kuypy5t3eDgWEbnQfBvrpT4g5ZOJds=
-github.com/chnsz/golangsdk v0.0.0-20240426063406-bcdd82442b07/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240429035359-1f8f46a24417 h1:fhZynygdDcoM9XPGykSKnzyqgScsYZY+TqityVoR79o=
+github.com/chnsz/golangsdk v0.0.0-20240429035359-1f8f46a24417/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
@@ -54,6 +54,7 @@ func TestAccPublicGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
 					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
@@ -66,6 +67,7 @@ func TestAccPublicGateway_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", updateName),
 					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeMedium)),
 					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "baaar"),
 					resource.TestCheckResourceAttr(rName, "tags.newkey", "value"),
@@ -88,6 +90,7 @@ resource "huaweicloud_nat_gateway" "test" {
   name                  = "%[2]s"
   spec                  = "1"
   description           = "Created by acc test"
+  ngport_ip_address     = "192.168.0.101"
   vpc_id                = huaweicloud_vpc.test.id
   subnet_id             = huaweicloud_vpc_subnet.test.id
   enterprise_project_id = "0"
@@ -107,6 +110,7 @@ func testAccPublicGateway_basic_step_2(name, relatedConfig string) string {
 resource "huaweicloud_nat_gateway" "test" {
   name                  = "%[2]s"
   spec                  = "2"
+  ngport_ip_address     = "192.168.0.101"
   vpc_id                = huaweicloud_vpc.test.id
   subnet_id             = huaweicloud_vpc_subnet.test.id
   enterprise_project_id = "0"

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
@@ -103,6 +103,13 @@ func ResourcePublicGateway() *schema.Resource {
 				Optional:    true,
 				Description: "The description of the NAT gateway.",
 			},
+			"ngport_ip_address": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The private IP address of the NAT gateway.",
+			},
 			"enterprise_project_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -155,6 +162,7 @@ func resourcePublicGatewayCreate(ctx context.Context, d *schema.ResourceData, me
 		InternalNetworkId:   d.Get("subnet_id").(string),
 		Spec:                d.Get("spec").(string),
 		Description:         d.Get("description").(string),
+		NgportIpAddress:     d.Get("ngport_ip_address").(string),
 		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 	}
 	resp, err := gateways.Create(client, opts)
@@ -214,6 +222,7 @@ func resourcePublicGatewayRead(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("vpc_id", resp.RouterId),
 		d.Set("subnet_id", resp.InternalNetworkId),
 		d.Set("description", resp.Description),
+		d.Set("ngport_ip_address", resp.NgportIpAddress),
 		d.Set("enterprise_project_id", resp.EnterpriseProjectId),
 		d.Set("status", resp.Status),
 	)

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/gateways/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/gateways/requests.go
@@ -14,6 +14,9 @@ type CreateOpts struct {
 	Spec string `json:"spec" required:"true"`
 	// The gateway description.
 	Description string `json:"description,omitempty"`
+	// The private IP address of the public NAT gateway.
+	// The IP address is assigned by the VPC subnet.
+	NgportIpAddress string `json:"ngport_ip_address,omitempty"`
 	// The enterprise project ID to which the gateway belongs.
 	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/gateways/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/nat/v2/gateways/results.go
@@ -33,6 +33,9 @@ type Gateway struct {
 	RouterId string `json:"router_id"`
 	// The network ID that VPC have.
 	InternalNetworkId string `json:"internal_network_id"`
+	// The private IP address of the public NAT gateway.
+	// The IP address is assigned by the VPC subnet.
+	NgportIpAddress string `json:"ngport_ip_address"`
 	// The enterprise project ID to which the gateway belongs.
 	EnterpriseProjectId string `json:"enterprise_project_id"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240426063406-bcdd82442b07
+# github.com/chnsz/golangsdk v0.0.0-20240429035359-1f8f46a24417
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The NAT gateway supports ngport_ip_address field.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_basic
--- PASS: TestAccPublicGateway_basic (127.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       127.944s
```
