### PR TITLE
refactor(apig/sign): support refresh functions for associate resource

### DIFF
--- a/docs/resources/apig_signature_associate.md
+++ b/docs/resources/apig_signature_associate.md
@@ -50,6 +50,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Resource ID. The format is `<instance_id>/<signature_id>`.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 3 minutes.
+* `update` - Default is 3 minutes.
+* `delete` - Default is 3 minutes.
+
 ## Import
 
 Associate resources can be imported using their `signature_id` and the APIG dedicated instance ID to which the signature


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support the refresh functions for the signature associate resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. support refresh functions for associate resource
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccSignatureAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccSignatureAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccSignatureAssociate_basic
=== PAUSE TestAccSignatureAssociate_basic
=== CONT  TestAccSignatureAssociate_basic
--- PASS: TestAccSignatureAssociate_basic (722.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      722.154s
```
