### PR TITLE
fix(error): do not using %#v to return errors

### DIFF
--- a/huaweicloud/services/aad/resource_huaweicloud_aad_forward_rule.go
+++ b/huaweicloud/services/aad/resource_huaweicloud_aad_forward_rule.go
@@ -186,7 +186,7 @@ func resourceForwardRuleUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 	err = rules.Update(client, instanceId, advancedIp, ruleId, opts)
 	if err != nil {
-		return diag.Errorf("error updating Advanced Anti-DDoS forward rule (%s): %#v", ruleId, err)
+		return diag.Errorf("error updating Advanced Anti-DDoS forward rule (%s): %v", ruleId, err)
 	}
 	return resourceForwardRuleRead(ctx, d, meta)
 }
@@ -208,7 +208,7 @@ func resourceForwardRuleDelete(_ context.Context, d *schema.ResourceData, meta i
 	}
 	_, err = rules.BatchDelete(client, instanceId, advancedIp, opts)
 	if err != nil {
-		return diag.Errorf("error deleting Advanced Anti-DDoS forward rule (%s): %#v", ruleId, err)
+		return diag.Errorf("error deleting Advanced Anti-DDoS forward rule (%s): %v", ruleId, err)
 	}
 	return nil
 }

--- a/huaweicloud/services/ccm/resource_huaweicloud_scm_certificate.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_scm_certificate.go
@@ -385,7 +385,7 @@ func processErr(err error) string {
 			"Bad request with: [%s %s], error message: %s", err500.Method, err500.URL, errBody)
 	} else {
 		// If 'err' is other error object, the default information will be printed.
-		log.Printf("[ERROR] Push certificate service error: %s, \n%#v", err.Error(), err)
+		log.Printf("[ERROR] Push certificate service error: %s, \n%v", err.Error(), err)
 		errMsg = fmt.Sprintf("push certificate service error: %s", err)
 	}
 	return errMsg

