### PR TITLE
fix(dli/privilege): splicing object when query privileges for database type

### DIFF
--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_privilege_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_privilege_test.go
@@ -18,8 +18,9 @@ func getDatabasePrivilegeResourceFunc(cfg *config.Config, state *terraform.Resou
 		return nil, fmt.Errorf("error creating DLI client: %s", err)
 	}
 
-	return dli.GetObjectPrivilegesForSpecifiedUser(client, state.Primary.Attributes["object"],
+	_, privilege, err := dli.GetObjectPrivilegesForSpecifiedUser(client, state.Primary.Attributes["object"],
 		state.Primary.Attributes["user_name"])
+	return privilege, err
 }
 
 func TestAccDatabasePrivilege_basic(t *testing.T) {
@@ -27,7 +28,7 @@ func TestAccDatabasePrivilege_basic(t *testing.T) {
 		obj interface{}
 
 		name        = acceptance.RandomAccResourceName()
-		rNameToUser = "huaweicloud_dli_database_privilege.grant_user"
+		rNameToUser = "huaweicloud_dli_database_privilege.test"
 
 		rcToUser = acceptance.InitResourceCheck(rNameToUser, &obj, getDatabasePrivilegeResourceFunc)
 	)
@@ -93,7 +94,7 @@ func testDatabasePrivilege_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_dli_database_privilege" "grant_user" {
+resource "huaweicloud_dli_database_privilege" "test" {
   object    = format("databases.%%s.tables.%%s", huaweicloud_dli_database.test.name, huaweicloud_dli_table.test.name)
   user_name = "%[2]s" # Make sure the user has correct permissions and has logged in to the DLI console.
 }
@@ -104,12 +105,82 @@ func testDatabasePrivilege_basic_step2(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_dli_database_privilege" "grant_user" {
+resource "huaweicloud_dli_database_privilege" "test" {
   object    = format("databases.%%s.tables.%%s", huaweicloud_dli_database.test.name, huaweicloud_dli_table.test.name)
   user_name = "%[2]s" # Make sure the user has correct permissions and has logged in to the DLI console.
 
   privileges = [
     "SELECT", "DESCRIBE_TABLE", "DISPLAY_TABLE"
+  ]
+}
+`, testDatabasePrivilege_base(name), acceptance.HW_DLI_AUTHORIZED_USER_NAME)
+}
+
+func TestAccDatabasePrivilege_database(t *testing.T) {
+	var (
+		obj interface{}
+
+		name        = acceptance.RandomAccResourceName()
+		rNameToUser = "huaweicloud_dli_database_privilege.test"
+
+		rcToUser = acceptance.InitResourceCheck(rNameToUser, &obj, getDatabasePrivilegeResourceFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliAuthorizedUserConfigured(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rcToUser.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDatabasePrivilege_database_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Resource that authorized IAM user.
+					rcToUser.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameToUser, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
+					resource.TestCheckResourceAttr(rNameToUser, "privileges.#", "1"),
+					resource.TestCheckResourceAttr(rNameToUser, "privileges.0", "SELECT"),
+				),
+			},
+			{
+				Config: testDatabasePrivilege_database_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rcToUser.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameToUser, "privileges.#", "3"),
+				),
+			},
+			{
+				ResourceName:      rNameToUser,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDatabasePrivilege_database_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dli_database_privilege" "test" {
+  object    = format("databases.%%s", huaweicloud_dli_database.test.name)
+  user_name = "%[2]s" # Make sure the user has correct permissions and has logged in to the DLI console.
+}
+`, testDatabasePrivilege_base(name), acceptance.HW_DLI_AUTHORIZED_USER_NAME)
+}
+
+func testDatabasePrivilege_database_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dli_database_privilege" "test" {
+  object    = format("databases.%%s", huaweicloud_dli_database.test.name)
+  user_name = "%[2]s" # Make sure the user has correct permissions and has logged in to the DLI console.
+
+  privileges = [
+    "SELECT", "CREATE_TABLE", "EXPLAIN"
   ]
 }
 `, testDatabasePrivilege_base(name), acceptance.HW_DLI_AUTHORIZED_USER_NAME)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Splicing object when query privileges for database type and saving to the object parameter because of the
object value will not be included in the structure 'privileges' if the grant object type is database,
but the strings that make up the object will be returned in the upper structure, which are 'object_type' and 'object_name'.

Type for database object, the query result is:
```
{
  "count": 2,
  "is_success": true,
  "message": "",
  "object_name": "tf_test_randx",
  "object_type": "database",
  "privileges": [
    {
      "is_admin": false,
      "privileges": [
        "SELECT"
      ],
      "user_name": "tf-user13"
    },
    {
      "is_admin": false,
      "privileges": [
        "ALL"
      ],
      "user_name": "servicestage"
    }
  ]
}
```

Type for data table object, the query result is:
```
{
  "action": "grant",
  "privileges": [
    {
      "object": "databases.tf_test_randx.tables.tf_test_randx",
      "privileges": [
        "SPARK_APP_ACCESS_META",
        "SELECT"
      ]
    }
  ],
  "user_name": "tf-user13"
}
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. splicing object when query privileges for database type.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dli' TESTARGS='-run=TestAccDatabasePrivilege'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dli -v -run=TestAccDatabasePrivilege -timeout 360m -parallel 4
=== RUN   TestAccDatabasePrivilege_basic
=== PAUSE TestAccDatabasePrivilege_basic
=== RUN   TestAccDatabasePrivilege_database
=== PAUSE TestAccDatabasePrivilege_database
=== CONT  TestAccDatabasePrivilege_basic
=== CONT  TestAccDatabasePrivilege_database
--- PASS: TestAccDatabasePrivilege_database (45.29s)
--- PASS: TestAccDatabasePrivilege_basic (57.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       57.350s
```
