### PR TITLE
fix(GaussDB): fix gaussdb mysql restore time ranges

### DIFF
--- a/docs/data-sources/gaussdb_mysql_restore_time_ranges.md
+++ b/docs/data-sources/gaussdb_mysql_restore_time_ranges.md
@@ -2,7 +2,8 @@
 subcategory: "GaussDB(for MySQL)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_gaussdb_mysql_restore_time_ranges"
-description: ""
+description: |-
+  Use this data source to get the list of GaussDB MySQL restore time ranges.
 ---
 
 # huaweicloud_gaussdb_mysql_restore_time_ranges
@@ -12,8 +13,11 @@ Use this data source to get the list of GaussDB MySQL restore time ranges.
 ## Example Usage
 
 ```hcl
+variable "instance_id" {}
+
 data "huaweicloud_gaussdb_mysql_restore_time_ranges" "test" {
-    date = "2024-04-07"
+    instance_id = var.instance_id
+    date        = "2024-04-07"
 }
 ```
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix gaussdb mysql restore time ranges
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix gaussdb mysql restore time ranges
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccDataSourceGaussdbMysqlRestoreTimeRanges_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccDataSourceGaussdbMysqlRestoreTimeRanges_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceGaussdbMysqlRestoreTimeRanges_basic
=== PAUSE TestAccDataSourceGaussdbMysqlRestoreTimeRanges_basic
=== CONT  TestAccDataSourceGaussdbMysqlRestoreTimeRanges_basic
--- PASS: TestAccDataSourceGaussdbMysqlRestoreTimeRanges_basic (1684.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1684.645s
```
