### PR TITLE
feat(dds): support to get database users

### DIFF
--- a/docs/data-sources/dds_database_users.md
+++ b/docs/data-sources/dds_database_users.md
@@ -1,0 +1,82 @@
+---
+subcategory: "Document Database Service (DDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dds_database_users"
+description: |-
+  Use this data source to get the list of DDS instance database users.
+---
+
+# huaweicloud_dds_database_users
+
+Use this data source to get the list of DDS instance database users.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "huaweicloud_dds_database_users" "test"{
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the instance ID.
+
+* `name` - (Optional, String) Specifies the username.
+
+* `db_name` - (Optional, String) Specifies the database name to which the user belongs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `users` - Indicates the backup list.
+  The [users](#users_struct) structure is documented below.
+
+<a name="users_struct"></a>
+The `users` block supports:
+
+* `name` - Indicates the username.
+
+* `db_name` - Indicates the database name to which the user belongs.
+
+* `roles` - Indicates the list of roles owned by the current user.
+  The [roles](#dds_database_owned_roles) structure is documented below.
+
+* `privileges` - The list of database privileges owned by the current user.
+  The [privileges](#dds_database_privileges) structure is documented below.
+
+* `inherited_privileges` - The list of database privileges owned by the current user, includes all privileges
+  inherited by owned roles.
+  The [inherited_privileges](#dds_database_privileges) structure is documented below.
+
+<a name="dds_database_privileges"></a>
+The `privileges` and `inherited_privileges` block supports:
+
+* `resources` - The details of the resource to which the privilege belongs.
+  The [resources](#dds_database_resources) structure is documented below.
+
+* `actions` - The operation permission list.
+
+<a name="dds_database_resources"></a>
+The `resources` block supports:
+
+* `collection` - The database collection type.
+
+* `db_name` - The database name.
+
+<a name="dds_database_owned_roles"></a>
+The `roles` block supports:
+
+* `name` - Indicates the name of role owned by the current user.
+
+* `db_name` - Indicates the database name to which this owned role belongs.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -535,6 +535,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_migrate_availability_zones": dds.DataSourceDDSMigrateAvailabilityZones(),
 			"huaweicloud_dds_instances":                  dds.DataSourceDdsInstance(),
 			"huaweicloud_dds_parameter_templates":        dds.DataSourceDdsParameterTemplates(),
+			"huaweicloud_dds_database_users":             dds.DateSourceDDSDatabaseUser(),
 			"huaweicloud_dds_storage_types":              dds.DataSourceDdsStorageTypes(),
 			"huaweicloud_dds_restore_time_ranges":        dds.DataSourceDdsRestoreTimeRanges(),
 			"huaweicloud_dds_backups":                    dds.DataSourceDDSBackups(),

--- a/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_database_users_test.go
+++ b/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_database_users_test.go
@@ -1,0 +1,79 @@
+package dds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceDdsDatabaseUsers_basic(t *testing.T) {
+	rName := "data.huaweicloud_dds_database_users.all"
+	name := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceDdsDatabaseUsers_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(rName, "users.#"),
+
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_db_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceDdsDatabaseUsers_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_dds_database_users" "all" {
+  depends_on = [huaweicloud_dds_database_user.test]
+
+  instance_id = huaweicloud_dds_instance.test.id
+}
+
+// filter by name
+data "huaweicloud_dds_database_users" "filter_by_name" {
+  depends_on = [huaweicloud_dds_database_user.test]
+
+  instance_id = huaweicloud_dds_instance.test.id
+  name        = huaweicloud_dds_database_user.test.name
+}
+
+locals {
+  filter_result_by_name = [for v in data.huaweicloud_dds_database_users.filter_by_name.users[*].name : 
+    v == huaweicloud_dds_database_user.test.name]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.filter_result_by_name) > 0 && alltrue(local.filter_result_by_name) 
+}
+
+// filter by db_name
+data "huaweicloud_dds_database_users" "filter_by_db_name" {
+  depends_on = [huaweicloud_dds_database_user.test]
+
+  instance_id = huaweicloud_dds_instance.test.id
+  db_name     = huaweicloud_dds_database_user.test.db_name
+}
+
+locals {
+  filter_result_by_db_name = [for v in data.huaweicloud_dds_database_users.filter_by_db_name.users[*].db_name : 
+    v == huaweicloud_dds_database_user.test.db_name]
+}
+
+output "is_db_name_filter_useful" {
+  value = length(local.filter_result_by_db_name) > 0 && alltrue(local.filter_result_by_db_name) 
+}
+`, testAccDatabaseUser_basic(name))
+}

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_role_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_role_test.go
@@ -97,27 +97,6 @@ func testAccDatabaseRole_base(rName string) string {
 
 data "huaweicloud_availability_zones" "test" {}
 
-data "huaweicloud_dds_flavors" "flavor_mongos" {
-  engine_name = "DDS-Community"
-  vcpus       = 2
-  memory      = 4
-  type        = "mongos"
-}
-
-data "huaweicloud_dds_flavors" "flavor_shared" {
-  engine_name = "DDS-Community"
-  vcpus       = 2
-  memory      = 4
-  type        = "shard"
-}
-
-data "huaweicloud_dds_flavors" "flavor_config" {
-  engine_name = "DDS-Community"
-  vcpus       = 4
-  memory      = 8
-  type        = "config"
-}
-
 resource "huaweicloud_dds_instance" "test" {
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   vpc_id            = huaweicloud_vpc.test.id
@@ -137,21 +116,21 @@ resource "huaweicloud_dds_instance" "test" {
   flavor {
     type      = "mongos"
     num       = 2
-    spec_code = data.huaweicloud_dds_flavors.flavor_mongos.flavors[0].spec_code
+    spec_code = "dds.mongodb.s6.xlarge.2.mongos"
   }
   flavor {
     type      = "shard"
     num       = 2
     storage   = "ULTRAHIGH"
     size      = 20
-    spec_code = data.huaweicloud_dds_flavors.flavor_shared.flavors[0].spec_code
+    spec_code = "dds.mongodb.s6.xlarge.2.shard"
   }
   flavor {
     type      = "config"
     num       = 1
     storage   = "ULTRAHIGH"
     size      = 20
-    spec_code = data.huaweicloud_dds_flavors.flavor_config.flavors[0].spec_code
+    spec_code = "dds.mongodb.s6.xlarge.2.config"
   }
 }
 `, common.TestBaseNetwork(rName), rName)

--- a/huaweicloud/services/dds/data_source_huaweicloud_dds_database_users.go
+++ b/huaweicloud/services/dds/data_source_huaweicloud_dds_database_users.go
@@ -1,0 +1,132 @@
+package dds
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/dds/v3/users"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API DDS GET /v3/{project_id}/instances/{instance_id}/db-user/detail
+func DateSourceDDSDatabaseUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDDSDatabaseUserRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"db_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"users": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"db_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"roles": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"db_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"privileges": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     privilegeSchemaResource(),
+						},
+						"inherited_privileges": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     privilegeSchemaResource(),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDDSDatabaseUserRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.DdsV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DDS client: %s", err)
+	}
+
+	opts := users.ListOpts{
+		DbName: d.Get("db_name").(string),
+		Name:   d.Get("name").(string),
+	}
+	resp, err := users.List(client, d.Get("instance_id").(string), opts)
+	if err != nil {
+		return diag.Errorf("error retrieving user list: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("users", flattenDatabaseUsers(resp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDatabaseUsers(userList []users.UserResp) []map[string]interface{} {
+	if len(userList) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(userList))
+	for i, user := range userList {
+		result[i] = map[string]interface{}{
+			"db_name":              user.DbName,
+			"name":                 user.Name,
+			"roles":                flattenDatabaseRoles(user.Roles),
+			"privileges":           flattenDatabasePrivileges(user.Privileges),
+			"inherited_privileges": flattenDatabasePrivileges(user.InheritedPrivileges),
+		}
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support to get database users.
And fix the acctest for `huaweicloud_dds_database_user`.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDatasourceDdsDatabaseUsers_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDatasourceDdsDatabaseUsers_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDdsDatabaseUsers_basic
=== PAUSE TestAccDatasourceDdsDatabaseUsers_basic
=== CONT  TestAccDatasourceDdsDatabaseUsers_basic
--- PASS: TestAccDatasourceDdsDatabaseUsers_basic (978.99s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       979.054s
```
