### PR TITLE
feat(dds): support instance to associate with eip

### DIFF
--- a/docs/resources/dds_instance_eip_associate.md
+++ b/docs/resources/dds_instance_eip_associate.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_instance_eip_associate"
+description: |-
+  Manages a DDS instance EIP associate resource within HuaweiCloud.
+---
+
+# huaweicloud_dds_instance_eip_associate
+
+Manages a DDS instance EIP associate resource within HuaweiCloud.
+
+-> **NOTE:** The shard and config nodes of a cluster instance, the read-only node of a replica set, and the hidden node
+  do not support to bind the EIP.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+variable "public_ip" {}
+
+resource "huaweicloud_dds_instance_eip_associate" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+  public_ip   = var.public_ip
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of a DDS instance.
+  Changing this creates a new resource.
+
+* `node_id` - (Required, String, ForceNew) Specifies the ID of a DDS instance node.
+  Changing this creates a new resource.
+
+* `public_ip` - (Required, String, ForceNew) Specifies the EIP address. Changing this creates a new resource.
+
+## Attribute Reference
+
+* `id` - Indicates the resource ID. Format is `<instance_id>/<node_id>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+
+* `delete` - Default is 30 minutes.
+
+## Import
+
+DDS instance node association information can be imported using `<instance_id>/<node_id>`, e.g.
+
+```bash
+terraform import huaweicloud_dds_instance_eip_associate.test <instance_id>/<node_id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1063,6 +1063,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_lts_log":                     dds.ResourceDdsLtsLog(),
 			"huaweicloud_dds_instance_restart":            dds.ResourceDDSInstanceRestart(),
 			"huaweicloud_dds_instance_internal_ip_modify": dds.ResourceDDSInstanceModifyIP(),
+			"huaweicloud_dds_instance_eip_associate":      dds.ResourceDDSInstanceBindEIP(),
 
 			"huaweicloud_ddm_instance":               ddm.ResourceDdmInstance(),
 			"huaweicloud_ddm_schema":                 ddm.ResourceDdmSchema(),

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_eip_associate_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_eip_associate_test.go
@@ -1,0 +1,106 @@
+package dds
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDDSInstanceEipAssociateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.DdsV3Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DDS client: %s ", err)
+	}
+
+	instID := state.Primary.Attributes["instance_id"]
+	getInstanceInfoHttpUrl := "v3/{project_id}/instances?id={instance_id}"
+	getInstanceInfoPath := client.Endpoint + getInstanceInfoHttpUrl
+	getInstanceInfoPath = strings.ReplaceAll(getInstanceInfoPath, "{project_id}", client.ProjectID)
+	getInstanceInfoPath = strings.ReplaceAll(getInstanceInfoPath, "{instance_id}", instID)
+	getInstanceInfoOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getInstanceInfoResp, err := client.Request("GET", getInstanceInfoPath, &getInstanceInfoOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error getting instance(%s) info: %s", instID, err)
+	}
+
+	getInstanceInfoRespBody, err := utils.FlattenResponse(getInstanceInfoResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flatten response: %s", err)
+	}
+
+	jsonPaths := fmt.Sprintf("instances|[0].groups[*].nodes[?id=='%s'][]|[0].public_ip", state.Primary.Attributes["node_id"])
+	publicIP := utils.PathSearch(jsonPaths, getInstanceInfoRespBody, "")
+	if publicIP.(string) == "" {
+		return nil, fmt.Errorf("error retrieving public IP")
+	}
+
+	return getInstanceInfoRespBody, nil
+}
+
+func TestAccDDSV3InstanceBindEIP_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_dds_instance_eip_associate.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDDSInstanceEipAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDDSInstanceBindEIP_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", "huaweicloud_vpc_eip.test", "address"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceDDSInstanceNodeImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccDDSInstanceBindEIP_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[2]s"
+    share_type  = "PER"
+    size        = 5
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_dds_instance_eip_associate" "test" { 
+  instance_id = huaweicloud_dds_instance.instance.id
+  node_id     = huaweicloud_dds_instance.instance.nodes.1.id
+  public_ip   = huaweicloud_vpc_eip.test.address
+}`, testAccDDSInstanceReplicaSetBasic(rName), rName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource `huaweicloud_dds_instance_eip_associate` to support instance to associate with eip


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run  TestAccDDSV3InstanceBindEIP_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run  TestAccDDSV3InstanceBindEIP_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSV3InstanceBindEIP_basic
=== PAUSE TestAccDDSV3InstanceBindEIP_basic
=== CONT  TestAccDDSV3InstanceBindEIP_basic
--- PASS: TestAccDDSV3InstanceBindEIP_basic (928.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       928.858s
```
