### PR TITLE
fix(apig): parameter value_type should be set

### DIFF
--- a/docs/resources/apig_plugin.md
+++ b/docs/resources/apig_plugin.md
@@ -47,29 +47,40 @@ resource "huaweicloud_apig_plugin" "test" {
   content     = jsonencode(
     {
       response_headers = [{
-        name   = "X-Custom-Pwd"
-        value  = "**********"
-        action = "override"
+        name       = "X-Custom-Pwd"
+        value      = "**********"
+        value_type = "custom_value"
+        action     = "override"
       },
       {
-        name   = "X-Custom-Debug-Step"
-        value  = "Beta"
-        action = "skip"
+        name       = "X-Custom-Debug-Step"
+        value      = "Beta"
+        value_type = "custom_value"
+        action     = "skip"
       },
       {
-        name   = "X-Custom-Config"
-        value  = "<HTTP response test>"
-        action = "append"
+        name       = "X-Custom-Config"
+        value      = "<HTTP response test>"
+        value_type = "custom_value"
+        action     = "append"
       },
       {
-        name   = "X-Custom-Id"
-        value  = ""
-        action = "delete"
+        name       = "X-Custom-Id"
+        value      = ""
+        value_type = "custom_value"
+        action     = "delete"
       },
       {
-        name   = "X-Custom-Log-Level"
-        value  = "DEBUG"
-        action = "add"
+        name       = "X-Custom-Log-Level"
+        value      = "DEBUG"
+        value_type = "custom_value"
+        action     = "add"
+      },
+      {
+        name       = "Sys-Param"
+        value      = "$context.cacheStatus"
+        value_type = "system_parameter"
+        action     = "add"
       }]
     }
   )

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_test.go
@@ -227,29 +227,40 @@ resource "huaweicloud_apig_plugin" "test" {
   content     = jsonencode(
     {
       response_headers = [{
-        name   = "X-Custom-Pwd"
-        value  = "**********"
-        action = "override"
+        name       = "X-Custom-Pwd"
+        value      = "**********"
+        value_type = "custom_value"
+        action     = "override"
       },
       {
-        name   = "X-Custom-Debug-Step"
-        value  = "Beta"
-        action = "skip"
+        name       = "X-Custom-Debug-Step"
+        value      = "Beta"
+        value_type = "custom_value"
+        action     = "skip"
       },
       {
-        name   = "X-Custom-Config"
-        value  = "<HTTP response test>"
-        action = "append"
+        name       = "X-Custom-Config"
+        value      = "<HTTP response test>"
+        action     = "append"
+        value_type = "custom_value"
       },
       {
-        name   = "X-Custom-Id"
-        value  = ""
-        action = "delete"
+        name       = "X-Custom-Id"
+        value      = ""
+        value_type = "custom_value"
+        action     = "delete"
       },
       {
-        name   = "X-Custom-Log-Level"
-        value  = "DEBUG"
-        action = "add"
+        name       = "X-Custom-Log-Level"
+        value      = "DEBUG"
+        value_type = "custom_value"
+        action     = "add"
+      },
+      {
+        name       = "Sys-Param"
+        value      = "$context.cacheStatus"
+        value_type = "system_parameter"
+        action     = "add"
       }]
     }
   )
@@ -269,14 +280,22 @@ resource "huaweicloud_apig_plugin" "test" {
   content     = jsonencode(
     {
       response_headers = [{
-        name   = "X-Custom-Pwd"
-        value  = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        action = "delete"
+        name       = "X-Custom-Pwd"
+        value      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        value_type = "custom_value"
+        action     = "delete"
       },
       {
-        name   = "X-Custom-Log-PATH"
-        value  = "/tmp/debug.log"
-        action = "add"
+        name       = "X-Custom-Log-PATH"
+        value      = "/tmp/debug.log"
+        value_type = "custom_value"
+        action     = "add"
+      },
+      {
+        name       = "Sys-Param-updated"
+        value      = "$context.cacheStatus"
+        value_type = "system_parameter"
+        action     = "append"
       }]
     }
   )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameter `value_type` (with values: 'system_parameter' and 'custom_value') should be set.
If not, the provider will display this:
```
Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # huaweicloud_apig_plugin.http_resp will be updated in-place
          ~ resource "huaweicloud_apig_plugin" "http_resp" {
              ~ content     = jsonencode(
                  ~ {
                      ~ response_headers = [
                          ~ {
                                name       = "X-Custom-Pwd"
                              - value_type = ""
                                # (2 unchanged attributes hidden)
                            },
                        ]
                    }
                )
                id          = "44e0f97d7a4440bfbd83e8ab6b2de6c7"
                name        = "tf_test_sc826_http_resp"
                # (3 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. parameter value_type should be set.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccPlugin_httpResponse'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccPlugin_httpResponse -timeout 360m -parallel 4
=== RUN   TestAccPlugin_httpResponse
=== PAUSE TestAccPlugin_httpResponse
=== CONT  TestAccPlugin_httpResponse
--- PASS: TestAccPlugin_httpResponse (549.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig   549.952s
```
