### PR TITLE
feat(css): add resource CSS logstash cluster restart

### DIFF
--- a/docs/resources/css_logstash_cluster_restart.md
+++ b/docs/resources/css_logstash_cluster_restart.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_css_logstash_cluster_restart"
+description: |-
+  Manages CSS logstash cluster restart resource within HuaweiCloud.
+---
+
+# huaweicloud_css_logstash_cluster_restart
+
+Manages CSS logstash cluster restart resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+resource "huaweicloud_css_logstash_cluster_restart" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies ID of the CSS logstash cluster.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1123,6 +1123,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_es_loadbalancer_config":      css.ResourceEsLoadbalancerConfig(),
 			"huaweicloud_css_log_setting":                 css.ResourceLogSetting(),
 			"huaweicloud_css_logstash_cluster":            css.ResourceLogstashCluster(),
+			"huaweicloud_css_logstash_cluster_restart":    css.ResourceLogstashClusterRestart(),
 			"huaweicloud_css_logstash_configuration":      css.ResourceLogstashConfiguration(),
 			"huaweicloud_css_logstash_pipeline":           css.ResourceLogstashPipeline(),
 			"huaweicloud_css_logstash_custom_certificate": css.ResourceLogstashCertificate(),

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_logstash_cluster_restart_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_logstash_cluster_restart_test.go
@@ -1,0 +1,48 @@
+package css
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/css/v1/cluster"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccLogstashClusterRestart_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "huaweicloud_css_logstash_cluster_restart.test"
+
+	var obj cluster.ClusterDetailResponse
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCssClusterFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLogstashClusterRestart_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccLogstashClusterRestart_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_css_logstash_cluster_restart" "test" {
+  cluster_id = huaweicloud_css_logstash_cluster.test.id
+}
+`, testAccLogstashCluster_basic(rName, 1, "bar"))
+}

--- a/huaweicloud/services/css/resource_huaweicloud_css_logstash_cluster_force_restart.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_logstash_cluster_force_restart.go
@@ -1,0 +1,102 @@
+package css
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/reboot
+// @API CSS GET /v1.0/{project_id}/clusters/{cluster_id}
+func ResourceLogstashClusterRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceLogstashClusterRestartCreate,
+		ReadContext:   resourceLogstashClusterRestartRead,
+		DeleteContext: resourceLogstashClusterRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceLogstashClusterRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	clusterID := d.Get("cluster_id").(string)
+	cssV1Client, err := conf.HcCssV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CSS client: %s", err)
+	}
+	client, err := conf.CssV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CSS client: %s", err)
+	}
+
+	// Check whether the logstash cluster status is available.
+	err = checkClusterOperationCompleted(ctx, cssV1Client, clusterID, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	restartLogstashHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/reboot"
+	restartLogstashPath := client.Endpoint + restartLogstashHttpUrl
+	restartLogstashPath = strings.ReplaceAll(restartLogstashPath, "{project_id}", client.ProjectID)
+	restartLogstashPath = strings.ReplaceAll(restartLogstashPath, "{cluster_id}", clusterID)
+
+	restartLogstashOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err = client.Request("POST", restartLogstashPath, &restartLogstashOpt)
+	if err != nil {
+		return diag.Errorf("error restart CSS logstash cluster: %s", err)
+	}
+
+	// Check whether the logstash cluster restart is complete
+	err = checkClusterOperationCompleted(ctx, cssV1Client, clusterID, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(clusterID)
+
+	return nil
+}
+
+func resourceLogstashClusterRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceLogstashClusterRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restart resource is not supported. The restart resource is only removed from the state," +
+		" the cluster instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
add resource CSS logstash cluster restart

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
add resource CSS logstash cluster restart
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccLogstashClusterRestart_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccLogstashClusterRestart_basic -timeout 360m -parallel 4
=== RUN   TestAccLogstashClusterRestart_basic
=== PAUSE TestAccLogstashClusterRestart_basic
=== CONT  TestAccLogstashClusterRestart_basic
--- PASS: TestAccLogstashClusterRestart_basic (926.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       926.980s
```
