### PR TITLE
feat(CDN): cdn domain support new fields

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -395,6 +395,11 @@ The `configs` block support:
 * `error_code_redirect_rules` - (Optional, List) Specifies the custom error pages.
   The [error_code_redirect_rules](#error_code_redirect_rules_object) structure is documented below.
 
+* `hsts` - (Optional, List) Specifies the HSTS settings. HSTS forces clients (such as browsers) to use HTTPS to access
+  your server, improving access security. The [hsts](#hsts_object) structure is documented below.
+
+  -> This field can only be used when the HTTPS certificate is enabled.
+
 <a name="https_settings_object"></a>
 The `https_settings` block support:
 
@@ -815,6 +820,18 @@ The `error_code_redirect_rules` block support:
 
 * `target_link` - (Required, String) Specifies the destination URL. The value must start with **http://** or **https://**.
   For example: `http://www.example.com`.
+
+<a name="hsts_object"></a>
+The `hsts` block support:
+
+* `enabled` - (Required, Bool) Specifies whether to enable HSTS settings.
+
+* `max_age` - (Optional, Int) Specifies the expiration time, which means the TTL of the response header
+  `Strict-Transport-Security` on the client. The value ranges from **0** to **63,072,000**. The unit is second.
+  This field is required when enable HSTS settings.
+
+* `include_subdomains` - (Optional, String) Specifies whether subdomain names are included.
+  The options are **on** (included) and **off** (not included). This field is required when enable HSTS settings.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -276,6 +276,18 @@ The `sources` block supports:
   + If `origin_type` is set to **ipaddr** or **domain**, the acceleration domain name will be used by default.
   + If `origin_type` is set to **obs_bucket**, the bucket's domain name will be used by default.
 
+* `weight` - (Optional, Int) Specifies the weight. The value ranges from **1** to **100**. Defaults to **50**.
+  A larger value indicates a larger number of times that content is pulled from this IP address.
+
+  -> If there are multiple origin servers with the same priority, the weight determines the proportion of content pulled
+  from each origin server.
+
+* `obs_bucket_type` - (Optional, String) Specifies the OBS bucket type. Valid values are as follows:
+  + **private**: Private bucket.
+  + **public**: Public bucket.
+
+  This field is valid only when `origin_type` is set to **obs_bucket**. Defaults to **public**.
+
 <a name="configs_object"></a>
 The `configs` block support:
 

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -303,6 +303,13 @@ The `configs` block support:
 * `origin_receive_timeout` - (Optional, Int) Specifies the origin response timeout.
   The value ranges from **5** to **60**, in seconds. Defaults to **30**.
 
+* `origin_follow302_status` - (Optional, String) Specifies whether to enable redirection from the origin.
+  Valid values are as follows:
+  + **on**: Enable.
+  + **off**: Disable.
+
+  Defaults to **off**.
+
 * `https_settings` - (Optional, List) Specifies the certificate configuration. The [https_settings](#https_settings_object)
   structure is documented below.
 

--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -385,6 +385,9 @@ The `configs` block support:
 * `user_agent_filter` - (Optional, List) Specifies the User-Agent blacklist or whitelist settings.
   The [user_agent_filter](#user_agent_filter_object) structure is documented below.
 
+* `error_code_redirect_rules` - (Optional, List) Specifies the custom error pages.
+  The [error_code_redirect_rules](#error_code_redirect_rules_object) structure is documented below.
+
 <a name="https_settings_object"></a>
 The `https_settings` block support:
 
@@ -794,6 +797,17 @@ The `user_agent_filter` block support:
 
 * `ua_list` - (Optional, List) Specifies the User-Agent blacklist or whitelist. This parameter is required when `type`
   is set to **black** or **white**. Up to `10` rules can be configured. A rule contains up to `100` characters.
+
+<a name="error_code_redirect_rules_object"></a>
+The `error_code_redirect_rules` block support:
+
+* `error_code` - (Required, Int) Specifies the redirect unique error code. Valid values are: **400**, **403**, **404**,
+  **405**, **414**, **416**, **451**, **500**, **501**, **502**, **503**, and **504**.
+
+* `target_code` - (Required, Int) Specifies the redirect status code. The value can be **301** or **302**.
+
+* `target_link` - (Required, String) Specifies the destination URL. The value must start with **http://** or **https://**.
+  For example: `http://www.example.com`.
 
 <a name="cache_settings_object"></a>
 The `cache_settings` block support:

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -265,6 +265,9 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.quic.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.hsts.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.hsts.0.include_subdomains", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.hsts.0.max_age", "0"),
 					testAccCheckTLSVersion(resourceName, "TLSv1.1,TLSv1.2"),
 
 					resource.TestCheckResourceAttrSet(resourceName, "configs.0.https_settings.0.certificate_body"),
@@ -285,6 +288,10 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.quic.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.hsts.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.hsts.0.include_subdomains", "on"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.hsts.0.max_age", "63072000"),
+
 					testAccCheckTLSVersion(resourceName, "TLSv1.1,TLSv1.2,TLSv1.3"),
 				),
 			},
@@ -297,6 +304,7 @@ func TestAccCdnDomain_configHttpSettings(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.https_status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.https_settings.0.http2_status", "off"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.hsts.0.enabled", "false"),
 				),
 			},
 			{
@@ -372,6 +380,12 @@ resource "huaweicloud_cdn_domain" "test" {
     quic {
       enabled = true
     }
+
+    hsts {
+      enabled            = true
+      include_subdomains = "off"
+      max_age            = 0
+    }
   }
 }
 `, acceptance.HW_CDN_DOMAIN_NAME, acceptance.HW_CDN_CERT_PATH, acceptance.HW_CDN_PRIVATE_KEY_PATH)
@@ -408,6 +422,12 @@ resource "huaweicloud_cdn_domain" "test" {
     quic {
       enabled = false
     }
+
+    hsts {
+      enabled            = true
+      include_subdomains = "on"
+      max_age            = 63072000
+    }
   }
 }
 `, acceptance.HW_CDN_DOMAIN_NAME, acceptance.HW_CDN_CERT_PATH, acceptance.HW_CDN_PRIVATE_KEY_PATH)
