### PR TITLE
feat(RDS): rds instance support slow log show original staus

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -278,31 +278,6 @@ The following arguments are supported:
 
   -> **NOTE:** Only adding MSDTC hosts is supported, deletion is not allowed.
 
-* `private_dns_name_prefix` - (Optional, String) Specifies the prefix of the private domain name. The value contains
-  **8** to **64** characters. Only uppercase letters, lowercase letters, and digits are allowed.
-
-The `db` block supports:
-
-* `type` - (Required, String, ForceNew) Specifies the DB engine. Available value are **MySQL**, **PostgreSQL**,
-  **SQLServer** and **MariaDB**. Changing this parameter will create a new resource.
-
-* `version` - (Required, String, ForceNew) Specifies the database version. Changing this parameter will create a new
-  resource. Available values detailed in
-  [DB Engines and Versions](https://support.huaweicloud.com/intl/en-us/productdesc-rds/en-us_topic_0043898356.html).
-
-* `password` - (Optional, String) Specifies the database password. The value should contain 8 to 32 characters,
-  including uppercase and lowercase letters, digits, and the following special characters: ~!@#%^*-_=+? You are advised
-  to enter a strong password to improve security, preventing security risks such as brute force cracking.
-
-* `port` - (Optional, Int) Specifies the database port.
-  + The MySQL database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are occupied by the RDS system
-      and cannot be used). The default value is 3306.
-  + The PostgreSQL database port ranges from 2100 to 9500. The default value is 5432.
-  + The Microsoft SQL Server database port can be 1433 or ranges from 2100 to 9500, excluding 5355 and 5985. The
-      default value is 1433.
-  + The MariaDB database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are occupied by the RDS system
-      and cannot be used). The default value is 3306.
-
 * `power_action` - (Optional, String) Specifies the power action to be done for the instance.
   Value options: **ON**, **OFF** and **REBOOT**.
 
@@ -331,6 +306,34 @@ The `db` block supports:
 
 * `seconds_level_monitoring_interval` - (Optional, Int) Specifies the seconds level monitoring interval. Valid values:
   **1**, **5**. It is mandatory when `seconds_level_monitoring_enabled` is **true**.
+
+* `private_dns_name_prefix` - (Optional, String) Specifies the prefix of the private domain name. The value contains
+  **8** to **64** characters. Only uppercase letters, lowercase letters, and digits are allowed.
+
+* `slow_log_show_original_status` - (Optional, String) Specifies the slow log show original status of the instance.
+  Only **MySQL** and **PostgreSQL** are supported. Value options: **on**, **off**.
+
+The `db` block supports:
+
+* `type` - (Required, String, ForceNew) Specifies the DB engine. Available value are **MySQL**, **PostgreSQL**,
+  **SQLServer** and **MariaDB**. Changing this parameter will create a new resource.
+
+* `version` - (Required, String, ForceNew) Specifies the database version. Changing this parameter will create a new
+  resource. Available values detailed in
+  [DB Engines and Versions](https://support.huaweicloud.com/intl/en-us/productdesc-rds/en-us_topic_0043898356.html).
+
+* `password` - (Optional, String) Specifies the database password. The value should contain 8 to 32 characters,
+  including uppercase and lowercase letters, digits, and the following special characters: ~!@#%^*-_=+? You are advised
+  to enter a strong password to improve security, preventing security risks such as brute force cracking.
+
+* `port` - (Optional, Int) Specifies the database port.
+  + The MySQL database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are occupied by the RDS system
+      and cannot be used). The default value is 3306.
+  + The PostgreSQL database port ranges from 2100 to 9500. The default value is 5432.
+  + The Microsoft SQL Server database port can be 1433 or ranges from 2100 to 9500, excluding 5355 and 5985. The
+      default value is 1433.
+  + The MariaDB database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are occupied by the RDS system
+      and cannot be used). The default value is 3306.
 
 The `volume` block supports:
 
