### PR TITLE
feat(RDS): rds instance support second level monitoring

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -327,6 +327,11 @@ The `db` block supports:
   + **readwrite**: read write permissions.
   + **readonly**: readonly permissions.
 
+* `seconds_level_monitoring_enabled` - (Optional, Bool) Specifies whether to enable seconds level monitoring.
+
+* `seconds_level_monitoring_interval` - (Optional, Int) Specifies the seconds level monitoring interval. Valid values:
+  **1**, **5**. It is mandatory when `seconds_level_monitoring_enabled` is **true**.
+
 The `volume` block supports:
 
 * `size` - (Required, Int) Specifies the volume size. Its value range is from 40 GB to 4000 GB. The value must be a

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -156,6 +156,8 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "div_precision_increment"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "12"),
 					resource.TestCheckResourceAttr(resourceName, "binlog_retention_hours", "12"),
+					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_interval", "1"),
 				),
 			},
 			{
@@ -173,6 +175,8 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "connect_timeout"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "14"),
 					resource.TestCheckResourceAttr(resourceName, "binlog_retention_hours", "0"),
+					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_interval", "5"),
 					resource.TestCheckResourceAttrSet(resourceName, "db.0.password"),
 				),
 			},
@@ -183,6 +187,7 @@ func TestAccRdsInstance_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.limit_size", "0"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.trigger_threshold", "0"),
 					resource.TestCheckResourceAttr(resourceName, "binlog_retention_hours", "6"),
+					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "false"),
 				),
 			},
 		},
@@ -669,6 +674,7 @@ data "huaweicloud_rds_flavors" "test" {
   db_version    = "8.0"
   instance_mode = "single"
   group_type    = "dedicated"
+  vcpus         = 4
 }
 
 resource "huaweicloud_rds_instance" "test" {
@@ -681,6 +687,9 @@ resource "huaweicloud_rds_instance" "test" {
   ssl_enable             = true  
   binlog_retention_hours = "12"
   read_write_permissions = "readonly"
+
+  seconds_level_monitoring_enabled  = true
+  seconds_level_monitoring_interval = 1
 
   db {
     type     = "MySQL"
@@ -720,6 +729,7 @@ data "huaweicloud_rds_flavors" "test" {
   db_version    = "8.0"
   instance_mode = "single"
   group_type    = "dedicated"
+  vcpus         = 4
 }
 
 resource "huaweicloud_rds_instance" "test" {
@@ -733,6 +743,9 @@ resource "huaweicloud_rds_instance" "test" {
   param_group_id         = huaweicloud_rds_parametergroup.pg_1.id
   binlog_retention_hours = "0"
   read_write_permissions = "readwrite"
+
+  seconds_level_monitoring_enabled  = true
+  seconds_level_monitoring_interval = 5
 
   db {
     password = "Huangwei!120521"
@@ -773,6 +786,7 @@ data "huaweicloud_rds_flavors" "test" {
   db_version    = "8.0"
   instance_mode = "single"
   group_type    = "dedicated"
+  vcpus         = 4
 }
 
 resource "huaweicloud_rds_instance" "test" {
@@ -786,6 +800,8 @@ resource "huaweicloud_rds_instance" "test" {
   param_group_id         = huaweicloud_rds_parametergroup.pg_1.id
   binlog_retention_hours = "6"
   read_write_permissions = "readwrite"
+
+  seconds_level_monitoring_enabled = false
 
   db {
     password = "Huangwei!120521"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=11
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 11
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_ssmysql_power_action
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_mysql
--- PASS: TestAccRdsInstance_mariadb (660.65s)
--- PASS: TestAccRdsInstance_ha (757.28s)
--- PASS: TestAccRdsInstance_basic (791.32s)
--- PASS: TestAccRdsInstance_mysql_power_action (1077.23s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1472.27s)
--- PASS: TestAccRdsInstance_prePaid (1644.73s)
--- PASS: TestAccRdsInstance_restore_pg (1675.27s)
--- PASS: TestAccRdsInstance_restore_mysql (1676.98s)
--- PASS: TestAccRdsInstance_mysql (1902.03s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2658.20s)
--- PASS: TestAccRdsInstance_sqlserver (3026.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3032.043s
```
