### PR TITLE
feat(dds): support to set slow log desensitization

### DIFF
--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -137,6 +137,9 @@ The following arguments are supported:
 
 * `second_level_monitoring_enabled` - (Optional, Bool) Specifies whether to enable second level monitoring.
 
+* `slow_log_desensitization` - (Optional, String) Specifies whether to enable slow original log.
+  The value can be **on** or **off**.
+
 * `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the instance.
   The valid values are as follows:
   + `prePaid`: indicates the yearly/monthly billing mode.

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -93,6 +93,7 @@ func TestAccDDSV3Instance_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccCheckDDSV3InstanceFlavor(&instance, "shard", "num", 3),
+					resource.TestCheckResourceAttr(resourceName, "slow_log_desensitization", "off"),
 				),
 			},
 			{
@@ -512,13 +513,14 @@ func testAccDDSInstanceV3Config_updateFlavorNum(rName string) string {
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_dds_instance" "instance" {
-  name              = "%s"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  vpc_id            = huaweicloud_vpc.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  password          = "Terraform@123"
-  mode              = "Sharding"
+  name                     = "%s"
+  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id                   = huaweicloud_vpc.test.id
+  subnet_id                = huaweicloud_vpc_subnet.test.id
+  security_group_id        = huaweicloud_networking_secgroup.test.id
+  password                 = "Terraform@123"
+  mode                     = "Sharding"
+  slow_log_desensitization = "off"
 
   datastore {
     type           = "DDS-Community"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support to set `slow_log_desensitization` in `resource.huaweicloud_dds_instance`.


## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_basic
=== PAUSE TestAccDDSV3Instance_basic
=== CONT  TestAccDDSV3Instance_basic
--- PASS: TestAccDDSV3Instance_basic (3237.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       3237.677s
```
