### PR TITLE
feat(cbh): instance support update vpc

### DIFF
--- a/docs/resources/cbh_ha_instance.md
+++ b/docs/resources/cbh_ha_instance.md
@@ -55,13 +55,9 @@ The following arguments are supported:
   -> 1. The flavor change is a high-risk operation, with a certain risk of failure.
   <br/>2. Flavor change failing may impact the usability of the instance. Please be sure to back up your data.
 
-* `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC.
+* `vpc_id` - (Required, String) Specifies the ID of a VPC.
 
-  Changing this parameter will create a new resource.
-
-* `subnet_id` - (Required, String, ForceNew) Specifies the ID of a subnet.
-
-  Changing this parameter will create a new resource.
+* `subnet_id` - (Required, String) Specifies the ID of a subnet.
 
 * `security_group_id` - (Required, String) Specifies the IDs of the security group. Multiple security group IDs are
   separated by commas (,) without spaces.
@@ -114,20 +110,18 @@ The following arguments are supported:
   -> 1. Storage expansion is a high-risk operation, with a certain risk of failure.
   <br/>2. Expansion failure may affect the usability of the instance. Please ensure to back up your data.
 
-* `master_private_ip` - (Optional, String, ForceNew) Specifies the private IP address of the master instance.
+* `master_private_ip` - (Optional, String) Specifies the private IP address of the master instance.
 
-  Changing this parameter will create a new resource.
+* `slave_private_ip` - (Optional, String) Specifies the private IP address of the slave instance.
 
-* `slave_private_ip` - (Optional, String, ForceNew) Specifies the private IP address of the slave instance.
+* `floating_ip` - (Optional, String) Specifies the floating IP address of the CBH HA instance.
 
-  Changing this parameter will create a new resource.
-
-* `floating_ip` - (Optional, String, ForceNew) Specifies the floating IP address of the CBH HA instance.
-
-  Changing this parameter will create a new resource.
-
--> For the parameters `master_private_ip`, `slave_private_ip`, and `floating_ip`, if none of them are specified,
+-> 1. For the parameters `master_private_ip`, `slave_private_ip`, and `floating_ip`, if none of them are specified,
 a new IP address will be assigned to each. If one is specified, then the other two must also be specified.
+<br>2. The CBH HA instance will automatically create two elastic network card based on `master_private_ip` and
+`slave_private_ip`, they will be deleted as the CBH HA instance is deleted. But if the `master_private_ip` and
+`slave_private_ip` parameters is updated, the elastic network card resources corresponding to the original master
+private IP and slave private IP will remain, you need to manually delete them in the console.
 
 * `power_action` - (Optional, String) Specifies the power action after the CBH HA instance is created.
   The valid values are as follows:

--- a/docs/resources/cbh_instance.md
+++ b/docs/resources/cbh_instance.md
@@ -13,6 +13,7 @@ Manages a CBH instance resource within HuaweiCloud.
 
 ```hcl
 variable "name" {}
+variable "flavor_id" {}
 variable "vpc_id" {}
 variable "subnet_id" {}
 variable "security_group_id" {}
