### PR TITLE
fix(ddm/instance): update the param behavior for az list

### DIFF
--- a/huaweicloud/services/ddm/resource_huaweicloud_ddm_instance.go
+++ b/huaweicloud/services/ddm/resource_huaweicloud_ddm_instance.go
@@ -94,7 +94,7 @@ func ResourceDdmInstance() *schema.Resource {
 				Description: `Specifies the ID of an Engine.`,
 			},
 			"availability_zones": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Required:    true,
 				ForceNew:    true,
@@ -323,7 +323,7 @@ func buildCreateInstanceInstanceChildBody(d *schema.ResourceData, cfg *config.Co
 		"node_num":              utils.ValueIngoreEmpty(d.Get("node_num")),
 		"engine_id":             utils.ValueIngoreEmpty(d.Get("engine_id")),
 		"enterprise_project_id": utils.ValueIngoreEmpty(common.GetEnterpriseProjectID(d, cfg)),
-		"available_zones":       utils.ValueIngoreEmpty(d.Get("availability_zones")),
+		"available_zones":       d.Get("availability_zones").(*schema.Set).List(), // The ordering of the AZ list returned by the API is unknown.
 		"vpc_id":                utils.ValueIngoreEmpty(d.Get("vpc_id")),
 		"security_group_id":     utils.ValueIngoreEmpty(d.Get("security_group_id")),
 		"subnet_id":             utils.ValueIngoreEmpty(d.Get("subnet_id")),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The ordering of the AZ list returned by the API is unknown.
```
-/+ resource "huaweicloud_ddm_instance" "test" {
  ~ availability_zones = [ # forces replacement
    - "cn-north-9b",
      "cn-north-9a"
    + "cn-north-9b",
  ]
}
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ddm' TESTARGS='-run=TestAccDdmInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ddm -v -run=TestAccDdmInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccDdmInstance_basic
=== PAUSE TestAccDdmInstance_basic
=== CONT  TestAccDdmInstance_basic
--- PASS: TestAccDdmInstance_basic (1745.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ddm       1745.043s
```
