### PR TITLE
feat(apig/appcode): add new data source to query appcodes

### DIFF
--- a/docs/data-sources/apig_appcodes.md
+++ b/docs/data-sources/apig_appcodes.md
@@ -1,0 +1,54 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_appcodes"
+description: |-
+  Use this data source to query the APPCODEs of the specified APIG application within HuaweiCloud.
+---
+
+# huaweicloud_apig_appcodes
+
+Use this data source to query the APPCODEs of the specified APIG application within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "application_id" {}
+
+data "huaweicloud_apig_appcodes" "test" {
+  instance_id    = var.instance_id
+  application_id = var.application_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the ID of the dedicated instance to which the application belongs.
+
+* `application_id` - (Required, String) Specifies the ID of the application to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `appcodes` - All APPCODEs of the specified application.
+  The [app_codes](#attrblock_appcodes) structure is documented below.
+
+<a name="attrblock_appcodes"></a>
+The `appcodes` block supports:
+
+* `id` - The ID of the APPCODE.
+
+* `value` - The APPCODE value (content).
+
+* `application_id` - The ID of the application.
+
+* `created_at` - The creation time of the APPCODE, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -410,6 +410,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_api_associated_signatures":          apig.DataSourceApiAssociatedSignatures(),
 			"huaweicloud_apig_api_associated_throttling_policies": apig.DataSourceApiAssociatedThrottlingPolicies(),
 			"huaweicloud_apig_api_basic_configurations":           apig.DataSourceApiBasicConfigurations(),
+			"huaweicloud_apig_appcodes":                           apig.DataSourceAppcodes(),
 			"huaweicloud_apig_applications":                       apig.DataSourceApplications(),
 			"huaweicloud_apig_application_quotas":                 apig.DataSourceApigApplicationQuotas(),
 			"huaweicloud_apig_channels":                           apig.DataSourceChannels(),

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_appcodes_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_appcodes_test.go
@@ -1,0 +1,90 @@
+package apig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataSourceAppcodes_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_apig_appcodes.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+
+		rNameNotFound = "data.huaweicloud_apig_appcodes.not_found"
+		dcNotFound    = acceptance.InitDataSourceCheck(rNameNotFound)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAppcodes_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "appcodes.#", "1"),
+					dcNotFound.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNameNotFound, "appcodes.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAppcodes_basic_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+%[1]s
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
+
+resource "huaweicloud_apig_application" "test" {
+  count = 2
+
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = format("%[2]s_%%d", count.index)
+}
+
+resource "huaweicloud_apig_appcode" "test" {
+  instance_id    = huaweicloud_apig_instance.test.id
+  application_id = huaweicloud_apig_application.test[0].id
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccDataSourceAppcodes_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_apig_appcodes" "test" {
+  depends_on = [
+    huaweicloud_apig_appcode.test
+  ]
+
+  instance_id    = huaweicloud_apig_instance.test.id
+  application_id = huaweicloud_apig_application.test[0].id
+}
+
+data "huaweicloud_apig_appcodes" "not_found" {
+  instance_id    = huaweicloud_apig_instance.test.id
+  application_id = huaweicloud_apig_application.test[1].id
+}
+`, testAccDataSourceAppcodes_basic_base())
+}

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_appcodes.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_appcodes.go
@@ -1,0 +1,155 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes
+func DataSourceAppcodes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAppcodesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the dedicated instance to which the application belongs.`,
+			},
+			"application_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the application to be queried.`,
+			},
+			"appcodes": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `All APPCODEs of the specified application.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the APPCODE.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The APPCODE value (content).`,
+						},
+						"application_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the application.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the APPCODE, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func queryAppcodes(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl    = "v2/{project_id}/apigw/instances/{instance_id}/apps/{app_id}/app-codes"
+		instanceId = d.Get("instance_id").(string)
+		appId      = d.Get("application_id").(string)
+		offset     = 0
+		result     = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{instance_id}", instanceId)
+	listPath = strings.ReplaceAll(listPath, "{app_id}", appId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s?limit=100&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving APPCODEs under specified application (%s): %s", appId, err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		appcodes := utils.PathSearch("app_codes", respBody, make([]interface{}, 0)).([]interface{})
+		if len(appcodes) < 1 {
+			break
+		}
+		result = append(result, appcodes...)
+		offset += len(appcodes)
+	}
+	return result, nil
+}
+
+func dataSourceAppcodesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("apig", region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+	signatures, err := queryAppcodes(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("appcodes", flattenAppcodes(signatures)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAppcodes(appcodes []interface{}) []interface{} {
+	if len(appcodes) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(appcodes))
+	for _, appcode := range appcodes {
+		result = append(result, map[string]interface{}{
+			"id":             utils.PathSearch("id", appcode, nil),
+			"value":          utils.PathSearch("app_code", appcode, nil),
+			"application_id": utils.PathSearch("app_id", appcode, nil),
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+				appcode, "").(string))/1000, false),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support a data source to query APPCODEs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query appcodes
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccDataSourceAppcodes_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccDataSourceAppcodes_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAppcodes_basic
=== PAUSE TestAccDataSourceAppcodes_basic
=== CONT  TestAccDataSourceAppcodes_basic
--- PASS: TestAccDataSourceAppcodes_basic (563.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      563.979s
```
