### PR TITLE
chore(apig): use invocation_type instead of invocation_mode

### DIFF
--- a/docs/resources/apig_api.md
+++ b/docs/resources/apig_api.md
@@ -308,7 +308,7 @@ The `func_graph_policy` block supports:
   Up to five conditions can be set.
   The [object](#apig_api_conditions) structure is documented below.
 
-* `invocation_mode` - (Optional, String) Specifies the invocation mode of the FunctionGraph function.  
+* `invocation_type` - (Optional, String) Specifies the invocation mode of the FunctionGraph function.  
   The valid values are **async** and **sync**, defaults to **sync**.
 
 * `effective_mode` - (Optional, String) Specifies the effective mode of the backend policy.  


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. use `invocation_type` instead of `invocation_mode`, and deprecated `invocation_mode` parameter.
2.  Fix error when creating functionGraph backend API.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/be1cb03c-3479-470d-9fc8-b6005614ba29)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccApi_functionGraph'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccApi_functionGraph -timeout 360m -parallel 4
=== RUN   TestAccApi_functionGraph
=== PAUSE TestAccApi_functionGraph
=== CONT  TestAccApi_functionGraph
--- PASS: TestAccApi_functionGraph (575.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      575.658s```
