### PR TITLE
feat(dms): support to set file reserved time for rocketmq instance

### DIFF
--- a/docs/resources/dms_rocketmq_instance.md
+++ b/docs/resources/dms_rocketmq_instance.md
@@ -114,6 +114,18 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the instance.
 
+* `configs` - (Optional, List) Specifies the instance configs.
+  The [configs](#dms_configs) structure is documented below.
+
+<a name="dms_configs"></a>
+The `configs` block supports:
+
+* `name` - (Required, String) Specifies the config name.
+
+* `value` - (Required, String) Specifies the config value.
+
+-> When `name` is **fileReservedTime**, `value` ranges from **1** to **720** and unit is **hour**. Defaults to **48**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_instance_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_instance_test.go
@@ -87,12 +87,15 @@ func TestAccDmsRocketMQInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "storage_space", "1200"),
 					resource.TestCheckResourceAttrPair(resourceName, "engine_version", "data.huaweicloud_dms_rocketmq_flavors.test", "versions.0"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor_id", "data.huaweicloud_dms_rocketmq_flavors.test", "flavors.1.id"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.name", "fileReservedTime"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.value", "72"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"configs"},
 			},
 		},
 	})
@@ -378,6 +381,11 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
   flavor_id         = local.newFlavor.id
   storage_space     = 1200 
   broker_num        = 2
+
+  configs {
+    name  = "fileReservedTime"
+    value = "72"
+  }
 
   tags = {
     key1 = "value1_update"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adding new param `file_reserved_time`, Support to set file reserved time for rocketmq instance.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccDmsRocketMQInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsRocketMQInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQInstance_basic
=== PAUSE TestAccDmsRocketMQInstance_basic
=== CONT  TestAccDmsRocketMQInstance_basic
--- PASS: TestAccDmsRocketMQInstance_basic (2955.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       2955.148s
```
