### PR TITLE
refactor: chore(apig/throttle): Support the refresh functions

### DIFF
--- a/docs/resources/apig_throttling_policy_associate.md
+++ b/docs/resources/apig_throttling_policy_associate.md
@@ -48,6 +48,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Resource ID. The format is `<instance_id>/<policy_id>`.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 3 minutes.
+* `update` - Default is 3 minutes.
+* `delete` - Default is 3 minutes.
+
 ## Import
 
 Associate resources can be imported using their `policy_id` and the APIG dedicated instance ID to which the policy

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_associate_test.go
@@ -44,7 +44,6 @@ func TestAccThrottlingPolicyAssociate_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t) // The creation of APIG instance needs the enterprise project ID.
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -212,6 +212,21 @@ func IsStrContainsSliceElement(str string, sl []string, ignoreCase, isExcat bool
 	return false
 }
 
+// IsSliceContainsAnyAnotherSliceElement is a method that used to determine whether a list contains any element of
+// another list (including its fragments belonging to the current string), returns true if it contains.
+// sl: The slice body used to determine the inclusion relationship.
+// another: The included slice object used to determine the inclusion relationship.
+// ignoreCase: Whether to ignore case.
+// isExcat: Whether the inclusion relationship of string objects applies exact matching rules.
+func IsSliceContainsAnyAnotherSliceElement(sl, another []string, ignoreCase, isExcat bool) bool {
+	for _, elem := range sl {
+		if IsStrContainsSliceElement(elem, another, ignoreCase, isExcat) {
+			return true
+		}
+	}
+	return false
+}
+
 func JsonMarshal(t interface{}) ([]byte, error) {
 	buffer := &bytes.Buffer{}
 	enc := json.NewEncoder(buffer)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support the refresh functions for the throttling policy associate resource.
And support a new public function to determine inclusion relationship for slice.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support the refresh functions for the throttling policy associate resource.
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccThrottlingPolicyAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccThrottlingPolicyAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccThrottlingPolicyAssociate_basic
=== PAUSE TestAccThrottlingPolicyAssociate_basic
=== CONT  TestAccThrottlingPolicyAssociate_basic
--- PASS: TestAccThrottlingPolicyAssociate_basic (668.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      668.745s
```
