### PR TITLE
feat(css): support restart and rolling restart CSS cluster

### DIFF
--- a/docs/resources/css_cluster_restart.md
+++ b/docs/resources/css_cluster_restart.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_css_cluster_restart"
+description: |-
+  Manages CSS cluster restart resource within HuaweiCloud.
+---
+
+# huaweicloud_css_cluster_restart
+
+Manages CSS cluster restart resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+resource "huaweicloud_css_cluster_restart" "test" {
+  cluster_id = var.cluster_id
+  type       = "role"
+  value      = "ess"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the ID of the CSS cluster.
+  Changing this creates a new resource.
+
+* `type` - (Required, String, ForceNew) Specifies the operation type of the CSS cluster restart.
+  The value can be **role** or **node**. The value can only be **role** when the `is_rolling` is **true**.
+  Changing this creates a new resource.
+
+* `value` - (Required, String, ForceNew) Specifies the value under the operation type. If the operation
+  role is node, the value is the node ID. If the operation role is role, the value is one or multiple node
+  types (such as **ess**, **ess-master**, **ess-client**, **ess-cold**, and **all**). Use commas (,) to
+  separate multiple node types.
+  Changing this creates a new resource.
+
+* `is_rolling` - (Optional, Bool, ForceNew) Specifies whether to roll restart.
+  Changing this creates a new resource.
+
+  -> **NOTE:** Rolling restart is only supported when the number of nodes in the cluster (including Master nodes,
+  Client nodes, and cold data nodes) is greater than 3.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1111,6 +1111,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_csms_secret": dew.ResourceCsmsSecret(),
 
 			"huaweicloud_css_cluster":                     css.ResourceCssCluster(),
+			"huaweicloud_css_cluster_restart":             css.ResourceCssClusterRestart(),
 			"huaweicloud_css_snapshot":                    css.ResourceCssSnapshot(),
 			"huaweicloud_css_thesaurus":                   css.ResourceCssthesaurus(),
 			"huaweicloud_css_configuration":               css.ResourceCssConfiguration(),

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_restart_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_cluster_restart_test.go
@@ -1,0 +1,89 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/css/v1/cluster"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCssClusterRestart_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_css_cluster_restart.test"
+
+	var obj cluster.ClusterDetailResponse
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCssClusterFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssClusterRestart_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCssClusterRestart_rolling_restart(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_css_cluster_restart.test"
+
+	var obj cluster.ClusterDetailResponse
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCssClusterFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssClusterRestart_rolling_restart(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccCssClusterRestart_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_css_cluster_restart" "test" {
+  cluster_id = huaweicloud_css_cluster.test.id
+  type       = "role"
+  value      = "ess"
+}
+`, testAccCssCluster_basic(rName, "Test@passw0rd", 7, "bar"))
+}
+
+func testAccCssClusterRestart_rolling_restart(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_css_cluster_restart" "test" {
+  cluster_id = huaweicloud_css_cluster.test.id
+  type       = "role"
+  value      = "ess"
+  is_rolling = true
+}
+`, testAccCssCluster_extend(rName, "ess.spec-4u8g", 3, 3, 1, 40))
+}

--- a/huaweicloud/services/css/resource_huaweicloud_css_cluster_restart.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_cluster_restart.go
@@ -1,0 +1,130 @@
+package css
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	cssv2model "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/css/v2/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API CSS POST /v2.0/{project_id}/clusters/{cluster_id}/restart
+// @API CSS POST /v2.0/{project_id}/clusters/{cluster_id}/rolling_restart
+// @API CSS GET /v1.0/{project_id}/clusters/{cluster_id}
+func ResourceCssClusterRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCssClusterRestartCreate,
+		ReadContext:   resourceCssClusterRestartRead,
+		DeleteContext: resourceCssClusterRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"is_rolling": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceCssClusterRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	clusterID := d.Get("cluster_id").(string)
+	cssV1Client, err := conf.HcCssV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CSS V1 client: %s", err)
+	}
+	cssV2Client, err := conf.HcCssV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CSS V2 client: %s", err)
+	}
+
+	// Check whether the cluster status is available.
+	err = checkClusterOperationCompleted(ctx, cssV1Client, clusterID, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.Get("is_rolling").(bool) {
+		rollingRestartClusterOpts := cssv2model.RollingRestartRequest{
+			ClusterId: clusterID,
+			Body: &cssv2model.RollingRestartReq{
+				Type:  d.Get("type").(string),
+				Value: d.Get("value").(string),
+			},
+		}
+
+		_, err = cssV2Client.RollingRestart(&rollingRestartClusterOpts)
+		if err != nil {
+			return diag.Errorf("error rolling restart CSS cluster, err: %s", err)
+		}
+	} else {
+		restartClusterOpts := cssv2model.RestartClusterRequest{
+			ClusterId: clusterID,
+			Body: &cssv2model.RestartClusterReq{
+				Type:  d.Get("type").(string),
+				Value: d.Get("value").(string),
+			},
+		}
+
+		_, err = cssV2Client.RestartCluster(&restartClusterOpts)
+		if err != nil {
+			return diag.Errorf("error restart CSS cluster, err: %s", err)
+		}
+	}
+
+	// Check whether the cluster restart is complete
+	err = checkClusterOperationCompleted(ctx, cssV1Client, clusterID, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(clusterID)
+
+	return nil
+}
+
+func resourceCssClusterRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceCssClusterRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restart resource is not supported. The restart resource is only removed from the state," +
+		" the cluster instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
support restart and rolling restart CSS cluster

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
support restart and rolling restart CSS cluster
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccCssClusterRestart_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssClusterRestart_ -timeout 360m -parallel 4
=== RUN   TestAccCssClusterRestart_basic
=== PAUSE TestAccCssClusterRestart_basic
=== RUN   TestAccCssClusterRestart_rolling_restart
=== PAUSE TestAccCssClusterRestart_rolling_restart
=== CONT  TestAccCssClusterRestart_basic
=== CONT  TestAccCssClusterRestart_rolling_restart
--- PASS: TestAccCssClusterRestart_basic (899.14s)
--- PASS: TestAccCssClusterRestart_rolling_restart (953.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       953.320s
```