@@ -461,10 +464,10 @@ $ terraform import huaweicloud_rds_instance.instance_1 52e4b497d2c94df88a2eb4c66
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `db`, `collation`, `availability_zone`,`lower_case_table_names`.
-It is generally recommended running `terraform plan` after importing a RDS instance. You can then decide if changes
-should be applied to the instance, or the resource definition should be updated to align with the instance.
-Also, you can ignore changes as below.
+API response, security or some other reason. The missing attributes include: `db`, `collation`, `availability_zone`,
+`lower_case_table_names`,`slow_log_show_original_status`. It is generally recommended running `terraform plan` after
+importing a RDS instance. You can then decide if changes should be applied to the instance, or the resource definition
+should be updated to align with the instance. Also, you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_rds_instance" "instance_1" {
@@ -472,7 +475,7 @@ resource "huaweicloud_rds_instance" "instance_1" {
 
   lifecycle {
     ignore_changes = [
-      "db", "collation", "availability_zone", "lower_case_table_names"
+      "db", "collation", "availability_zone", "lower_case_table_names", "slow_log_show_original_status"
     ]
   }
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_instance_test.go
@@ -78,6 +78,7 @@ func TestAccRdsInstance_basic(t *testing.T) {
 					"db",
 					"status",
 					"availability_zone",
+					"slow_log_show_original_status",
 				},
 			},
 		},
