### PR TITLE
fix: feat(apig): new parameters supported for custom authorizer resource

### DIFF
--- a/docs/resources/apig_custom_authorizer.md
+++ b/docs/resources/apig_custom_authorizer.md
@@ -51,6 +51,14 @@ The following arguments are supported:
 
 * `function_version` - (Required, String) Specifies the version of the FGS function.
 
+* `network_type` - (Optional, String) Specifies the framework type of the function.
+  + **V1**: Non-VPC network architecture.
+  + **V2**: VPC network architecture.
+
+  Defaults to **V1**.
+
+* `function_alias_uri` - (Optional, String) Specifies the version alias URI of the FGS function.
+
 * `type` - (Optional, String, ForceNew) Specifies the custom authorize type.
   The valid values are **FRONTEND** and **BACKEND**. Defaults to **FRONTEND**.
   Changing this will create a new custom authorizer resource.

--- a/docs/resources/apig_custom_authorizer.md
+++ b/docs/resources/apig_custom_authorizer.md
@@ -17,11 +17,12 @@ variable "authorizer_name" {}
 variable "function_urn" {}
 
 resource "huaweicloud_apig_custom_authorizer" "test" {
-  instance_id  = var.instance_id
-  name         = var.authorizer_name
-  function_urn = var.function_urn
-  type         = "FRONTEND"
-  cache_age    = 60
+  instance_id      = var.instance_id
+  name             = var.authorizer_name
+  function_urn     = var.function_urn
+  function_version = "latest"
+  type             = "FRONTEND"
+  cache_age        = 60
 
   identity {
     name     = "user_name"
@@ -47,6 +48,8 @@ The following arguments are supported:
   Only letters, digits and underscores (_) are allowed.
 
 * `function_urn` - (Required, String) Specifies the uniform function URN of the function graph resource.
+
+* `function_version` - (Required, String) Specifies the version of the FGS function.
 
 * `type` - (Optional, String, ForceNew) Specifies the custom authorize type.
   The valid values are **FRONTEND** and **BACKEND**. Defaults to **FRONTEND**.

--- a/examples/apig/api-custom-authorizer/main.tf
+++ b/examples/apig/api-custom-authorizer/main.tf
@@ -149,10 +149,11 @@ resource "huaweicloud_apig_instance" "default" {
 }
 
 resource "huaweicloud_apig_custom_authorizer" "default" {
-  instance_id  = huaweicloud_apig_instance.default.id
-  name         = var.apig_auth_name
-  function_urn = huaweicloud_fgs_function.default.urn
-  type         = "FRONTEND"
+  instance_id      = huaweicloud_apig_instance.default.id
+  name             = var.apig_auth_name
+  function_urn     = huaweicloud_fgs_function.default.urn
+  function_version = "latest"
+  type             = "FRONTEND"
 }
 
 resource "huaweicloud_apig_response" "default" {

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
@@ -221,11 +221,12 @@ EOF
 }
 
 resource "huaweicloud_apig_custom_authorizer" "test" {
-  instance_id  = huaweicloud_apig_instance.test.id
-  name         = "%[2]s"
-  function_urn = huaweicloud_fgs_function.test.urn
-  type         = "BACKEND"
-  cache_age    = 60
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  function_urn     = huaweicloud_fgs_function.test.urn
+  function_version = "latest"
+  type             = "BACKEND"
+  cache_age        = 60
 }
 `, common.TestBaseComputeResources(name), name)
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
@@ -205,12 +205,13 @@ func testAccCustomAuthorizer_front(name string) string {
 %[1]s
 
 resource "huaweicloud_apig_custom_authorizer" "test" {
-  instance_id  = huaweicloud_apig_instance.test.id
-  name         = "%[2]s"
-  function_urn = huaweicloud_fgs_function.test.urn
-  type         = "FRONTEND"
-  is_body_send = true
-  cache_age    = 60
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  function_urn     = huaweicloud_fgs_function.test.urn
+  function_version = "latest"
+  type             = "FRONTEND"
+  is_body_send     = true
+  cache_age        = 60
   
   identity {
     name     = "user_name"
@@ -225,10 +226,11 @@ func testAccCustomAuthorizer_frontUpdate(name string) string {
 %[1]s
 
 resource "huaweicloud_apig_custom_authorizer" "test" {
-  instance_id  = huaweicloud_apig_instance.test.id
-  name         = "%[2]s"
-  function_urn = huaweicloud_fgs_function.test.urn
-  type         = "FRONTEND"
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  function_urn     = huaweicloud_fgs_function.test.urn
+  function_version = "latest"
+  type             = "FRONTEND"
 }
 `, testAccCustomAuthorizer_base(name), name)
 }
