### PR TITLE
feat(hss): support web tamper hosts datasource

### DIFF
--- a/docs/data-sources/hss_webtamper_hosts.md
+++ b/docs/data-sources/hss_webtamper_hosts.md
@@ -1,0 +1,86 @@
+---
+subcategory: "Host Security Service (HSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_hss_webtamper_hosts"
+description: |-
+  Use this data source to get the list of HSS web tamper hosts within HuaweiCloud.
+---
+
+# huaweicloud_hss_webtamper_hosts
+
+Use this data source to get the list of HSS web tamper hosts within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable host_id {}
+
+data "huaweicloud_hss_webtamper_hosts" "test" {
+  host_id = var.host_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the HSS web tamper hosts.
+  If omitted, the provider-level region will be used.
+
+* `host_id` - (Optional, String) Specifies the ID of the web tamper host to be queried.
+
+* `name` - (Optional, String) Specifies the name of the web tamper host to be queried.
+  This field will undergo a fuzzy matching query, the query result is for all web tamper hosts whose names contain this
+  value.
+
+* `public_ip` - (Optional, String) Specifies the elastic public IP address of the web tamper host to be queried.
+
+* `private_ip` - (Optional, String) Specifies the private IP address of the web tamper host to be queried.
+
+* `group_name` - (Optional, String) Specifies the host group name to which the web tamper hosts belong to be queried.
+
+* `os_type` - (Optional, String) Specifies the operating system type of the web tamper host to be queried.
+  The value can be **linux** or **windows**.
+
+* `protect_status` - (Optional, String) Specifies the protection status of the web tamper hosts to be queried.
+  The value can be **closed** or **opened**.
+
+* `rasp_protect_status` - (Optional, String) Specifies the dynamic protection status of the web tamper hosts to be
+  queried. The value can be **closed** or **opened**.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the web tamper hosts
+  belong. For enterprise users, if omitted, will query the web tamper hosts under all enterprise projects.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `hosts` - All web tamper hosts that match the filter parameters.  
+  The [hosts](#hss_webtamper_hosts) structure is documented below.
+
+<a name="hss_webtamper_hosts"></a>
+The `hosts` block supports:
+
+* `id` - The ID of the web tamper host.
+
+* `name` - The name of the web tamper host.
+
+* `public_ip` - The elastic public IP address of the web tamper host.
+
+* `private_ip` - The private IP address of the web tamper host.
+
+* `group_name` - The host group name to which the web tamper host belongs.
+
+* `os_bit` - The operating system bits of the web tamper host.
+
+* `os_type` - The operating system type of the web tamper host.
+
+* `protect_status` - The protection status of the web tamper host.
+
+* `rasp_protect_status` - The dynamic protection status of the web tamper host.
+
+* `anti_tampering_times` - The number of defended tampering attacks.
+
+* `detect_tampering_times` - The number of detected tampering attacks.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -588,8 +588,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_backups":                gaussdb.DataSourceGaussdbMysqlBackups(),
 			"huaweicloud_gaussdb_mysql_restore_time_ranges":    gaussdb.DataSourceGaussdbMysqlRestoreTimeRanges(),
 
-			"huaweicloud_hss_host_groups": hss.DataSourceHostGroups(),
-			"huaweicloud_hss_hosts":       hss.DataSourceHosts(),
+			"huaweicloud_hss_host_groups":     hss.DataSourceHostGroups(),
+			"huaweicloud_hss_hosts":           hss.DataSourceHosts(),
+			"huaweicloud_hss_webtamper_hosts": hss.DataSourceWebTamperHosts(),
 
 			"huaweicloud_identity_permissions": iam.DataSourceIdentityPermissions(),
 			"huaweicloud_identity_role":        iam.DataSourceIdentityRole(),

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_hosts_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_hosts_test.go
@@ -1,0 +1,105 @@
+package hss
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceWebTamperHosts_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_hss_webtamper_hosts.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceWebTamperHosts_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.private_ip"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.os_bit"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.os_type"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.protect_status"),
+					resource.TestCheckResourceAttrSet(dataSource, "hosts.0.rasp_protect_status"),
+
+					resource.TestCheckOutput("is_host_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_protect_status_filter_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceWebTamperHosts_basic() string {
+	return `
+data "huaweicloud_hss_webtamper_hosts" "test" {}
+
+# Filter using host ID.
+locals {
+  host_id = data.huaweicloud_hss_webtamper_hosts.test.hosts[0].id
+}
+
+data "huaweicloud_hss_webtamper_hosts" "host_id_filter" {
+  host_id = local.host_id
+}
+
+output "is_host_id_filter_useful" {
+  value = length(data.huaweicloud_hss_webtamper_hosts.host_id_filter.hosts) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_webtamper_hosts.host_id_filter.hosts[*].id : v == local.host_id]
+  )
+}
+
+# Filter using name
+locals {
+  name = data.huaweicloud_hss_webtamper_hosts.test.hosts[0].name
+}
+
+data "huaweicloud_hss_webtamper_hosts" "name_filter" {
+  name = local.name
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_hss_webtamper_hosts.name_filter.hosts) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_webtamper_hosts.name_filter.hosts[*].name : v == local.name]
+  )
+}
+
+# Filter using protect_status
+locals {
+  protect_status = data.huaweicloud_hss_webtamper_hosts.test.hosts[0].protect_status
+}
+
+data "huaweicloud_hss_webtamper_hosts" "protect_status_filter" {
+  protect_status = local.protect_status
+}
+
+output "is_protect_status_filter_filter_useful" {
+  value = length(data.huaweicloud_hss_webtamper_hosts.protect_status_filter.hosts) > 0 && alltrue(
+    [for v in data.huaweicloud_hss_webtamper_hosts.protect_status_filter.hosts[*].protect_status : v == local.protect_status]
+  )
+}
+
+# Filter using non existent name.
+data "huaweicloud_hss_webtamper_hosts" "not_found" {
+  name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_hss_webtamper_hosts.not_found.hosts) == 0
+}
+`
+}

--- a/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_hosts.go
+++ b/huaweicloud/services/hss/data_source_huaweicloud_hss_webtamper_hosts.go
@@ -1,0 +1,225 @@
+package hss
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	hssv5model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/hss/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API HSS GET /v5/{project_id}/webtamper/hosts
+func DataSourceWebTamperHosts() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceWebTamperHostsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"host_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"protect_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rasp_protect_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"hosts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"private_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"os_bit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"os_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protect_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rasp_protect_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"anti_tampering_times": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"detect_tampering_times": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceWebTamperHostsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		epsId       = cfg.DataGetEnterpriseProjectID(d)
+		limit       = int32(20)
+		offset      int32
+		allWtpHosts []hssv5model.WtpProtectHostResponseInfo
+	)
+
+	client, err := cfg.HcHssV5Client(region)
+	if err != nil {
+		return diag.Errorf("error creating HSS v5 client: %s", err)
+	}
+
+	for {
+		request := hssv5model.ListWtpProtectHostRequest{
+			Region:              region,
+			EnterpriseProjectId: utils.String(epsId),
+			HostName:            utils.StringIgnoreEmpty(d.Get("name").(string)),
+			HostId:              utils.StringIgnoreEmpty(d.Get("host_id").(string)),
+			PublicIp:            utils.StringIgnoreEmpty(d.Get("public_ip").(string)),
+			PrivateIp:           utils.StringIgnoreEmpty(d.Get("private_ip").(string)),
+			GroupName:           utils.StringIgnoreEmpty(d.Get("group_name").(string)),
+			OsType:              utils.StringIgnoreEmpty(d.Get("os_type").(string)),
+			ProtectStatus:       utils.StringIgnoreEmpty(d.Get("protect_status").(string)),
+			Limit:               utils.Int32(limit),
+			Offset:              utils.Int32(offset),
+		}
+
+		listResp, listErr := client.ListWtpProtectHost(&request)
+		if listErr != nil {
+			return diag.Errorf("error querying HSS web tamper hosts: %s", listErr)
+		}
+
+		if listResp == nil || listResp.DataList == nil || listResp.TotalNum == nil {
+			break
+		}
+		if len(*listResp.DataList) == 0 {
+			break
+		}
+		allWtpHosts = append(allWtpHosts, *listResp.DataList...)
+
+		if int(*listResp.TotalNum) == len(allWtpHosts) {
+			break
+		}
+
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuId)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("hosts", flattenWebTamperHosts(filterWebTamperHosts(allWtpHosts, d))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterWebTamperHosts(wtpHosts []hssv5model.WtpProtectHostResponseInfo, d *schema.ResourceData) []hssv5model.WtpProtectHostResponseInfo {
+	if len(wtpHosts) == 0 {
+		return nil
+	}
+
+	rst := make([]hssv5model.WtpProtectHostResponseInfo, 0, len(wtpHosts))
+	for _, v := range wtpHosts {
+		if raspProtectStatus, ok := d.GetOk("rasp_protect_status"); ok &&
+			fmt.Sprint(raspProtectStatus) != utils.StringValue(v.RaspProtectStatus) {
+			continue
+		}
+		rst = append(rst, v)
+	}
+
+	return rst
+}
+
+func flattenWebTamperHosts(wtpHosts []hssv5model.WtpProtectHostResponseInfo) []interface{} {
+	if len(wtpHosts) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(wtpHosts))
+	for _, v := range wtpHosts {
+		rst = append(rst, map[string]interface{}{
+			"id":                     v.HostId,
+			"name":                   v.HostName,
+			"public_ip":              v.PublicIp,
+			"private_ip":             v.PrivateIp,
+			"group_name":             v.GroupName,
+			"os_bit":                 v.OsBit,
+			"os_type":                v.OsType,
+			"protect_status":         v.ProtectStatus,
+			"rasp_protect_status":    v.RaspProtectStatus,
+			"anti_tampering_times":   v.AntiTamperingTimes,
+			"detect_tampering_times": v.DetectTamperingTimes,
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support web tamper hosts datasource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Support web tamper hosts datasource

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ export HW_HSS_HOST_PROTECTION_HOST_ID=xxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceWebTamperHosts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceWebTamperHosts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWebTamperHosts_basic
=== PAUSE TestAccDataSourceWebTamperHosts_basic
=== CONT  TestAccDataSourceWebTamperHosts_basic
--- PASS: TestAccDataSourceWebTamperHosts_basic (182.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       182.515s

```
