### PR TITLE
feat(cci): CCI network availability_zone attribute changed from required to optional

### DIFF
--- a/docs/resources/cci_network.md
+++ b/docs/resources/cci_network.md
@@ -17,10 +17,7 @@ variable "network_name" {}
 variable "vpc_network_id" {}
 variable "security_group_id" {}
 
-data "huaweicloud_availability_zones" "test" {}
-
 resource "huaweicloud_cci_network" "test" {
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
   namespace         = var.namespace_name
   name              = var.network_name
   network_id        = var.vpc_network_id
@@ -35,7 +32,7 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the CCI network.
   If omitted, the provider-level region will be used. Changing this will create a new CCI network resource.
 
-* `availability_zone` - (Required, String, ForceNew) Specifies the availability zone (AZ) to which the CCI network
+* `availability_zone` - (Optional, String, ForceNew) Specifies the availability zone (AZ) to which the CCI network
   belongs. Changing this will create a new CCI network resource.
 
 * `namespace` - (Required, String, ForceNew) Specifies the namespace to logically divide your cloud container instances

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240521014404-1fc9fbf1e07a
+	github.com/chnsz/golangsdk v0.0.0-20240524090804-ac6a27dd5751
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240521014404-1fc9fbf1e07a h1:V6Qf7Chj1DdlNqY8nGb9I+4/1//G8b8uK7opoGhqZ9I=
-github.com/chnsz/golangsdk v0.0.0-20240521014404-1fc9fbf1e07a/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240524090804-ac6a27dd5751 h1:iUs8gGT2658wrIRw/aMm6GJITdo6a5lGw6GUHftY6EM=
+github.com/chnsz/golangsdk v0.0.0-20240524090804-ac6a27dd5751/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -337,6 +337,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_network_test.go
+++ b/huaweicloud/services/acceptance/cci/resource_huaweicloud_cci_network_test.go
@@ -56,8 +56,6 @@ func TestAccCciNetwork_basic(t *testing.T) {
 						"huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
 						"huaweicloud_vpc.test", "id"),
-					resource.TestCheckResourceAttrPair(resourceName, "availability_zone",
-						"data.huaweicloud_availability_zones.test", "names.0"),
 				),
 			},
 			{
@@ -99,11 +97,8 @@ func testAccCciNetwork_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_availability_zones" "test" {}
-
 resource "huaweicloud_cci_network" "test" {
   name              = "%s"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
   namespace         = huaweicloud_cci_namespace.test.name
   network_id        = huaweicloud_vpc_subnet.test.id
   security_group_id = huaweicloud_networking_secgroup.test.id

--- a/huaweicloud/services/cci/resource_huaweicloud_cci_network.go
+++ b/huaweicloud/services/cci/resource_huaweicloud_cci_network.go
@@ -50,7 +50,7 @@ func ResourceCciNetworkV1() *schema.Resource {
 			},
 			"availability_zone": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"namespace": {
@@ -132,11 +132,14 @@ func resourceCciNetworkCreate(ctx context.Context, d *schema.ResourceData, meta 
 			Annotations: resourceNetworkAnnotations(d, conf),
 		},
 		Spec: networks.Spec{
-			AvailableZone: d.Get("availability_zone").(string),
-			NetworkType:   "underlay_neutron",
-			AttachedVPC:   subnet.VPC_ID,
-			NetworkID:     networkId,
+			NetworkType: "underlay_neutron",
+			AttachedVPC: subnet.VPC_ID,
+			NetworkID:   networkId,
 		},
+	}
+
+	if az, ok := d.GetOk("availability_zone"); ok {
+		opt.Spec.AvailableZone = az.(string)
 	}
 
 	ns := d.Get("namespace").(string)

--- a/vendor/github.com/chnsz/golangsdk/openstack/cci/v1/networks/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cci/v1/networks/requests.go
@@ -43,7 +43,7 @@ type Spec struct {
 	// Network ID
 	NetworkID string `json:"networkID" required:"true"`
 	// Network AZ
-	AvailableZone string `json:"availableZone" required:"true"`
+	AvailableZone string `json:"availableZone,omitempty"`
 	// Network CIDR
 	Cidr string `json:"cidr,omitempty"`
 	// Subnet ID

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240521014404-1fc9fbf1e07a
+# github.com/chnsz/golangsdk v0.0.0-20240524090804-ac6a27dd5751
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
**What this PR does / why we need it**:
CCI network availability_zone attribute changed from required to optional

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
CCI network availability_zone attribute changed from required to optional
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cci" TESTARGS="-run TestAccCciNetwork_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cci -v -run TestAccCciNetwork_basic -timeout 360m -parallel 4
=== RUN   TestAccCciNetwork_basic
=== PAUSE TestAccCciNetwork_basic
=== CONT  TestAccCciNetwork_basic
--- PASS: TestAccCciNetwork_basic (110.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cci       110.131s
```