@@ -238,11 +240,12 @@ func testAccCustomAuthorizer_backend(name string) string {
 %[1]s
 
 resource "huaweicloud_apig_custom_authorizer" "test" {
-  instance_id  = huaweicloud_apig_instance.test.id
-  name         = "%[2]s"
-  function_urn = huaweicloud_fgs_function.test.urn
-  type         = "BACKEND"
-  cache_age    = 60
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  function_urn     = huaweicloud_fgs_function.test.urn
+  function_version = "latest"
+  type             = "BACKEND"
+  cache_age        = 60
 }
 `, testAccCustomAuthorizer_base(name), name)
 }
@@ -252,11 +255,12 @@ func testAccCustomAuthorizer_backendUpdate(name string) string {
 %[1]s
 
 resource "huaweicloud_apig_custom_authorizer" "test" {
-  instance_id  = huaweicloud_apig_instance.test.id
-  name         = "%[2]s"
-  function_urn = huaweicloud_fgs_function.test.urn
-  type         = "BACKEND"
-  cache_age    = 45
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  function_urn     = huaweicloud_fgs_function.test.urn
+  function_version = "latest"
+  type             = "BACKEND"
+  cache_age        = 45
 }
 `, testAccCustomAuthorizer_base(name), name)
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
@@ -69,6 +69,21 @@ func ResourceApigCustomAuthorizerV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The URN of the FGS function.",
+				DiffSuppressFunc: func(_, o, n string, _ *schema.ResourceData) bool {
+					return o != "" && o != n && strings.Contains(n, o)
+				},
+			},
+			"function_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The version of the FGS function.`,
+					utils.SchemaDescInput{
+						Required: true,
+					},
+				),
+				// To ensure compatibility with older versions, RequiredWith is not used.
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -162,15 +177,24 @@ func buildCustomAuthorizerOpts(d *schema.ResourceData) (authorizers.CustomAuthOp
 		return authorizers.CustomAuthOpts{}, fmt.Errorf("the identities can only be set when the type is 'FRONTEND'")
 	}
 
+	functionUrn := d.Get("function_urn").(string)
+	functionVersion := d.Get("function_version").(string)
+	regex := regexp.MustCompile(`^.*:function:\w+:\w+:(\w+)$`)
+	result := regex.FindStringSubmatch(functionUrn)
+	if len(result) > 1 && functionVersion == "" {
+		functionVersion = result[1]
+	}
+
 	return authorizers.CustomAuthOpts{
-		Name:           d.Get("name").(string),
-		Type:           t,
-		AuthorizerType: "FUNC", // The custom authorizer only support 'FUNC'.
-		AuthorizerURI:  d.Get("function_urn").(string),
-		IsBodySend:     utils.Bool(d.Get("is_body_send").(bool)),
-		TTL:            utils.Int(d.Get("cache_age").(int)),
-		UserData:       utils.String(d.Get("user_data").(string)),
-		Identities:     buildIdentities(identities),
+		Name:              d.Get("name").(string),
+		Type:              t,
+		AuthorizerType:    "FUNC", // The custom authorizer only support 'FUNC'.
+		AuthorizerURI:     functionUrn,
+		AuthorizerVersion: functionVersion,
+		IsBodySend:        utils.Bool(d.Get("is_body_send").(bool)),
+		TTL:               utils.Int(d.Get("cache_age").(int)),
+		UserData:          utils.String(d.Get("user_data").(string)),
+		Identities:        buildIdentities(identities),
 	}, nil
 }
 
@@ -229,6 +253,7 @@ func resourceCustomAuthorizerRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("region", region),
 		d.Set("name", resp.Name),
 		d.Set("function_urn", resp.AuthorizerURI),
+		d.Set("function_version", resp.AuthorizerVersion),
 		d.Set("type", resp.Type),
 		d.Set("is_body_send", resp.IsBodySend),
 		d.Set("cache_age", resp.TTL),

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
@@ -85,6 +85,18 @@ func ResourceApigCustomAuthorizerV2() *schema.Resource {
 				),
 				// To ensure compatibility with older versions, RequiredWith is not used.
 			},
+			"network_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The framework type of the function.`,
+			},
+			"function_alias_uri": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The version alias URI of the FGS function.",
+			},
 			"type": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -186,15 +198,17 @@ func buildCustomAuthorizerOpts(d *schema.ResourceData) (authorizers.CustomAuthOp
 	}
 
 	return authorizers.CustomAuthOpts{
-		Name:              d.Get("name").(string),
-		Type:              t,
-		AuthorizerType:    "FUNC", // The custom authorizer only support 'FUNC'.
-		AuthorizerURI:     functionUrn,
-		AuthorizerVersion: functionVersion,
-		IsBodySend:        utils.Bool(d.Get("is_body_send").(bool)),
-		TTL:               utils.Int(d.Get("cache_age").(int)),
-		UserData:          utils.String(d.Get("user_data").(string)),
-		Identities:        buildIdentities(identities),
+		Name:               d.Get("name").(string),
+		Type:               t,
+		AuthorizerType:     "FUNC", // The custom authorizer only support 'FUNC'.
+		AuthorizerURI:      functionUrn,
+		AuthorizerVersion:  functionVersion,
+		NetworkType:        d.Get("network_type").(string),
+		AuthorizerAliasUri: d.Get("function_alias_uri").(string),
+		IsBodySend:         utils.Bool(d.Get("is_body_send").(bool)),
+		TTL:                utils.Int(d.Get("cache_age").(int)),
+		UserData:           utils.String(d.Get("user_data").(string)),
+		Identities:         buildIdentities(identities),
 	}, nil
 }
 
@@ -254,6 +268,8 @@ func resourceCustomAuthorizerRead(_ context.Context, d *schema.ResourceData, met
 		d.Set("name", resp.Name),
 		d.Set("function_urn", resp.AuthorizerURI),
 		d.Set("function_version", resp.AuthorizerVersion),
+		d.Set("network_type", resp.NetworkType),
+		d.Set("function_alias_uri", resp.AuthorizerAliasUri),
 		d.Set("type", resp.Type),
 		d.Set("is_body_send", resp.IsBodySend),
 		d.Set("cache_age", resp.TTL),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameter `authorizer_uri` is no longer support the function version, and they are provide `authorizer_version` to support it.
It is a breaking changes for API users, and it cause the creation of the provider resource failed.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new version parameter supported and fix the compare error.
2. new parameters are supported for custom authorizer.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
PENDING
```
