### PR TITLE
feat(ga): the accelerator and listener resource support update tags

### DIFF
--- a/docs/resources/ga_accelerator.md
+++ b/docs/resources/ga_accelerator.md
@@ -51,9 +51,7 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the global accelerator.
-
-  Changing this parameter will create a new resource.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the global accelerator.
 
 <a name="Accelerator_AccelerateIp"></a>
 The `AccelerateIp` block supports:

--- a/docs/resources/ga_listener.md
+++ b/docs/resources/ga_listener.md
@@ -57,9 +57,7 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies the information about the listener.
   The value can contain 0 to 255 characters. The following characters are not allowed: <>
 
-* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the listener.
-
-  Changing this parameter will create a new resource.
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the listener.
 
 <a name="Listener_PortRange"></a>
 The `PortRange` block supports:

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_accelerator_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_accelerator_test.go
@@ -78,6 +78,8 @@ func TestAccAccelerator_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name+"-update"),
 					resource.TestCheckResourceAttr(rName, "description", "terraform test update"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
 				),
 			},
 			{
@@ -118,8 +120,8 @@ resource "huaweicloud_ga_accelerator" "test" {
   }
 
   tags = {
-    foo = "bar"
-    key = "value"
+    foo   = "bar"
+    owner = "terraform"
   }
 }
 `, name)

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_listener_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_listener_test.go
@@ -85,6 +85,8 @@ func TestAccListener_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "description", "Terraform test update"),
 					resource.TestCheckResourceAttr(rName, "port_ranges.0.from_port", "5000"),
 					resource.TestCheckResourceAttr(rName, "port_ranges.0.to_port", "5200"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
 				),
 			},
 			{
@@ -135,8 +137,8 @@ resource "huaweicloud_ga_listener" "test" {
   }
 
   tags = {
-    foo = "bar"
-    key = "value"
+    key   = "value"
+    owner = "terraform"
   }
 }
 `, testAccelerator_basic(name), name)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The accelerator and listener resource support update tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccAccelerator_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccAccelerator_basic -timeout 360m -parallel 4
=== RUN   TestAccAccelerator_basic
=== PAUSE TestAccAccelerator_basic
=== CONT  TestAccAccelerator_basic
--- PASS: TestAccAccelerator_basic (77.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        77.457s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/ga" TESTARGS="-run TestAccListener_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAccListener_basic -timeout 360m -parallel 4
=== RUN   TestAccListener_basic
=== PAUSE TestAccListener_basic
=== CONT  TestAccListener_basic
--- PASS: TestAccListener_basic (126.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        126.551s
```
