### PR TITLE
feat(apig): add new datasource to get list of custom authorizers

### DIFF
--- a/docs/data-sources/apig_custom_authorizers.md
+++ b/docs/data-sources/apig_custom_authorizers.md
@@ -1,0 +1,91 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_custom_authorizers"
+description: |-
+  Use this data source to query the custom authorizers within HuaweiCloud.
+---
+
+# huaweicloud_apig_custom_authorizers
+
+Use this data source to query the custom authorizers within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "authorizer_name" {}
+
+data "huaweicloud_apig_custom_authorizers" "test" {
+  instance_id = var.instance_id
+  name        = var.authorizer_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the custom authorizers belong.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the custom authorizer.
+
+* `name` - (Optional, String) Specifies the name of the custom authorizer.  
+  The custom authorizer name consists of `3` to `64` characters, starting with a letter.  
+  Only letters, digits and underscores (_) are allowed.
+
+* `type` - (Optional, String) Specifies the type of the custom authorizer.  
+  The valid values are as follows:
+  + **FRONTEND**
+  + **BACKEND**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `authorizers` - All custom authorizers that match the filter parameters.
+  The [authorizers](#authorizers) structure is documented below.
+
+<a name="authorizers"></a>
+The `authorizers` block supports:
+
+* `id` - The ID of the custom authorizer.
+
+* `name` - The name of the custom authorizer.
+
+* `type` - The type of the custom authorizer.
+
+* `function_type` - The type of the FGS function.
+
+* `function_urn` - The URN of the FGS function.
+
+* `network_type` - The network architecture types of function.
+
+* `function_version` - The version of the FGS function.
+
+* `function_alias_uri` - The version alias URI of the FGS function.
+
+* `cache_age` - The maximum cache age of custom authorizer.
+
+* `created_at` - The creation time of custom authorizer.
+
+* `is_body_send` - Whether to send the body of custom authorizer.
+
+* `user_data` - The user data of custom authorizer.
+
+* `identity` - The parameter identities of the custom authorizer.
+  The [identity](#authorizers_identity) structure is documented below.
+
+<a name="authorizers_identity"></a>
+The `identity` block supports:
+
+* `name` - The name of the parameter to be verified.
+
+* `location` - The parameter location of identity.
+
+* `validation` - The parameter verification expression of identity.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -402,6 +402,7 @@ func Provider() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"huaweicloud_apig_acl_policies":                       apig.DataSourceAclPolicies(),
+			"huaweicloud_apig_custom_authorizers":                 apig.DataSourceCustomAuthorizers(),
 			"huaweicloud_apig_api_associated_acl_policies":        apig.DataSourceApiAssociatedAclPolicies(),
 			"huaweicloud_apig_api_associated_applications":        apig.DataSourceApiAssociatedApplications(),
 			"huaweicloud_apig_api_associated_throttling_policies": apig.DataSourceApiAssociatedThrottlingPolicies(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_custom_authorizers_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_custom_authorizers_test.go
@@ -1,0 +1,127 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCustomAuthorizers_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_apig_custom_authorizers.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		rName      = acceptance.RandomAccResourceName()
+
+		byId   = "data.huaweicloud_apig_custom_authorizers.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byName   = "data.huaweicloud_apig_custom_authorizers.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byType   = "data.huaweicloud_apig_custom_authorizers.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceCustomAuthorizers_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "authorizers.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "authorizers.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "authorizers.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "authorizers.0.type"),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("authorizer_id_filter_is_useful", "true"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceCustomAuthorizers_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_apig_custom_authorizers" "test" {
+  depends_on = [
+    huaweicloud_apig_custom_authorizer.test
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+# Filter by ID
+locals {
+  authorizer_id = data.huaweicloud_apig_custom_authorizers.test.authorizers[0].id
+}
+
+data "huaweicloud_apig_custom_authorizers" "filter_by_id" {
+  instance_id  = huaweicloud_apig_instance.test.id
+  authorizer_id = local.authorizer_id
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_apig_custom_authorizers.filter_by_id.authorizers[*].id : v == local.authorizer_id
+  ]
+}
+
+output "authorizer_id_filter_is_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+}
+
+# Filter by name
+locals {
+  name = data.huaweicloud_apig_custom_authorizers.test.authorizers[0].name
+}
+
+data "huaweicloud_apig_custom_authorizers" "filter_by_name" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = local.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_apig_custom_authorizers.filter_by_name.authorizers[*].name : v == local.name
+  ]
+}
+
+output "name_filter_is_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by type
+locals {
+  type = data.huaweicloud_apig_custom_authorizers.test.authorizers[0].type
+}
+
+data "huaweicloud_apig_custom_authorizers" "filter_by_type" {
+  instance_id = huaweicloud_apig_instance.test.id
+  type        = local.type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_apig_custom_authorizers.filter_by_type.authorizers[*].type : v == local.type
+  ]
+}
+
+output "type_filter_is_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+`, testAccCustomAuthorizer_front(name))
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_custom_authorizers.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_custom_authorizers.go
@@ -1,0 +1,267 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/authorizers
+func DataSourceCustomAuthorizers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCustomAuthorizersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the dedicated instance to which the custom authorizers belong.`,
+			},
+			"authorizer_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the custom authorizer.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the custom authorizer.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the type of the custom authorizer.`,
+			},
+			"authorizers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `All custom authorizers that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the custom authorizer.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the custom authorizer.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the custom authorizer.`,
+						},
+						"function_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the FGS function.`,
+						},
+						"function_urn": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The URN of the FGS function.`,
+						},
+						"network_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The network architecture types of function.`,
+						},
+						"function_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version of the FGS function.`,
+						},
+						"function_alias_uri": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version alias URI of the FGS function.`,
+						},
+						"identity": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The parameter identities of the custom authorizer.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The name of the parameter to be verified.`,
+									},
+									"location": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The parameter location of identity.`,
+									},
+									"validation": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The parameter verification expression of identity.`,
+									},
+								},
+							},
+						},
+						"cache_age": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum cache age of custom authorizer.`,
+						},
+						"user_data": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The user data of custom authorizer.`,
+						},
+						"is_body_send": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether to send the body of custom authorizer.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of custom authorizer.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListCustomAuthorizersParams(d *schema.ResourceData) string {
+	res := ""
+	if authorizer, ok := d.GetOk("authorizer_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, authorizer)
+	}
+	if name, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, name)
+	}
+	if customType, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&type=%v", res, customType)
+	}
+	return res
+}
+
+func queryCustomAuthorizers(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/authorizers?limit=500"
+		instanceId = d.Get("instance_id").(string)
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+
+	queryParams := buildListCustomAuthorizersParams(d)
+	listPath += queryParams
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving custom authorizers under specified "+
+				"dedicated instance (%s): %s", instanceId, err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		authorizers := utils.PathSearch("authorizer_list", respBody, make([]interface{}, 0)).([]interface{})
+		if len(authorizers) < 1 {
+			break
+		}
+		result = append(result, authorizers...)
+		offset += len(authorizers)
+	}
+	return result, nil
+}
+
+func dataSourceCustomAuthorizersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+	authorizers, err := queryCustomAuthorizers(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("authorizers", flattenCustomAuthorizers(authorizers)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCustomAuthorizers(authorizers []interface{}) []interface{} {
+	if len(authorizers) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(authorizers))
+	for _, authorizer := range authorizers {
+		result = append(result, map[string]interface{}{
+			"id":                 utils.PathSearch("id", authorizer, nil),
+			"name":               utils.PathSearch("name", authorizer, nil),
+			"type":               utils.PathSearch("type", authorizer, nil),
+			"function_type":      utils.PathSearch("authorizer_type", authorizer, nil),
+			"function_urn":       utils.PathSearch("authorizer_uri", authorizer, nil),
+			"network_type":       utils.PathSearch("network_type", authorizer, nil),
+			"function_version":   utils.PathSearch("authorizer_version", authorizer, nil),
+			"function_alias_uri": utils.PathSearch("authorizeralias_uri", authorizer, nil),
+			"identity":           flattenCustomAuthorizersIdentity(utils.PathSearch("identities", authorizer, make([]interface{}, 0))),
+			"cache_age":          int(utils.PathSearch("ttl", authorizer, 0).(float64)),
+			"user_data":          utils.PathSearch("user_data", authorizer, nil),
+			"is_body_send":       utils.PathSearch("need_body", authorizer, false).(bool),
+			"created_at":         utils.PathSearch("create_time", authorizer, nil),
+		})
+	}
+	return result
+}
+
+func flattenCustomAuthorizersIdentity(identities interface{}) []map[string]interface{} {
+	identitiesArray := identities.([]interface{})
+	result := make([]map[string]interface{}, len(identitiesArray))
+	for i, identity := range identitiesArray {
+		result[i] = map[string]interface{}{
+			"name":       utils.PathSearch("name", identity, nil),
+			"location":   utils.PathSearch("location", identity, nil),
+			"validation": utils.PathSearch("validation", identity, nil),
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add new datasource to get list of custom authorizers.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccDataSourceCustomAuthorizers_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccDataSourceCustomAuthorizers_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCustomAuthorizers_basic
=== PAUSE TestAccDataSourceCustomAuthorizers_basic
=== CONT  TestAccDataSourceCustomAuthorizers_basic
--- PASS: TestAccDataSourceCustomAuthorizers_basic (572.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      572.995s
```
