### PR TITLE
feat(cbh/ha_instance): supports startup, shutdown, and reboot actions

### DIFF
--- a/docs/resources/cbh_ha_instance.md
+++ b/docs/resources/cbh_ha_instance.md
@@ -129,6 +129,18 @@ The following arguments are supported:
 -> For the parameters `master_private_ip`, `slave_private_ip`, and `floating_ip`, if none of them are specified,
 a new IP address will be assigned to each. If one is specified, then the other two must also be specified.
 
+* `power_action` - (Optional, String) Specifies the power action after the CBH HA instance is created.
+  The valid values are as follows:
+  + **start**: Startup instance.
+  + **stop**: Shutdown instance.
+  + **soft-reboot**: Normal reboot, shut down virtual machine service.
+  + **hard-reboot**: Force reboot, reboot virtual machine.
+
+  -> The usage of `power_action` has some limitations:
+  <br/>1. The **start** operation can only be performed when the instance status is **SHUTOFF**.
+  <br/>2. The **stop**, **soft-reboot**, and **hard-reboot** operations can only be performed when the instance status
+  is **ACTIVE**.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CBH HA instance.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the CBH HA instance belongs.
@@ -171,7 +183,7 @@ $ terraform import huaweicloud_cbh_ha_instance.test <master_id>/<slave_id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `charging_mode`, `period`, `period_unit`,
-`auto_renew`, `password`, `ipv6_enable`, `attach_disk_size`.
+`auto_renew`, `password`, `ipv6_enable`, `attach_disk_size`, `power_action`.
 It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated
 to align with the instance. Also, you can ignore changes as below.
@@ -182,7 +194,7 @@ resource "huaweicloud_cbh_ha_instance" "test" {
 
   lifecycle {
     ignore_changes = [
-      charging_mode, period, period_unit, auto_renew, password, ipv6_enable, attach_disk_size,
+      charging_mode, period, period_unit, auto_renew, password, ipv6_enable, attach_disk_size, power_action,
     ]
   }
 }

--- a/docs/resources/cbh_ha_instance.md
+++ b/docs/resources/cbh_ha_instance.md
@@ -98,21 +98,6 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `master_private_ip` - (Optional, String, ForceNew) Specifies the private IP address of the master instance.
-
-  Changing this parameter will create a new resource.
-
-* `slave_private_ip` - (Optional, String, ForceNew) Specifies the private IP address of the slave instance.
-
-  Changing this parameter will create a new resource.
-
-* `floating_ip` - (Optional, String, ForceNew) Specifies the floating IP address of the CBH HA instance.
-
-  Changing this parameter will create a new resource.
-
--> For the parameters `master_private_ip`, `slave_private_ip`, and `floating_ip`, if none of them are specified,
-  a new IP address will be assigned to each. If one is specified, then the other two must also be specified.
-
 * `auto_renew` - (Optional, String) Specifies whether auto-renew is enabled.
   Valid values are **true** and **false**. Defaults to **false**.
 
@@ -128,6 +113,21 @@ The following arguments are supported:
 
   -> 1. Storage expansion is a high-risk operation, with a certain risk of failure.
   <br/>2. Expansion failure may affect the usability of the instance. Please ensure to back up your data.
+
+* `master_private_ip` - (Optional, String, ForceNew) Specifies the private IP address of the master instance.
+
+  Changing this parameter will create a new resource.
+
+* `slave_private_ip` - (Optional, String, ForceNew) Specifies the private IP address of the slave instance.
+
+  Changing this parameter will create a new resource.
+
+* `floating_ip` - (Optional, String, ForceNew) Specifies the floating IP address of the CBH HA instance.
+
+  Changing this parameter will create a new resource.
+
+-> For the parameters `master_private_ip`, `slave_private_ip`, and `floating_ip`, if none of them are specified,
+a new IP address will be assigned to each. If one is specified, then the other two must also be specified.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CBH HA instance.
 

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_ha_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_ha_instance.go
@@ -142,24 +142,6 @@ func ResourceCBHHAInstance() *schema.Resource {
 				ForceNew:    true,
 				Description: `Specifies the charging period of the CBH HA instance.`,
 			},
-			"master_private_ip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: `Specifies the private IP address of the master instance.`,
-			},
-			"slave_private_ip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: `Specifies the private IP address of the slave instance.`,
-			},
-			"floating_ip": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: `Specifies the floating IP address of the CBH HA instance.`,
-			},
 			"auto_renew": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -180,6 +162,27 @@ func ResourceCBHHAInstance() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: `Specifies the size of the additional data disk for the CBH HA instance.`,
+			},
+			"master_private_ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `Specifies the private IP address of the master instance.`,
+			},
+			"slave_private_ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `Specifies the private IP address of the slave instance.`,
+			},
+			"floating_ip": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `Specifies the floating IP address of the CBH HA instance.`,
 			},
 			"tags": common.TagsSchema(),
 			"enterprise_project_id": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new field `power_action` is used to control the startup, shutdown, and reboot actions of a CBH HA instance.
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Commit1: Add `Computed` attribute to the `master_private_ip`, `slave_private_ip`, and `floating_ip` parameters in the schema.

Commit2: Add new field `power_action` is used to control the startup, shutdown, and reboot actions of a CBH HA instance.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### Power Action Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHHAInstance_WithPowerAction"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHHAInstance_WithPowerAction -timeout 360m -parallel 4
=== RUN   TestAccCBHHAInstance_WithPowerAction
=== PAUSE TestAccCBHHAInstance_WithPowerAction
=== CONT  TestAccCBHHAInstance_WithPowerAction
--- PASS: TestAccCBHHAInstance_WithPowerAction (2225.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       2225.317s

```

### Basic Test
```
$ export HW_ENTERPRISE_PROJECT_ID_TEST=xxxxxxxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHHAInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHHAInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHHAInstance_basic
=== PAUSE TestAccCBHHAInstance_basic
=== CONT  TestAccCBHHAInstance_basic
--- PASS: TestAccCBHHAInstance_basic (3931.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       3931.817s

```