### PR TITLE
fix(WAF): WAF dedicated support resource tenant instance

### DIFF
--- a/docs/resources/waf_dedicated_instance.md
+++ b/docs/resources/waf_dedicated_instance.md
@@ -110,6 +110,9 @@ The following arguments are supported:
 
   Defaults to **false**.
 
+* `anti_affinity` - (Optional, Bool, ForceNew) Specifies whether to enable anti-affinity. This field is valid only
+  when `res_tenant` is set to **true**. Changing this will create a new instance.
+
 ## Attribute Reference
 
 The following attributes are exported:
@@ -155,9 +158,9 @@ $ terraform import huaweicloud_waf_dedicated_instance.test <id>/<enterprise_proj
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response. The missing attributes include: `res_tenant`. It is generally recommended running `terraform plan` after
-importing the resource. You can then decide if changes should be applied to the resource, or the resource
-definition should be updated to align with the resource. Also, you can ignore changes as below.
+API response. The missing attributes include: `res_tenant`, `anti_affinity`. It is generally recommended running
+`terraform plan` after importing the resource. You can then decide if changes should be applied to the resource,
+or the resource definition should be updated to align with the resource. Also, you can ignore changes as below.
 
 ```
 resource "huaweicloud_waf_dedicated_instance" "test" {
@@ -165,7 +168,7 @@ resource "huaweicloud_waf_dedicated_instance" "test" {
 
   lifecycle {
     ignore_changes = [
-      res_tenant,
+      res_tenant, anti_affinity,
     ]
   }
 }

--- a/docs/resources/waf_dedicated_instance.md
+++ b/docs/resources/waf_dedicated_instance.md
@@ -11,6 +11,8 @@ Manages a WAF dedicated instance resource within HuaweiCloud.
 
 ## Example Usage
 
+### Creating with common tenant
+
 ```hcl
 variable az_name {}
 variable ecs_flavor_id {}
@@ -27,6 +29,30 @@ resource "huaweicloud_waf_dedicated_instance" "instance_1" {
   vpc_id                = var.vpc_id
   subnet_id             = var.subnet_id
   enterprise_project_id = var.enterprise_project_id
+
+  security_group = [
+    var.security_group_id
+  ]
+}
+```
+
+### Creating with resource tenant
+
+```hcl
+variable az_name {}
+variable vpc_id {}
+variable subnet_id {}
+variable security_group_id {}
+variable enterprise_project_id {}
+
+resource "huaweicloud_waf_dedicated_instance" "instance_1" {
+  name                  = "instance_1"
+  available_zone        = var.az_name
+  specification_code    = "waf.instance.professional"
+  vpc_id                = var.vpc_id
+  subnet_id             = var.subnet_id
+  enterprise_project_id = var.enterprise_project_id
+  res_tenant            = true
 
   security_group = [
     var.security_group_id
@@ -52,12 +78,6 @@ The following arguments are supported:
   + `waf.instance.professional` - The professional edition, throughput: 100 Mbit/s; QPS: 2,000 (Reference only).
   + `waf.instance.enterprise` - The enterprise edition, throughput: 500 Mbit/s; QPS: 10,000 (Reference only).
 
-* `ecs_flavor` - (Required, String, ForceNew) The flavor of the ECS used by the WAF instance. Flavors can be obtained
-  through this data source `huaweicloud_compute_flavors`. Changing this will create a new instance.
-
-  -> **NOTE:** If the instance specification is the professional edition, the ECS specification should be 2U4G. If the
-  instance specification is the enterprise edition, the ECS specification should be 8U16G.
-
 * `vpc_id` - (Required, String, ForceNew) The VPC id of WAF dedicated instance. Changing this will create a new
   instance.
 
@@ -73,8 +93,22 @@ The following arguments are supported:
 * `cpu_architecture` - (Optional, String, ForceNew) The ECS cpu architecture of instance, Default value is `x86`.
   Changing this will create a new instance.
 
+* `ecs_flavor` - (Optional, String, ForceNew) Specifies the flavor of the ECS used by the WAF instance. Flavors can be
+  obtained through this data source `huaweicloud_compute_flavors`. Changing this will create a new instance.
+  This field is valid and required only when `res_tenant` is set to **false**.
+
+  -> **NOTE:** If the instance specification is the professional edition, the ECS specification should be 2U4G. If the
+  instance specification is the enterprise edition, the ECS specification should be 8U16G.
+
 * `group_id` - (Optional, String, ForceNew) The instance group ID used by the WAF dedicated instance in ELB mode.
   Changing this will create a new instance.
+
+* `res_tenant` - (Optional, Bool, ForceNew) Specifies whether this is resource tenant.
+  Changing this will create a new instance.
+  + **false**: Common tenant.
+  + **true**: Resource tenant.
+
+  Defaults to **false**.
 
 ## Attribute Reference
 
@@ -118,4 +152,21 @@ $ terraform import huaweicloud_waf_dedicated_instance.test <id>
 
 ```bash
 $ terraform import huaweicloud_waf_dedicated_instance.test <id>/<enterprise_project_id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `res_tenant`. It is generally recommended running `terraform plan` after
+importing the resource. You can then decide if changes should be applied to the resource, or the resource
+definition should be updated to align with the resource. Also, you can ignore changes as below.
+
+```
+resource "huaweicloud_waf_dedicated_instance" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      res_tenant,
+    ]
+  }
+}
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240531093804-71e344f541e8
+	github.com/chnsz/golangsdk v0.0.0-20240603092804-85780436a24c
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240531093804-71e344f541e8 h1:TFPjAfOsUpO6UZFfDoYImYpchjbPBjMgtAPu5UJ8Zpg=
-github.com/chnsz/golangsdk v0.0.0-20240531093804-71e344f541e8/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240603092804-85780436a24c h1:UeRisWXSxs28L3ArebuWpxIEz28dszYLdwQ6PbLbCyE=
+github.com/chnsz/golangsdk v0.0.0-20240603092804-85780436a24c/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
@@ -180,6 +180,54 @@ func TestAccWafDedicatedInstance_elb_model(t *testing.T) {
 	})
 }
 
