### PR TITLE
feat(css): add resource CSS manual log backup

### DIFF
--- a/docs/resources/css_manual_log_backup.md
+++ b/docs/resources/css_manual_log_backup.md
@@ -1,0 +1,58 @@
+---
+subcategory: "Cloud Search Service (CSS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_css_manual_log_backup"
+description: |-
+  Manages CSS manual log backup resource within HuaweiCloud.
+---
+
+# huaweicloud_css_manual_log_backup
+
+Manages CSS manual log backup resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "cluster_id" {}
+
+resource "huaweicloud_css_manual_log_backup" "test" {
+  cluster_id = var.cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the ID of the CSS cluster.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `job_id` - The ID of the log backup job.
+
+* `type` - The type of the log backup job.
+
+* `status` - The status of the log backup job.
+
+* `log_path` - The storage path of backed up logs in the OBS bucket.
+
+* `created_at` - The creation time.
+
+* `finished_at` - The end time.
+
+* `failed_msg` - The error information.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1139,6 +1139,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_css_scan_task":                   css.ResourceScanTask(),
 			"huaweicloud_css_es_loadbalancer_config":      css.ResourceEsLoadbalancerConfig(),
 			"huaweicloud_css_log_setting":                 css.ResourceLogSetting(),
+			"huaweicloud_css_manual_log_backup":           css.ResourceManualLogBackup(),
 			"huaweicloud_css_logstash_cluster":            css.ResourceLogstashCluster(),
 			"huaweicloud_css_logstash_cluster_restart":    css.ResourceLogstashClusterRestart(),
 			"huaweicloud_css_logstash_configuration":      css.ResourceLogstashConfiguration(),

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_manual_log_backup_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_manual_log_backup_test.go
@@ -1,0 +1,153 @@
+package css
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getManualLogBackupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.CssV1Client(acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CSS v1 client: %s", err)
+	}
+
+	getLogBackupJobHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/records"
+	getLogBackupJobPath := client.Endpoint + getLogBackupJobHttpUrl
+	getLogBackupJobPath = strings.ReplaceAll(getLogBackupJobPath, "{project_id}", client.ProjectID)
+	getLogBackupJobPath = strings.ReplaceAll(getLogBackupJobPath, "{cluster_id}", state.Primary.Attributes["cluster_id"])
+
+	getLogBackupJobPathOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	expression := fmt.Sprintf("clusterLogRecord[?jobId=='%s'] | [0]", state.Primary.ID)
+	currentTotal := 1
+	for {
+		currentPath := fmt.Sprintf("%s?limit=10&start=%d", getLogBackupJobPath, currentTotal)
+		getLogBackupJobResp, err := client.Request("GET", currentPath, &getLogBackupJobPathOpt)
+		if err != nil {
+			return getLogBackupJobResp, err
+		}
+		getLogBackupJobRespBody, err := utils.FlattenResponse(getLogBackupJobResp)
+		if err != nil {
+			return getLogBackupJobRespBody, err
+		}
+		logBackupJob, err := jmespath.Search(expression, getLogBackupJobRespBody)
+		if err != nil {
+			return nil, err
+		}
+		if logBackupJob != nil {
+			return logBackupJob, nil
+		}
+		logBackupJobs := utils.PathSearch("clusterLogRecord",
+			getLogBackupJobRespBody, make([]interface{}, 0)).([]interface{})
+		if len(logBackupJobs) < 10 {
+			break
+		}
+		currentTotal += len(logBackupJobs)
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func TestAccManualLogBackup_elastic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_css_manual_log_backup.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getManualLogBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testManualLogBackup_elastic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "cluster_id", "huaweicloud_css_cluster.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "job_id"),
+					resource.TestCheckResourceAttrSet(rName, "type"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "log_path"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccManualLogBackup_logstash(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_css_manual_log_backup.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getManualLogBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testManualLogBackup_logstash(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "cluster_id", "huaweicloud_css_logstash_cluster.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "job_id"),
+					resource.TestCheckResourceAttrSet(rName, "type"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "log_path"),
+					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+		},
+	})
+}
+
+func testManualLogBackup_elastic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_css_manual_log_backup" "test" {
+  depends_on = [huaweicloud_css_log_setting.test]
+
+  cluster_id = huaweicloud_css_cluster.test.id
+}
+`, testLogSetting_elastic(name))
+}
+
+func testManualLogBackup_logstash(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_css_manual_log_backup" "test" {
+  depends_on = [huaweicloud_css_log_setting.test]
+  
+  cluster_id = huaweicloud_css_logstash_cluster.test.id
+}
+`, testLogSetting_logstash(name))
+}

