### PR TITLE
feat(css): support CSS cluster updating security_group_id

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -160,8 +160,7 @@ The following arguments are supported:
 
 * `subnet_id` - (Required, String, ForceNew) Specifies the Subnet ID. Changing this parameter will create a new resource.
 
-* `security_group_id` - (Required, String, ForceNew) Specifies Security group ID.
-  Changing this parameter will create a new resource.
+* `security_group_id` - (Required, String) Specifies the security group ID.
 
 * `availability_zone` - (Required, String, ForceNew) Specifies the availability zone name.
   Separate multiple AZs with commas (,), for example, az1,az2. AZs must be unique. The number of nodes must be greater

--- a/docs/resources/css_logstash_cluster.md
+++ b/docs/resources/css_logstash_cluster.md
@@ -70,8 +70,7 @@ The following arguments are supported:
 * `subnet_id` - (Required, String, ForceNew) Specifies the subnet ID.
   Changing this parameter will create a new resource.
 
-* `security_group_id` - (Required, String, ForceNew) Specifies the security group ID.
-  Changing this parameter will create a new resource.
+* `security_group_id` - (Required, String) Specifies the security group ID.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the logstash cluster.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
support CSS cluster updating security_group_id

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
support CSS cluster updating security_group_id
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccCssCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_basic
=== PAUSE TestAccCssCluster_basic
=== CONT  TestAccCssCluster_basic
--- PASS: TestAccCssCluster_basic (1517.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1517.960s
```

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccLogstashCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccLogstashCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccLogstashCluster_basic
=== PAUSE TestAccLogstashCluster_basic
=== CONT  TestAccLogstashCluster_basic
--- PASS: TestAccLogstashCluster_basic (1711.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1711.390s
```
