### PR TITLE
refactor(vpn): make the peer_subnets of vpn connection optional

### DIFF
--- a/docs/resources/vpn_connection.md
+++ b/docs/resources/vpn_connection.md
@@ -92,9 +92,11 @@ The following arguments are supported:
 
 * `customer_gateway_id` - (Required, String) The customer gateway ID.
 
-* `peer_subnets` - (Required, List) The CIDR list of customer subnets.
-
 * `psk` - (Required, String) The pre-shared key.
+
+* `peer_subnets` - (Optional, List) The CIDR list of customer subnets. This parameter must be empty
+  when the `attachment_type` of the VPN gateway is set to **er** and `vpn_type` is set to **policy** or **bgp**.
+  This parameter is mandatory in other scenarios.
 
 * `tunnel_local_address` - (Optional, String) The local tunnel address.
 

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
@@ -85,7 +85,8 @@ func ResourceConnection() *schema.Resource {
 			"peer_subnets": {
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: `The customer subnets.`,
 			},
 			"psk": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
there is no enough VPN gateway resource to run the test cases
it's tested by scripts
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```