+func TestAccWafDedicatedInstance_resourceTenant(t *testing.T) {
+	var instance instances.DedicatedInstance
+	resourceName := "huaweicloud_waf_dedicated_instance.instance_1"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&instance,
+		getWafDedicatedInstanceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedInstanceV1_resourceTenant(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cpu_architecture", "x86"),
+					resource.TestCheckResourceAttr(resourceName, "specification_code", "waf.instance.professional"),
+					resource.TestCheckResourceAttr(resourceName, "security_group.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "run_status", "1"),
+					resource.TestCheckResourceAttr(resourceName, "access_status", "0"),
+					resource.TestCheckResourceAttr(resourceName, "upgradable", "0"),
+					resource.TestCheckResourceAttr(resourceName, "res_tenant", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
+					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "available_zone"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"res_tenant"},
+			},
+		},
+	})
+}
+
 func testAccWafDedicatedInstanceV1_conf(name string) string {
 	return fmt.Sprintf(`
 %s
@@ -256,6 +304,25 @@ resource "huaweicloud_waf_dedicated_instance" "instance_1" {
   subnet_id          = huaweicloud_vpc_subnet.test.id
   group_id           = huaweicloud_waf_instance_group.group_1.id
   
+  security_group = [
+    huaweicloud_networking_secgroup.test.id
+  ]
+}
+`, common.TestBaseComputeResources(name), name)
+}
+
+func testAccWafDedicatedInstanceV1_resourceTenant(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_waf_dedicated_instance" "instance_1" {
+  name               = "%s"
+  available_zone     = data.huaweicloud_availability_zones.test.names[1]
+  specification_code = "waf.instance.professional"
+  vpc_id             = huaweicloud_vpc.test.id
+  subnet_id          = huaweicloud_vpc_subnet.test.id
+  res_tenant         = true
+
   security_group = [
     huaweicloud_networking_secgroup.test.id
   ]

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_dedicated_instance_test.go
@@ -211,6 +211,7 @@ func TestAccWafDedicatedInstance_resourceTenant(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "access_status", "0"),
 					resource.TestCheckResourceAttr(resourceName, "upgradable", "0"),
 					resource.TestCheckResourceAttr(resourceName, "res_tenant", "true"),
+					resource.TestCheckResourceAttr(resourceName, "anti_affinity", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "server_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "service_ip"),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_id"),
@@ -222,7 +223,7 @@ func TestAccWafDedicatedInstance_resourceTenant(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"res_tenant"},
+				ImportStateVerifyIgnore: []string{"res_tenant", "anti_affinity"},
 			},
 		},
 	})
