### PR TITLE
fix(cfw): add pre-check function for some CFW test cases

### DIFF
--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_address_group_members_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_address_group_members_test.go
@@ -17,6 +17,7 @@ func TestAccDataSourceCfwAddressGroupMembers_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_black_white_lists_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_black_white_lists_test.go
@@ -16,6 +16,7 @@ func TestAccDataSourceCfwBlackWhiteLists_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_domain_name_groups_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_domain_name_groups_test.go
@@ -17,6 +17,7 @@ func TestAccDataSourceCfwDomainNameGroups_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_protection_rules_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_protection_rules_test.go
@@ -17,6 +17,7 @@ func TestAccDataSourceCfwProtectionRules_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_service_group_members_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_service_group_members_test.go
@@ -17,6 +17,7 @@ func TestAccDataSourceCfwServiceGroupMembers_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add pre-check function for some CFW test cases
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add pre-check function for address group members test case
2. add pre-check function for black white lists test case
3. add pre-check function for domain name groups test case
4. add pre-check function for protection rules test case 
5. add pre-check function for service group members test case
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST                                                       ="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceCfwAddressGroupMembers_b                                                       asic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDataSourceCfwAddressGroupMe                                                       mbers_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCfwAddressGroupMembers_basic
=== PAUSE TestAccDataSourceCfwAddressGroupMembers_basic
=== CONT  TestAccDataSourceCfwAddressGroupMembers_basic
--- PASS: TestAccDataSourceCfwAddressGroupMembers_basic (61.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw                                                       61.304s

make testacc TEST                                                       ="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceCfwBlackWhiteLists_basic                                                       "
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDataSourceCfwBlackWhiteList                                                       s_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCfwBlackWhiteLists_basic
=== PAUSE TestAccDataSourceCfwBlackWhiteLists_basic
=== CONT  TestAccDataSourceCfwBlackWhiteLists_basic
--- PASS: TestAccDataSourceCfwBlackWhiteLists_basic (82.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw                                                       82.742s

 make testacc TEST                                                       ="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceCfwDomainNameGroups_basi                                                       c"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDataSourceCfwDomainNameGrou                                                       ps_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCfwDomainNameGroups_basic
=== PAUSE TestAccDataSourceCfwDomainNameGroups_basic
=== CONT  TestAccDataSourceCfwDomainNameGroups_basic
--- PASS: TestAccDataSourceCfwDomainNameGroups_basic (194.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw                                                       194.886s

 make testacc TEST                                                       ="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceCfwProtectionRules_basic                                                       "
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDataSourceCfwProtectionRule                                                       s_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCfwProtectionRules_basic
=== PAUSE TestAccDataSourceCfwProtectionRules_basic
=== CONT  TestAccDataSourceCfwProtectionRules_basic
--- PASS: TestAccDataSourceCfwProtectionRules_basic (78.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw                                                       78.493s

 make testacc TEST                                                       ="./huaweicloud/services/acceptance/cfw" TESTARGS="-run TestAccDataSourceCfwServiceGroupMembers_b                                                       asic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run TestAccDataSourceCfwServiceGroupMe                                                       mbers_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCfwServiceGroupMembers_basic
=== PAUSE TestAccDataSourceCfwServiceGroupMembers_basic
=== CONT  TestAccDataSourceCfwServiceGroupMembers_basic
--- PASS: TestAccDataSourceCfwServiceGroupMembers_basic (70.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw                                                       70.997s

```