@@ -20,8 +21,8 @@ variable "password" {}
 variable "availability_zone" {}
 
 resource "huaweicloud_cbh_instance" "test" {
-  flavor_id         = "cbh.basic.10"
   name              = var.name
+  flavor_id         = var.flavor_id
   vpc_id            = var.vpc_id
   subnet_id         = var.subnet_id
   security_group_id = var.security_group_id
@@ -51,13 +52,9 @@ The following arguments are supported:
   -> 1. The flavor change is a high-risk operation, with a certain risk of failure.
   <br/>2. Flavor change failing may impact the usability of the instance. Please be sure to back up your data.
 
-* `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC.
+* `vpc_id` - (Required, String) Specifies the ID of a VPC.
 
-  Changing this parameter will create a new resource.
-
-* `subnet_id` - (Required, String, ForceNew) Specifies the ID of a subnet.
-
-  Changing this parameter will create a new resource.
+* `subnet_id` - (Required, String) Specifies the ID of a subnet.
 
 * `security_group_id` - (Required, String) Specifies the IDs of the security group. Multiple security group IDs are
   separated by commas (,) without spaces.
@@ -95,6 +92,10 @@ The following arguments are supported:
 
 * `subnet_address` - (Optional, String) Specifies the IP address of the subnet.
   If not specified, a new IP address will be assigned.
+
+  -> The CBH instance will automatically create an elastic network card based on the subnet address, which will be
+  deleted along with the instance deletion. But if the `subnet_address` parameter is updated, the elastic network card
+  resource corresponding to the original subnet address will remain, you need to manually delete it in the console.
 
 * `public_ip_id` - (Optional, String) Specifies the ID of the elastic IP.
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -43,6 +43,7 @@ var (
 	HW_VPC_ID                 = os.Getenv("HW_VPC_ID")
 	HW_NETWORK_ID             = os.Getenv("HW_NETWORK_ID")
 	HW_SUBNET_ID              = os.Getenv("HW_SUBNET_ID")
+	HW_SECURITY_GROUP_ID      = os.Getenv("HW_SECURITY_GROUP_ID")
 	HW_ENTERPRISE_PROJECT_ID  = os.Getenv("HW_ENTERPRISE_PROJECT_ID")
 	HW_ADMIN                  = os.Getenv("HW_ADMIN")
 
@@ -1782,5 +1783,26 @@ func TestAccPreCheckAsDedicatedHostId(t *testing.T) {
 func TestAccPreCheckAsDataDiskImageId(t *testing.T) {
 	if HW_IMS_DATA_DISK_IMAGE_ID == "" {
 		t.Skip("HW_IMS_DATA_DISK_IMAGE_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckVpcId(t *testing.T) {
+	if HW_VPC_ID == "" {
+		t.Skip("HW_VPC_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSubnetId(t *testing.T) {
+	if HW_SUBNET_ID == "" {
+		t.Skip("HW_SUBNET_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSecurityGroupId(t *testing.T) {
+	if HW_SECURITY_GROUP_ID == "" {
+		t.Skip("HW_SECURITY_GROUP_ID must be set for the acceptance test")
 	}
 }

--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_instance_test.go
@@ -357,3 +357,120 @@ resource "huaweicloud_cbh_instance" "test" {
 }
 `, testCBHInstance_base(name), name, action)
 }
+
+func TestAccCBHInstance_updateVpc(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_cbh_instance.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getCBHInstanceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		// 1.Because the CBH instance will automatically create an extended elastic network card and bind it to the
+		// instance and security group. After switching to VPC, the original extended elastic network card will not be
+		// deleted, so it cannot be completed through automated test cases. So use environment variables to inject
+		// `vpc_id`, `subnet_id`, and `security_group_id`.
+		// 2.After updating the 'subnet_address' parameter, the elastic network card corresponding to the original
+		// subnet address will remain, and you need to manually delete it in the console.
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckVpcId(t)
+			acceptance.TestAccPreCheckSubnetId(t)
+			acceptance.TestAccPreCheckSecurityGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testCBHInstance_updateVpc_stp1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "vpc_id", acceptance.HW_VPC_ID),
+					resource.TestCheckResourceAttr(rName, "subnet_id", acceptance.HW_SUBNET_ID),
+					resource.TestCheckResourceAttr(rName, "security_group_id", acceptance.HW_SECURITY_GROUP_ID),
+					resource.TestCheckResourceAttr(rName, "subnet_address", "192.168.0.154"),
+				),
+			},
+			{
+				Config: testCBHInstance_updateVpc_stp2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "subnet_address", "192.168.0.155"),
+
+					resource.TestCheckResourceAttrPair(rName, "vpc_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id",
+						"huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "security_group_id",
+						"huaweicloud_networking_secgroup.test", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"charging_mode",
+					"password",
+					"period",
+					"period_unit",
+				},
+			},
+		},
+	})
+}
+
+func testCBHInstance_updateVpc_stp1(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_cbh_flavors" "test" {
+  type = "basic"
+}
+
+resource "huaweicloud_cbh_instance" "test" {
+  flavor_id         = data.huaweicloud_cbh_flavors.test.flavors[0].id
+  name              = "%[1]s"
+  vpc_id            = "%[2]s"
+  subnet_id         = "%[3]s"
+  subnet_address    = "192.168.0.154"
+  security_group_id = "%[4]s"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  password          = "test_123456"
+  charging_mode     = "prePaid"
+  period_unit       = "month"
+  period            = 1
+}
+`, name, acceptance.HW_VPC_ID, acceptance.HW_SUBNET_ID, acceptance.HW_SECURITY_GROUP_ID)
+}
+
+func testCBHInstance_updateVpc_stp2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_cbh_flavors" "test" {
+  type = "basic"
+}
+
+resource "huaweicloud_cbh_instance" "test" {
+  flavor_id         = data.huaweicloud_cbh_flavors.test.flavors[0].id
+  name              = "%[2]s"
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  subnet_address    = "192.168.0.155"
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  password          = "test_123456"
+  charging_mode     = "prePaid"
+  period_unit       = "month"
+  period            = 1
+}
+`, common.TestBaseNetwork(name), name)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
instance support update vpc
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Commit1: instance support update vpc related parameters

