### PR TITLE
feat(CDN): cdn domain support new resource to manage cache refresh

### DIFF
--- a/docs/resources/cdn_cache_refresh.md
+++ b/docs/resources/cdn_cache_refresh.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Content Delivery Network (CDN)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_cache_refresh"
+description: |-
+  Manages a CDN cache refresh resource within HuaweiCloud.
+---
+
+# huaweicloud_cdn_cache_refresh
+
+Manages a CDN cache refresh resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "urls" {
+  type = list(string)
+}
+
+resource "huaweicloud_cdn_cache_refresh" "test" {
+  urls = var.urls
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `urls` - (Required, List, ForceNew) Specifies the URLs that need to be refreshed.
+  A URL must start with `http://` or `https://` and must contain the accelerated domain name.
+  A URL can contain up to `4,096` characters. Enter up to `1,000` URLs or `100` directories and separate them by commas (,).
+  Changing this parameter will create a new resource.
+  + When `type` is set to **file**, the value should be file path. Example: `http://www.example.com/file01.html` or
+    `http://www.example.com/`.
+  + When `type` is set to **directory**, the value should be directory path. The URL must end with a slash (/).
+    Example: `http://www.example.com/tt/ee/`.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the accelerated
+  domain name belongs. This parameter is mandatory when you use an IAM user to call this API.
+  For enterprise users, if omitted, default enterprise project will be used.
+
+  Changing this parameter will create a new resource.
+
+* `type` - (Optional, String, ForceNew) Specifies the refresh type. Possible values: **file** and **directory**.
+  Defaults to **file**.
+
+  Changing this parameter will create a new resource.
+
+* `mode` - (Optional, String, ForceNew) Specifies the directory refresh mode. Valid values are:
+  + **all**: Refresh all resources in the directory.
+  + **detect_modify_refresh**: Refresh changed resources in the directory.
+
+  This field is valid only when `type` is set to **directory**. Defaults to **all**.
+  Changing this parameter will create a new resource.
+
+* `zh_url_encode` - (Optional, Bool, ForceNew) Specifies whether to encode Chinese characters in URLs before cache refresh.
+  The value **false** indicates disabled, and **true** indicates enabled. After enabled, cache is refreshed only for
+  transcode URLs. Defaults to **false**.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `status` - The task execution result. Possible values: **task_done** (successful) and **task_inprocess** (processing).
+
+* `created_at` - The creation time.
+
+* `processing` - The number of URLs that are being processed.
+
+* `succeed` - The number of URLs processed.
+
+* `failed` - The number of URLs that failed to be processed.
+
+* `total` - The total number of URLs in historical tasks.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1021,6 +1021,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_domain":         cdn.ResourceCdnDomain(),
 			"huaweicloud_cdn_billing_option": cdn.ResourceBillingOption(),
 			"huaweicloud_cdn_cache_preheat":  cdn.ResourceCachePreheat(),
+			"huaweicloud_cdn_cache_refresh":  cdn.ResourceCacheRefresh(),
 
 			"huaweicloud_ces_alarmrule":      ces.ResourceAlarmRule(),
 			"huaweicloud_ces_resource_group": ces.ResourceResourceGroup(),

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_cache_refresh_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_cache_refresh_test.go
@@ -1,0 +1,88 @@
+package cdn
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getCacheRefreshResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	hcCdnClient, err := cfg.HcCdnV2Client(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CDN v2 client: %s", err)
+	}
+
+	request := &model.ShowHistoryTaskDetailsRequest{
+		EnterpriseProjectId: utils.StringIgnoreEmpty(state.Primary.Attributes["enterprise_project_id"]),
+		HistoryTasksId:      state.Primary.ID,
+	}
+
+	resp, err := hcCdnClient.ShowHistoryTaskDetails(request)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CDN cache refresh: %s", err)
+	}
+
+	if resp == nil {
+		return nil, fmt.Errorf("error retrieving CDN cache refresh: Task is not found in API response")
+	}
+	return resp, nil
+}
+
+func TestAccCacheRefresh_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := "huaweicloud_cdn_cache_refresh.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getCacheRefreshResourceFunc,
+	)
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCDNURL(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testCacheRefresh_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "urls.0", acceptance.HW_CDN_DOMAIN_URL),
+					resource.TestCheckResourceAttr(rName, "type", "directory"),
+					resource.TestCheckResourceAttr(rName, "mode", "detect_modify_refresh"),
+					resource.TestCheckResourceAttr(rName, "zh_url_encode", "true"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+					resource.TestCheckResourceAttrSet(rName, "processing"),
+					resource.TestCheckResourceAttrSet(rName, "succeed"),
+					resource.TestCheckResourceAttrSet(rName, "failed"),
+					resource.TestCheckResourceAttrSet(rName, "total"),
+				),
+			},
+		},
+	})
+}
+
+func testCacheRefresh_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_cdn_cache_refresh" "test" {
+  urls          = ["%s"]
+  type          = "directory"
+  mode          = "detect_modify_refresh"
+  zh_url_encode = true
+}
+`, acceptance.HW_CDN_DOMAIN_URL)
+}

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_refresh.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_cache_refresh.go
@@ -1,0 +1,195 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CDN
+// ---------------------------------------------------------------
+
+package cdn
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN POST /v1.0/cdn/content/refresh-tasks
+// @API CDN GET /v1.0/cdn/historytasks/{history_tasks_id}/detail
+func ResourceCacheRefresh() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCacheRefreshCreate,
+		ReadContext:   resourceCacheRefreshRead,
+		DeleteContext: resourceCacheRefreshDelete,
+
+		Schema: map[string]*schema.Schema{
+			"urls": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the URLs that need to be refreshed.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the enterprise project ID.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the refresh type.`,
+			},
+			"mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the directory refresh mode.`,
+			},
+			"zh_url_encode": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies whether to encode Chinese characters in URLs before cache refresh.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The task execution result.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"processing": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of URLs that are being processed.`,
+			},
+			"succeed": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of URLs processed.`,
+			},
+			"failed": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of URLs that failed to be processed.`,
+			},
+			"total": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The total number of URLs in historical tasks.`,
+			},
+		},
+	}
+}
+
+func resourceCacheRefreshCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	hcCdnClient, err := cfg.HcCdnV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CDN v2 client: %s", err)
+	}
+
+	request := &model.CreateRefreshTasksRequest{
+		EnterpriseProjectId: utils.StringIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
+		Body: &model.RefreshTaskRequest{
+			RefreshTask: &model.RefreshTaskRequestBody{
+				Type:        buildRefreshTaskRequestBodyTypeOpts(d.Get("type").(string)),
+				Mode:        buildRefreshTaskRequestBodyModeOpts(d.Get("mode").(string)),
+				ZhUrlEncode: utils.Bool(d.Get("zh_url_encode").(bool)),
+				Urls:        utils.ExpandToStringList(d.Get("urls").(*schema.Set).List()),
+			},
+		},
+	}
+
+	resp, err := hcCdnClient.CreateRefreshTasks(request)
+	if err != nil {
+		return diag.Errorf("error creating CDN cache refresh: %s", err)
+	}
+
+	if resp == nil || resp.RefreshTask == nil || len(*resp.RefreshTask) == 0 {
+		return diag.Errorf("error creating CDN cache refresh: ID is not found in API response")
+	}
+	d.SetId(*resp.RefreshTask)
+	return resourceCacheRefreshRead(ctx, d, meta)
+}
+
+func buildRefreshTaskRequestBodyTypeOpts(refreshTask string) *model.RefreshTaskRequestBodyType {
+	if refreshTask == "" {
+		return nil
+	}
+
+	refreshTaskToReq := new(model.RefreshTaskRequestBodyType)
+	if err := refreshTaskToReq.UnmarshalJSON([]byte(refreshTask)); err != nil {
+		log.Printf("[WARN] failed to parse task %s: %s", refreshTask, err)
+		return nil
+	}
+	return refreshTaskToReq
+}
+
+func buildRefreshTaskRequestBodyModeOpts(mode string) *model.RefreshTaskRequestBodyMode {
+	if mode == "" {
+		return nil
+	}
+
+	modeToReq := new(model.RefreshTaskRequestBodyMode)
+	if err := modeToReq.UnmarshalJSON([]byte(mode)); err != nil {
+		log.Printf("[WARN] failed to parse mode %s: %s", mode, err)
+		return nil
+	}
+	return modeToReq
+}
+
+func resourceCacheRefreshRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	hcCdnClient, err := cfg.HcCdnV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CDN v2 client: %s", err)
+	}
+
+	request := &model.ShowHistoryTaskDetailsRequest{
+		EnterpriseProjectId: utils.StringIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
+		HistoryTasksId:      d.Id(),
+	}
+
+	resp, err := hcCdnClient.ShowHistoryTaskDetails(request)
+	if err != nil {
+		return diag.Errorf("error retrieving CDN cache refresh: %s", err)
+	}
+
+	if resp == nil {
+		return diag.Errorf("error retrieving CDN cache refresh: Task is not found in API response")
+	}
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(
+		mErr,
+		d.Set("urls", flattenUrls(resp.Urls)),
+		d.Set("type", resp.FileType),
+		d.Set("status", resp.Status),
+		d.Set("created_at", flattenCreatedAt(resp.CreateTime)),
+		d.Set("processing", resp.Processing),
+		d.Set("succeed", resp.Succeed),
+		d.Set("failed", resp.Failed),
+		d.Set("total", resp.Total),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCacheRefreshDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

cdn domain support new resource to manage cache refresh

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCacheRefresh_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCacheRefresh_basic -timeout 360m -parallel 4
=== RUN   TestAccCacheRefresh_basic
=== PAUSE TestAccCacheRefresh_basic
=== CONT  TestAccCacheRefresh_basic
--- PASS: TestAccCacheRefresh_basic (11.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       11.128s
```
