### PR TITLE
feat(apig): add new resource support configuring instance feature

### DIFF
--- a/docs/resources/apig_instance_feature.md
+++ b/docs/resources/apig_instance_feature.md
@@ -1,0 +1,68 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_instance_feature"
+description: |-
+  Manages an APIG instance feature resource within HuaweiCloud.
+---
+
+# huaweicloud_apig_instance_feature
+
+Manages an APIG instance feature resource within HuaweiCloud.
+
+-> For various types of feature parameter configurations, please refer to the
+   [documentation](https://support.huaweicloud.com/intl/en-us/api-apig/apig-api-20200402.html).
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_apig_instance_feature" "test" {
+  instance_id = var.instance_id
+  name        = "ratelimit"
+  enabled     = true
+
+  config = jsonencode({
+    api_limits = 300
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specified the ID of the dedicated instance to which the feature belongs.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specified the name of the feature.
+  Changing this creates a new resource.
+
+* `enabled` - (Optional, Bool) Specified whether to enable the feature. Default value is `false`.
+
+* `config` - (Optional, String) Specified the detailed configuration of the feature.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is the feature name.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+
+## Import
+
+The resource can be imported using `instance_id` and `name`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_apig_instance_feature.test <instance_id>/<name>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -953,6 +953,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_environment":                 apig.ResourceApigEnvironmentV2(),
 			"huaweicloud_apig_environment_variable":        apig.ResourceEnvironmentVariable(),
 			"huaweicloud_apig_group":                       apig.ResourceApigGroupV2(),
+			"huaweicloud_apig_instance_feature":            apig.ResourceInstanceFeature(),
 			"huaweicloud_apig_instance_routes":             apig.ResourceInstanceRoutes(),
 			"huaweicloud_apig_instance":                    apig.ResourceApigInstanceV2(),
 			"huaweicloud_apig_plugin_associate":            apig.ResourcePluginAssociate(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_feature_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_feature_test.go
@@ -1,0 +1,137 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func getInstanceFeatureFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.ApigV2Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
+	}
+
+	return apig.GetInstanceFeature(client, state.Primary.Attributes["instance_id"], state.Primary.ID)
+}
+
+func TestAccInstanceFeature_basic(t *testing.T) {
+	var (
+		feature interface{}
+		rName   = "huaweicloud_apig_instance_feature.test"
+		name    = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&feature,
+		getInstanceFeatureFunc,
+	)
+
+	// Avoid CheckDestroy because this resource already exists and does not need to be deleted.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceFeature_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", "ratelimit"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "config", "{\"api_limits\":200}"),
+				),
+			},
+			{
+				Config: testAccInstanceFeature_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", "ratelimit"),
+					resource.TestCheckResourceAttr(rName, "config", "{\"api_limits\":300}"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccInstanceFeatureResourceImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func testAccInstanceFeatureResourceImportStateFunc(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		instanceId := rs.Primary.Attributes["instance_id"]
+		featureName := rs.Primary.ID
+		if instanceId == "" || featureName == "" {
+			return "", fmt.Errorf("missing some attributes, want '<instance_id>/<name>', but '%s/%s'",
+				instanceId, featureName)
+		}
+		return fmt.Sprintf("%s/%s", instanceId, featureName), nil
+	}
+}
+
+func testAccInstanceFeature_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+  availability_zones    = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccInstanceFeature_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_instance_feature" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "ratelimit"
+  enabled     = true
+
+  config = jsonencode({
+    api_limits = 200
+  })
+}
+`, testAccInstanceFeature_base(name))
+}
+
+func testAccInstanceFeature_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_apig_instance_feature" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "ratelimit"
+  enabled     = true
+
+  config = jsonencode({
+    api_limits = 300
+  })
+}
+`, testAccInstanceFeature_base(name))
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
@@ -1,0 +1,264 @@
+package apig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/features
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/features
+func ResourceInstanceFeature() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInstanceFeatureCreate,
+		ReadContext:   resourceInstanceFeatureRead,
+		UpdateContext: resourceInstanceFeatureUpdate,
+		DeleteContext: resourceInstanceFeatureDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceInstanceFeatureImportState,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Specified the ID of the dedicated instance to which the feature belongs.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Specified the name of the feature.",
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Specified whether to enable the feature.",
+			},
+			// The format is `config="off"` or `config={\"max_timeout\":80000}`
+			"config": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specified the detailed configuration of the feature.",
+			},
+		},
+	}
+}
+
+func updateFeatureConfiguration(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData,
+	instanceId, name string) (*http.Response, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/features"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{instance_id}", instanceId)
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildConfigInstanceFeatureParams(name, d.Get("enabled"), d.Get("config"))),
+	}
+	// The same configuration feature can only be modified once per minute.
+	var resp *http.Response
+	var reqErr error
+	err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		resp, reqErr = client.Request("POST", path, &opts)
+		isRetry, err := handleOperationError409(reqErr)
+		if isRetry {
+			// lintignore:R018
+			time.Sleep(30 * time.Second)
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	return resp, err
+}
+
+func resourceInstanceFeatureCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		instanceId = d.Get("instance_id").(string)
+		name       = d.Get("name").(string)
+	)
+	client, err := cfg.NewServiceClient("apig", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG Client: %s", err)
+	}
+
+	createResp, err := updateFeatureConfiguration(ctx, client, d, instanceId, name)
+	if err != nil {
+		return diag.Errorf("error creating instance feature: %s", err)
+	}
+
+	creatRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	featureName, err := jmespath.Search("name", creatRespBody)
+	if err != nil {
+		return diag.Errorf("error creating feature (%s) configuration under specified instance (%s): %s", name, instanceId, err)
+	}
+
+	d.SetId(featureName.(string))
+	return resourceInstanceFeatureRead(ctx, d, meta)
+}
+
+func handleOperationError409(err error) (bool, error) {
+	if err == nil {
+		return false, nil
+	}
+	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
+		var apiError interface{}
+		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
+			return false, jsonErr
+		}
+
+		errCode, searchErr := jmespath.Search("error_code", apiError)
+		if searchErr != nil {
+			return false, err
+		}
+
+		// APIG.3711: A configuration parameter can be modified only once per minute.
+		if errCode == "APIG.3711" {
+			return true, err
+		}
+	}
+	return false, err
+}
+
+func buildConfigInstanceFeatureParams(featrueName string, enabled, cfg interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"name":   featrueName,
+		"enable": enabled.(bool),
+		"config": utils.ValueIngoreEmpty(cfg.(string)),
+	}
+}
+
+// GetInstanceFeature is a method that used to query the list of the features under specified APIG instance.
+func GetInstanceFeature(client *golangsdk.ServiceClient, instanceId, featureName string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/features?limit=500"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	offset := 0
+	var feature interface{}
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		features := utils.PathSearch("features", respBody, make([]interface{}, 0)).([]interface{})
+		if len(features) < 1 {
+			break
+		}
+
+		if feature = utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0]", featureName), features, nil); feature != nil {
+			return feature, nil
+		}
+		offset += len(features)
+	}
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func resourceInstanceFeatureRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		instanceId = d.Get("instance_id").(string)
+	)
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG Client: %s", err)
+	}
+
+	feature, err := GetInstanceFeature(client, instanceId, d.Id())
+	if err != nil {
+		// When instance ID not exist, status code is 404, error code id APIG.3030
+		return common.CheckDeletedDiag(d, err, "Instance feature configuration")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("name", utils.PathSearch("name", feature, nil)),
+		d.Set("enabled", utils.PathSearch("enable", feature, false)),
+		d.Set("config", utils.PathSearch("config", feature, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceInstanceFeatureUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		instanceId  = d.Get("instance_id").(string)
+		featureName = d.Get("name").(string)
+	)
+	client, err := cfg.ApigV2Client(cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	_, err = updateFeatureConfiguration(ctx, client, d, instanceId, featureName)
+	if err != nil {
+		return diag.Errorf("error creating instance feature: %s", err)
+	}
+	if err != nil {
+		return diag.Errorf("error updating feature (%s) under specified instance (%s): %s", featureName, instanceId, err)
+	}
+
+	return resourceInstanceFeatureRead(ctx, d, meta)
+}
+
+func resourceInstanceFeatureDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceInstanceFeatureImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want <instance_id>/<name>, but got '%s'", importedId)
+	}
+
+	mErr := multierror.Append(
+		d.Set("instance_id", parts[0]),
+	)
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource support configuring instance feature.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

When creating a resource, a status code of 409 will appear, as shown in the figure below, so the public method `resource.RetryContext` is called to process the logic
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/b6b27fe9-6412-42c1-b9f4-fd30ec5e1ebd)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource support configuring instance feature.
2. add corresponsing document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccInstanceFeature_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccInstanceFeature_basic -timeout 360m -parallel 4
=== RUN   TestAccInstanceFeature_basic
=== PAUSE TestAccInstanceFeature_basic
=== CONT  TestAccInstanceFeature_basic
--- PASS: TestAccInstanceFeature_basic (575.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      575.292s
```
