### PR TITLE
fix(dws/cluster): status 417 is returned when deleting the only existing cluster

### DIFF
--- a/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
@@ -440,6 +440,7 @@ func resourceLogicalClusterDelete(ctx context.Context, d *schema.ResourceData, m
 	deleteOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
+		OkCodes:          []int{200, 202, 204, 417},
 	}
 
 	// When the cluster is operated concurrently, the deletion operation may also fail and needs to be retried.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When deleting a logical cluster and the number of logical clusters is 1, the status code returned by the deletion interface is 417.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Add more allowed status codes for delete method.
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
NONE
```
