### PR TITLE
fix(RDS): fix rds read seconds level monitoring

### DIFF
--- a/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_instance.go
@@ -883,10 +883,11 @@ func resourceRdsInstanceRead(ctx context.Context, d *schema.ResourceData, meta i
 	if isMySQLDatabase(d) {
 		secondsLevelMonitoring, err := instances.GetSecondLevelMonitoring(client, instanceID).Extract()
 		if err != nil {
-			return diag.Errorf("error getting RDS seconds level monitoring: %s", err)
+			log.Printf("[WARN] fetching RDS seconds level monitoring failed: %s", err)
+		} else {
+			d.Set("seconds_level_monitoring_enabled", secondsLevelMonitoring.SwitchOption)
+			d.Set("seconds_level_monitoring_interval", secondsLevelMonitoring.Interval)
 		}
-		d.Set("seconds_level_monitoring_enabled", secondsLevelMonitoring.SwitchOption)
-		d.Set("seconds_level_monitoring_interval", secondsLevelMonitoring.Interval)
 	}
 
 	return setRdsInstanceParameters(ctx, d, client, instanceID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds read seconds level monitoring
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds read seconds level monitoring
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=11
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 11
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_prePaid
--- PASS: TestAccRdsInstance_mariadb (684.10s)
--- PASS: TestAccRdsInstance_ha (783.38s)
--- PASS: TestAccRdsInstance_basic (909.68s)
--- PASS: TestAccRdsInstance_mysql_power_action (1121.55s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1605.33s)
--- PASS: TestAccRdsInstance_prePaid (1667.32s)
--- PASS: TestAccRdsInstance_restore_pg (1681.78s)
--- PASS: TestAccRdsInstance_restore_mysql (1706.30s)
--- PASS: TestAccRdsInstance_mysql (1931.58s)
--- PASS: TestAccRdsInstance_sqlserver (2779.65s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2800.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2800.431s
```