@@ -432,6 +452,10 @@ resource "huaweicloud_cdn_domain" "test" {
 
     https_settings {
       https_enabled = false
+    }
+
+    hsts {
+      enabled = false
     }
   }
 }

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -512,6 +512,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.#", "2"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.#", "2"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.type", "white"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.ua_list.#", "3"),
 
@@ -626,6 +628,11 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.type", "black"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.ua_list.0", "t1*"),
 
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.0.error_code", "416"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.0.target_code", "301"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.0.target_link", "http://example.com"),
+
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName,
 						"configs.0.remote_auth.0.remote_auth_rules.0.auth_failed_status", "503"),
@@ -674,6 +681,8 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.type", "off"),
+
+					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.remote_auth_rules.#", "0"),
@@ -873,6 +882,18 @@ resource "huaweicloud_cdn_domain" "test" {
       ]
     }
 
+    error_code_redirect_rules {
+      error_code  = 416
+      target_code = 301
+      target_link = "http://example.com"
+    }
+
+    error_code_redirect_rules {
+      error_code  = 502
+      target_code = 302
+      target_link = "https://xxx.cn/"
+    }
+
     remote_auth {
       enabled = true
 
@@ -1039,6 +1060,12 @@ resource "huaweicloud_cdn_domain" "test" {
       ua_list = [
         "t1*",
       ]
+    }
+
+    error_code_redirect_rules {
+      error_code  = 416
+      target_code = 301
+      target_link = "http://example.com"
     }
 
     remote_auth {

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -469,6 +469,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "test description"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "60"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_follow302_status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.url_signing.0.type", "type_a"),
@@ -561,6 +562,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", "update description"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_follow302_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.name", "test-name-update"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.value", "test-val-update"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.retrieval_request_header.0.action", "set"),
@@ -674,6 +676,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.description", ""),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.slice_etag_status", "on"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_receive_timeout", "5"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_follow302_status", "off"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.flexible_origin.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.request_limit_rules.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_cache.#", "0"),
@@ -961,6 +964,7 @@ resource "huaweicloud_cdn_domain" "test" {
     description                   = "update description"
     slice_etag_status             = "off"
     origin_receive_timeout        = "30"
+    origin_follow302_status       = "on"
 
     retrieval_request_header {
       name   = "test-name-update"
@@ -1113,6 +1117,7 @@ resource "huaweicloud_cdn_domain" "test" {
     range_based_retrieval_enabled = false
     slice_etag_status             = "on"
     origin_receive_timeout        = "5"
+    origin_follow302_status       = "off"
 
     remote_auth {
       enabled = false

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -66,6 +66,7 @@ func TestAccCdnDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sources.0.origin_type", "ipaddr"),
 					resource.TestCheckResourceAttr(resourceName, "sources.0.http_port", "80"),
 					resource.TestCheckResourceAttr(resourceName, "sources.0.https_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "sources.0.weight", "50"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "val"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
@@ -78,6 +79,7 @@ func TestAccCdnDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "download"),
 					resource.TestCheckResourceAttr(resourceName, "service_area", "global"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "sources.0.weight", "100"),
 				),
 			},
 			{
@@ -91,6 +93,7 @@ func TestAccCdnDomain_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sources.0.retrieval_host", "customize.test.huaweicloud.com"),
 					resource.TestCheckResourceAttr(resourceName, "sources.0.http_port", "8001"),
 					resource.TestCheckResourceAttr(resourceName, "sources.0.https_port", "8002"),
+					resource.TestCheckResourceAttr(resourceName, "sources.0.weight", "1"),
 				),
 			},
 			{
@@ -167,6 +170,7 @@ resource "huaweicloud_cdn_domain" "test" {
     origin_type = "ipaddr"
     http_port   = 80
     https_port  = 443
+    weight      = 100
   }
 
   cache_settings {
@@ -200,6 +204,7 @@ resource "huaweicloud_cdn_domain" "test" {
     retrieval_host = "customize.test.huaweicloud.com"
     http_port      = 8001
     https_port     = 8002
+    weight         = 1
   }
 
   cache_settings {}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -796,6 +796,16 @@ func ResourceCdnDomain() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"weight": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
+						"obs_bucket_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -1457,6 +1467,8 @@ func buildSourcesOpts(rawSources []interface{}) *[]model.SourcesConfig {
 			HttpPort:            utils.Int32IgnoreEmpty(int32(source["http_port"].(int))),
 			HttpsPort:           utils.Int32IgnoreEmpty(int32(source["https_port"].(int))),
 			HostName:            utils.StringIgnoreEmpty(source["retrieval_host"].(string)),
+			Weight:              utils.Int32IgnoreEmpty(int32(source["weight"].(int))),
+			ObsBucketType:       utils.StringIgnoreEmpty(source["obs_bucket_type"].(string)),
 		}
 	}
 	return &sourcesOpts
@@ -2178,6 +2190,8 @@ func flattenSourcesAttrs(sources *[]model.SourcesConfig) []map[string]interface{
 			"http_port":               v.HttpPort,
 			"https_port":              v.HttpsPort,
 			"retrieval_host":          v.HostName,
+			"weight":                  v.Weight,
+			"obs_bucket_type":         v.ObsBucketType,
 		}
 	}
 

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -823,6 +823,12 @@ func ResourceCdnDomain() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						// Cloud will configure this field to `off` by default
+						"origin_follow302_status": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 						"https_settings":             &httpsConfig,
 						"retrieval_request_header":   &requestAndResponseHeader,
 						"http_response_header":       &requestAndResponseHeader,
@@ -1486,6 +1492,9 @@ func buildUpdateDomainFullConfigsOpts(configsOpts *model.Configs, configs map[st
 	if d.HasChange("configs.0.origin_receive_timeout") {
 		configsOpts.OriginReceiveTimeout = utils.Int32IgnoreEmpty(int32(configs["origin_receive_timeout"].(int)))
 	}
+	if d.HasChange("configs.0.origin_follow302_status") {
+		configsOpts.OriginFollow302Status = utils.StringIgnoreEmpty(configs["origin_follow302_status"].(string))
+	}
 	if d.HasChange("configs.0.https_settings") {
 		configsOpts.Https = buildHTTPSOpts(configs["https_settings"].([]interface{}))
 	}
@@ -2141,6 +2150,7 @@ func flattenConfigAttrs(configsResp *model.ConfigsGetBody, d *schema.ResourceDat
 		"description":                   configsResp.Remark,
 		"slice_etag_status":             configsResp.SliceEtagStatus,
 		"origin_receive_timeout":        configsResp.OriginReceiveTimeout,
+		"origin_follow302_status":       configsResp.OriginFollow302Status,
 		"quic":                          flattenQUICAttrs(configsResp.Quic),
 		"referer":                       flattenRefererAttrs(configsResp.Referer),
 		"video_seek":                    flattenVideoSeekAttrs(configsResp.VideoSeek),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- commit1: Support new field `configs.0.error_code_redirect_rules`.
- commit2: Support new field `configs.0.origin_follow302_status`.
- commit3: Support new field `configs.0.hsts`.
- commit4: Support new field `sources.0.weight` and `sources.0.obs_bucket_type`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (789.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       789.194s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (1019.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       1019.271s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (447.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       448.028s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_epsID_migrate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_epsID_migrate -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_epsID_migrate (335.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       335.966s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (910.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       910.051s
```