### PR TITLE
feat(ELB): elb monitor add params

### DIFF
--- a/docs/resources/elb_monitor.md
+++ b/docs/resources/elb_monitor.md
@@ -82,13 +82,19 @@ The following arguments are supported:
 
   Defaults to **200**.
 
+* `http_method` - (Optional, String) Specifies the HTTP method. Value options: **GET**, **HEAD**, **POST**. Defaults to **GET**.
+
+* `enabled` - (Optional, Bool) Specifies whether the health check is enabled.
+  + **true(default)**: Health check is enabled.
+  + **false**: Health check is disabled.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID of the monitor.
 
-* `created_at` - The create time of the monitor.
+* `created_at` - The creation time of the monitor.
 
 * `updated_at` - The update time of the monitor.
 

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_monitor_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_monitor_test.go
@@ -52,6 +52,8 @@ func TestAccElbV3Monitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "domain_name", "www.aa.com"),
 					resource.TestCheckResourceAttr(resourceName, "port", "8000"),
 					resource.TestCheckResourceAttr(resourceName, "status_code", "200,401-500,502"),
+					resource.TestCheckResourceAttr(resourceName, "http_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 				),
 			},
 			{
@@ -68,6 +70,8 @@ func TestAccElbV3Monitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "domain_name", "www.bb.com"),
 					resource.TestCheckResourceAttr(resourceName, "port", "8888"),
 					resource.TestCheckResourceAttr(resourceName, "status_code", "200,301,404-500,504"),
+					resource.TestCheckResourceAttr(resourceName, "http_method", "HEAD"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 				),
 			},
 			{
@@ -95,6 +99,7 @@ resource "huaweicloud_elb_monitor" "monitor_1" {
   domain_name      = "www.aa.com"
   port             = "8000"
   status_code      = "200,401-500,502"
+  enabled          = false
 }
 `, testAccElbV3PoolConfig_basic(rName), rName)
 }
@@ -115,6 +120,8 @@ resource "huaweicloud_elb_monitor" "monitor_1" {
   domain_name      = "www.bb.com"
   port             = 8888
   status_code      = "200,301,404-500,504"
+  http_method      = "HEAD"
+  enabled          = true
 }
 `, testAccElbV3PoolConfig_basic(rName), rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
   elb monitor add http_method and admin_state_up
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   elb monitor add http_method and admin_state_up
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccElbV3Monitor_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbV3Monitor_basic -timeout 360m -parallel 4
=== RUN   TestAccElbV3Monitor_basic
=== PAUSE TestAccElbV3Monitor_basic
=== CONT  TestAccElbV3Monitor_basic
--- PASS: TestAccElbV3Monitor_basic (76.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       76.447s
```
