### PR TITLE
feat(RDS): rds instance support private dns name

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -278,6 +278,9 @@ The following arguments are supported:
 
   -> **NOTE:** Only adding MSDTC hosts is supported, deletion is not allowed.
 
+* `private_dns_name_prefix` - (Optional, String) Specifies the prefix of the private domain name. The value contains
+  **8** to **64** characters. Only uppercase letters, lowercase letters, and digits are allowed.
+
 The `db` block supports:
 
 * `type` - (Required, String, ForceNew) Specifies the DB engine. Available value are **MySQL**, **PostgreSQL**,
@@ -410,6 +413,8 @@ In addition to all arguments above, the following attributes are exported:
 * `nodes` - Indicates the instance nodes information. Structure is documented below.
 
 * `private_ips` - Indicates the private IP address list. It is a blank string until an ECS is created.
+
+* `private_dns_names` - Indicates the private domain name list of the DB instance.
 
 * `public_ips` - Indicates the public IP address list.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240430094404-2d1676601798
+	github.com/chnsz/golangsdk v0.0.0-20240506093406-85a3fbfa605b
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240430094404-2d1676601798 h1:fVv2bj5J+p2ETATj/mqAqN4BI2NoL4hrXWN3p6uuOXQ=
-github.com/chnsz/golangsdk v0.0.0-20240430094404-2d1676601798/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240506093406-85a3fbfa605b h1:PaoG9kxv7Nnk/79co8UR99cVoJJExli8vafnrAWFmIs=
+github.com/chnsz/golangsdk v0.0.0-20240506093406-85a3fbfa605b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -46,6 +46,8 @@ func TestAccRdsInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8634"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "09:00"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_prefix", "terraformTest"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_dns_names.0"),
 				),
 			},
 			{
@@ -65,6 +67,7 @@ func TestAccRdsInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8636"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "15:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "17:00"),
+					resource.TestCheckResourceAttr(resourceName, "private_dns_name_prefix", "terraformTestUpdate"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttrSet(resourceName, "db.0.password"),
 				),