Commit2: ha_instance support update vpc related parameters

Specification: Because the CBH instance will automatically create an extended elastic network card and bind it to the instance and security group. After switching to VPC, the original extended elastic network card will not be deleted, so it cannot be completed through automated test cases. So use environment variables to inject `vpc_id`, `subnet_id`, and `security_group_id`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

### Instance Test
```
$ export HW_VPC_ID=xxxxxxx
$ export HW_SUBNET_ID=xxxxxxxx
$ export HW_SECURITY_GROUP_ID=xxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_updateVpc"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_updateVpc -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_updateVpc
=== PAUSE TestAccCBHInstance_updateVpc
=== CONT  TestAccCBHInstance_updateVpc
--- PASS: TestAccCBHInstance_updateVpc (1644.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1644.228s




$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_basic
=== PAUSE TestAccCBHInstance_basic
=== CONT  TestAccCBHInstance_basic
--- PASS: TestAccCBHInstance_basic (1973.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1974.004s


$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_WithPowerAction"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_WithPowerAction -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_WithPowerAction
=== PAUSE TestAccCBHInstance_WithPowerAction
=== CONT  TestAccCBHInstance_WithPowerAction
--- PASS: TestAccCBHInstance_WithPowerAction (1340.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1340.950s


$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_epsId_migrate"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_epsId_migrate -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_epsId_migrate
=== PAUSE TestAccCBHInstance_epsId_migrate
=== CONT  TestAccCBHInstance_epsId_migrate
--- PASS: TestAccCBHInstance_epsId_migrate (1102.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       1102.343s

```

### HA_instance Test
```
$ export HW_VPC_ID=xxxxxxx
$ export HW_SUBNET_ID=xxxxxxxx
$ export HW_SECURITY_GROUP_ID=xxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHHAInstance_updateVpc"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHHAInstance_updateVpc -timeout 360m -parallel 4
=== RUN   TestAccCBHHAInstance_updateVpc
=== PAUSE TestAccCBHHAInstance_updateVpc
=== CONT  TestAccCBHHAInstance_updateVpc
--- PASS: TestAccCBHHAInstance_updateVpc (2349.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       2349.595s



$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHHAInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHHAInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHHAInstance_basic
=== PAUSE TestAccCBHHAInstance_basic
=== CONT  TestAccCBHHAInstance_basic
--- PASS: TestAccCBHHAInstance_basic (3836.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       3836.679s


$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHHAInstance_WithPowerAction"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHHAInstance_WithPowerAction -timeout 360m -parallel 4
=== RUN   TestAccCBHHAInstance_WithPowerAction
=== PAUSE TestAccCBHHAInstance_WithPowerAction
=== CONT  TestAccCBHHAInstance_WithPowerAction
--- PASS: TestAccCBHHAInstance_WithPowerAction (2241.22s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       2241.298s

```