--- a/huaweicloud/services/cdm/resource_huaweicloud_cdm_job.go
+++ b/huaweicloud/services/cdm/resource_huaweicloud_cdm_job.go
@@ -285,7 +285,7 @@ func resourceCdmJobRead(_ context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	rst, gErr := job.Get(client, clusterId, jobName, job.GetJobsOpts{})
-	log.Printf("[DEBUG] read CDM job opts: %#v", gErr)
+	log.Printf("[DEBUG] read CDM job opts: %v", gErr)
 
 	if gErr != nil {
 		return common.CheckDeletedDiag(d, parseCdmJobErrorToError404(gErr), "Error retrieving CDM job")

--- a/huaweicloud/services/css/resource_huaweicloud_css_scan_task.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_scan_task.go
@@ -352,7 +352,7 @@ func flattenScanTaskSummaryResponse(resp interface{}) []interface{} {
 	var rst []interface{}
 	curJson, err := jmespath.Search("summary", resp)
 	if err != nil {
-		log.Printf("[WARN] error parsing summary object from response: %#v", err)
+		log.Printf("[WARN] error parsing summary object from response: %v", err)
 		return rst
 	}
 

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_instance.go
@@ -961,7 +961,7 @@ func waitForOrderComplete(ctx context.Context, d *schema.ResourceData, cfg *conf
 	err = common.WaitOrderComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return fmt.Errorf("[DEBUG] error the order is not completed while "+
-			"creating DCS instance. %s : %#v", d.Id(), err)
+			"creating DCS instance. %s : %v", d.Id(), err)
 	}
 	_, err = common.WaitOrderResourceComplete(ctx, bssClient, orderId, d.Timeout(schema.TimeoutCreate))
 	return err
@@ -980,7 +980,7 @@ func waitForDcsInstanceCompleted(ctx context.Context, c *golangsdk.ServiceClient
 	}
 	_, err := stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return fmt.Errorf("[DEBUG] error while waiting to create/resize/delete DCS instance. %s : %#v",
+		return fmt.Errorf("[DEBUG] error while waiting to create/resize/delete DCS instance. %s : %v",
 			id, err)
 	}
 	return nil

--- a/huaweicloud/services/deprecated/resource_huaweicloud_vpc_route_v2.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_vpc_route_v2.go
@@ -159,7 +159,7 @@ func waitForVpcRouteDelete(vpcRouteClient *golangsdk.ServiceClient, routeId stri
 		}
 
 		err = routes.Delete(vpcRouteClient, routeId).ExtractErr()
-		log.Printf("[DEBUG] Value if error: %#v", err)
+		log.Printf("[DEBUG] Value if error: %v", err)
 
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
@@ -868,7 +868,7 @@ func flattenGetDwsClusterRespBodyElb(resp interface{}) []interface{} {
 	var rst []interface{}
 	curJson, err := jmespath.Search("cluster.elb", resp)
 	if err != nil {
-		log.Printf("[WARN] error parsing elb object from response: %#v", err)
+		log.Printf("[WARN] error parsing elb object from response: %v", err)
 		return rst
 	}
 

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_instance.go
@@ -1166,7 +1166,7 @@ func resourceComputeInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 			}
 			err = common.WaitOrderComplete(ctx, bssClient, resp.OrderID, d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
-				return diag.Errorf("The order (%s) is not completed while extending system disk (%s) size: %#v",
+				return diag.Errorf("The order (%s) is not completed while extending system disk (%s) size: %v",
 					resp.OrderID, serverID, err)
 			}
 		}

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -430,7 +430,7 @@ func resourceLoadBalancerV3Create(ctx context.Context, d *schema.ResourceData, m
 		}
 		err = common.WaitOrderComplete(ctx, bssClient, resp.OrderID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return diag.Errorf("the order is not completed while creating ELB LoadBalancer (%s): %#v", resp.LoadBalancerID, err)
+			return diag.Errorf("the order is not completed while creating ELB LoadBalancer (%s): %v", resp.LoadBalancerID, err)
 		}
 		resourceId, err := common.WaitOrderResourceComplete(ctx, bssClient, resp.OrderID,
 			d.Timeout(schema.TimeoutCreate))
@@ -848,7 +848,7 @@ func updateLoadBalancer(ctx context.Context, d *schema.ResourceData, cfg *config
 		}
 		err = common.WaitOrderComplete(ctx, bssClient, resp.OrderID, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.Errorf("the order is not completed while updating ELB LoadBalancer (%s): %#v",
+			return diag.Errorf("the order is not completed while updating ELB LoadBalancer (%s): %v",
 				resp.LoadBalancerID, err)
 		}
 	} else {

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume.go
@@ -303,7 +303,7 @@ func resourceEvsVolumeCreate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 		err = common.WaitOrderComplete(ctx, bssClient, job.OrderID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return diag.Errorf("the order is not completed while creating EVS volume (%s): %#v", d.Id(), err)
+			return diag.Errorf("the order is not completed while creating EVS volume (%s): %v", d.Id(), err)
 		}
 		_, err = common.WaitOrderAllResourceComplete(ctx, bssClient, job.OrderID, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
@@ -566,7 +566,7 @@ func resourceEvsVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta i
 			}
 			err = common.WaitOrderComplete(ctx, bssClient, resp.OrderID, d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
-				return diag.Errorf("the order (%s) is not completed while extending EVS volume (%s) size: %#v",
+				return diag.Errorf("the order (%s) is not completed while extending EVS volume (%s) size: %v",
 					resp.OrderID, d.Id(), err)
 			}
 		}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_log_converge_switch.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_log_converge_switch.go
@@ -52,16 +52,16 @@ func modifyLogConvergeConfigsMessageSwitch(client *golangsdk.ServiceClient, swit
 	}
 	requestResp, err := client.Request("PUT", getPath, &opts)
 	if err != nil {
-		return fmt.Errorf("failed to enable log receiving status (target: %v): %#v", switchTarget, err)
+		return fmt.Errorf("failed to enable log receiving status (target: %v): %s", switchTarget, err)
 	}
 
 	respBody, err := utils.FlattenResponse(requestResp)
 	if err != nil {
-		return fmt.Errorf("error retrieving API response body: %#v", err)
+		return fmt.Errorf("error retrieving API response body: %v", err)
 	}
 	requestResult := utils.PathSearch("result", respBody, nil)
 	if requestResult != "success" {
-		return fmt.Errorf("failed to enable log receiving status (target: %v), but the result of API request is: %#v",
+		return fmt.Errorf("failed to enable log receiving status (target: %v), but the result of API request is: %v",
 			switchTarget, requestResult)
 	}
 	return nil

--- a/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
+++ b/huaweicloud/services/obs/resource_huaweicloud_obs_bucket.go
@@ -1694,7 +1694,7 @@ func deleteAllBucketObjects(obsClient *obs.ObsClient, bucket string) error {
 		return getObsError("Error deleting all objects of OBS bucket", bucket, err)
 	}
 	if len(output.Errors) > 0 {
-		return fmt.Errorf("error some objects are still exist in %s: %#v", bucket, output.Errors)
+		return fmt.Errorf("error some objects are still exist in %s: %v", bucket, output.Errors)
 	}
 	return nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_cloud_instance.go
@@ -451,7 +451,7 @@ func updateExtendedPackages(ctx context.Context, wafClient *golangsdk.ServiceCli
 
 		err = common.WaitOrderComplete(ctx, bssClient, *orderId, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf("the order is not completed while creating extended packages: %#v", err)
+			return fmt.Errorf("the order is not completed while creating extended packages: %v", err)
 		}
 	}
 
@@ -463,7 +463,7 @@ func updateExtendedPackages(ctx context.Context, wafClient *golangsdk.ServiceCli
 
 		err = common.WaitOrderComplete(ctx, bssClient, *orderId, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return fmt.Errorf("the order is not completed while updating extended packages: %#v", err)
+			return fmt.Errorf("the order is not completed while updating extended packages: %v", err)
 		}
 	}
 
@@ -508,7 +508,7 @@ func resourceCloudInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 		err = common.WaitOrderComplete(ctx, bssClient, *orderId, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return diag.Errorf("the order is not completed while updating specification code: %#v", err)
+			return diag.Errorf("the order is not completed while updating specification code: %v", err)
 		}
 	}
 

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
@@ -223,7 +223,7 @@ func resourceDedicatedInstanceCreate(ctx context.Context, d *schema.ResourceData
 		err = updateInstanceName(client, r.Instances[0].Id, d.Get("name").(string), epsId)
 	}
 	if err != nil {
-		logp.Printf("[DEBUG] Error while waiting to create  Waf dedicated instance. %s : %#v", d.Id(), err)
+		logp.Printf("[DEBUG] Error while waiting to create  Waf dedicated instance. %s : %v", d.Id(), err)
 		return diag.FromErr(err)
 	}
 
@@ -365,7 +365,7 @@ func resourceDedicatedInstanceDelete(ctx context.Context, d *schema.ResourceData
 	}
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		logp.Printf("[DEBUG] Error while waiting to delete Waf dedicated instance. \n%s : %#v", d.Id(), err)
+		logp.Printf("[DEBUG] Error while waiting to delete Waf dedicated instance. \n%s : %v", d.Id(), err)
 		return diag.FromErr(err)
 	}
 	d.SetId("")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We shouldn't use `%#v` to return errors, because:

If we are using `%#v` to return the errors, that wil be display as follows:
```bash
golangsdk.ErrDefault404{ErrUnexpectedResponseCode:golangsdk.ErrUnexpectedResponseCode{BaseError:golangsdk.BaseError{DefaultErrString:"", Info:""}, URL:"https://lts.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/groupsAAA", Method:"POST", RequestId:"b40a49a488c19fe32be285b44e7d2e91", Expected:[]int{200, 201, 202}, Actual:404, Body:[]uint8{0x7b, 0x22, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x6d, 0x73, 0x67, 0x22, 0x3a, 0x22, 0x54, 0x68, 0x65, 0x20, 0x41, 0x50, 0x49, 0x20, 0x64, 0x6f, 0x65, 0x73, 0x20, 0x6e, 0x6f, 0x74, 0x20, 0x65, 0x78, 0x69, 0x73, 0x74, 0x20, 0x6f, 0x72, 0x20, 0x68, 0x61, 0x73, 0x20, 0x6e, 0x6f, 0x74, 0x20, 0x62, 0x65, 0x65, 0x6e, 0x20, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x73, 0x68, 0x65, 0x64, 0x20, 0x69, 0x6e, 0x20, 0x74, 0x68, 0x65, 0x20, 0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x22, 0x2c, 0x22, 0x65, 0x72, 0x72, 0x6f, 0x72, 0x5f, 0x63, 0x6f, 0x64, 0x65, 0x22, 0x3a, 0x22, 0x41, 0x50, 0x49, 0x47, 0x57, 0x2e, 0x30, 0x31, 0x30, 0x31, 0x22, 0x2c, 0x22, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x5f, 0x69, 0x64, 0x22, 0x3a, 0x22, 0x62, 0x34, 0x30, 0x61, 0x34, 0x39, 0x61, 0x34, 0x38, 0x38, 0x63, 0x31, 0x39, 0x66, 0x65, 0x33, 0x32, 0x62, 0x65, 0x32, 0x38, 0x35, 0x62, 0x34, 0x34, 0x65, 0x37, 0x64, 0x32, 0x65, 0x39, 0x31, 0x22, 0x7d, 0xa}}}: timestamp="2024-05-16T16:40:36.426+0800"
```
If we are using `%v` to return the errors, that wil be display as follows:
```bash
Resource not found: [POST https://lts.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/groupsAAA], request_id: b40a49a488c19fe32be285b44e7d2e91, error message: {"error_msg":"The API does not exist or has not been published in the environment","error_code":"APIGW.0101","request_id":"b40a49a488c19fe32be285b44e7d2e91"}: timestamp="2024-05-16T16:40:36.426+0800"
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
we shouldn't use `%#v` to return errors in codes.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
