### PR TITLE
fix(vpc): fix error return of vpc v3 API

### DIFF
--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc.go
@@ -252,7 +252,7 @@ func resourceVirtualPrivateCloudRead(_ context.Context, d *schema.ResourceData, 
 
 	res, err := obtainV3VpcResp(v3Client, d.Id())
 	if err != nil {
-		diag.Errorf("error retrieving VPC (%s) v3 detail: %s", d.Id(), err)
+		return diag.Errorf("error retrieving VPC (%s) v3 detail: %s", d.Id(), err)
 	}
 
 	if val, ok := d.GetOk("secondary_cidr"); ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
the error of calling v3 API to get vpc info not returned, fix it
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcV1_basic -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== CONT  TestAccVpcV1_basic
--- PASS: TestAccVpcV1_basic (55.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       55.067s

make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcV1_secondaryCIDR'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcV1_secondaryCIDR -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_secondaryCIDR
=== PAUSE TestAccVpcV1_secondaryCIDR
=== RUN   TestAccVpcV1_secondaryCIDRs
=== PAUSE TestAccVpcV1_secondaryCIDRs
=== CONT  TestAccVpcV1_secondaryCIDR
=== CONT  TestAccVpcV1_secondaryCIDRs
--- PASS: TestAccVpcV1_secondaryCIDR (69.02s)
--- PASS: TestAccVpcV1_secondaryCIDRs (83.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       83.877s
```