@@ -543,18 +544,19 @@ func testAccRdsInstance_basic(name string) string {
 %[1]s
 
 resource "huaweicloud_rds_instance" "test" {
-  name                    = "%[2]s"
-  description             = "test_description"
-  flavor                  = "rds.pg.n1.large.2"
-  availability_zone       = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id       = huaweicloud_networking_secgroup.test.id
-  subnet_id               = data.huaweicloud_vpc_subnet.test.id
-  vpc_id                  = data.huaweicloud_vpc.test.id
-  time_zone               = "UTC+08:00"
-  fixed_ip                = "192.168.0.210"
-  maintain_begin          = "06:00"
-  maintain_end            = "09:00"
-  private_dns_name_prefix = "terraformTest"
+  name                          = "%[2]s"
+  description                   = "test_description"
+  flavor                        = "rds.pg.n1.large.2"
+  availability_zone             = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id             = huaweicloud_networking_secgroup.test.id
+  subnet_id                     = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                        = data.huaweicloud_vpc.test.id
+  time_zone                     = "UTC+08:00"
+  fixed_ip                      = "192.168.0.210"
+  maintain_begin                = "06:00"
+  maintain_end                  = "09:00"
+  private_dns_name_prefix       = "terraformTest"
+  slow_log_show_original_status = "on"
 
   db {
     type     = "PostgreSQL"
@@ -584,18 +586,19 @@ func testAccRdsInstance_update(name string) string {
 %[1]s
 
 resource "huaweicloud_rds_instance" "test" {
-  name                    = "%[2]s-update"
-  flavor                  = "rds.pg.n1.large.2"
-  availability_zone       = [data.huaweicloud_availability_zones.test.names[0]]
-  security_group_id       = huaweicloud_networking_secgroup.test.id
-  subnet_id               = data.huaweicloud_vpc_subnet.test.id
-  vpc_id                  = data.huaweicloud_vpc.test.id
-  enterprise_project_id   = "%[3]s"
-  time_zone               = "UTC+08:00"
-  fixed_ip                = "192.168.0.230"
-  maintain_begin          = "15:00"
-  maintain_end            = "17:00"
-  private_dns_name_prefix = "terraformTestUpdate"
+  name                          = "%[2]s-update"
+  flavor                        = "rds.pg.n1.large.2"
+  availability_zone             = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id             = huaweicloud_networking_secgroup.test.id
+  subnet_id                     = data.huaweicloud_vpc_subnet.test.id
+  vpc_id                        = data.huaweicloud_vpc.test.id
+  enterprise_project_id         = "%[3]s"
+  time_zone                     = "UTC+08:00"
+  fixed_ip                      = "192.168.0.230"
+  maintain_begin                = "15:00"
+  maintain_end                  = "17:00"
+  private_dns_name_prefix       = "terraformTestUpdate"
+  slow_log_show_original_status = "off"
 
   db {
     password = "Huangwei!120521"
@@ -1294,6 +1297,7 @@ resource "huaweicloud_rds_instance" "test_backup" {
   security_group_id = huaweicloud_networking_secgroup.test.id
   subnet_id         = data.huaweicloud_vpc_subnet.test.id
   vpc_id            = data.huaweicloud_vpc.test.id
+  time_zone         = "UTC+08:00"
   availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
 
   restore {

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/authorizers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/authorizers/requests.go
@@ -17,6 +17,12 @@ type CustomAuthOpts struct {
 	AuthorizerType string `json:"authorizer_type" required:"true"`
 	// Function URN.
 	AuthorizerURI string `json:"authorizer_uri" required:"true"`
+	// The framework type of the function.
+	NetworkType string `json:"network_type,omitempty"`
+	// The version of the FGS function.
+	AuthorizerVersion string `json:"authorizer_version,omitempty"`
+	// The version alias URI of the FGS function.
+	AuthorizerAliasUri string `json:"authorizer_alias_uri,omitempty"`
 	// Indicates whether to send the body.
 	IsBodySend *bool `json:"need_body,omitempty"`
 	// Identity source.

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/authorizers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/authorizers/results.go
@@ -35,6 +35,12 @@ type CustomAuthorizer struct {
 	AuthorizerType string `json:"authorizer_type"`
 	// Function URN.
 	AuthorizerURI string `json:"authorizer_uri"`
+	// The framework type of the function.
+	NetworkType string `json:"network_type"`
+	// The version of the FGS function.
+	AuthorizerVersion string `json:"authorizer_version"`
+	// The version alias URI of the FGS function.
+	AuthorizerAliasUri string `json:"authorizer_alias_uri"`
 	// Identity source.
 	Identities []Identity `json:"identities"`
 	// Maximum cache age.

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -1,6 +1,7 @@
 package instances
 
 import (
+	"fmt"
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
 	"github.com/chnsz/golangsdk/pagination"
@@ -885,7 +886,7 @@ func (opts ModifyPrivateDnsNamePrefixOpts) ToActionInstanceMap() (map[string]int
 	return toActionInstanceMap(opts)
 }
 
-// ModifyPrivateDnsNamePrefix is a method used to private dns name prefix of the instance.
+// ModifyPrivateDnsNamePrefix is a method used to modify private dns name prefix of the instance.
 func ModifyPrivateDnsNamePrefix(c *golangsdk.ServiceClient, opts ActionInstanceBuilder, instanceId string) (r JobResult) {
 	b, err := opts.ToActionInstanceMap()
 	if err != nil {
@@ -893,5 +894,12 @@ func ModifyPrivateDnsNamePrefix(c *golangsdk.ServiceClient, opts ActionInstanceB
 		return
 	}
 	_, r.Err = c.Put(updateURL(c, instanceId, "modify-dns"), b, &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+// ModifySlowLogShowOriginalStatus is a method used to modify slow log show original status of the instance.
+func ModifySlowLogShowOriginalStatus(c *golangsdk.ServiceClient, instanceId, status string) (r ModifySlowLogShowOriginalStatusResult) {
+	_, r.Err = c.Put(updateURL(c, instanceId, fmt.Sprintf("slowlog-sensitization/%s", status)), nil,
+		&r.Body, &golangsdk.RequestOpts{})
 	return
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -74,6 +74,10 @@ type GetSecondLevelMonitoringResult struct {
 	commonResult
 }
 
+type ModifySlowLogShowOriginalStatusResult struct {
+	commonResult
+}
+
 type JobResult struct {
 	commonResult
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  rds instance support slow log show original staus
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  rds instance support slow log show original staus
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=11
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 11
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_prePaid
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
--- PASS: TestAccRdsInstance_mariadb (681.43s)
--- PASS: TestAccRdsInstance_ha (729.45s)
--- PASS: TestAccRdsInstance_basic (906.65s)
--- PASS: TestAccRdsInstance_mysql_power_action (1136.66s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1504.01s)
--- PASS: TestAccRdsInstance_restore_pg (1589.45s)
--- PASS: TestAccRdsInstance_prePaid (1599.89s)
--- PASS: TestAccRdsInstance_restore_mysql (1748.67s)
--- PASS: TestAccRdsInstance_mysql (1808.42s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2479.94s)
--- PASS: TestAccRdsInstance_sqlserver (3047.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       3047.649s
```
