### PR TITLE
feat(apig): add a new resource to manage application quota

### DIFF
--- a/docs/resources/apig_application_quota.md
+++ b/docs/resources/apig_application_quota.md
@@ -1,0 +1,76 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_apig_application_quota"
+description: |-
+  Manages an APIG application quota resource within HuaweiCloud.
+---
+
+# huaweicloud_apig_application_quota
+
+Manages an APIG application quota resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "name" {}
+
+resource "huaweicloud_apig_application_quota" "test" {
+  instance_id   = var.instance_id
+  name          = var.name
+  time_unit     = "MINUTE"
+  call_limits   = 200
+  time_interval = 3
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the dedicated instance to
+  which the application quota belongs. Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of the application quota.  
+  The value only Chinese and English letters, digits and underscores (_) are allowed,
+  and must start with a Chinese or English letter. The valid value ranges from `3` to `255`.
+
+* `time_unit` - (Required, String) Specifies the limited time unit of the application quota.  
+  The valid values are as follows:
+  + **SECOND**
+  + **MINUTE**
+  + **HOUR**
+  + **DAY**
+
+* `call_limits` - (Required, Int) Specifies the access limit of the application quota.  
+  The valid value ranges from `1` to `2,147,483,647`.
+
+* `time_interval` - (Required, Int) Specifies the limited time value for flow control of the application quota.  
+  The valid value ranges from `1` to `2,147,483,647`.
+
+* `description` - (Optional, String) Specifies the description of the application quota.  
+  The description contain a maximum of `255` characters and the angle brackets (< and >) are not allowed.  
+  Chinese characters must be in **UTF-8** or **Unicode** format.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `bind_num` - The number of bound APPs.
+
+* `created_at` - The creation time of the application quota, in RFC3339 format.
+
+## Import
+
+The application quota can be imported using the `instance_id` and `id` separated by a slash, e.g.
+
+```bash
+$ terraform import huaweicloud_apig_application_quota.test <instance_id>/<id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -979,6 +979,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_apig_appcode":                     apig.ResourceAppcode(),
 			"huaweicloud_apig_application":                 apig.ResourceApigApplicationV2(),
 			"huaweicloud_apig_application_authorization":   apig.ResourceAppAuth(),
+			"huaweicloud_apig_application_quota":           apig.ResourceApplicationQuota(),
 			"huaweicloud_apig_certificate":                 apig.ResourceCertificate(),
 			"huaweicloud_apig_channel":                     apig.ResourceChannel(),
 			"huaweicloud_apig_custom_authorizer":           apig.ResourceApigCustomAuthorizerV2(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_quota_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_quota_test.go
@@ -1,0 +1,172 @@
+package apig
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAppQuotaResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}"
+		product = "apig"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", state.Primary.Attributes["instance_id"])
+	getPath = strings.ReplaceAll(getPath, "{app_quota_id}", state.Primary.ID)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving APIG application quota: %s", err)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccResourceAppQuota_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_apig_application_quota.test"
+		baseConfig   = testAccAppQuota_basic_base()
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getAppQuotaResourceFunc)
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppQuota_basic(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "call_limits", "5"),
+					resource.TestCheckResourceAttr(resourceName, "time_unit", "SECOND"),
+					resource.TestCheckResourceAttr(resourceName, "time_interval", "3"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccAppQuota_updateBasic(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", "update_"+name),
+					resource.TestCheckResourceAttr(resourceName, "call_limits", "6"),
+					resource.TestCheckResourceAttr(resourceName, "time_unit", "DAY"),
+					resource.TestCheckResourceAttr(resourceName, "time_interval", "8"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform script"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceAppQuotaImportFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccAppQuota_basic_base() string {
+	name := acceptance.RandomAccResourceName()
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+%[1]s
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
+}
+
+resource "huaweicloud_apig_application" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+}
+`, common.TestBaseNetwork(name), name)
+}
+
+func testAccAppQuota_basic(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_application_quota" "test" {
+  instance_id   = huaweicloud_apig_instance.test.id
+  name          = "%[2]s"
+  time_unit     = "SECOND"
+  call_limits   = 5
+  time_interval = 3
+  description   = "Created by terraform script"
+}
+`, baseConfig, name)
+}
+
+func testAccAppQuota_updateBasic(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_application_quota" "test" {
+  instance_id   = huaweicloud_apig_instance.test.id
+  name          = "update_%[2]s"
+  time_unit     = "DAY"
+  call_limits   = 6
+  time_interval = 8
+  description   = "Updated by terraform script"
+}
+`, baseConfig, name)
+}
+
+func testAccResourceAppQuotaImportFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		instanceId := rs.Primary.Attributes["instance_id"]
+		quotaId := rs.Primary.ID
+		if instanceId == "" || quotaId == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want to'<instance_id>/<id>', but got '%s/%s'",
+				instanceId, quotaId)
+		}
+		return fmt.Sprintf("%s/%s", instanceId, quotaId), nil
+	}
+}

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application_quota.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application_quota.go
@@ -1,0 +1,255 @@
+package apig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/app-quotas
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}
+// @API APIG PUT /v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}
+func ResourceApplicationQuota() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceApplicationQuotaCreate,
+		ReadContext:   resourceApplicationQuotaRead,
+		UpdateContext: resourceApplicationQuotaUpdate,
+		DeleteContext: resourceApplicationQuotaDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceApplicationQuotaImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Specifies the ID of the dedicated instance to which the application quota belongs.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the name of the application quota.",
+			},
+			"time_unit": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the limited time unit of the application quota.",
+			},
+			"call_limits": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Specifies the access limit of the application quota.",
+			},
+			"time_interval": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Specifies the limited time value for flow control of the application quota.",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the description of the application quota.",
+			},
+			"bind_num": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The number of bound APPs.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the application quota, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildQuotaParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"name":          d.Get("name"),
+		"time_unit":     d.Get("time_unit"),
+		"call_limits":   d.Get("call_limits"),
+		"time_interval": d.Get("time_interval"),
+		"remark":        d.Get("description"),
+	}
+	return bodyParams
+}
+
+func resourceApplicationQuotaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                = meta.(*config.Config)
+		region             = cfg.GetRegion(d)
+		createQuotaHttpUrl = "v2/{project_id}/apigw/instances/{instance_id}/app-quotas"
+		createQuotaProduct = "apig"
+	)
+
+	quotaClient, err := cfg.NewServiceClient(createQuotaProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating APIG Client: %s", err)
+	}
+	createQuotaPath := quotaClient.Endpoint + createQuotaHttpUrl
+	createQuotaPath = strings.ReplaceAll(createQuotaPath, "{project_id}", quotaClient.ProjectID)
+	createQuotaPath = strings.ReplaceAll(createQuotaPath, "{instance_id}", d.Get("instance_id").(string))
+	createQuotaOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createQuotaOpt.JSONBody = utils.RemoveNil(buildQuotaParams(d))
+	createQuotaResp, err := quotaClient.Request("POST", createQuotaPath, &createQuotaOpt)
+	if err != nil {
+		return diag.Errorf("error creating APIG application quota: %s", err)
+	}
+
+	createQuotaBody, err := utils.FlattenResponse(createQuotaResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	quotaId, err := jmespath.Search("app_quota_id", createQuotaBody)
+	if err != nil {
+		return diag.Errorf("error creating APIG application quota: app_quota_id is not found in API response")
+	}
+	d.SetId(quotaId.(string))
+
+	return resourceApplicationQuotaRead(ctx, d, meta)
+}
+
+func resourceApplicationQuotaRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	getApplicationQuotaHttpUrl := "v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}"
+	getApplicationQuotaProduct := "apig"
+
+	getApplicationQuotaClient, err := cfg.NewServiceClient(getApplicationQuotaProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating APIG client: %s", err)
+	}
+
+	getApplicationQuotaPath := getApplicationQuotaClient.Endpoint + getApplicationQuotaHttpUrl
+	getApplicationQuotaPath = strings.ReplaceAll(getApplicationQuotaPath, "{project_id}", getApplicationQuotaClient.ProjectID)
+	getApplicationQuotaPath = strings.ReplaceAll(getApplicationQuotaPath, "{instance_id}", d.Get("instance_id").(string))
+	getApplicationQuotaPath = strings.ReplaceAll(getApplicationQuotaPath, "{app_quota_id}", d.Id())
+
+	getApplicationQuotaOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getApplicationQuotaResp, err := getApplicationQuotaClient.Request("GET", getApplicationQuotaPath, &getApplicationQuotaOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "APIG application quota")
+	}
+
+	respBody, err := utils.FlattenResponse(getApplicationQuotaResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("time_unit", utils.PathSearch("time_unit", respBody, nil)),
+		d.Set("call_limits", utils.PathSearch("call_limits", respBody, nil)),
+		d.Set("time_interval", utils.PathSearch("time_interval", respBody, nil)),
+		d.Set("description", utils.PathSearch("remark", respBody, nil)),
+		d.Set("bind_num", utils.PathSearch("bound_app_num", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("create_time",
+			respBody, "").(string))/1000, false)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting APIG application quota fields: %s", err)
+	}
+
+	return nil
+}
+
+func resourceApplicationQuotaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	updateQuotaHttpUrl := "v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}"
+	updateQuotaProduct := "apig"
+
+	updateQuotaClient, err := cfg.NewServiceClient(updateQuotaProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating APIG Client: %s", err)
+	}
+	updateQuotaPath := updateQuotaClient.Endpoint + updateQuotaHttpUrl
+	updateQuotaPath = strings.ReplaceAll(updateQuotaPath, "{project_id}", updateQuotaClient.ProjectID)
+	updateQuotaPath = strings.ReplaceAll(updateQuotaPath, "{instance_id}", d.Get("instance_id").(string))
+	updateQuotaPath = strings.ReplaceAll(updateQuotaPath, "{app_quota_id}", d.Id())
+
+	updateQuotaOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildQuotaParams(d),
+	}
+
+	_, err = updateQuotaClient.Request("PUT", updateQuotaPath, &updateQuotaOpt)
+	if err != nil {
+		return diag.Errorf("error updating APIG application quota: %s", err)
+	}
+	return resourceApplicationQuotaRead(ctx, d, meta)
+}
+
+func resourceApplicationQuotaDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	quotaProduct := "apig"
+	quotaClient, err := cfg.NewServiceClient(quotaProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating APIG Client: %s", err)
+	}
+	delQuotaHttpUrl := "v2/{project_id}/apigw/instances/{instance_id}/app-quotas/{app_quota_id}"
+	delQuotaPath := quotaClient.Endpoint + delQuotaHttpUrl
+	delQuotaPath = strings.ReplaceAll(delQuotaPath, "{project_id}", quotaClient.ProjectID)
+	delQuotaPath = strings.ReplaceAll(delQuotaPath, "{instance_id}", d.Get("instance_id").(string))
+	delQuotaPath = strings.ReplaceAll(delQuotaPath, "{app_quota_id}", d.Id())
+
+	delQuotaOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	_, err = quotaClient.Request("DELETE", delQuotaPath, &delQuotaOpt)
+
+	if err != nil {
+		return diag.Errorf("error deleting APIG application quota: %s", err)
+	}
+	return nil
+}
+
+func resourceApplicationQuotaImport(_ context.Context, d *schema.ResourceData, _ interface{}) (
+	[]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format of import ID, want to '<instance_id>/<id>', but got '%s'", d.Id())
+	}
+
+	d.SetId(parts[1])
+	mErr := multierror.Append(nil,
+		d.Set("instance_id", parts[0]),
+	)
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add a new resource to manage application quota.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/apig" TESTARGS="-run TestAccResourceAppQuota_basic"
...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccResourceAppQuota_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceAppQuota_basic
=== PAUSE TestAccResourceAppQuota_basic
=== CONT  TestAccResourceAppQuota_basic
--- PASS: TestAccResourceAppQuota_basic (585.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      585.609s
```
