### PR TITLE
feat(as): AS configuration resource supports three new fields

### DIFF
--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -244,6 +244,22 @@ The `disk` block supports:
   [Disk Types and Performance](https://support.huaweicloud.com/intl/en-us/productdesc-evs/en-us_topic_0014580744.html).
   <br/>Only pay-per-use billing is supported currently.
 
+* `dedicated_storage_id` - (Optional, String, ForceNew) Specifies a DSS device ID for creating an ECS disk.
+
+  -> Specify DSS devices for all disks in an AS configuration or not. If DSS devices are specified, all the
+  data stores must belong to the same AZ, and the disk types supported by a DSS device for a disk must be
+  the same as the `volume_type` value.
+
+* `data_disk_image_id` - (Optional, String, ForceNew) Specifies the ID of a data disk image used to export data disks of
+  an ECS.
+
+* `snapshot_id` - (Optional, String, ForceNew) Specifies the disk backup snapshot ID for restoring the system disk and
+  data disks using a full-ECS backup when a full-ECS image is used.
+
+  -> You can obtain the disk backup snapshot ID using the full-ECS backup ID in
+  [Querying a Single Backup](https://support.huaweicloud.com/intl/en-us/api-csbs/en-us_topic_0059304234.html).
+  <br/>Each disk in an AS configuration must correspond to a disk backup in the full-ECS backup by `snapshot_id`.
+
 <a name="instance_config_public_ip_object"></a>
 The `public_ip` block supports:
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -35,15 +35,16 @@ var (
 	HW_ENTERPRISE_PROJECT_ID_TEST         = os.Getenv("HW_ENTERPRISE_PROJECT_ID_TEST")
 	HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST = os.Getenv("HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST")
 
-	HW_FLAVOR_ID             = os.Getenv("HW_FLAVOR_ID")
-	HW_FLAVOR_NAME           = os.Getenv("HW_FLAVOR_NAME")
-	HW_IMAGE_ID              = os.Getenv("HW_IMAGE_ID")
-	HW_IMAGE_NAME            = os.Getenv("HW_IMAGE_NAME")
-	HW_VPC_ID                = os.Getenv("HW_VPC_ID")
-	HW_NETWORK_ID            = os.Getenv("HW_NETWORK_ID")
-	HW_SUBNET_ID             = os.Getenv("HW_SUBNET_ID")
-	HW_ENTERPRISE_PROJECT_ID = os.Getenv("HW_ENTERPRISE_PROJECT_ID")
-	HW_ADMIN                 = os.Getenv("HW_ADMIN")
+	HW_FLAVOR_ID              = os.Getenv("HW_FLAVOR_ID")
+	HW_FLAVOR_NAME            = os.Getenv("HW_FLAVOR_NAME")
+	HW_IMAGE_ID               = os.Getenv("HW_IMAGE_ID")
+	HW_IMAGE_NAME             = os.Getenv("HW_IMAGE_NAME")
+	HW_IMS_DATA_DISK_IMAGE_ID = os.Getenv("HW_IMS_DATA_DISK_IMAGE_ID")
+	HW_VPC_ID                 = os.Getenv("HW_VPC_ID")
+	HW_NETWORK_ID             = os.Getenv("HW_NETWORK_ID")
+	HW_SUBNET_ID              = os.Getenv("HW_SUBNET_ID")
+	HW_ENTERPRISE_PROJECT_ID  = os.Getenv("HW_ENTERPRISE_PROJECT_ID")
+	HW_ADMIN                  = os.Getenv("HW_ADMIN")
 
 	HW_CAE_ENVIRONMENT_ID     = os.Getenv("HW_CAE_ENVIRONMENT_ID")
 	HW_CAE_APPLICATION_ID     = os.Getenv("HW_CAE_APPLICATION_ID")
@@ -1766,5 +1767,12 @@ func TestAccPreCheckDMSRocketMQTopicName(t *testing.T) {
 func TestAccPreCheckAsDedicatedHostId(t *testing.T) {
 	if HW_DEDICATED_HOST_ID == "" {
 		t.Skip("HW_DEDICATED_HOST_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckAsDataDiskImageId(t *testing.T) {
+	if HW_IMS_DATA_DISK_IMAGE_ID == "" {
+		t.Skip("HW_IMS_DATA_DISK_IMAGE_ID must be set for the acceptance test")
 	}
 }

--- a/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
@@ -166,6 +166,24 @@ func ResourceASConfiguration() *schema.Resource {
 										Computed: true,
 										ForceNew: true,
 									},
+									"dedicated_storage_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"data_disk_image_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"snapshot_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
 								},
 							},
 						},
@@ -299,13 +317,19 @@ func buildDiskOpts(diskMeta []interface{}) []configurations.DiskOpts {
 		diskType := disk["disk_type"].(string)
 		iops := disk["iops"].(int)
 		throughput := disk["throughput"].(int)
+		dedicatedStorageId := disk["dedicated_storage_id"].(string)
+		dataDiskImageId := disk["data_disk_image_id"].(string)
+		snapshotId := disk["snapshot_id"].(string)
 
 		diskOpts := configurations.DiskOpts{
-			Size:       size,
-			VolumeType: volumeType,
-			DiskType:   diskType,
-			Iops:       iops,
-			Throughput: throughput,
+			Size:               size,
+			VolumeType:         volumeType,
+			DiskType:           diskType,
+			Iops:               iops,
+			Throughput:         throughput,
+			DedicatedStorageID: dedicatedStorageId,
+			DataDiskImageID:    dataDiskImageId,
+			SnapshotId:         snapshotId,
 		}
 		kmsId := disk["kms_id"].(string)
 		if kmsId != "" {
@@ -545,11 +569,14 @@ func flattenInstanceDisks(disks []configurations.Disk) []map[string]interface{} 
 	res := make([]map[string]interface{}, len(disks))
 	for i, item := range disks {
 		res[i] = map[string]interface{}{
-			"volume_type": item.VolumeType,
-			"size":        item.Size,
-			"disk_type":   item.DiskType,
-			"iops":        item.Iops,
-			"throughput":  item.Throughput,
+			"volume_type":          item.VolumeType,
+			"size":                 item.Size,
+			"disk_type":            item.DiskType,
+			"iops":                 item.Iops,
+			"throughput":           item.Throughput,
+			"dedicated_storage_id": item.DedicatedStorageID,
+			"data_disk_image_id":   item.DataDiskImageID,
+			"snapshot_id":          item.SnapshotID,
 		}
 
 		if kms, ok := item.Metadata["__system__cmkid"]; ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

AS configuration resource supports three new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
AS configuration resource support new fields contain instance_config.0.disk.0.dedicated_storage_id,
instance_config.0.disk.0.snapshot_id, instance_config.0.disk.1.data_disk_image_id,
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASConfiguration_snapshot"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_snapshot -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_snapshot
=== PAUSE TestAccASConfiguration_snapshot
=== CONT  TestAccASConfiguration_snapshot
--- PASS: TestAccASConfiguration_snapshot (727.03s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        727.082s

```
```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASConfiguration_dataDiskImage"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_dataDiskImage -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_dataDiskImage
=== PAUSE TestAccASConfiguration_dataDiskImage
=== CONT  TestAccASConfiguration_dataDiskImage
--- PASS: TestAccASConfiguration_dataDiskImage (99.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        99.343s
```