### PR TITLE
feat(RDS): rds pg account support modify memberof

### DIFF
--- a/docs/resources/rds_pg_account.md
+++ b/docs/resources/rds_pg_account.md
@@ -43,6 +43,8 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the remarks of the DB account. The parameter must be 1 to 512 characters.
 
+* `memberof` - (Optional, List) Specifies the list of default rights of an account.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -51,8 +53,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `attributes` - Indicates the permission attributes of a user.
   The [attributes](#PgAccount_Attributes) structure is documented below.
-
-* `memberof` - Indicates the default rights of a user.
 
 <a name="PgAccount_Attributes"></a>
 The `attributes` block supports:

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_accounts_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_accounts_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -13,8 +12,6 @@ import (
 func TestAccDatasourcePgAccounts_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_pg_accounts.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
-		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
 	dc := acceptance.InitDataSourceCheck(rName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -22,7 +19,7 @@ func TestAccDatasourcePgAccounts_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourcePgAccounts_basic(name, dbPwd),
+				Config: testAccDatasourcePgAccounts_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(rName, "users.#"),
@@ -35,7 +32,7 @@ func TestAccDatasourcePgAccounts_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "users.0.attributes.0.rolconnlimit"),
 					resource.TestCheckResourceAttrSet(rName, "users.0.attributes.0.rolreplication"),
 					resource.TestCheckResourceAttrSet(rName, "users.0.attributes.0.rolbypassrls"),
-					resource.TestCheckResourceAttrSet(rName, "users.1.description"),
+					resource.TestCheckResourceAttrSet(rName, "users.0.description"),
 					resource.TestCheckOutput("user_name_filter_is_useful", "true"),
 				),
 			},
@@ -43,13 +40,14 @@ func TestAccDatasourcePgAccounts_basic(t *testing.T) {
 	})
 }
 
-func testAccDatasourcePgAccounts_basic(name string, dbPwd string) string {
+func testAccDatasourcePgAccounts_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
 data "huaweicloud_rds_pg_accounts" "test" {
   depends_on  = [huaweicloud_rds_pg_account.test]
   instance_id = huaweicloud_rds_pg_account.test.instance_id
+  user_name   = "%s"
 }
 
 data "huaweicloud_rds_pg_accounts" "user_name_filter" {
@@ -68,5 +66,5 @@ output "user_name_filter_is_useful" {
   )
 }
 
-`, testPgAccount_basic(name, dbPwd, "test"))
+`, testPgAccount_basic(name), name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds pg account support modify memberof
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds pg account support modify memberof
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgAccount_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgAccount_basic -timeout 360m -parallel 4
=== RUN   TestAccPgAccount_basic
=== PAUSE TestAccPgAccount_basic
=== CONT  TestAccPgAccount_basic
--- PASS: TestAccPgAccount_basic (702.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       702.755s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDatasourcePgAccounts_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDatasourcePgAccounts_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePgAccounts_basic
=== PAUSE TestAccDatasourcePgAccounts_basic
=== CONT  TestAccDatasourcePgAccounts_basic
--- PASS: TestAccDatasourcePgAccounts_basic (663.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       663.648s
```
