### PR TITLE
feat(apig): add new datasource to get throttling policies

### DIFF
--- a/docs/data-sources/apig_throttling_policies.md
+++ b/docs/data-sources/apig_throttling_policies.md
@@ -1,0 +1,95 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_api_associated_throttling_policies"
+description: |-
+  Use this data source to get the list of the throttling policies under the APIG instance within HuaweiCloud.
+---
+
+# huaweicloud_apig_throttling_policies
+
+Use this data source to get the list of the throttling policies under the APIG instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_apig_throttling_policies" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the throttling policies belong.
+
+* `name` - (Optional, String) Specifies the name of the throttling policy. Fuzzy search is supported.
+
+* `policy_id` - (Optional, String) Specifies the ID of the throttling policy.
+
+* `type` - (Optional, String) The type of the throttling policy.
+  The valid values are as follows:
+  + **API-based**: Limiting the maximum number of times a single API bound to the policy can be called within the
+    specified period.
+  + **API-shared**: Limiting the maximum number of times all APIs bound to the policy can be called within the specified
+    period.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `policies` - All throttling policies that match the filter parameters.
+  The [policies](#throttling_policies) structure is documented below.
+
+<a name="throttling_policies"></a>
+The `policies` block supports:
+
+* `id` - The ID of the throttling policy.
+
+* `name` - The name of the throttling policy.
+
+* `period` - The period of time for limiting the number of API calls.
+
+* `period_unit` - The time unit for limiting the number of API calls.
+  The valid values are **SECOND**, **MINUTE**, **HOUR** and **DAY**.
+
+* `max_api_requests` - The maximum number of times an API can be accessed within a specified period.
+
+* `max_app_requests` - The maximum number of times the API can be accessed by an app within the same period.
+
+* `max_ip_requests` - The maximum number of times the API can be accessed by an IP address within the same period.
+
+* `max_user_requests` - The maximum number of times the API can be accessed by a user within the same period.
+
+* `type` - The type of the throttling policy.
+
+* `user_throttles` - The array of one or more special throttling policies for IAM user limit.
+  The [user_throttles](#special_throttling_policies) structure is documented below.
+
+* `app_throttles` - The array of one or more special throttling policies for APP limit.
+  The [app_throttles](#special_throttling_policies) structure is documented below.
+
+* `bind_num` - The number of APIs bound to the throttling policy.
+
+* `description` - The description of throttling policy.
+
+* `created_at` - The creation time of the throttling policy, in RFC3339 format.
+
+<a name="special_throttling_policies"></a>
+The `user_throttles` and `app_throttles` blocks support:
+
+* `id` - The ID of the special user/application throttling policy.
+
+* `max_api_requests` - The maximum number of times an API can be accessed within a specified period.
+
+* `throttling_object_id` - The object ID which the special user/application throttling policy belongs.
+
+* `throttling_object_name` - The object name which the special user/application throttling policy belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -405,6 +405,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_api_associated_throttling_policies": apig.DataSourceApiAssociatedThrottlingPolicies(),
 			"huaweicloud_apig_environments":                       apig.DataSourceEnvironments(),
 			"huaweicloud_apig_groups":                             apig.DataSourceGroups(),
+			"huaweicloud_apig_throttling_policies":                apig.DataSourceThrottlingPolicies(),
 
 			"huaweicloud_as_configurations":      as.DataSourceASConfigurations(),
 			"huaweicloud_as_groups":              as.DataSourceASGroups(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_throttling_policies_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_throttling_policies_test.go
@@ -1,0 +1,178 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceThrottlingPolicies_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_apig_throttling_policies.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+
+		byId   = "data.huaweicloud_apig_throttling_policies.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byName   = "data.huaweicloud_apig_throttling_policies.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNotFoundName   = "data.huaweicloud_apig_throttling_policies.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+
+		byType   = "data.huaweicloud_apig_throttling_policies.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceThrottlingPolicies_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "policies.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byId, "policies.0.type", "API-based"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.name"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.period"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.period_unit"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.max_api_requests"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.created_at"),
+					resource.TestCheckResourceAttr(byId, "policies.0.app_throttles.#", "1"),
+					resource.TestCheckResourceAttr(byId, "policies.0.app_throttles.0.%", "4"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.app_throttles.0.id"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.app_throttles.0.max_api_requests"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.app_throttles.0.throttling_object_id"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.app_throttles.0.throttling_object_name"),
+					resource.TestCheckResourceAttr(byId, "policies.0.user_throttles.#", "1"),
+					resource.TestCheckResourceAttr(byId, "policies.0.user_throttles.0.%", "4"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.user_throttles.0.id"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.user_throttles.0.max_api_requests"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.user_throttles.0.throttling_object_id"),
+					resource.TestCheckResourceAttrSet(byId, "policies.0.user_throttles.0.throttling_object_name"),
+					resource.TestCheckResourceAttr(byId, "policies.0.bind_num", "1"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_not_found_filter_useful", "true"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceThrottlingPolicies_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_throttling_policies" "test" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+# Filter by ID
+locals {
+  policy_id = data.huaweicloud_apig_throttling_policies.test.policies[0].id
+}
+
+data "huaweicloud_apig_throttling_policies" "filter_by_id" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+  instance_id = huaweicloud_apig_instance.test.id
+  policy_id   = local.policy_id
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_apig_throttling_policies.filter_by_id.policies[*].id : v == local.policy_id
+  ]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+}
+
+# Filter by name
+locals {
+  policy_name = data.huaweicloud_apig_throttling_policies.test.policies[0].name
+}
+
+data "huaweicloud_apig_throttling_policies" "filter_by_name" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = local.policy_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_apig_throttling_policies.filter_by_name.policies[*].name : v == local.policy_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by name (not found)
+locals {
+  not_found_name = "not_found"
+}
+
+data "huaweicloud_apig_throttling_policies" "filter_by_not_found_name" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = local.not_found_name
+}
+
+locals {
+  not_found_name_filter_result = [
+    for v in data.huaweicloud_apig_throttling_policies.filter_by_not_found_name.policies[*].name : strcontains(v, local.not_found_name)
+  ]
+}
+
+output "is_name_not_found_filter_useful" {
+  value = length(local.not_found_name_filter_result) == 0
+}
+
+# Filter by type
+locals {
+  policy_type = data.huaweicloud_apig_throttling_policies.test.policies[0].type
+}
+
+data "huaweicloud_apig_throttling_policies" "filter_by_type" {
+  depends_on = [
+    huaweicloud_apig_throttling_policy_associate.test,
+  ]
+  instance_id = huaweicloud_apig_instance.test.id
+  type        = local.policy_type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_apig_throttling_policies.filter_by_type.policies[*].type : v == local.policy_type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+`, testAccDataSourceApiAssociatedThrottlingPolicies_base())
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_throttling_policies.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_throttling_policies.go
@@ -1,0 +1,266 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/throttles
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/throttles/{throttle_id}/throttle-specials
+func DataSourceThrottlingPolicies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceThrottlingPoliciesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the ID of the dedicated instance to which the throttling policies belong.",
+			},
+			"policy_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the ID of the throttling policy.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the name of the throttling policy.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The type of the throttling policy.",
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the throttling policy.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the throttling policy.",
+						},
+						"period": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The period of time for limiting the number of API calls.",
+						},
+						"period_unit": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The time unit for limiting the number of API calls.",
+						},
+						"max_api_requests": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The maximum number of times an API can be accessed within a specified period.",
+						},
+						"max_app_requests": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The maximum number of times the API can be accessed by an app within the same period.",
+						},
+						"max_ip_requests": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The maximum number of times the API can be accessed by an IP address within the same period.",
+						},
+						"max_user_requests": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The maximum number of times the API can be accessed by a user within the same period.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the throttling policy.",
+						},
+						"user_throttles": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataSpecialThrottleSchemaResource(),
+							Description: "The array of one or more special throttling policies for IAM user limit.",
+						},
+						"app_throttles": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataSpecialThrottleSchemaResource(),
+							Description: "The array of one or more special throttling policies for APP limit.",
+						},
+						"bind_num": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The number of APIs bound to the throttling policy.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of throttling policy.",
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The creation time of the throttling policy, in RFC3339 format.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListThrottlingPoliciesParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("policy_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+
+	return res
+}
+
+func getThrottlingPolicies(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/throttles?limit=500"
+		instanceId = d.Get("instance_id").(string)
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+
+	queryParams := buildListThrottlingPoliciesParams(d)
+	listPath += queryParams
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving throttling policies under specified dedicated instance (%s): %s", instanceId, err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		policies := utils.PathSearch("throttles", respBody, make([]interface{}, 0)).([]interface{})
+		if len(policies) < 1 {
+			break
+		}
+		result = append(result, policies...)
+		offset += len(policies)
+	}
+	return result, nil
+}
+
+func dataSourceThrottlingPoliciesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+	policies, err := getThrottlingPolicies(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("policies", filterThrottlingPolicies(flattenThrottlingPolicies(client, instanceId, policies), d)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterThrottlingPolicies(all []interface{}, d *schema.ResourceData) []interface{} {
+	result := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("type"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("type", v, nil)) {
+			continue
+		}
+
+		result = append(result, v)
+	}
+	return result
+}
+
+func flattenThrottlingPolicies(client *golangsdk.ServiceClient, instanceId string, policies []interface{}) []interface{} {
+	if len(policies) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(policies))
+	for _, policy := range policies {
+		policyId := utils.PathSearch("id", policy, "").(string)
+		policyDetail := map[string]interface{}{
+			"id":                policyId,
+			"name":              utils.PathSearch("name", policy, nil),
+			"period":            utils.PathSearch("time_interval", policy, nil),
+			"period_unit":       utils.PathSearch("time_unit", policy, nil),
+			"max_api_requests":  utils.PathSearch("api_call_limits", policy, nil),
+			"max_app_requests":  utils.PathSearch("app_call_limits", policy, nil),
+			"max_ip_requests":   utils.PathSearch("ip_call_limits", policy, 0),
+			"max_user_requests": utils.PathSearch("user_call_limits", policy, 0),
+			"type":              *analyseThrottlingPolicyType(int(utils.PathSearch("type", policy, 0).(float64))),
+			"description":       utils.PathSearch("remark", policy, nil),
+			"bind_num":          utils.PathSearch("bind_num", policy, nil),
+			"created_at":        utils.PathSearch("create_time", policy, nil), // Already in RFC3339 format.
+		}
+
+		if int(utils.PathSearch("is_inclu_special_throttle", policy, 0).(float64)) == includeSpecialThrottle {
+			// Get related special throttling policies.
+			specResp, err := querySpecialThrottlingPolicies(client, instanceId, policyId)
+			if err != nil {
+				log.Printf("[ERROR] unable to find the special throttles from policy: %s", err)
+			} else {
+				userThrottles, appThrottles := flattenSpecialThrottlingPolicies(specResp)
+				policyDetail["user_throttles"] = userThrottles
+				policyDetail["app_throttles"] = appThrottles
+			}
+		}
+		result = append(result, policyDetail)
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add a new datasource to get the list of the throttling policies under the specified Dedicated APIG instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

1. add a new datasource.
2. add corresponding to documat and acceptance test.

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccDataSourceThrottlingPolicies_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccDataSourceThrottlingPolicies_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceThrottlingPolicies_basic
=== PAUSE TestAccDataSourceThrottlingPolicies_basic
=== CONT  TestAccDataSourceThrottlingPolicies_basic
--- PASS: TestAccDataSourceThrottlingPolicies_basic (646.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      646.762s
```
