### PR TITLE
chore(apig): add checkdeleted to delete logic

### DIFF
--- a/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_acl_policy.go
@@ -175,7 +175,7 @@ func resourceAclPolicyDelete(_ context.Context, d *schema.ResourceData, meta int
 		policyId   = d.Id()
 	)
 	if err = acls.Delete(client, instanceId, policyId); err != nil {
-		return diag.Errorf("unable to delete the ACL policy (%s): %s", policyId, err)
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to delete the ACL policy (%s)", policyId))
 	}
 
 	return nil

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application_authorization.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application_authorization.go
@@ -185,9 +185,8 @@ func resourceAppAuthDelete(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	apiIds := d.Get("api_ids").(*schema.Set)
-	err = deleteAppAuthFromApis(ctx, client, d, utils.ExpandToStringListBySet(apiIds), d.Timeout(schema.TimeoutDelete))
-	if err != nil {
-		return diag.FromErr(err)
+	if err = deleteAppAuthFromApis(ctx, client, d, utils.ExpandToStringListBySet(apiIds), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return common.CheckDeletedDiag(d, err, "error unbinding APIs from application")
 	}
 	return nil
 }
@@ -246,7 +245,7 @@ func deleteAppAuthFromApis(ctx context.Context, client *golangsdk.ServiceClient,
 	if err != nil {
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			log.Println(notFoundErr)
-			return nil
+			return err
 		}
 		return fmt.Errorf("error querying authorized APIs for application (%s) under dedicated instance (%s)", appId, instanceId)
 	}
@@ -263,6 +262,10 @@ func deleteAppAuthFromApis(ctx context.Context, client *golangsdk.ServiceClient,
 		authId := val.ID
 		err = appauths.Delete(client, instanceId, authId)
 		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				log.Printf("[DEBUG] All APIs has been unauthorized from the application (%s)", appId)
+				continue
+			}
 			return fmt.Errorf("error unauthorizing APIs form application (%s) under dedicated instance (%s): %s", appId, instanceId, err)
 		}
 	}
@@ -313,6 +316,11 @@ func unauthApisStateRefreshFunc(client *golangsdk.ServiceClient, instanceId, app
 		}
 		resp, err := appauths.ListAuthorized(client, opts)
 		if err != nil {
+			// The API returns a 404 error, which means that the instance or application has been deleted.
+			// In this case, there's no need to disassociate API, also this action has been completed.
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return "instance_or_application_not_exist", "COMPLETED", nil
+			}
 			return resp, "", err
 		}
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_channel.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_channel.go
@@ -708,7 +708,7 @@ func resourceChannelDelete(_ context.Context, d *schema.ResourceData, meta inter
 	instanceId := d.Get("instance_id").(string)
 	channelId := d.Id()
 	if err = channels.Delete(client, instanceId, channelId); err != nil {
-		return diag.Errorf("error deleting APIG channel (%s): %s", channelId, err)
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting APIG channel (%s)", channelId))
 	}
 
 	return nil

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_custom_authorizer.go
@@ -320,8 +320,8 @@ func resourceCustomAuthorizerDelete(_ context.Context, d *schema.ResourceData, m
 
 	err = authorizers.Delete(client, instanceId, authorizerId).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting custom authorizer (%s) from the instance (%s): %s",
-			authorizerId, instanceId, err)
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting custom authorizer (%s) from the instance (%s)",
+			authorizerId, instanceId))
 	}
 	return nil
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_response.go
@@ -232,8 +232,8 @@ func resourceResponseDelete(_ context.Context, d *schema.ResourceData, meta inte
 	)
 	err = responses.Delete(client, instanceId, groupId, responseId).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting APIG custom response (%s) from the dedicated group (%s): %s",
-			responseId, groupId, err)
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting APIG custom response (%s) from the dedicated group (%s)",
+			responseId, groupId))
 	}
 	return nil
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_signature.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_signature.go
@@ -193,7 +193,7 @@ func resourceSignatureDelete(_ context.Context, d *schema.ResourceData, meta int
 	)
 	err = signs.Delete(client, instanceId, signatureId)
 	if err != nil {
-		return diag.Errorf("error deleting the signature (%s): %s", signatureId, err)
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting the signature (%s)", signatureId))
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add `CheckDeletedDiag` method to delete logic of the resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
1. make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccSignature_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccSignature_basic -timeout 360m -parallel 4
=== RUN   TestAccSignature_basic
=== PAUSE TestAccSignature_basic
=== CONT  TestAccSignature_basic
--- PASS: TestAccSignature_basic (593.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      593.236s

2.make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccSignatureAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccSignatureAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccSignatureAssociate_basic
=== PAUSE TestAccSignatureAssociate_basic
=== CONT  TestAccSignatureAssociate_basic
--- PASS: TestAccSignatureAssociate_basic (821.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      821.961s

3.make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccThrottlingPolicyAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccThrottlingPolicyAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccThrottlingPolicyAssociate_basic
=== PAUSE TestAccThrottlingPolicyAssociate_basic
=== CONT  TestAccThrottlingPolicyAssociate_basic
--- PASS: TestAccThrottlingPolicyAssociate_basic (786.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      786.168s

4.make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccAppAuth_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccAppAuth_basic -timeout 360m -parallel 4
=== RUN   TestAccAppAuth_basic
=== PAUSE TestAccAppAuth_basic
=== CONT  TestAccAppAuth_basic
--- PASS: TestAccAppAuth_basic (773.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      773.758s

5. make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccAclPolicy_basic '
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccAclPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccAclPolicy_basic
=== PAUSE TestAccAclPolicy_basic
=== CONT  TestAccAclPolicy_basic
--- PASS: TestAccAclPolicy_basic (599.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      599.571s

6. make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccAclPolicyAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccAclPolicyAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccAclPolicyAssociate_basic
=== PAUSE TestAccAclPolicyAssociate_basic
=== CONT  TestAccAclPolicyAssociate_basic
--- PASS: TestAccAclPolicyAssociate_basic (742.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      742.455s

7. make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccCustomAuthorize_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccCustomAuthorizer_basic -timeout 360m -parallel 4
=== RUN   TestAccCustomAuthorizer_basic
=== PAUSE TestAccCustomAuthorizer_basic
=== CONT  TestAccCustomAuthorizer_basic
--- PASS: TestAccCustomAuthorizer_basic (607.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      607.263s

8.make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccChannel_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccChannel_basic -timeout 360m -parallel 4
=== RUN   TestAccChannel_basic
=== PAUSE TestAccChannel_basic
=== CONT  TestAccChannel_basic
--- PASS: TestAccChannel_basic (696.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      696.314s

9. make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccResponse_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccResponse_basic -timeout 360m -parallel 4
=== RUN   TestAccResponse_basic
=== PAUSE TestAccResponse_basic
=== CONT  TestAccResponse_basic
--- PASS: TestAccResponse_basic (594.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      594.165s
```
