### PR TITLE
chore(dds): change name from recovery to restore

### DIFF
--- a/docs/resources/dds_instance_restore.md
+++ b/docs/resources/dds_instance_restore.md
@@ -1,39 +1,39 @@
 ---
 subcategory: "Document Database Service (DDS)"
 layout: "huaweicloud"
-page_title: "HuaweiCloud: huaweicloud_dds_instance_recovery"
+page_title: "HuaweiCloud: huaweicloud_dds_instance_restore"
 description: |-
-  Manages a DDS instance recovery resource within HuaweiCloud.
+  Manages a DDS instance restore resource within HuaweiCloud.
 ---
 
-# huaweicloud_dds_instance_recovery
+# huaweicloud_dds_instance_restore
 
-Manages a DDS instance recovery resource within HuaweiCloud.
+Manages a DDS instance restore resource within HuaweiCloud.
 
 ## Example Usage
 
-### Recovery insatnce by backup ID
+### Restore insatnce by backup ID
 
 ```hcl
 variable "source_id" {}
 variable "backup_id" {}
 variable "target_id" {}
 
-resource "huaweicloud_dds_instance_recovery" "test" {
+resource "huaweicloud_dds_instance_restore" "test" {
   source_id = var.source_id
   backup_id = var.backup_id
   target_id = var.target_id
 }
 ```
 
-### Recovery insatnce by time stamp
+### Restore insatnce by time stamp
 
 ```hcl
 variable "source_id" {}
 variable "restore_time" {}
 variable "target_id" {}
 
-resource "huaweicloud_dds_instance_recovery" "test" {
+resource "huaweicloud_dds_instance_restore" "test" {
   source_id    = var.source_id
   restore_time = var.restore_time
   target_id    = var.target_id

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1112,7 +1112,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_instance_restart":            dds.ResourceDDSInstanceRestart(),
 			"huaweicloud_dds_instance_internal_ip_modify": dds.ResourceDDSInstanceModifyIP(),
 			"huaweicloud_dds_instance_eip_associate":      dds.ResourceDDSInstanceBindEIP(),
-			"huaweicloud_dds_instance_recovery":           dds.ResourceDDSInstanceRecovery(),
+			"huaweicloud_dds_instance_restore":            dds.ResourceDDSInstanceRestore(),
 			"huaweicloud_dds_instance_parameters_modify":  dds.ResourceDDSInstanceParametersModify(),
 
 			"huaweicloud_ddm_instance":               ddm.ResourceDdmInstance(),
@@ -1631,6 +1631,7 @@ func Provider() *schema.Provider {
 
 			// Legacy
 			"huaweicloud_networking_eip_associate": eip.ResourceEIPAssociate(),
+			"huaweicloud_dds_instance_recovery":    dds.ResourceDDSInstanceRestore(),
 
 			"huaweicloud_projectman_project": codearts.ResourceProject(),
 			"huaweicloud_codehub_repository": codearts.ResourceRepository(),

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_restore_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_restore_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func TestAccDDSV3InstanceRecovery_basic(t *testing.T) {
+func TestAccDDSV3InstanceRestore_basic(t *testing.T) {
 	rName := acceptance.RandomAccResourceName()
 
 	// Avoid CheckDestroy
@@ -20,13 +20,13 @@ func TestAccDDSV3InstanceRecovery_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDDSInstanceRecovery_basic(rName),
+				Config: testAccDDSInstanceRestore_basic(rName),
 			},
 		},
 	})
 }
 
-func testAccDDSInstanceRecovery_basic(rName string) string {
+func testAccDDSInstanceRestore_basic(rName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -41,16 +41,16 @@ resource "huaweicloud_dds_backup" "test" {
   name        = "%s"
 }
 
-resource "huaweicloud_dds_instance_recovery" "test" {
+resource "huaweicloud_dds_instance_restore" "test" {
   depends_on = [huaweicloud_dds_instance.instance1, huaweicloud_dds_backup.test]
 
   target_id = huaweicloud_dds_instance.instance1.id
   source_id = huaweicloud_dds_instance.instance2.id
   backup_id = huaweicloud_dds_backup.test.id
-}`, common.TestBaseNetwork(rName), testAccDDSInstanceRecoveryBase(rName, 1), testAccDDSInstanceRecoveryBase(rName, 2), rName)
+}`, common.TestBaseNetwork(rName), testAccDDSInstanceRestoreBase(rName, 1), testAccDDSInstanceRestoreBase(rName, 2), rName)
 }
 
-func testAccDDSInstanceRecoveryBase(rName string, i int) string {
+func testAccDDSInstanceRestoreBase(rName string, i int) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dds_instance" "instance%[1]v" {
   name              = "%[2]s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Change name from `huaweicloud_dds_instance_recovery` to `huaweicloud_dds_instance_restore`.

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3InstanceRestore_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3InstanceRestore_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSV3InstanceRestore_basic
=== PAUSE TestAccDDSV3InstanceRestore_basic
=== CONT  TestAccDDSV3InstanceRestore_basic
--- PASS: TestAccDDSV3InstanceRestore_basic (2136.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       2136.416s
```
