### PR TITLE
feat(ELB): elb loadbalancer support param ipv6_address

### DIFF
--- a/docs/resources/elb_loadbalancer.md
+++ b/docs/resources/elb_loadbalancer.md
@@ -122,6 +122,8 @@ The following arguments are supported:
 
 * `ipv4_address` - (Optional, String) The ipv4 address of the load balancer.
 
+* `ipv6_address` - (Optional, String) The ipv6 address of the Load Balancer.
+
 * `ipv4_eip_id` - (Optional, String, ForceNew) The ID of the EIP. Changing this parameter will create a new resource.
 
   -> **NOTE:** If the ipv4_eip_id parameter is configured, you do not need to configure the bandwidth parameters:
@@ -216,7 +218,6 @@ In addition to all arguments above, the following attributes are exported:
 * `ipv4_eip` - The ipv4 eip address of the Load Balancer.
 * `ipv6_eip` - The ipv6 eip address of the Load Balancer.
 * `ipv6_eip_id` - The ipv6 eip id of the Load Balancer.
-* `ipv6_address` - The ipv6 address of the Load Balancer.
 
 * `charge_mode` - Indicates the billing mode. The value can be one of the following:
   + **flavor**: Billed by the specifications you will select.

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_loadbalancer.go
@@ -133,6 +133,12 @@ func ResourceLoadBalancerV3() *schema.Resource {
 				Computed: true,
 			},
 
+			"ipv6_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"ipv4_eip_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -317,10 +323,6 @@ func ResourceLoadBalancerV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ipv6_address": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"autoscaling_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -361,6 +363,7 @@ func resourceLoadBalancerV3Create(ctx context.Context, d *schema.ResourceData, m
 		VipSubnetID:              d.Get("ipv4_subnet_id").(string),
 		IpV6VipSubnetID:          d.Get("ipv6_network_id").(string),
 		VipAddress:               d.Get("ipv4_address").(string),
+		Ipv6VipAddress:           d.Get("ipv6_address").(string),
 		L4Flavor:                 d.Get("l4_flavor_id").(string),
 		L7Flavor:                 d.Get("l7_flavor_id").(string),
 		ProtectionStatus:         d.Get("protection_status").(string),
@@ -604,8 +607,8 @@ func resourceLoadBalancerV3Update(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	updateLoadBalancerChanges := []string{"name", "description", "cross_vpc_backend", "ipv4_subnet_id", "ipv6_network_id",
-		"ipv6_bandwidth_id", "ipv4_address", "l4_flavor_id", "l7_flavor_id", "autoscaling_enabled", "min_l7_flavor_id",
-		"protection_status", "protection_reason", "deletion_protection_enable", "waf_failure_action",
+		"ipv6_bandwidth_id", "ipv4_address", "ipv6_address", "l4_flavor_id", "l7_flavor_id", "autoscaling_enabled",
+		"min_l7_flavor_id", "protection_status", "protection_reason", "deletion_protection_enable", "waf_failure_action",
 	}
 
 	if d.HasChanges(updateLoadBalancerChanges...) {
@@ -752,6 +755,9 @@ func buildUpdateLoadBalancerBodyParams(d *schema.ResourceData) loadbalancers.Upd
 	}
 	if d.HasChange("ipv4_address") {
 		updateOpts.VipAddress = d.Get("ipv4_address").(string)
+	}
+	if d.HasChange("ipv6_address") {
+		updateOpts.Ipv6VipAddress = d.Get("ipv6_address").(string)
 	}
 	if d.HasChange("l4_flavor_id") {
 		updateOpts.L4Flavor = d.Get("l4_flavor_id").(string)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
   elb loadbalancer support param ipv6_address
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
   elb loadbalancer support param ipv6_address
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccElbV3LoadBalancer_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbV3LoadBalancer_ -timeout 360m -parallel 4
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_with_deletion_protection
=== PAUSE TestAccElbV3LoadBalancer_with_deletion_protection
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== PAUSE TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid
=== RUN   TestAccElbV3LoadBalancer_availabilityZone
=== PAUSE TestAccElbV3LoadBalancer_availabilityZone
=== RUN   TestAccElbV3LoadBalancer_updateChargingMode
=== PAUSE TestAccElbV3LoadBalancer_updateChargingMode
=== RUN   TestAccElbV3LoadBalancer_withIpv6
=== PAUSE TestAccElbV3LoadBalancer_withIpv6
=== CONT  TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_prePaid
=== CONT  TestAccElbV3LoadBalancer_withEIP
=== CONT  TestAccElbV3LoadBalancer_updateChargingMode
--- PASS: TestAccElbV3LoadBalancer_withEIP (43.12s)
=== CONT  TestAccElbV3LoadBalancer_withIpv6
--- PASS: TestAccElbV3LoadBalancer_withIpv6 (80.43s)
=== CONT  TestAccElbV3LoadBalancer_availabilityZone
--- PASS: TestAccElbV3LoadBalancer_basic (154.48s)
=== CONT  TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
--- PASS: TestAccElbV3LoadBalancer_updateChargingMode (175.66s)
=== CONT  TestAccElbV3LoadBalancer_withEpsId
--- PASS: TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id (54.46s)
=== CONT  TestAccElbV3LoadBalancer_with_deletion_protection
--- PASS: TestAccElbV3LoadBalancer_withEpsId (38.87s)
--- PASS: TestAccElbV3LoadBalancer_availabilityZone (140.45s)
--- PASS: TestAccElbV3LoadBalancer_prePaid (299.82s)
--- PASS: TestAccElbV3LoadBalancer_with_deletion_protection (124.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       333.069s
```
