### PR TITLE
feat(fgs): add new datasource to get function triggers

### DIFF
--- a/docs/data-sources/fgs_function_triggers.md
+++ b/docs/data-sources/fgs_function_triggers.md
@@ -1,0 +1,89 @@
+---
+subcategory: "FunctionGraph"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_fgs_function_triggers"
+description: |-
+  Use this data source to get the list of function triggers of FunctionGraph within HuaweiCloud.
+---
+
+# huaweicloud_fgs_function_triggers
+
+Use this data source to get the list of function triggers of FunctionGraph within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable function_urn {}
+
+data "huaweicloud_fgs_function_triggers" "test" {
+  function_urn = var.function_urn
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `function_urn` - (Required, String) Specifies the function URN to which the trigger belongs.
+
+* `trigger_id` - (Optional, String) Specifies the ID of the function trigger.
+
+* `type` - (Optional, String) Specifies type of the function trigger.
+  The valid values are as follows:
+  + **TIMER**
+  + **APIG**
+  + **CTS**
+  + **DDS**
+  + **DMS**
+  + **DIS**
+  + **LTS**
+  + **OBS**
+  + **SMN**
+  + **KAFKA**
+  + **RABBITMQ**
+  + **DEDICATEDGATEWAY**
+  + **OPENSOURCEKAFKA**
+  + **APIC**
+  + **GAUSSMONGO**
+  + **EVENTGRID**
+  + **IOTDA**
+
+* `status` - (Optional, String) Specifies status of the function trigger.
+  The valid values are as follows:
+  + **ACTIVE**
+  + **DISABLED**
+
+* `start_time` - (Optional, String) Specifies start time of creation time of the function trigger.
+  The format is `YYYY-MM-DDThh:mm:ss{timezone}`.
+
+* `end_time` - (Optional, String) Specifies end time of creation time of the function trigger.
+  The format is `YYYY-MM-DDThh:mm:ss{timezone}`.
+
+  -> The `status`, `start_time` and `end_time` parameters does not take effect for some triggers, e.g. `SMN`.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `triggers` - All triggers that match the filter parameters.
+  The [triggers](#function_triggers) structure is documented below.
+
+<a name="function_triggers"></a>
+The `triggers` block supports:
+
+* `id` - The ID of the function trigger.
+
+* `type` - The type of the function trigger.
+
+* `event_data` - The detailed configuration of the function trigger.
+
+* `status` - The current status of the function trigger.
+
+* `created_at` - The creation time of the function trigger, in RFC3339 format.
+
+* `updated_at` - The latest update time of the function trigger, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -616,6 +616,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_fgs_application_templates": fgs.DataSourceFunctionGraphApplicationTemplates(),
 			"huaweicloud_fgs_dependencies":          fgs.DataSourceFunctionGraphDependencies(),
 			"huaweicloud_fgs_dependency_versions":   fgs.DataSourceDependencieVersions(),
+			"huaweicloud_fgs_function_triggers":     fgs.DataSourceFunctionTriggers(),
 			"huaweicloud_fgs_functions":             fgs.DataSourceFunctionGraphFunctions(),
 
 			"huaweicloud_ga_accelerators":       ga.DataSourceAccelerators(),

--- a/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_function_triggers_test.go
+++ b/huaweicloud/services/acceptance/fgs/data_source_huaweicloud_fgs_function_triggers_test.go
@@ -1,0 +1,154 @@
+package fgs
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccFunctionTriggers_basic(t *testing.T) {
+	var (
+		rName      = acceptance.RandomAccResourceName()
+		dataSource = "data.huaweicloud_fgs_function_triggers.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byId   = "data.huaweicloud_fgs_function_triggers.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byType   = "data.huaweicloud_fgs_function_triggers.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byStatus   = "data.huaweicloud_fgs_function_triggers.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byCreatedAt   = "data.huaweicloud_fgs_function_triggers.filter_by_created_at"
+		dcByCreatedAt = acceptance.InitDataSourceCheck(byCreatedAt)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionTriggers_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "triggers.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					resource.TestMatchResourceAttr(dataSource, "triggers.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(dataSource, "triggers.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					dcByCreatedAt.CheckResourceExists(),
+					resource.TestCheckOutput("is_created_at_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccFunctionTriggers_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_fgs_function_triggers" "test" {
+  depends_on = [
+    huaweicloud_fgs_function_trigger.timer_rate
+  ]
+
+  function_urn = huaweicloud_fgs_function.test.urn
+}
+
+// Filter by ID
+locals {
+  trigger_id = huaweicloud_fgs_function_trigger.timer_rate.id
+}
+
+data "huaweicloud_fgs_function_triggers" "filter_by_id" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  trigger_id   = local.trigger_id
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_fgs_function_triggers.filter_by_id.triggers[*].id : v == local.trigger_id
+  ]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+}
+
+// Filter by type
+locals {
+  trigger_type = data.huaweicloud_fgs_function_triggers.test.triggers[0].type
+}
+
+data "huaweicloud_fgs_function_triggers" "filter_by_type" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  type         = local.trigger_type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_fgs_function_triggers.filter_by_type.triggers[*].type : v == local.trigger_type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+// Filter by status
+locals {
+  trigger_status = huaweicloud_fgs_function_trigger.timer_rate.status
+}
+
+data "huaweicloud_fgs_function_triggers" "filter_by_status" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  status       = local.trigger_status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_fgs_function_triggers.filter_by_status.triggers[*].status : v == local.trigger_status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+// Filter by creation time
+locals {
+  created_time = huaweicloud_fgs_function_trigger.timer_rate.created_at
+}
+
+data "huaweicloud_fgs_function_triggers" "filter_by_created_at" {
+  function_urn = huaweicloud_fgs_function.test.urn
+  start_time   = local.created_time
+  end_time     = local.created_time
+}
+
+locals {
+  created_at_filter_result = [
+    for v in data.huaweicloud_fgs_function_triggers.filter_by_created_at.triggers[*].created_at : timecmp(v, local.created_time) == 0
+  ]
+}
+
+output "is_created_at_filter_useful" {
+  value = length(local.created_at_filter_result) > 0 && alltrue(local.created_at_filter_result)
+}
+`, testAccFunctionTimingTrigger_basic_step1(name))
+}

--- a/huaweicloud/services/fgs/data_source_huaweicloud_fgs_function_triggers.go
+++ b/huaweicloud/services/fgs/data_source_huaweicloud_fgs_function_triggers.go
@@ -1,0 +1,207 @@
+package fgs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API FunctionGraph GET /v2/{project_id}/fgs/triggers/{function_urn}
+func DataSourceFunctionTriggers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceFunctionTriggersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"function_urn": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the function URN to which the trigger belongs.",
+			},
+			"trigger_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the ID of the function trigger.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies type of the function trigger.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies status of the function trigger.",
+			},
+			"start_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies start time of creation time of the function trigger.",
+			},
+			"end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies end time of creation time of the function trigger.",
+			},
+			"triggers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the function trigger.",
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the function trigger.",
+						},
+						"event_data": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The detailed configuration of the function trigger.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The current status of the function trigger.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the function trigger, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the function trigger, in RFC3339 format.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceFunctionTriggersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg         = meta.(*config.Config)
+		region      = cfg.GetRegion(d)
+		httpUrl     = "v2/{project_id}/fgs/triggers/{function_urn}"
+		functionUrn = d.Get("function_urn").(string)
+	)
+	client, err := cfg.NewServiceClient("fgs", region)
+	if err != nil {
+		return diag.Errorf("error creating FunctionGraph client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{function_urn}", functionUrn)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return diag.Errorf("error retrieving triggers under specified function (%s): %s", functionUrn, err)
+	}
+
+	triggers, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("triggers", filterTriggers(flattenTriggers(triggers.([]interface{})), d)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func filterTriggers(all []interface{}, d *schema.ResourceData) []interface{} {
+	rst := make([]interface{}, 0, len(all))
+
+	for _, v := range all {
+		if param, ok := d.GetOk("trigger_id"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("id", v, nil)) {
+			continue
+		}
+
+		if param, ok := d.GetOk("type"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("type", v, nil)) {
+			continue
+		}
+
+		if param, ok := d.GetOk("status"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("status", v, nil)) {
+			continue
+		}
+
+		createdAt := utils.PathSearch("created_at", v, "").(string)
+		// Some triggers do not return creation time, such as: "SMN".
+		if createdAt == "" {
+			continue
+		}
+
+		createdAtTimestamp := utils.ConvertTimeStrToNanoTimestamp(createdAt)
+		if param, ok := d.GetOk("start_time"); ok &&
+			utils.ConvertTimeStrToNanoTimestamp(param.(string)) > createdAtTimestamp {
+			continue
+		}
+
+		if param, ok := d.GetOk("end_time"); ok &&
+			utils.ConvertTimeStrToNanoTimestamp(param.(string)) < createdAtTimestamp {
+			continue
+		}
+
+		rst = append(rst, v)
+	}
+	return rst
+}
+
+func flattenTriggers(triggers []interface{}) []interface{} {
+	if len(triggers) < 1 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(triggers))
+	for _, trigger := range triggers {
+		result = append(result, map[string]interface{}{
+			"id":         utils.PathSearch("trigger_id", trigger, nil),
+			"type":       utils.PathSearch("trigger_type_code", trigger, nil),
+			"status":     utils.PathSearch("trigger_status", trigger, nil),
+			"event_data": parseEventData(utils.PathSearch("event_data", trigger, nil)),
+			"created_at": convertTimeToRFC339(utils.PathSearch("created_time", trigger, "").(string)),
+			"updated_at": convertTimeToRFC339(utils.PathSearch("last_updated_time", trigger, "").(string)),
+		})
+	}
+	return result
+}
+
+// The timeStr format is "yyyy-MM-ddTHH:mm:ss+08:00".
+// Formats time according to the local computer time.
+func convertTimeToRFC339(timeStr string) string {
+	return utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(timeStr)/1000, false)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new datasource to get triggers under specified function.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new dataSource to get the list of the function triggers.
2. add corresponding to document and acceptance test.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/fgs TESTARGS='-run TestAccFunctionTriggers_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run TestAccFunctionTriggers_basic -timeout 360m -parallel 4
=== RUN   TestAccFunctionTriggers_basic
=== PAUSE TestAccFunctionTriggers_basic
=== CONT  TestAccFunctionTriggers_basic
--- PASS: TestAccFunctionTriggers_basic (80.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       80.411s
```
