### PR TITLE
feat(dms): support new params for kafka topic

### DIFF
--- a/docs/resources/dms_kafka_topic.md
+++ b/docs/resources/dms_kafka_topic.md
@@ -35,22 +35,51 @@ The following arguments are supported:
   64 characters, and supports only letters, digits, hyphens (-) and underscores (_). Changing this creates a new
   resource.
 
-* `partitions` - (Required, Int) Specifies the partition number. The value ranges from 1 to 100.
+* `partitions` - (Required, Int) Specifies the partition number. The value ranges from **1** to **100**.
+  
+  -> Only support to add partitions.
 
-* `replicas` - (Optional, Int, ForceNew) Specifies the replica number. The value ranges from 1 to 3 and defaults to 3.
-  Changing this creates a new resource.
+* `new_partition_brokers` - (Optional, List) Specifies the integers list of brokers for new partitions.
+  
+  -> It's only valid when adding partitions.
 
-* `aging_time` - (Optional, Int) Specifies the aging time in hours. The value ranges from 1 to 168 and defaults to 72.
+* `replicas` - (Optional, Int, ForceNew) Specifies the replica number.
+  The value ranges from **1** to **3** and defaults to **3**. Changing this creates a new resource.
+
+* `aging_time` - (Optional, Int) Specifies the aging time in hours.
+  The value ranges from **1** to **168** and defaults to **72**.
 
 * `sync_replication` - (Optional, Bool) Whether or not to enable synchronous replication.
 
 * `sync_flushing` - (Optional, Bool) Whether or not to enable synchronous flushing.
+
+* `description` - (Optional, String) Specifies the description of topic.
+
+* `configs` - (Optional, List) Specifies the other topic configurations.
+
+  The [configs](#topics_configs_struct) structure is documented below.
+
+<a name="topics_configs_struct"></a>
+The `configs` block supports:
+
+* `name` - (Required, String) Specifies the configuration name.
+
+* `value` - (Required, String) Specifies the configuration value.
+
+  -> When `name` is **max.message.bytes**, `value` ranges from **0** to **10485760**.
+  When `name` is **message.timestamp.type**, `value` can be **LogAppendTime** and **CreateTime**.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID which equals to the topic name.
+
+* `policies_only` - Indicates whether this policy is the default policy.
+
+* `type` - Indicates the topic type.
+
+* `created_at` - Indicates the topic create time.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_topic_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_topic_test.go
@@ -2,6 +2,7 @@ package dms
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -60,6 +61,12 @@ func TestAccDmsKafkaTopic_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "aging_time", "36"),
 					resource.TestCheckResourceAttr(resourceName, "sync_replication", "false"),
 					resource.TestCheckResourceAttr(resourceName, "sync_flushing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
+					resource.TestCheckResourceAttrSet(resourceName, "policies_only"),
+					resource.TestCheckResourceAttrSet(resourceName, "configs.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "type"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{
@@ -119,6 +126,7 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
   name        = "%s"
   partitions  = 10
   aging_time  = 36
+  description = "test"
 }
 `, testAccKafkaInstance_basic(rName), rName)
 }
@@ -147,6 +155,87 @@ resource "huaweicloud_dms_kafka_topic" "topic" {
   aging_time       = 72
   sync_flushing    = true
   sync_replication = true
+
+  configs {
+    name  = "max.message.bytes"
+    value = "10000000"
+  }
+
+  configs {
+    name  = "message.timestamp.type"
+    value = "LogAppendTime"
+  }
 }
 `, testAccKafkaInstance_basic(rName), rName)
