### PR TITLE
fix(apig/whitelist): The EPS ID of instance must be set for EPS user

### DIFF
--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_endpoint_whitelist_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_endpoint_whitelist_test.go
@@ -60,6 +60,7 @@ func TestAccEndpointWhiteList_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add the pre-check into the acceptance test of endpoint whitelist.

```
=== CONT  TestAccEndpointWhiteList_basic
    resource_huaweicloud_apig_endpoint_whitelist_test.go:60: Step 1/3 error: Error running apply: exit status 1
        
        Error: error creating the dedicated instance: Bad request with: [POST https://apig.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/apigw/instances], request_id: d6f28ae6b305f0dbb902fdd2317f30ff, error message: {
          "error_code" : "APIC.7241",
          "error_msg" : "enterprise project id can not be null for eps user"
        }
        
          with huaweicloud_apig_instance.test,
          on terraform_plugin_test.tf line 30, in resource "huaweicloud_apig_instance" "test":
          30: resource "huaweicloud_apig_instance" "test" {

```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add the pre-check into the acceptance test of endpoint whitelist.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

enterprise project ID has been configured
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccEndpointWhiteList_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccEndpointWhiteList_basic -timeout 360m -parallel 4
=== RUN   TestAccEndpointWhiteList_basic
=== PAUSE TestAccEndpointWhiteList_basic
=== CONT  TestAccEndpointWhiteList_basic
--- PASS: TestAccEndpointWhiteList_basic (552.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      552.057s
```
skip the test
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccEndpointWhiteList_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccEndpointWhiteList_basic -timeout 360m -parallel 4
=== RUN   TestAccEndpointWhiteList_basic
=== PAUSE TestAccEndpointWhiteList_basic
=== CONT  TestAccEndpointWhiteList_basic
    acceptance.go:521: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccEndpointWhiteList_basic (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      0.093
```
