### PR TITLE
feat(apig/plugin): new data source supported for associated res query

### DIFF
--- a/docs/data-sources/apig_api_associated_plugins.md
+++ b/docs/data-sources/apig_api_associated_plugins.md
@@ -1,0 +1,76 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_api_associated_plugins"
+description: |-
+  Use this data source to query the plugins associated with the specified API within HuaweiCloud.
+---
+
+# huaweicloud_apig_api_associated_plugins
+
+Use this data source to query the plugins associated with the specified API within HuaweiCloud.
+
+## Example Usage
+
+### Query the contents of all plugins bound to the current API
+
+```hcl
+variable "instance_id" {}
+variable "associated_api_id" {}
+
+data "huaweicloud_apig_api_associated_plugins" "test" {
+  instance_id = var.instance_id
+  api_id      = var.associated_api_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the associated plugins.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the plugins belong.
+
+* `api_id` - (Required, String) Specifies the ID of the API bound to the plugin.
+
+* `plugin_id` - (Optional, String) Specifies the ID of the plugin.
+
+* `name` - (Optional, String) Specifies the name of the plugin.
+
+* `type` - (Optional, String) Specifies the type of the plugin.
+
+* `env_id` - (Optional, String) Specifies the ID of the environment where the API is published.
+
+* `env_name` - (Optional, String) Specifies the name of the environment where the API is published.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `plugins` - All plugins that match the filter parameters.
+  The [plugins](#api_associated_plugins) structure is documented below.
+
+<a name="api_associated_plugins"></a>
+The `plugins` block supports:
+
+* `id` - The ID of the plugin.
+
+* `name` - The name of the plugin.
+
+* `type` - The type of the plugin.
+
+* `description` - The description of the plugin.
+
+* `content` - The configuration details for the plugin.
+
+* `env_id` - The ID of the environment where the API is published.
+
+* `env_name` - The name of the environment where the API is published.
+
+* `bind_id` - The bind ID.
+
+* `bind_time` - The time that the plugin is bound to the API.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -405,6 +405,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_custom_authorizers":                 apig.DataSourceCustomAuthorizers(),
 			"huaweicloud_apig_api_associated_acl_policies":        apig.DataSourceApiAssociatedAclPolicies(),
 			"huaweicloud_apig_api_associated_applications":        apig.DataSourceApiAssociatedApplications(),
+			"huaweicloud_apig_api_associated_plugins":             apig.DataSourceApiAssociatedPlugins(),
 			"huaweicloud_apig_api_associated_throttling_policies": apig.DataSourceApiAssociatedThrottlingPolicies(),
 			"huaweicloud_apig_api_basic_configurations":           apig.DataSourceApiBasicConfigurations(),
 			"huaweicloud_apig_environments":                       apig.DataSourceEnvironments(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_associated_plugins_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_associated_plugins_test.go
@@ -1,0 +1,393 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceApiAssociatedPlugins_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_apig_api_associated_plugins.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+
+		byId   = "data.huaweicloud_apig_api_associated_plugins.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byName   = "data.huaweicloud_apig_api_associated_plugins.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNotFoundName   = "data.huaweicloud_apig_api_associated_plugins.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+
+		byType   = "data.huaweicloud_apig_api_associated_plugins.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byEnvId   = "data.huaweicloud_apig_api_associated_plugins.filter_by_env_id"
+		dcByEnvId = acceptance.InitDataSourceCheck(byEnvId)
+
+		byEnvName   = "data.huaweicloud_apig_api_associated_plugins.filter_by_env_name"
+		dcByEnvName = acceptance.InitDataSourceCheck(byEnvName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceApiAssociatedPlugins_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "plugins.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.type"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.description"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.content"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.env_id"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.env_name"),
+					resource.TestCheckResourceAttrSet(rName, "plugins.0.bind_id"),
+					resource.TestMatchResourceAttr(rName, "plugins.0.bind_time",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_not_found_filter_useful", "true"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcByEnvId.CheckResourceExists(),
+					resource.TestCheckOutput("is_env_id_filter_useful", "true"),
+					dcByEnvName.CheckResourceExists(),
+					resource.TestCheckOutput("is_env_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceApiAssociatedPlugins_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  system_disk_type   = "SSD"
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_apig_instance.test.id
+}
+
+resource "huaweicloud_apig_channel" "test" {
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  port             = 8000
+  balance_strategy = 2
+  member_type      = "ecs"
+  type             = 2
+
+  health_check {
+    protocol           = "HTTPS"
+    threshold_normal   = 10  # maximum value
+    threshold_abnormal = 10  # maximum value
+    interval           = 300 # maximum value
+    timeout            = 30  # maximum value
+    path               = "/"
+    method             = "HEAD"
+    port               = 8080
+    http_codes         = "201,202,303-404"
+  }
+
+  member {
+    id   = huaweicloud_compute_instance.test.id
+    name = huaweicloud_compute_instance.test.name
+  }
+}
+
+resource "huaweicloud_apig_api" "test" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_age}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+
+  request_params {
+    name     = "user_age"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+  
+  backend_params {
+    type     = "REQUEST"
+    name     = "userAge"
+    location = "PATH"
+    value    = "user_age"
+  }
+
+  web {
+    path             = "/getUserAge/{userAge}"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+
+  web_policy {
+    name             = "%[2]s_policy1"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getUserAge/{userAge}"
+    timeout          = 30000
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "userAge"
+      location = "PATH"
+      value    = "user_age"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_age"
+      type       = "Equal"
+      value      = "28"
+    }
+  }
+}
+
+resource "huaweicloud_apig_environment" "test" {
+  count = 2
+
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_${count.index}"
+}
+
+resource "huaweicloud_apig_api_publishment" "test" {
+  count = 2
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+  env_id      = huaweicloud_apig_environment.test[count.index].id
+}
+
+resource "huaweicloud_apig_plugin" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_cors"
+  type        = "cors"
+  description = "Created by terraform script"
+  content     = jsonencode(
+    {
+      allow_origin      = "*"
+      allow_methods     = "GET,PUT,DELETE,HEAD,PATCH"
+      allow_headers     = "Content-Type,Accept,Cache-Control"
+      expose_headers    = "X-Request-Id,X-Apig-Latency"
+      max_age           = 12700
+      allow_credentials = true
+    }
+  )
+}
+
+resource "huaweicloud_apig_plugin_associate" "test" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.test
+  ]
+
+  count = 2
+
+  instance_id = huaweicloud_apig_instance.test.id
+  plugin_id   = huaweicloud_apig_plugin.test.id
+  env_id      = huaweicloud_apig_environment.test[count.index].id
+  api_ids     = [huaweicloud_apig_api.test.id]
+}
+`, common.TestBaseComputeResources(name), name)
+}
+
+func testAccDataSourceApiAssociatedPlugins_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_api_associated_plugins" "test" {
+  depends_on = [
+    huaweicloud_apig_plugin_associate.test,
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+}
+
+# Filter by ID
+locals {
+  plugin_id = data.huaweicloud_apig_api_associated_plugins.test.plugins[0].id
+}
+
+data "huaweicloud_apig_api_associated_plugins" "filter_by_id" {
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  plugin_id = local.plugin_id
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_plugins.filter_by_id.plugins[*].id : v == local.plugin_id
+  ]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+}
+
+# Filter by name
+locals {
+  plugin_name = data.huaweicloud_apig_api_associated_plugins.test.plugins[0].name
+}
+
+data "huaweicloud_apig_api_associated_plugins" "filter_by_name" {
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  name = local.plugin_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_plugins.filter_by_name.plugins[*].name : v == local.plugin_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by name (not found)
+locals {
+  not_found_name = "not_found"
+}
+
+data "huaweicloud_apig_api_associated_plugins" "filter_by_not_found_name" {
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  name = local.not_found_name
+}
+
+locals {
+  not_found_name_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_plugins.filter_by_not_found_name.plugins[*].name : strcontains(v, local.not_found_name)
+  ]
+}
+
+output "is_name_not_found_filter_useful" {
+  value = length(local.not_found_name_filter_result) == 0
+}
+
+# Filter by type
+locals {
+  plugin_type = data.huaweicloud_apig_api_associated_plugins.test.plugins[0].type
+}
+
+data "huaweicloud_apig_api_associated_plugins" "filter_by_type" {
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  type = local.plugin_type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_plugins.filter_by_type.plugins[*].type : v == local.plugin_type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+# Filter by env ID
+locals {
+  env_id = data.huaweicloud_apig_api_associated_plugins.test.plugins[0].env_id
+}
+
+data "huaweicloud_apig_api_associated_plugins" "filter_by_env_id" {
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  env_id = local.env_id
+}
+
+locals {
+  env_id_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_plugins.filter_by_env_id.plugins[*].env_id : v == local.env_id
+  ]
+}
+
+output "is_env_id_filter_useful" {
+  value = length(local.env_id_filter_result) > 0 && alltrue(local.env_id_filter_result)
+}
+
+# Filter by env name
+locals {
+  env_name = data.huaweicloud_apig_api_associated_plugins.test.plugins[0].env_name
+}
+
+data "huaweicloud_apig_api_associated_plugins" "filter_by_env_name" {
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.test.id
+
+  env_name = local.env_name
+}
+
+locals {
+  env_name_filter_result = [
+    for v in data.huaweicloud_apig_api_associated_plugins.filter_by_env_name.plugins[*].env_name : v == local.env_name
+  ]
+}
+
+output "is_env_name_filter_useful" {
+  value = length(local.env_name_filter_result) > 0 && alltrue(local.env_name_filter_result)
+}
+`, testAccDataSourceApiAssociatedPlugins_base())
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_api_associated_plugins.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_api_associated_plugins.go
@@ -1,0 +1,233 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/app-auths/binded-apps
+func DataSourceApiAssociatedPlugins() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApiAssociatedPluginsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the plugins belong.`,
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the API bound to the plugin.`,
+			},
+			"plugin_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the plugin.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the plugin.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the plugin.`,
+			},
+			"env_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the environment where the API is published.`,
+			},
+			"env_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the environment where the API is published.`,
+			},
+			"plugins": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `All plugins that match the filter parameters.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the plugin.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the plugin.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the plugin.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the plugin.`,
+						},
+						"content": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The configuration details for the plugin.`,
+						},
+						"env_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the environment where the API is published.`,
+						},
+						"env_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the environment where the API is published.`,
+						},
+						"bind_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The bind ID.`,
+						},
+						"bind_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time that the plugin is bound to the API.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildListApiAssociatedPluginsParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("env_id"); ok {
+		res = fmt.Sprintf("%s&env_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("env_name"); ok {
+		res = fmt.Sprintf("%s&env_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("plugin_id"); ok {
+		res = fmt.Sprintf("%s&plugin_id=%v", res, v)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&plugin_name=%v", res, v)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&plugin_type=%v", res, v)
+	}
+	return res
+}
+
+func queryApiAssociatedPlugins(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/apis/{api_id}/attached-plugins?limit=100"
+		instanceId = d.Get("instance_id").(string)
+		apiId      = d.Get("api_id").(string)
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{api_id}", apiId)
+
+	queryParams := buildListApiAssociatedPluginsParams(d)
+	listPath += queryParams
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving associated plugins (bound to the API: %s) under specified "+
+				"dedicated instance (%s): %s", apiId, instanceId, err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		plugins := utils.PathSearch("plugins", respBody, make([]interface{}, 0)).([]interface{})
+		if len(plugins) < 1 {
+			break
+		}
+		result = append(result, plugins...)
+		offset += len(plugins)
+	}
+	return result, nil
+}
+
+func dataSourceApiAssociatedPluginsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+	plugins, err := queryApiAssociatedPlugins(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("plugins", flattenAssociatedPlugins(plugins)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAssociatedPlugins(plugins []interface{}) []interface{} {
+	if len(plugins) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(plugins))
+	for _, plugin := range plugins {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("plugin_id", plugin, nil),
+			"name":        utils.PathSearch("plugin_name", plugin, nil),
+			"type":        utils.PathSearch("plugin_type", plugin, nil),
+			"description": utils.PathSearch("remark", plugin, nil),
+			"content":     utils.PathSearch("plugin_content", plugin, nil),
+			"env_id":      utils.PathSearch("env_id", plugin, nil),
+			"env_name":    utils.PathSearch("env_name", plugin, nil),
+			"bind_id":     utils.PathSearch("plugin_attach_id", plugin, nil),
+			"bind_time":   utils.PathSearch("attached_time", plugin, nil),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a new data source to query associated plugins.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. new data source supported for associated res query
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccDataSourceApiAssociatedPlugins_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccDataSourceApiAssociatedPlugins_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceApiAssociatedPlugins_basic
=== PAUSE TestAccDataSourceApiAssociatedPlugins_basic
=== CONT  TestAccDataSourceApiAssociatedPlugins_basic
--- PASS: TestAccDataSourceApiAssociatedPlugins_basic (660.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      660.832s
```