@@ -537,17 +540,18 @@ func testAccRdsInstance_basic(name string) string {
 %[1]s
 
 resource "huaweicloud_rds_instance" "test" {
-  name              = "%[2]s"
-  description       = "test_description"
-  flavor            = "rds.pg.n1.large.2"
-  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  subnet_id         = data.huaweicloud_vpc_subnet.test.id
-  vpc_id            = data.huaweicloud_vpc.test.id
-  time_zone         = "UTC+08:00"
-  fixed_ip          = "192.168.0.210"
-  maintain_begin    = "06:00"
-  maintain_end      = "09:00"
+  name                    = "%[2]s"
+  description             = "test_description"
+  flavor                  = "rds.pg.n1.large.2"
+  availability_zone       = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id       = huaweicloud_networking_secgroup.test.id
+  subnet_id               = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                  = data.huaweicloud_vpc.test.id
+  time_zone               = "UTC+08:00"
+  fixed_ip                = "192.168.0.210"
+  maintain_begin          = "06:00"
+  maintain_end            = "09:00"
+  private_dns_name_prefix = "terraformTest"
 
   db {
     type     = "PostgreSQL"
@@ -577,17 +581,18 @@ func testAccRdsInstance_update(name string) string {
 %[1]s
 
 resource "huaweicloud_rds_instance" "test" {
-  name                  = "%[2]s-update"
-  flavor                = "rds.pg.n1.large.2"
-  availability_zone     = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id     = huaweicloud_networking_secgroup.test.id
-  subnet_id             = data.huaweicloud_vpc_subnet.test.id
-  vpc_id                = data.huaweicloud_vpc.test.id
-  enterprise_project_id = "%[3]s"
-  time_zone             = "UTC+08:00"
-  fixed_ip              = "192.168.0.230"
-  maintain_begin        = "15:00"
-  maintain_end          = "17:00"
+  name                    = "%[2]s-update"
+  flavor                  = "rds.pg.n1.large.2"
+  availability_zone       = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id       = huaweicloud_networking_secgroup.test.id
+  subnet_id               = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                  = data.huaweicloud_vpc.test.id
+  enterprise_project_id   = "%[3]s"
+  time_zone               = "UTC+08:00"
+  fixed_ip                = "192.168.0.230"
+  maintain_begin          = "15:00"
+  maintain_end            = "17:00"
+  private_dns_name_prefix = "terraformTestUpdate"
 
   db {
     password = "Huangwei!120521"

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
@@ -43,11 +43,29 @@ type CreateOpts struct {
 	LogConfig           *FuncLogConfig    `json:"log_config,omitempty"`
 	GPUMemory           int               `json:"gpu_memory,omitempty"`
 	GPUType             string            `json:"gpu_type,omitempty"`
+	// The pre-stop handler of the function.
+	// The value must contain a period (.) in the format of "xx.xx".
+	PreStopHandler string `json:"pre_stop_handler,omitempty"`
+	// Maximum duration the function can be initialized.
+	// Value range: 1s–90s.
+	PreStopTimeout int `json:"pre_stop_timeout,omitempty"`
 }
 
 type CustomImage struct {
 	Enabled bool   `json:"enabled" required:"true"`
 	Image   string `json:"image" required:"true"`
+	// The startup commands of the SWR image.
+	// Multiple commands are separated by commas (,). For example, "/bin/sh".
+	Command string `json:"command,omitempty"`
+	// The command line arguments used to start the SWR image.
+	// Multiple parameters are separated by commas (,).
+	Args string `json:"args,omitempty"`
+	// The working directory of the SWR image.
+	WorkingDir string `json:"working_dir,omitempty"`
+	// The user ID of the SWR image.
+	UserId string `json:"uid,omitempty"`
+	// The user group ID of the SWR image.
+	UserGroupId string `json:"gid,omitempty"`
 }
 
 func (opts CreateOpts) ToCreateFunctionMap() (map[string]interface{}, error) {
@@ -192,6 +210,12 @@ type UpdateMetadataOpts struct {
 	// Restore Hook timeout of snapshot-based cold start.
 	// Range: 1s to 300s.
 	RestoreHookTimeout int `json:"restore_hook_timeout,omitempty"`
+	// The pre-stop handler of the function.\
+	// The value must contain a period (.) in the format of "xx.xx".
+	PreStopHandler string `json:"pre_stop_handler,omitempty"`
+	// Maximum duration the function can be initialized.
+	// Value range: 1s–90s.
+	PreStopTimeout int `json:"pre_stop_timeout,omitempty"`
 }
 
 type StrategyConfig struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
@@ -73,6 +73,10 @@ type Function struct {
 	EnableAuthInHeader bool `json:"enable_auth_in_header"`
 	// Private domain name.
 	DomainNames string `json:"domain_names"`
+	// The pre-stop handler of the function.
+	PreStopHandler string `json:"pre_stop_handler"`
+	// Maximum duration the function can be initialized.
+	PreStopTimeout int `json:"pre_stop_timeout"`
 }
 
 type FuncMount struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -848,3 +848,50 @@ func ModifyReadWritePermissions(c *golangsdk.ServiceClient, opts ActionInstanceB
 	_, r.Err = c.Put(updateURL(c, instanceId, "readonly-status"), b, &r.Body, &golangsdk.RequestOpts{})
 	return
 }
+
+type ModifySecondLevelMonitoringOpts struct {
+	SwitchOption bool `json:"switch_option"`
+	Interval     int  `json:"interval" required:"true"`
+}
+
+func (opts ModifySecondLevelMonitoringOpts) ToActionInstanceMap() (map[string]interface{}, error) {
+	return toActionInstanceMap(opts)
+}
+
+// ModifySecondLevelMonitoring is a method used to switch second level monitoring of the instance.
+func ModifySecondLevelMonitoring(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r ModifySecondLevelMonitoringResult) {
+	b, err := opts.ToActionInstanceMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, instanceId, "second-level-monitor"), b, &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+// GetSecondLevelMonitoring is a method used to obtain the second level monitoring.
+func GetSecondLevelMonitoring(c *golangsdk.ServiceClient, instanceId string) (r GetSecondLevelMonitoringResult) {
+	_, r.Err = c.Get(getURL(c, instanceId, "second-level-monitor"), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return
+}
+
+type ModifyPrivateDnsNamePrefixOpts struct {
+	DnsName string `json:"dns_name" required:"true"`
+}
+
+func (opts ModifyPrivateDnsNamePrefixOpts) ToActionInstanceMap() (map[string]interface{}, error) {
+	return toActionInstanceMap(opts)
+}
+
+// ModifyPrivateDnsNamePrefix is a method used to private dns name prefix of the instance.
+func ModifyPrivateDnsNamePrefix(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r JobResult) {
+	b, err := opts.ToActionInstanceMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, instanceId, "modify-dns"), b, &r.Body, &golangsdk.RequestOpts{})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -54,6 +54,10 @@ type ModifyConfigurationResult struct {
 	commonResult
 }
 
+type ModifySecondLevelMonitoringResult struct {
+	commonResult
+}
+
 type GetConfigurationResult struct {
 	commonResult
 }
@@ -63,6 +67,10 @@ type GetBinlogRetentionHoursResult struct {
 }
 
 type GetTdeStatusResult struct {
+	commonResult
+}
+
+type GetSecondLevelMonitoringResult struct {
 	commonResult
 }
 
@@ -200,6 +208,17 @@ type GetTdeStatusResp struct {
 
 func (r GetTdeStatusResult) Extract() (*GetTdeStatusResp, error) {
 	var response GetTdeStatusResp
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+type GetSecondLevelMonitoringResp struct {
+	SwitchOption bool `json:"switch_option"`
+	Interval     int  `json:"interval"`
+}
+
+func (r GetSecondLevelMonitoringResult) Extract() (*GetSecondLevelMonitoringResp, error) {
+	var response GetSecondLevelMonitoringResp
 	err := r.ExtractInto(&response)
 	return &response, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240430094404-2d1676601798
+# github.com/chnsz/golangsdk v0.0.0-20240506093406-85a3fbfa605b
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. rds instance support the param of private_dns_name_prefix
2. rds instance support the attribute of private_dns_names

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. rds instance support the param of private_dns_name_prefix
2. rds instance support the attribute of private_dns_names
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=11
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 11
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_prePaid
--- PASS: TestAccRdsInstance_mariadb (673.44s)
--- PASS: TestAccRdsInstance_ha (754.15s)
--- PASS: TestAccRdsInstance_basic (869.55s)
--- PASS: TestAccRdsInstance_mysql_power_action (1074.13s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1456.50s)
--- PASS: TestAccRdsInstance_restore_pg (1552.56s)
--- PASS: TestAccRdsInstance_prePaid (1651.60s)
--- PASS: TestAccRdsInstance_restore_mysql (1699.83s)
--- PASS: TestAccRdsInstance_mysql (1828.61s)
--- PASS: TestAccRdsInstance_sqlserver (3091.51s)
--- PASS: TestAccRdsInstance_restore_sqlserver (3355.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3828.707s
```
