### PR TITLE
feat(iotda/dataforwarding_rule): support data forwarding to FunctionGraph service

### DIFF
--- a/docs/resources/iotda_dataforwarding_rule.md
+++ b/docs/resources/iotda_dataforwarding_rule.md
@@ -125,6 +125,10 @@ The `targets` block supports:
   + **DMS_KAFKA_FORWARDING**: Distributed Message Service (DMS) for Kafka features high throughput, concurrency, and
    scalability. It is suitable for real-time data transmission, stream data processing, system decoupling,
    and traffic balancing.
+  + **FUNCTIONGRAPH_FORWARDING**: By forwarding data to FunctionGraph service, you only need to write your business
+    function code and set the conditions for execution in FunctionGraph. There is no need to configure and manage
+    servers or other infrastructure. Functions will run in an elastic, maintenance-free, and highly reliable manner.
+    Currently, only standard and enterprise edition IoTDA instances are supported.
 
 * `http_forwarding` - (Optional, List) Specifies the detail of the HTTP forwards. It is required when type
   is `HTTP_FORWARDING`. The [http_forwarding](#IoTDA_http_forwarding) structure is documented below.
@@ -140,6 +144,9 @@ The `targets` block supports:
 
 * `kafka_forwarding` - (Optional, List) Specifies the detail of the KAFKA forwards. It is required when type
   is `DMS_KAFKA_FORWARDING`. The [properties](#IoTDA_kafka_forwarding) structure is documented below.
+
+* `fgs_forwarding` - (Optional, List) Specifies the detail of the FunctionGraph forwards. It is required when
+  type is **FUNCTIONGRAPH_FORWARDING**. The [fgs_forwarding](#IoTDA_fgs_forwarding) structure is documented below.
 
 <a name="IoTDA_http_forwarding"></a>
 The `http_forwarding` block supports:
@@ -194,6 +201,13 @@ If omitted, the default project in the region will be used.
 * `user_name` - (Optional, String) Specifies the SASL user name.
 
 * `password` - (Optional, String) Specifies the password.
+
+<a name="IoTDA_fgs_forwarding"></a>
+The `fgs_forwarding` block supports:
+
+* `func_urn` - (Required, String) Specifies the function URN.
+
+* `func_name` - (Required, String) Specifies the function name.
 
 <a name="IoTDA_forwarding_addresses"></a>
 The `addresses` block supports:

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_dataforwarding_rule_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
@@ -175,4 +174,150 @@ resource "huaweicloud_iotda_dataforwarding_rule" "test" {
   }
 }
 `, buildIoTDAEndpoint(), name, name, region)
+}
+
+func TestAccDataForwardingRule_forwardFGS(t *testing.T) {
+	var obj model.ShowRoutingRuleResponse
+
+	name := acceptance.RandomAccResourceNameWithDash()
+	updateName := acceptance.RandomAccResourceNameWithDash()
+	rName := "huaweicloud_iotda_dataforwarding_rule.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDataForwardingRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDataForwardingRule_forwardFGS_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "trigger", "product:delete"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(rName, "targets.0.type", "FUNCTIONGRAPH_FORWARDING"),
+					resource.TestCheckResourceAttrSet(rName, "targets.0.id"),
+					resource.TestCheckResourceAttrPair(rName, "targets.0.fgs_forwarding.0.func_urn",
+						"huaweicloud_fgs_function.test.0", "urn"),
+					resource.TestCheckResourceAttrPair(rName, "targets.0.fgs_forwarding.0.func_name",
+						"huaweicloud_fgs_function.test.0", "name"),
+				),
+			},
+			{
+				Config: testDataForwardingRule_forwardFGS_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "trigger", "product:delete"),
+					resource.TestCheckResourceAttr(rName, "enabled", "true"),
+					resource.TestCheckResourceAttr(rName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(rName, "targets.0.type", "FUNCTIONGRAPH_FORWARDING"),
+					resource.TestCheckResourceAttrSet(rName, "targets.0.id"),
+					resource.TestCheckResourceAttrPair(rName, "targets.0.fgs_forwarding.0.func_urn",
+						"huaweicloud_fgs_function.test.1", "urn"),
+					resource.TestCheckResourceAttrPair(rName, "targets.0.fgs_forwarding.0.func_name",
+						"huaweicloud_fgs_function.test.1", "name"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDataForwardingRule_forwardFGS_base() string {
+	rName := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+variable "request_resp_print_script_content" {
+  default = <<EOT
+exports.handler = async (event, context) => {
+    const result =
+    {
+        'repsonse_code': 200,
+        'headers':
+        {
+            'Content-Type': 'application/json'
+        },
+        'isBase64Encoded': false,
+        'body': JSON.stringify(event)
+    }
+    return result
+}
+EOT
+}
+
+resource "huaweicloud_fgs_function" "test" {
+  count = 2
+
+  name        = format("%s-%%d", count.index)
+  app         = "default"
+  description = "function test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = base64encode(var.request_resp_print_script_content)
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName)
+}
+
+func testDataForwardingRule_forwardFGS_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "huaweicloud_iotda_dataforwarding_rule" "test" {
+  name    = "%[3]s"
+  trigger = "product:delete"
+  enabled = true
+
+  targets {
+    type = "FUNCTIONGRAPH_FORWARDING"
+    fgs_forwarding {
+      func_urn  = huaweicloud_fgs_function.test[0].urn
+      func_name = huaweicloud_fgs_function.test[0].name
+    }
+  }
+}
+`, testDataForwardingRule_forwardFGS_base(), buildIoTDAEndpoint(), name)
+}
+
+func testDataForwardingRule_forwardFGS_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+%[2]s
+
+resource "huaweicloud_iotda_dataforwarding_rule" "test" {
+  name    = "%[3]s"
+  trigger = "product:delete"
+  enabled = true
+
+  targets {
+    type = "FUNCTIONGRAPH_FORWARDING"
+    fgs_forwarding {
+      func_urn  = huaweicloud_fgs_function.test[1].urn
+      func_name = huaweicloud_fgs_function.test[1].name
+    }
+  }
+}
+`, testDataForwardingRule_forwardFGS_base(), buildIoTDAEndpoint(), name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support data forwarding to FunctionGraph service
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Support data forwarding to FunctionGraph service

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### FGS Test
```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataForwardingRule_forwardFGS"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataForwardingRule_forwardFGS -timeout 360m -parallel 4
=== RUN   TestAccDataForwardingRule_forwardFGS
=== PAUSE TestAccDataForwardingRule_forwardFGS
=== CONT  TestAccDataForwardingRule_forwardFGS
--- PASS: TestAccDataForwardingRule_forwardFGS (19.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     19.833s


```

### Original Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataForwardingRule_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataForwardingRule_derived -timeout 360m -parallel 4
=== RUN   TestAccDataForwardingRule_derived
=== PAUSE TestAccDataForwardingRule_derived
=== CONT  TestAccDataForwardingRule_derived
--- PASS: TestAccDataForwardingRule_derived (19.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     20.025s



$ unset HW_IOTDA_ACCESS_ADDRESS
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataForwardingRule_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataForwardingRule_basic -timeout 360m -parallel 4
=== RUN   TestAccDataForwardingRule_basic
=== PAUSE TestAccDataForwardingRule_basic
=== CONT  TestAccDataForwardingRule_basic
--- PASS: TestAccDataForwardingRule_basic (16.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     16.208s

```