--- a/huaweicloud/services/css/resource_huaweicloud_css_manual_log_backup.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_manual_log_backup.go
@@ -1,0 +1,298 @@
+package css
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSS GET /v1.0/{project_id}/clusters/{cluster_id}/logs/settings
+// @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/logs/collect
+// @API CSS GET /v1.0/{project_id}/clusters/{cluster_id}/logs/records
+func ResourceManualLogBackup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceManualLogBackupCreate,
+		ReadContext:   resourceManualLogBackupRead,
+		DeleteContext: resourceManualLogBackupDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the region in which to create the resource.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the ID of the CSS cluster.`,
+			},
+			"job_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the log backup job.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the log backup job.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The status of the log backup job.`,
+			},
+			"log_path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The storage path of backed up logs in the OBS bucket.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time.`,
+			},
+			"finished_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The end time.`,
+			},
+			"failed_msg": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The error information.`,
+			},
+		},
+	}
+}
+
+func resourceManualLogBackupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	clusterID := d.Get("cluster_id").(string)
+	client, err := conf.CssV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CSS V1 client: %s", err)
+	}
+
+	// Check whether opening log function.
+	err = checkOpeningLogBackupFunc(client, clusterID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// manual backup logs
+	err = createLogBackup(client, clusterID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	// There can be at most one log backup task for the same period.
+	// So we get the created job ID through the "RUNNING" status.
+	expression := "clusterLogRecord[?status=='RUNNING'] | [0]"
+	resp, err := getLogBackupJob(client, clusterID, expression)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	id := utils.PathSearch("jobId", resp, "").(string)
+	if id == "" {
+		return diag.Errorf("not found job ID of the manual log backup, resp: %v", resp)
+	}
+	d.SetId(id)
+
+	// Check whether manual backup log has completed.
+	err = checkLogBackupCompleted(ctx, client, clusterID, d.Id(), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceManualLogBackupRead(ctx, d, meta)
+}
+
+func resourceManualLogBackupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	clusterID := d.Get("cluster_id").(string)
+	client, err := conf.CssV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CSS V1 client: %s", err)
+	}
+
+	expression := fmt.Sprintf("clusterLogRecord[?jobId=='%s'] | [0]", d.Id())
+	resp, err := getLogBackupJob(client, clusterID, expression)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	createdAt := utils.PathSearch("createAt", resp, float64(0)).(float64) / 1000
+	finishedAt := utils.PathSearch("finishedAt", resp, float64(0)).(float64) / 1000
+	mErr := multierror.Append(
+		nil,
+		d.Set("region", region),
+		d.Set("job_id", utils.PathSearch("jobId", resp, nil)),
+		d.Set("type", utils.PathSearch("jobTypes", resp, nil)),
+		d.Set("status", utils.PathSearch("status", resp, nil)),
+		d.Set("log_path", utils.PathSearch("logPath", resp, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(createdAt), false)),
+		d.Set("finished_at", utils.FormatTimeStampRFC3339(int64(finishedAt), false)),
+		d.Set("failed_msg", utils.PathSearch("failedMsg", resp, nil)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceManualLogBackupDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting manual log backup resource is not supported. The manual log backup resource" +
+		"is only removed from the state, the manual log backup content and record remain in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func checkOpeningLogBackupFunc(client *golangsdk.ServiceClient, clusterID string) error {
+	getLogSettingHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/settings"
+	getLogSettingPath := client.Endpoint + getLogSettingHttpUrl
+	getLogSettingPath = strings.ReplaceAll(getLogSettingPath, "{project_id}", client.ProjectID)
+	getLogSettingPath = strings.ReplaceAll(getLogSettingPath, "{cluster_id}", clusterID)
+
+	getLogSettingPathOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getLogSettingResp, err := client.Request("GET", getLogSettingPath, &getLogSettingPathOpt)
+	if err != nil {
+		return err
+	}
+
+	getLogSettingRespBody, err := utils.FlattenResponse(getLogSettingResp)
+	if err != nil {
+		return err
+	}
+
+	logSetting := utils.PathSearch("logConfiguration", getLogSettingRespBody, nil)
+	logSwitch := utils.PathSearch("logSwitch", logSetting, false).(bool)
+
+	if logSetting == nil || !logSwitch {
+		return fmt.Errorf("before backing up logs, please enable the log backup function")
+	}
+
+	return nil
+}
+
+func createLogBackup(client *golangsdk.ServiceClient, clusterID string) error {
+	createLogBackupHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/collect"
+	createLogBackupPath := client.Endpoint + createLogBackupHttpUrl
+	createLogBackupPath = strings.ReplaceAll(createLogBackupPath, "{project_id}", client.ProjectID)
+	createLogBackupPath = strings.ReplaceAll(createLogBackupPath, "{cluster_id}", clusterID)
+
+	createLogBackupPathOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	_, err := client.Request("POST", createLogBackupPath, &createLogBackupPathOpt)
+	if err != nil {
+		return fmt.Errorf("error creating manual backup log, err: %s", err)
+	}
+
+	return nil
+}
+
+func checkLogBackupCompleted(ctx context.Context, client *golangsdk.ServiceClient, clusterId, id string,
+	timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"RUNNING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      logBackupStateRefreshFunc(client, clusterId, id),
+		Timeout:      timeout,
+		PollInterval: 10 * timeout,
+		Delay:        10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for CSS (%s) to be extend: %s", clusterId, err)
+	}
+	return nil
+}
+
+func logBackupStateRefreshFunc(client *golangsdk.ServiceClient, clusterID, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		expression := fmt.Sprintf("clusterLogRecord[?jobId=='%s'] | [0]", id)
+		resp, err := getLogBackupJob(client, clusterID, expression)
+		if err != nil {
+			return resp, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", resp, "").(string)
+		if status == "RUNNING" {
+			return resp, "RUNNING", nil
+		}
+
+		if status == "FAIL" {
+			failedMsg := utils.PathSearch("failedMsg", resp, "").(string)
+			return resp, "FAIL", fmt.Errorf("manual backup log failed: %s", failedMsg)
+		}
+
+		return resp, "COMPLETED", nil
+	}
+}
+
+func getLogBackupJob(client *golangsdk.ServiceClient, clusterID, expression string) (interface{}, error) {
+	getLogBackupJobHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/logs/records"
+	getLogBackupJobPath := client.Endpoint + getLogBackupJobHttpUrl
+	getLogBackupJobPath = strings.ReplaceAll(getLogBackupJobPath, "{project_id}", client.ProjectID)
+	getLogBackupJobPath = strings.ReplaceAll(getLogBackupJobPath, "{cluster_id}", clusterID)
+
+	getLogBackupJobPathOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	currentTotal := 1
+	for {
+		currentPath := fmt.Sprintf("%s?limit=10&start=%d", getLogBackupJobPath, currentTotal)
+		getLogBackupJobResp, err := client.Request("GET", currentPath, &getLogBackupJobPathOpt)
+		if err != nil {
+			return getLogBackupJobResp, err
+		}
+		getLogBackupJobRespBody, err := utils.FlattenResponse(getLogBackupJobResp)
+		if err != nil {
+			return getLogBackupJobRespBody, err
+		}
+		logBackupJob, err := jmespath.Search(expression, getLogBackupJobRespBody)
+		if err != nil {
+			return nil, err
+		}
+		if logBackupJob != nil {
+			return logBackupJob, nil
+		}
+		logBackupJobs := utils.PathSearch("clusterLogRecord",
+			getLogBackupJobRespBody, make([]interface{}, 0)).([]interface{})
+		if len(logBackupJobs) < 10 {
+			break
+		}
+		currentTotal += len(logBackupJobs)
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
add resource CSS manual log backup

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
add resource CSS manual log backup
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccManualLogBackup_logstash'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccManualLogBackup_logstash -timeout 360m -parallel 4
=== RUN   TestAccManualLogBackup_logstash
=== PAUSE TestAccManualLogBackup_logstash
=== CONT  TestAccManualLogBackup_logstash
--- PASS: TestAccManualLogBackup_logstash (998.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       998.960s
```

```
make testacc TEST='./huaweicloud/services/acceptance/css' TESTARGS='-run TestAccManualLogBackup_elastic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccManualLogBackup_elastic -timeout 360m -parallel 4
=== RUN   TestAccManualLogBackup_elastic
=== PAUSE TestAccManualLogBackup_elastic
=== CONT  TestAccManualLogBackup_elastic
--- PASS: TestAccManualLogBackup_elastic (1073.99s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1074.106s
```