### PR TITLE
feat(dds): support to set maintenance window for instance

### DIFF
--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -28,6 +28,9 @@ resource "huaweicloud_dds_instance" "instance" {
   security_group_id = "{{ security_group_id }}"
   password          = var.dds_password
   mode              = "Sharding"
+  maintain_begin    = "02:00"
+  maintain_end      = "03:00"
+
   flavor {
     type      = "mongos"
     num       = 2
@@ -134,6 +137,14 @@ The following arguments are supported:
 * `ssl` - (Optional, Bool) Specifies whether to enable or disable SSL. Defaults to true.
 
 **NOTE:** The instance will be restarted in the background when switching SSL. Please operate with caution.
+
+* `maintain_begin` - (Optional, String) Specifies begin time of the time range within which you are allowed to start a
+  task that affects the running of database instances. It must be a valid value in the format of **hh:mm** in UTC+0,
+  such as **02:00**, meanwhile, this time in console displays in the format of **hh:mm** in UTC+08:00, e.g. **10:00**.
+
+* `maintain_end` - (Optional, String) Specifies end time of the time range within which you are allowed to start a
+  task that affects the running of database instances. It must be a valid value in the format of **hh:mm** in UTC+0,
+  such as **04:00**, meanwhile, this time in console displays in the format of **hh:mm** in UTC+08:00, e.g. **12:00**.
 
 * `second_level_monitoring_enabled` - (Optional, Bool) Specifies whether to enable second level monitoring.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240509073804-d248417507cd
+	github.com/chnsz/golangsdk v0.0.0-20240511015204-c22623d67cbb
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240509073804-d248417507cd h1:gqnIPcOKmT4/RLlSiaJr4Ty7iZPJ5OfX/eX2R7SJi3E=
-github.com/chnsz/golangsdk v0.0.0-20240509073804-d248417507cd/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240511015204-c22623d67cbb h1:UvsvIqo5f6NAlVLRndrs2vwdEmwmuDnMuhf7Ma4p0J4=
+github.com/chnsz/golangsdk v0.0.0-20240511015204-c22623d67cbb/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -290,6 +290,8 @@ func TestAccDDSV3Instance_withConfigurationReplicaSet(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.type", "replica"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "02:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "03:00"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.id", "huaweicloud_dds_parameter_template.replica2", "id"),
 				),
 			},
@@ -1096,6 +1098,8 @@ resource "huaweicloud_dds_instance" "instance" {
   password          = "Terraform@123"
   mode              = "ReplicaSet"
   replica_set_name  = "replicaName"
+  maintain_begin    = "02:00"
+  maintain_end      = "03:00"
 
   datastore {
     type           = "DDS-Community"

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
@@ -340,6 +340,11 @@ type RemarkOpts struct {
 	Remark string `json:"remark"`
 }
 
+type ChangeMaintenanceWindowOpts struct {
+	StartTime string `json:"start_time" required:"true"`
+	EndTime   string `json:"end_time" required:"true"`
+}
+
 // UpdateReplicaSetName is a method to update the replica set name.
 func UpdateReplicaSetName(c *golangsdk.ServiceClient, instanceId string, opts ReplicaSetNameOpts) (*CommonResp, error) {
 	b, err := golangsdk.BuildRequestBody(opts, "")
@@ -409,4 +414,21 @@ func RestartInstance(c *golangsdk.ServiceClient, instanceId string, opts Restart
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
 	return &r, err
+}
+
+// UpdateMaintenanceWindow is a method to update maintenance time.
+func UpdateMaintenanceWindow(c *golangsdk.ServiceClient, instanceId string, opts ChangeMaintenanceWindowOpts) error {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	var r ChangeMaintenanceWindowOpts
+	_, err = c.Put(maintenanceWindowURL(c, instanceId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+		OkCodes: []int{
+			204,
+		},
+	})
+	return err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/urls.go
@@ -49,3 +49,7 @@ func slowLogStatusURL(c *golangsdk.ServiceClient, instanceId string, status stri
 func restartURL(c *golangsdk.ServiceClient, instanceId string) string {
 	return c.ServiceURL("instances", instanceId, "restart")
 }
+
+func maintenanceWindowURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "maintenance-window")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240509073804-d248417507cd
+# github.com/chnsz/golangsdk v0.0.0-20240511015204-c22623d67cbb
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support to set maintenance window for instance.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_withConfigurationReplicaSet"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withConfigurationReplicaSet -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withConfigurationReplicaSet
=== PAUSE TestAccDDSV3Instance_withConfigurationReplicaSet
=== CONT  TestAccDDSV3Instance_withConfigurationReplicaSet
--- PASS: TestAccDDSV3Instance_withConfigurationReplicaSet (1820.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       1820.270s
```
