### PR TITLE
feat(cbh/flavors): support querying modifiable flavors

### DIFF
--- a/docs/data-sources/cbh_flavors.md
+++ b/docs/data-sources/cbh_flavors.md
@@ -31,18 +31,6 @@ The following arguments are supported:
 * `spec_code` - (Optional, String) Specifies the ID of the CBH specification, the query result shows all specifications
   that can be changed by this specification. This parameter is required when `action` is set to **update**.
 
-* `asset` - (Optional, Int) Specifies the number of CBH assets.
-
-* `type` - (Optional, String) Specifies the type of CBH specification. The value can be:
-  + **basic**: Standard version.
-  + **enhance**: Professional version.
-
-* `vcpus` - (Optional, Int) Specifies the number of CPU cores of the CBH.
-
-* `memory` - (Optional, Int) Specifies the memory size of the CBH, in GB.
-
-* `max_connection` - (Optional, Int) Specifies the maximum number of connections to the CBH.
-
 * `flavor_id` - (Optional, String) Specifies the ID of the specification of CBH.
   At present, CBH provides two functional versions: standard version and professional version.
   The standard version is equipped with asset specifications of 10(for example the `flavor_id` is: **cbh.basic.10**),
@@ -50,6 +38,18 @@ The following arguments are supported:
   The professional version is equipped with 10(for example the `flavor_id` is: **cbh.enhance.10**),
   20, 50, 100, 200, 500, 1000, 2000, 5000, 10000 asset specifications.
   The specification 'enhance' is more advanced than the specification 'basic'.
+
+* `type` - (Optional, String) Specifies the type of CBH specification. The value can be:
+  + **basic**: Standard version.
+  + **enhance**: Professional version.
+
+* `asset` - (Optional, Int) Specifies the number of CBH assets.
+
+* `memory` - (Optional, Int) Specifies the memory size of the CBH, in GB.
+
+* `vcpus` - (Optional, Int) Specifies the number of CPU cores of the CBH.
+
+* `max_connection` - (Optional, Int) Specifies the maximum number of connections to the CBH.
 
 ## Attribute Reference
 

--- a/docs/data-sources/cbh_flavors.md
+++ b/docs/data-sources/cbh_flavors.md
@@ -21,6 +21,16 @@ The following arguments are supported:
 * `region` - (Optional, String) Specifies the region in which to query the data source.
   If omitted, the provider-level region will be used.
 
+* `action` - (Optional, String) Specifies the action of querying instances specification information.
+  The valid values are as follows:
+  + **create**: Query instance specification information that can be created.
+  + **update**: Query instance specification information that can be updated.
+
+  If omitted, the CBH specifications that can be created will be queried.
+
+* `spec_code` - (Optional, String) Specifies the ID of the CBH specification, the query result shows all specifications
+  that can be changed by this specification. This parameter is required when `action` is set to **update**.
+
 * `asset` - (Optional, Int) Specifies the number of CBH assets.
 
 * `type` - (Optional, String) Specifies the type of CBH specification. The value can be:

--- a/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_flavors_test.go
+++ b/huaweicloud/services/acceptance/cbh/data_source_huaweicloud_cbh_flavors_test.go
@@ -29,6 +29,7 @@ func TestAccDatasourceCbhFlavors_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "flavors.0.type"),
 					resource.TestCheckResourceAttrSet(rName, "flavors.0.data_disk_size"),
 
+					resource.TestCheckOutput("action_is_useful", "true"),
 					resource.TestCheckOutput("flavor_id_filter_is_useful", "true"),
 					resource.TestCheckOutput("type_filter_is_useful", "true"),
 					resource.TestCheckOutput("asset_filter_is_useful", "true"),
@@ -48,6 +49,16 @@ data "huaweicloud_cbh_flavors" "test" {}
 locals {
   flavor_id = data.huaweicloud_cbh_flavors.test.flavors[0].id
 }
+
+data "huaweicloud_cbh_flavors" "action_filter" {
+  action    = "update"
+  spec_code = local.flavor_id
+}
+
+output "action_is_useful" {
+  value = length(data.huaweicloud_cbh_flavors.action_filter.flavors) > 0
+}
+
 data "huaweicloud_cbh_flavors" "flavor_id_filter" {
   flavor_id = local.flavor_id
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support querying modifiable flavors
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
Currently, this datasource only support querying flavors that can be created, but the flavor_id field of the instance resource already support updating, so this datasource also needs to support querying flavors that can be updated.
1. Support querying modifiable flavors.
2. Modify the parameter order in the document to be consistent with the schema.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Support querying modifiable flavors
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccDatasourceCbhFlavors_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccDatasourceCbhFlavors_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCbhFlavors_basic
=== PAUSE TestAccDatasourceCbhFlavors_basic
=== CONT  TestAccDatasourceCbhFlavors_basic
--- PASS: TestAccDatasourceCbhFlavors_basic (11.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       11.590s

```
