### PR TITLE
feat(apig): add new datasource get instance supported features

### DIFF
--- a/docs/data-sources/apig_instance_supported_features.md
+++ b/docs/data-sources/apig_instance_supported_features.md
@@ -1,0 +1,38 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_instance_supported_features"
+description: |-
+  Use this data source to get the list of supported features under the APIG instance within HuaweiCloud.
+---
+
+# huaweicloud_apig_instance_supported_features
+
+Use this data source to get the list of supported features under the APIG instance within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_apig_instance_supported_features" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) The ID of the dedicated instance to which the features belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `features` - All names of the supported features that match the filter parameters.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -413,6 +413,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_custom_authorizers":                 apig.DataSourceCustomAuthorizers(),
 			"huaweicloud_apig_environments":                       apig.DataSourceEnvironments(),
 			"huaweicloud_apig_groups":                             apig.DataSourceGroups(),
+			"huaweicloud_apig_instance_supported_features":        apig.DataSourceInstanceSupportedFeatures(),
 			"huaweicloud_apig_instances":                          apig.DataSourceInstances(),
 			"huaweicloud_apig_signatures":                         apig.DataSourceSignatures(),
 			"huaweicloud_apig_throttling_policies":                apig.DataSourceThrottlingPolicies(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_supported_features_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instance_supported_features_test.go
@@ -1,0 +1,45 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceInstanceSupportedFeatures_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_apig_instance_supported_features.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceInstanceSupportedFeatures_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "features.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceInstanceSupportedFeatures_basic() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_apig_instance_supported_features" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+}
+`, testAccInstanceFeature_base(name))
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_supported_features.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_instance_supported_features.go
@@ -1,0 +1,106 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/instance-features
+func DataSourceInstanceSupportedFeatures() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInstanceSupportedFeaturesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the features belong.`,
+			},
+			"features": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `All names of the supported features that match the filter parameters.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func queryInstanceSupportedFeatures(client *golangsdk.ServiceClient, instanceId string) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/instance-features?limit=500"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving features supported by dedicated instance (%s): %s", instanceId, err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		features := utils.PathSearch("features", respBody, make([]interface{}, 0)).([]interface{})
+		if len(features) < 1 {
+			break
+		}
+		result = append(result, features...)
+		offset += len(features)
+	}
+	return result, nil
+}
+
+func dataSourceInstanceSupportedFeaturesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+	features, err := queryInstanceSupportedFeatures(client, instanceId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("features", features),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource get instance supported features of the dedicated APIG.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

1. add new datasource to get the list of the specified instance supported features under the APIG.
2. add corresponding document and acceptance test.

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccDataSourceInstanceSupportedFeatures_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccDataSourceInstanceSupportedFeatures_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceInstanceSupportedFeatures_basic
=== PAUSE TestAccDataSourceInstanceSupportedFeatures_basic
=== CONT  TestAccDataSourceInstanceSupportedFeatures_basic
--- PASS: TestAccDataSourceInstanceSupportedFeatures_basic (517.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      517.516s
```
