### PR TITLE
feat(apig/throttle): new data source supported for associated res query

### DIFF
--- a/docs/data-sources/apig_api_associated_throttling_policies.md
+++ b/docs/data-sources/apig_api_associated_throttling_policies.md
@@ -1,0 +1,109 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_api_associated_throttling_policies"
+description: |-
+  Use this data source to query the throttling policies associated with the specified API within HuaweiCloud.
+---
+
+# huaweicloud_apig_api_associated_throttling_policies
+
+Use this data source to query the throttling policies associated with the specified API within HuaweiCloud.
+
+## Example Usage
+
+### Query the contents of all throttling policies bound to the current API
+
+```hcl
+variable "instance_id" {}
+variable "associated_api_id" {}
+
+data "huaweicloud_apig_api_associated_throttling_policies" "test" {
+  instance_id = var.instance_id
+  api_id      = var.associated_api_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the associated throttling policies.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the throttling policies belong.
+
+* `api_id` - (Required, String) Specifies the ID of the API bound to the throttling policy.
+
+* `policy_id` - (Optional, String) Specifies the ID of the throttling policy.
+
+* `name` - (Optional, String) Specifies the name of the throttling policy.
+
+* `type` - (Optional, String) Specifies the type of the throttling policy.  
+  The valid values are as follows:
+  + **API-based**: limiting the maximum number of times a single API bound to the policy can be called within the
+    specified period.
+  + **API-shared**: limiting the maximum number of times all APIs bound to the policy can be called within the specified
+    period.
+
+* `env_name` - (Optional, String) Specifies the name of the environment where the API is published.
+
+* `period_unit` - (Optional, String) Specifies the time unit for limiting the number of API calls.  
+  The valid values are **SECOND**, **MINUTE**, **HOUR** and **DAY**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `policies` - All throttling policies that match the filter parameters.
+  The [policies](#api_associated_throttling_policies) structure is documented below.
+
+<a name="api_associated_throttling_policies"></a>
+The `policies` block supports:
+
+* `id` - The ID of the throttling policy.
+
+* `name` - The name of the throttling policy.
+
+* `type` - The type of the throttling policy.
+
+* `period_unit` - The time unit for limiting the number of API calls.
+
+* `period` - The period of time for limiting the number of API calls.
+
+* `max_api_requests` - The maximum number of times an API can be accessed within a specified period.
+
+* `max_app_requests` - The maximum number of times the API can be accessed by an app within the same period.
+
+* `max_ip_requests` - The maximum number of times the API can be accessed by an IP address within the same period.
+
+* `max_user_requests` - The maximum number of times the API can be accessed by a user within the same period.
+
+* `env_name` - The name of the environment where the API is published.
+
+* `description` - The description of the throttling policy.
+
+* `user_throttles` - The array of one or more special throttling policies for IAM user limit.
+  The [user_throttles](#throttling_policy_rule_detail_attr) structure is documented below.
+
+* `app_throttles` - The array of one or more special throttling policies for APP limit.
+  The [app_throttles](#throttling_policy_rule_detail_attr) structure is documented below.
+
+* `bind_id` - The bind ID.
+
+* `bind_time` - The time that the throttling policy is bound to the API, in RFC3339 format.
+
+* `created_at` - The creation time of the throttling policy, in RFC3339 format.
+
+<a name="throttling_policy_rule_detail_attr"></a>
+The `user_throttles` and `app_throttles` blocks support:
+
+* `max_api_requests` - The maximum number of times an API can be accessed within a specified period.
+
+* `throttling_object_id` - The object ID which the special user/application throttling policy belongs.
+
+* `throttling_object_name` - The object name which the special user/application throttling policy belongs.
+
+* `id` - The ID of the special user/application throttling policy.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -401,9 +401,10 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"huaweicloud_apig_api_associated_acl_policies": apig.DataSourceApiAssociatedAclPolicies(),
-			"huaweicloud_apig_environments":                apig.DataSourceEnvironments(),
-			"huaweicloud_apig_groups":                      apig.DataSourceGroups(),
+			"huaweicloud_apig_api_associated_acl_policies":        apig.DataSourceApiAssociatedAclPolicies(),
+			"huaweicloud_apig_api_associated_throttling_policies": apig.DataSourceApiAssociatedThrottlingPolicies(),
+			"huaweicloud_apig_environments":                       apig.DataSourceEnvironments(),
+			"huaweicloud_apig_groups":                             apig.DataSourceGroups(),
 
 			"huaweicloud_as_configurations":      as.DataSourceASConfigurations(),
 			"huaweicloud_as_groups":              as.DataSourceASGroups(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_associated_throttling_policies_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_associated_throttling_policies_test.go
@@ -1,0 +1,412 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceApiAssociatedThrottlingPolicies_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_apig_api_associated_throttling_policies.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+
+		byId   = "data.huaweicloud_apig_api_associated_throttling_policies.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byName   = "data.huaweicloud_apig_api_associated_throttling_policies.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNotFoundName   = "data.huaweicloud_apig_api_associated_throttling_policies.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+
+		byType   = "data.huaweicloud_apig_api_associated_throttling_policies.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byEnvName   = "data.huaweicloud_apig_api_associated_throttling_policies.filter_by_env_name"
+		dcByEnvName = acceptance.InitDataSourceCheck(byEnvName)
+
+		byPeriodUnit   = "data.huaweicloud_apig_api_associated_throttling_policies.filter_by_period_unit"
+		dcByPeriodUnit = acceptance.InitDataSourceCheck(byPeriodUnit)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckUserId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceApiAssociatedThrottlingPolicies_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "policies.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(rName, "policies.0.max_api_requests", "100"),
+					resource.TestMatchResourceAttr(rName, "policies.0.user_throttles.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestMatchResourceAttr(rName, "policies.0.app_throttles.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrPair(rName, "policies.0.user_throttles.0.throttling_object_id",
+						"huaweicloud_apig_throttling_policy.test", "user_throttles.0.throttling_object_id"),
+					resource.TestCheckResourceAttrPair(rName, "policies.0.app_throttles.0.throttling_object_id",
+						"huaweicloud_apig_throttling_policy.test", "app_throttles.0.throttling_object_id"),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_not_found_filter_useful", "true"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcByEnvName.CheckResourceExists(),
+					resource.TestCheckOutput("is_env_name_filter_useful", "true"),
+					dcByPeriodUnit.CheckResourceExists(),
+					resource.TestCheckOutput("is_period_unit_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceApiAssociatedThrottlingPolicies_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+resource "huaweicloud_apig_channel" "test" {
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  port             = 8000
+  balance_strategy = 2
+  member_type        = "ecs"
+  type               = 2
+
+  health_check {
+    protocol           = "HTTPS"
+    threshold_normal   = 10  # maximum value
+    threshold_abnormal = 10  # maximum value
+    interval           = 300 # maximum value
+    timeout            = 30  # maximum value
+    path               = "/"
+    method             = "HEAD"
+    port               = 8080
+    http_codes         = "201,202,303-404"
+  }
+
+  member {
+    id   = huaweicloud_compute_instance.test.id
+    name = huaweicloud_compute_instance.test.name
+  }
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_age}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+
+  request_params {
+    name     = "user_age"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+  
+  backend_params {
+    type     = "REQUEST"
+    name     = "userAge"
+    location = "PATH"
+    value    = "user_age"
+  }
+
+  web {
+    path             = "/getUserAge/{userAge}"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+
+  web_policy {
+    name             = "%[2]s_policy1"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getUserAge/{userAge}"
+    timeout          = 30000
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "userAge"
+      location = "PATH"
+      value    = "user_age"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_age"
+      type       = "Equal"
+      value      = "28"
+    }
+  }
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_api_publishment" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+}
+
+resource "huaweicloud_apig_application" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+resource "huaweicloud_apig_throttling_policy" "test" {
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  type             = "API-based"
+  period           = 15000
+  period_unit      = "SECOND"
+  max_api_requests = 100
+
+  app_throttles {
+    max_api_requests     = 30
+    throttling_object_id = huaweicloud_apig_application.test.id
+  }
+  user_throttles {
+    max_api_requests     = 30
+    throttling_object_id = "%[3]s"
+  }
+}
+
+resource "huaweicloud_apig_throttling_policy_associate" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  policy_id   = huaweicloud_apig_throttling_policy.test.id
+  publish_ids = [
+    huaweicloud_apig_api_publishment.test.publish_id
+  ]
+}
+`, common.TestBaseComputeResources(name), name, acceptance.HW_USER_ID)
+}
+
+func testAccDataSourceApiAssociatedThrottlingPolicies_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_api_associated_throttling_policies" "test" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+}
+
+# Filter by ID
+locals {
+  policy_id = data.huaweicloud_apig_api_associated_throttling_policies.test.policies[0].id
+}
+
+data "huaweicloud_apig_api_associated_throttling_policies" "filter_by_id" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  policy_id = local.policy_id
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_throttling_policies.filter_by_id.policies[*].id : v == local.policy_id
+  ]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+}
+
+# Filter by name
+locals {
+  policy_name = data.huaweicloud_apig_api_associated_throttling_policies.test.policies[0].name
+}
+
+data "huaweicloud_apig_api_associated_throttling_policies" "filter_by_name" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  name = local.policy_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_throttling_policies.filter_by_name.policies[*].name : v == local.policy_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by name (not found)
+locals {
+  not_found_name = "not_found"
+}
+
+data "huaweicloud_apig_api_associated_throttling_policies" "filter_by_not_found_name" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  name = local.not_found_name
+}
+
+locals {
+  not_found_name_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_throttling_policies.filter_by_not_found_name.policies[*].name : strcontains(v, local.not_found_name)
+  ]
+}
+
+output "is_name_not_found_filter_useful" {
+  value = length(local.not_found_name_filter_result) == 0
+}
+
+# Filter by type
+locals {
+  policy_type = data.huaweicloud_apig_api_associated_throttling_policies.test.policies[0].type
+}
+
+data "huaweicloud_apig_api_associated_throttling_policies" "filter_by_type" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  type = local.policy_type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_throttling_policies.filter_by_type.policies[*].type : v == local.policy_type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+# Filter by env name
+locals {
+  env_name = data.huaweicloud_apig_api_associated_throttling_policies.test.policies[0].env_name
+}
+
+data "huaweicloud_apig_api_associated_throttling_policies" "filter_by_env_name" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  env_name = local.env_name
+}
+
+locals {
+  env_name_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_throttling_policies.filter_by_env_name.policies[*].env_name : v == local.env_name
+  ]
+}
+
+output "is_env_name_filter_useful" {
+  value = length(local.env_name_filter_result) > 0 && alltrue(local.env_name_filter_result)
+}
+
+# Filter by period unit
+locals {
+  period_unit = data.huaweicloud_apig_api_associated_throttling_policies.test.policies[0].period_unit
+}
+
+data "huaweicloud_apig_api_associated_throttling_policies" "filter_by_period_unit" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  period_unit = local.period_unit
+}
+
+locals {
+  period_unit_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_throttling_policies.filter_by_period_unit.policies[*].period_unit : v == local.period_unit
+  ]
+}
+
+output "is_period_unit_filter_useful" {
+  value = length(local.period_unit_filter_result) > 0 && alltrue(local.period_unit_filter_result)
+}
+`, testAccDataSourceApiAssociatedThrottlingPolicies_base())
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_api_associated_throttling_policies.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_api_associated_throttling_policies.go
@@ -1,0 +1,392 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/throttle-bindings/binded-throttles
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/throttles/{throttle_id}/throttle-specials
+func DataSourceApiAssociatedThrottlingPolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApiAssociatedThrottlingPoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the throttling policies belong.`,
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the API bound to the throttling policy.`,
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the throttling policy.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the throttling policy.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the throttling policy.`,
+			},
+			"env_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the environment where the API is published.`,
+			},
+			"period_unit": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The time unit for limiting the number of API calls.`,
+			},
+			"policies": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `All throttling policies that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the throttling policy.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the throttling policy.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the throttling policy.`,
+						},
+						"period_unit": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time unit for limiting the number of API calls.`,
+						},
+						"period": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The period of time for limiting the number of API calls.`,
+						},
+						"max_api_requests": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum number of times an API can be accessed within a specified period.`,
+						},
+						"max_app_requests": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum number of times the API can be accessed by an app within the same period.`,
+						},
+						"max_ip_requests": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum number of times the API can be accessed by an IP address within the same period.`,
+						},
+						"max_user_requests": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum number of times the API can be accessed by a user within the same period.`,
+						},
+						"env_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the environment where the API is published.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the throttling policy.`,
+						},
+						"user_throttles": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataSpecialThrottleSchemaResource(),
+							Description: "The array of one or more special throttling policies for IAM user limit.",
+						},
+						"app_throttles": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataSpecialThrottleSchemaResource(),
+							Description: "The array of one or more special throttling policies for APP limit.",
+						},
+						"bind_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The bind ID.`,
+						},
+						"bind_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time that the throttling policy is bound to the API, in RFC3339 format.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the throttling policy, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSpecialThrottleSchemaResource() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"max_api_requests": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The maximum number of times an API can be accessed within a specified period.`,
+			},
+			"throttling_object_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The object ID which the special user/application throttling policy belongs.`,
+			},
+			"throttling_object_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The object name which the special user/application throttling policy belongs.`,
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the special user/application throttling policy.`,
+			},
+		},
+	}
+}
+
+func buildListApiAssociatedThrottlingPoliciesParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("policy_id"); ok {
+		res = fmt.Sprintf("%s&throttle_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&throttle_name=%v", res, v)
+	}
+	return res
+}
+
+func queryApiAssociatedThrottlingPolicies(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/throttle-bindings/binded-throttles?api_id={api_id}"
+		instanceId = d.Get("instance_id").(string)
+		apiId      = d.Get("api_id").(string)
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{api_id}", apiId)
+
+	queryParams := buildListApiAssociatedThrottlingPoliciesParams(d)
+	listPath += queryParams
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&limit=100&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving associated throttling policies (bound to the API: %s) under "+
+				"specified dedicated instance (%s): %s", apiId, instanceId, err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		policies := utils.PathSearch("throttles", respBody, make([]interface{}, 0)).([]interface{})
+		if len(policies) < 1 {
+			break
+		}
+		result = append(result, policies...)
+		offset += len(policies)
+	}
+	return result, nil
+}
+
+func dataSourceApiAssociatedThrottlingPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+	policies, err := queryApiAssociatedThrottlingPolicies(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("policies", filterAssociatedThrottlingPolicies(flattenAssociatedThrottlingPolicies(client, instanceId, policies), d)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterAssociatedThrottlingPolicies(all []interface{}, d *schema.ResourceData) []interface{} {
+	result := make([]interface{}, 0, len(all))
+
+	for _, v := range all {
+		if param, ok := d.GetOk("type"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("type", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("env_name"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("env_name", v, nil)) {
+			continue
+		}
+		if param, ok := d.GetOk("period_unit"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("period_unit", v, nil)) {
+			continue
+		}
+
+		result = append(result, v)
+	}
+	return result
+}
+
+func querySpecialThrottlingPolicies(client *golangsdk.ServiceClient, instanceId, policyId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/throttles/{throttle_id}/throttle-specials"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{throttle_id}", policyId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s?limit=100&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving special throttling policies: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		policies := utils.PathSearch("throttle_specials", respBody, make([]interface{}, 0)).([]interface{})
+		if len(policies) < 1 {
+			break
+		}
+		result = append(result, policies...)
+		offset += len(policies)
+	}
+	return result, nil
+}
+
+func flattenSpecialThrottlingPolicies(specPolicies []interface{}) (userThrottles, appThrottles []interface{}) {
+	// The special throttling policies contain IAM user throttles and app throttles.
+	// According to the rules of append method, the maximum memory is expanded to 32,
+	// and the average waste of memory is less than the waste caused by directly setting it to 30.
+	for _, specPolicy := range specPolicies {
+		objectType := utils.PathSearch("object_type", specPolicy, "").(string)
+		throttle := map[string]interface{}{
+			"max_api_requests":       utils.PathSearch("call_limits", specPolicy, ""),
+			"throttling_object_id":   utils.PathSearch("object_id", specPolicy, ""),
+			"throttling_object_name": utils.PathSearch("object_name", specPolicy, ""),
+			"id":                     utils.PathSearch("id", specPolicy, ""),
+		}
+		switch objectType {
+		case string(PolicyTypeApplication):
+			appThrottles = append(appThrottles, throttle)
+		case string(PolicyTypeUser):
+			userThrottles = append(userThrottles, throttle)
+		default:
+			log.Printf("invalid object type, want 'APP' or 'USER', but got '%v'", objectType)
+		}
+	}
+	return
+}
+
+func flattenAssociatedThrottlingPolicies(client *golangsdk.ServiceClient, instanceId string, policies []interface{}) []interface{} {
+	if len(policies) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(policies))
+	for _, policy := range policies {
+		policyId := utils.PathSearch("id", policy, "").(string)
+		policyDetail := map[string]interface{}{
+			"id":                policyId,
+			"name":              utils.PathSearch("name", policy, nil),
+			"type":              *analyseThrottlingPolicyType(int(utils.PathSearch("type", policy, 0).(float64))),
+			"period_unit":       utils.PathSearch("time_unit", policy, nil),
+			"period":            utils.PathSearch("time_interval", policy, nil),
+			"max_api_requests":  utils.PathSearch("api_call_limits", policy, nil),
+			"max_app_requests":  utils.PathSearch("app_call_limits", policy, nil),
+			"max_ip_requests":   utils.PathSearch("ip_call_limits", policy, nil),
+			"max_user_requests": utils.PathSearch("user_call_limits", policy, nil),
+			"env_name":          utils.PathSearch("env_name", policy, nil),
+			"description":       utils.PathSearch("remark", policy, nil),
+			"bind_id":           utils.PathSearch("bind_id", policy, nil),
+			"bind_time":         utils.PathSearch("bind_time", policy, nil),   // Already in RFC3339 format.
+			"created_at":        utils.PathSearch("create_time", policy, nil), // Already in RFC3339 format.
+		}
+
+		if int(utils.PathSearch("is_inclu_special_throttle", policy, 0).(float64)) == includeSpecialThrottle {
+			// Get related special throttling policies.
+			specResp, err := querySpecialThrottlingPolicies(client, instanceId, policyId)
+			if err != nil {
+				log.Printf("[ERROR] unable to find the special throttles from policy: %s", err)
+			} else {
+				userThrottles, appThrottles := flattenSpecialThrottlingPolicies(specResp)
+				policyDetail["user_throttles"] = userThrottles
+				policyDetail["app_throttles"] = appThrottles
+			}
+		}
+		result = append(result, policyDetail)
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new data source that used to query throttling policies associated with the API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new data source supported for associated resources query.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccDataSourceApiAssociatedThrottlingPolicies_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccDataSourceApiAssociatedThrottlingPolicies_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceApiAssociatedThrottlingPolicies_basic
=== PAUSE TestAccDataSourceApiAssociatedThrottlingPolicies_basic
=== CONT  TestAccDataSourceApiAssociatedThrottlingPolicies_basic
--- PASS: TestAccDataSourceApiAssociatedThrottlingPolicies_basic (620.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      620.340s
```
