### PR TITLE
feat(CDN): cdn domain support new datasource to query cache url tasks

### DIFF
--- a/docs/data-sources/cdn_cache_url_tasks.md
+++ b/docs/data-sources/cdn_cache_url_tasks.md
@@ -1,0 +1,66 @@
+---
+subcategory: Content Delivery Network (CDN)
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_cache_url_tasks"
+description: ""
+---
+
+# huaweicloud_cdn_cache_url_tasks
+
+Use this data source to get CDN cache url tasks.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cdn_cache_url_tasks" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `start_time` - (Optional, Int) Specifies the start timestamp, in milliseconds. The default value is 00:00 of the
+  current day.
+
+* `end_time` - (Optional, Int) Specifies the end timestamp, in milliseconds. The default value is 00:00 of the next day.
+
+* `url` - (Optional, String) Specifies the refresh or preheat URL.
+
+* `task_type` - (Optional, String) Specifies the task type. Possible values: **REFRESH** (cache refresh) and
+  **PREHEATING** (cache preheat).
+
+* `status` - (Optional, String) Specifies the URL status. Possible values: **processing**, **succeed**, **failed**,
+  **waiting**, **refreshing**, and **preheating**.
+
+* `file_type` - (Optional, String) Specifies the file type. Possible values: **file** and **directory**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tasks` - The list of URL task information. The [tasks](#CacheUrlTasks_tasks) structure is documented below.
+
+<a name="CacheUrlTasks_tasks"></a>
+The `tasks` block supports:
+
+* `id` - Indicates the URL ID.
+
+* `url` - Indicates the URL.
+
+* `status` - Indicates the URL status. Possible values: **processing**, **succeed**, **failed**, **waiting**,
+  **refreshing**, and **preheating**.
+
+* `task_type` - Indicates the task type. Possible values: **REFRESH** (cache refresh) and **PREHEATING** (cache preheat).
+
+* `mode` - Indicates the directory refresh mode. Possible values: **all** (refresh all resources in the directory) and
+  **detect_modify_refresh** (refresh changed resources in the directory).
+
+* `task_id` - Indicates the task ID.
+
+* `modify_time` - Indicates the modification time.
+
+* `created_at` - Indicates the creation time.
+
+* `file_type` - Indicates the file type. Possible values: **file** and **directory**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -468,6 +468,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_domain_statistics":   cdn.DataSourceStatistics(),
 			"huaweicloud_cdn_domains":             cdn.DataSourceCdnDomains(),
 			"huaweicloud_cdn_domain_certificates": cdn.DataSourceDomainCertificates(),
+			"huaweicloud_cdn_cache_url_tasks":     cdn.DataSourceCacheUrlTasks(),
 
 			"huaweicloud_cfw_firewalls":             cfw.DataSourceFirewalls(),
 			"huaweicloud_cfw_address_groups":        cfw.DataSourceCfwAddressGroups(),

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_cache_url_tasks_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_cache_url_tasks_test.go
@@ -1,0 +1,135 @@
+package cdn
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCacheUrlTasks_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_cdn_cache_url_tasks.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCDNURL(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCacheUrlTasks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.url"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.task_type"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.task_id"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.modify_time"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.file_type"),
+
+					resource.TestCheckOutput("time_filter_is_useful", "true"),
+					resource.TestCheckOutput("url_filter_is_useful", "true"),
+					resource.TestCheckOutput("task_type_filter_is_useful", "true"),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+					resource.TestCheckOutput("file_type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCacheUrlTasks_basic() string {
+	now := time.Now()
+	startTime := now.Add(-1 * time.Hour).UnixMilli()
+	endTime := now.Add(time.Hour).UnixMilli()
+
+	return fmt.Sprintf(`
+%[1]s
+
+# Basic test
+data "huaweicloud_cdn_cache_url_tasks" "test" {
+  depends_on = [huaweicloud_cdn_cache_preheat.test]
+}
+
+# Test with start time and end time
+data "huaweicloud_cdn_cache_url_tasks" "time_filter" {
+  start_time = "%[2]d"
+  end_time   = "%[3]d"
+
+  depends_on = [huaweicloud_cdn_cache_preheat.test]
+}
+
+output "time_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_url_tasks.time_filter.tasks) > 0
+}
+
+# Test with URL
+locals {
+  url = data.huaweicloud_cdn_cache_url_tasks.test.tasks[0].url
+}
+
+data "huaweicloud_cdn_cache_url_tasks" "url_filter" {
+  url = local.url
+}
+
+output "url_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_url_tasks.url_filter.tasks) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_cache_url_tasks.url_filter.tasks[*].url : v == local.url]
+  )  
+}
+
+# Test with task type
+locals {
+  task_type = data.huaweicloud_cdn_cache_url_tasks.test.tasks[0].task_type
+}
+
+data "huaweicloud_cdn_cache_url_tasks" "task_type_filter" {
+  task_type = local.task_type
+}
+
+output "task_type_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_url_tasks.task_type_filter.tasks) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_cache_url_tasks.task_type_filter.tasks[*].task_type : v == local.task_type]
+  )  
+}
+
+# Test with status
+locals {
+  status = data.huaweicloud_cdn_cache_url_tasks.test.tasks[0].status
+}
+
+data "huaweicloud_cdn_cache_url_tasks" "status_filter" {
+  status = local.status
+}
+
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_url_tasks.status_filter.tasks) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_cache_url_tasks.status_filter.tasks[*].status : v == local.status]
+  )  
+}
+
+# Test with file type
+locals {
+  file_type = data.huaweicloud_cdn_cache_url_tasks.test.tasks[0].file_type
+}
+
+data "huaweicloud_cdn_cache_url_tasks" "file_type_filter" {
+  file_type = local.file_type
+}
+
+output "file_type_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_url_tasks.file_type_filter.tasks) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_cache_url_tasks.file_type_filter.tasks[*].file_type : v == local.file_type]
+  )  
+}
+`, testCachePreheat_basic(), startTime, endTime)
+}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_url_tasks.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_url_tasks.go
@@ -1,0 +1,193 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CDN
+// ---------------------------------------------------------------
+
+package cdn
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN GET /v1.0/cdn/contentgateway/url-tasks
+func DataSourceCacheUrlTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceCacheUrlTasksRead,
+		Schema: map[string]*schema.Schema{
+			"start_time": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the start timestamp, in milliseconds.`,
+			},
+			"end_time": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the end timestamp, in milliseconds.`,
+			},
+			"url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the refresh or preheat URL.`,
+			},
+			"task_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the task type.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the URL status.`,
+			},
+			"file_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the file type.`,
+			},
+			"tasks": {
+				Type:        schema.TypeList,
+				Elem:        cacheUrlTasksSchema(),
+				Computed:    true,
+				Description: `The list of URL task information.`,
+			},
+		},
+	}
+}
+
+func cacheUrlTasksSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The URL ID.`,
+			},
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URL.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URL status.`,
+			},
+			"task_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The task type.`,
+			},
+			"mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The directory refresh mode.`,
+			},
+			"task_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The task ID.`,
+			},
+			"modify_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The modification time.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"file_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The file type.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceCacheUrlTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		limit    = int32(100)
+		offset   int32
+		respUrls []model.Urls
+		mErr     *multierror.Error
+	)
+
+	hcCdnClient, err := cfg.HcCdnV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CDN v2 client: %s", err)
+	}
+
+	request := &model.ShowUrlTaskInfoRequest{
+		StartTime: utils.Int64IgnoreEmpty(int64(d.Get("start_time").(int))),
+		EndTime:   utils.Int64IgnoreEmpty(int64(d.Get("end_time").(int))),
+		Limit:     utils.Int32(limit),
+		Url:       utils.StringIgnoreEmpty(d.Get("url").(string)),
+		TaskType:  utils.StringIgnoreEmpty(d.Get("task_type").(string)),
+		Status:    utils.StringIgnoreEmpty(d.Get("status").(string)),
+		FileType:  utils.StringIgnoreEmpty(d.Get("file_type").(string)),
+	}
+
+	for {
+		request.Offset = utils.Int32(offset)
+		resp, err := hcCdnClient.ShowUrlTaskInfo(request)
+		if err != nil {
+			return diag.Errorf("error retrieving CDN cache url tasks: %s", err)
+		}
+
+		if resp == nil || resp.Result == nil || len(*resp.Result) == 0 {
+			break
+		}
+		respUrls = append(respUrls, *resp.Result...)
+		offset += limit
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("tasks", flattenCacheUrlTasks(respUrls)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCacheUrlTasks(respUrls []model.Urls) []interface{} {
+	if len(respUrls) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respUrls))
+	for _, v := range respUrls {
+		rst = append(rst, map[string]interface{}{
+			"id":          v.Id,
+			"url":         v.Url,
+			"status":      v.Status,
+			"task_type":   v.Type,
+			"mode":        v.Mode,
+			"task_id":     v.TaskId,
+			"modify_time": flattenCreatedAt(v.ModifyTime),
+			"created_at":  flattenCreatedAt(v.CreateTime),
+			"file_type":   v.FileType,
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

cdn domain support new datasource to query cache url tasks

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceCacheUrlTasks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceCacheUrlTasks_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCacheUrlTasks_basic
=== PAUSE TestAccDatasourceCacheUrlTasks_basic
=== CONT  TestAccDatasourceCacheUrlTasks_basic
--- PASS: TestAccDatasourceCacheUrlTasks_basic (36.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       36.973s
```