+}
+
+func TestAccDmsKafkaTopic_test_update_partition(t *testing.T) {
+	var kafkaTopic topics.Topic
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_kafka_topic.topic"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&kafkaTopic,
+		getDmsKafkaTopicFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsKafkaTopic_testUpdatePartitionsBasic(rName, 3),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccDmsKafkaTopic_testUpdatePartitionsBasic(rName, 5),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config:      testAccDmsKafkaTopic_testError(rName, 3),
+				ExpectError: regexp.MustCompile(`only support to add partitions`),
+			},
+			{
+				Config: testAccDmsKafkaTopic_testError(rName, 7),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "partitions", "7"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDmsKafkaTopic_testUpdatePartitionsBasic(rName string, partitions int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_topic" "topic" {
+  instance_id = huaweicloud_dms_kafka_instance.test.id
+  name        = "%s"
+  partitions  = %v
+  replicas    = 1
+}
+`, testAccKafkaInstance_basic(rName), rName, partitions)
+}
+
+func testAccDmsKafkaTopic_testError(rName string, partitions int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_kafka_topic" "topic" {
+  instance_id           = huaweicloud_dms_kafka_instance.test.id
+  name                  = "%s"
+  partitions            = %v
+  replicas              = 1
+  new_partition_brokers = [0]
+}
+`, testAccKafkaInstance_basic(rName), rName, partitions)
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/topics/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/topics/requests.go
@@ -20,8 +20,15 @@ type CreateOps struct {
 	// aging time in hours, value range: 1-168, defaults to 72
 	RetentionTime int `json:"retention_time,omitempty"`
 
-	SyncMessageFlush bool `json:"sync_message_flush,omitempty"`
-	SyncReplication  bool `json:"sync_replication,omitempty"`
+	SyncMessageFlush bool          `json:"sync_message_flush,omitempty"`
+	SyncReplication  bool          `json:"sync_replication,omitempty"`
+	Description      string        `json:"topic_desc,omitempty"`
+	Configs          []ConfigParam `json:"topic_other_configs,omitempty"`
+}
+
+type ConfigParam struct {
+	Name  string `json:"name" required:"true"`
+	Value string `json:"value" required:"true"`
 }
 
 // ToTopicCreateMap is used for type convert
@@ -57,11 +64,14 @@ type UpdateOpts struct {
 // UpdateItem represents the object of one topic in update function
 type UpdateItem struct {
 	// Name can not be updated
-	Name             string `json:"id" required:"true"`
-	Partition        *int   `json:"new_partition_numbers,omitempty"`
-	RetentionTime    *int   `json:"retention_time,omitempty"`
-	SyncMessageFlush *bool  `json:"sync_message_flush,omitempty"`
-	SyncReplication  *bool  `json:"sync_replication,omitempty"`
+	Name                string        `json:"id" required:"true"`
+	Partition           *int          `json:"new_partition_numbers,omitempty"`
+	NewPartitionBrokers []int         `json:"new_partition_brokers,omitempty"`
+	RetentionTime       *int          `json:"retention_time,omitempty"`
+	SyncMessageFlush    *bool         `json:"sync_message_flush,omitempty"`
+	SyncReplication     *bool         `json:"sync_replication,omitempty"`
+	Description         *string       `json:"topic_desc,omitempty"`
+	Configs             []ConfigParam `json:"topic_other_configs,omitempty"`
 }
 
 // ToTopicUpdateMap is used for type convert

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/topics/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/topics/results.go
@@ -11,15 +11,18 @@ type CreateResponse struct {
 
 // Topic includes the parameters of an topic
 type Topic struct {
-	Name             string      `json:"name"`
-	Partition        int         `json:"partition"`
-	Replication      int         `json:"replication"`
-	RetentionTime    int         `json:"retention_time"`
-	SyncReplication  bool        `json:"sync_replication"`
-	SyncMessageFlush bool        `json:"sync_message_flush"`
-	TopicType        int         `json:"topic_type"`
-	PoliciesOnly     bool        `json:"policiesOnly"`
-	ExternalConfigs  interface{} `json:"external_configs"`
+	Name             string        `json:"name"`
+	Partition        int           `json:"partition"`
+	Replication      int           `json:"replication"`
+	RetentionTime    int           `json:"retention_time"`
+	SyncReplication  bool          `json:"sync_replication"`
+	SyncMessageFlush bool          `json:"sync_message_flush"`
+	TopicType        int           `json:"topic_type"`
+	PoliciesOnly     bool          `json:"policiesOnly"`
+	ExternalConfigs  interface{}   `json:"external_configs"`
+	CreatedAt        int64         `json:"created_at"`
+	Description      string        `json:"topic_desc"`
+	Configs          []ConfigParam `json:"topic_other_configs"`
 }
 
 // ListResponse is a struct that contains the list response


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new params for kafka topic.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccDmsKafkaTopic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsKafkaTopic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaTopic_basic
=== PAUSE TestAccDmsKafkaTopic_basic
=== RUN   TestAccDmsKafkaTopic_test_update_partition
=== PAUSE TestAccDmsKafkaTopic_test_update_partition
=== CONT  TestAccDmsKafkaTopic_basic
=== CONT  TestAccDmsKafkaTopic_test_update_partition
--- PASS: TestAccDmsKafkaTopic_basic (833.53s)
--- PASS: TestAccDmsKafkaTopic_test_update_partition (954.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       954.236s
```
