### PR TITLE
feat(css): support changing CSS cluster to pre-paid mode

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -189,18 +189,18 @@ The following arguments are supported:
   This parameter is valid only when security_mode is set to **true**.
   The [kibana_public_access](#Css_kibana_public_access) structure is documented below.
 
-* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the cluster.
+* `charging_mode` - (Optional, String) Specifies the charging mode of the cluster.
   Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.
-  Changing this parameter will create a new resource.
 
-* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the instance.
+* `period_unit` - (Optional, String) Specifies the charging period unit of the instance.
   Valid values are **month** and **year**.
-  Changing this parameter will create a new resource.
 
-* `period` - (Optional, Int, ForceNew) Specifies the charging period of the instance.
+* `period` - (Optional, Int) Specifies the charging period of the instance.
   If `period_unit` is set to **month**, the value ranges from **1** to **9**.
   If `period_unit` is set to **year**, the value ranges from **1** to **3**.
-  Changing this parameter will create a new resource.
+
+  -> **NOTE:** `charging_mode`, `period_unit`, `period` can only be updated when changing
+  from **postPaid** to **prePaid** billing mode.
 
 * `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
   The valid values are **true** and **false**, defaults to **false**.

--- a/docs/resources/css_logstash_cluster.md
+++ b/docs/resources/css_logstash_cluster.md
@@ -77,18 +77,18 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the CSS logstash cluster,
   The value `0` indicates the default enterprise project.
 
-* `charging_mode` - (Optional, String, ForceNew) Specifies the charging mode of the CSS logstash cluster.
+* `charging_mode` - (Optional, String) Specifies the charging mode of the CSS logstash cluster.
   The valid values are **prePaid** and **postPaid**, defaults to **postPaid**.
-  Changing this parameter will create a new resource.
 
-* `period_unit` - (Optional, String, ForceNew) Specifies the charging period unit of the instance.
+* `period_unit` - (Optional, String) Specifies the charging period unit of the instance.
   The valid values are **month** and **year**.
-  Changing this parameter will create a new resource.
 
-* `period` - (Optional, Int, ForceNew) Specifies the charging period of the instance.
+* `period` - (Optional, Int) Specifies the charging period of the instance.
   If `period_unit` is set to **month**, the value ranges from **1** to **9**.
   If `period_unit` is set to **year**, the value ranges from **1** to **3**.
-  Changing this parameter will create a new resource.
+
+  -> **NOTE:** `charging_mode`, `period_unit`, `period` can only be updated when changing
+  from **postPaid** to **prePaid** billing mode.
 
 * `auto_renew` - (Optional, String) Specifies whether auto renew is enabled.
   The valid values are **true** and **false**, defaults to **false**.


### PR DESCRIPTION
**What this PR does / why we need it**:
support changing CSS cluster to pre-paid mode

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
support changing CSS cluster to pre-paid mode
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccCssCluster_changeToPeriod'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssCluster_changeToPeriod -timeout 360m -parallel 4
=== RUN   TestAccCssCluster_changeToPeriod
=== PAUSE TestAccCssCluster_changeToPeriod
=== CONT  TestAccCssCluster_changeToPeriod
--- PASS: TestAccCssCluster_changeToPeriod (1321.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1322.290s
```

```
 make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccLogstashCluster_changeToPeriod'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccLogstashCluster_changeToPeriod -timeout 360m -parallel 4
=== RUN   TestAccLogstashCluster_changeToPeriod
=== PAUSE TestAccLogstashCluster_changeToPeriod
=== CONT  TestAccLogstashCluster_changeToPeriod
--- PASS: TestAccLogstashCluster_changeToPeriod (1339.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1339.532s
```
