### PR TITLE
chore(utils/time): refactor the color and time convert methods

### DIFF
--- a/huaweicloud/utils/colors.go
+++ b/huaweicloud/utils/colors.go
@@ -1,0 +1,17 @@
+package utils
+
+import "fmt"
+
+const (
+	greenCode  = "\033[1;32m"
+	yellowCode = "\033[1;33m"
+	resetCode  = "\033[0m"
+)
+
+func Green(str interface{}) string {
+	return fmt.Sprintf("%s%#v%s", greenCode, str, resetCode)
+}
+
+func Yellow(str interface{}) string {
+	return fmt.Sprintf("%s%#v%s", yellowCode, str, resetCode)
+}

--- a/huaweicloud/utils/times.go
+++ b/huaweicloud/utils/times.go
@@ -8,14 +8,33 @@ import (
 	"time"
 )
 
-// ConvertTimeStrToNanoTimestamp is a method that used to convert the time in RFC3339 format into the corresponding
-// timestamp (in nanosecond), e.g.
-// Before: 2007-09-02T00:00:00.00000Z
-// After:  1188691200000
-func ConvertTimeStrToNanoTimestamp(timeStr string) int64 {
-	t, err := time.Parse(time.RFC3339, timeStr)
+// ConvertTimeStrToNanoTimestamp is a method that used to convert the time string into the corresponding timestamp (in
+// nanosecond), e.g.
+// The supported time formats are as follows:
+//   - RFC3339 format:
+//     2006-01-02T15:04:05Z (default time format, if you are missing customFormat input)
+//     2006-01-02T15:04:05.000000Z
+//     2006-01-02T15:04:05Z08:00
+//   - Other time formats:
+//     2006-01-02 15:04:05
+//     2006-01-02 15:04:05+08:00
+//     2006-01-02T15:04:05
+//     ...
+//
+// Two common uses are shown below:
+// - ConvertTimeStrToNanoTimestamp("2024-01-01T00:00:00Z")
+// - ConvertTimeStrToNanoTimestamp("2024-01-01T00:00:00+08:00", "2006-01-02T15:04:05Z08:00")
+func ConvertTimeStrToNanoTimestamp(timeStr string, customFormat ...string) int64 {
+	// The default time format is RFC3339.
+	timeFormat := time.RFC3339
+	if len(customFormat) > 0 {
+		timeFormat = customFormat[0]
+	}
+	t, err := time.Parse(timeFormat, timeStr)
 	if err != nil {
-		log.Printf("error parsing time string, it's not RFC3339 format: %s", err)
+		log.Printf("error parsing the input time (%s), the time string does not match time format (%s): %s",
+			timeStr, timeFormat, err)
+		return 0
 	}
 
 	return t.UnixNano() / int64(time.Millisecond)

--- a/huaweicloud/utils/times_test.go
+++ b/huaweicloud/utils/times_test.go
@@ -1,0 +1,43 @@
+package utils_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func TestTimeFunc_ConvertTimeStrToNanoTimestamp(t *testing.T) {
+	var (
+		// Test the function and without the custom time format.
+		defaultTimeInput       = "2024-01-01T00:00:00Z"
+		defaultExpected  int64 = 1704067200000
+
+		timeInputs = [][]interface{}{
+			// timeInput, timeFormat, expected
+			{"2024-01-01T00:00:00Z", "2006-01-02T15:04:05Z", int64(1704067200000)},
+			{"2024-01-01T00:00:00.000000Z", "2006-01-02T15:04:05.000000Z", int64(1704067200000)},
+			{"2024-01-01T00:00:00+08:00", "2006-01-02T15:04:05Z07:00", int64(1704038400000)},
+			{"2024-01-01 00:00:00", "2006-01-02 15:04:05", int64(1704067200000)},
+			{"2024-01-01 00:00:00+08:00", "2006-01-02 15:04:05Z07:00", int64(1704038400000)},
+			{"2024-01-01T00:00:00", "2006-01-02T15:04:05", int64(1704067200000)},
+			{"", "2006-01-02T15:04:05", int64(0)},
+		}
+	)
+
+	// Compatibility test
+	testOutput := utils.ConvertTimeStrToNanoTimestamp(defaultTimeInput)
+	if !reflect.DeepEqual(testOutput, defaultExpected) {
+		t.Fatalf("The processing result of the ConvertTimeStrToNanoTimestamp method is not as expected, want %s, but got %s",
+			utils.Green(defaultExpected), utils.Yellow(testOutput))
+	}
+
+	for _, v := range timeInputs {
+		testOutput := utils.ConvertTimeStrToNanoTimestamp(v[0].(string), v[1].(string))
+		if !reflect.DeepEqual(testOutput, v[2].(int64)) {
+			t.Fatalf("The processing result of the ConvertTimeStrToNanoTimestamp method is not as expected, want %s, but got %s",
+				utils.Green(v[2]), utils.Yellow(testOutput))
+		}
+	}
+	t.Logf("All processing results of the ConvertTimeStrToNanoTimestamp method meets expectation")
+}

--- a/huaweicloud/utils/utils_test.go
+++ b/huaweicloud/utils/utils_test.go
@@ -1,24 +1,9 @@
 package utils
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
-
-const (
-	greenCode  = "\033[1;32m"
-	yellowCode = "\033[1;33m"
-	resetCode  = "\033[0m"
-)
-
-func green(str interface{}) string {
-	return fmt.Sprintf("%s%#v%s", greenCode, str, resetCode)
-}
-
-func yellow(str interface{}) string {
-	return fmt.Sprintf("%s%#v%s", yellowCode, str, resetCode)
-}
 
 func TestAccFunction_RemoveNil(t *testing.T) {
 	var (
@@ -53,9 +38,9 @@ func TestAccFunction_RemoveNil(t *testing.T) {
 
 	testOutput := RemoveNil(testInput)
 	if !reflect.DeepEqual(testOutput, expected) {
-		t.Fatalf("The processing result of RemoveNil method is not as expected, want %s, but %s", green(expected), yellow(testOutput))
+		t.Fatalf("The processing result of RemoveNil method is not as expected, want %s, but %s", Green(expected), Yellow(testOutput))
 	}
-	t.Logf("The processing result of RemoveNil method meets expectation: %s", green(expected))
+	t.Logf("The processing result of RemoveNil method meets expectation: %s", Green(expected))
 }
 
 func TestAccFunction_reverse(t *testing.T) {
@@ -66,9 +51,9 @@ func TestAccFunction_reverse(t *testing.T) {
 
 	if !reflect.DeepEqual(Reverse(testInput), expected) {
 		t.Fatalf("The processing result of the function 'Reverse' is not as expected, want '%s', but got '%s'",
-			green(expected), yellow(testInput))
+			Green(expected), Yellow(testInput))
 	}
-	t.Logf("The processing result of function 'Reverse' meets expectation: %s", green(expected))
+	t.Logf("The processing result of function 'Reverse' meets expectation: %s", Green(expected))
 }
 
 func TestAccFunction_jsonStringsEqual(t *testing.T) {
@@ -79,9 +64,9 @@ func TestAccFunction_jsonStringsEqual(t *testing.T) {
 
 	if !JSONStringsEqual(jsonStr1, jsonStr2) {
 		t.Fatalf("The processing result of the function 'JSONStringsEqual' is not as expected, want '%v', "+
-			"but got '%v'", green(true), yellow(false))
+			"but got '%v'", Green(true), Yellow(false))
 	}
-	t.Logf("The processing result of function 'JSONStringsEqual' meets expectation: %s", green(true))
+	t.Logf("The processing result of function 'JSONStringsEqual' meets expectation: %s", Green(true))
 }
 
 func TestAccFunction_PasswordEncrypt(t *testing.T) {
@@ -90,14 +75,14 @@ func TestAccFunction_PasswordEncrypt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("The encrypted string of %s is %s", password, green(encrypted))
+	t.Logf("The encrypted string of %s is %s", password, Green(encrypted))
 
 	newEncrypted, err := TryPasswordEncrypt(encrypted)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if newEncrypted != encrypted {
-		t.Fatalf("The encrypted string is not as expected, want %s, but %s", green(encrypted), yellow(newEncrypted))
+		t.Fatalf("The encrypted string is not as expected, want %s, but %s", Green(encrypted), Yellow(newEncrypted))
 	}
 }
 
@@ -111,9 +96,9 @@ func TestAccFunction_ConvertMemoryUnit(t *testing.T) {
 	for i, memory := range memories {
 		testOutput := ConvertMemoryUnit(memory, diffLevels[i])
 		if !reflect.DeepEqual(testOutput, expected[i]) {
-			t.Fatalf("The processing result of ConvertMemoryUnit method is not as expected, want %s, but %s", green(expected[i]), yellow(testOutput))
+			t.Fatalf("The processing result of ConvertMemoryUnit method is not as expected, want %s, but %s", Green(expected[i]), Yellow(testOutput))
 		}
-		t.Logf("The processing result of ConvertMemoryUnit method meets expectation: %s", green(expected[i]))
+		t.Logf("The processing result of ConvertMemoryUnit method meets expectation: %s", Green(expected[i]))
 	}
 }
 
@@ -126,8 +111,8 @@ func TestAccFunction_IsUUID(t *testing.T) {
 	for i, idInput := range ids {
 		if isValid := IsUUID(idInput); isValid != expected[i] {
 			t.Fatalf("The processing result of IsUUID method is not as expected, want %s, but %s, the ID is %s",
-				green(expected[i]), yellow(isValid), idInput)
+				Green(expected[i]), Yellow(isValid), idInput)
 		}
-		t.Logf("The processing result of IsUUID method meets expectation: %s", green(expected[i]))
+		t.Logf("The processing result of IsUUID method meets expectation: %s", Green(expected[i]))
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Refactor the color and time convert methods.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. strip all color methods under utils package.
2. refactor the convert method for time package.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
go test -v -run=TestTimeFunc_ConvertTimeStrToNanoTimestamp
=== RUN   TestTimeFunc_ConvertTimeStrToNanoTimestamp
    times_test.go:40: All processing results of the ConvertTimeStrToNanoTimestamp method meets expectation
--- PASS: TestTimeFunc_ConvertTimeStrToNanoTimestamp (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.009s
```
