### PR TITLE
feat(RAM): RAM support a new resource to manage organization

### DIFF
--- a/docs/resources/ram_organization.md
+++ b/docs/resources/ram_organization.md
@@ -1,0 +1,34 @@
+---
+subcategory: "Resource Access Manager (RAM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ram_organization"
+description: "Manages a RAM organization resource within HuaweiCloud."
+---
+
+# huaweicloud_ram_organization
+
+Manages a RAM organization resource within HuaweiCloud.
+
+-> Only organization administrators can enable or disable sharing with the organization. After enabling sharing with
+organizations, resources can be shared to organizations and organizational units, and the resource users do not need to
+accept the sharing to take effect. Destroying resources does not change the current enabled state.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_ram_organization" "test" {
+  enabled = true
+} 
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `enabled` - (Required, Bool) Specifies whether sharing with organizations is enabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1455,6 +1455,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_oms_migration_task":       oms.ResourceMigrationTask(),
 			"huaweicloud_oms_migration_task_group": oms.ResourceMigrationTaskGroup(),
 
+			"huaweicloud_ram_organization":            ram.ResourceRAMOrganization(),
 			"huaweicloud_ram_resource_share":          ram.ResourceRAMShare(),
 			"huaweicloud_ram_resource_share_accepter": ram.ResourceShareAccepter(),
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -802,7 +802,7 @@ func TestAccPreCheckRAM(t *testing.T) {
 }
 
 // lintignore:AT003
-func TestAccPreCheckRAMSharedPrincipals(t *testing.T) {
+func TestAccPreCheckRAMEnableFlag(t *testing.T) {
 	if HW_RAM_ENABLE_FLAG == "" {
 		t.Skip("Skip the RAM acceptance tests.")
 	}

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_shared_principals_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_shared_principals_test.go
@@ -19,7 +19,7 @@ func TestAccDatasourceRAMSharedPrincipals_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckRAMSharedPrincipals(t)
+			acceptance.TestAccPreCheckRAMEnableFlag(t)
 			acceptance.TestAccPreCheckRAMSharedPrincipalsQueryFields(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/ram/resource_huaweicloud_ram_organization_test.go
+++ b/huaweicloud/services/acceptance/ram/resource_huaweicloud_ram_organization_test.go
@@ -1,0 +1,90 @@
+package ram
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getRAMOrganizationResourceFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/organization-share"
+		product = "ram"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RAM client: %s", err)
+	}
+
+	getOrganizationPath := client.Endpoint + httpUrl
+	getOrganizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getOrganizationResp, err := client.Request("GET", getOrganizationPath, &getOrganizationOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RAM organization: %s", err)
+	}
+
+	return utils.FlattenResponse(getOrganizationResp)
+}
+
+// Only organization administrators have permission to run this test case
+func TestAccRAMOrganization_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_ram_organization.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getRAMOrganizationResourceFunc,
+	)
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRAMEnableFlag(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testRAMOrganization_basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
+				),
+			},
+			{
+				Config: testRAMOrganization_basic_update,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+const testRAMOrganization_basic = `
+resource "huaweicloud_ram_organization" "test" {
+  enabled = true
+}
+`
+
+const testRAMOrganization_basic_update = `
+resource "huaweicloud_ram_organization" "test" {
+  enabled = false
+}
+`

--- a/huaweicloud/services/ram/resource_huaweicloud_ram_organization.go
+++ b/huaweicloud/services/ram/resource_huaweicloud_ram_organization.go
@@ -1,0 +1,167 @@
+// ---------------------------------------------------------------
+// *** AUTO GENERATED CODE ***
+// @Product RAM
+// ---------------------------------------------------------------
+
+package ram
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RAM POST /v1/organization-share/enable
+// @API RAM POST /v1/organization-share/disable
+// @API RAM GET /v1/organization-share
+func ResourceRAMOrganization() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRAMOrganizationCreate,
+		UpdateContext: resourceRAMOrganizationUpdate,
+		ReadContext:   resourceRAMOrganizationRead,
+		DeleteContext: resourceRAMOrganizationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"enabled": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Specifies whether sharing with organizations is enabled.`,
+			},
+		},
+	}
+}
+
+func resourceRAMOrganizationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "ram"
+		enabled  = d.Get("enabled").(bool)
+		ramError error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RAM client: %s", err)
+	}
+
+	if enabled {
+		ramError = enableRAMOrganization(client)
+	} else {
+		ramError = disableRAMOrganization(client)
+	}
+
+	if ramError != nil {
+		return diag.FromErr(ramError)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+	return resourceRAMOrganizationRead(ctx, d, meta)
+}
+
+func resourceRAMOrganizationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg      = meta.(*config.Config)
+		region   = cfg.GetRegion(d)
+		product  = "ram"
+		enabled  = d.Get("enabled").(bool)
+		ramError error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RAM client: %s", err)
+	}
+
+	if enabled {
+		ramError = enableRAMOrganization(client)
+	} else {
+		ramError = disableRAMOrganization(client)
+	}
+
+	if ramError != nil {
+		return diag.FromErr(ramError)
+	}
+
+	return resourceRAMOrganizationRead(ctx, d, meta)
+}
+
+func enableRAMOrganization(client *golangsdk.ServiceClient) error {
+	enableOrganizationPath := client.Endpoint + "v1/organization-share/enable"
+	enableOrganizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("POST", enableOrganizationPath, &enableOrganizationOpt)
+	if err != nil {
+		return fmt.Errorf("error enabling RAM organization: %s", err)
+	}
+	return nil
+}
+
+func disableRAMOrganization(client *golangsdk.ServiceClient) error {
+	disableOrganizationPath := client.Endpoint + "v1/organization-share/disable"
+	disableOrganizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err := client.Request("POST", disableOrganizationPath, &disableOrganizationOpt)
+	if err != nil {
+		return fmt.Errorf("error disabling RAM organization: %s", err)
+	}
+	return nil
+}
+
+func resourceRAMOrganizationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ram"
+		httpUrl = "v1/organization-share"
+		mErr    *multierror.Error
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RAM client: %s", err)
+	}
+
+	getOrganizationPath := client.Endpoint + httpUrl
+	getOrganizationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getOrganizationResp, err := client.Request("GET", getOrganizationPath, &getOrganizationOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving RAM organization: %s", err)
+	}
+
+	getOrganizationRespBody, err := utils.FlattenResponse(getOrganizationResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("enabled", utils.PathSearch("enabled", getOrganizationRespBody, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceRAMOrganizationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

RAM support a new resource to manage organization

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Rename acceptance function name from `TestAccPreCheckRAMSharedPrincipals` to `TestAccPreCheckRAMEnableFlag`.
- The resource does not supporting `delete` operation.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/ram' TESTARGS='-run TestAccRAMOrganization_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccRAMOrganization_basic -timeout 360m -parallel 4
=== RUN   TestAccRAMOrganization_basic
=== PAUSE TestAccRAMOrganization_basic
=== CONT  TestAccRAMOrganization_basic
--- PASS: TestAccRAMOrganization_basic (18.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       18.064s
```
