### PR TITLE
feat(dataarts): use this data source to get the data connection list

### DIFF
--- a/docs/data-sources/dataarts_studio_data_connections.md
+++ b/docs/data-sources/dataarts_studio_data_connections.md
@@ -1,0 +1,63 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_studio_data_connections"
+description: |-
+  Use this data source to get the list of the DataArts Studio data connections.
+---
+
+# huaweicloud_dataarts_studio_data_connections
+
+Use this data source to get the list of the DataArts Studio data connections.
+
+## Example Usage
+
+```hcl
+variable workspace_id {}
+
+data "huaweicloud_dataarts_studio_data_connections" "test" {
+  workspace_id  = var.workspace_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the data connection belongs.
+
+* `connection_id` - (Optional, String) Specifies the ID of the data connection.
+
+* `name` - (Optional, String) Specifies the name of the data connection.
+  Supports fuzzy search.
+
+* `type` - (Optional, String) Specifies the type of the data connection.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `connections` - The list of the data connections.
+  The [connections](#data_connections) structure is documented below.
+
+<a name="data_connections"></a>
+The `connections` block supports:
+
+* `id` - The ID of the data connection.
+
+* `name` - The name of the data connection.
+
+* `type` - The type of the data connection.
+
+* `agent_id` - The agent ID corresponding to the data connection.
+
+* `qualified_name` - The qualified name of the data connection.
+
+* `created_by` - The creator of the data connection.
+
+* `created_at` - The creation time of the data connection.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -488,8 +488,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_csms_events":         dew.DataSourceDewCsmsEvents(),
 			"huaweicloud_css_flavors":         css.DataSourceCssFlavors(),
 
-			"huaweicloud_dataarts_studio_workspaces":                  dataarts.DataSourceDataArtsStudioWorkspaces(),
 			"huaweicloud_dataarts_architecture_ds_template_optionals": dataarts.DataSourceTemplateOptionalFields(),
+			"huaweicloud_dataarts_studio_data_connections":            dataarts.DataSourceDataConnections(),
+			"huaweicloud_dataarts_studio_workspaces":                  dataarts.DataSourceDataArtsStudioWorkspaces(),
 
 			"huaweicloud_dbss_flavors": dbss.DataSourceDbssFlavors(),
 

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_data_connections_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_studio_data_connections_test.go
@@ -1,0 +1,79 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceDataConnections_basic(t *testing.T) {
+	var (
+		name             = acceptance.RandomAccResourceName()
+		byConnectionId   = "data.huaweicloud_dataarts_studio_data_connections.by_connection_id"
+		dcByConnectionId = acceptance.InitDataSourceCheck(byConnectionId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDataConnections_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dcByConnectionId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byConnectionId, "connections.#", "1"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.qualified_name"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.created_by"),
+					resource.TestCheckResourceAttrSet(byConnectionId, "connections.0.created_at"),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDataConnections_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dataarts_studio_data_connections" "by_connection_id" {
+  workspace_id  = "%[2]s"
+  connection_id = huaweicloud_dataarts_studio_data_connection.test.id
+}
+
+data "huaweicloud_dataarts_studio_data_connections" "by_name_filter" {
+  depends_on   = [huaweicloud_dataarts_studio_data_connection.test]
+
+  workspace_id = "%[2]s"
+  name         = "%[3]s"
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_dataarts_studio_data_connections.by_name_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_dataarts_studio_data_connections.by_name_filter.connections[*].name : 
+    v == "%[3]s"]
+  )  
+}
+
+data "huaweicloud_dataarts_studio_data_connections" "by_type_filter" {
+  depends_on   = [huaweicloud_dataarts_studio_data_connection.test]
+
+  workspace_id = "%[2]s"
+  type         = "DLI"
+}
+
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_dataarts_studio_data_connections.by_type_filter.connections) > 0 && alltrue(
+    [for v in data.huaweicloud_dataarts_studio_data_connections.by_type_filter.connections[*].type : 
+    v == "DLI"]
+  )  
+}
+`, testAccDataConnection_basic(name), acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_data_connections.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_studio_data_connections.go
@@ -1,0 +1,165 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/dayu/v1/connections"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/data-connections
+func DataSourceDataConnections() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceDataConnectionsRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the workspace to which the data connection belongs.`,
+			},
+			"connection_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the data connection.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the data connection.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the type of the data connection.`,
+			},
+			"connections": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the data connections.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the data connection.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the data connection.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the data connection.`,
+						},
+						"agent_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The agent ID corresponding to the data connection.`,
+						},
+						"qualified_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The qualified name of the data connection.`,
+						},
+						"created_by": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator of the data connection.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the data connection.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceDataConnectionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.DataArtsV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio v1 client: %s", err)
+	}
+
+	// When limit and offset are used together, limit cannot be equal to the total number of connections.
+	// If limit is not specified, all connections are queried by default. A maximum of 200 data connections can be created.
+	opts := connections.ListOpts{
+		WorkspaceId: d.Get("workspace_id").(string),
+		Name:        d.Get("name").(string),
+		Type:        d.Get("type").(string),
+	}
+
+	resp, err := connections.List(client, opts)
+	if err != nil {
+		return diag.Errorf("error retrieving data connections: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("connections", filterByConnectionId(flattenConnections(resp), d.Get("connection_id").(string))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConnections(resp []connections.Connection) []map[string]interface{} {
+	if len(resp) == 0 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(resp))
+	for i, connection := range resp {
+		result[i] = map[string]interface{}{
+			"id":             connection.DwId,
+			"name":           connection.DwName,
+			"type":           connection.DwType,
+			"agent_id":       connection.AgentId,
+			"qualified_name": connection.QualifiedName,
+			"created_by":     connection.CreateUser,
+			"created_at":     utils.FormatTimeStampRFC3339(int64(connection.CreateTime), false),
+		}
+	}
+	return result
+}
+
+func filterByConnectionId(all []map[string]interface{}, connectionId string) []map[string]interface{} {
+	if connectionId == "" {
+		return all
+	}
+
+	rst := make([]map[string]interface{}, 0, len(all))
+	for _, v := range all {
+		if connectionId == fmt.Sprint(utils.PathSearch("id", v, nil)) {
+			rst = append(rst, v)
+			return rst
+		}
+	}
+	return rst
+}


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Use this data source to get the list of the DataArts Studio data connections.
Support corresponding document and  acceptance test.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

When limit and offset are used together, limit cannot be equal to the total number of connections.
If limit is not specified, all connections are queried by default. A maximum of 200 data connections can be created.

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dataarts TESTARGS='-run TestAccDatasourceDataConnections_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccDatasourceDataConnections_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDataConnections_basic
=== PAUSE TestAccDatasourceDataConnections_basic
=== CONT  TestAccDatasourceDataConnections_basic
--- PASS: TestAccDatasourceDataConnections_basic (34.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  34.720s
```
