### PR TITLE
feat: fix(modelarts): support a new parameter and support the scope waiting

### DIFF
--- a/docs/resources/modelarts_notebook.md
+++ b/docs/resources/modelarts_notebook.md
@@ -11,21 +11,52 @@ Manages ModelArts notebook resource within HuaweiCloud.
 
 ## Example Usage
 
+### Create a notebook with the EVS storage type
+
 ```hcl
 variable "notebook_name" {}
 variable "key_pair_name" {}
-variable "ip" {}
+variable "image_id" {}
+variable "allowed_ip_addresses" {
+  type = list(string)
+}
+variable "key_pair_name" {}
 
-resource "huaweicloud_modelarts_notebook" "notebook" {
+resource "huaweicloud_modelarts_notebook" "test" {
   name      = var.notebook_name
   flavor_id = "modelarts.vm.cpu.2u"
-  image_id  = "e1a07296-22a8-4f05-8bc8-e936c8e54090"
+  image_id  = var.image_id
 
-  allowed_access_ips = [var.ip]
+  allowed_access_ips = var.allowed_ip_addresses
   key_pair           = var.key_pair_name
 
   volume {
-    type = "EFS"
+    type = "EVS"
+    size = 5
+  }
+}
+```
+
+### Create a notebook with the EFS storage type
+
+```hcl
+variable "notebook_name" {} 
+variable "image_id" {}
+variable "resource_pool_id" {}
+variable "sfs_export_location" {}
+variable "sfs_turbo_id" {}
+
+resource "huaweicloud_modelarts_notebook" "test" {
+  name      = var.notebook_name
+  flavor_id = "modelarts.vm.cpu.2u"
+  image_id  = var.image_id
+  pool_id   = var.resource_pool_id
+
+  volume {
+    type      = "EFS"
+    ownership = "DEDICATED"
+    uri       = var.sfs_export_location
+    id        = var.sfs_turbo_id
   }
 }
 ```
@@ -89,8 +120,12 @@ The `volume` block supports:
 
  Changing this parameter will create a new resource.
 
-* `uri` - (Optional, String, ForceNew) Specifies the uri of dedicated storage disk, which is mandatory when the `type`
+* `uri` - (Optional, String, ForceNew) Specifies the URL of dedicated storage disk, which is mandatory when the `type`
  is `EFS` and the `ownership` is `DEDICATED`. Example: `192.168.0.1:/user-9sfdsdgdfgh5ea4d56871e75d6966aa274/mount/`.
+ Changing this parameter will create a new resource.
+
+* `id` - (Optional, String, ForceNew) Specifies the ID of dedicated storage disk, which is mandatory when the `type`
+ is `EFS` and the `ownership` is `DEDICATED`.
  Changing this parameter will create a new resource.
 
 ## Attribute Reference

