### PR TITLE
feat(cbh): instance and ha_instance resources support reset administrator login method

### DIFF
--- a/docs/resources/cbh_ha_instance.md
+++ b/docs/resources/cbh_ha_instance.md
@@ -141,6 +141,10 @@ a new IP address will be assigned to each. If one is specified, then the other t
   <br/>2. The **stop**, **soft-reboot**, and **hard-reboot** operations can only be performed when the instance status
   is **ACTIVE**.
 
+* `reset_admin_login` - (Optional, String) Specifies whether to reset the CBH HA instance administrator login method.
+  The values can be **true** or **false**. The administrator login method can only be reset when the instance status is
+  **ACTIVE**.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CBH HA instance.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the CBH HA instance belongs.
@@ -183,7 +187,7 @@ $ terraform import huaweicloud_cbh_ha_instance.test <master_id>/<slave_id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `charging_mode`, `period`, `period_unit`,
-`auto_renew`, `password`, `ipv6_enable`, `attach_disk_size`, `power_action`.
+`auto_renew`, `password`, `ipv6_enable`, `attach_disk_size`, `power_action`, `reset_admin_login`.
 It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated
 to align with the instance. Also, you can ignore changes as below.
@@ -195,6 +199,7 @@ resource "huaweicloud_cbh_ha_instance" "test" {
   lifecycle {
     ignore_changes = [
       charging_mode, period, period_unit, auto_renew, password, ipv6_enable, attach_disk_size, power_action,
+      reset_admin_login,
     ]
   }
 }

--- a/docs/resources/cbh_instance.md
+++ b/docs/resources/cbh_instance.md
@@ -121,6 +121,10 @@ The following arguments are supported:
     <br/>2. The **stop**, **soft-reboot**, and **hard-reboot** operations can only be performed when the instance status
     is **ACTIVE**.
 
+* `reset_admin_login` - (Optional, String) Specifies whether to reset the instance administrator login method.
+  The values can be **true** or **false**. The administrator login method can only be reset when the instance status is
+  **ACTIVE**.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CBH instance.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the CBH instance
@@ -161,7 +165,7 @@ $ terraform import huaweicloud_cbh_instance.test <id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `charging_mode`, `period`, `period_unit`,
-`auto_renew`, `password`, `ipv6_enable`, `attach_disk_size`, `power_action`.
+`auto_renew`, `password`, `ipv6_enable`, `attach_disk_size`, `power_action`, `reset_admin_login`.
 It is generally recommended running `terraform plan` after importing an instance.
 You can then decide if changes should be applied to the instance, or the resource definition should be updated
 to align with the instance. Also, you can ignore changes as below.
@@ -173,6 +177,7 @@ resource "huaweicloud_cbh_instance" "test" {
   lifecycle {
     ignore_changes = [
       charging_mode, period, period_unit, auto_renew, password, ipv6_enable, attach_disk_size, power_action,
+      reset_admin_login,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_ha_instance_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_ha_instance_test.go
@@ -159,6 +159,7 @@ func TestAccCBHHAInstance_basic(t *testing.T) {
 					"auto_renew",
 					"ipv6_enable",
 					"attach_disk_size",
+					"reset_admin_login",
 				},
 			},
 		},
@@ -218,6 +219,7 @@ resource "huaweicloud_cbh_ha_instance" "test" {
   auto_renew               = "false"
   attach_disk_size         = 2
   enterprise_project_id    = "%[3]s"
+  reset_admin_login        = "true"
 
   tags = {
     foo = "bar_update"

--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
@@ -129,6 +129,7 @@ func TestAccCBHInstance_basic(t *testing.T) {
 					"auto_renew",
 					"ipv6_enable",
 					"attach_disk_size",
+					"reset_admin_login",
 				},
 			},
 		},
@@ -309,6 +310,7 @@ resource "huaweicloud_cbh_instance" "test" {
   auto_renew        = "true"
   period            = 1
   attach_disk_size  = 2
+  reset_admin_login = "true"
 
   tags = {
     foo = "bar_update"

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_ha_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_ha_instance.go
@@ -35,6 +35,7 @@ import (
 // @API CBH POST /v2/{project_id}/cbs/instance/start
 // @API CBH POST /v2/{project_id}/cbs/instance/stop
 // @API CBH POST /v2/{project_id}/cbs/instance/reboot
+// @API CBH PUT /v2/{project_id}/cbs/instance/login-method
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/suscriptions/resources/query
 // @API BSS POST /v2/orders/subscriptions/resources/unsubscribe
@@ -191,6 +192,11 @@ func ResourceCBHHAInstance() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: `Specifies the power action after the CBH HA instance is created.`,
+			},
+			"reset_admin_login": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies whether to reset the CBH HA instance administrator login method.`,
 			},
 			"tags": common.TagsSchema(),
 			"enterprise_project_id": {
@@ -802,6 +808,13 @@ func resourceHAInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			if err := doActionInstanceTags(masterResourceId, "create", client, nMap); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	isReset, ok := d.GetOk("reset_admin_login")
+	if d.HasChange("reset_admin_login") && (ok && isReset.(string) == "true") {
+		if err := resetInstanceAdminLoginMethod(client, masterId); err != nil {
+			return diag.Errorf("err resetting administrator login method for CBH HA instance (%s): %s", id, err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Instance and ha_instance resources support reset administrator login method
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Commit1: instance resource support reset administrator login method

Commit2: ha_instance resource support reset administrator login metnod
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### Instance Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_basic
=== PAUSE TestAccCBHInstance_basic
=== CONT  TestAccCBHInstance_basic
--- PASS: TestAccCBHInstance_basic (1927.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1927.368s


$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_epsId_migrate"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_epsId_migrate -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_epsId_migrate
=== PAUSE TestAccCBHInstance_epsId_migrate
=== CONT  TestAccCBHInstance_epsId_migrate
--- PASS: TestAccCBHInstance_epsId_migrate (1072.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1072.081s


$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_WithPowerAction"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_WithPowerAction -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_WithPowerAction
=== PAUSE TestAccCBHInstance_WithPowerAction
=== CONT  TestAccCBHInstance_WithPowerAction
--- PASS: TestAccCBHInstance_WithPowerAction (1396.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1396.446s

```

### HA_instance Test
```
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHHAInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHHAInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHHAInstance_basic
=== PAUSE TestAccCBHHAInstance_basic
=== CONT  TestAccCBHHAInstance_basic
--- PASS: TestAccCBHHAInstance_basic (3729.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       3729.324s


$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHHAInstance_WithPowerAction"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHHAInstance_WithPowerAction -timeout 360m -parallel 4
=== RUN   TestAccCBHHAInstance_WithPowerAction
=== PAUSE TestAccCBHHAInstance_WithPowerAction
=== CONT  TestAccCBHHAInstance_WithPowerAction
--- PASS: TestAccCBHHAInstance_WithPowerAction (2288.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       2288.847s

```
