### PR TITLE
feat: Upgrade huaweicloud-sdk-go-v3 sdk from v0.1.94 to v0.1.98

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
-	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.94
+	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.98
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jmespath/go-jmespath v0.4.0
 	github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKL
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.94 h1:I77BU6cIp/f+RdRicvzCni1zKUKkxuMWjKXHuJtoXy0=
-github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.94/go.mod h1:j8hJuz4uvsxnzkYmEDO7lB6Jj3TY09KY/DxLUPcO6a8=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.98 h1:R1/GNmGvltl40XxwmcMecJipjXwT8KIkJsQhENAx3KE=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.98/go.mod h1:lhdEO9Bbb3hZ0wG+JeK9/GqMOp/sgc92mFmVk5tNSCk=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -246,7 +246,7 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
+golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -274,6 +274,7 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -307,15 +308,16 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
-golang.org/x/term v0.16.0/go.mod h1:yn7UURbUtPyrVJPGPq404EukNFxcm/foM+bV/bfcDsY=
+golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
 golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
+golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -2171,7 +2171,7 @@ func flattenHstsAttrs(hsts *model.HstsQuery) []map[string]interface{} {
 	return []map[string]interface{}{hstsAttrs}
 }
 
-func flattenSourcesAttrs(sources *[]model.SourcesConfig) []map[string]interface{} {
+func flattenSourcesAttrs(sources *[]model.SourcesConfigResponseBody) []map[string]interface{} {
 	if sources == nil || len(*sources) == 0 {
 		return nil
 	}

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/requests.go
@@ -67,6 +67,8 @@ type DiskOpts struct {
 	DedicatedStorageID string            `json:"dedicated_storage_id,omitempty"`
 	DataDiskImageID    string            `json:"data_disk_image_id,omitempty"`
 	SnapshotId         string            `json:"snapshot_id,omitempty"`
+	Iops               int               `json:"iops,omitempty"`
+	Throughput         int               `json:"throughput,omitempty"`
 	Metadata           map[string]string `json:"metadata,omitempty"`
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/configurations/results.go
@@ -67,6 +67,8 @@ type Disk struct {
 	DedicatedStorageID string            `json:"dedicated_storage_id"`
 	DataDiskImageID    string            `json:"data_disk_image_id"`
 	SnapshotID         string            `json:"snapshot_id"`
+	Iops               int               `json:"iops"`
+	Throughput         int               `json:"throughput"`
 	Metadata           map[string]string `json:"metadata"`
 }
 
@@ -88,6 +90,7 @@ type Bandwidth struct {
 	Size         int    `json:"size"`
 	ShareType    string `json:"share_type"`
 	ChargingMode string `json:"charging_mode"`
+	ID           string `json:"id"`
 }
 
 type SecurityGroup struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
@@ -48,7 +48,9 @@ type CreateOpts struct {
 	PreStopHandler string `json:"pre_stop_handler,omitempty"`
 	// Maximum duration the function can be initialized.
 	// Value range: 1s–90s.
-	PreStopTimeout int `json:"pre_stop_timeout,omitempty"`
+	PreStopTimeout    int                   `json:"pre_stop_timeout,omitempty"`
+	FuncVpc           *FuncVpc              `json:"func_vpc,omitempty"`
+	NetworkController *NetworkControlConfig `json:"network_controller,omitempty"`
 }
 
 type CustomImage struct {
@@ -195,7 +197,7 @@ type UpdateMetadataOpts struct {
 	// Function log configuration.
 	LogConfig *FuncLogConfig `json:"log_config,omitempty"`
 	// Network configuration.
-	NetworkController NetworkControlConfig `json:"network_controller,omitempty"`
+	NetworkController *NetworkControlConfig `json:"network_controller,omitempty"`
 	// Whether stateful functions are supported.
 	IsStatefulFunction bool `json:"is_stateful_function,omitempty"`
 	// Whether to enable dynamic memory allocation.

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/results.go
@@ -171,15 +171,26 @@ type FunctionBase struct {
 }
 
 type FuncVpc struct {
-	Id         string `json:"-"`
-	DomainId   string `json:"-" validate:"regexp=^[a-zA-Z0-9-]+$" description:"domain id"`
-	Namespace  string `json:"-"`
-	VpcName    string `json:"vpc_name,omitempty"`
-	VpcId      string `json:"vpc_id,omitempty"`
-	SubnetName string `json:"subnet_name,omitempty"`
-	SubnetId   string `json:"subnet_id,omitempty"`
-	Cidr       string `json:"cidr,omitempty"`
-	Gateway    string `json:"gateway,omitempty"`
+	Id             string   `json:"-"`
+	DomainId       string   `json:"-" validate:"regexp=^[a-zA-Z0-9-]+$" description:"domain id"`
+	Namespace      string   `json:"-"`
+	VpcName        string   `json:"vpc_name,omitempty"`
+	VpcId          string   `json:"vpc_id,omitempty"`
+	SubnetName     string   `json:"subnet_name,omitempty"`
+	SubnetId       string   `json:"subnet_id,omitempty"`
+	Cidr           string   `json:"cidr,omitempty"`
+	Gateway        string   `json:"gateway,omitempty"`
+	SecurityGroups []string `json:"security_groups,omitempty"`
+}
+
+type TriggerAccessVpcs struct {
+	VpcId   string `json:"vpc_id"`
+	VpcName string `json:"trigger_access_vpcs"`
+}
+
+type NetworkController struct {
+	DisablePublicNetwork bool                 `json:"disable_public_network"`
+	TriggerAccessVpcs    []*TriggerAccessVpcs `json:"trigger_access_vpcs"`
 }
 
 type commonResult struct {

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/signer/derived_signer.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/signer/derived_signer.go
@@ -36,6 +36,10 @@ const (
 	AlgorithmV11      = "V11-HMAC-SHA256"
 )
 
+func SignDerived(r *request.DefaultHttpRequest, ak string, sk string, derivedAuthServiceName string, regionId string) (map[string]string, error) {
+	return DerivedSigner{}.Sign(r, ak, sk, derivedAuthServiceName, regionId)
+}
+
 type DerivedSigner struct {
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/signer/signer.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth/signer/signer.go
@@ -22,6 +22,10 @@ const (
 	xSdkContentSha256 = "X-Sdk-Content-Sha256"
 )
 
+func Sign(req *request.DefaultHttpRequest, ak, sk string) (map[string]string, error) {
+	return Signer{}.Sign(req, ak, sk)
+}
+
 type Signer struct {
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v1/cdn_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v1/cdn_client.go
@@ -187,6 +187,7 @@ func (c *CdnClient) EnableDomainInvoker(request *model.EnableDomainRequest) *Ena
 	return &EnableDomainInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
 }
 
+// Deprecated: This function is deprecated and will be removed in the future versions.
 // ListDomains 查询加速域名
 //
 // 查询加速域名信息
@@ -202,6 +203,7 @@ func (c *CdnClient) ListDomains(request *model.ListDomainsRequest) (*model.ListD
 	}
 }
 
+// Deprecated: This function is deprecated and will be removed in the future versions.
 // ListDomainsInvoker 查询加速域名
 func (c *CdnClient) ListDomainsInvoker(request *model.ListDomainsRequest) *ListDomainsInvoker {
 	requestDef := GenReqDefForListDomains()
@@ -292,6 +294,7 @@ func (c *CdnClient) ShowDomainDetailInvoker(request *model.ShowDomainDetailReque
 	return &ShowDomainDetailInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
 }
 
+// Deprecated: This function is deprecated and will be removed in the future versions.
 // ShowDomainFullConfig 查询域名配置接口
 //
 // 查询域名配置接口，
@@ -308,6 +311,7 @@ func (c *CdnClient) ShowDomainFullConfig(request *model.ShowDomainFullConfigRequ
 	}
 }
 
+// Deprecated: This function is deprecated and will be removed in the future versions.
 // ShowDomainFullConfigInvoker 查询域名配置接口
 func (c *CdnClient) ShowDomainFullConfigInvoker(request *model.ShowDomainFullConfigRequest) *ShowDomainFullConfigInvoker {
 	requestDef := GenReqDefForShowDomainFullConfig()
@@ -758,6 +762,7 @@ func (c *CdnClient) UpdateCacheRulesInvoker(request *model.UpdateCacheRulesReque
 	return &UpdateCacheRulesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
 }
 
+// Deprecated: This function is deprecated and will be removed in the future versions.
 // UpdateDomainFullConfig 修改域名全量配置接口
 //
 // 修改域名配置接口，
@@ -774,6 +779,7 @@ func (c *CdnClient) UpdateDomainFullConfig(request *model.UpdateDomainFullConfig
 	}
 }
 
+// Deprecated: This function is deprecated and will be removed in the future versions.
 // UpdateDomainFullConfigInvoker 修改域名全量配置接口
 func (c *CdnClient) UpdateDomainFullConfigInvoker(request *model.UpdateDomainFullConfigRequest) *UpdateDomainFullConfigInvoker {
 	requestDef := GenReqDefForUpdateDomainFullConfig()

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v1/cdn_invoker.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v1/cdn_invoker.go
@@ -105,6 +105,7 @@ type ListDomainsInvoker struct {
 	*invoker.BaseInvoker
 }
 
+// Deprecated: This function is deprecated and will be removed in the future versions.
 func (i *ListDomainsInvoker) Invoke() (*model.ListDomainsResponse, error) {
 	if result, err := i.BaseInvoker.Invoke(); err != nil {
 		return nil, err
@@ -165,6 +166,7 @@ type ShowDomainFullConfigInvoker struct {
 	*invoker.BaseInvoker
 }
 
+// Deprecated: This function is deprecated and will be removed in the future versions.
 func (i *ShowDomainFullConfigInvoker) Invoke() (*model.ShowDomainFullConfigResponse, error) {
 	if result, err := i.BaseInvoker.Invoke(); err != nil {
 		return nil, err
@@ -398,6 +400,7 @@ type UpdateDomainFullConfigInvoker struct {
 	*invoker.BaseInvoker
 }
 
+// Deprecated: This function is deprecated and will be removed in the future versions.
 func (i *UpdateDomainFullConfigInvoker) Invoke() (*model.UpdateDomainFullConfigResponse, error) {
 	if result, err := i.BaseInvoker.Invoke(); err != nil {
 		return nil, err

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/cdn_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/cdn_client.go
@@ -461,7 +461,7 @@ func (c *CdnClient) ShowDomainDetailByNameInvoker(request *model.ShowDomainDetai
 
 // ShowDomainFullConfig 查询域名配置接口
 //
-// 查询域名配置接口，支持查询业务类型、服务范围、备注、IPv6开关、回源方式、回源URL改写、高级回源、Range回源、回源跟随、回源是否校验Etag、回源超时时间、回源请求头、HTTPS配置、TLS版本配置、强制跳转、HSTS、HTTP/2、OCSP Stapling、QUIC、缓存规则、状态码缓存时间、防盗链、IP黑白名单、 Use-Agent黑白名单、URL鉴权配置、远程鉴权配置、IP访问限频、HTTP header配置、自定义错误页面配置、智能压缩、请求限速配置、WebSocket配置、视频拖拽、回源SNI、访问URL重写、浏览器缓存过期时间。
+// 查询域名配置接口，支持查询业务类型、服务范围、备注、IPv6开关、回源方式、回源URL改写、高级回源、Range回源、回源跟随、回源是否校验Etag、回源超时时间、回源请求头、HTTPS配置、TLS版本配置、强制跳转、HSTS、HTTP/2、OCSP Stapling、QUIC、缓存规则、状态码缓存时间、防盗链、IP黑白名单、 Use-Agent黑白名单、URL鉴权配置、远程鉴权配置、IP访问限频、HTTP header配置、自定义错误页面配置、智能压缩、请求限速配置、WebSocket配置、视频拖拽、回源SNI、访问URL重写、浏览器缓存过期时间、区域访问控制。
 //
 // Please refer to HUAWEI cloud API Explorer for details.
 func (c *CdnClient) ShowDomainFullConfig(request *model.ShowDomainFullConfigRequest) (*model.ShowDomainFullConfigResponse, error) {
@@ -784,7 +784,7 @@ func (c *CdnClient) ShowVerifyDomainOwnerInfoInvoker(request *model.ShowVerifyDo
 
 // UpdateDomainFullConfig 修改域名全量配置接口
 //
-// 修改域名配置接口，支持修改业务类型、服务范围、备注、IPv6开关、回源方式、回源URL改写、高级回源、Range回源、回源跟随、回源是否校验Etag、回源超时时间、回源请求头、HTTPS配置、TLS版本配置、强制跳转、HSTS、HTTP/2、OCSP Stapling、QUIC、缓存规则、状态码缓存时间、防盗链、IP黑白名单、Use-Agent黑白名单、URL鉴权配置、远程鉴权配置、IP访问限频、HTTP header配置、自定义错误页面配置、智能压缩、请求限速配置、WebSocket配置、视频拖拽、回源SNI、访问URL重写、浏览器缓存过期时间。
+// 修改域名配置接口，支持修改业务类型、服务范围、备注、IPv6开关、回源方式、回源URL改写、高级回源、Range回源、回源跟随、回源是否校验Etag、回源超时时间、回源请求头、HTTPS配置、TLS版本配置、强制跳转、HSTS、HTTP/2、OCSP Stapling、QUIC、缓存规则、状态码缓存时间、防盗链、IP黑白名单、Use-Agent黑白名单、URL鉴权配置、远程鉴权配置、IP访问限频、HTTP header配置、自定义错误页面配置、智能压缩、请求限速配置、WebSocket配置、视频拖拽、回源SNI、访问URL重写、浏览器缓存过期时间、区域访问控制。
 //
 // Please refer to HUAWEI cloud API Explorer for details.
 func (c *CdnClient) UpdateDomainFullConfig(request *model.UpdateDomainFullConfigRequest) (*model.UpdateDomainFullConfigResponse, error) {

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_access_area_filter.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_access_area_filter.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// AccessAreaFilter 区域访问控制。   > - 使用该功能需要提交工单开通区域访问控制功能。   > - CDN会定期更新IP地址库，部分未在地址库的IP将无法识别到所属位置。如果CDN无法识别用户所在位置，将采取放行策略，返回对应的资源给用户。
+type AccessAreaFilter struct {
+
+	// 规则类型，黑、白名单二选一。   - black: 黑名单，如果匹配到黑名单规则，则黑名单所选区域内的用户将无法访问当前资源，返回403状态码。   - white: 白名单，白名单所选区域以外的用户均无法访问当前资源，返回403状态码。
+	Type *string `json:"type,omitempty"`
+
+	// 生效类型。   - all: 所有文件，所有文件均遵循配置的规则。   - file_directory: 目录路径，指定目录路径的资源遵循配置的规则。   - file_path: 全路径，指定路径的资源遵循配置的规则。
+	ContentType *string `json:"content_type,omitempty"`
+
+	// 生效规则。当content_type为all时，为空或不传。 当content_type为file_directory时，输入要求以“/”作为首字符，多个目录以“,”进行分隔，如/test/folder01,/test/folder02，并且输入的目录路径总数不超过100个。 当content_type为file_path时，输入要求以“/”或“\\*”作为首字符，支持配置通配符“\\*”，通配符不能连续出现且不能超过两个。多个路径以“,”进行分割，如/test/a.txt,/test/b.txt，并且输出的总数不能超过100个。   > - 不允许配置两条完全一样的白名单或黑名单规则。   > - 仅允许配置一条生效类型为“所有文件”的规则。
+	ContentValue *string `json:"content_value,omitempty"`
+
+	// 配置规则适用的区域，多个区域以“,”进行分隔，支持的区域如：CN_IN：中国大陆，AF：阿富汗，IE：爱尔兰，EG：埃及，AU：澳大利亚等。具体的位置编码参见《附录-地理位置编码》查询。
+	Area *string `json:"area,omitempty"`
+
+	// 例外IP，配置指定IP不执行当前规则。
+	ExceptionIp *string `json:"exception_ip,omitempty"`
+}
+
+func (o AccessAreaFilter) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AccessAreaFilter struct{}"
+	}
+
+	return strings.Join([]string{"AccessAreaFilter", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_certificates_get_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_certificates_get_body.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CertificatesGetBody 双证书配置查询响应体。
+type CertificatesGetBody struct {
+
+	// 证书类型，server：国际证书；server_sm：国密证书。
+	CertificateType *string `json:"certificate_type,omitempty"`
+
+	// 证书名字。
+	CertificateName *string `json:"certificate_name,omitempty"`
+
+	// HTTPS协议使用的证书内容，PEM编码格式。
+	CertificateValue *string `json:"certificate_value,omitempty"`
+
+	// 国密证书加密证书内容，PEM编码格式。
+	EncCertificateValue *string `json:"enc_certificate_value,omitempty"`
+
+	// 证书过期时间。  > UTC时间。
+	ExpireTime *int64 `json:"expire_time,omitempty"`
+}
+
+func (o CertificatesGetBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CertificatesGetBody struct{}"
+	}
+
+	return strings.Join([]string{"CertificatesGetBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_certificates_put_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_certificates_put_body.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CertificatesPutBody 配置双证书时必传，需要同时传入国际证书和国密证书，不支持传两个国际证书或两个国密证书。   > - 您也可以在certificates参数下传入一个国际证书或一个国密证书。   > - 如果certificates传了证书（国际证书、国密证书或国际+国密双证书），外层证书配置将失效，仅保留当前参数传入的证书信息。
+type CertificatesPutBody struct {
+
+	// 证书类型，server：国际证书；server_sm：国密证书。
+	CertificateType string `json:"certificate_type"`
+
+	// 证书名字，长度限制为3-64字符。
+	CertificateName string `json:"certificate_name"`
+
+	// HTTPS协议使用的证书内容。  > PEM编码格式。
+	CertificateValue string `json:"certificate_value"`
+
+	// HTTPS协议使用的私钥。  > PEM编码格式。
+	PrivateKey string `json:"private_key"`
+
+	// 加密证书内容，证书类型为国密证书时必传。  > PEM编码格式。
+	EncCertificateValue *string `json:"enc_certificate_value,omitempty"`
+
+	// 加密私钥内容，证书类型为国密证书时必传。  > PEM编码格式。
+	EncPrivateKey *string `json:"enc_private_key,omitempty"`
+}
+
+func (o CertificatesPutBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CertificatesPutBody struct{}"
+	}
+
+	return strings.Join([]string{"CertificatesPutBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_configs.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_configs.go
@@ -98,6 +98,8 @@ type Configs struct {
 
 	// 浏览器缓存过期时间。
 	BrowserCacheRules *[]BrowserCacheRules `json:"browser_cache_rules,omitempty"`
+
+	AccessAreaFilter *[]AccessAreaFilter `json:"access_area_filter,omitempty"`
 }
 
 func (o Configs) String() string {

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_configs_get_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_configs_get_body.go
@@ -29,7 +29,7 @@ type ConfigsGetBody struct {
 	Https *HttpGetBody `json:"https,omitempty"`
 
 	// 源站配置。
-	Sources *[]SourcesConfig `json:"sources,omitempty"`
+	Sources *[]SourcesConfigResponseBody `json:"sources,omitempty"`
 
 	// 回源协议，follow：协议跟随回源，http：HTTP回源(默认)，https：https回源。
 	OriginProtocol *string `json:"origin_protocol,omitempty"`
@@ -98,6 +98,8 @@ type ConfigsGetBody struct {
 
 	// 浏览器缓存过期时间。
 	BrowserCacheRules *[]BrowserCacheRules `json:"browser_cache_rules,omitempty"`
+
+	AccessAreaFilter *[]AccessAreaFilter `json:"access_area_filter,omitempty"`
 }
 
 func (o ConfigsGetBody) String() string {

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domain_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_domain_body.go
@@ -19,7 +19,7 @@ type DomainBody struct {
 	BusinessType DomainBodyBusinessType `json:"business_type"`
 
 	// 源站配置。
-	Sources []Sources `json:"sources"`
+	Sources []SourcesRequestBody `json:"sources"`
 
 	// 域名服务范围，若为mainland_china，则表示服务范围为中国大陆；若为outside_mainland_china，则表示服务范围为中国大陆境外；若为global，则表示服务范围为全球。
 	ServiceArea DomainBodyServiceArea `json:"service_area"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_get_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_get_body.go
@@ -12,6 +12,12 @@ type HttpGetBody struct {
 	// HTTPS证书是否启用，on：开启，off：关闭。
 	HttpsStatus *string `json:"https_status,omitempty"`
 
+	// 证书类型。server：国际证书；server_sm：国密证书。
+	CertificateType *string `json:"certificate_type,omitempty"`
+
+	// 证书来源，1：华为云托管证书，0：自有证书。
+	CertificateSource *int32 `json:"certificate_source,omitempty"`
+
 	// 证书名字。
 	CertificateName *string `json:"certificate_name,omitempty"`
 
@@ -21,11 +27,10 @@ type HttpGetBody struct {
 	// 证书过期时间。  > UTC时间。
 	ExpireTime *int64 `json:"expire_time,omitempty"`
 
-	// 证书来源,0：自有证书。
-	CertificateSource *int32 `json:"certificate_source,omitempty"`
+	// 国密证书加密证书内容，PEM编码格式。
+	EncCertificateValue *string `json:"enc_certificate_value,omitempty"`
 
-	// 证书类型。server：国际证书；server_sm：国密证书。
-	CertificateType *string `json:"certificate_type,omitempty"`
+	Certificates *[]CertificatesGetBody `json:"certificates,omitempty"`
 
 	// 是否使用HTTP2.0，on：是，off：否。
 	Http2Status *string `json:"http2_status,omitempty"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_put_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_http_put_body.go
@@ -12,6 +12,12 @@ type HttpPutBody struct {
 	// HTTPS证书是否启用，on：开启，off：关闭。
 	HttpsStatus *string `json:"https_status,omitempty"`
 
+	// 证书类型，server：国际证书；server_sm：国密证书。
+	CertificateType *string `json:"certificate_type,omitempty"`
+
+	// 证书来源，0：自有证书，默认值0。  > 证书开启时必传
+	CertificateSource *int32 `json:"certificate_source,omitempty"`
+
 	// 证书名字，长度限制为3-64字符。  > 当证书开启时必传。
 	CertificateName *string `json:"certificate_name,omitempty"`
 
@@ -21,11 +27,13 @@ type HttpPutBody struct {
 	// HTTPS协议使用的私钥，当证书开启时必传。  > PEM编码格式。
 	PrivateKey *string `json:"private_key,omitempty"`
 
-	// 证书来源,1：华为云托管证书,0：自有证书, 默认值0。  > 证书开启时必传
-	CertificateSource *int32 `json:"certificate_source,omitempty"`
+	// 加密证书内容，证书类型为国密证书时必传。  > PEM编码格式。
+	EncCertificateValue *string `json:"enc_certificate_value,omitempty"`
 
-	// 证书类型，server：国际证书；server_sm：国密证书。
-	CertificateType *string `json:"certificate_type,omitempty"`
+	// 加密私钥内容，证书类型为国密证书时必传。  > PEM编码格式。
+	EncPrivateKey *string `json:"enc_private_key,omitempty"`
+
+	Certificates *[]CertificatesPutBody `json:"certificates,omitempty"`
 
 	// 是否使用HTTP2.0，on：是，off：否。  > 默认关闭，https_status=off时，该值不生效。
 	Http2Status *string `json:"http2_status,omitempty"`

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_preheating_task_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_preheating_task_request_body.go
@@ -11,7 +11,7 @@ type PreheatingTaskRequestBody struct {
 	// 是否对url中的中文字符进行编码后预热，false代表不开启，true代表开启，开启后仅预热转码后的URL。
 	ZhUrlEncode *bool `json:"zh_url_encode,omitempty"`
 
-	// 需要预热的URL必须带有“http://”或“https://”，多个URL用逗号分隔，目前不支持对目录的预热，单个url的长度限制为4096字符,单次最多输入1000个url。
+	// 需要预热的URL必须带有“http://”或“https://”，多个URL用逗号分隔（\"url1\", \"url2\"），目前不支持对目录的预热，单个url的长度限制为4096字符,单次最多输入1000个url。
 	Urls []string `json:"urls"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_refresh_task_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_refresh_task_request_body.go
@@ -20,7 +20,7 @@ type RefreshTaskRequestBody struct {
 	// 是否对url中的中文字符进行编码后刷新，false代表不开启，true代表开启，开启后仅刷新转码后的URL。
 	ZhUrlEncode *bool `json:"zh_url_encode,omitempty"`
 
-	// 需要刷新的URL必须带有“http://”或“https://”，多个URL用逗号分隔，单个url的长度限制为4096字符，单次最多输入1000个url，如果输入的是目录，支持100个目录刷新。  >   如果您需要刷新的URL中有中文，请同时刷新中文URL和转码后的URL。
+	// 需要刷新的URL必须带有“http://”或“https://”，多个URL用逗号分隔（\"url1\", \"url2\"），单个url的长度限制为4096字符，单次最多输入1000个url，如果输入的是目录，支持100个目录刷新。   > - 如果您需要刷新的URL中有中文，请同时刷新中文URL（输入中文URL且不开启zh_url_encode）和转码后的URL（输入中文URL且开启zh_url_encode）。   > - 如果您的URL中带有空格，请自行转码后输入，且不要开启URL Encode。
 	Urls []string `json:"urls"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_url_task_info_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_url_task_info_request.go
@@ -15,10 +15,10 @@ type ShowUrlTaskInfoRequest struct {
 	// 结束时间戳（毫秒），默认次日00:00。
 	EndTime *int64 `json:"end_time,omitempty"`
 
-	// 偏移量：特定数据字段与起始数据字段位置的距离。
+	// 偏移量：特定数据字段与起始数据字段位置的距离，默认为0。
 	Offset *int32 `json:"offset,omitempty"`
 
-	// 单次查询数据条数，上限为100。
+	// 单次查询数据条数，上限为100，默认为10。
 	Limit *int32 `json:"limit,omitempty"`
 
 	// 刷新预热url。

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_url_task_info_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_show_url_task_info_response.go
@@ -12,7 +12,7 @@ type ShowUrlTaskInfoResponse struct {
 	// 查询结果总数。
 	Total *int32 `json:"total,omitempty"`
 
-	// 当前查询到的总页数。
+	// 当前页查询到的总数。
 	Count *int32 `json:"count,omitempty"`
 
 	// url信息。

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_source_with_port.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_source_with_port.go
@@ -21,6 +21,9 @@ type SourceWithPort struct {
 	// 源站类型，ipaddr：源站IP、 domain：源站域名、obs_bucket：OBS桶域名。
 	OriginType SourceWithPortOriginType `json:"origin_type"`
 
+	// OBS桶类型。   - private: 私有桶（除桶ACL授权外的其他用户无桶的访问权限）。   - public: 公有桶（任何用户都可以对桶内对象进行读操作）。
+	ObsBucketType *string `json:"obs_bucket_type,omitempty"`
+
 	// 主备状态（1代表主源站；0代表备源站）。
 	ActiveStandby int32 `json:"active_standby"`
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources.go
@@ -21,6 +21,9 @@ type Sources struct {
 	// 源站类型取值：ipaddr：源站IP、 domain：源站域名、obs_bucket：OBS桶域名。
 	OriginType SourcesOriginType `json:"origin_type"`
 
+	// OBS桶类型。   - private: 私有桶（除桶ACL授权外的其他用户无桶的访问权限）。   - public: 公有桶（任何用户都可以对桶内对象进行读操作）。
+	ObsBucketType *string `json:"obs_bucket_type,omitempty"`
+
 	// 主备状态，1代表主源站，0代表备源站。
 	ActiveStandby int32 `json:"active_standby"`
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_config.go
@@ -33,7 +33,7 @@ type SourcesConfig struct {
 	// 回源HOST，默认加速域名。
 	HostName *string `json:"host_name,omitempty"`
 
-	// OBS桶源站类型： - “private” 私有桶； - “public” 公有桶，默认为公有桶。
+	// OBS桶类型，源站类型是“OBS桶域名”时需要传该参数，不传默认为“public”。   - private: 私有桶（除桶ACL授权外的其他用户无桶的访问权限）。   - public: 公有桶（任何用户都可以对桶内对象进行读操作）。
 	ObsBucketType *string `json:"obs_bucket_type,omitempty"`
 
 	// 第三方对象存储访问密钥。  > 源站类型为第三方桶时必填

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_config_response_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_config_response_body.go
@@ -1,0 +1,59 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// SourcesConfigResponseBody 源站配置。
+type SourcesConfigResponseBody struct {
+
+	// 源站类型， - ipaddr：源站IP； - domain：源站域名； - obs_bucket：OBS桶域名； - third_bucket：第三方桶。
+	OriginType string `json:"origin_type"`
+
+	// 源站IP或者域名。
+	OriginAddr string `json:"origin_addr"`
+
+	// 源站优先级，70：主，30：备。
+	Priority int32 `json:"priority"`
+
+	// 权重，取值范围1-100。
+	Weight *int32 `json:"weight,omitempty"`
+
+	// 是否开启OBS静态网站托管，源站类型为obs_bucket时传递，off：关闭，on：开启。
+	ObsWebHostingStatus *string `json:"obs_web_hosting_status,omitempty"`
+
+	// HTTP端口，默认80,端口取值取值范围1-65535。
+	HttpPort *int32 `json:"http_port,omitempty"`
+
+	// HTTPS端口，默认443,端口取值取值范围1-65535。
+	HttpsPort *int32 `json:"https_port,omitempty"`
+
+	// 回源HOST，默认加速域名。
+	HostName *string `json:"host_name,omitempty"`
+
+	// OBS桶类型。   - private: 私有桶（除桶ACL授权外的其他用户无桶的访问权限）。   - public: 公有桶（任何用户都可以对桶内对象进行读操作）。
+	ObsBucketType *string `json:"obs_bucket_type,omitempty"`
+
+	// 第三方对象存储访问密钥。  > 源站类型为第三方桶时必填
+	BucketAccessKey *string `json:"bucket_access_key,omitempty"`
+
+	// 第三方对象存储密钥。  > 源站类型为第三方桶时必填
+	BucketSecretKey *string `json:"bucket_secret_key,omitempty"`
+
+	// 第三方对象存储区域。  > 源站类型为第三方桶时必填
+	BucketRegion *string `json:"bucket_region,omitempty"`
+
+	// 第三方对象存储名称。  > 源站类型为第三方桶时必填
+	BucketName *string `json:"bucket_name,omitempty"`
+}
+
+func (o SourcesConfigResponseBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SourcesConfigResponseBody struct{}"
+	}
+
+	return strings.Join([]string{"SourcesConfigResponseBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_domain_config.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_domain_config.go
@@ -30,7 +30,7 @@ type SourcesDomainConfig struct {
 	// 回源HOST，默认加速域名。
 	HostName *string `json:"host_name,omitempty"`
 
-	// OBS桶源站类型： - “private” 私有桶； - “public” 公有桶，默认为公有桶。
+	// OBS桶类型。   - private: 私有桶（除桶ACL授权外的其他用户无桶的访问权限）。   - public: 公有桶（任何用户都可以对桶内对象进行读操作）。
 	ObsBucketType *string `json:"obs_bucket_type,omitempty"`
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_sources_request_body.go
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// SourcesRequestBody 源站信息
+type SourcesRequestBody struct {
+
+	// 加速域名id。
+	DomainId *string `json:"domain_id,omitempty"`
+
+	// 源站IP（非内网IP）或者域名。
+	IpOrDomain string `json:"ip_or_domain"`
+
+	// 源站类型取值：ipaddr：源站IP、 domain：源站域名、obs_bucket：OBS桶域名。
+	OriginType SourcesRequestBodyOriginType `json:"origin_type"`
+
+	// OBS桶类型，源站类型是“OBS桶域名”时需要传该参数，不传默认为“public”。   - private: 私有桶（除桶ACL授权外的其他用户无桶的访问权限）。   - public: 公有桶（任何用户都可以对桶内对象进行读操作）。
+	ObsBucketType *string `json:"obs_bucket_type,omitempty"`
+
+	// 主备状态，1代表主源站，0代表备源站。
+	ActiveStandby int32 `json:"active_standby"`
+
+	// 是否开启OBS静态网站托管(0表示关闭,1表示则为开启)，源站类型为obs_bucket时传递。
+	EnableObsWebHosting *int32 `json:"enable_obs_web_hosting,omitempty"`
+}
+
+func (o SourcesRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SourcesRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"SourcesRequestBody", string(data)}, " ")
+}
+
+type SourcesRequestBodyOriginType struct {
+	value string
+}
+
+type SourcesRequestBodyOriginTypeEnum struct {
+	IPADDR     SourcesRequestBodyOriginType
+	DOMAIN     SourcesRequestBodyOriginType
+	OBS_BUCKET SourcesRequestBodyOriginType
+}
+
+func GetSourcesRequestBodyOriginTypeEnum() SourcesRequestBodyOriginTypeEnum {
+	return SourcesRequestBodyOriginTypeEnum{
+		IPADDR: SourcesRequestBodyOriginType{
+			value: "ipaddr",
+		},
+		DOMAIN: SourcesRequestBodyOriginType{
+			value: "domain",
+		},
+		OBS_BUCKET: SourcesRequestBodyOriginType{
+			value: "obs_bucket",
+		},
+	}
+}
+
+func (c SourcesRequestBodyOriginType) Value() string {
+	return c.value
+}
+
+func (c SourcesRequestBodyOriginType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *SourcesRequestBodyOriginType) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_url_object.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cdn/v2/model/model_url_object.go
@@ -25,6 +25,12 @@ type UrlObject struct {
 
 	// 任务的类型， 其值可以为REFRESH：刷新任务、PREHEATING：预热任务、REFRESH_AFTER_PREHEATING：预热后刷新
 	TaskType *string `json:"task_type,omitempty"`
+
+	// 失败原因，url状态为failed时返回。   - ORIGIN_ERROR：源站错误。   - INNER_ERROR：内部错误。   - UNKNOWN_ERROR：未知错误。
+	FailClassify *string `json:"fail_classify,omitempty"`
+
+	// 刷新预热失败描述。
+	FailDesc *string `json:"fail_desc,omitempty"`
 }
 
 func (o UrlObject) String() string {

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3/model/model_service_statement.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iam/v3/model/model_service_statement.go
@@ -21,7 +21,7 @@ type ServiceStatement struct {
 	Condition map[string]map[string][]string `json:"Condition,omitempty"`
 
 	// 资源。规则如下： > - 可填 * 的五段式：<service-name>:<region>:<account-id>:<resource-type>:<resource-path>，例：\"obs:*:*:bucket:*\"。 > - region字段为*或用户可访问的region。service必须存在且resource属于对应service。
-	Resource *[]string `json:"Resource,omitempty"`
+	Resource *interface{} `json:"Resource,omitempty"`
 }
 
 func (o ServiceStatement) String() string {

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/ioTDA_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/ioTDA_client.go
@@ -575,6 +575,92 @@ func (c *IoTDAClient) UploadBatchTaskFileInvoker(request *model.UploadBatchTaskF
 	return &UploadBatchTaskFileInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
 }
 
+// AddBridge 创建网桥
+//
+// 应用服务器可调用此接口在物联网平台创建一个网桥，仅在创建后的网桥才可以接入物联网平台。
+// - 一个实例最多支持20个网桥。
+// - 仅**标准版实例、企业版实例**支持该接口调用，基础版不支持。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *IoTDAClient) AddBridge(request *model.AddBridgeRequest) (*model.AddBridgeResponse, error) {
+	requestDef := GenReqDefForAddBridge()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.AddBridgeResponse), nil
+	}
+}
+
+// AddBridgeInvoker 创建网桥
+func (c *IoTDAClient) AddBridgeInvoker(request *model.AddBridgeRequest) *AddBridgeInvoker {
+	requestDef := GenReqDefForAddBridge()
+	return &AddBridgeInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// DeleteBridge 删除网桥
+//
+// 应用服务器可调用此接口在物联网平台上删除指定网桥。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *IoTDAClient) DeleteBridge(request *model.DeleteBridgeRequest) (*model.DeleteBridgeResponse, error) {
+	requestDef := GenReqDefForDeleteBridge()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteBridgeResponse), nil
+	}
+}
+
+// DeleteBridgeInvoker 删除网桥
+func (c *IoTDAClient) DeleteBridgeInvoker(request *model.DeleteBridgeRequest) *DeleteBridgeInvoker {
+	requestDef := GenReqDefForDeleteBridge()
+	return &DeleteBridgeInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListBridges 查询网桥列表
+//
+// 应用服务器可调用此接口在物联网平台查询网桥列表。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *IoTDAClient) ListBridges(request *model.ListBridgesRequest) (*model.ListBridgesResponse, error) {
+	requestDef := GenReqDefForListBridges()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListBridgesResponse), nil
+	}
+}
+
+// ListBridgesInvoker 查询网桥列表
+func (c *IoTDAClient) ListBridgesInvoker(request *model.ListBridgesRequest) *ListBridgesInvoker {
+	requestDef := GenReqDefForListBridges()
+	return &ListBridgesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ResetBridgeSecret 重置网桥密钥
+//
+// 应用服务器可调用此接口在物联网平台上重置网桥密钥。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *IoTDAClient) ResetBridgeSecret(request *model.ResetBridgeSecretRequest) (*model.ResetBridgeSecretResponse, error) {
+	requestDef := GenReqDefForResetBridgeSecret()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ResetBridgeSecretResponse), nil
+	}
+}
+
+// ResetBridgeSecretInvoker 重置网桥密钥
+func (c *IoTDAClient) ResetBridgeSecretInvoker(request *model.ResetBridgeSecretRequest) *ResetBridgeSecretInvoker {
+	requestDef := GenReqDefForResetBridgeSecret()
+	return &ResetBridgeSecretInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
 // BroadcastMessage 下发广播消息
 //
 // 应用服务器可调用此接口向订阅了指定Topic的所有在线设备发布广播消息。应用将广播消息下发给平台后，平台会先返回应用响应结果，再将消息广播给设备。
@@ -680,6 +766,27 @@ func (c *IoTDAClient) ListCertificates(request *model.ListCertificatesRequest) (
 func (c *IoTDAClient) ListCertificatesInvoker(request *model.ListCertificatesRequest) *ListCertificatesInvoker {
 	requestDef := GenReqDefForListCertificates()
 	return &ListCertificatesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateCertificate 更新CA证书
+//
+// 应用服务器可调用此接口在物联网平台上更新CA证书。仅标准版实例、企业版实例支持该接口调用，基础版不支持。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *IoTDAClient) UpdateCertificate(request *model.UpdateCertificateRequest) (*model.UpdateCertificateResponse, error) {
+	requestDef := GenReqDefForUpdateCertificate()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateCertificateResponse), nil
+	}
+}
+
+// UpdateCertificateInvoker 更新CA证书
+func (c *IoTDAClient) UpdateCertificateInvoker(request *model.UpdateCertificateRequest) *UpdateCertificateInvoker {
+	requestDef := GenReqDefForUpdateCertificate()
+	return &UpdateCertificateInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
 }
 
 // CreateCommand 下发设备命令
@@ -919,6 +1026,27 @@ func (c *IoTDAClient) FreezeDevice(request *model.FreezeDeviceRequest) (*model.F
 func (c *IoTDAClient) FreezeDeviceInvoker(request *model.FreezeDeviceRequest) *FreezeDeviceInvoker {
 	requestDef := GenReqDefForFreezeDevice()
 	return &FreezeDeviceInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListDeviceGroupsByDevice 查询指定设备加入的设备组列表
+//
+// 应用服务器可调用此接口查询物联网平台中的某个设备加入的设备组信息列表。仅标准版实例、企业版实例支持该接口调用，基础版不支持。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *IoTDAClient) ListDeviceGroupsByDevice(request *model.ListDeviceGroupsByDeviceRequest) (*model.ListDeviceGroupsByDeviceResponse, error) {
+	requestDef := GenReqDefForListDeviceGroupsByDevice()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListDeviceGroupsByDeviceResponse), nil
+	}
+}
+
+// ListDeviceGroupsByDeviceInvoker 查询指定设备加入的设备组列表
+func (c *IoTDAClient) ListDeviceGroupsByDeviceInvoker(request *model.ListDeviceGroupsByDeviceRequest) *ListDeviceGroupsByDeviceInvoker {
+	requestDef := GenReqDefForListDeviceGroupsByDevice()
+	return &ListDeviceGroupsByDeviceInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
 }
 
 // ListDevices 查询设备列表

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/ioTDA_invoker.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/ioTDA_invoker.go
@@ -317,6 +317,54 @@ func (i *UploadBatchTaskFileInvoker) Invoke() (*model.UploadBatchTaskFileRespons
 	}
 }
 
+type AddBridgeInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *AddBridgeInvoker) Invoke() (*model.AddBridgeResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.AddBridgeResponse), nil
+	}
+}
+
+type DeleteBridgeInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *DeleteBridgeInvoker) Invoke() (*model.DeleteBridgeResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DeleteBridgeResponse), nil
+	}
+}
+
+type ListBridgesInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListBridgesInvoker) Invoke() (*model.ListBridgesResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListBridgesResponse), nil
+	}
+}
+
+type ResetBridgeSecretInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ResetBridgeSecretInvoker) Invoke() (*model.ResetBridgeSecretResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ResetBridgeSecretResponse), nil
+	}
+}
+
 type BroadcastMessageInvoker struct {
 	*invoker.BaseInvoker
 }
@@ -374,6 +422,18 @@ func (i *ListCertificatesInvoker) Invoke() (*model.ListCertificatesResponse, err
 		return nil, err
 	} else {
 		return result.(*model.ListCertificatesResponse), nil
+	}
+}
+
+type UpdateCertificateInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateCertificateInvoker) Invoke() (*model.UpdateCertificateResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateCertificateResponse), nil
 	}
 }
 
@@ -506,6 +566,18 @@ func (i *FreezeDeviceInvoker) Invoke() (*model.FreezeDeviceResponse, error) {
 		return nil, err
 	} else {
 		return result.(*model.FreezeDeviceResponse), nil
+	}
+}
+
+type ListDeviceGroupsByDeviceInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListDeviceGroupsByDeviceInvoker) Invoke() (*model.ListDeviceGroupsByDeviceResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListDeviceGroupsByDeviceResponse), nil
 	}
 }
 

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/ioTDA_meta.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/ioTDA_meta.go
@@ -651,6 +651,105 @@ func GenReqDefForUploadBatchTaskFile() *def.HttpRequestDef {
 	return requestDef
 }
 
+func GenReqDefForAddBridge() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v5/iot/{project_id}/bridges").
+		WithResponse(new(model.AddBridgeResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("Instance-Id").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteBridge() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v5/iot/{project_id}/bridges/{bridge_id}").
+		WithResponse(new(model.DeleteBridgeResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("BridgeId").
+		WithJsonTag("bridge_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("Instance-Id").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithResponseField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListBridges() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v5/iot/{project_id}/bridges").
+		WithResponse(new(model.ListBridgesResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Marker").
+		WithJsonTag("marker").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("Instance-Id").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForResetBridgeSecret() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v5/iot/{project_id}/bridges/{bridge_id}/reset-secret").
+		WithResponse(new(model.ResetBridgeSecretResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("BridgeId").
+		WithJsonTag("bridge_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("Instance-Id").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
 func GenReqDefForBroadcastMessage() *def.HttpRequestDef {
 	reqDefBuilder := def.NewHttpRequestDefBuilder().
 		WithMethod(http.MethodPost).
@@ -810,6 +909,31 @@ func GenReqDefForListCertificates() *def.HttpRequestDef {
 		WithName("InstanceId").
 		WithJsonTag("Instance-Id").
 		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateCertificate() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v5/iot/{project_id}/certificates/{certificate_id}").
+		WithResponse(new(model.UpdateCertificateResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("CertificateId").
+		WithJsonTag("certificate_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("Instance-Id").
+		WithLocationType(def.Header))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
 
 	requestDef := reqDefBuilder.Build()
 	return requestDef
@@ -1109,6 +1233,27 @@ func GenReqDefForFreezeDevice() *def.HttpRequestDef {
 	reqDefBuilder.WithResponseField(def.NewFieldDef().
 		WithName("Body").
 		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListDeviceGroupsByDevice() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v5/iot/{project_id}/devices/{device_id}/list-device-group").
+		WithResponse(new(model.ListDeviceGroupsByDeviceResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("DeviceId").
+		WithJsonTag("device_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("Instance-Id").
+		WithLocationType(def.Header))
 
 	requestDef := reqDefBuilder.Build()
 	return requestDef

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_add_bridge.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_add_bridge.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// AddBridge 添加网桥结构体。
+type AddBridge struct {
+
+	// 网桥名称。**取值范围**：长度不超过64，只允许中文、字母、数字、以及_?'#().,&%@!-等字符的组合。
+	BridgeName string `json:"bridge_name"`
+
+	// 网桥ID。**取值范围**：长度不超过36，只允许字母、数字、_-字符的组合。
+	BridgeId *string `json:"bridge_id,omitempty"`
+}
+
+func (o AddBridge) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AddBridge struct{}"
+	}
+
+	return strings.Join([]string{"AddBridge", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_add_bridge_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_add_bridge_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// AddBridgeRequest Request Object
+type AddBridgeRequest struct {
+
+	// **参数说明**：实例ID。物理多租下各实例的唯一标识，建议携带该参数，在使用专业版时必须携带该参数。您可以在IoTDA管理控制台界面，选择左侧导航栏“总览”页签查看当前实例的ID，具体获取方式请参考[[查看实例详情](https://support.huaweicloud.com/usermanual-iothub/iot_01_0079.html#section1)](tag:hws) [[查看实例详情](https://support.huaweicloud.com/intl/zh-cn/usermanual-iothub/iot_01_0079.html#section1)](tag:hws_hk)。
+	InstanceId *string `json:"Instance-Id,omitempty"`
+
+	Body *AddBridge `json:"body,omitempty"`
+}
+
+func (o AddBridgeRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AddBridgeRequest struct{}"
+	}
+
+	return strings.Join([]string{"AddBridgeRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_add_bridge_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_add_bridge_response.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// AddBridgeResponse Response Object
+type AddBridgeResponse struct {
+
+	// 网桥ID，用于唯一标识一个网桥。在注册网桥时直接指定，或者由物联网平台分配获得。
+	BridgeId *string `json:"bridge_id,omitempty"`
+
+	// 网桥名称。
+	BridgeName *string `json:"bridge_name,omitempty"`
+
+	AuthInfo *BridgeAuthInfo `json:"auth_info,omitempty"`
+
+	// 在物联网平台注册网桥的时间。格式：yyyyMMdd'T'HHmmss'Z'，如20151212T121212Z。
+	CreateTime     *string `json:"create_time,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o AddBridgeResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AddBridgeResponse struct{}"
+	}
+
+	return strings.Join([]string{"AddBridgeResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_bridge_auth_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_bridge_auth_info.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BridgeAuthInfo 网桥鉴权信息
+type BridgeAuthInfo struct {
+
+	// 鉴权类型。当前支持密钥认证接入(SECRET)。使用密钥认证接入方式(SECRET)填写secret字段，不填写auth_type默认为密钥认证接入方式(SECRET)。
+	AuthType *string `json:"auth_type,omitempty"`
+
+	// 网桥密钥，认证类型使用密钥认证接入(SECRET)可填写该字段。
+	Secret *string `json:"secret,omitempty"`
+}
+
+func (o BridgeAuthInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BridgeAuthInfo struct{}"
+	}
+
+	return strings.Join([]string{"BridgeAuthInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_bridge_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_bridge_response.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BridgeResponse struct {
+
+	// 网桥ID
+	BridgeId *string `json:"bridge_id,omitempty"`
+
+	// 网桥名称。
+	BridgeName *string `json:"bridge_name,omitempty"`
+
+	// 网桥状态。 - ONLINE：网桥在线。 - OFFLINE：网桥离线。
+	Status *string `json:"status,omitempty"`
+}
+
+func (o BridgeResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BridgeResponse struct{}"
+	}
+
+	return strings.Join([]string{"BridgeResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_delete_bridge_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_delete_bridge_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DeleteBridgeRequest Request Object
+type DeleteBridgeRequest struct {
+
+	// **参数说明**：实例ID。物理多租下各实例的唯一标识，建议携带该参数，在使用专业版时必须携带该参数。您可以在IoTDA管理控制台界面，选择左侧导航栏“总览”页签查看当前实例的ID，具体获取方式请参考[[查看实例详情](https://support.huaweicloud.com/usermanual-iothub/iot_01_0079.html#section1)](tag:hws) [[查看实例详情](https://support.huaweicloud.com/intl/zh-cn/usermanual-iothub/iot_01_0079.html#section1)](tag:hws_hk)。
+	InstanceId *string `json:"Instance-Id,omitempty"`
+
+	// 网桥ID。**取值范围**：长度不超过36，只允许字母、数字、_-字符的组合。
+	BridgeId string `json:"bridge_id"`
+}
+
+func (o DeleteBridgeRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteBridgeRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteBridgeRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_delete_bridge_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_delete_bridge_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DeleteBridgeResponse Response Object
+type DeleteBridgeResponse struct {
+	Body           *string `json:"body,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o DeleteBridgeResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteBridgeResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteBridgeResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_bridges_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_bridges_request.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListBridgesRequest Request Object
+type ListBridgesRequest struct {
+
+	// **参数说明**：实例ID。物理多租下各实例的唯一标识，建议携带该参数，在使用专业版时必须携带该参数。您可以在IoTDA管理控制台界面，选择左侧导航栏“总览”页签查看当前实例的ID，具体获取方式请参考[[查看实例详情](https://support.huaweicloud.com/usermanual-iothub/iot_01_0079.html#section1)](tag:hws) [[查看实例详情](https://support.huaweicloud.com/intl/zh-cn/usermanual-iothub/iot_01_0079.html#section1)](tag:hws_hk)。
+	InstanceId *string `json:"Instance-Id,omitempty"`
+
+	// **参数说明**：分页查询时每页显示的记录数。 **取值范围**：1-50的整数，默认值为10。
+	Limit *int32 `json:"limit,omitempty"`
+
+	// **参数说明**：上一次分页查询结果中最后一条记录的ID，在上一次分页查询时由物联网平台返回获得。分页查询时物联网平台是按marker也就是记录ID降序查询的，越新的数据记录ID也会越大。若填写marker，则本次只查询记录ID小于marker的数据记录。若不填写，则从记录ID最大也就是最新的一条数据开始查询。如果需要依次查询所有数据，则每次查询时必须填写上一次查询响应中的marker值。 **取值范围**：长度为24的十六进制字符串，默认值为ffffffffffffffffffffffff。
+	Marker *string `json:"marker,omitempty"`
+
+	// **参数说明**：表示从marker后偏移offset条记录开始查询。默认为0，取值范围为0-500的整数。当offset为0时，表示从marker后第一条记录开始输出。限制offset最大值是出于API性能考虑，您可以搭配marker使用该参数实现翻页，例如每页50条记录，1-11页内都可以直接使用offset跳转到指定页，但到11页后，由于offset限制为500，您需要使用第11页返回的marker作为下次查询的marker，以实现翻页到12-22页。 **取值范围**：0-500的整数，默认为0。
+	Offset *int32 `json:"offset,omitempty"`
+}
+
+func (o ListBridgesRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListBridgesRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListBridgesRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_bridges_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_bridges_response.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListBridgesResponse Response Object
+type ListBridgesResponse struct {
+
+	// 网桥列表。
+	Bridges *[]BridgeResponse `json:"bridges,omitempty"`
+
+	Page           *Page `json:"page,omitempty"`
+	HttpStatusCode int   `json:"-"`
+}
+
+func (o ListBridgesResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListBridgesResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListBridgesResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_device_group_summary.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_device_group_summary.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListDeviceGroupSummary 设备组信息结构体，创建、查询、修改设备组时返回
+type ListDeviceGroupSummary struct {
+
+	// 设备组ID，用于唯一标识一个设备组，在创建设备组时由物联网平台分配。
+	GroupId *string `json:"group_id,omitempty"`
+
+	// 设备组名称，单个资源空间下不可重复。
+	Name *string `json:"name,omitempty"`
+
+	// 设备组描述。
+	Description *string `json:"description,omitempty"`
+
+	// 父设备组ID，该设备组的父设备组ID。
+	SuperGroupId *string `json:"super_group_id,omitempty"`
+
+	// **参数说明**：设备组类型，默认为静态设备组；当设备组类型为动态设备组时，需要填写动态设备组规则
+	GroupType *string `json:"group_type,omitempty"`
+}
+
+func (o ListDeviceGroupSummary) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListDeviceGroupSummary struct{}"
+	}
+
+	return strings.Join([]string{"ListDeviceGroupSummary", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_device_groups_by_device_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_device_groups_by_device_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListDeviceGroupsByDeviceRequest Request Object
+type ListDeviceGroupsByDeviceRequest struct {
+
+	// **参数说明**：实例ID。物理多租下各实例的唯一标识，建议携带该参数，在使用专业版时必须携带该参数。您可以在IoTDA管理控制台界面，选择左侧导航栏“总览”页签查看当前实例的ID，具体获取方式请参考[[查看实例详情](https://support.huaweicloud.com/usermanual-iothub/iot_01_0079.html#section1)](tag:hws) [[查看实例详情](https://support.huaweicloud.com/intl/zh-cn/usermanual-iothub/iot_01_0079.html#section1)](tag:hws_hk)。
+	InstanceId *string `json:"Instance-Id,omitempty"`
+
+	// **参数说明**：设备ID，用于唯一标识一个设备。在注册设备时直接指定，或者由物联网平台分配获得。 **取值范围**：长度不超过128，只允许字母、数字、下划线（_）、连接符（-）的组合。
+	DeviceId string `json:"device_id"`
+}
+
+func (o ListDeviceGroupsByDeviceRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListDeviceGroupsByDeviceRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListDeviceGroupsByDeviceRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_device_groups_by_device_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_list_device_groups_by_device_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListDeviceGroupsByDeviceResponse Response Object
+type ListDeviceGroupsByDeviceResponse struct {
+
+	// 设备组信息列表。
+	DeviceGroups   *[]ListDeviceGroupSummary `json:"device_groups,omitempty"`
+	HttpStatusCode int                       `json:"-"`
+}
+
+func (o ListDeviceGroupsByDeviceResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListDeviceGroupsByDeviceResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListDeviceGroupsByDeviceResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_reset_bridge_secret.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_reset_bridge_secret.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ResetBridgeSecret struct {
+
+	// 是否强制断开网桥的连接，当前仅限长连接。
+	ForceDisconnect *bool `json:"force_disconnect,omitempty"`
+}
+
+func (o ResetBridgeSecret) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetBridgeSecret struct{}"
+	}
+
+	return strings.Join([]string{"ResetBridgeSecret", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_reset_bridge_secret_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_reset_bridge_secret_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ResetBridgeSecretRequest Request Object
+type ResetBridgeSecretRequest struct {
+
+	// **参数说明**：实例ID。物理多租下各实例的唯一标识，建议携带该参数，在使用专业版时必须携带该参数。您可以在IoTDA管理控制台界面，选择左侧导航栏“总览”页签查看当前实例的ID，具体获取方式请参考[[查看实例详情](https://support.huaweicloud.com/usermanual-iothub/iot_01_0079.html#section1)](tag:hws) [[查看实例详情](https://support.huaweicloud.com/intl/zh-cn/usermanual-iothub/iot_01_0079.html#section1)](tag:hws_hk)。
+	InstanceId *string `json:"Instance-Id,omitempty"`
+
+	// 网桥ID。**取值范围**：长度不超过36，只允许字母、数字、_-字符的组合。
+	BridgeId string `json:"bridge_id"`
+
+	Body *ResetBridgeSecret `json:"body,omitempty"`
+}
+
+func (o ResetBridgeSecretRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetBridgeSecretRequest struct{}"
+	}
+
+	return strings.Join([]string{"ResetBridgeSecretRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_reset_bridge_secret_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_reset_bridge_secret_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ResetBridgeSecretResponse Response Object
+type ResetBridgeSecretResponse struct {
+
+	// 网桥ID
+	BridgeId *string `json:"bridge_id,omitempty"`
+
+	// 网桥密钥。
+	Secret         *string `json:"secret,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ResetBridgeSecretResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResetBridgeSecretResponse struct{}"
+	}
+
+	return strings.Join([]string{"ResetBridgeSecretResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_update_certificate_dto.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_update_certificate_dto.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateCertificateDto 更新CA证书结构体。
+type UpdateCertificateDto struct {
+
+	// 是否开启自注册能力，当为true时该功能必须配合预调配功能使用，true：是，false：否。
+	ProvisionEnable *bool `json:"provision_enable,omitempty"`
+
+	// 预调配模板ID，该CA证书绑定的预调配模板id，当该字段传null时表示解除绑定关系。
+	TemplateId *string `json:"template_id,omitempty"`
+}
+
+func (o UpdateCertificateDto) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateCertificateDto struct{}"
+	}
+
+	return strings.Join([]string{"UpdateCertificateDto", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_update_certificate_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_update_certificate_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateCertificateRequest Request Object
+type UpdateCertificateRequest struct {
+
+	// 实例ID。物理多租下各实例的唯一标识，建议携带该参数，在使用专业版时必须携带该参数。您可以在IoTDA管理控制台界面，选择左侧导航栏“总览”页签查看当前实例的ID，具体获取方式请参考[[查看实例详情](https://support.huaweicloud.com/usermanual-iothub/iot_01_0079.html#section1)](tag:hws) [[查看实例详情](https://support.huaweicloud.com/intl/zh-cn/usermanual-iothub/iot_01_0079.html#section1)](tag:hws_hk)。
+	InstanceId *string `json:"Instance-Id,omitempty"`
+
+	// CA证书ID，在上传CA证书时由平台分配的唯一标识。
+	CertificateId string `json:"certificate_id"`
+
+	Body *UpdateCertificateDto `json:"body,omitempty"`
+}
+
+func (o UpdateCertificateRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateCertificateRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateCertificateRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_update_certificate_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model/model_update_certificate_response.go
@@ -1,0 +1,51 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateCertificateResponse Response Object
+type UpdateCertificateResponse struct {
+
+	// CA证书ID，在上传CA证书时由平台分配的唯一标识。
+	CertificateId *string `json:"certificate_id,omitempty"`
+
+	// CA证书CN名称。
+	CnName *string `json:"cn_name,omitempty"`
+
+	// CA证书所有者。
+	Owner *string `json:"owner,omitempty"`
+
+	// CA证书验证状态。true代表证书已通过验证，可进行设备证书认证接入。false代表证书未通过验证。
+	Status *bool `json:"status,omitempty"`
+
+	// CA证书验证码。
+	VerifyCode *string `json:"verify_code,omitempty"`
+
+	// 是否开启自注册能力，当为true时该功能必须配合自注册模板使用，true：是，false：否。
+	ProvisionEnable *bool `json:"provision_enable,omitempty"`
+
+	// 绑定的自注册模板ID。
+	TemplateId *string `json:"template_id,omitempty"`
+
+	// 创建证书日期。格式：yyyyMMdd'T'HHmmss'Z'，如20151212T121212Z。
+	CreateDate *string `json:"create_date,omitempty"`
+
+	// CA证书生效日期。格式：yyyyMMdd'T'HHmmss'Z'，如20151212T121212Z。
+	EffectiveDate *string `json:"effective_date,omitempty"`
+
+	// CA证书失效日期。格式：yyyyMMdd'T'HHmmss'Z'，如20151212T121212Z。
+	ExpiryDate     *string `json:"expiry_date,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o UpdateCertificateResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateCertificateResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateCertificateResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3/model/model_create_keypair_action.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kps/v3/model/model_create_keypair_action.go
@@ -12,7 +12,7 @@ import (
 // CreateKeypairAction 创建密钥对请求体请求参数
 type CreateKeypairAction struct {
 
-	// SSH密钥对的名称。 - 新创建的密钥对名称不能和已有密钥对的名称相同。 - SSH密钥对名称由英文字母、数字、下划线、中划线组成，长度不能超过64个字节
+	// SSH密钥对的名称。 - 新创建的密钥对名称不能和已有密钥对的名称相同。 - SSH密钥对名称由英文字母、数字、下划线、中划线组成，长度不能超过255个字节
 	Name string `json:"name"`
 
 	// SSH密钥对的类型。ssh或x509。

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/mpc/v1/model/model_video_process.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/mpc/v1/model/model_video_process.go
@@ -28,6 +28,9 @@ type VideoProcess struct {
 
 	// 是否开启上采样，如支持从480P的片源转为720P，可取值为:  - 0：表示上采样关闭， - 1：表示上采样开启.
 	Upsample *int32 `json:"upsample,omitempty"`
+
+	// HLS切片类型。  取值如下所示： - mpegts：ts切片 - fmp4：fmp4切片  不设置默认为ts切片。
+	HlsSegmentType *VideoProcessHlsSegmentType `json:"hls_segment_type,omitempty"`
 }
 
 func (o VideoProcess) String() string {
@@ -119,6 +122,53 @@ func (c VideoProcessAdaptation) MarshalJSON() ([]byte, error) {
 }
 
 func (c *VideoProcessAdaptation) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}
+
+type VideoProcessHlsSegmentType struct {
+	value string
+}
+
+type VideoProcessHlsSegmentTypeEnum struct {
+	MPEGTS VideoProcessHlsSegmentType
+	FMP4   VideoProcessHlsSegmentType
+}
+
+func GetVideoProcessHlsSegmentTypeEnum() VideoProcessHlsSegmentTypeEnum {
+	return VideoProcessHlsSegmentTypeEnum{
+		MPEGTS: VideoProcessHlsSegmentType{
+			value: "mpegts",
+		},
+		FMP4: VideoProcessHlsSegmentType{
+			value: "fmp4",
+		},
+	}
+}
+
+func (c VideoProcessHlsSegmentType) Value() string {
+	return c.value
+}
+
+func (c VideoProcessHlsSegmentType) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *VideoProcessHlsSegmentType) UnmarshalJSON(b []byte) error {
 	myConverter := converter.StringConverterFactory("string")
 	if myConverter == nil {
 		return errors.New("unsupported StringConverter type: string")

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model/model_download_errorlog_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model/model_download_errorlog_request.go
@@ -1,0 +1,76 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"errors"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/converter"
+
+	"strings"
+)
+
+// DownloadErrorlogRequest Request Object
+type DownloadErrorlogRequest struct {
+
+	// 语言
+	XLanguage *DownloadErrorlogRequestXLanguage `json:"X-Language,omitempty"`
+
+	// 实例ID。
+	InstanceId string `json:"instance_id"`
+}
+
+func (o DownloadErrorlogRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DownloadErrorlogRequest struct{}"
+	}
+
+	return strings.Join([]string{"DownloadErrorlogRequest", string(data)}, " ")
+}
+
+type DownloadErrorlogRequestXLanguage struct {
+	value string
+}
+
+type DownloadErrorlogRequestXLanguageEnum struct {
+	ZH_CN DownloadErrorlogRequestXLanguage
+	EN_US DownloadErrorlogRequestXLanguage
+}
+
+func GetDownloadErrorlogRequestXLanguageEnum() DownloadErrorlogRequestXLanguageEnum {
+	return DownloadErrorlogRequestXLanguageEnum{
+		ZH_CN: DownloadErrorlogRequestXLanguage{
+			value: "zh-cn",
+		},
+		EN_US: DownloadErrorlogRequestXLanguage{
+			value: "en-us",
+		},
+	}
+}
+
+func (c DownloadErrorlogRequestXLanguage) Value() string {
+	return c.value
+}
+
+func (c DownloadErrorlogRequestXLanguage) MarshalJSON() ([]byte, error) {
+	return utils.Marshal(c.value)
+}
+
+func (c *DownloadErrorlogRequestXLanguage) UnmarshalJSON(b []byte) error {
+	myConverter := converter.StringConverterFactory("string")
+	if myConverter == nil {
+		return errors.New("unsupported StringConverter type: string")
+	}
+
+	interf, err := myConverter.CovertStringToInterface(strings.Trim(string(b[:]), "\""))
+	if err != nil {
+		return err
+	}
+
+	if val, ok := interf.(string); ok {
+		c.value = val
+		return nil
+	} else {
+		return errors.New("convert enum data to string error")
+	}
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model/model_download_errorlog_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model/model_download_errorlog_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DownloadErrorlogResponse Response Object
+type DownloadErrorlogResponse struct {
+
+	// 错误日志下载链接列表
+	List *[]ErrorlogDownloadInfo `json:"list,omitempty"`
+
+	// - 错误日志下载链接生成状态。FINISH，表示下载链接已经生成完成。CREATING，表示正在生成文件，准备下载链接。FAILED，表示存在日志文件准备失败。
+	Status *string `json:"status,omitempty"`
+
+	// - 错误日志链接数量。
+	Count          *int32 `json:"count,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o DownloadErrorlogResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DownloadErrorlogResponse struct{}"
+	}
+
+	return strings.Join([]string{"DownloadErrorlogResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model/model_errorlog_download_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/model/model_errorlog_download_info.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ErrorlogDownloadInfo struct {
+
+	// 任务ID
+	WorkflowId string `json:"workflow_id"`
+
+	// 生成的下载文件名
+	FileName string `json:"file_name"`
+
+	// 生成链接的生成状态
+	Status string `json:"status"`
+
+	// 文件大小
+	FileSize string `json:"file_size"`
+
+	// 下载链接
+	FileLink string `json:"file_link"`
+
+	// 生成时间
+	CreateAt int64 `json:"create_at"`
+
+	// 更新时间
+	UpdateAt int64 `json:"update_at"`
+}
+
+func (o ErrorlogDownloadInfo) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ErrorlogDownloadInfo struct{}"
+	}
+
+	return strings.Join([]string{"ErrorlogDownloadInfo", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/rds_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/rds_client.go
@@ -626,6 +626,27 @@ func (c *RdsClient) DeleteSqlLimitInvoker(request *model.DeleteSqlLimitRequest) 
 	return &DeleteSqlLimitInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
 }
 
+// DownloadErrorlog 获取错误日志下载链接
+//
+// 获取错误日志下载链接。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *RdsClient) DownloadErrorlog(request *model.DownloadErrorlogRequest) (*model.DownloadErrorlogResponse, error) {
+	requestDef := GenReqDefForDownloadErrorlog()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DownloadErrorlogResponse), nil
+	}
+}
+
+// DownloadErrorlogInvoker 获取错误日志下载链接
+func (c *RdsClient) DownloadErrorlogInvoker(request *model.DownloadErrorlogRequest) *DownloadErrorlogInvoker {
+	requestDef := GenReqDefForDownloadErrorlog()
+	return &DownloadErrorlogInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
 // DownloadSlowlog 获取慢日志下载链接
 //
 // 获取慢日志下载链接。

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/rds_invoker.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/rds_invoker.go
@@ -353,6 +353,18 @@ func (i *DeleteSqlLimitInvoker) Invoke() (*model.DeleteSqlLimitResponse, error) 
 	}
 }
 
+type DownloadErrorlogInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *DownloadErrorlogInvoker) Invoke() (*model.DownloadErrorlogResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DownloadErrorlogResponse), nil
+	}
+}
+
 type DownloadSlowlogInvoker struct {
 	*invoker.BaseInvoker
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/rds_meta.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/rds/v3/rds_meta.go
@@ -653,6 +653,27 @@ func GenReqDefForDeleteSqlLimit() *def.HttpRequestDef {
 	return requestDef
 }
 
+func GenReqDefForDownloadErrorlog() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/instances/{instance_id}/errorlog-download").
+		WithResponse(new(model.DownloadErrorlogResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("InstanceId").
+		WithJsonTag("instance_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("XLanguage").
+		WithJsonTag("X-Language").
+		WithLocationType(def.Header))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
 func GenReqDefForDownloadSlowlog() *def.HttpRequestDef {
 	reqDefBuilder := def.NewHttpRequestDefBuilder().
 		WithMethod(http.MethodPost).

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_add_clouddcn_subnets_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_add_clouddcn_subnets_tags_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// AddClouddcnSubnetsTagsRequest Request Object
+type AddClouddcnSubnetsTagsRequest struct {
+
+	// Clouddcn子网的id
+	ResourceId string `json:"resource_id"`
+
+	Body *AddResourceTagsRequestBody `json:"body,omitempty"`
+}
+
+func (o AddClouddcnSubnetsTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AddClouddcnSubnetsTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"AddClouddcnSubnetsTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_add_clouddcn_subnets_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_add_clouddcn_subnets_tags_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// AddClouddcnSubnetsTagsResponse Response Object
+type AddClouddcnSubnetsTagsResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o AddClouddcnSubnetsTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AddClouddcnSubnetsTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"AddClouddcnSubnetsTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_add_resource_tags_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_add_resource_tags_request_body.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type AddResourceTagsRequestBody struct {
+	Tag *AddResourceTagsRequestBodyTag `json:"tag"`
+}
+
+func (o AddResourceTagsRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AddResourceTagsRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"AddResourceTagsRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_add_resource_tags_request_body_tag.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_add_resource_tags_request_body_tag.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// AddResourceTagsRequestBodyTag 标签对象
+type AddResourceTagsRequestBodyTag struct {
+
+	// 标签键，最大长度128个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，中文。
+	Key string `json:"key"`
+
+	// 标签值，最大长度255个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，点“.”，中文。
+	Value string `json:"value"`
+}
+
+func (o AddResourceTagsRequestBodyTag) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "AddResourceTagsRequestBodyTag struct{}"
+	}
+
+	return strings.Join([]string{"AddResourceTagsRequestBodyTag", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_clouddcn_subnets_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_clouddcn_subnets_tags_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchCreateClouddcnSubnetsTagsRequest Request Object
+type BatchCreateClouddcnSubnetsTagsRequest struct {
+
+	// Clouddcn子网的id
+	ResourceId string `json:"resource_id"`
+
+	Body *BatchCreateRequestBody `json:"body,omitempty"`
+}
+
+func (o BatchCreateClouddcnSubnetsTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCreateClouddcnSubnetsTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"BatchCreateClouddcnSubnetsTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_clouddcn_subnets_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_clouddcn_subnets_tags_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchCreateClouddcnSubnetsTagsResponse Response Object
+type BatchCreateClouddcnSubnetsTagsResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o BatchCreateClouddcnSubnetsTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCreateClouddcnSubnetsTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"BatchCreateClouddcnSubnetsTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_request_body.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchCreateRequestBody struct {
+
+	// 资源标签
+	Tags []BatchCreateRequestBodyTags `json:"tags"`
+
+	// 系统标签
+	SysTags *[]BatchCreateRequestBodySysTags `json:"sys_tags,omitempty"`
+}
+
+func (o BatchCreateRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCreateRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"BatchCreateRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_request_body_sys_tags.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_request_body_sys_tags.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchCreateRequestBodySysTags struct {
+
+	// 标签键，最大长度128个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，中文。
+	Key string `json:"key"`
+
+	// 标签值，最大长度255个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，点“.”，中文。
+	Value string `json:"value"`
+}
+
+func (o BatchCreateRequestBodySysTags) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCreateRequestBodySysTags struct{}"
+	}
+
+	return strings.Join([]string{"BatchCreateRequestBodySysTags", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_request_body_tags.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_create_request_body_tags.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchCreateRequestBodyTags struct {
+
+	// 标签键，最大长度128个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，中文。
+	Key string `json:"key"`
+
+	// 标签值，最大长度255个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，点“.”，中文。
+	Value string `json:"value"`
+}
+
+func (o BatchCreateRequestBodyTags) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchCreateRequestBodyTags struct{}"
+	}
+
+	return strings.Join([]string{"BatchCreateRequestBodyTags", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_clouddcn_subnets_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_clouddcn_subnets_tags_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchDeleteClouddcnSubnetsTagsRequest Request Object
+type BatchDeleteClouddcnSubnetsTagsRequest struct {
+
+	// Clouddcn子网的id
+	ResourceId string `json:"resource_id"`
+
+	Body *BatchDeleteRequestBody `json:"body,omitempty"`
+}
+
+func (o BatchDeleteClouddcnSubnetsTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteClouddcnSubnetsTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteClouddcnSubnetsTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_clouddcn_subnets_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_clouddcn_subnets_tags_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// BatchDeleteClouddcnSubnetsTagsResponse Response Object
+type BatchDeleteClouddcnSubnetsTagsResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o BatchDeleteClouddcnSubnetsTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteClouddcnSubnetsTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteClouddcnSubnetsTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_request_body.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchDeleteRequestBody struct {
+
+	// 资源标签
+	Tags []BatchDeleteRequestBodyTags `json:"tags"`
+
+	// 系统标签
+	SysTags *[]BatchDeleteRequestBodySysTags `json:"sys_tags,omitempty"`
+}
+
+func (o BatchDeleteRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_request_body_sys_tags.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_request_body_sys_tags.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchDeleteRequestBodySysTags struct {
+
+	// 标签键，最大长度128个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，中文。
+	Key string `json:"key"`
+
+	// 标签值，最大长度255个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，点“.”，中文。
+	Value *string `json:"value,omitempty"`
+}
+
+func (o BatchDeleteRequestBodySysTags) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteRequestBodySysTags struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteRequestBodySysTags", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_request_body_tags.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_batch_delete_request_body_tags.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type BatchDeleteRequestBodyTags struct {
+
+	// 标签键，最大长度128个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，中文。
+	Key string `json:"key"`
+
+	// 标签值，最大长度255个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，点“.”，中文。
+	Value *string `json:"value,omitempty"`
+}
+
+func (o BatchDeleteRequestBodyTags) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "BatchDeleteRequestBodyTags struct{}"
+	}
+
+	return strings.Join([]string{"BatchDeleteRequestBodyTags", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_clouddcn_resource.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_clouddcn_resource.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ClouddcnResource 查询过滤标签的资源
+type ClouddcnResource struct {
+
+	// 资源ID标识符。
+	ResourceId string `json:"resource_id"`
+
+	// 资源详情。
+	ResourceDetail *interface{} `json:"resource_detail"`
+
+	// 包含标签。
+	Tags []Tag `json:"tags"`
+
+	// 实例名字。
+	ResourceName string `json:"resource_name"`
+}
+
+func (o ClouddcnResource) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ClouddcnResource struct{}"
+	}
+
+	return strings.Join([]string{"ClouddcnResource", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_clouddcn_subnet.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_clouddcn_subnet.go
@@ -1,0 +1,60 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdktime"
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ClouddcnSubnet
+type ClouddcnSubnet struct {
+
+	// clouddcn子网ID
+	Id string `json:"id"`
+
+	// 功能说明：VPC所属的项目ID
+	ProjectId string `json:"project_id"`
+
+	// 功能说明：子网名称 取值范围：1-64个字符，支持数字、字母、中文、_(下划线)、-（中划线）、.（点）
+	Name string `json:"name"`
+
+	// 功能说明：子网描述 取值范围：0-255个字符，不能包含“<”和“>”。
+	Description string `json:"description"`
+
+	// 功能说明：子网的网段 取值范围：必须在vpc对应cidr范围内 约束：必须是cidr格式。掩码长度不能大于28
+	Cidr string `json:"cidr"`
+
+	// 功能说明：子网的网关 取值范围：子网网段中的IP地址 约束：必须是ip格式
+	GatewayIp string `json:"gateway_ip"`
+
+	// clouddcn子网dns服务器地址列表
+	DnsNameservers []string `json:"dns_nameservers"`
+
+	// clouddcn子网所在VPC标识
+	VpcId string `json:"vpc_id"`
+
+	// 功能说明：资源创建UTC时间 格式：yyyy-MM-ddTHH:mm:ss
+	CreatedAt *sdktime.SdkTime `json:"created_at"`
+
+	// 功能说明：资源更新UTC时间 格式：yyyy-MM-ddTHH:mm:ss
+	UpdatedAt *sdktime.SdkTime `json:"updated_at"`
+
+	// 功能说明：可用区
+	AvailabilityZone string `json:"availability_zone"`
+
+	// 功能说明：对接TMS
+	Tags []TagEntity `json:"tags"`
+
+	// 功能说明：对接TPS
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+}
+
+func (o ClouddcnSubnet) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ClouddcnSubnet struct{}"
+	}
+
+	return strings.Join([]string{"ClouddcnSubnet", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_clouddcn_subnet_option.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_clouddcn_subnet_option.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateClouddcnSubnetOption
+type CreateClouddcnSubnetOption struct {
+
+	// 功能说明：clouddcn子网名称 取值范围：1-64个字符，支持数字、字母、中文、_(下划线)、-（中划线）、.（点）
+	Name string `json:"name"`
+
+	// 功能说明：clouddcn子网描述 取值范围：0-255个字符，不能包含“<”和“>”。
+	Description *string `json:"description,omitempty"`
+
+	// 功能说明：clouddcn子网的网段 取值范围：必须在vpc对应cidr范围内，不能和同vpc下其他普通子网的网段冲突 约束：必须是cidr格式。掩码长度不能大于28
+	Cidr string `json:"cidr"`
+
+	// clouddcn子网所在VPC标识
+	VpcId string `json:"vpc_id"`
+
+	// 功能说明：clouddcn子网的网关 取值范围：clouddcn子网网段中的IP地址 约束：必须是ip格式
+	GatewayIp string `json:"gateway_ip"`
+
+	// 功能说明：clouddcn子网dns服务器地址的集合；如果想使用两个以上dns服务器，请使用该字段 约束：是子网dns服务器地址1跟子网dns服务器地址2的合集的父集，不支持IPv6地址。 默认值：不填时为空，无法使用云内网DNS功能 [内网DNS地址请参见](https://support.huaweicloud.com/dns_faq/dns_faq_002.html) [通过API获取请参见](https://support.huaweicloud.com/api-dns/dns_api_69001.html)
+	DnsNameservers *[]string `json:"dns_nameservers,omitempty"`
+
+	// 功能说明：可用区
+	AvailabilityZone *string `json:"availability_zone,omitempty"`
+
+	// 功能说明：对接TMS
+	Tags *[]TagEntity `json:"tags,omitempty"`
+}
+
+func (o CreateClouddcnSubnetOption) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateClouddcnSubnetOption struct{}"
+	}
+
+	return strings.Join([]string{"CreateClouddcnSubnetOption", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_clouddcn_subnet_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_clouddcn_subnet_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateClouddcnSubnetRequest Request Object
+type CreateClouddcnSubnetRequest struct {
+	Body *CreateClouddcnSubnetRequestBody `json:"body,omitempty"`
+}
+
+func (o CreateClouddcnSubnetRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateClouddcnSubnetRequest struct{}"
+	}
+
+	return strings.Join([]string{"CreateClouddcnSubnetRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_clouddcn_subnet_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_clouddcn_subnet_request_body.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateClouddcnSubnetRequestBody 创建clouddcn子网对象
+type CreateClouddcnSubnetRequestBody struct {
+	ClouddcnSubnet *CreateClouddcnSubnetOption `json:"clouddcn_subnet"`
+}
+
+func (o CreateClouddcnSubnetRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateClouddcnSubnetRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"CreateClouddcnSubnetRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_clouddcn_subnet_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_clouddcn_subnet_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// CreateClouddcnSubnetResponse Response Object
+type CreateClouddcnSubnetResponse struct {
+	ClouddcnSubnet *ClouddcnSubnet `json:"clouddcn_subnet,omitempty"`
+	HttpStatusCode int             `json:"-"`
+}
+
+func (o CreateClouddcnSubnetResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "CreateClouddcnSubnetResponse struct{}"
+	}
+
+	return strings.Join([]string{"CreateClouddcnSubnetResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_firewall_option.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_firewall_option.go
@@ -18,6 +18,9 @@ type CreateFirewallOption struct {
 	// 功能说明：ACL企业项目ID。 取值范围：最大长度36字节，带“-”连字符的UUID格式，或者是字符串“0”。“0”表示默认企业项目。
 	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
 
+	// 功能描述：ACL资源标签
+	Tags *[]ResourceTag `json:"tags,omitempty"`
+
 	// 功能说明：ACL是否开启，默认值true 取值范围：true表示ACL开启；false表示ACL关闭
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_security_group_option.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_create_security_group_option.go
@@ -17,6 +17,9 @@ type CreateSecurityGroupOption struct {
 
 	// 功能说明：企业项目ID。创建安全组时，给安全组绑定企业项目ID。 取值范围：最大长度36字节，带“-”连字符的UUID格式，或者是字符串“0”。“0”表示默认企业项目。
 	EnterpriseProjectId *string `json:"enterprise_project_id,omitempty"`
+
+	// 功能描述：安全组的标签信息
+	Tags *[]ResourceTag `json:"tags,omitempty"`
 }
 
 func (o CreateSecurityGroupOption) String() string {

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_delete_clouddcn_subnet_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_delete_clouddcn_subnet_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DeleteClouddcnSubnetRequest Request Object
+type DeleteClouddcnSubnetRequest struct {
+
+	// clouddcn子网ID
+	ClouddcnSubnetId string `json:"clouddcn_subnet_id"`
+}
+
+func (o DeleteClouddcnSubnetRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteClouddcnSubnetRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteClouddcnSubnetRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_delete_clouddcn_subnet_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_delete_clouddcn_subnet_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DeleteClouddcnSubnetResponse Response Object
+type DeleteClouddcnSubnetResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o DeleteClouddcnSubnetResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteClouddcnSubnetResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteClouddcnSubnetResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_delete_clouddcn_subnets_tag_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_delete_clouddcn_subnets_tag_request.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DeleteClouddcnSubnetsTagRequest Request Object
+type DeleteClouddcnSubnetsTagRequest struct {
+
+	// Clouddcn子网的id
+	ResourceId string `json:"resource_id"`
+
+	// 待删除标签的key
+	TagKey string `json:"tag_key"`
+}
+
+func (o DeleteClouddcnSubnetsTagRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteClouddcnSubnetsTagRequest struct{}"
+	}
+
+	return strings.Join([]string{"DeleteClouddcnSubnetsTagRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_delete_clouddcn_subnets_tag_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_delete_clouddcn_subnets_tag_response.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// DeleteClouddcnSubnetsTagResponse Response Object
+type DeleteClouddcnSubnetsTagResponse struct {
+	HttpStatusCode int `json:"-"`
+}
+
+func (o DeleteClouddcnSubnetsTagResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "DeleteClouddcnSubnetsTagResponse struct{}"
+	}
+
+	return strings.Join([]string{"DeleteClouddcnSubnetsTagResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_count_filter_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_count_filter_tags_request.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListClouddcnSubnetsCountFilterTagsRequest Request Object
+type ListClouddcnSubnetsCountFilterTagsRequest struct {
+	Body *ListResourcesByTagsRequestBody `json:"body,omitempty"`
+}
+
+func (o ListClouddcnSubnetsCountFilterTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListClouddcnSubnetsCountFilterTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListClouddcnSubnetsCountFilterTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_count_filter_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_count_filter_tags_response.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListClouddcnSubnetsCountFilterTagsResponse Response Object
+type ListClouddcnSubnetsCountFilterTagsResponse struct {
+
+	// 本次请求的编号
+	RequestId *string `json:"request_id,omitempty"`
+
+	// 当前列表中资源数量。
+	TotalCount     *int32 `json:"total_count,omitempty"`
+	HttpStatusCode int    `json:"-"`
+}
+
+func (o ListClouddcnSubnetsCountFilterTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListClouddcnSubnetsCountFilterTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListClouddcnSubnetsCountFilterTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_filter_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_filter_tags_request.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListClouddcnSubnetsFilterTagsRequest Request Object
+type ListClouddcnSubnetsFilterTagsRequest struct {
+
+	// 每页返回的个数
+	Limit *int32 `json:"limit,omitempty"`
+
+	// 分页起始点
+	Offset *int32 `json:"offset,omitempty"`
+
+	Body *ListResourcesByTagsRequestBody `json:"body,omitempty"`
+}
+
+func (o ListClouddcnSubnetsFilterTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListClouddcnSubnetsFilterTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListClouddcnSubnetsFilterTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_filter_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_filter_tags_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListClouddcnSubnetsFilterTagsResponse Response Object
+type ListClouddcnSubnetsFilterTagsResponse struct {
+
+	// 资源列表
+	Resources *[]ClouddcnResource `json:"resources,omitempty"`
+
+	// 当前列表中资源数量。
+	TotalCount *int32 `json:"total_count,omitempty"`
+
+	// 本次请求的编号
+	RequestId      *string `json:"request_id,omitempty"`
+	HttpStatusCode int     `json:"-"`
+}
+
+func (o ListClouddcnSubnetsFilterTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListClouddcnSubnetsFilterTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListClouddcnSubnetsFilterTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_request.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListClouddcnSubnetsRequest Request Object
+type ListClouddcnSubnetsRequest struct {
+
+	// 每页返回的个数
+	Limit *int32 `json:"limit,omitempty"`
+
+	// 分页查询起始的资源id，为空时查询第一页
+	Marker *string `json:"marker,omitempty"`
+
+	// 按照vpc_id过滤查询 企业项目细粒度授权场景下，该字段必传
+	VpcId *string `json:"vpc_id,omitempty"`
+}
+
+func (o ListClouddcnSubnetsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListClouddcnSubnetsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListClouddcnSubnetsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_response.go
@@ -1,0 +1,24 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListClouddcnSubnetsResponse Response Object
+type ListClouddcnSubnetsResponse struct {
+
+	// clouddcn subnet对象列表
+	ClouddcnSubnets *[]ClouddcnSubnet `json:"clouddcn_subnets,omitempty"`
+	HttpStatusCode  int               `json:"-"`
+}
+
+func (o ListClouddcnSubnetsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListClouddcnSubnetsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListClouddcnSubnetsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_tags_request.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListClouddcnSubnetsTagsRequest Request Object
+type ListClouddcnSubnetsTagsRequest struct {
+}
+
+func (o ListClouddcnSubnetsTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListClouddcnSubnetsTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ListClouddcnSubnetsTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_clouddcn_subnets_tags_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ListClouddcnSubnetsTagsResponse Response Object
+type ListClouddcnSubnetsTagsResponse struct {
+
+	// 本次请求的编号
+	RequestId *string `json:"request_id,omitempty"`
+
+	// 当前列表中资源数量。
+	TotalCount *int32 `json:"total_count,omitempty"`
+
+	// tag列表信息
+	Tags           *[]ResourceTags `json:"tags,omitempty"`
+	HttpStatusCode int             `json:"-"`
+}
+
+func (o ListClouddcnSubnetsTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListClouddcnSubnetsTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ListClouddcnSubnetsTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_resources_by_tags_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_list_resources_by_tags_request_body.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+type ListResourcesByTagsRequestBody struct {
+
+	// 包含标签。
+	Tags *[]ResourceTags `json:"tags,omitempty"`
+}
+
+func (o ListResourcesByTagsRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ListResourcesByTagsRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"ListResourcesByTagsRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_resource_tags.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_resource_tags.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ResourceTags 资源标签。
+type ResourceTags struct {
+
+	// 标签键，最大长度128个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，中文。
+	Key string `json:"key"`
+
+	// tag的value列表
+	Values []string `json:"values"`
+}
+
+func (o ResourceTags) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ResourceTags struct{}"
+	}
+
+	return strings.Join([]string{"ResourceTags", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_security_group.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_security_group.go
@@ -30,6 +30,9 @@ type SecurityGroup struct {
 
 	// 功能说明：安全组所属的企业项目ID。 取值范围：最大长度36字节，带“-”连字符的UUID格式，或者是字符串“0”。“0”表示默认企业项目。
 	EnterpriseProjectId string `json:"enterprise_project_id"`
+
+	// 功能描述：安全组的标签信息
+	Tags []ResourceTag `json:"tags"`
 }
 
 func (o SecurityGroup) String() string {

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_security_group_info.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_security_group_info.go
@@ -31,6 +31,9 @@ type SecurityGroupInfo struct {
 	// 功能说明：安全组所属的企业项目ID。 取值范围：最大长度36字节，带“-”连字符的UUID格式，或者是字符串“0”。“0”表示默认企业项目。
 	EnterpriseProjectId string `json:"enterprise_project_id"`
 
+	// 功能描述：安全组的标签信息
+	Tags []ResourceTag `json:"tags"`
+
 	// 安全组规则
 	SecurityGroupRules []SecurityGroupRule `json:"security_group_rules"`
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_show_clouddcn_subnet_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_show_clouddcn_subnet_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowClouddcnSubnetRequest Request Object
+type ShowClouddcnSubnetRequest struct {
+
+	// clouddcn子网ID
+	ClouddcnSubnetId string `json:"clouddcn_subnet_id"`
+}
+
+func (o ShowClouddcnSubnetRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowClouddcnSubnetRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowClouddcnSubnetRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_show_clouddcn_subnet_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_show_clouddcn_subnet_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowClouddcnSubnetResponse Response Object
+type ShowClouddcnSubnetResponse struct {
+	ClouddcnSubnet *ClouddcnSubnet `json:"clouddcn_subnet,omitempty"`
+	HttpStatusCode int             `json:"-"`
+}
+
+func (o ShowClouddcnSubnetResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowClouddcnSubnetResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowClouddcnSubnetResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_show_clouddcn_subnets_tags_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_show_clouddcn_subnets_tags_request.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowClouddcnSubnetsTagsRequest Request Object
+type ShowClouddcnSubnetsTagsRequest struct {
+
+	// Clouddcn子网的id
+	ResourceId string `json:"resource_id"`
+}
+
+func (o ShowClouddcnSubnetsTagsRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowClouddcnSubnetsTagsRequest struct{}"
+	}
+
+	return strings.Join([]string{"ShowClouddcnSubnetsTagsRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_show_clouddcn_subnets_tags_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_show_clouddcn_subnets_tags_response.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// ShowClouddcnSubnetsTagsResponse Response Object
+type ShowClouddcnSubnetsTagsResponse struct {
+
+	// 本次请求的编号
+	RequestId *string `json:"request_id,omitempty"`
+
+	// 单个资源的租户标签列表。
+	Tags *[]TagEntity `json:"tags,omitempty"`
+
+	// 单个资源的系统标签列表。
+	SysTags        *[]SysTag `json:"sys_tags,omitempty"`
+	HttpStatusCode int       `json:"-"`
+}
+
+func (o ShowClouddcnSubnetsTagsResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "ShowClouddcnSubnetsTagsResponse struct{}"
+	}
+
+	return strings.Join([]string{"ShowClouddcnSubnetsTagsResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_sys_tag.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_sys_tag.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// SysTag 资源标签。
+type SysTag struct {
+
+	// 标签键，最大长度128个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，中文。
+	Key string `json:"key"`
+
+	// 标签值，最大长度255个unicode字符，格式为大小写字母，数字，中划线“-”，下划线“_”，点“.”，中文。
+	Value string `json:"value"`
+}
+
+func (o SysTag) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "SysTag struct{}"
+	}
+
+	return strings.Join([]string{"SysTag", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_tag_entity.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_tag_entity.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// TagEntity tags标签key-value
+type TagEntity struct {
+
+	//
+	Key *interface{} `json:"key"`
+
+	//
+	Value *interface{} `json:"value"`
+}
+
+func (o TagEntity) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "TagEntity struct{}"
+	}
+
+	return strings.Join([]string{"TagEntity", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_update_clouddcn_subnet_option.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_update_clouddcn_subnet_option.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateClouddcnSubnetOption
+type UpdateClouddcnSubnetOption struct {
+
+	// 功能说明：子网名称 取值范围：1-64，支持数字、字母、中文、_(下划线)、-（中划线）、.（点）
+	Name *string `json:"name,omitempty"`
+
+	// 功能说明：子网描述 取值范围：0-255个字符，不能包含“<”和“>”。
+	Description *string `json:"description,omitempty"`
+}
+
+func (o UpdateClouddcnSubnetOption) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateClouddcnSubnetOption struct{}"
+	}
+
+	return strings.Join([]string{"UpdateClouddcnSubnetOption", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_update_clouddcn_subnet_request.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_update_clouddcn_subnet_request.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateClouddcnSubnetRequest Request Object
+type UpdateClouddcnSubnetRequest struct {
+
+	// clouddcn子网ID
+	ClouddcnSubnetId string `json:"clouddcn_subnet_id"`
+
+	Body *UpdateClouddcnSubnetRequestBody `json:"body,omitempty"`
+}
+
+func (o UpdateClouddcnSubnetRequest) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateClouddcnSubnetRequest struct{}"
+	}
+
+	return strings.Join([]string{"UpdateClouddcnSubnetRequest", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_update_clouddcn_subnet_request_body.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_update_clouddcn_subnet_request_body.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateClouddcnSubnetRequestBody
+type UpdateClouddcnSubnetRequestBody struct {
+	ClouddcnSubnet *UpdateClouddcnSubnetOption `json:"clouddcn_subnet"`
+}
+
+func (o UpdateClouddcnSubnetRequestBody) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateClouddcnSubnetRequestBody struct{}"
+	}
+
+	return strings.Join([]string{"UpdateClouddcnSubnetRequestBody", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_update_clouddcn_subnet_response.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/model/model_update_clouddcn_subnet_response.go
@@ -1,0 +1,22 @@
+package model
+
+import (
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/utils"
+
+	"strings"
+)
+
+// UpdateClouddcnSubnetResponse Response Object
+type UpdateClouddcnSubnetResponse struct {
+	ClouddcnSubnet *ClouddcnSubnet `json:"clouddcn_subnet,omitempty"`
+	HttpStatusCode int             `json:"-"`
+}
+
+func (o UpdateClouddcnSubnetResponse) String() string {
+	data, err := utils.Marshal(o)
+	if err != nil {
+		return "UpdateClouddcnSubnetResponse struct{}"
+	}
+
+	return strings.Join([]string{"UpdateClouddcnSubnetResponse", string(data)}, " ")
+}

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/vpc_client.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/vpc_client.go
@@ -1006,6 +1006,279 @@ func (c *VpcClient) UpdateFirewallRulesInvoker(request *model.UpdateFirewallRule
 	return &UpdateFirewallRulesInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
 }
 
+// AddClouddcnSubnetsTags 添加Clouddcn子网标签
+//
+// 添加Clouddcn子网的标签
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) AddClouddcnSubnetsTags(request *model.AddClouddcnSubnetsTagsRequest) (*model.AddClouddcnSubnetsTagsResponse, error) {
+	requestDef := GenReqDefForAddClouddcnSubnetsTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.AddClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+// AddClouddcnSubnetsTagsInvoker 添加Clouddcn子网标签
+func (c *VpcClient) AddClouddcnSubnetsTagsInvoker(request *model.AddClouddcnSubnetsTagsRequest) *AddClouddcnSubnetsTagsInvoker {
+	requestDef := GenReqDefForAddClouddcnSubnetsTags()
+	return &AddClouddcnSubnetsTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// BatchCreateClouddcnSubnetsTags 批量添加Clouddcn子网标签
+//
+// 批量添加Clouddcn子网的标签
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) BatchCreateClouddcnSubnetsTags(request *model.BatchCreateClouddcnSubnetsTagsRequest) (*model.BatchCreateClouddcnSubnetsTagsResponse, error) {
+	requestDef := GenReqDefForBatchCreateClouddcnSubnetsTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.BatchCreateClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+// BatchCreateClouddcnSubnetsTagsInvoker 批量添加Clouddcn子网标签
+func (c *VpcClient) BatchCreateClouddcnSubnetsTagsInvoker(request *model.BatchCreateClouddcnSubnetsTagsRequest) *BatchCreateClouddcnSubnetsTagsInvoker {
+	requestDef := GenReqDefForBatchCreateClouddcnSubnetsTags()
+	return &BatchCreateClouddcnSubnetsTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// BatchDeleteClouddcnSubnetsTags 批量删除Clouddcn子网标签
+//
+// 批量删除Clouddcn子网的标签
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) BatchDeleteClouddcnSubnetsTags(request *model.BatchDeleteClouddcnSubnetsTagsRequest) (*model.BatchDeleteClouddcnSubnetsTagsResponse, error) {
+	requestDef := GenReqDefForBatchDeleteClouddcnSubnetsTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.BatchDeleteClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+// BatchDeleteClouddcnSubnetsTagsInvoker 批量删除Clouddcn子网标签
+func (c *VpcClient) BatchDeleteClouddcnSubnetsTagsInvoker(request *model.BatchDeleteClouddcnSubnetsTagsRequest) *BatchDeleteClouddcnSubnetsTagsInvoker {
+	requestDef := GenReqDefForBatchDeleteClouddcnSubnetsTags()
+	return &BatchDeleteClouddcnSubnetsTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// CreateClouddcnSubnet 创建clouddcn子网
+//
+// 创建clouddcn子网。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) CreateClouddcnSubnet(request *model.CreateClouddcnSubnetRequest) (*model.CreateClouddcnSubnetResponse, error) {
+	requestDef := GenReqDefForCreateClouddcnSubnet()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.CreateClouddcnSubnetResponse), nil
+	}
+}
+
+// CreateClouddcnSubnetInvoker 创建clouddcn子网
+func (c *VpcClient) CreateClouddcnSubnetInvoker(request *model.CreateClouddcnSubnetRequest) *CreateClouddcnSubnetInvoker {
+	requestDef := GenReqDefForCreateClouddcnSubnet()
+	return &CreateClouddcnSubnetInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// DeleteClouddcnSubnet 删除clouddcn子网
+//
+// 删除clouddcn子网
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) DeleteClouddcnSubnet(request *model.DeleteClouddcnSubnetRequest) (*model.DeleteClouddcnSubnetResponse, error) {
+	requestDef := GenReqDefForDeleteClouddcnSubnet()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteClouddcnSubnetResponse), nil
+	}
+}
+
+// DeleteClouddcnSubnetInvoker 删除clouddcn子网
+func (c *VpcClient) DeleteClouddcnSubnetInvoker(request *model.DeleteClouddcnSubnetRequest) *DeleteClouddcnSubnetInvoker {
+	requestDef := GenReqDefForDeleteClouddcnSubnet()
+	return &DeleteClouddcnSubnetInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// DeleteClouddcnSubnetsTag 删除Clouddcn子网标签
+//
+// 删除Clouddcn子网的标签
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) DeleteClouddcnSubnetsTag(request *model.DeleteClouddcnSubnetsTagRequest) (*model.DeleteClouddcnSubnetsTagResponse, error) {
+	requestDef := GenReqDefForDeleteClouddcnSubnetsTag()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.DeleteClouddcnSubnetsTagResponse), nil
+	}
+}
+
+// DeleteClouddcnSubnetsTagInvoker 删除Clouddcn子网标签
+func (c *VpcClient) DeleteClouddcnSubnetsTagInvoker(request *model.DeleteClouddcnSubnetsTagRequest) *DeleteClouddcnSubnetsTagInvoker {
+	requestDef := GenReqDefForDeleteClouddcnSubnetsTag()
+	return &DeleteClouddcnSubnetsTagInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListClouddcnSubnets 查询clouddcn子网列表
+//
+// 查询clouddcn子网列表
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) ListClouddcnSubnets(request *model.ListClouddcnSubnetsRequest) (*model.ListClouddcnSubnetsResponse, error) {
+	requestDef := GenReqDefForListClouddcnSubnets()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListClouddcnSubnetsResponse), nil
+	}
+}
+
+// ListClouddcnSubnetsInvoker 查询clouddcn子网列表
+func (c *VpcClient) ListClouddcnSubnetsInvoker(request *model.ListClouddcnSubnetsRequest) *ListClouddcnSubnetsInvoker {
+	requestDef := GenReqDefForListClouddcnSubnets()
+	return &ListClouddcnSubnetsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListClouddcnSubnetsCountFilterTags 查询资源实例列表数目
+//
+// 查询资源实例列表数目
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) ListClouddcnSubnetsCountFilterTags(request *model.ListClouddcnSubnetsCountFilterTagsRequest) (*model.ListClouddcnSubnetsCountFilterTagsResponse, error) {
+	requestDef := GenReqDefForListClouddcnSubnetsCountFilterTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListClouddcnSubnetsCountFilterTagsResponse), nil
+	}
+}
+
+// ListClouddcnSubnetsCountFilterTagsInvoker 查询资源实例列表数目
+func (c *VpcClient) ListClouddcnSubnetsCountFilterTagsInvoker(request *model.ListClouddcnSubnetsCountFilterTagsRequest) *ListClouddcnSubnetsCountFilterTagsInvoker {
+	requestDef := GenReqDefForListClouddcnSubnetsCountFilterTags()
+	return &ListClouddcnSubnetsCountFilterTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListClouddcnSubnetsFilterTags 查询资源实例列表
+//
+// 查询资源实例列表
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) ListClouddcnSubnetsFilterTags(request *model.ListClouddcnSubnetsFilterTagsRequest) (*model.ListClouddcnSubnetsFilterTagsResponse, error) {
+	requestDef := GenReqDefForListClouddcnSubnetsFilterTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListClouddcnSubnetsFilterTagsResponse), nil
+	}
+}
+
+// ListClouddcnSubnetsFilterTagsInvoker 查询资源实例列表
+func (c *VpcClient) ListClouddcnSubnetsFilterTagsInvoker(request *model.ListClouddcnSubnetsFilterTagsRequest) *ListClouddcnSubnetsFilterTagsInvoker {
+	requestDef := GenReqDefForListClouddcnSubnetsFilterTags()
+	return &ListClouddcnSubnetsFilterTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ListClouddcnSubnetsTags 查询Clouddcn子网项目标签
+//
+// 查询Clouddcn子网的项目标签
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) ListClouddcnSubnetsTags(request *model.ListClouddcnSubnetsTagsRequest) (*model.ListClouddcnSubnetsTagsResponse, error) {
+	requestDef := GenReqDefForListClouddcnSubnetsTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ListClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+// ListClouddcnSubnetsTagsInvoker 查询Clouddcn子网项目标签
+func (c *VpcClient) ListClouddcnSubnetsTagsInvoker(request *model.ListClouddcnSubnetsTagsRequest) *ListClouddcnSubnetsTagsInvoker {
+	requestDef := GenReqDefForListClouddcnSubnetsTags()
+	return &ListClouddcnSubnetsTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowClouddcnSubnet 查询clouddcn子网
+//
+// 查询clouddcn子网详情。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) ShowClouddcnSubnet(request *model.ShowClouddcnSubnetRequest) (*model.ShowClouddcnSubnetResponse, error) {
+	requestDef := GenReqDefForShowClouddcnSubnet()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowClouddcnSubnetResponse), nil
+	}
+}
+
+// ShowClouddcnSubnetInvoker 查询clouddcn子网
+func (c *VpcClient) ShowClouddcnSubnetInvoker(request *model.ShowClouddcnSubnetRequest) *ShowClouddcnSubnetInvoker {
+	requestDef := GenReqDefForShowClouddcnSubnet()
+	return &ShowClouddcnSubnetInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// ShowClouddcnSubnetsTags 查询Clouddcn子网标签
+//
+// 查询Clouddcn子网的标签
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) ShowClouddcnSubnetsTags(request *model.ShowClouddcnSubnetsTagsRequest) (*model.ShowClouddcnSubnetsTagsResponse, error) {
+	requestDef := GenReqDefForShowClouddcnSubnetsTags()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.ShowClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+// ShowClouddcnSubnetsTagsInvoker 查询Clouddcn子网标签
+func (c *VpcClient) ShowClouddcnSubnetsTagsInvoker(request *model.ShowClouddcnSubnetsTagsRequest) *ShowClouddcnSubnetsTagsInvoker {
+	requestDef := GenReqDefForShowClouddcnSubnetsTags()
+	return &ShowClouddcnSubnetsTagsInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
+// UpdateClouddcnSubnet 更新clouddcn子网
+//
+// 更新clouddcn子网。
+//
+// Please refer to HUAWEI cloud API Explorer for details.
+func (c *VpcClient) UpdateClouddcnSubnet(request *model.UpdateClouddcnSubnetRequest) (*model.UpdateClouddcnSubnetResponse, error) {
+	requestDef := GenReqDefForUpdateClouddcnSubnet()
+
+	if resp, err := c.HcClient.Sync(request, requestDef); err != nil {
+		return nil, err
+	} else {
+		return resp.(*model.UpdateClouddcnSubnetResponse), nil
+	}
+}
+
+// UpdateClouddcnSubnetInvoker 更新clouddcn子网
+func (c *VpcClient) UpdateClouddcnSubnetInvoker(request *model.UpdateClouddcnSubnetRequest) *UpdateClouddcnSubnetInvoker {
+	requestDef := GenReqDefForUpdateClouddcnSubnet()
+	return &UpdateClouddcnSubnetInvoker{invoker.NewBaseInvoker(c.HcClient, request, requestDef)}
+}
+
 // CreateAddressGroup 创建地址组
 //
 // 创建地址组

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/vpc_invoker.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/vpc_invoker.go
@@ -569,6 +569,162 @@ func (i *UpdateFirewallRulesInvoker) Invoke() (*model.UpdateFirewallRulesRespons
 	}
 }
 
+type AddClouddcnSubnetsTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *AddClouddcnSubnetsTagsInvoker) Invoke() (*model.AddClouddcnSubnetsTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.AddClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+type BatchCreateClouddcnSubnetsTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *BatchCreateClouddcnSubnetsTagsInvoker) Invoke() (*model.BatchCreateClouddcnSubnetsTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.BatchCreateClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+type BatchDeleteClouddcnSubnetsTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *BatchDeleteClouddcnSubnetsTagsInvoker) Invoke() (*model.BatchDeleteClouddcnSubnetsTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.BatchDeleteClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+type CreateClouddcnSubnetInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *CreateClouddcnSubnetInvoker) Invoke() (*model.CreateClouddcnSubnetResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.CreateClouddcnSubnetResponse), nil
+	}
+}
+
+type DeleteClouddcnSubnetInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *DeleteClouddcnSubnetInvoker) Invoke() (*model.DeleteClouddcnSubnetResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DeleteClouddcnSubnetResponse), nil
+	}
+}
+
+type DeleteClouddcnSubnetsTagInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *DeleteClouddcnSubnetsTagInvoker) Invoke() (*model.DeleteClouddcnSubnetsTagResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.DeleteClouddcnSubnetsTagResponse), nil
+	}
+}
+
+type ListClouddcnSubnetsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListClouddcnSubnetsInvoker) Invoke() (*model.ListClouddcnSubnetsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListClouddcnSubnetsResponse), nil
+	}
+}
+
+type ListClouddcnSubnetsCountFilterTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListClouddcnSubnetsCountFilterTagsInvoker) Invoke() (*model.ListClouddcnSubnetsCountFilterTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListClouddcnSubnetsCountFilterTagsResponse), nil
+	}
+}
+
+type ListClouddcnSubnetsFilterTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListClouddcnSubnetsFilterTagsInvoker) Invoke() (*model.ListClouddcnSubnetsFilterTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListClouddcnSubnetsFilterTagsResponse), nil
+	}
+}
+
+type ListClouddcnSubnetsTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ListClouddcnSubnetsTagsInvoker) Invoke() (*model.ListClouddcnSubnetsTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ListClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+type ShowClouddcnSubnetInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowClouddcnSubnetInvoker) Invoke() (*model.ShowClouddcnSubnetResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowClouddcnSubnetResponse), nil
+	}
+}
+
+type ShowClouddcnSubnetsTagsInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *ShowClouddcnSubnetsTagsInvoker) Invoke() (*model.ShowClouddcnSubnetsTagsResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.ShowClouddcnSubnetsTagsResponse), nil
+	}
+}
+
+type UpdateClouddcnSubnetInvoker struct {
+	*invoker.BaseInvoker
+}
+
+func (i *UpdateClouddcnSubnetInvoker) Invoke() (*model.UpdateClouddcnSubnetResponse, error) {
+	if result, err := i.BaseInvoker.Invoke(); err != nil {
+		return nil, err
+	} else {
+		return result.(*model.UpdateClouddcnSubnetResponse), nil
+	}
+}
+
 type CreateAddressGroupInvoker struct {
 	*invoker.BaseInvoker
 }

--- a/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/vpc_meta.go
+++ b/vendor/github.com/huaweicloud/huaweicloud-sdk-go-v3/services/vpc/v3/vpc_meta.go
@@ -1049,6 +1049,243 @@ func GenReqDefForUpdateFirewallRules() *def.HttpRequestDef {
 	return requestDef
 }
 
+func GenReqDefForAddClouddcnSubnetsTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/clouddcn-subnets/{resource_id}/tags").
+		WithResponse(new(model.AddClouddcnSubnetsTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ResourceId").
+		WithJsonTag("resource_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForBatchCreateClouddcnSubnetsTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/clouddcn-subnets/{resource_id}/tags/create").
+		WithResponse(new(model.BatchCreateClouddcnSubnetsTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ResourceId").
+		WithJsonTag("resource_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForBatchDeleteClouddcnSubnetsTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/clouddcn-subnets/{resource_id}/tags/delete").
+		WithResponse(new(model.BatchDeleteClouddcnSubnetsTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ResourceId").
+		WithJsonTag("resource_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForCreateClouddcnSubnet() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/vpc/clouddcn-subnets").
+		WithResponse(new(model.CreateClouddcnSubnetResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteClouddcnSubnet() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v3/{project_id}/vpc/clouddcn-subnets/{clouddcn_subnet_id}").
+		WithResponse(new(model.DeleteClouddcnSubnetResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ClouddcnSubnetId").
+		WithJsonTag("clouddcn_subnet_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForDeleteClouddcnSubnetsTag() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodDelete).
+		WithPath("/v3/{project_id}/clouddcn-subnets/{resource_id}/tags/{tag_key}").
+		WithResponse(new(model.DeleteClouddcnSubnetsTagResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ResourceId").
+		WithJsonTag("resource_id").
+		WithLocationType(def.Path))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("TagKey").
+		WithJsonTag("tag_key").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListClouddcnSubnets() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/vpc/clouddcn-subnets").
+		WithResponse(new(model.ListClouddcnSubnetsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Marker").
+		WithJsonTag("marker").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("VpcId").
+		WithJsonTag("vpc_id").
+		WithLocationType(def.Query))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListClouddcnSubnetsCountFilterTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/clouddcn-subnets/resource-instances/count").
+		WithResponse(new(model.ListClouddcnSubnetsCountFilterTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListClouddcnSubnetsFilterTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPost).
+		WithPath("/v3/{project_id}/clouddcn-subnets/resource-instances/filter").
+		WithResponse(new(model.ListClouddcnSubnetsFilterTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Limit").
+		WithJsonTag("limit").
+		WithLocationType(def.Query))
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Offset").
+		WithJsonTag("offset").
+		WithLocationType(def.Query))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForListClouddcnSubnetsTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/clouddcn-subnets/tags").
+		WithResponse(new(model.ListClouddcnSubnetsTagsResponse)).
+		WithContentType("application/json")
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowClouddcnSubnet() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/vpc/clouddcn-subnets/{clouddcn_subnet_id}").
+		WithResponse(new(model.ShowClouddcnSubnetResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ClouddcnSubnetId").
+		WithJsonTag("clouddcn_subnet_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForShowClouddcnSubnetsTags() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodGet).
+		WithPath("/v3/{project_id}/clouddcn-subnets/{resource_id}/tags").
+		WithResponse(new(model.ShowClouddcnSubnetsTagsResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ResourceId").
+		WithJsonTag("resource_id").
+		WithLocationType(def.Path))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
+func GenReqDefForUpdateClouddcnSubnet() *def.HttpRequestDef {
+	reqDefBuilder := def.NewHttpRequestDefBuilder().
+		WithMethod(http.MethodPut).
+		WithPath("/v3/{project_id}/vpc/clouddcn-subnets/{clouddcn_subnet_id}").
+		WithResponse(new(model.UpdateClouddcnSubnetResponse)).
+		WithContentType("application/json")
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("ClouddcnSubnetId").
+		WithJsonTag("clouddcn_subnet_id").
+		WithLocationType(def.Path))
+
+	reqDefBuilder.WithRequestField(def.NewFieldDef().
+		WithName("Body").
+		WithLocationType(def.Body))
+
+	requestDef := reqDefBuilder.Build()
+	return requestDef
+}
+
 func GenReqDefForCreateAddressGroup() *def.HttpRequestDef {
 	reqDefBuilder := def.NewHttpRequestDefBuilder().
 		WithMethod(http.MethodPost).

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -512,7 +512,7 @@ github.com/hashicorp/terraform-svchost
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 ## explicit
 github.com/hashicorp/yamux
-# github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.94
+# github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.98
 ## explicit; go 1.14
 github.com/huaweicloud/huaweicloud-sdk-go-v3/core
 github.com/huaweicloud/huaweicloud-sdk-go-v3/core/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Upgrade huaweicloud-sdk-go-v3 sdk from v0.1.94 to v0.1.98.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Upgrading the huaweicloud-sdk-go-v3 will involve changes to 5 services in total。
  - CDN: Including 6 data sources and 4 resources.
    - datasources: `huaweicloud_cdn_billing_option`, `huaweicloud_cdn_cache_history_tasks`, `huaweicloud_cdn_cache_url_tasks`, `huaweicloud_cdn_domain_certificates`, `huaweicloud_cdn_domain_statistics`, `huaweicloud_cdn_domains`.
    -  resources: `huaweicloud_cdn_billing_option`, `huaweicloud_cdn_cache_preheat`, `huaweicloud_cdn_cache_refresh`, `huaweicloud_cdn_domain`.
  - IOTDA: Including 8 data sources and 10 resources.
    - datasources: `huaweicloud_iotda_amqps`, `huaweicloud_iotda_dataforwarding_rules`, `huaweicloud_iotda_device_certificates`, `huaweicloud_iotda_device_groups`, `huaweicloud_iotda_device_linkage_rules`, `huaweicloud_iotda_devices`, `huaweicloud_iotda_products`, `huaweicloud_iotda_spaces`.
    - resources: `huaweicloud_iotda_amqp`, `huaweicloud_iotda_batchtask`, `huaweicloud_iotda_dataforwarding_rule`, `huaweicloud_iotda_device`, `huaweicloud_iotda_device_certificate`, `huaweicloud_iotda_device_group`, `huaweicloud_iotda_device_linkage_rule`, `huaweicloud_iotda_product`, `huaweicloud_iotda_space`, `huaweicloud_iotda_upgrade_package`.
  - KPS: Including 1 data source and 1 resource.
    - datasources: `huaweicloud_kps_keypairs`.
    - resources: `huaweicloud_kps_keypair`.
  - MPC: Including 2 resources.
    - resources: `huaweicloud_mpc_transcoding_template` , `huaweicloud_mpc_transcoding_template_group`.
  - VPC: Including 2 resources.
  - resources: `huaweicloud_vpc`, `huaweicloud_vpc_address_group`.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

**CDN Test**

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_basic
--- PASS: TestAccCdnDomain_basic (852.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       852.202s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configs -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configs
--- PASS: TestAccCdnDomain_configs (858.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       858.316s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configTypeWholeSite'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configTypeWholeSite -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configTypeWholeSite
--- PASS: TestAccCdnDomain_configTypeWholeSite (568.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       568.306s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_epsID_migrate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_epsID_migrate -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_epsID_migrate (409.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       409.343s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain_configHttpSettings'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain_configHttpSettings -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configHttpSettings (769.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       769.211s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCacheRefresh_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCacheRefresh_basic -timeout 360m -parallel 4
=== RUN   TestAccCacheRefresh_basic
=== PAUSE TestAccCacheRefresh_basic
=== CONT  TestAccCacheRefresh_basic
--- PASS: TestAccCacheRefresh_basic (10.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       10.526s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCachePreheat_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCachePreheat_basic -timeout 360m -parallel 4
=== RUN   TestAccCachePreheat_basic
=== PAUSE TestAccCachePreheat_basic
=== CONT  TestAccCachePreheat_basic
--- PASS: TestAccCachePreheat_basic (11.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       11.943s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccBillingOption_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccBillingOption_basic -timeout 360m -parallel 4
=== RUN   TestAccBillingOption_basic
=== PAUSE TestAccBillingOption_basic
=== CONT  TestAccBillingOption_basic
--- PASS: TestAccBillingOption_basic (18.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       18.427s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceCDNDomains_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceCDNDomains_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCDNDomains_basic
=== PAUSE TestAccDatasourceCDNDomains_basic
=== CONT  TestAccDatasourceCDNDomains_basic
--- PASS: TestAccDatasourceCDNDomains_basic (352.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       352.650s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceStatistics_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceStatistics_basic
=== PAUSE TestAccDatasourceStatistics_basic
=== CONT  TestAccDatasourceStatistics_basic
--- PASS: TestAccDatasourceStatistics_basic (9.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       9.756s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceCDNDomainCertificates_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceCDNDomainCertificates_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCDNDomainCertificates_basic
=== PAUSE TestAccDatasourceCDNDomainCertificates_basic
=== CONT  TestAccDatasourceCDNDomainCertificates_basic
--- PASS: TestAccDatasourceCDNDomainCertificates_basic (21.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       21.222s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceCacheUrlTasks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceCacheUrlTasks_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCacheUrlTasks_basic
=== PAUSE TestAccDatasourceCacheUrlTasks_basic
=== CONT  TestAccDatasourceCacheUrlTasks_basic
--- PASS: TestAccDatasourceCacheUrlTasks_basic (41.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       41.302s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceCacheHistoryTasks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceCacheHistoryTasks_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCacheHistoryTasks_basic
=== PAUSE TestAccDatasourceCacheHistoryTasks_basic
=== CONT  TestAccDatasourceCacheHistoryTasks_basic
--- PASS: TestAccDatasourceCacheHistoryTasks_basic (42.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       42.337s

make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceBillingOption_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceBillingOption_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceBillingOption_basic
=== PAUSE TestAccDatasourceBillingOption_basic
=== CONT  TestAccDatasourceBillingOption_basic
--- PASS: TestAccDatasourceBillingOption_basic (16.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       16.552s
```

**KPS Test**

```
make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run TestAccKpsKeypair'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKpsKeypair -timeout 360m -parallel 4
=== RUN   TestAccKpsKeypair_basic
--- PASS: TestAccKpsKeypair_basic (21.17s)
=== RUN   TestAccKpsKeypair_domain
--- PASS: TestAccKpsKeypair_domain (28.44s)
=== RUN   TestAccKpsKeypair_publicKey
--- PASS: TestAccKpsKeypair_publicKey (20.12s)
=== RUN   TestAccKpsKeypair_privateKey
--- PASS: TestAccKpsKeypair_privateKey (45.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       115.460s

make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run TestAccDataKpsKeypairs_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDataKpsKeypairs_basic -timeout 360m -parallel 4
=== RUN   TestAccDataKpsKeypairs_basic
=== PAUSE TestAccDataKpsKeypairs_basic
=== CONT  TestAccDataKpsKeypairs_basic
--- PASS: TestAccDataKpsKeypairs_basic (16.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       16.448s
```

**MPC Test**

```
make testacc TEST='./huaweicloud/services/acceptance/mpc' TESTARGS='-run TestAccTranscodingTemplate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/mpc -v -run TestAccTranscodingTemplate -timeout 360m -parallel 4
=== RUN   TestAccTranscodingTemplateGroup_basic
=== PAUSE TestAccTranscodingTemplateGroup_basic
=== RUN   TestAccTranscodingTemplate_basic
=== PAUSE TestAccTranscodingTemplate_basic
=== CONT  TestAccTranscodingTemplateGroup_basic
=== CONT  TestAccTranscodingTemplate_basic
--- PASS: TestAccTranscodingTemplate_basic (21.81s)
--- PASS: TestAccTranscodingTemplateGroup_basic (21.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/mpc       21.921s
```

**VPC Test**

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcV1_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcV1_ -timeout 360m -parallel 4
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== RUN   TestAccVpcV1_secondaryCIDR
=== PAUSE TestAccVpcV1_secondaryCIDR
=== RUN   TestAccVpcV1_secondaryCIDRs
=== PAUSE TestAccVpcV1_secondaryCIDRs
=== RUN   TestAccVpcV1_WithEpsId
=== PAUSE TestAccVpcV1_WithEpsId
=== RUN   TestAccVpcV1_WithCustomRegion
=== PAUSE TestAccVpcV1_WithCustomRegion
=== CONT  TestAccVpcV1_basic
=== CONT  TestAccVpcV1_WithEpsId
=== CONT  TestAccVpcV1_secondaryCIDRs
=== CONT  TestAccVpcV1_secondaryCIDR
=== NAME  TestAccVpcV1_WithEpsId
    acceptance.go:543: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccVpcV1_WithEpsId (0.01s)
=== CONT  TestAccVpcV1_WithCustomRegion
    acceptance.go:510: HW_CUSTOM_REGION_NAME must be set for acceptance tests
--- SKIP: TestAccVpcV1_WithCustomRegion (0.01s)
--- PASS: TestAccVpcV1_basic (49.63s)
--- PASS: TestAccVpcV1_secondaryCIDR (55.28s)
--- PASS: TestAccVpcV1_secondaryCIDRs (64.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       64.585s
```

**IOTDA Test**

```
make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccUpgradePackage_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccUpgradePackage_ -timeout 360m -parallel 4
=== RUN   TestAccUpgradePackage_basic
--- PASS: TestAccUpgradePackage_basic (38.73s)
=== RUN   TestAccUpgradePackage_derived
--- PASS: TestAccUpgradePackage_derived (33.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     72.605s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccSpace_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccSpace_ -timeout 360m -parallel 4
=== RUN   TestAccSpace_basic
--- PASS: TestAccSpace_basic (11.71s)
=== RUN   TestAccSpace_derived
--- PASS: TestAccSpace_derived (11.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     23.421s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccProduct_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccProduct_ -timeout 360m -parallel 4
=== RUN   TestAccProduct_basic
--- PASS: TestAccProduct_basic (29.77s)
=== RUN   TestAccProduct_derived
--- PASS: TestAccProduct_derived (30.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     60.005s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccDevice_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDevice_ -timeout 360m -parallel 4
=== RUN   TestAccDevice_basic
--- PASS: TestAccDevice_basic (62.67s)
=== RUN   TestAccDevice_derived
--- PASS: TestAccDevice_derived (61.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     124.668s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccDeviceLinkageRule_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceLinkageRule_ -timeout 360m -parallel 4
=== RUN   TestAccDeviceLinkageRule_basic
=== PAUSE TestAccDeviceLinkageRule_basic
=== RUN   TestAccDeviceLinkageRule_derived
=== PAUSE TestAccDeviceLinkageRule_derived
=== CONT  TestAccDeviceLinkageRule_basic
=== CONT  TestAccDeviceLinkageRule_derived
--- PASS: TestAccDeviceLinkageRule_basic (146.23s)
--- PASS: TestAccDeviceLinkageRule_derived (147.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     147.248s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccDeviceGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceGroup_ -timeout 360m -parallel 4
=== RUN   TestAccDeviceGroup_basic
--- PASS: TestAccDeviceGroup_basic (65.10s)
=== RUN   TestAccDeviceGroup_derived
--- PASS: TestAccDeviceGroup_derived (66.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     131.718s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccDeviceCertificate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceCertificate_ -timeout 360m -parallel 4
=== RUN   TestAccDeviceCertificate_basic
=== PAUSE TestAccDeviceCertificate_basic
=== RUN   TestAccDeviceCertificate_derived
=== PAUSE TestAccDeviceCertificate_derived
=== CONT  TestAccDeviceCertificate_basic
=== CONT  TestAccDeviceCertificate_derived
--- PASS: TestAccDeviceCertificate_derived (12.50s)
--- PASS: TestAccDeviceCertificate_basic (12.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     12.617s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccDataForwardingRule_derived'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataForwardingRule_derived -timeout 360m -parallel 4
=== RUN   TestAccDataForwardingRule_derived
=== PAUSE TestAccDataForwardingRule_derived
=== CONT  TestAccDataForwardingRule_derived
--- PASS: TestAccDataForwardingRule_derived (26.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     26.188s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccBatchTask_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccBatchTask_ -timeout 360m -parallel 4
=== RUN   TestAccBatchTask_basic
--- PASS: TestAccBatchTask_basic (57.04s)
=== RUN   TestAccBatchTask_withTargetsFilterField
--- PASS: TestAccBatchTask_withTargetsFilterField (20.99s)
=== RUN   TestAccBatchTask_withTargetsFileField
    acceptance.go:1630: HW_IOTDA_BATCHTASK_FILE_PATH must be set for the acceptance test
--- SKIP: TestAccBatchTask_withTargetsFileField (0.01s)
=== RUN   TestAccBatchTask_derived
--- PASS: TestAccBatchTask_derived (21.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     99.226s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccAmqp_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccAmqp_ -timeout 360m -parallel 4
=== RUN   TestAccAmqp_basic
=== PAUSE TestAccAmqp_basic
=== RUN   TestAccAmqp_derived
=== PAUSE TestAccAmqp_derived
=== CONT  TestAccAmqp_basic
=== CONT  TestAccAmqp_derived
--- PASS: TestAccAmqp_basic (12.61s)
--- PASS: TestAccAmqp_derived (12.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     12.713s

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccData'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccData -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAMQPQueues_basic
=== PAUSE TestAccDataSourceAMQPQueues_basic
=== RUN   TestAccDataSourceAMQPQueues_derived
=== PAUSE TestAccDataSourceAMQPQueues_derived
=== RUN   TestAccDataSourceDataForwardingRules_basic
=== PAUSE TestAccDataSourceDataForwardingRules_basic
=== RUN   TestAccDataSourceDataForwardingRules_derived
=== PAUSE TestAccDataSourceDataForwardingRules_derived
=== RUN   TestAccDataSourceDeviceCertificates_basic
=== PAUSE TestAccDataSourceDeviceCertificates_basic
=== RUN   TestAccDataSourceDeviceCertificates_derived
=== PAUSE TestAccDataSourceDeviceCertificates_derived
=== RUN   TestAccDataSourceDeviceGroups_basic
=== PAUSE TestAccDataSourceDeviceGroups_basic
=== RUN   TestAccDataSourceDeviceGroups_derived
=== PAUSE TestAccDataSourceDeviceGroups_derived
=== RUN   TestAccDataSourceDeviceLinkageRules_basic
=== PAUSE TestAccDataSourceDeviceLinkageRules_basic
=== RUN   TestAccDataSourceDeviceLinkageRules_derived
=== PAUSE TestAccDataSourceDeviceLinkageRules_derived
=== RUN   TestAccDataSourceDevices_basic
=== PAUSE TestAccDataSourceDevices_basic
=== RUN   TestAccDataSourceDevices_derived
=== PAUSE TestAccDataSourceDevices_derived
=== RUN   TestAccDataSourceProducts_basic
=== PAUSE TestAccDataSourceProducts_basic
=== RUN   TestAccDataSourceSpaces_basic
=== PAUSE TestAccDataSourceSpaces_basic
=== RUN   TestAccDataSourceSpaces_derived
=== PAUSE TestAccDataSourceSpaces_derived
=== CONT  TestAccDataSourceAMQPQueues_basic
=== CONT  TestAccDataSourceDeviceLinkageRules_basic
=== CONT  TestAccDataSourceProducts_basic
=== CONT  TestAccDataSourceSpaces_derived
--- PASS: TestAccDataSourceAMQPQueues_basic (52.29s)
=== CONT  TestAccDataSourceSpaces_basic
--- PASS: TestAccDataSourceSpaces_derived (69.60s)
=== CONT  TestAccDataSourceDevices_basic
--- PASS: TestAccDataSourceProducts_basic (80.08s)
=== CONT  TestAccDataSourceDevices_derived
--- PASS: TestAccDataSourceSpaces_basic (69.87s)
=== CONT  TestAccDataSourceDeviceLinkageRules_derived
--- PASS: TestAccDataSourceDeviceLinkageRules_basic (138.51s)
=== CONT  TestAccDataSourceDeviceCertificates_basic
--- PASS: TestAccDataSourceDevices_basic (86.66s)
=== CONT  TestAccDataSourceDeviceGroups_derived
--- PASS: TestAccDataSourceDevices_derived (86.31s)
=== CONT  TestAccDataSourceDeviceGroups_basic
--- PASS: TestAccDataSourceDeviceCertificates_basic (58.62s)
=== CONT  TestAccDataSourceDeviceCertificates_derived
--- PASS: TestAccDataSourceDeviceGroups_derived (98.00s)
=== CONT  TestAccDataSourceDataForwardingRules_basic
--- PASS: TestAccDataSourceDeviceCertificates_derived (57.77s)
--- PASS: TestAccDataSourceDeviceLinkageRules_derived (134.90s)
=== CONT  TestAccDataSourceAMQPQueues_derived
--- PASS: TestAccDataSourceDeviceGroups_basic (98.22s)
--- PASS: TestAccDataSourceAMQPQueues_derived (42.41s)
--- PASS: TestAccDataSourceDataForwardingRules_basic (54.07s)

make testacc TEST='./huaweicloud/services/acceptance/iotda' TESTARGS='-run TestAccDataSourceDataForwardingRules_derived'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataForwardingRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataForwardingRules_derived
=== PAUSE TestAccDataSourceDataForwardingRules_derived
=== CONT  TestAccDataSourceDataForwardingRules_derived
--- PASS: TestAccDataSourceDataForwardingRules_derived (40.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     40.844s
```
