### PR TITLE
feat(CDN): cdn domain support new datasource to query cache history tasks

### DIFF
--- a/docs/data-sources/cdn_cache_history_tasks.md
+++ b/docs/data-sources/cdn_cache_history_tasks.md
@@ -1,0 +1,83 @@
+---
+subcategory: Content Delivery Network (CDN)
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cdn_cache_history_tasks"
+description: "Use this data source to get CDN cache history tasks."
+---
+
+# huaweicloud_cdn_cache_history_tasks
+
+Use this data source to get CDN cache history tasks.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cdn_cache_history_tasks" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the resource belongs.
+  This parameter is valid only when the enterprise project function is enabled. The value **all** indicates all projects.
+  This parameter is mandatory when you are an IAM user.
+  For enterprise users, if omitted, default enterprise project will be used.
+
+* `status` - (Optional, String) Specifies the task status. Valid values are as follows:
+  + **task_inprocess**: The task is being processed.
+  + **task_done**: The task is completed.
+
+* `start_date` - (Optional, Int) Specifies the query start time. The value is the number of milliseconds since
+  the UNIX epoch (Jan 1, 1970).
+
+* `end_date` - (Optional, Int) Specifies the query end time. The value is the number of milliseconds since
+  the UNIX epoch (Jan 1, 1970).
+
+* `order_field` - (Optional, String) Specifies the field used for sorting. Supported fields include
+  **task_type** (task type), **total** (total number of URLs), **processing** (number of URLs that are being processed),
+  **succeed** (number of processed URLs), **failed** (number of URLs that fail to be processed),
+  and **create_time** (task creation time). Both `order_field` and `order_type` must be set together.
+  Otherwise, the default values **create_time** and **desc** are used.
+
+* `order_type` - (Optional, String) Specifies the sorting type. Valid values are as follows:
+  + **desc**: Descending order.
+  + **asc**: Ascending order.
+
+  Defaults to **desc**.
+
+* `file_type` - (Optional, String) Specifies the file type. Possible values: **file** and **directory**.
+
+* `task_type` - (Optional, String) Specifies the task type. Possible values: **refresh** (cache refresh) and
+  **preheating** (cache preheat).
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `tasks` - The history task list.
+  The [tasks](#CacheHistoryTasks_tasks) structure is documented below.
+
+<a name="CacheHistoryTasks_tasks"></a>
+The `tasks` block supports:
+
+* `id` - Indicates the task ID.
+
+* `status` - Indicates the task result. Possible values: **task_done** (task is completed) and
+  **task_inprocess** (task is being processed).
+
+* `processing` - Indicates the number of URLs that are being processed.
+
+* `succeed` - Indicates the number of URLs processed.
+
+* `failed` - Indicates the number of URLs that failed to be processed.
+
+* `total` - Indicates the total number of URLs in the task.
+
+* `task_type` - Indicates the task type. Possible values: **refresh** (cache refresh) and **preheating** (cache preheat).
+
+* `created_at` - Indicates the time when the task was created.
+
+* `file_type` - Indicates the file type. Possible values: **file** and **directory**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -469,6 +469,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_cdn_domains":             cdn.DataSourceCdnDomains(),
 			"huaweicloud_cdn_domain_certificates": cdn.DataSourceDomainCertificates(),
 			"huaweicloud_cdn_cache_url_tasks":     cdn.DataSourceCacheUrlTasks(),
+			"huaweicloud_cdn_cache_history_tasks": cdn.DataSourceCacheHistoryTasks(),
 
 			"huaweicloud_cfw_firewalls":             cfw.DataSourceFirewalls(),
 			"huaweicloud_cfw_address_groups":        cfw.DataSourceCfwAddressGroups(),

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_cache_history_tasks_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_cache_history_tasks_test.go
@@ -1,0 +1,148 @@
+package cdn
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceCacheHistoryTasks_basic(t *testing.T) {
+	rName := "data.huaweicloud_cdn_cache_history_tasks.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCDNURL(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCacheHistoryTasks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.id"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.processing"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.succeed"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.failed"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.total"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.task_type"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.created_at"),
+					resource.TestCheckResourceAttrSet(rName, "tasks.0.file_type"),
+
+					resource.TestCheckOutput("enterprise_project_id_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("date_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("order_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("file_type_filter_is_useful", "true"),
+
+					resource.TestCheckOutput("task_type_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCacheHistoryTasks_basic() string {
+	now := time.Now()
+	startDate := now.Add(-1 * time.Hour).UnixMilli()
+	endDate := now.Add(time.Hour).UnixMilli()
+
+	return fmt.Sprintf(`
+%[1]s
+
+# Basic test
+data "huaweicloud_cdn_cache_history_tasks" "test" {
+  depends_on = [huaweicloud_cdn_cache_preheat.test]
+}
+
+# Test with enterprise project ID
+data "huaweicloud_cdn_cache_history_tasks" "enterprise_project_id_filter" {
+  enterprise_project_id = "all"
+
+  depends_on = [huaweicloud_cdn_cache_preheat.test]
+}
+
+output "enterprise_project_id_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_history_tasks.enterprise_project_id_filter.tasks) > 0
+}
+
+# Test with status
+locals {
+  status = data.huaweicloud_cdn_cache_history_tasks.test.tasks[0].status
+}
+
+data "huaweicloud_cdn_cache_history_tasks" "status_filter" {
+  status = local.status
+}
+
+output "status_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_history_tasks.status_filter.tasks) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_cache_history_tasks.status_filter.tasks[*].status : v == local.status]
+  )  
+}
+
+# Test with start date and end date
+data "huaweicloud_cdn_cache_history_tasks" "date_filter" {
+  start_date = "%[2]d"
+  end_date   = "%[3]d"
+
+  depends_on = [huaweicloud_cdn_cache_preheat.test]
+}
+
+output "date_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_history_tasks.date_filter.tasks) > 0
+}
+
+# Test with order field and order type
+data "huaweicloud_cdn_cache_history_tasks" "order_filter" {
+  order_field = "succeed"
+  order_type  = "asc"
+
+  depends_on = [huaweicloud_cdn_cache_preheat.test]
+}
+
+output "order_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_history_tasks.order_filter.tasks) > 0
+}
+
+# Test with file type
+locals {
+  file_type = data.huaweicloud_cdn_cache_history_tasks.test.tasks[0].file_type
+}
+
+data "huaweicloud_cdn_cache_history_tasks" "file_type_filter" {
+  file_type = local.file_type
+}
+
+output "file_type_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_history_tasks.file_type_filter.tasks) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_cache_history_tasks.file_type_filter.tasks[*].file_type : v == local.file_type]
+  )  
+}
+
+# Test with task type
+locals {
+  task_type = data.huaweicloud_cdn_cache_history_tasks.test.tasks[0].task_type
+}
+
+data "huaweicloud_cdn_cache_history_tasks" "task_type_filter" {
+  task_type = local.task_type
+}
+
+output "task_type_filter_is_useful" {
+  value = length(data.huaweicloud_cdn_cache_history_tasks.task_type_filter.tasks) > 0 && alltrue(
+    [for v in data.huaweicloud_cdn_cache_history_tasks.task_type_filter.tasks[*].task_type : v == local.task_type]
+  )  
+}
+`, testCachePreheat_basic(), startDate, endDate)
+}

--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_history_tasks.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_cache_history_tasks.go
@@ -1,0 +1,259 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product CDN
+// ---------------------------------------------------------------
+
+package cdn
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CDN GET /v1.0/cdn/historytasks
+func DataSourceCacheHistoryTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceCacheHistoryTasksRead,
+		Schema: map[string]*schema.Schema{
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the enterprise project to which the resource belongs.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the task status.`,
+			},
+			"start_date": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the query start time.`,
+			},
+			"end_date": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: `Specifies the query end time.`,
+			},
+			"order_field": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the field used for sorting.`,
+			},
+			"order_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the sorting type.`,
+			},
+			"file_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the file type.`,
+			},
+			"task_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the task type.`,
+			},
+			"tasks": {
+				Type:        schema.TypeList,
+				Elem:        cacheHistoryTasksSchema(),
+				Computed:    true,
+				Description: `The history task list.`,
+			},
+		},
+	}
+}
+
+func cacheHistoryTasksSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the task ID.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the task result.`,
+			},
+			"processing": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Indicates the number of URLs that are being processed.`,
+			},
+			"succeed": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Indicates the number of URLs processed.`,
+			},
+			"failed": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Indicates the number of URLs that failed to be processed.`,
+			},
+			"total": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `Indicates the total number of URLs in the task.`,
+			},
+			"task_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the task type.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the time when the task was created.`,
+			},
+			"file_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Indicates the file type.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildHistoryTaskRequestBodyStatusOpts(status string) *model.ShowHistoryTasksRequestStatus {
+	if status == "" {
+		return nil
+	}
+
+	statusToReq := new(model.ShowHistoryTasksRequestStatus)
+	if err := statusToReq.UnmarshalJSON([]byte(status)); err != nil {
+		log.Printf("[WARN] failed to parse status %s: %s", status, err)
+		return nil
+	}
+	return statusToReq
+}
+
+func buildHistoryTaskRequestBodyFileTypeOpts(fileType string) *model.ShowHistoryTasksRequestFileType {
+	if fileType == "" {
+		return nil
+	}
+
+	fileTypeToReq := new(model.ShowHistoryTasksRequestFileType)
+	if err := fileTypeToReq.UnmarshalJSON([]byte(fileType)); err != nil {
+		log.Printf("[WARN] failed to parse file type %s: %s", fileType, err)
+		return nil
+	}
+	return fileTypeToReq
+}
+
+func buildHistoryTaskRequestBodyTaskTypeOpts(taskType string) *model.ShowHistoryTasksRequestTaskType {
+	if taskType == "" {
+		return nil
+	}
+
+	taskTypeToReq := new(model.ShowHistoryTasksRequestTaskType)
+	if err := taskTypeToReq.UnmarshalJSON([]byte(taskType)); err != nil {
+		log.Printf("[WARN] failed to parse task type %s: %s", taskType, err)
+		return nil
+	}
+	return taskTypeToReq
+}
+
+func resourceCacheHistoryTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		pageSize   = int32(10000)
+		PageNumber = int32(1)
+		respTasks  []model.TasksObject
+		mErr       *multierror.Error
+	)
+
+	hcCdnClient, err := cfg.HcCdnV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CDN v2 client: %s", err)
+	}
+
+	request := &model.ShowHistoryTasksRequest{
+		EnterpriseProjectId: utils.StringIgnoreEmpty(cfg.GetEnterpriseProjectID(d)),
+		PageSize:            utils.Int32(pageSize),
+		Status:              buildHistoryTaskRequestBodyStatusOpts(d.Get("status").(string)),
+		StartDate:           utils.Int64IgnoreEmpty(int64(d.Get("start_date").(int))),
+		EndDate:             utils.Int64IgnoreEmpty(int64(d.Get("end_date").(int))),
+		OrderField:          utils.StringIgnoreEmpty(d.Get("order_field").(string)),
+		OrderType:           utils.StringIgnoreEmpty(d.Get("order_type").(string)),
+		FileType:            buildHistoryTaskRequestBodyFileTypeOpts(d.Get("file_type").(string)),
+		TaskType:            buildHistoryTaskRequestBodyTaskTypeOpts(d.Get("task_type").(string)),
+	}
+
+	for {
+		request.PageNumber = utils.Int32(PageNumber)
+		resp, err := hcCdnClient.ShowHistoryTasks(request)
+		if err != nil {
+			return diag.Errorf("error retrieving CDN cache history tasks: %s", err)
+		}
+
+		if resp == nil || resp.Tasks == nil || len(*resp.Tasks) == 0 {
+			break
+		}
+		respTasks = append(respTasks, *resp.Tasks...)
+		PageNumber++
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("tasks", flattenCacheHistoryTasks(respTasks)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenCacheHistoryTasks(respTasks []model.TasksObject) []interface{} {
+	if len(respTasks) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(respTasks))
+	for _, v := range respTasks {
+		rst = append(rst, map[string]interface{}{
+			"id":         v.Id,
+			"status":     v.Status,
+			"processing": v.Processing,
+			"succeed":    v.Succeed,
+			"failed":     v.Failed,
+			"total":      v.Total,
+			"task_type":  flattenHistoryTaskTaskType(v.TaskType),
+			"created_at": flattenCreatedAt(v.CreateTime),
+			"file_type":  flattenHistoryTaskFileType(v.FileType),
+		})
+	}
+	return rst
+}
+
+func flattenHistoryTaskTaskType(taskType *model.TasksObjectTaskType) string {
+	if taskType == nil {
+		return ""
+	}
+	return taskType.Value()
+}
+
+func flattenHistoryTaskFileType(fileType *model.TasksObjectFileType) string {
+	if fileType == nil {
+		return ""
+	}
+	return fileType.Value()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

cdn domain support new datasource to query cache history tasks

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceCacheHistoryTasks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceCacheHistoryTasks_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCacheHistoryTasks_basic
=== PAUSE TestAccDatasourceCacheHistoryTasks_basic
=== CONT  TestAccDatasourceCacheHistoryTasks_basic
--- PASS: TestAccDatasourceCacheHistoryTasks_basic (40.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       40.700s
```
