### PR TITLE
feat(dds): support setting client network ranges for instance

### DIFF
--- a/docs/resources/dds_instance.md
+++ b/docs/resources/dds_instance.md
@@ -134,6 +134,12 @@ The following arguments are supported:
   It must be `3` to `128` characters long and start with a letter. It is case-sensitive and can contain only letters,
   digits, and underscores (_). Default is **replica**.
 
+* `client_network_ranges` - (Optional, List) Specifies the CIDR block where the client is located. Cross-CIDR access is
+  required only when the CIDR blocks of the client and the replica set instance are different. For example, if the client
+  CIDR block is 192.168.0.0/16 and the replica set instance's CIDR block is 172.16.0.0/24, add the CIDR block
+  192.168.0.0/16 so that the client can access the replica set instance.
+  It's only for replica set instance.
+
 * `ssl` - (Optional, Bool) Specifies whether to enable or disable SSL. Defaults to true.
 
 **NOTE:** The instance will be restarted in the background when switching SSL. Please operate with caution.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240515030006-d0907889f8d6
+	github.com/chnsz/golangsdk v0.0.0-20240517015606-20a97b5700f9
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240515030006-d0907889f8d6 h1:M0iCatz8K1y4r2aMgRSEstp81bEoVp0kn8t3SUjRNLo=
-github.com/chnsz/golangsdk v0.0.0-20240515030006-d0907889f8d6/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240517015606-20a97b5700f9 h1:HoI4LpdHh49BYkrtzeiUK0f9WRMY5Jab47qc4d0HZaY=
+github.com/chnsz/golangsdk v0.0.0-20240517015606-20a97b5700f9/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -286,6 +286,7 @@ func TestAccDDSV3Instance_withConfigurationReplicaSet(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "replica_set_name", "replicaName"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.0.type", "replica"),
+					resource.TestCheckResourceAttr(resourceName, "client_network_ranges.0", "192.168.0.0/24"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration.0.id", "huaweicloud_dds_parameter_template.replica1", "id"),
 				),
 			},
@@ -1061,18 +1062,19 @@ func testAccDDSInstanceV3Config_withReplicaSetConfiguration(rName string) string
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_dds_instance" "instance" {
-  name              = "%[3]s"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  vpc_id            = huaweicloud_vpc.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  password          = "Terraform@123"
-  mode              = "ReplicaSet"
-  replica_set_name  = "replicaName"
+  name                  = "%[3]s"
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  password              = "Terraform@123"
+  mode                  = "ReplicaSet"
+  replica_set_name      = "replicaName"
+  client_network_ranges = ["192.168.0.0/24"]
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
   configuration {
@@ -1112,7 +1114,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
   configuration {

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/requests.go
@@ -350,6 +350,10 @@ type ChangeMaintenanceWindowOpts struct {
 	EndTime   string `json:"end_time" required:"true"`
 }
 
+type UpdateClientNetworkOpts struct {
+	ClientNetworkRanges *[]string `json:"client_network_ranges" required:"true"`
+}
+
 // UpdateReplicaSetName is a method to update the replica set name.
 func UpdateReplicaSetName(c *golangsdk.ServiceClient, instanceId string, opts ReplicaSetNameOpts) (*CommonResp, error) {
 	b, err := golangsdk.BuildRequestBody(opts, "")
@@ -428,8 +432,7 @@ func UpdateMaintenanceWindow(c *golangsdk.ServiceClient, instanceId string, opts
 		return err
 	}
 
-	var r ChangeMaintenanceWindowOpts
-	_, err = c.Put(maintenanceWindowURL(c, instanceId), b, &r, &golangsdk.RequestOpts{
+	_, err = c.Put(maintenanceWindowURL(c, instanceId), b, nil, &golangsdk.RequestOpts{
 		MoreHeaders: requestOpts.MoreHeaders,
 		OkCodes: []int{
 			204,
@@ -468,4 +471,26 @@ func GetBalancer(c *golangsdk.ServiceClient, instanceId string) (*BalancerResp, 
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
 	return &r, err
+}
+
+// GetClientNetWorkRanges is a method to get the client network ranges.
+func GetClientNetWorkRanges(c *golangsdk.ServiceClient, instanceId string) (*UpdateClientNetworkOpts, error) {
+	var r UpdateClientNetworkOpts
+	_, err := c.Get(clientNetworkRangesURL(c, instanceId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
+}
+
+// UpdateClientNetWorkRanges is a method to update client network ranges.
+func UpdateClientNetWorkRanges(c *golangsdk.ServiceClient, instanceId string, opts UpdateClientNetworkOpts) error {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = c.Post(clientNetworkRangesURL(c, instanceId), b, nil, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dds/v3/instances/urls.go
@@ -65,3 +65,7 @@ func balancerSwitchURL(c *golangsdk.ServiceClient, instanceId, action string) st
 func balancerActiveWindowURL(c *golangsdk.ServiceClient, instanceId string) string {
 	return c.ServiceURL("instances", instanceId, "balancer/active-window")
 }
+
+func clientNetworkRangesURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "client-network")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240515030006-d0907889f8d6
+# github.com/chnsz/golangsdk v0.0.0-20240517015606-20a97b5700f9
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support setting client network ranges for instance

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_withConfigurationReplicaSet"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withConfigurationReplicaSet -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withConfigurationReplicaSet
=== PAUSE TestAccDDSV3Instance_withConfigurationReplicaSet
=== CONT  TestAccDDSV3Instance_withConfigurationReplicaSet
--- PASS: TestAccDDSV3Instance_withConfigurationReplicaSet (1939.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       1940.048s
```