--- a/docs/resources/modelarts_resource_pool.md
+++ b/docs/resources/modelarts_resource_pool.md
@@ -104,7 +104,7 @@ The following arguments are supported:
   Including resource flavors and the number of resources of the corresponding flavors.
   The [resources](#ModelartsResourcePool_ResourceFlavor) structure is documented below.
 
-* `scope` - (Optional, List) Specifies the list of job types supported by the resource pool. It is mandatory when
+* `scope` - (Required, List) Specifies the list of job types supported by the resource pool. It is mandatory when
   `network_id` is specified and can not be specified when `vpc_id` is specified. The options are as follows:
   + **Train**: training job.
   + **Infer**: inference job.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240529073340-b68ab4ec7a36
+	github.com/chnsz/golangsdk v0.0.0-20240531093804-71e344f541e8
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240529073340-b68ab4ec7a36 h1:MiPVVsb+UjJOJa1Jydc0QCPrX1RIVrqXI8nqj1Yz6X4=
-github.com/chnsz/golangsdk v0.0.0-20240529073340-b68ab4ec7a36/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240531093804-71e344f541e8 h1:TFPjAfOsUpO6UZFfDoYImYpchjbPBjMgtAPu5UJ8Zpg=
+github.com/chnsz/golangsdk v0.0.0-20240531093804-71e344f541e8/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_notebook_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func getNotebookResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -93,6 +94,105 @@ resource "huaweicloud_modelarts_notebook" "test" {
   }
 }
 `, rName)
+}
+
+func TestAccResourceNotebook_dedicated(t *testing.T) {
+	var instance notebook.CreateOpts
+	resourceName := "huaweicloud_modelarts_notebook.test"
+	name := acceptance.RandomAccResourceNameWithDash()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&instance,
+		getNotebookResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotebook_dedicated(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", "modelarts.vm.cpu.2u"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "EFS"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.ownership", "DEDICATED"),
+					resource.TestCheckResourceAttrPair(resourceName, "volume.0.uri", "huaweicloud_sfs_turbo.test", "export_location"),
+					resource.TestCheckResourceAttrPair(resourceName, "volume.0.id", "huaweicloud_sfs_turbo.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "auto_stop_enabled", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_swr_path"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "url"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNotebook_dedicated(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_sfs_turbo" "test" {
+  name              = "%[2]s"
+  size              = 1228
+  share_proto       = "NFS"
+  share_type        = "HPC"
+  hpc_bandwidth     = "40M"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+}
+
+resource "huaweicloud_modelarts_network" "test" {
+  name = "%[2]s"
+  cidr = "172.16.0.0/12"
+
+  peer_connections {
+    vpc_id    = huaweicloud_vpc.test.id 
+    subnet_id = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_modelarts_resource_pool" "test" {
+  name        = "%[2]s"
+  scope       = ["Notebook", "Train", "Infer"]
+  network_id  = huaweicloud_modelarts_network.test.id
+
+  resources {
+    flavor_id = "modelarts.vm.cpu.8ud"
+    count     = 1
+  }
+}
+
+resource "huaweicloud_modelarts_notebook" "test" {
+  name      = "%[2]s"
+  flavor_id = "modelarts.vm.cpu.2u"
+  image_id  = "e1a07296-22a8-4f05-8bc8-e936c8e54090"
+  pool_id   = huaweicloud_modelarts_resource_pool.test.id
+
+  volume {
+    type      = "EFS"
+    ownership = "DEDICATED"
+    uri       = huaweicloud_sfs_turbo.test.export_location
+    id        = huaweicloud_sfs_turbo.test.id
+  }
+}
+`, common.TestBaseNetwork(rName), rName)
 }
 
 func TestAccResourceNotebook_all(t *testing.T) {

--- a/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_resource_pool_test.go
+++ b/huaweicloud/services/acceptance/modelarts/resource_huaweicloud_modelarts_resource_pool_test.go
@@ -270,7 +270,7 @@ func testModelartsResourcePool_basic_update(name string) string {
 resource "huaweicloud_modelarts_resource_pool" "test" {
   name        = "%s"
   description = "This is a demo update"
-  scope       = ["Train", "Infer"]
+  scope       = ["Infer", "Train"]
   network_id  = huaweicloud_modelarts_network.test.id
 
   resources {

--- a/vendor/github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook/requests.go
@@ -31,6 +31,7 @@ type VolumeReq struct {
 	Ownership string `json:"ownership" required:"true"`
 	Capacity  *int   `json:"capacity,omitempty"`
 	Uri       string `json:"uri,omitempty"`
+	ID        string `json:"id,omitempty"`
 }
 
 type ListOpts struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/modelarts/v1/notebook/results.go
@@ -83,6 +83,8 @@ type VolumeRes struct {
 	MountPath string `json:"mount_path"`
 	Ownership string `json:"ownership"`
 	Status    string `json:"status"`
+	URI       string `json:"uri"`
+	ID        string `json:"id"`
 }
 
 type ListNotebooks struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240529073340-b68ab4ec7a36
+# github.com/chnsz/golangsdk v0.0.0-20240531093804-71e344f541e8
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. We are not support parameter `volume.id` and it is the required input for dedicated EPS volume's configuration.
2. After resource pool creation, the notebook scope have not complete yet and needs to wait a few time.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add a new parameter `volume.id`.
2. support the scope waiting after resource pool creation
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run=TestAccResourceNotebook_dedicated'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run=TestAccResourceNotebook_dedicated -timeout 360m -parallel 4
=== RUN   TestAccResourceNotebook_dedicated
=== PAUSE TestAccResourceNotebook_dedicated
=== CONT  TestAccResourceNotebook_dedicated
--- PASS: TestAccResourceNotebook_dedicated (1673.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 1673.182s
```
```
make testacc TEST='./huaweicloud/services/acceptance/modelarts' TESTARGS='-run=TestAccModelartsResourcePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/modelarts -v -run=TestAccModelartsResourcePool_basic -timeout 360m -parallel 4
=== RUN   TestAccModelartsResourcePool_basic
=== PAUSE TestAccModelartsResourcePool_basic
=== CONT  TestAccModelartsResourcePool_basic
--- PASS: TestAccModelartsResourcePool_basic (1258.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/modelarts 1258.130s
```
