### PR TITLE
refactor(apig/acl): support refresh functions for associate resource

### DIFF
--- a/docs/resources/apig_acl_policy_associate.md
+++ b/docs/resources/apig_acl_policy_associate.md
@@ -49,6 +49,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Resource ID. The format is `<instance_id>/<policy_id>`.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 3 minutes.
+* `update` - Default is 3 minutes.
+* `delete` - Default is 3 minutes.
+
 ## Import
 
 Associate resources can be imported using their `policy_id` and the APIG dedicated instance ID to which the policy

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy_associate.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy_associate.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/chnsz/golangsdk"
@@ -17,8 +19,9 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/acl-bindings/binded-apis
 // @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/acl-bindings
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/acl-bindings/unbinded-apis
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/acl-bindings/binded-apis
 // @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/acl-bindings
 func ResourceAclPolicyAssociate() *schema.Resource {
 	return &schema.Resource{
@@ -26,6 +29,12 @@ func ResourceAclPolicyAssociate() *schema.Resource {
 		ReadContext:   resourceAclPolicyAssociateRead,
 		UpdateContext: resourceAclPolicyAssociateUpdate,
 		DeleteContext: resourceAclPolicyAssociateDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Update: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
 
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceAclPolicyAssociateImportState,
@@ -61,6 +70,80 @@ func ResourceAclPolicyAssociate() *schema.Resource {
 	}
 }
 
+func aclPolicyBindingRefreshFunc(client *golangsdk.ServiceClient, instanceId, policyId string,
+	publishIds []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			httpUrl  = "v2/{project_id}/apigw/instances/{instance_id}/acl-bindings/unbinded-apis"
+			queryUrl = "?acl_id={acl_id}"
+			offset   = 0
+			result   = make([]interface{}, 0)
+		)
+
+		listPath := client.Endpoint + httpUrl
+		listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+		listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+		queryUrl = strings.ReplaceAll(queryUrl, "{acl_id}", policyId)
+		listPath += queryUrl
+
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		for {
+			listPathWithOffset := fmt.Sprintf("%s&limit=100&offset=%d", listPath, offset)
+			requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+			if err != nil {
+				return nil, "ERROR", fmt.Errorf("error retrieving unassociated ACL policies: %s", err)
+			}
+			respBody, err := utils.FlattenResponse(requestResp)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+			unbindPublishIds := utils.PathSearch("apis[*].publish_id", respBody, make([]interface{}, 0)).([]interface{})
+			if len(unbindPublishIds) < 1 {
+				break
+			}
+			result = append(result, unbindPublishIds...)
+			offset += len(unbindPublishIds)
+		}
+
+		if utils.IsSliceContainsAnyAnotherSliceElement(utils.ExpandToStringList(result), publishIds, false, true) {
+			return result, "PENDING", nil
+		}
+		return result, "COMPLETED", nil
+	}
+}
+
+func bindAclPolicyToApis(ctx context.Context, client *golangsdk.ServiceClient, opts acls.BindOpts,
+	timeout time.Duration) error {
+	var (
+		instanceId = opts.InstanceId
+		policyId   = opts.PolicyId
+		publishIds = opts.PublishIds
+	)
+
+	_, err := acls.Bind(client, opts)
+	if err != nil {
+		return fmt.Errorf("error binding ACL policy to one or more APIs: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: aclPolicyBindingRefreshFunc(client, instanceId, policyId, publishIds),
+		Timeout: timeout,
+		// In most cases, the bind operation will be completed immediately, but in a few cases, it needs to wait
+		// for a short period of time, and the polling is performed by incrementing the time here.
+		MinTimeout: 2 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for the binding completed: %s", err)
+	}
+	return nil
+}
+
 func resourceAclPolicyAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
@@ -73,15 +156,15 @@ func resourceAclPolicyAssociateCreate(ctx context.Context, d *schema.ResourceDat
 		policyId   = d.Get("policy_id").(string)
 		publishIds = d.Get("publish_ids").(*schema.Set)
 
-		opts = acls.BindOpts{
+		opt = acls.BindOpts{
 			InstanceId: instanceId,
 			PolicyId:   policyId,
 			PublishIds: utils.ExpandToStringListBySet(publishIds),
 		}
 	)
-	_, err = acls.Bind(client, opts)
+	err = bindAclPolicyToApis(ctx, client, opt, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error binding policy to the API: %s", err)
+		return diag.FromErr(err)
 	}
 	d.SetId(fmt.Sprintf("%s/%s", instanceId, policyId))
 
@@ -133,32 +216,96 @@ func resourceAclPolicyAssociateRead(_ context.Context, d *schema.ResourceData, m
 	return diag.FromErr(d.Set("publish_ids", flattenApiPublishIdsForAclPolicy(resp)))
 }
 
-func unbindAclPolicy(client *golangsdk.ServiceClient, instanceId, policyId string, unbindSet *schema.Set) error {
-	opt := buildAclPolicyListOpts(instanceId, policyId)
+func aclPolicyUnbindingRefreshFunc(client *golangsdk.ServiceClient, instanceId, policyId string,
+	publishIds []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var (
+			httpUrl  = "v2/{project_id}/apigw/instances/{instance_id}/acl-bindings/binded-apis"
+			queryUrl = "?acl_id={acl_id}"
+			offset   = 0
+			result   = make([]interface{}, 0)
+		)
+
+		listPath := client.Endpoint + httpUrl
+		listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+		listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+		queryUrl = strings.ReplaceAll(queryUrl, "{acl_id}", policyId)
+		listPath += queryUrl
+
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+
+		for {
+			listPathWithOffset := fmt.Sprintf("%s&limit=100&offset=%d", listPath, offset)
+			requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+			if err != nil {
+				return nil, "ERROR", fmt.Errorf("error retrieving associated ACL policies: %s", err)
+			}
+			respBody, err := utils.FlattenResponse(requestResp)
+			if err != nil {
+				return nil, "ERROR", err
+			}
+			unbindPublishIds := utils.PathSearch("apis[*].publish_id", respBody, make([]interface{}, 0)).([]interface{})
+			if len(unbindPublishIds) < 1 {
+				break
+			}
+			result = append(result, unbindPublishIds...)
+			offset += len(unbindPublishIds)
+		}
+
+		if utils.IsSliceContainsAnyAnotherSliceElement(utils.ExpandToStringList(result), publishIds, false, true) {
+			return result, "PENDING", nil
+		}
+		return result, "COMPLETED", nil
+	}
+}
+
+func unbindAclPolicy(ctx context.Context, client *golangsdk.ServiceClient, opt acls.ListBindOpts, publishIds *schema.Set,
+	timeout time.Duration) error {
+	var (
+		instanceId = opt.InstanceId
+		policyId   = opt.PolicyId
+		unbindOpt  = acls.BatchUnbindOpts{
+			InstanceId: instanceId,
+		}
+	)
 	resp, err := acls.ListBind(client, opt)
 	if err != nil {
 		return fmt.Errorf("error getting binding APIs based on ACL policy (%s): %s", policyId, err)
 	}
 
-	unbindList := make([]string, 0, unbindSet.Len())
-	for _, rm := range unbindSet.List() {
+	bindIds := make([]string, 0, publishIds.Len())
+	for _, publishId := range publishIds.List() {
 		for _, api := range resp {
 			// If the publish ID is not found, it means the policy has been unbound from the API by other ways.
-			if rm == api.PublishId {
-				unbindList = append(unbindList, api.BindId)
+			if publishId == api.PublishId {
+				bindIds = append(bindIds, api.BindId)
 			}
 		}
 	}
-	opts := acls.BatchUnbindOpts{
-		InstanceId:  instanceId,
-		AclBindings: unbindList,
-	}
-	unbindResp, err := acls.BatchUnbind(client, opts, "delete")
+
+	unbindOpt.AclBindings = bindIds
+	unbindResp, err := acls.BatchUnbind(client, unbindOpt, "delete")
 	if err != nil {
 		return err
 	}
 	if len(unbindResp.Failures) > 0 {
 		return fmt.Errorf("an error occurred during unbind: %#v", unbindResp.Failures)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: aclPolicyUnbindingRefreshFunc(client, instanceId, policyId, utils.ExpandToStringList(publishIds.List())),
+		Timeout: timeout,
+		// In most cases, the bind operation will be completed immediately, but in a few cases, it needs to wait
+		// for a short period of time, and the polling is performed by incrementing the time here.
+		MinTimeout: 2 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for the binding completed: %s", err)
 	}
 	return nil
 }
@@ -180,7 +327,8 @@ func resourceAclPolicyAssociateUpdate(ctx context.Context, d *schema.ResourceDat
 	)
 
 	if rmSet.Len() > 0 {
-		err = unbindAclPolicy(client, instanceId, policyId, rmSet)
+		opt := buildAclPolicyListOpts(instanceId, policyId)
+		err = unbindAclPolicy(ctx, client, opt, rmSet, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -191,16 +339,16 @@ func resourceAclPolicyAssociateUpdate(ctx context.Context, d *schema.ResourceDat
 			PolicyId:   policyId,
 			PublishIds: utils.ExpandToStringListBySet(addSet),
 		}
-		_, err = acls.Bind(client, opt)
+		err = bindAclPolicyToApis(ctx, client, opt, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return diag.Errorf("error binding published APIs to the ACL policy (%s): %s", policyId, err)
+			return diag.FromErr(err)
 		}
 	}
 
 	return resourceAclPolicyAssociateRead(ctx, d, meta)
 }
 
-func resourceAclPolicyAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAclPolicyAssociateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
 	if err != nil {
@@ -211,9 +359,10 @@ func resourceAclPolicyAssociateDelete(_ context.Context, d *schema.ResourceData,
 		instanceId = d.Get("instance_id").(string)
 		policyId   = d.Get("policy_id").(string)
 		publishIds = d.Get("publish_ids").(*schema.Set)
+		opt        = buildAclPolicyListOpts(instanceId, policyId)
 	)
 
-	return diag.FromErr(unbindAclPolicy(client, instanceId, policyId, publishIds))
+	return diag.FromErr(unbindAclPolicy(ctx, client, opt, publishIds, d.Timeout(schema.TimeoutUpdate)))
 }
 
 func resourceAclPolicyAssociateImportState(_ context.Context, d *schema.ResourceData,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support the refresh functions for the ACL policy associate resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supprot refresh functions for associate resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccAclPolicyAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccAclPolicyAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccAclPolicyAssociate_basic
=== PAUSE TestAccAclPolicyAssociate_basic
=== CONT  TestAccAclPolicyAssociate_basic
--- PASS: TestAccAclPolicyAssociate_basic (699.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      699.151s
```
