### PR TITLE
ci(golang): new word is supported for var naming

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,7 +100,7 @@ linters-settings:
       - name: var-naming
         disabled: false
         arguments:
-          - ["API", "ID", "IP", "VM", "JSON", "HTTP", "URL", "XML", "YAML", "CSS", "ACL", "CPU", "SQL"] # AllowList
+          - ["API", "ID", "IDS", "IP", "VM", "JSON", "HTTP", "URL", "XML", "YAML", "CSS", "ACL", "CPU", "SQL"] # AllowList
           - [] # DenyList
       - name: argument-limit
         disabled: false


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New word is supported for var naming to avoid warning as follows:
```
Warning: var-naming: var publishIds should be publishIDs
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
new word is supported for var naming
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
