### PR TITLE
feat(dds): support to add nodes for replica set instance

### DIFF
--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -75,7 +75,7 @@ resource "huaweicloud_dds_instance" "instance" {
   mode              = "ReplicaSet"
   flavor {
     type      = "replica"
-    num       = 1
+    num       = 3
     storage   = "ULTRAHIGH"
     size      = 30
     spec_code = "dds.mongodb.c3.medium.4.repset"
@@ -199,7 +199,7 @@ The `flavor` block supports:
   + If the value of type is **replica**, num indicates the number of replica nodes in the replica set instance. Value
     can be **3**, **5**, or **7**.
 
-  This parameter can be updated when the value of `type` is mongos or shard.
+  This parameter can be updated when the value of `type` is **mongos**, **shard** or **replica**.
 
 * `storage` - (Optional, String, ForceNew) Specifies the disk type. Valid value:
   + **ULTRAHIGH**: SSD storage.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240508070804-0122098edca9
+	github.com/chnsz/golangsdk v0.0.0-20240509073804-d248417507cd
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240508070804-0122098edca9 h1:Gzr8TSkYOfthiUdU82Ei2mM+DNXpUZAro+jvjm+iazI=
-github.com/chnsz/golangsdk v0.0.0-20240508070804-0122098edca9/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240509073804-d248417507cd h1:gqnIPcOKmT4/RLlSiaJr4Ty7iZPJ5OfX/eX2R7SJi3E=
+github.com/chnsz/golangsdk v0.0.0-20240509073804-d248417507cd/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -237,6 +237,7 @@ func TestAccDDSV3Instance_withConfigurationSharding(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.1.id", "huaweicloud_dds_parameter_template.shard1", "id"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.2.type", "config"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.2.id", "huaweicloud_dds_parameter_template.config1", "id"),
+					testAccCheckDDSV3InstanceFlavor(&instance, "replica", "num", 3),
 				),
 			},
 			{
@@ -250,6 +251,7 @@ func TestAccDDSV3Instance_withConfigurationSharding(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.1.id", "huaweicloud_dds_parameter_template.shard2", "id"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.2.type", "config"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.2.id", "huaweicloud_dds_parameter_template.config2", "id"),
+					testAccCheckDDSV3InstanceFlavor(&instance, "replica", "num", 5),
 				),
 			},
 		},
@@ -337,7 +339,7 @@ func TestAccDDSV3Instance_withSecondLevelMonitoring(t *testing.T) {
 func testAccCheckDDSV3InstanceFlavor(instance *instances.InstanceResponse, groupType, key string, v interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if key == "num" {
-			if groupType != "mongos" {
+			if groupType == "shard" {
 				groupIDs := make([]string, 0)
 				for _, group := range instance.Groups {
 					if group.Type == "shard" {
@@ -353,11 +355,10 @@ func testAccCheckDDSV3InstanceFlavor(instance *instances.InstanceResponse, group
 			}
 
 			for _, group := range instance.Groups {
-				if group.Type == "mongos" {
+				if group.Type == groupType {
 					if len(group.Nodes) != v.(int) {
 						return fmt.Errorf(
-							"Error updating DDS instance: num of mongos nodes expect %d, but got %d",
-							v.(int), len(group.Nodes))
+							"Error updating DDS instance: num of %s nodes expect %d, but got %d", groupType, v.(int), len(group.Nodes))
 					}
 					return nil
 				}
@@ -1070,7 +1071,7 @@ resource "huaweicloud_dds_instance" "instance" {
   flavor {
     type      = "replica"
     storage   = "ULTRAHIGH"
-    num       = 1
+    num       = 3
     size      = 20
     spec_code = "dds.mongodb.s6.large.2.repset"
   }
@@ -1108,7 +1109,7 @@ resource "huaweicloud_dds_instance" "instance" {
   flavor {
     type      = "replica"
     storage   = "ULTRAHIGH"
-    num       = 1
+    num       = 5
     size      = 20
     spec_code = "dds.mongodb.s6.large.2.repset"
   }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
@@ -183,6 +183,11 @@ type UpdateNodeNumOpts struct {
 	IsAutoPay bool        `json:"is_auto_pay,omitempty"`
 }
 
+type UpdateReplicaSetNodeNumOpts struct {
+	Num       int  `json:"num" required:"true"`
+	IsAutoPay bool `json:"is_auto_pay,omitempty"`
+}
+
 type SpecOpts struct {
 	TargetType     string `json:"target_type,omitempty"`
 	TargetID       string `json:"target_id" required:"true"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240508070804-0122098edca9
+# github.com/chnsz/golangsdk v0.0.0-20240509073804-d248417507cd
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support to add nodes for replica set instance in `huaweicloud_dds_instance`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_withConfigurationSharding"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withConfigurationSharding -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withConfigurationSharding
=== PAUSE TestAccDDSV3Instance_withConfigurationSharding
=== CONT  TestAccDDSV3Instance_withConfigurationSharding
--- PASS: TestAccDDSV3Instance_withConfigurationSharding (1673.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       1673.741s
```