@@ -322,6 +323,7 @@ resource "huaweicloud_waf_dedicated_instance" "instance_1" {
   vpc_id             = huaweicloud_vpc.test.id
   subnet_id          = huaweicloud_vpc_subnet.test.id
   res_tenant         = true
+  anti_affinity      = true
 
   security_group = [
     huaweicloud_networking_secgroup.test.id

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
@@ -118,6 +118,11 @@ func ResourceWafDedicatedInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"anti_affinity": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -170,6 +175,11 @@ func buildCreateOpts(d *schema.ResourceData, region string) *instances.CreateIns
 		PoolId:        d.Get("group_id").(string),
 		ResTenant:     utils.Bool(d.Get("res_tenant").(bool)),
 	}
+	if d.Get("res_tenant").(bool) {
+		// `anti_affinity` is valid only when `res_tenant` is true
+		createOpts.AntiAffinity = utils.Bool(d.Get("anti_affinity").(bool))
+	}
+
 	return &createOpts
 }
 

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
@@ -80,17 +80,6 @@ func ResourceWafDedicatedInstance() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"cpu_architecture": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "x86",
-				ForceNew: true,
-			},
-			"ecs_flavor": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -107,16 +96,27 @@ func ResourceWafDedicatedInstance() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"cpu_architecture": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "x86",
+				ForceNew: true,
+			},
+			"ecs_flavor": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 			"res_tenant": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "schema: Internal; Specifies whether this is resource tenant.",
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
 			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,

--- a/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_instances/requests.go
@@ -22,7 +22,6 @@ type CreateInstanceOpts struct {
 	Arch          string   `json:"arch" required:"true"`
 	NamePrefix    string   `json:"instancename" required:"true"`
 	Specification string   `json:"specification" required:"true"`
-	CpuFlavor     string   `json:"cpu_flavor" required:"true"`
 	VpcId         string   `json:"vpc_id" required:"true"`
 	SubnetId      string   `json:"subnet_id" required:"true"`
 	SecurityGroup []string `json:"security_group" required:"true"`
@@ -32,6 +31,8 @@ type CreateInstanceOpts struct {
 	ClusterId     string   `json:"cluster_id,omitempty"`
 	PoolId        string   `json:"pool_id,omitempty"`
 	ResTenant     *bool    `json:"res_tenant,omitempty"`
+	CpuFlavor     string   `json:"cpu_flavor,omitempty"`
+	AntiAffinity  *bool    `json:"anti_affinity,omitempty"`
 }
 
 // ListInstanceOpts the parameters in the querying request.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240531093804-71e344f541e8
+# github.com/chnsz/golangsdk v0.0.0-20240603092804-85780436a24c
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- commit1: WAF dedicated instance support resource tenant.
- commit2: WAF dedicated instance support new field `anti_affinity`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicatedInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicatedInstance_ -timeout 360m -parallel 4
=== RUN   TestAccWafDedicatedInstance_basic
=== PAUSE TestAccWafDedicatedInstance_basic
=== RUN   TestAccWafDedicatedInstance_withEpsId
=== PAUSE TestAccWafDedicatedInstance_withEpsId
=== RUN   TestAccWafDedicatedInstance_elb_model
=== PAUSE TestAccWafDedicatedInstance_elb_model
=== RUN   TestAccWafDedicatedInstance_resourceTenant
=== PAUSE TestAccWafDedicatedInstance_resourceTenant
=== CONT  TestAccWafDedicatedInstance_basic
=== CONT  TestAccWafDedicatedInstance_elb_model
=== CONT  TestAccWafDedicatedInstance_withEpsId
=== CONT  TestAccWafDedicatedInstance_resourceTenant
--- PASS: TestAccWafDedicatedInstance_basic (387.93s)
--- PASS: TestAccWafDedicatedInstance_elb_model (448.86s)
--- PASS: TestAccWafDedicatedInstance_withEpsId (451.31s)
--- PASS: TestAccWafDedicatedInstance_resourceTenant (467.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       467.089s
```
