### PR TITLE
feat(as): AS configuration resource support new fields

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -28,6 +28,8 @@ var (
 	HW_PROJECT_ID_2       = os.Getenv("HW_PROJECT_ID_2")
 	HW_PROJECT_ID_3       = os.Getenv("HW_PROJECT_ID_3")
 
+	HW_DEDICATED_HOST_ID = os.Getenv("HW_DEDICATED_HOST_ID")
+
 	HW_DOMAIN_ID                          = os.Getenv("HW_DOMAIN_ID")
 	HW_DOMAIN_NAME                        = os.Getenv("HW_DOMAIN_NAME")
 	HW_ENTERPRISE_PROJECT_ID_TEST         = os.Getenv("HW_ENTERPRISE_PROJECT_ID_TEST")
@@ -1740,5 +1742,12 @@ func TestAccPreCheckRdsTimeRange(t *testing.T) {
 func TestAccPreCheckCssLowEngineVersion(t *testing.T) {
 	if HW_CSS_LOW_ENGINE_VERSION == "" {
 		t.Skip("HW_CSS_LOW_ENGINE_VERSION must be set for CSS acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckAsDedicatedHostId(t *testing.T) {
+	if HW_DEDICATED_HOST_ID == "" {
+		t.Skip("HW_DEDICATED_HOST_ID must be set for the acceptance test")
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

AS configuration resource support new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
AS configuration resource support new fields contain instance_config.0.tenancy, instance_config.0.dedicated_host_id,
instance_config.0.disk.0.iops, instance_config.0.disk.0.throughput, instance_config.0.public_ip.0.eip.0.bandwidth.0.id.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASConfiguration_NewDiskTypeAndDEH"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_NewDiskTypeAndDEH -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_NewDiskTypeAndDEH
=== PAUSE TestAccASConfiguration_NewDiskTypeAndDEH
=== CONT  TestAccASConfiguration_NewDiskTypeAndDEH
--- PASS: TestAccASConfiguration_NewDiskTypeAndDEH (102.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        102.110s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASConfiguration_sharedBandwidth"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_sharedBandwidth -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_sharedBandwidth
=== PAUSE TestAccASConfiguration_sharedBandwidth
=== CONT  TestAccASConfiguration_sharedBandwidth
--- PASS: TestAccASConfiguration_sharedBandwidth (109.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        109.497s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASConfiguration_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_basic
=== PAUSE TestAccASConfiguration_basic
=== CONT  TestAccASConfiguration_basic
--- PASS: TestAccASConfiguration_basic (100.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        100.635s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASConfiguration_instance"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_instance -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_instance
=== PAUSE TestAccASConfiguration_instance
=== CONT  TestAccASConfiguration_instance
--- PASS: TestAccASConfiguration_instance (223.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        223.195s
```