### PR TITLE
feat(cbh): instance resource supports startup, shutdown, and reboot actions

### DIFF
--- a/docs/resources/cbh_instance.md
+++ b/docs/resources/cbh_instance.md
@@ -109,6 +109,18 @@ The following arguments are supported:
   -> 1. Storage expansion is a high-risk operation, with a certain risk of failure.
   <br/>2. Expansion failure may affect the usability of the instance. Please ensure to back up your data.
 
+* `power_action` - (Optional, String) Specifies the power action after the CBH instance is created.
+  The valid values are as follows:
+  + **start**: Startup instance.
+  + **stop**: Shutdown instance.
+  + **soft-reboot**: Normal reboot, shut down virtual machine service.
+  + **hard-reboot**: Force reboot, reboot virtual machine.
+
+  -> The usage of `power_action` has some limitations:
+    <br/>1. The **start** operation can only be performed when the instance status is **SHUTOFF**.
+    <br/>2. The **stop**, **soft-reboot**, and **hard-reboot** operations can only be performed when the instance status
+    is **ACTIVE**.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CBH instance.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the CBH instance
@@ -149,7 +161,7 @@ $ terraform import huaweicloud_cbh_instance.test <id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `charging_mode`, `period`, `period_unit`,
-`auto_renew`, `password`, `ipv6_enable`, `attach_disk_size`.
+`auto_renew`, `password`, `ipv6_enable`, `attach_disk_size`, `power_action`.
 It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated
 to align with the instance. Also, you can ignore changes as below.
@@ -160,7 +172,7 @@ resource "huaweicloud_cbh_instance" "test" {
 
   lifecycle {
     ignore_changes = [
-      charging_mode, period, period_unit, auto_renew, password, ipv6_enable, attach_disk_size,
+      charging_mode, period, period_unit, auto_renew, password, ipv6_enable, attach_disk_size, power_action,
     ]
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:
Add new field `power_action` is used to control the startup, shutdown, and reboot actions of a CBH instance.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
1. Add new field `power_action` is used to control the startup, shutdown, and reboot actions of a CBH instance.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### Basic And EPS migrate Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_basic
=== PAUSE TestAccCBHInstance_basic
=== CONT  TestAccCBHInstance_basic
--- PASS: TestAccCBHInstance_basic (1921.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1921.965s


$ export HW_ENTERPRISE_PROJECT_ID_TEST=xxxxxxxx  
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_epsId_migrate"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_epsId_migrate -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_epsId_migrate
=== PAUSE TestAccCBHInstance_epsId_migrate
=== CONT  TestAccCBHInstance_epsId_migrate
--- PASS: TestAccCBHInstance_epsId_migrate (1050.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1050.108s

```

### Power Action Test 
```
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_WithPowerAction"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_WithPowerAction -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_WithPowerAction
=== PAUSE TestAccCBHInstance_WithPowerAction
=== CONT  TestAccCBHInstance_WithPowerAction
--- PASS: TestAccCBHInstance_WithPowerAction (1315.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1315.475s

```