### PR TITLE
feat(fgs): supplement function resource parameters

### DIFF
--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -321,6 +321,11 @@ The following arguments are supported:
 * `reserved_instances` - (Optional, List) Specifies the reserved instance policies of the function.
   The [reserved_instances](#functiongraph_reserved_instances) structure is documented below.
 
+* `concurrency_num` - (Optional, Int) Specifies the number of concurrent requests of the function.
+  The valid value ranges from `1` to `1,000`, the default value is `1`.
+  
+  -> This parameter is only supported by the `v2` version of the function.
+
 * `gpu_memory` - (Optional, Int) Specifies the GPU memory size allocated to the function, in MByte (MB).
   The valid value ranges form `1,024` to `16,384`, the value must be a multiple of `1,024`.
   If not specified, the GPU function is disabled.
@@ -345,15 +350,22 @@ The `func_mounts` block supports:
 
 * `local_mount_path` - (Required, String) Specifies the function access path.
 
-* `concurrency_num` - (Optional, Int) Specifies the number of concurrent requests of the function.
-  The valid value ranges from `1` to `1,000`, the default value is `1`.
-  
-  -> This parameter is only supported by the `v2` version of the function.
-
 <a name="functiongraph_custom_image"></a>
 The `custom_image` block supports:
 
 * `url` - (Required, String) Specifies the URL of SWR image, the URL must start with `swr.`.
+
+* `command` - (Optional, String) Specifies the startup commands of the SWR image.
+  Multiple commands are separated by commas (,). e.g. `/bin/sh`.
+  If this parameter is not specified, the entrypoint or CMD in the image configuration will be used by default.
+
+* `args` - (Optional, String) Specifies the command line arguments used to start the SWR image.
+  If multiple arguments are separated by commas (,). e.g. `-args,value`.
+  If this parameter is not specified, the CMD in the image configuration will be used by default.
+
+* `working_dir` - (Optional, String) Specifies the working directory of the SWR image.
+  If not specified, the default value is `/`.
+  Currently, the folder path can only be set to `/` and it cannot be created or modified.
 
 <a name="functiongraph_versions_management"></a>
 The `versions` block supports:

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_function_test.go
@@ -210,6 +210,9 @@ func TestAccFgsV2Function_createByImage(t *testing.T) {
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.url", acceptance.HW_BUILD_IMAGE_URL),
 					resource.TestCheckResourceAttrPair(rName1, "vpc_id", "huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttrPair(rName1, "network_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(rName1, "custom_image.0.command", "/bin/sh"),
+					resource.TestCheckResourceAttr(rName1, "custom_image.0.args", "-args,value"),
+					resource.TestCheckResourceAttr(rName1, "custom_image.0.working_dir", "/"),
 					rc2.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName2, "name", randName+"_2"),
 					resource.TestCheckResourceAttr(rName2, "agency", "functiongraph_swr_trust"),
@@ -228,6 +231,9 @@ func TestAccFgsV2Function_createByImage(t *testing.T) {
 					resource.TestCheckResourceAttr(rName1, "vpc_id", ""),
 					resource.TestCheckResourceAttr(rName1, "network_id", ""),
 					resource.TestCheckResourceAttr(rName1, "custom_image.0.url", acceptance.HW_BUILD_IMAGE_URL_UPDATED),
+					resource.TestCheckResourceAttr(rName1, "custom_image.0.command", ""),
+					resource.TestCheckResourceAttr(rName1, "custom_image.0.args", ""),
+					resource.TestCheckResourceAttr(rName1, "custom_image.0.working_dir", "/"),
 					rc2.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName2, "handler", "-"),
 					resource.TestCheckResourceAttrPair(rName2, "vpc_id", "huaweicloud_vpc.test", "id"),
@@ -485,7 +491,10 @@ resource "huaweicloud_fgs_function" "create_with_vpc_access" {
   agency      = "functiongraph_swr_trust"
 
   custom_image {
-    url = "%[3]s"
+    url         = "%[3]s"
+    command     = "/bin/sh"
+    args        = "-args,value"
+    working_dir = "/"
   }
 
   vpc_id     = huaweicloud_vpc.test.id


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Fix position of concurrency_num parameter in documentation.
2. The resource supports ne parameters.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

The function resource adds the following parameters
  + pre_stop_handler
  + pre_stop_timeout
  + custom_image.command
  + custom_image.args
  + custom_image.working_dir
  + custom_image.uid
  + custom_image.gid

   Currently, the `pre_stop_handler`, `pre_stop_timeout`, `custom_image.uid` and  `custom_image.gid
`  parameters are internal.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/fgs TESTARGS='-run TestAccFgsV2Function_createByImage'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccFgsV2Function_createByImage -timeout 360m -parallel 4
=== RUN   TestAccFgsV2Function_createByImage
=== PAUSE TestAccFgsV2Function_createByImage
=== CONT  TestAccFgsV2Function_createByImage
--- PASS: TestAccFgsV2Function_createByImage (98.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       98.947s
```
