### PR TITLE
feat(RDS): add rds restore resource

### DIFF
--- a/docs/resources/rds_restore.md
+++ b/docs/resources/rds_restore.md
@@ -1,0 +1,107 @@
+---
+subcategory: "Relational Database Service (RDS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_rds_restore"
+description: |-
+  Manages an RDS instance restore resource within HuaweiCloud.
+---
+
+# huaweicloud_rds_restore
+
+Manages an RDS instance restore resource within HuaweiCloud.
+
+## Example Usage
+
+### restore by backup_id
+
+```hcl
+variable "target_instance_id" {}
+variable "source_instance_id" {}
+variable "backup_id" {}
+
+resource "huaweicloud_rds_restore" "test" {
+  target_instance_id = var.target_instance_id
+  source_instance_id = var.source_instance_id
+  type               = "backup"
+  backup_id          = var.backup_id
+}
+```
+
+### restore by timestamp
+
+```hcl
+variable "target_instance_id" {}
+variable "source_instance_id" {}
+
+resource "huaweicloud_rds_restore" "test" {
+  target_instance_id = var.target_instance_id
+  source_instance_id = var.source_instance_id
+  type               = "timestamp"
+  restore_time       = 1673852043000
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the rds instance resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `target_instance_id` - (Required, String, ForceNew) Specifies the target instance ID.
+
+  Changing this creates a new resource.
+
+* `source_instance_id` - (Required, String, ForceNew) Specifies the source instance ID.
+
+  Changing this creates a new resource.
+
+* `type` - (Optional, String, ForceNew) Specifies the restoration type. Value options:
+  + **backup**: indicates using backup files for restoration.
+  + **timestamp**: indicates the point-in-time restoration mode.
+
+  Changing this creates a new resource.
+
+* `backup_id` - (Optional, String, ForceNew) Specifies the ID of the backup to be restored. This parameter must be
+  specified when `type` is set to **backup** or left empty.
+
+  Changing this creates a new resource.
+
+* `restore_time` - (Optional, Int, ForceNew) Specifies the time point of data restoration in the UNIX timestamp format.
+  The unit is millisecond and the time zone is UTC. This parameter must be specified when `type` is set to **timestamp**.
+
+  Changing this creates a new resource.
+
+* `database_name` - (Optional, Map, ForceNew) Specifies the databases that will be restored. This parameter applies only
+  to the SQL Server DB engine. The key is the old database name, the value is the new database name. If this parameter is
+  specified, you can restore all or specific databases and rename new databases. If this parameter is not specified, all
+  databases are restored by default. You can enter multiple new database names and separate them with commas (,). The new
+  database names can contain but cannot be the same as the original database names. Note the following when you are
+  specifying new database names:
+  + New database names must be different from the original database names. If they are left blank, the original database
+    names will be used for restoration by default.
+  + The case-sensitivity settings of the new databases are the same as those of the original databases. Make sure the new
+    database names are unique.
+  + The total number of new and existing databases on the existing or original DB instances where data is restored cannot
+    exceed the database quota specified by **rds_databases_quota**.
+  + New database names cannot contain the following fields (case-insensitive): **rdsadmin**, **master**, **msdb**,
+    **tempdb**, **model** and **resource**.
+  + New database names must consist of **1** to **64** characters, including only letters, digits, underscores (_), and
+    hyphens (-). If you want to restore data to multiple new databases, separate them with commas (,).
+  + New database names must be different from any database names on the original DB instance.
+  + New database names must be different from any database names on the existing or original DB instances where data is
+    restored.
+
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attribute is exported:
+
+* `id` - The resource ID. The value is the restore job ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1472,6 +1472,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_rds_parametergroup":               rds.ResourceRdsConfiguration(),
 			"huaweicloud_rds_read_replica_instance":        rds.ResourceRdsReadReplicaInstance(),
 			"huaweicloud_rds_backup":                       rds.ResourceBackup(),
+			"huaweicloud_rds_restore":                      rds.ResourceRdsRestore(),
 			"huaweicloud_rds_cross_region_backup_strategy": rds.ResourceBackupStrategy(),
 			"huaweicloud_rds_sql_audit":                    rds.ResourceSQLAudit(),
 			"huaweicloud_rds_pg_plugin":                    rds.ResourceRdsPgPlugin(),

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_restore_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_restore_test.go
@@ -1,0 +1,138 @@
+package rds
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccRdsInstanceRestore_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceRestoreConfig_basic(name),
+			},
+		},
+	})
+}
+
+func TestAccRdsInstanceRestore_withTimestamp(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRdsInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceRestoreConfig_withTimestamp(name),
+			},
+		},
+	})
+}
+
+func testAccRdsInstanceRestoreConfig_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_rds_flavors" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+  group_type    = "dedicated"
+  vcpus         = 4
+}
+
+resource "huaweicloud_rds_instance" "instance" {
+  count                    = 2
+  name                   = "%[2]s__${count.index}"
+  flavor                 = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id      = huaweicloud_networking_secgroup.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  vpc_id                 = huaweicloud_vpc.test.id
+  availability_zone      = [data.huaweicloud_availability_zones.test.names[0]]
+
+  db {
+    type    = "MySQL"
+    version = "8.0"
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 40
+  }
+}
+
+resource "huaweicloud_rds_backup" "backup" {
+  instance_id = huaweicloud_rds_instance.instance[0].id
+  name        = "%[2]s_backup"
+}
+
+resource "huaweicloud_rds_restore" "test" {
+  target_instance_id = huaweicloud_rds_instance.instance[1].id
+  source_instance_id = huaweicloud_rds_instance.instance[0].id
+  type               = "backup"
+  backup_id          = huaweicloud_rds_backup.backup.id
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccRdsInstanceRestoreConfig_withTimestamp(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_rds_flavors" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+  group_type    = "dedicated"
+  vcpus         = 4
+}
+
+resource "huaweicloud_rds_instance" "instance" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  vpc_id            = huaweicloud_vpc.test.id
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+
+  db {
+    type    = "MySQL"
+    version = "8.0"
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 40
+  }
+}
+
+data "huaweicloud_rds_restore_time_ranges" "test" {
+  instance_id = "%[3]s"
+}
+
+resource "huaweicloud_rds_restore" "test" {
+  target_instance_id = huaweicloud_rds_instance.instance.id
+  source_instance_id = "%[3]s"
+  type               = "timestamp"
+  restore_time       = data.huaweicloud_rds_restore_time_ranges.test.restore_time[0].start_time
+}
+`, common.TestBaseNetwork(name), name, acceptance.HW_RDS_INSTANCE_ID)
+}

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_restore.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_restore.go
@@ -1,0 +1,171 @@
+package rds
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RDS POST /v3.1/{project_id}/instances/recovery
+func ResourceRdsRestore() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRdsRestoreCreate,
+		ReadContext:   resourceRdsRestoreRead,
+		DeleteContext: resourceRdsRestoreDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"target_instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the target instance ID.`,
+			},
+			"source_instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the source instance ID.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the restoration type.`,
+			},
+			"backup_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the backup to be restored.`,
+			},
+			"restore_time": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"backup_id"},
+				Description:  `Specifies the time point of data restoration in the UNIX timestamp format.`,
+			},
+			"database_name": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the databases that will be restored.`,
+			},
+		},
+	}
+}
+
+func resourceRdsRestoreCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3.1/{project_id}/instances/recovery"
+		product = "rds"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RDS client: %s", err)
+	}
+
+	targetInstanceId := d.Get("target_instance_id").(string)
+	backupId := d.Get("backup_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{KeepResponseBody: true}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateRestoreBodyParams(d))
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("POST", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     rdsInstanceStateRefreshFunc(client, d.Get("target_instance_id").(string)),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return diag.Errorf("error restoring from backup(%s) to RDS instance (%s): %s", backupId, targetInstanceId, err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, nil)
+	if jobId == nil {
+		return diag.Errorf("unable to find the job_id from the response: %s", err)
+	}
+
+	d.SetId(jobId.(string))
+
+	err = checkRDSInstanceJobFinish(client, jobId.(string), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for restoring from backup(%s) to RDS instance(%s) to complete: %s",
+			backupId, targetInstanceId, err)
+	}
+
+	return nil
+}
+
+func buildCreateRestoreBodyParams(d *schema.ResourceData) map[string]interface{} {
+	databaseName := d.Get("database_name").(map[string]interface{})
+	bodyParams := map[string]interface{}{
+		"source": map[string]interface{}{
+			"instance_id":   d.Get("source_instance_id"),
+			"type":          utils.ValueIngoreEmpty(d.Get("type")),
+			"backup_id":     utils.ValueIngoreEmpty(d.Get("backup_id")),
+			"restore_time":  utils.ValueIngoreEmpty(d.Get("restore_time")),
+			"database_name": utils.ValueIngoreEmpty(databaseName),
+		},
+		"target": map[string]interface{}{
+			"instance_id": d.Get("target_instance_id"),
+		},
+	}
+	if len(databaseName) == 0 {
+		bodyParams["source"].(map[string]interface{})["restore_all_database"] = true
+	}
+	return bodyParams
+}
+
+func resourceRdsRestoreRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceRdsRestoreDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restoration record is not supported. The restoration record is only removed from the state," +
+		" but it remains in the cloud. And the instance doesn't return to the state before restoration."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add rds restore resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add rds restore resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstanceRestore_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstanceRestore_ -timeout 360m -parallel 4
=== RUN   TestAccRdsInstanceRestore_basic
=== PAUSE TestAccRdsInstanceRestore_basic
=== RUN   TestAccRdsInstanceRestore_withTimestamp
=== PAUSE TestAccRdsInstanceRestore_withTimestamp
=== CONT  TestAccRdsInstanceRestore_basic
=== CONT  TestAccRdsInstanceRestore_withTimestamp
--- PASS: TestAccRdsInstanceRestore_withTimestamp (1022.35s)
--- PASS: TestAccRdsInstanceRestore_basic (1274.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1274.491s
```
