### PR TITLE
feat(apig): add datasource to get basic configurations of the api

### DIFF
--- a/docs/data-sources/apig_api_basic_configurations.md
+++ b/docs/data-sources/apig_api_basic_configurations.md
@@ -1,0 +1,125 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_api_basic_configurations"
+description: |-
+  Use this data source to get the basic configuration list of the APIs within HuaweiCloud.
+---
+
+# huaweicloud_apig_api_basic_configurations
+
+Use this data source to get the basic configuration list of the APIs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_apig_api_basic_configurations" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the APIs belong.
+
+* `api_id` - (Optional, String) Specifies the ID of the API.
+
+* `name` - (Optional, String) Specifies the name of the API. Fuzzy search is supported.
+
+* `group_id` - (Optional, String) Specifies the ID of the API group to which the APIs belong.
+
+* `type` - (Optional, String) Specifies the type of the API.  
+  The valid values are **Public** and **Private**.
+
+* `request_method` - (Optional, String) Specifies the request method of the API.  
+  The valid values are **GET**, **POST**, **PUT**, **DELETE**, **HEAD**, **PATCH**, **OPTIONS** and **ANY**.
+
+* `request_path` - (Optional, String) Specifies the request address of the API. Fuzzy search is supported.
+
+* `request_protocol` - (Optional, String) Specifies the request protocol of the API.  
+  The valid values are **HTTP**, **HTTPS**, **BOTH** and **GRPCS**.
+
+* `security_authentication` - (Optional, String) Specifies the security authentication mode of the API request.  
+  The valid values are **NONE**, **APP**, **IAM** and **AUTHORIZER**.
+
+* `vpc_channel_name` - (Optional, String) Specifies the name of the VPC channel. Fuzzy search is supported.
+
+* `precise_search` - (Optional, String) Specifies the parameter name that you want to match exactly.  
+  The valid values are as follows:
+  + **name**: API name, corresponding to the field `name` in this data source arguments.
+  + **req_uri**: Request path, corresponding to the field `request_path` in this data source arguments.
+
+  This parameter can also be set to multiple enumerated values and separated by a comma (,), e.g. `name,req_uri`.  
+  This parameter takes effect only after the corresponding parameter(s) is(are) set.
+
+* `env_id` - (Optional, String) Specifies the ID of the environment where the API is published.
+
+* `env_name` - (Optional, String) Specifies the name of the environment where the API is published.
+
+* `backend_type` - (Optional, String) Specifies the backend type of the API.  
+  The valid values are **HTTP**, **FUNCTION**, **MOCK** and **GRPC**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `configurations` - All API configurations that match the filter parameters.
+  The [configurations](#basic_configurations) structure is documented below.
+
+<a name="basic_configurations"></a>
+The `configurations` block supports:
+
+* `id` - The ID of the API.
+
+* `name` - The name of the API.
+
+* `type` - The type of the API.
+
+* `request_method` - The request method of the API.
+
+* `request_path` - The request address of the API.
+
+* `request_protocol` - The request protocol of the API.
+
+* `security_authentication` - The security authentication mode of the API request.
+
+* `simple_authentication` - Whether the authentication of the application code is enabled.
+
+* `group_id` - The ID of group corresponding to the API.
+
+* `group_name` - The name of group corresponding to the API.
+
+* `group_version` - The version of group corresponding to the API.
+
+* `env_id` - The ID of the environment where the API is published.
+
+* `env_name` - The name of the environment where the API is published.
+
+* `authorizer_id` - The ID of the authorizer to which the API request used.
+
+* `publish_id` - The ID of publish corresponding to the API.
+
+* `backend_type` - The backend type of the API.
+
+* `cors` - Whether CORS is supported.
+
+* `matching` - The matching mode of the API.  
+  + **Exact**
+  + **Prefix**
+
+* `description` - The description of the API.
+
+* `registered_at` - The registered time of the API, in RFC3339 format.
+
+* `updated_at` - The latest update time of the API, in RFC3339 format.
+
+* `published_at` - The published time of the API, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -405,6 +405,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_api_associated_acl_policies":        apig.DataSourceApiAssociatedAclPolicies(),
 			"huaweicloud_apig_api_associated_applications":        apig.DataSourceApiAssociatedApplications(),
 			"huaweicloud_apig_api_associated_throttling_policies": apig.DataSourceApiAssociatedThrottlingPolicies(),
+			"huaweicloud_apig_api_basic_configurations":           apig.DataSourceApiBasicConfigurations(),
 			"huaweicloud_apig_environments":                       apig.DataSourceEnvironments(),
 			"huaweicloud_apig_groups":                             apig.DataSourceGroups(),
 			"huaweicloud_apig_throttling_policies":                apig.DataSourceThrottlingPolicies(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_basic_configurations_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_basic_configurations_test.go
@@ -1,0 +1,508 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceApiBasicConfigurations_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_apig_api_basic_configurations.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+
+		byId   = "data.huaweicloud_apig_api_basic_configurations.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byName   = "data.huaweicloud_apig_api_basic_configurations.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byExactName   = "data.huaweicloud_apig_api_basic_configurations.filter_by_exact_name"
+		dcByExactName = acceptance.InitDataSourceCheck(byExactName)
+
+		byNotFoundName   = "data.huaweicloud_apig_api_basic_configurations.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+
+		byGroupId   = "data.huaweicloud_apig_api_basic_configurations.filter_by_group_id"
+		dcByGroupId = acceptance.InitDataSourceCheck(byGroupId)
+
+		byType   = "data.huaweicloud_apig_api_basic_configurations.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byRequestMethod   = "data.huaweicloud_apig_api_basic_configurations.filter_by_request_method"
+		dcByRequestMethod = acceptance.InitDataSourceCheck(byRequestMethod)
+
+		byRequestPath   = "data.huaweicloud_apig_api_basic_configurations.filter_by_request_path"
+		dcByRequestPath = acceptance.InitDataSourceCheck(byRequestPath)
+
+		byRequestProtocol   = "data.huaweicloud_apig_api_basic_configurations.filter_by_request_protocol"
+		dcByRequestProtocol = acceptance.InitDataSourceCheck(byRequestProtocol)
+
+		bySecurityAuthentication   = "data.huaweicloud_apig_api_basic_configurations.filter_by_security_authentication"
+		dcBySecurityAuthentication = acceptance.InitDataSourceCheck(bySecurityAuthentication)
+
+		byVpcChannelName   = "data.huaweicloud_apig_api_basic_configurations.filter_by_vpc_channel_name"
+		dcByVpcChannelName = acceptance.InitDataSourceCheck(byVpcChannelName)
+
+		byEnvId   = "data.huaweicloud_apig_api_basic_configurations.filter_by_env_id"
+		dcByEnvId = acceptance.InitDataSourceCheck(byEnvId)
+
+		byEnvName   = "data.huaweicloud_apig_api_basic_configurations.filter_by_env_name"
+		dcByEnvName = acceptance.InitDataSourceCheck(byEnvName)
+
+		byBackEndType   = "data.huaweicloud_apig_api_basic_configurations.filter_by_backend_type"
+		dcByBackEndType = acceptance.InitDataSourceCheck(byBackEndType)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceApiBasicConfigurations_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "configurations.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(byId, "configurations.0.group_name"),
+					resource.TestCheckResourceAttrSet(byId, "configurations.0.group_version"),
+					resource.TestCheckResourceAttrSet(byId, "configurations.0.publish_id"),
+					resource.TestCheckResourceAttrSet(byId, "configurations.0.backend_type"),
+					resource.TestCheckResourceAttr(byId, "configurations.0.simple_authentication", "false"),
+					resource.TestCheckResourceAttr(byId, "configurations.0.cors", "true"),
+					resource.TestCheckResourceAttr(byId, "configurations.0.matching", "Exact"),
+					resource.TestCheckResourceAttrSet(byId, "configurations.0.registered_at"),
+					resource.TestCheckResourceAttrSet(byId, "configurations.0.updated_at"),
+					resource.TestCheckResourceAttrSet(byId, "configurations.0.published_at"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByExactName.CheckResourceExists(),
+					resource.TestCheckOutput("is_exact_name_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_not_found_filter_useful", "true"),
+					dcByGroupId.CheckResourceExists(),
+					resource.TestCheckOutput("is_group_id_filter_useful", "true"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcByRequestMethod.CheckResourceExists(),
+					resource.TestCheckOutput("is_request_method_filter_useful", "true"),
+					dcByRequestPath.CheckResourceExists(),
+					resource.TestCheckOutput("is_request_path_filter_useful", "true"),
+					dcByRequestProtocol.CheckResourceExists(),
+					resource.TestCheckOutput("is_request_protocol_filter_useful", "true"),
+					dcBySecurityAuthentication.CheckResourceExists(),
+					resource.TestCheckOutput("is_security_authentication_filter_useful", "true"),
+					dcByVpcChannelName.CheckResourceExists(),
+					resource.TestCheckOutput("is_vpc_channel_name_filter_useful", "true"),
+					dcByEnvId.CheckResourceExists(),
+					resource.TestCheckOutput("is_env_id_filter_useful", "true"),
+					dcByEnvName.CheckResourceExists(),
+					resource.TestCheckOutput("is_env_name_filter_useful", "true"),
+					dcByBackEndType.CheckResourceExists(),
+					resource.TestCheckOutput("is_backend_type_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceApiBasicConfigurations_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_custom_authorizer" "frontEnd" {
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s_front"
+  function_urn     = huaweicloud_fgs_function.test.urn
+  function_version = "latest"
+  type             = "FRONTEND"
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/{%[2]s}"
+  security_authentication = "AUTHORIZER"
+  matching                = "Exact"
+  authorizer_id           = huaweicloud_apig_custom_authorizer.frontEnd.id
+  cors                    = true
+  description             = "Updated by script"
+  
+  request_params {
+    name     = "%[2]s"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+
+  web {
+    path             = "/"
+    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+    retry_count      = 1
+  }
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_apig_api_publishment" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  api_id      = huaweicloud_apig_api.test.id
+}
+
+`, testAccApi_base(name), name)
+}
+
+func testAccDataSourceApiBasicConfigurations_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_api_basic_configurations" "test" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+# Filter by ID
+locals {
+  api_id = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].id
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_id" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = local.api_id
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_id.configurations[*].id : v == local.api_id
+  ]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+}
+
+# Filter by name (fuzzy search)
+locals {
+  api_name = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].name
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_name" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = local.api_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_name.configurations[*].name : strcontains(v, local.api_name)
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by name (exact search)
+locals {
+  api_name_exact = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].name
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_exact_name" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id    = huaweicloud_apig_instance.test.id
+  name           = local.api_name_exact
+  precise_search = "name,req_uri"
+}
+
+output "is_exact_name_filter_useful" {
+  value = length(data.huaweicloud_apig_api_basic_configurations.filter_by_exact_name.configurations) == 1
+}
+
+# Filter by name (not found)
+locals {
+  not_found_name = "not_found"
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_not_found_name" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id    = huaweicloud_apig_instance.test.id
+  name           = local.not_found_name
+  precise_search = "name"
+}
+
+output "is_name_not_found_filter_useful" {
+  value = length(data.huaweicloud_apig_api_basic_configurations.filter_by_not_found_name.configurations) == 0
+}
+
+# Filter by group ID
+locals {
+  group_id = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].group_id
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_group_id" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  group_id    = local.group_id
+}
+
+locals {
+  group_id_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_id.configurations[*].group_id : v == local.group_id
+  ]
+}
+
+output "is_group_id_filter_useful" {
+  value = length(local.group_id_filter_result) > 0 && alltrue(local.group_id_filter_result)
+}
+
+# Filter by type
+locals {
+  api_type = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].type
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_type" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  type        = local.api_type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_type.configurations[*].type : v == local.api_type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+# Filter by request method
+locals {
+  request_method = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].request_method
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_request_method" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id    = huaweicloud_apig_instance.test.id
+  request_method = local.request_method
+}
+
+locals {
+  request_method_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_request_method.configurations[*].request_method : v == local.request_method
+  ]
+}
+
+output "is_request_method_filter_useful" {
+  value = length(local.request_method_filter_result) > 0 && alltrue(local.request_method_filter_result)
+}
+
+# Filter by request path
+locals {
+  request_path = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].request_path
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_request_path" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id    = huaweicloud_apig_instance.test.id
+  request_path   = local.request_path
+  precise_search = "req_url"
+}
+
+locals {
+  request_path_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_request_path.configurations[*].request_path : v == local.request_path
+  ]
+}
+
+output "is_request_path_filter_useful" {
+  value = length(local.request_path_filter_result) > 0 && alltrue(local.request_path_filter_result)
+}
+
+# Filter by request protocol
+locals {
+  request_protocol = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].request_protocol
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_request_protocol" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id      = huaweicloud_apig_instance.test.id
+  request_protocol = local.request_protocol
+}
+
+locals {
+  request_protocol_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_request_protocol.configurations[*].request_protocol : 
+      v == local.request_protocol
+  ]
+}
+
+output "is_request_protocol_filter_useful" {
+  value = length(local.request_protocol_filter_result) > 0 && alltrue(local.request_protocol_filter_result)
+}
+
+# Filter by security authentication type
+locals {
+  security_authentication = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].security_authentication
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_security_authentication" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id             = huaweicloud_apig_instance.test.id
+  security_authentication = local.security_authentication
+}
+
+locals {
+  security_auth_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_security_authentication.configurations[*].security_authentication : 
+      v == local.security_authentication
+  ]
+}
+
+output "is_security_authentication_filter_useful" {
+  value = length(local.security_auth_filter_result) > 0 && alltrue(local.security_auth_filter_result)
+}
+
+# Filter by vpc channel name
+data "huaweicloud_apig_api_basic_configurations" "filter_by_vpc_channel_name" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id      = huaweicloud_apig_instance.test.id
+  vpc_channel_name = huaweicloud_apig_vpc_channel.test.name
+}
+
+output "is_vpc_channel_name_filter_useful" {
+  value = length(data.huaweicloud_apig_api_basic_configurations.filter_by_vpc_channel_name.configurations) > 0
+}
+
+# Filter by env ID
+locals {
+  env_id = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].env_id
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_env_id" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  env_id      = local.env_id
+}
+
+locals {
+  env_id_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_env_id.configurations[*].env_id : v == local.env_id
+  ]
+}
+
+output "is_env_id_filter_useful" {
+  value = length(local.env_id_filter_result) > 0 && alltrue(local.env_id_filter_result)
+}
+
+# Filter by env name
+locals {
+  env_name = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].env_name
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_env_name" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  env_name    = local.env_name
+}
+
+locals {
+  env_name_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_env_name.configurations[*].env_name : v == local.env_name
+  ]
+}
+
+output "is_env_name_filter_useful" {
+  value = length(local.env_name_filter_result) > 0 && alltrue(local.env_name_filter_result)
+}
+
+# Filter by backend type
+locals {
+  backend_type = data.huaweicloud_apig_api_basic_configurations.test.configurations[0].backend_type
+}
+
+data "huaweicloud_apig_api_basic_configurations" "filter_by_backend_type" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  instance_id  = huaweicloud_apig_instance.test.id
+  backend_type = local.backend_type
+}
+
+locals {
+  backend_type_filter_result = [
+    for v in data.huaweicloud_apig_api_basic_configurations.filter_by_backend_type.configurations[*].backend_type : v == local.backend_type
+  ]
+}
+
+output "is_backend_type_filter_useful" {
+  value = length(local.backend_type_filter_result) > 0 && alltrue(local.backend_type_filter_result)
+}
+`, testAccDataSourceApiBasicConfigurations_base())
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_api_basic_configurations.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_api_basic_configurations.go
@@ -1,0 +1,389 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apis
+func DataSourceApiBasicConfigurations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApiBasicConfigurationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the dedicated instance to which the APIs belong.`,
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the API.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the API.`,
+			},
+			"group_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the ID of the API group to which the APIs belong.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the type of the API.`,
+			},
+			"request_method": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the request method of the API.",
+			},
+			"request_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the request address of the API.",
+			},
+			"request_protocol": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the request protocol of the API.",
+			},
+			"security_authentication": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the security authentication mode of the API request.",
+			},
+			"vpc_channel_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the name of the VPC channel.",
+			},
+			"precise_search": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the parameter name for exact matching.",
+			},
+			"env_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the environment where the API is published.`,
+			},
+			"env_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the name of the environment where the API is published.`,
+			},
+			"backend_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the backend type of the API.`,
+			},
+			"configurations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `All API configurations that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the API.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the API.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the API.`,
+						},
+						"request_method": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The request method of the API.",
+						},
+						"request_path": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The request address of the API.",
+						},
+						"request_protocol": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The request protocol of the API.",
+						},
+						"security_authentication": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The security authentication mode of the API request.",
+						},
+						"simple_authentication": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether the authentication of the application code is enabled.",
+						},
+						"authorizer_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the authorizer to which the API request used.`,
+						},
+						"group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of group corresponding to the API.`,
+						},
+						"group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of group corresponding to the API.`,
+						},
+						"group_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version of group corresponding to the API.`,
+						},
+						"env_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the environment where the API is published.`,
+						},
+						"env_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the environment where the API is published.`,
+						},
+						"publish_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of publish corresponding to the API.`,
+						},
+						"backend_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The backend type of the API.`,
+						},
+						"cors": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether CORS is supported.",
+						},
+						"matching": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The matching mode of the API.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the API.",
+						},
+						"registered_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The registered time of the API, in RFC3339 format.",
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The latest update time of the API, in RFC3339 format.",
+						},
+						"published_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The published time of the API, in RFC3339 format.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListApisParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("api_id"); ok {
+		res = fmt.Sprintf("%s&id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, v)
+	}
+	if v, ok := d.GetOk("group_id"); ok {
+		res = fmt.Sprintf("%s&group_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&type=%v", res, buildApiType(v.(string)))
+	}
+	if v, ok := d.GetOk("request_method"); ok {
+		res = fmt.Sprintf("%s&req_method=%v", res, v)
+	}
+	if v, ok := d.GetOk("request_path"); ok {
+		res = fmt.Sprintf("%s&req_uri=%v", res, v)
+	}
+	if v, ok := d.GetOk("request_protocol"); ok {
+		res = fmt.Sprintf("%s&req_protocol=%v", res, v)
+	}
+	if v, ok := d.GetOk("security_authentication"); ok {
+		res = fmt.Sprintf("%s&auth_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("vpc_channel_name"); ok {
+		res = fmt.Sprintf("%s&vpc_channel_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("precise_search"); ok {
+		res = fmt.Sprintf("%s&precise_search=%v", res, v)
+	}
+	if v, ok := d.GetOk("env_id"); ok {
+		res = fmt.Sprintf("%s&env_id=%v", res, v)
+	}
+	return res
+}
+
+func GetApiBasicConfigurations(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/apis?limit=500"
+		instanceId = d.Get("instance_id").(string)
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+
+	queryParams := buildListApisParams(d)
+	listPath += queryParams
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving apis under specified dedicated instance (%s): %s", instanceId, err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		apiBasicConfigurations := utils.PathSearch("apis", respBody, make([]interface{}, 0)).([]interface{})
+		if len(apiBasicConfigurations) < 1 {
+			break
+		}
+		result = append(result, apiBasicConfigurations...)
+		offset += len(apiBasicConfigurations)
+	}
+	return result, nil
+}
+
+func dataSourceApiBasicConfigurationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	apiBasicConfigurations, err := GetApiBasicConfigurations(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("configurations", filterApiBasicConfigurations(flattenApiBasicConfigurations(apiBasicConfigurations), d)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterApiBasicConfigurations(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+	for _, v := range all {
+		if param, ok := d.GetOk("env_name"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("env_name", v, nil)) {
+			continue
+		}
+
+		if param, ok := d.GetOk("backend_type"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("backend_type", v, nil)) {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func flattenApiBasicConfigurations(configurations []interface{}) []interface{} {
+	if len(configurations) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(configurations))
+	for _, conf := range configurations {
+		result = append(result, map[string]interface{}{
+			"id":                      utils.PathSearch("id", conf, nil),
+			"name":                    utils.PathSearch("name", conf, nil),
+			"type":                    analyseApiType(int(utils.PathSearch("type", conf, float64(0)).(float64))),
+			"request_method":          utils.PathSearch("req_method", conf, nil),
+			"request_path":            utils.PathSearch("req_uri", conf, nil),
+			"request_protocol":        utils.PathSearch("req_protocol", conf, nil),
+			"security_authentication": utils.PathSearch("auth_type", conf, nil),
+			"simple_authentication":   flattenSimpleAuth(utils.PathSearch("auth_opt.app_code_auth_type", conf, "").(string)),
+			"authorizer_id":           utils.PathSearch("authorizer_id", conf, nil),
+			"group_id":                utils.PathSearch("group_id", conf, nil),
+			"group_name":              utils.PathSearch("group_name", conf, nil),
+			"group_version":           utils.PathSearch("group_version", conf, nil),
+			"env_id":                  utils.PathSearch("env_id", conf, nil),
+			"env_name":                utils.PathSearch("env_name", conf, nil),
+			"publish_id":              utils.PathSearch("publish_id", conf, nil),
+			"backend_type":            utils.PathSearch("backend_type", conf, nil),
+			"cors":                    utils.PathSearch("cors", conf, nil),
+			"matching":                analyseApiMatchMode(utils.PathSearch("match_mode", conf, "").(string)),
+			"description":             utils.PathSearch("remark", conf, nil),
+			"registered_at":           utils.PathSearch("register_time", conf, nil),
+			"updated_at":              utils.PathSearch("update_time", conf, nil),
+			"published_at":            flattenPulishTime(utils.PathSearch("publish_time", conf, "").(string)),
+		})
+	}
+	return result
+}
+
+func flattenSimpleAuth(authType string) bool {
+	return authType == string(AppCodeAuthTypeEnable)
+}
+
+func flattenPulishTime(utcTime string) string {
+	pulishTime := utils.ConvertTimeStrToNanoTimestamp(utcTime, "2006-01-02 15:04:05")
+	return utils.FormatTimeStampRFC3339(pulishTime/1000, false, "2006-01-02T15:04:05Z")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource to get basci configurations of the api under specified dedicated  APIG instance.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 1. add new dataSource to get basci configurations of the api.
 2. add corresponding to document and acceptance test.

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccDataSourceApiBasicConfigurations_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccDataSourceApiBasicConfigurations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceApiBasicConfigurations_basic
=== PAUSE TestAccDataSourceApiBasicConfigurations_basic
=== CONT  TestAccDataSourceApiBasicConfigurations_basic
--- PASS: TestAccDataSourceApiBasicConfigurations_basic (680.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      680.234s
```
