### PR TITLE
feat(GaussDB): gaussdb redis instance support mode

### DIFF
--- a/docs/resources/gaussdb_redis_instance.md
+++ b/docs/resources/gaussdb_redis_instance.md
@@ -86,6 +86,9 @@ The following arguments are supported:
 * `subnet_id` - (Required, String, ForceNew) Specifies the network ID of a subnet. Changing this parameter will create a
   new resource.
 
+* `mode` - (Optional, String, ForceNew) Specifies the instance type. Value options: **Cluster**, **Replication**.
+  Defaults to **Cluster**.
+
 * `security_group_id` - (Optional, String) Specifies the security group ID. Required if the selected subnet doesn't
   enable network ACL.
 
@@ -154,7 +157,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Indicates the DB instance ID.
 * `status` - Indicates the DB instance status.
-* `mode` - Indicates the instance type.
 * `db_user_name` - Indicates the default username.
 * `nodes` - Indicates the instance nodes information. Structure is documented below.
 * `private_ips` - Indicates the IP address list of the db.

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_redis_instance.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_redis_instance.go
@@ -104,6 +104,12 @@ func ResourceGaussRedisInstanceV3() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Cluster",
+				ForceNew: true,
+			},
 			"security_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -182,10 +188,6 @@ func ResourceGaussRedisInstanceV3() *schema.Resource {
 			},
 
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"mode": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -375,7 +377,7 @@ func resourceGaussRedisInstanceV3Create(ctx context.Context, d *schema.ResourceD
 		SubnetId:            d.Get("subnet_id").(string),
 		SecurityGroupId:     d.Get("security_group_id").(string),
 		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
-		Mode:                "Cluster",
+		Mode:                d.Get("mode").(string),
 		Flavor:              resourceGaussRedisFlavor(d),
 		DataStore:           resourceGaussRedisDataStore(d),
 		BackupStrategy:      resourceGaussRedisBackupStrategy(d),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  gaussdb redis instance support mode
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb redis instance support mode
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussRedisInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussRedisInstance_ -timeout 360m -parallel 4
=== RUN   TestAccGaussRedisInstance_basic
=== PAUSE TestAccGaussRedisInstance_basic
=== RUN   TestAccGaussRedisInstance_withReplication
=== PAUSE TestAccGaussRedisInstance_withReplication
=== RUN   TestAccGaussRedisInstance_updateWithEpsId
=== PAUSE TestAccGaussRedisInstance_updateWithEpsId
=== CONT  TestAccGaussRedisInstance_basic
=== CONT  TestAccGaussRedisInstance_updateWithEpsId
=== CONT  TestAccGaussRedisInstance_withReplication
=== CONT  TestAccGaussRedisInstance_updateWithEpsId
    acceptance.go:531: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccGaussRedisInstance_updateWithEpsId (0.00s)
--- PASS: TestAccGaussRedisInstance_withReplication (1269.40s)
--- PASS: TestAccGaussRedisInstance_basic (3449.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   3449.722s
```
