### PR TITLE
feat(fgs): add datasource to get dependency package versions

### DIFF
--- a/docs/data-sources/fgs_dependencies.md
+++ b/docs/data-sources/fgs_dependencies.md
@@ -55,19 +55,33 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - A data source ID.
 
 * `packages` - All dependent packages that match.
+  The [packages](#dependency_packages) structure is documented below.
 
-  + `id` - Dependent package ID.
+<a name="dependency_packages"></a>
+The `packages` block supports:
 
-  + `name` - Dependent package name.
+* `id` - Dependent package ID.
 
-  + `owner` - Dependent package owner.
+* `name` - Dependent package name.
 
-  + `link` - URL of the dependent package in the OBS console.
+* `owner` - Dependent package owner.
 
-  + `etag` - Unique ID of the dependent package.
+* `link` - URL of the dependent package in the OBS console.
 
-  + `size` - Dependent package size.
+* `etag` - Unique ID of the dependent package.
 
-  + `file_name` - File name of the Dependent package.
+* `size` - Dependent package size.
 
-  + `runtime` - Dependent package runtime.
+* `file_name` - File name of the Dependent package.
+
+* `runtime` - Dependent package runtime.
+
+* `versions` - The list of the versions.
+  The [versions](#dependency_versions) structure is documented below.
+
+<a name="dependency_versions"></a>
+The `versions` block supports:
+
+* `id` - The ID of the dependency package version.
+
+* `version` - The dependency package version.

--- a/docs/data-sources/fgs_dependency_versions.md
+++ b/docs/data-sources/fgs_dependency_versions.md
@@ -1,0 +1,87 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_dependency_versions"
+description: |-
+  Use this data source to get the list of dependency package versions of FGS within HuaweiCloud.
+---
+
+# huaweicloud_fgs_dependency_versions
+
+Use this data source to get the list of dependency package versions of FGS within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "dependency_id" {}
+
+data "huaweicloud_fgs_dependency_versions" "test" {
+  dependency_id = var.dependency_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `dependency_id` - (Required, String) Specifies the ID of the dependency package to which the versions belong.
+
+* `version_id` - (Optional, String) Specifies the ID of the dependency package version.
+
+* `version` - (Optional, Int) Specifies the version of the dependency package.
+
+* `runtime` - (Optional, String) Specifies the runtime of the dependency package version.  
+  The valid values are as follows:
+  + **Java8**
+  + **Java11**
+  + **Node.js6.10**
+  + **Node.js8.10**
+  + **Node.js10.16**
+  + **Node.js12.13**
+  + **Node.js14.18**
+  + **Python2.7**
+  + **Python3.6**
+  + **Python3.9**
+  + **Go1.8**
+  + **Go1.x**
+  + **C#(.NET Core 2.0)**
+  + **C#(.NET Core 2.1)**
+  + **C#(.NET Core 3.1)**
+  + **Custom**
+  + **PHP 7.3**
+  + **http**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `versions` - All dependency package versions that match the filter parameters.
+  The [versions](#dependency_versions) structure is documented below.
+
+<a name="dependency_versions"></a>
+The `versions` block supports:
+
+* `id` - The ID of the dependency package version.
+
+* `version` - The dependency package version.
+
+* `dependency_id` - The ID of the dependency package corresponding to the version.
+
+* `dependency_name` - The name of the dependency package corresponding to the version.
+
+* `runtime` - The runtime of the dependency package version.
+
+* `link` - The OBS bucket path where the dependency package version is located.
+
+* `size` - The size of the ZIP file used by the dependency package version, in bytes.
+
+* `etag` - The unique ID of the dependency.
+
+* `owner` - The dependency owner, `public` indicates a public dependency.
+
+* `description` - The description of the dependency package version.

--- a/docs/resources/fgs_dependency_version.md
+++ b/docs/resources/fgs_dependency_version.md
@@ -87,6 +87,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `size` - The dependency size, in bytes.
 
+* `dependency_id` - The ID of the dependency package.
+
 ## Import
 
 Dependency version can be imported using the resource `id`, e.g.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240514091406-cdd8228b06c2
+	github.com/chnsz/golangsdk v0.0.0-20240515030006-d0907889f8d6
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240514091406-cdd8228b06c2 h1:bf1FB35yK2qys++lrdYxGOTMwZOBqp4jpAbQIh/xFz4=
-github.com/chnsz/golangsdk v0.0.0-20240514091406-cdd8228b06c2/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240515030006-d0907889f8d6 h1:M0iCatz8K1y4r2aMgRSEstp81bEoVp0kn8t3SUjRNLo=
+github.com/chnsz/golangsdk v0.0.0-20240515030006-d0907889f8d6/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -584,6 +584,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_applications":          fgs.DataSourceFunctionGraphApplications(),
 			"huaweicloud_fgs_application_templates": fgs.DataSourceFunctionGraphApplicationTemplates(),
 			"huaweicloud_fgs_dependencies":          fgs.DataSourceFunctionGraphDependencies(),
+			"huaweicloud_fgs_dependency_versions":   fgs.DataSourceDependencieVersions(),
 			"huaweicloud_fgs_functions":             fgs.DataSourceFunctionGraphFunctions(),
 
 			"huaweicloud_ga_accelerators":       ga.DataSourceAccelerators(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -146,9 +146,10 @@ var (
 	// The internet access port to which the Workspace service.
 	HW_WORKSPACE_INTERNET_ACCESS_PORT = os.Getenv("HW_WORKSPACE_INTERNET_ACCESS_PORT")
 
-	HW_FGS_AGENCY_NAME = os.Getenv("HW_FGS_AGENCY_NAME")
-	HW_FGS_TEMPLATE_ID = os.Getenv("HW_FGS_TEMPLATE_ID")
-	HW_FGS_GPU_TYPE    = os.Getenv("HW_FGS_GPU_TYPE")
+	HW_FGS_AGENCY_NAME         = os.Getenv("HW_FGS_AGENCY_NAME")
+	HW_FGS_TEMPLATE_ID         = os.Getenv("HW_FGS_TEMPLATE_ID")
+	HW_FGS_GPU_TYPE            = os.Getenv("HW_FGS_GPU_TYPE")
+	HW_FGS_DEPENDENCY_OBS_LINK = os.Getenv("HW_FGS_DEPENDENCY_OBS_LINK")
 
 	HW_KMS_ENVIRONMENT     = os.Getenv("HW_KMS_ENVIRONMENT")
 	HW_KMS_HSM_CLUSTER_ID  = os.Getenv("HW_KMS_HSM_CLUSTER_ID")
@@ -591,6 +592,13 @@ func TestAccPreCheckFgsTemplateId(t *testing.T) {
 func TestAccPreCheckFgsGpuType(t *testing.T) {
 	if HW_FGS_GPU_TYPE == "" {
 		t.Skip("HW_FGS_GPU_TYPE must be set for FGS acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckFgsDependencyLink(t *testing.T) {
+	if HW_FGS_DEPENDENCY_OBS_LINK == "" {
+		t.Skip("HW_FGS_DEPENDENCY_OBS_LINK must be set for FGS acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependencies_test.go
@@ -44,6 +44,9 @@ func TestAccFunctionGraphDependencies_filterByName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestMatchResourceAttr(byName, "packages.0.versions.#", regexp.MustCompile(`[1-9][0-9]*`)),
+					resource.TestCheckResourceAttrSet(byName, "packages.0.versions.0.id"),
+					resource.TestCheckResourceAttrSet(byName, "packages.0.versions.0.version"),
 					dcNotFound.CheckResourceExists(),
 					resource.TestCheckOutput("not_found_validation_pass", "true"),
 				),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependency_versions_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_dependency_versions_test.go
@@ -1,0 +1,111 @@
+package fgs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDependencyVersions_basic(t *testing.T) {
+	var (
+		rName          = acceptance.RandomAccResourceName()
+		dataSourceName = "data.huaweicloud_fgs_dependency_versions.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byVersionId   = "data.huaweicloud_fgs_dependency_versions.filter_by_version_id"
+		dcByVersionId = acceptance.InitDataSourceCheck(byVersionId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckFgsDependencyLink(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDependencyVersions_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "versions.#"),
+					dcByVersionId.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.id", "huaweicloud_fgs_dependency_version.test", "version_id"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.version", "huaweicloud_fgs_dependency_version.test", "version"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.dependency_id", "huaweicloud_fgs_dependency_version.test",
+						"dependency_id"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.dependency_name", "huaweicloud_fgs_dependency_version.test", "name"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.runtime", "huaweicloud_fgs_dependency_version.test", "runtime"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.link", "huaweicloud_fgs_dependency_version.test", "link"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.size", "huaweicloud_fgs_dependency_version.test", "size"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.etag", "huaweicloud_fgs_dependency_version.test", "etag"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.owner", "huaweicloud_fgs_dependency_version.test", "owner"),
+					resource.TestCheckResourceAttrPair(byVersionId, "versions.0.description", "huaweicloud_fgs_dependency_version.test",
+						"description"),
+					resource.TestCheckOutput("is_version_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_version_filter_useful", "true"),
+					resource.TestCheckOutput("is_runtime_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+func testAccDependencyVersions_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_fgs_dependency_versions" "test" {
+  dependency_id = huaweicloud_fgs_dependency_version.test.dependency_id
+}
+
+// Filter by version ID
+locals {
+  version_id = huaweicloud_fgs_dependency_version.test.version_id
+}
+
+data "huaweicloud_fgs_dependency_versions" "filter_by_version_id" {
+  dependency_id = huaweicloud_fgs_dependency_version.test.dependency_id
+  version_id    = local.version_id
+}
+
+output "is_version_id_filter_useful" {
+  value = length(data.huaweicloud_fgs_dependency_versions.filter_by_version_id.versions) >= 1 && alltrue(
+    [for v in data.huaweicloud_fgs_dependency_versions.filter_by_version_id.versions[*].id : v == local.version_id]
+  )
+}
+
+// Filter by version
+locals {
+  version = huaweicloud_fgs_dependency_version.test.version
+}
+
+data "huaweicloud_fgs_dependency_versions" "filter_by_version" {
+  dependency_id = huaweicloud_fgs_dependency_version.test.dependency_id
+  version       = local.version
+}
+
+output "is_version_filter_useful" {
+  value = length(data.huaweicloud_fgs_dependency_versions.filter_by_version.versions) > 0 && alltrue(
+    [for v in data.huaweicloud_fgs_dependency_versions.filter_by_version.versions[*].version : v == local.version]
+  )
+}
+
+// Filter by runtime
+locals {
+  runtime = data.huaweicloud_fgs_dependency_versions.test.versions[0].runtime
+}
+
+data "huaweicloud_fgs_dependency_versions" "filter_by_runtime" {
+  dependency_id = huaweicloud_fgs_dependency_version.test.dependency_id
+  runtime       = local.runtime
+}
+
+output "is_runtime_filter_useful" {
+  value = length(data.huaweicloud_fgs_dependency_versions.filter_by_runtime.versions) > 0 && alltrue(
+    [for v in data.huaweicloud_fgs_dependency_versions.filter_by_runtime.versions[*].runtime : v == local.runtime]
+  )
+}
+`, testAccDependencyVersion_basic(name, acceptance.HW_FGS_DEPENDENCY_OBS_LINK))
+}

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
@@ -55,6 +55,7 @@ func TestAccDependencyVersion_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
 					resource.TestCheckResourceAttr(resourceName, "runtime", "Python2.7"),
 					resource.TestCheckResourceAttr(resourceName, "link", pkgLocation),
+					resource.TestCheckResourceAttrSet(resourceName, "dependency_id"),
 				),
 			},
 			{

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_dependency_versions.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_dependency_versions.go
@@ -1,0 +1,178 @@
+package fgs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/fgs/dependencies/{depend_id}/version
+func DataSourceDependencieVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDependencieVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"dependency_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the ID of the dependency package to which the versions belong.",
+			},
+			"version_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the ID of the dependency package version.",
+			},
+			"version": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the version of the dependency package.",
+			},
+			"runtime": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the runtime of the dependency package version.",
+			},
+			"versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the dependency package version.",
+						},
+						"version": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The dependency package version.",
+						},
+						"dependency_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the dependency package corresponding to the version.",
+						},
+						"dependency_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the dependency package corresponding to the version.",
+						},
+						"runtime": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The runtime of the dependency package version.",
+						},
+						"link": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The OBS bucket path where the dependency package version is located.",
+						},
+						"size": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The size of the ZIP file used by the dependency package version, in bytes.",
+						},
+						"etag": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique ID of the dependency.",
+						},
+						"owner": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The dependency owner, public indicates a public dependency.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the dependency package version.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDependencieVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.FgsV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+
+	dependencyId := d.Get("dependency_id").(string)
+	listOpts := dependencies.ListVersionsOpts{
+		DependId: dependencyId,
+	}
+	dependencyVersions, err := dependencies.ListVersions(client, listOpts)
+	if err != nil {
+		return diag.Errorf("error retrieving versions under specified dependency package (%s): %s", dependencyId, err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("versions", filterVersions(flattenVersions(dependencyVersions), d)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterVersions(versions []map[string]interface{}, d *schema.ResourceData) []map[string]interface{} {
+	rst := make([]map[string]interface{}, 0, len(versions))
+	for _, v := range versions {
+		if param, ok := d.GetOk("version_id"); ok && fmt.Sprint(param) != v["id"] {
+			continue
+		}
+
+		if param, ok := d.GetOk("version"); ok && param.(int) != v["version"] {
+			continue
+		}
+
+		if param, ok := d.GetOk("runtime"); ok && fmt.Sprint(param) != v["runtime"] {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func flattenVersions(versions []dependencies.DependencyVersion) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(versions))
+	for i, version := range versions {
+		result[i] = map[string]interface{}{
+			"id":              version.ID,
+			"version":         version.Version,
+			"dependency_id":   version.DepId,
+			"dependency_name": version.Name,
+			"runtime":         version.Runtime,
+			"link":            version.Link,
+			"size":            version.Size,
+			"etag":            version.Etag,
+			"owner":           version.Owner,
+			"description":     version.Description,
+		}
+	}
+
+	return result
+}

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
@@ -90,6 +90,11 @@ func ResourceDependencyVersion() *schema.Resource {
 				Computed:    true,
 				Description: "The dependency size, in bytes.",
 			},
+			"dependency_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The ID of the dependency package corresponding to the version.",
+			},
 		},
 	}
 }
@@ -162,6 +167,7 @@ func resourceDependencyVersionRead(_ context.Context, d *schema.ResourceData, me
 		d.Set("owner", resp.Owner),
 		d.Set("version", resp.Version),
 		d.Set("version_id", resp.ID),
+		d.Set("dependency_id", resp.DepId),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error setting resource fields of custom dependency version (%s): %s", d.Id(), err)

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies/requests.go
@@ -197,7 +197,9 @@ func ListVersions(c *golangsdk.ServiceClient, opts ListVersionsOpts) ([]Dependen
 	url += query.String()
 
 	pager := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
-		return DependencyVersionPage{pagination.SinglePageBase(r)}
+		p := DependencyVersionPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
 	})
 	pager.Headers = requestOpts.MoreHeaders
 	pages, err := pager.AllPages()

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies/results.go
@@ -117,7 +117,30 @@ type DependencyVersion struct {
 }
 
 type DependencyVersionPage struct {
-	pagination.SinglePageBase
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no dependent package version.
+func (r DependencyVersionPage) IsEmpty() (bool, error) {
+	versions, err := extractDependencieVersions(r)
+	return len(versions) == 0, err
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (ListResp, error) {
+	var s ListResp
+	err := r.(DependencyVersionPage).Result.ExtractInto(&s)
+	return s, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r DependencyVersionPage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+
+	return strconv.Itoa(resp.Next), nil
 }
 
 func extractDependencieVersions(r pagination.Page) ([]DependencyVersion, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240514091406-cdd8228b06c2
+# github.com/chnsz/golangsdk v0.0.0-20240515030006-d0907889f8d6
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Add attribute parameter `dependency_id` for dependency package version resource.
2. Add attribute parameter `versions` for dependency package datasource.
3. Add new dataSource to get the list of theversions under specified dependency package.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/fgs TESTARGS='-run TestAccDependencyVersion_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccDependencyVersion_basic -timeout 360m -parallel 4

=== RUN   TestAccDependencyVersion_basic
=== PAUSE TestAccDependencyVersion_basic
=== CONT  TestAccDependencyVersion_basic
--- PASS: TestAccDependencyVersion_basic (49.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       51.023s

make testacc TEST=./huaweicloud/services/acceptance/fgs TESTARGS='-run TestAccFunctionGraphDependencies_filterByName'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccFunctionGraphDependencies_filterByName -timeout 360m -parallel 4
=== RUN   TestAccFunctionGraphDependencies_filterByName
=== PAUSE TestAccFunctionGraphDependencies_filterByName
=== CONT  TestAccFunctionGraphDependencies_filterByName
--- PASS: TestAccFunctionGraphDependencies_filterByName (20.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       20.591s

make testacc TEST=./huaweicloud/services/acceptance/fgs TESTARGS='-run TestAccDependencyVersions_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccDependencyVersions_basic -timeout 360m -parallel 4
=== RUN   TestAccDependencyVersions_basic
=== PAUSE TestAccDependencyVersions_basic
=== CONT  TestAccDependencyVersions_basic
--- PASS: TestAccDependencyVersions_basic (50.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       50.937s

```
