### PR TITLE
test(fgs/async): standardize time format check with regex for RFC3339

### DIFF
--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_invoke_configuration_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_invoke_configuration_test.go
@@ -2,6 +2,7 @@ package fgs
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -55,6 +56,8 @@ func TestAccAsyncInvokeConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "on_failure.0.destination", "SMN"),
 					resource.TestCheckResourceAttrSet(rName, "on_failure.0.param"),
 					resource.TestCheckResourceAttr(rName, "enable_async_status_log", "true"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{
@@ -70,6 +73,8 @@ func TestAccAsyncInvokeConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "on_failure.0.destination", "FunctionGraph"),
 					resource.TestCheckResourceAttrSet(rName, "on_failure.0.param"),
 					resource.TestCheckResourceAttr(rName, "enable_async_status_log", "false"),
+					resource.TestMatchResourceAttr(rName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support the regex check to standardize time format for `created_at` and `updated_at`, in order to make sure the time format is the RFC3339.
Right RFC3339 format are as follows:
- 2024-05-24T15:23:25+08:00
- 2024-05-24T15:23:25Z (Z means Zulu, it is the UTC zone, same as the +00:00)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. standardize time format and remove the timezone.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccAsyncInvokeConfig_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccAsyncInvokeConfig_basic -timeout 360m -parallel 4
=== RUN   TestAccAsyncInvokeConfig_basic
=== PAUSE TestAccAsyncInvokeConfig_basic
=== CONT  TestAccAsyncInvokeConfig_basic
--- PASS: TestAccAsyncInvokeConfig_basic (94.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       94.143s
```
