### PR TITLE
test(apig): upgrade script contents to avoid update operation

### DIFF
--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_applications_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_applications_test.go
@@ -59,9 +59,15 @@ func TestAccDataSourceApplications_basic(t *testing.T) {
 }
 
 func testAccDataSourceApplications_basic(name string) string {
-	description := "Created by script"
+	baseConfig := testAccApigApplication_base(name)
+
 	return fmt.Sprintf(`
-%s
+%[1]s
+
+resource "huaweicloud_apig_application" "test" {
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s"
+}
 
 data "huaweicloud_apig_applications" "test" {
   depends_on = [
@@ -150,5 +156,5 @@ locals {
 output "created_by_filter_is_useful" {
   value = length(local.created_by_filter_result) > 0 && alltrue(local.created_by_filter_result)
 }
-`, testAccApplication_basic(name, description))
+`, baseConfig, name)
 }

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_custom_authorizers_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_custom_authorizers_test.go
@@ -52,6 +52,27 @@ func TestAccDataSourceCustomAuthorizers_basic(t *testing.T) {
 	})
 }
 
+func testAccDataSourceCustomAuthorizers_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_custom_authorizer" "test" {
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  function_urn     = huaweicloud_fgs_function.test.urn
+  function_version = "latest"
+  type             = "FRONTEND"
+  is_body_send     = true
+  cache_age        = 60
+  
+  identity {
+    name     = "user_name"
+    location = "QUERY"
+  }
+}
+`, testAccCustomAuthorizer_base(name), name)
+}
+
 func testAccDataSourceCustomAuthorizers_basic(name string) string {
 	return fmt.Sprintf(`
 %s
@@ -123,5 +144,5 @@ locals {
 output "type_filter_is_useful" {
   value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
 }
-`, testAccCustomAuthorizer_front(name))
+`, testAccDataSourceCustomAuthorizers_base(name))
 }

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_throttling_policies_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_throttling_policies_test.go
@@ -31,6 +31,7 @@ func TestAccDataSourceThrottlingPolicies_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckUserId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_application_test.go
@@ -32,6 +32,7 @@ func TestAccApplication_basic(t *testing.T) {
 		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccApigApplication_base(name)
 
 		description       = "Created by script"
 		updateDescription = "Updated by script"
@@ -51,7 +52,7 @@ func TestAccApplication_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccApplication_basic(name, description),
+				Config: testAccApplication_basic(baseConfig, name, description),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -62,7 +63,7 @@ func TestAccApplication_basic(t *testing.T) {
 			},
 			{
 				// update name, description and app_code.
-				Config: testAccApplication_basic(updateName, updateDescription),
+				Config: testAccApplication_basic(baseConfig, updateName, updateDescription),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
@@ -114,7 +115,7 @@ resource "huaweicloud_apig_instance" "test" {
 `, common.TestBaseNetwork(name), name)
 }
 
-func testAccApplication_basic(name, description string) string {
+func testAccApplication_basic(baseConfig, name, description string) string {
 	code := utils.Base64EncodeString(acctest.RandString(64))
 	return fmt.Sprintf(`
 %[1]s
@@ -126,5 +127,5 @@ resource "huaweicloud_apig_application" "test" {
 
   app_codes = ["%[4]s"]
 }
-`, testAccApigApplication_base(name), name, description, code)
+`, baseConfig, name, description, code)
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_certificate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_certificate_test.go
@@ -109,6 +109,7 @@ func TestAccCertificate_instance(t *testing.T) {
 		rName      = "huaweicloud_apig_certificate.test"
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccCertificate_instanceBase(name)
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -126,7 +127,7 @@ func TestAccCertificate_instance(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificate_instance_step1(name),
+				Config: testAccCertificate_instance_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -145,7 +146,7 @@ func TestAccCertificate_instance(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccCertificate_instance_step2(updateName),
+				Config: testAccCertificate_instance_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
@@ -178,7 +179,7 @@ resource "huaweicloud_apig_instance" "test" {
 `, common.TestBaseNetwork(name), name)
 }
 
-func testAccCertificate_instance_step1(name string) string {
+func testAccCertificate_instance_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -189,11 +190,11 @@ resource "huaweicloud_apig_certificate" "test" {
   content     = "%[3]s"
   private_key = "%[4]s"
 }
-`, testAccCertificate_instanceBase(name), name, acceptance.HW_CERTIFICATE_CONTENT,
+`, baseConfig, name, acceptance.HW_CERTIFICATE_CONTENT,
 		acceptance.HW_CERTIFICATE_PRIVATE_KEY)
 }
 
-func testAccCertificate_instance_step2(name string) string {
+func testAccCertificate_instance_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -204,7 +205,7 @@ resource "huaweicloud_apig_certificate" "test" {
   content     = "%[3]s"
   private_key = "%[4]s"
 }
-`, testAccCertificate_instanceBase(name), name, acceptance.HW_NEW_CERTIFICATE_CONTENT,
+`, baseConfig, name, acceptance.HW_NEW_CERTIFICATE_CONTENT,
 		acceptance.HW_NEW_CERTIFICATE_PRIVATE_KEY)
 }
 
@@ -215,6 +216,7 @@ func TestAccCertificate_instanceWithRootCA(t *testing.T) {
 		rName      = "huaweicloud_apig_certificate.test"
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccCertificate_instanceBase(name)
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -232,7 +234,7 @@ func TestAccCertificate_instanceWithRootCA(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCertificate_instanceWithRootCA_step1(name),
+				Config: testAccCertificate_instanceWithRootCA_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -244,7 +246,7 @@ func TestAccCertificate_instanceWithRootCA(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCertificate_instanceWithRootCA_step2(updateName),
+				Config: testAccCertificate_instanceWithRootCA_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
@@ -267,7 +269,7 @@ func TestAccCertificate_instanceWithRootCA(t *testing.T) {
 	})
 }
 
-func testAccCertificate_instanceWithRootCA_step1(name string) string {
+func testAccCertificate_instanceWithRootCA_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -279,11 +281,11 @@ resource "huaweicloud_apig_certificate" "test" {
   private_key     = "%[4]s"
   trusted_root_ca = "%[5]s"
 }
-`, testAccCertificate_instanceBase(name), name, acceptance.HW_CERTIFICATE_CONTENT,
+`, baseConfig, name, acceptance.HW_CERTIFICATE_CONTENT,
 		acceptance.HW_CERTIFICATE_PRIVATE_KEY, acceptance.HW_CERTIFICATE_ROOT_CA)
 }
 
-func testAccCertificate_instanceWithRootCA_step2(name string) string {
+func testAccCertificate_instanceWithRootCA_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -295,6 +297,6 @@ resource "huaweicloud_apig_certificate" "test" {
   private_key     = "%[4]s"
   trusted_root_ca = "%[5]s"
 }
-`, testAccCertificate_instanceBase(name), name, acceptance.HW_NEW_CERTIFICATE_CONTENT,
+`, baseConfig, name, acceptance.HW_NEW_CERTIFICATE_CONTENT,
 		acceptance.HW_NEW_CERTIFICATE_PRIVATE_KEY, acceptance.HW_NEW_CERTIFICATE_ROOT_CA)
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_channel_test.go
@@ -30,6 +30,7 @@ func TestAccChannel_basic(t *testing.T) {
 		rName      = "huaweicloud_apig_channel.test"
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccChannel_base(name)
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -46,7 +47,7 @@ func TestAccChannel_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccChannel_basic_step1(name),
+				Config: testAccChannel_basic_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -67,7 +68,7 @@ func TestAccChannel_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccChannel_basic_step2(updateName),
+				Config: testAccChannel_basic_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
@@ -128,7 +129,7 @@ resource "huaweicloud_apig_instance" "test" {
 `, common.TestBaseComputeResources(name), name)
 }
 
-func testAccChannel_basic_step1(name string) string {
+func testAccChannel_basic_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -172,10 +173,10 @@ resource "huaweicloud_apig_channel" "test" {
     }
   }
 }
-`, testAccChannel_base(name), name)
+`, baseConfig, name)
 }
 
-func testAccChannel_basic_step2(name string) string {
+func testAccChannel_basic_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -223,7 +224,7 @@ resource "huaweicloud_apig_channel" "test" {
     }
   }
 }
-`, testAccChannel_base(name), name)
+`, baseConfig, name)
 }
 
 func TestAccChannel_eipMembers(t *testing.T) {
@@ -231,8 +232,9 @@ func TestAccChannel_eipMembers(t *testing.T) {
 		channel channels.Channel
 
 		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
-		rName = "huaweicloud_apig_channel.test"
-		name  = acceptance.RandomAccResourceName()
+		rName      = "huaweicloud_apig_channel.test"
+		name       = acceptance.RandomAccResourceName()
+		baseConfig = testAccChannel_eipBase(name)
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -249,7 +251,7 @@ func TestAccChannel_eipMembers(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccChannel_eipMembers_step1(name),
+				Config: testAccChannel_eipMembers_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -270,7 +272,7 @@ func TestAccChannel_eipMembers(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccChannel_eipMembers_step2(name),
+				Config: testAccChannel_eipMembers_step2(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -306,7 +308,7 @@ resource "huaweicloud_apig_instance" "test" {
 `, common.TestBaseNetwork(name), name)
 }
 
-func testAccChannel_eipMembers_step1(rName string) string {
+func testAccChannel_eipMembers_step1(baseConfig, rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -353,10 +355,10 @@ resource "huaweicloud_apig_channel" "test" {
     }
   }
 }
-`, testAccChannel_eipBase(rName), rName)
+`, baseConfig, rName)
 }
 
-func testAccChannel_eipMembers_step2(rName string) string {
+func testAccChannel_eipMembers_step2(baseConfig, rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -403,5 +405,5 @@ resource "huaweicloud_apig_channel" "test" {
     }
   }
 }
-`, testAccChannel_eipBase(rName), rName)
+`, baseConfig, rName)
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_custom_authorizer_test.go
@@ -29,6 +29,7 @@ func TestAccCustomAuthorizer_basic(t *testing.T) {
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
 		rName      = "huaweicloud_apig_custom_authorizer.test"
+		baseConfig = testAccCustomAuthorizer_base(name)
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -45,7 +46,7 @@ func TestAccCustomAuthorizer_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomAuthorizer_front(name),
+				Config: testAccCustomAuthorizer_front_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -56,7 +57,7 @@ func TestAccCustomAuthorizer_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCustomAuthorizer_frontUpdate(updateName),
+				Config: testAccCustomAuthorizer_front_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
@@ -83,6 +84,7 @@ func TestAccCustomAuthorizer_backend(t *testing.T) {
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
 		rName      = "huaweicloud_apig_custom_authorizer.test"
+		baseConfig = testAccCustomAuthorizer_base(name)
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -99,7 +101,7 @@ func TestAccCustomAuthorizer_backend(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomAuthorizer_backend(name),
+				Config: testAccCustomAuthorizer_backend_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -109,7 +111,7 @@ func TestAccCustomAuthorizer_backend(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCustomAuthorizer_backendUpdate(updateName),
+				Config: testAccCustomAuthorizer_backend_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
@@ -200,7 +202,7 @@ EOF
 `, common.TestBaseNetwork(name), name)
 }
 
-func testAccCustomAuthorizer_front(name string) string {
+func testAccCustomAuthorizer_front_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -218,10 +220,10 @@ resource "huaweicloud_apig_custom_authorizer" "test" {
     location = "QUERY"
   }
 }
-`, testAccCustomAuthorizer_base(name), name)
+`, baseConfig, name)
 }
 
-func testAccCustomAuthorizer_frontUpdate(name string) string {
+func testAccCustomAuthorizer_front_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -232,10 +234,10 @@ resource "huaweicloud_apig_custom_authorizer" "test" {
   function_version = "latest"
   type             = "FRONTEND"
 }
-`, testAccCustomAuthorizer_base(name), name)
+`, baseConfig, name)
 }
 
-func testAccCustomAuthorizer_backend(name string) string {
+func testAccCustomAuthorizer_backend_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -247,10 +249,10 @@ resource "huaweicloud_apig_custom_authorizer" "test" {
   type             = "BACKEND"
   cache_age        = 60
 }
-`, testAccCustomAuthorizer_base(name), name)
+`, baseConfig, name)
 }
 
-func testAccCustomAuthorizer_backendUpdate(name string) string {
+func testAccCustomAuthorizer_backend_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -262,5 +264,5 @@ resource "huaweicloud_apig_custom_authorizer" "test" {
   type             = "BACKEND"
   cache_age        = 45
 }
-`, testAccCustomAuthorizer_base(name), name)
+`, baseConfig, name)
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_endpoint_whitelist_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_endpoint_whitelist_test.go
@@ -60,7 +60,6 @@ func TestAccEndpointWhiteList_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -92,7 +91,7 @@ func TestAccEndpointWhiteList_basic(t *testing.T) {
 	})
 }
 
-func testAccInstance_base(rName string) string {
+func testAccEndpointWhiteList_base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -108,11 +107,11 @@ resource "huaweicloud_apig_instance" "test" {
 
   edition               = "BASIC"
   name                  = "%[2]s"
-  enterprise_project_id = "%[3]s"
+  enterprise_project_id = "0"
   maintain_begin        = "14:00:00"
   description           = "created by acc test"
 }
-`, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, common.TestBaseNetwork(rName), rName)
 }
 
 func testAccEndpointWhiteList_basic(rName string) string {
@@ -126,7 +125,7 @@ resource "huaweicloud_apig_endpoint_whitelist" "test" {
     "iam:domain::2cc2018e40394f7c9692f1713e76234d",
   ]
 }
-`, testAccInstance_base(rName))
+`, testAccEndpointWhiteList_base(rName))
 }
 
 func testAccEndpointWhiteList_update(rName string) string {
@@ -141,5 +140,5 @@ resource "huaweicloud_apig_endpoint_whitelist" "test" {
     "iam:domain::5cc2018e40394f7c9692f1713e76234d",
   ]
 }
-`, testAccInstance_base(rName))
+`, testAccEndpointWhiteList_base(rName))
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_test.go
@@ -32,6 +32,7 @@ func TestAccEnvironment_basic(t *testing.T) {
 		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccEnvironment_base(name)
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -48,7 +49,7 @@ func TestAccEnvironment_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEnvironment_basic(name),
+				Config: testAccEnvironment_basic_step1(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -57,7 +58,7 @@ func TestAccEnvironment_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccEnvironment_update(updateName),
+				Config: testAccEnvironment_basic_step2(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
@@ -110,7 +111,7 @@ resource "huaweicloud_apig_instance" "test" {
 `, common.TestBaseNetwork(name), name)
 }
 
-func testAccEnvironment_basic(name string) string {
+func testAccEnvironment_basic_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -119,10 +120,10 @@ resource "huaweicloud_apig_environment" "test" {
   instance_id = huaweicloud_apig_instance.test.id
   description = "Created by script"
 }
-`, testAccEnvironment_base(name), name)
+`, baseConfig, name)
 }
 
-func testAccEnvironment_update(name string) string {
+func testAccEnvironment_basic_step2(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -130,5 +131,5 @@ resource "huaweicloud_apig_environment" "test" {
   name        = "%[2]s"
   instance_id = huaweicloud_apig_instance.test.id
 }
-`, testAccEnvironment_base(name), name)
+`, baseConfig, name)
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_variable_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_environment_variable_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func getEnvironmentVariableFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -91,13 +92,34 @@ func testAccEnvironmentVariableImportStateFunc() resource.ImportStateIdFunc {
 
 func testAccEnvironmentVariable_base(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0],
+  ]
+}
 
 resource "huaweicloud_apig_environment" "test" {
-  name        = "%s"
+  name        = "%[2]s"
   instance_id = huaweicloud_apig_instance.test.id
 }
-`, testAccGroup_basic(name), name)
+
+resource "huaweicloud_apig_group" "test" {
+  name        = "%[2]s"
+  instance_id = huaweicloud_apig_instance.test.id
+  description = "Created by script"
+}
+`, common.TestBaseNetwork(name), name)
 }
 
 func testAccEnvironmentVariable_basic(name string) string {

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_routes_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_routes_test.go
@@ -55,7 +55,6 @@ func TestAccInstanceRoutes_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_associate_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_associate_test.go
@@ -351,9 +351,10 @@ resource "huaweicloud_apig_plugin" "http_resp" {
   content     = jsonencode(
     {
       response_headers = [{
-        name   = "X-Custom-Pwd"
-        value  = "**********"
-        action = "override"
+        name       = "X-Custom-Pwd"
+        value      = "**********"
+        value_type = "custom_value"
+        action     = "override"
       }]
     }
   )

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_plugin_test.go
@@ -634,6 +634,7 @@ resource "huaweicloud_dms_kafka_instance" "test" {
   engine_version     = element(local.query_results.versions, length(local.query_results.versions)-1)
   storage_space      = local.flavor.properties[0].min_broker * local.flavor.properties[0].min_storage_per_node
   broker_num         = 3
+  enable_auto_topic  = true
 
   access_user      = "user"
   password         = "Kafkatest@123"
@@ -650,7 +651,7 @@ resource "huaweicloud_dms_kafka_instance" "test" {
 resource "huaweicloud_dms_kafka_topic" "test" {
   instance_id = huaweicloud_dms_kafka_instance.test.id
   name        = "%[2]s"
-  partitions  = 20
+  partitions  = 1
 }
 `, testAccPlugin_basicConfig(name), name)
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
@@ -30,6 +30,7 @@ func TestAccThrottlingPolicy_basic(t *testing.T) {
 		rName      = "huaweicloud_apig_throttling_policy.test"
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
+		baseConfig = testAccApigThrottlingPolicy_base(name)
 		appCode    = acctest.RandString(64)
 	)
 
@@ -47,7 +48,7 @@ func TestAccThrottlingPolicy_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccApigThrottlingPolicy_basic(name, appCode),
+				Config: testAccApigThrottlingPolicy_basic_step1(baseConfig, name, appCode),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -62,7 +63,7 @@ func TestAccThrottlingPolicy_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccApigThrottlingPolicy_update(updateName, appCode),
+				Config: testAccApigThrottlingPolicy_basic_step2(baseConfig, updateName, appCode),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
@@ -109,7 +110,7 @@ func TestAccThrottlingPolicy_spec(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccApigThrottlingPolicy_basic(name, appCode),
+				Config: testAccApigThrottlingPolicy_spec_step1(name, appCode),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -117,24 +118,25 @@ func TestAccThrottlingPolicy_spec(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "period", "15000"),
 					resource.TestCheckResourceAttr(rName, "period_unit", "SECOND"),
 					resource.TestCheckResourceAttr(rName, "max_api_requests", "100"),
+					resource.TestCheckResourceAttr(rName, "app_throttles.#", "0"),
 				),
 			},
 			{
-				Config: testAccApigThrottlingPolicy_spec(name, appCode),
+				Config: testAccApigThrottlingPolicy_spec_step2(name, appCode),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "app_throttles.#", "1"),
 				),
 			},
 			{
-				Config: testAccApigThrottlingPolicy_specUpdate(name, appCode),
+				Config: testAccApigThrottlingPolicy_spec_step3(name, appCode),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "app_throttles.#", "1"),
 				),
 			},
 			{
-				Config: testAccApigThrottlingPolicy_basic(name, appCode),
+				Config: testAccApigThrottlingPolicy_spec_step4(name, appCode),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "app_throttles.#", "0"),
@@ -186,7 +188,7 @@ resource "huaweicloud_apig_instance" "test" {
 `, common.TestBaseNetwork(name), name)
 }
 
-func testAccApigThrottlingPolicy_basic(name, appCode string) string {
+func testAccApigThrottlingPolicy_basic_step1(baseConfig, name, appCode string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -211,10 +213,10 @@ resource "huaweicloud_apig_throttling_policy" "test" {
   max_ip_requests   = 60
   description       = "Created by script"
 }
-`, testAccApigThrottlingPolicy_base(name), appCode, name)
+`, baseConfig, appCode, name)
 }
 
-func testAccApigThrottlingPolicy_update(name, appCode string) string {
+func testAccApigThrottlingPolicy_basic_step2(baseConfig, name, appCode string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -239,10 +241,15 @@ resource "huaweicloud_apig_throttling_policy" "test" {
   max_ip_requests   = 45
   description       = "Updated by script"
 }
-`, testAccApigThrottlingPolicy_base(name), appCode, name)
+`, baseConfig, appCode, name)
 }
 
-func testAccApigThrottlingPolicy_spec(name, appCode string) string {
+func testAccApigThrottlingPolicy_spec_step1(name, appCode string) string {
+	baseConfig := testAccApigThrottlingPolicy_base(name)
+	return testAccApigThrottlingPolicy_basic_step1(baseConfig, name, appCode)
+}
+
+func testAccApigThrottlingPolicy_spec_step2(name, appCode string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -280,7 +287,7 @@ resource "huaweicloud_apig_throttling_policy" "test" {
 `, testAccApigThrottlingPolicy_base(name), appCode, name)
 }
 
-func testAccApigThrottlingPolicy_specUpdate(name, appCode string) string {
+func testAccApigThrottlingPolicy_spec_step3(name, appCode string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -316,4 +323,8 @@ resource "huaweicloud_apig_throttling_policy" "test" {
   }
 }
 `, testAccApigThrottlingPolicy_base(name), appCode, name)
+}
+
+func testAccApigThrottlingPolicy_spec_step4(name, appCode string) string {
+	return testAccApigThrottlingPolicy_spec_step1(name, appCode)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Update some acceptance tests to fix the testing errors as below:
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=Test -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAclPolicies_basic
=== PAUSE TestAccDataSourceAclPolicies_basic
=== RUN   TestAccDataSourceApiAssociatedAclPolicies_basic
=== PAUSE TestAccDataSourceApiAssociatedAclPolicies_basic
=== RUN   TestAccDataSourceApiAssociatedApplications_basic
=== PAUSE TestAccDataSourceApiAssociatedApplications_basic
=== RUN   TestAccDataSourceApiAssociatedPlugins_basic
=== PAUSE TestAccDataSourceApiAssociatedPlugins_basic
=== RUN   TestAccDataSourceApiAssociatedSignatures_basic
=== PAUSE TestAccDataSourceApiAssociatedSignatures_basic
=== RUN   TestAccDataSourceApiAssociatedThrottlingPolicies_basic
=== PAUSE TestAccDataSourceApiAssociatedThrottlingPolicies_basic
=== RUN   TestAccDataSourceApiBasicConfigurations_basic
=== PAUSE TestAccDataSourceApiBasicConfigurations_basic
=== RUN   TestAccDataSourceAppcodes_basic
=== PAUSE TestAccDataSourceAppcodes_basic
=== RUN   TestAccDataSourceApplicationAcl_basic
=== PAUSE TestAccDataSourceApplicationAcl_basic
=== RUN   TestAccDataSourceApplicationAcl_expectError
=== PAUSE TestAccDataSourceApplicationAcl_expectError
=== RUN   TestAccDataSourceApplicationQuotas_basic
=== PAUSE TestAccDataSourceApplicationQuotas_basic
=== RUN   TestAccDataSourceApplications_basic
=== PAUSE TestAccDataSourceApplications_basic
=== RUN   TestAccDataSourceChannels_basic
=== PAUSE TestAccDataSourceChannels_basic
=== RUN   TestAccDataSourceCustomAuthorizers_basic
=== PAUSE TestAccDataSourceCustomAuthorizers_basic
=== RUN   TestAccDataSourceEndpointConnections_basic
=== PAUSE TestAccDataSourceEndpointConnections_basic
=== RUN   TestAccDataSourceApigEnvironmentVariables_basic
=== PAUSE TestAccDataSourceApigEnvironmentVariables_basic
=== RUN   TestAccDataEnvironments_basic
=== PAUSE TestAccDataEnvironments_basic
=== RUN   TestAccGroupsDataSource_basic
=== PAUSE TestAccGroupsDataSource_basic
=== RUN   TestAccGroupsDataSource_filterById
=== PAUSE TestAccGroupsDataSource_filterById
=== RUN   TestAccDataSourceInstanceFeatures_basic
=== PAUSE TestAccDataSourceInstanceFeatures_basic
=== RUN   TestAccDataSourceInstanceSupportedFeatures_basic
=== PAUSE TestAccDataSourceInstanceSupportedFeatures_basic
=== RUN   TestAccDataSourceInstances_basic
=== PAUSE TestAccDataSourceInstances_basic
=== RUN   TestAccDataSourceSignatures_basic
=== PAUSE TestAccDataSourceSignatures_basic
=== RUN   TestAccDataSourceThrottlingPolicies_basic
=== PAUSE TestAccDataSourceThrottlingPolicies_basic
=== RUN   TestAccAclPolicyAssociate_basic
=== PAUSE TestAccAclPolicyAssociate_basic
=== RUN   TestAccAclPolicy_basic
=== PAUSE TestAccAclPolicy_basic
=== RUN   TestAccApiPublishment_basic
=== PAUSE TestAccApiPublishment_basic
=== RUN   TestAccApi_basic
=== PAUSE TestAccApi_basic
=== RUN   TestAccApi_functionGraph
=== PAUSE TestAccApi_functionGraph
=== RUN   TestAccAppcode_basic
=== PAUSE TestAccAppcode_basic
=== RUN   TestAccAppcode_manuallyConfig
=== PAUSE TestAccAppcode_manuallyConfig
=== RUN   TestAccApplicationAcl_basic
=== PAUSE TestAccApplicationAcl_basic
=== RUN   TestAccAppAuth_basic
=== PAUSE TestAccAppAuth_basic
=== RUN   TestAccApplicationQuotaAssociate_basic
=== PAUSE TestAccApplicationQuotaAssociate_basic
=== RUN   TestAccResourceAppQuota_basic
=== PAUSE TestAccResourceAppQuota_basic
=== RUN   TestAccApplication_basic
=== PAUSE TestAccApplication_basic
=== RUN   TestAccCertificate_basic
=== PAUSE TestAccCertificate_basic
=== RUN   TestAccCertificate_instance
=== PAUSE TestAccCertificate_instance
=== RUN   TestAccCertificate_instanceWithRootCA
=== PAUSE TestAccCertificate_instanceWithRootCA
=== RUN   TestAccChannel_basic
=== PAUSE TestAccChannel_basic
=== RUN   TestAccChannel_eipMembers
=== PAUSE TestAccChannel_eipMembers
=== RUN   TestAccCustomAuthorizer_basic
=== PAUSE TestAccCustomAuthorizer_basic
=== RUN   TestAccCustomAuthorizer_backend
=== PAUSE TestAccCustomAuthorizer_backend
=== RUN   TestAccEndpointConnectionManagement_basic
=== PAUSE TestAccEndpointConnectionManagement_basic
=== RUN   TestAccEndpointWhiteList_basic
=== PAUSE TestAccEndpointWhiteList_basic
=== RUN   TestAccEnvironment_basic
=== PAUSE TestAccEnvironment_basic
=== RUN   TestAccEnvironmentVariable_basic
=== PAUSE TestAccEnvironmentVariable_basic
=== RUN   TestAccGroup_basic
=== PAUSE TestAccGroup_basic
=== RUN   TestAccGroup_variables
=== PAUSE TestAccGroup_variables
=== RUN   TestAccGroup_urlDomains
=== PAUSE TestAccGroup_urlDomains
=== RUN   TestAccGroup_DomainAccessEnabled
=== PAUSE TestAccGroup_DomainAccessEnabled
=== RUN   TestAccInstanceFeature_basic
=== PAUSE TestAccInstanceFeature_basic
=== RUN   TestAccInstanceRoutes_basic
=== PAUSE TestAccInstanceRoutes_basic
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== RUN   TestAccInstance_egress
=== PAUSE TestAccInstance_egress
=== RUN   TestAccInstance_ingress
=== PAUSE TestAccInstance_ingress
=== RUN   TestAccPluginAssociate_basic
=== PAUSE TestAccPluginAssociate_basic
=== RUN   TestAccPlugin_basic
=== PAUSE TestAccPlugin_basic
=== RUN   TestAccPlugin_httpResponse
=== PAUSE TestAccPlugin_httpResponse
=== RUN   TestAccPlugin_rateLimit
=== PAUSE TestAccPlugin_rateLimit
=== RUN   TestAccPlugin_kafkaLog
=== PAUSE TestAccPlugin_kafkaLog
=== RUN   TestAccPlugin_breaker
=== PAUSE TestAccPlugin_breaker
=== RUN   TestAccResponse_basic
=== PAUSE TestAccResponse_basic
=== RUN   TestAccResponse_customRules
=== PAUSE TestAccResponse_customRules
=== RUN   TestAccSignatureAssociate_basic
=== PAUSE TestAccSignatureAssociate_basic
=== RUN   TestAccSignature_basic
=== PAUSE TestAccSignature_basic
=== RUN   TestAccSignature_hmac
=== PAUSE TestAccSignature_hmac
=== RUN   TestAccSignature_aes
=== PAUSE TestAccSignature_aes
=== RUN   TestAccThrottlingPolicyAssociate_basic
=== PAUSE TestAccThrottlingPolicyAssociate_basic
=== RUN   TestAccThrottlingPolicy_basic
=== PAUSE TestAccThrottlingPolicy_basic
=== RUN   TestAccThrottlingPolicy_spec
=== PAUSE TestAccThrottlingPolicy_spec
=== CONT  TestAccDataSourceAclPolicies_basic
=== CONT  TestAccCertificate_basic
=== CONT  TestAccThrottlingPolicy_spec
=== CONT  TestAccGroupsDataSource_filterById
=== CONT  TestAccCertificate_basic
    acceptance.go:1280: HW_CERTIFICATE_CONTENT, HW_CERTIFICATE_PRIVATE_KEY, HW_NEW_CERTIFICATE_CONTENT and HW_NEW_CERTIFICATE_PRIVATE_KEY must be set for simple acceptance tests of SSL certificate resource
--- SKIP: TestAccCertificate_basic (0.02s)
=== CONT  TestAccInstance_basic
    acceptance.go:544: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccInstance_basic (0.02s)
=== CONT  TestAccThrottlingPolicy_basic
--- PASS: TestAccThrottlingPolicy_basic (587.61s)
=== CONT  TestAccThrottlingPolicyAssociate_basic
--- PASS: TestAccGroupsDataSource_filterById (592.35s)
=== CONT  TestAccSignature_aes
--- PASS: TestAccDataSourceAclPolicies_basic (636.16s)
=== CONT  TestAccSignature_hmac
--- PASS: TestAccThrottlingPolicy_spec (677.27s)
=== CONT  TestAccEnvironment_basic
--- PASS: TestAccSignature_aes (523.17s)
=== CONT  TestAccSignature_basic
--- PASS: TestAccSignature_hmac (549.94s)
=== CONT  TestAccInstanceRoutes_basic
    acceptance.go:544: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccInstanceRoutes_basic (0.01s)
=== CONT  TestAccSignatureAssociate_basic
--- PASS: TestAccEnvironment_basic (558.33s)
=== CONT  TestAccInstanceFeature_basic
--- PASS: TestAccThrottlingPolicyAssociate_basic (691.41s)
=== CONT  TestAccGroup_DomainAccessEnabled
--- PASS: TestAccSignature_basic (572.22s)
=== CONT  TestAccGroup_urlDomains
--- PASS: TestAccInstanceFeature_basic (540.54s)
=== CONT  TestAccResponse_customRules
--- PASS: TestAccGroup_DomainAccessEnabled (547.05s)
=== CONT  TestAccGroup_variables
--- PASS: TestAccSignatureAssociate_basic (722.90s)
=== CONT  TestAccResponse_basic
--- PASS: TestAccGroup_urlDomains (590.83s)
=== CONT  TestAccGroup_basic
--- PASS: TestAccResponse_customRules (588.94s)
=== CONT  TestAccPlugin_breaker
--- PASS: TestAccGroup_variables (583.75s)
=== CONT  TestAccEnvironmentVariable_basic
--- PASS: TestAccResponse_basic (550.31s)
=== CONT  TestAccPlugin_kafkaLog
--- PASS: TestAccGroup_basic (554.13s)
=== CONT  TestAccDataSourceApplicationAcl_expectError
--- PASS: TestAccPlugin_breaker (548.05s)
=== CONT  TestAccGroupsDataSource_basic
--- PASS: TestAccEnvironmentVariable_basic (577.08s)
=== CONT  TestAccPlugin_rateLimit
=== CONT  TestAccPlugin_kafkaLog
    resource_huaweicloud_apig_plugin_test.go:572: Step 1/3 error: Error running apply: exit status 1
        
        Error: Provider produced inconsistent result after apply
        
        When applying changes to huaweicloud_dms_kafka_topic.test, provider
        "provider[\"registry.terraform.io/hashicorp/huaweicloud\"]" produced an
        unexpected new value: Root object was present, but now absent.
        
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
--- FAIL: TestAccPlugin_kafkaLog (746.84s)
=== CONT  TestAccDataEnvironments_basic
--- PASS: TestAccDataSourceApplicationAcl_expectError (502.56s)
=== CONT  TestAccPlugin_httpResponse
--- PASS: TestAccGroupsDataSource_basic (515.15s)
=== CONT  TestAccDataSourceChannels_basic
--- PASS: TestAccPlugin_rateLimit (544.56s)
=== CONT  TestAccPlugin_basic
--- PASS: TestAccDataEnvironments_basic (523.18s)
=== CONT  TestAccDataSourceApplications_basic
--- PASS: TestAccPlugin_httpResponse (531.93s)
=== CONT  TestAccDataSourceApplicationQuotas_basic
--- PASS: TestAccDataSourceChannels_basic (535.14s)
=== CONT  TestAccPluginAssociate_basic
--- PASS: TestAccPlugin_basic (526.47s)
=== CONT  TestAccCustomAuthorizer_basic
--- PASS: TestAccDataSourceApplications_basic (547.63s)
=== CONT  TestAccInstance_ingress
    acceptance.go:544: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccInstance_ingress (0.01s)
=== CONT  TestAccEndpointWhiteList_basic
    acceptance.go:544: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccEndpointWhiteList_basic (0.01s)
=== CONT  TestAccEndpointConnectionManagement_basic
--- PASS: TestAccDataSourceApplicationQuotas_basic (520.33s)
=== CONT  TestAccInstance_egress
    acceptance.go:544: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccInstance_egress (0.01s)
=== CONT  TestAccCustomAuthorizer_backend
--- PASS: TestAccCustomAuthorizer_basic (557.65s)
=== CONT  TestAccChannel_basic
--- PASS: TestAccEndpointConnectionManagement_basic (597.11s)
=== CONT  TestAccApi_basic
--- PASS: TestAccCustomAuthorizer_backend (567.00s)
=== CONT  TestAccChannel_eipMembers
--- PASS: TestAccPluginAssociate_basic (1006.61s)
=== CONT  TestAccApplication_basic
--- PASS: TestAccChannel_basic (631.75s)
=== CONT  TestAccCertificate_instanceWithRootCA
    acceptance.go:1280: HW_CERTIFICATE_CONTENT, HW_CERTIFICATE_PRIVATE_KEY, HW_NEW_CERTIFICATE_CONTENT and HW_NEW_CERTIFICATE_PRIVATE_KEY must be set for simple acceptance tests of SSL certificate resource
--- SKIP: TestAccCertificate_instanceWithRootCA (0.01s)
=== CONT  TestAccResourceAppQuota_basic
--- PASS: TestAccApi_basic (632.48s)
=== CONT  TestAccApplicationQuotaAssociate_basic
--- PASS: TestAccApplication_basic (543.84s)
=== CONT  TestAccAppAuth_basic
--- PASS: TestAccChannel_eipMembers (575.52s)
=== CONT  TestAccDataSourceApiAssociatedThrottlingPolicies_basic
--- PASS: TestAccResourceAppQuota_basic (555.31s)
=== CONT  TestAccApplicationAcl_basic
--- PASS: TestAccApplicationQuotaAssociate_basic (588.81s)
=== CONT  TestAccDataSourceApplicationAcl_basic
--- PASS: TestAccDataSourceApiAssociatedThrottlingPolicies_basic (644.09s)
=== CONT  TestAccAppcode_manuallyConfig
--- PASS: TestAccAppAuth_basic (712.44s)
=== CONT  TestAccAppcode_basic
--- PASS: TestAccApplicationAcl_basic (619.51s)
=== CONT  TestAccDataSourceAppcodes_basic
--- PASS: TestAccDataSourceApplicationAcl_basic (533.53s)
=== CONT  TestAccApi_functionGraph
--- PASS: TestAccAppcode_manuallyConfig (510.48s)
=== CONT  TestAccDataSourceCustomAuthorizers_basic
--- PASS: TestAccAppcode_basic (508.41s)
=== CONT  TestAccDataSourceThrottlingPolicies_basic
--- PASS: TestAccDataSourceAppcodes_basic (538.13s)
=== CONT  TestAccApiPublishment_basic
--- PASS: TestAccApi_functionGraph (532.57s)
=== CONT  TestAccDataSourceApigEnvironmentVariables_basic
--- PASS: TestAccDataSourceCustomAuthorizers_basic (547.62s)
=== CONT  TestAccAclPolicy_basic
--- PASS: TestAccDataSourceThrottlingPolicies_basic (623.00s)
=== CONT  TestAccDataSourceApiBasicConfigurations_basic
--- PASS: TestAccApiPublishment_basic (580.17s)
=== CONT  TestAccDataSourceEndpointConnections_basic
--- PASS: TestAccDataSourceApigEnvironmentVariables_basic (555.52s)
=== CONT  TestAccAclPolicyAssociate_basic
--- PASS: TestAccAclPolicy_basic (527.71s)
=== CONT  TestAccCertificate_instance
    acceptance.go:1280: HW_CERTIFICATE_CONTENT, HW_CERTIFICATE_PRIVATE_KEY, HW_NEW_CERTIFICATE_CONTENT and HW_NEW_CERTIFICATE_PRIVATE_KEY must be set for simple acceptance tests of SSL certificate resource
--- SKIP: TestAccCertificate_instance (0.01s)
=== CONT  TestAccDataSourceInstances_basic
--- PASS: TestAccDataSourceApiBasicConfigurations_basic (667.72s)
=== CONT  TestAccDataSourceApiAssociatedApplications_basic
--- PASS: TestAccDataSourceEndpointConnections_basic (616.67s)
=== CONT  TestAccDataSourceSignatures_basic
--- PASS: TestAccDataSourceInstances_basic (541.82s)
=== CONT  TestAccDataSourceApiAssociatedAclPolicies_basic
--- PASS: TestAccAclPolicyAssociate_basic (683.16s)
=== CONT  TestAccDataSourceApiAssociatedPlugins_basic
--- PASS: TestAccDataSourceApiAssociatedApplications_basic (636.11s)
=== CONT  TestAccDataSourceInstanceSupportedFeatures_basic
--- PASS: TestAccDataSourceSignatures_basic (557.69s)
=== CONT  TestAccDataSourceApiAssociatedSignatures_basic
--- PASS: TestAccDataSourceApiAssociatedAclPolicies_basic (610.10s)
=== CONT  TestAccDataSourceInstanceFeatures_basic
--- PASS: TestAccDataSourceApiAssociatedPlugins_basic (604.87s)
--- PASS: TestAccDataSourceInstanceSupportedFeatures_basic (495.86s)
--- PASS: TestAccDataSourceApiAssociatedSignatures_basic (646.42s)
--- PASS: TestAccDataSourceInstanceFeatures_basic (511.57s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      9423.484s
FAIL
GNUmakefile:21: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

Before running acceptance tests, we should configure these environment vairbales:
```
HW_USER_ID
HW_ENTERPRISE_PROJECT_ID_TEST
export HW_ACCESS_KEY
export HW_SECRET_KEY
export HW_REGION_NAME
export HW_PROJECT_ID
HW_CERTIFICATE_CONTENT
HW_CERTIFICATE_PRIVATE_KEY
HW_NEW_CERTIFICATE_CONTENT
HW_NEW_CERTIFICATE_PRIVATE_KEY
HW_CERTIFICATE_ROOT_CA
HW_NEW_CERTIFICATE_ROOT_CA
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=Test'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=Test -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAclPolicies_basic
=== PAUSE TestAccDataSourceAclPolicies_basic
=== RUN   TestAccDataSourceApiAssociatedAclPolicies_basic
=== PAUSE TestAccDataSourceApiAssociatedAclPolicies_basic
=== RUN   TestAccDataSourceApiAssociatedApplications_basic
=== PAUSE TestAccDataSourceApiAssociatedApplications_basic
=== RUN   TestAccDataSourceApiAssociatedPlugins_basic
=== PAUSE TestAccDataSourceApiAssociatedPlugins_basic
=== RUN   TestAccDataSourceApiAssociatedSignatures_basic
=== PAUSE TestAccDataSourceApiAssociatedSignatures_basic
=== RUN   TestAccDataSourceApiAssociatedThrottlingPolicies_basic
=== PAUSE TestAccDataSourceApiAssociatedThrottlingPolicies_basic
=== RUN   TestAccDataSourceApiBasicConfigurations_basic
=== PAUSE TestAccDataSourceApiBasicConfigurations_basic
=== RUN   TestAccDataSourceAppcodes_basic
=== PAUSE TestAccDataSourceAppcodes_basic
=== RUN   TestAccDataSourceApplicationAcl_basic
=== PAUSE TestAccDataSourceApplicationAcl_basic
=== RUN   TestAccDataSourceApplicationAcl_expectError
=== PAUSE TestAccDataSourceApplicationAcl_expectError
=== RUN   TestAccDataSourceApplicationQuotas_basic
=== PAUSE TestAccDataSourceApplicationQuotas_basic
=== RUN   TestAccDataSourceApplications_basic
=== PAUSE TestAccDataSourceApplications_basic
=== RUN   TestAccDataSourceChannels_basic
=== PAUSE TestAccDataSourceChannels_basic
=== RUN   TestAccDataSourceCustomAuthorizers_basic
=== PAUSE TestAccDataSourceCustomAuthorizers_basic
=== RUN   TestAccDataSourceEndpointConnections_basic
=== PAUSE TestAccDataSourceEndpointConnections_basic
=== RUN   TestAccDataSourceApigEnvironmentVariables_basic
=== PAUSE TestAccDataSourceApigEnvironmentVariables_basic
=== RUN   TestAccDataEnvironments_basic
=== PAUSE TestAccDataEnvironments_basic
=== RUN   TestAccGroupsDataSource_basic
=== PAUSE TestAccGroupsDataSource_basic
=== RUN   TestAccGroupsDataSource_filterById
=== PAUSE TestAccGroupsDataSource_filterById
=== RUN   TestAccDataSourceInstanceFeatures_basic
=== PAUSE TestAccDataSourceInstanceFeatures_basic
=== RUN   TestAccDataSourceInstanceSupportedFeatures_basic
=== PAUSE TestAccDataSourceInstanceSupportedFeatures_basic
=== RUN   TestAccDataSourceInstances_basic
=== PAUSE TestAccDataSourceInstances_basic
=== RUN   TestAccDataSourceSignatures_basic
=== PAUSE TestAccDataSourceSignatures_basic
=== RUN   TestAccDataSourceThrottlingPolicies_basic
=== PAUSE TestAccDataSourceThrottlingPolicies_basic
=== RUN   TestAccAclPolicyAssociate_basic
=== PAUSE TestAccAclPolicyAssociate_basic
=== RUN   TestAccAclPolicy_basic
=== PAUSE TestAccAclPolicy_basic
=== RUN   TestAccApiPublishment_basic
=== PAUSE TestAccApiPublishment_basic
=== RUN   TestAccApi_basic
=== PAUSE TestAccApi_basic
=== RUN   TestAccApi_functionGraph
=== PAUSE TestAccApi_functionGraph
=== RUN   TestAccAppcode_basic
=== PAUSE TestAccAppcode_basic
=== RUN   TestAccAppcode_manuallyConfig
=== PAUSE TestAccAppcode_manuallyConfig
=== RUN   TestAccApplicationAcl_basic
=== PAUSE TestAccApplicationAcl_basic
=== RUN   TestAccAppAuth_basic
=== PAUSE TestAccAppAuth_basic
=== RUN   TestAccApplicationQuotaAssociate_basic
=== PAUSE TestAccApplicationQuotaAssociate_basic
=== RUN   TestAccResourceAppQuota_basic
=== PAUSE TestAccResourceAppQuota_basic
=== RUN   TestAccApplication_basic
=== PAUSE TestAccApplication_basic
=== RUN   TestAccCertificate_basic
=== PAUSE TestAccCertificate_basic
=== RUN   TestAccCertificate_instance
=== PAUSE TestAccCertificate_instance
=== RUN   TestAccCertificate_instanceWithRootCA
=== PAUSE TestAccCertificate_instanceWithRootCA
=== RUN   TestAccChannel_basic
=== PAUSE TestAccChannel_basic
=== RUN   TestAccChannel_eipMembers
=== PAUSE TestAccChannel_eipMembers
=== RUN   TestAccCustomAuthorizer_basic
=== PAUSE TestAccCustomAuthorizer_basic
=== RUN   TestAccCustomAuthorizer_backend
=== PAUSE TestAccCustomAuthorizer_backend
=== RUN   TestAccEndpointConnectionManagement_basic
=== PAUSE TestAccEndpointConnectionManagement_basic
=== RUN   TestAccEndpointWhiteList_basic
=== PAUSE TestAccEndpointWhiteList_basic
=== RUN   TestAccEnvironment_basic
=== PAUSE TestAccEnvironment_basic
=== RUN   TestAccEnvironmentVariable_basic
=== PAUSE TestAccEnvironmentVariable_basic
=== RUN   TestAccGroup_basic
=== PAUSE TestAccGroup_basic
=== RUN   TestAccGroup_variables
=== PAUSE TestAccGroup_variables
=== RUN   TestAccGroup_urlDomains
=== PAUSE TestAccGroup_urlDomains
=== RUN   TestAccGroup_DomainAccessEnabled
=== PAUSE TestAccGroup_DomainAccessEnabled
=== RUN   TestAccInstanceFeature_basic
=== PAUSE TestAccInstanceFeature_basic
=== RUN   TestAccInstanceRoutes_basic
=== PAUSE TestAccInstanceRoutes_basic
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== RUN   TestAccInstance_egress
=== PAUSE TestAccInstance_egress
=== RUN   TestAccInstance_ingress
=== PAUSE TestAccInstance_ingress
=== RUN   TestAccPluginAssociate_basic
=== PAUSE TestAccPluginAssociate_basic
=== RUN   TestAccPlugin_basic
=== PAUSE TestAccPlugin_basic
=== RUN   TestAccPlugin_httpResponse
=== PAUSE TestAccPlugin_httpResponse
=== RUN   TestAccPlugin_rateLimit
=== PAUSE TestAccPlugin_rateLimit
=== RUN   TestAccPlugin_kafkaLog
=== PAUSE TestAccPlugin_kafkaLog
=== RUN   TestAccPlugin_breaker
=== PAUSE TestAccPlugin_breaker
=== RUN   TestAccResponse_basic
=== PAUSE TestAccResponse_basic
=== RUN   TestAccResponse_customRules
=== PAUSE TestAccResponse_customRules
=== RUN   TestAccSignatureAssociate_basic
=== PAUSE TestAccSignatureAssociate_basic
=== RUN   TestAccSignature_basic
=== PAUSE TestAccSignature_basic
=== RUN   TestAccSignature_hmac
=== PAUSE TestAccSignature_hmac
=== RUN   TestAccSignature_aes
=== PAUSE TestAccSignature_aes
=== RUN   TestAccThrottlingPolicyAssociate_basic
=== PAUSE TestAccThrottlingPolicyAssociate_basic
=== RUN   TestAccThrottlingPolicy_basic
=== PAUSE TestAccThrottlingPolicy_basic
=== RUN   TestAccThrottlingPolicy_spec
=== PAUSE TestAccThrottlingPolicy_spec
=== CONT  TestAccDataSourceAclPolicies_basic
=== CONT  TestAccCertificate_basic
=== CONT  TestAccGroupsDataSource_filterById
=== CONT  TestAccInstance_egress
--- PASS: TestAccCertificate_basic (30.63s)
=== CONT  TestAccThrottlingPolicy_spec
--- PASS: TestAccGroupsDataSource_filterById (553.50s)
=== CONT  TestAccThrottlingPolicy_basic
--- PASS: TestAccDataSourceAclPolicies_basic (635.83s)
=== CONT  TestAccThrottlingPolicyAssociate_basic
--- PASS: TestAccInstance_egress (660.55s)
=== CONT  TestAccSignature_aes
--- PASS: TestAccThrottlingPolicy_spec (667.82s)
=== CONT  TestAccSignature_hmac
--- PASS: TestAccThrottlingPolicy_basic (557.81s)
=== CONT  TestAccSignature_basic
--- PASS: TestAccSignature_aes (554.23s)
=== CONT  TestAccSignatureAssociate_basic
--- PASS: TestAccSignature_hmac (554.90s)
=== CONT  TestAccResponse_customRules
--- PASS: TestAccThrottlingPolicyAssociate_basic (672.45s)
=== CONT  TestAccResponse_basic
--- PASS: TestAccSignature_basic (562.23s)
=== CONT  TestAccPlugin_breaker
--- PASS: TestAccResponse_customRules (614.19s)
=== CONT  TestAccPlugin_kafkaLog
--- PASS: TestAccResponse_basic (569.65s)
=== CONT  TestAccDataSourceApplicationAcl_expectError
--- PASS: TestAccSignatureAssociate_basic (727.44s)
=== CONT  TestAccPlugin_rateLimit
--- PASS: TestAccPlugin_breaker (556.31s)
=== CONT  TestAccGroupsDataSource_basic
--- PASS: TestAccDataSourceApplicationAcl_expectError (480.89s)
=== CONT  TestAccDataEnvironments_basic
--- PASS: TestAccPlugin_rateLimit (544.35s)
=== CONT  TestAccPlugin_httpResponse
--- PASS: TestAccPlugin_kafkaLog (834.46s)
=== CONT  TestAccDataSourceApigEnvironmentVariables_basic
--- PASS: TestAccGroupsDataSource_basic (557.25s)
=== CONT  TestAccDataSourceEndpointConnections_basic
--- PASS: TestAccDataEnvironments_basic (523.28s)
=== CONT  TestAccPlugin_basic
--- PASS: TestAccPlugin_httpResponse (532.32s)
=== CONT  TestAccDataSourceCustomAuthorizers_basic
--- PASS: TestAccDataSourceApigEnvironmentVariables_basic (541.40s)
=== CONT  TestAccPluginAssociate_basic
--- PASS: TestAccDataSourceEndpointConnections_basic (580.46s)
=== CONT  TestAccDataSourceChannels_basic
--- PASS: TestAccPlugin_basic (556.66s)
=== CONT  TestAccInstance_ingress
--- PASS: TestAccDataSourceCustomAuthorizers_basic (553.07s)
=== CONT  TestAccDataSourceApplications_basic
--- PASS: TestAccDataSourceChannels_basic (554.55s)
=== CONT  TestAccDataSourceApplicationQuotas_basic
--- PASS: TestAccDataSourceApplications_basic (544.35s)
=== CONT  TestAccApi_basic
--- PASS: TestAccInstance_ingress (726.72s)
=== CONT  TestAccApplication_basic
--- PASS: TestAccPluginAssociate_basic (1011.47s)
=== CONT  TestAccResourceAppQuota_basic
--- PASS: TestAccDataSourceApplicationQuotas_basic (511.75s)
=== CONT  TestAccDataSourceApiAssociatedThrottlingPolicies_basic
--- PASS: TestAccApplication_basic (542.75s)
=== CONT  TestAccApplicationQuotaAssociate_basic
--- PASS: TestAccApi_basic (637.50s)
=== CONT  TestAccDataSourceApplicationAcl_basic
--- PASS: TestAccResourceAppQuota_basic (520.26s)
=== CONT  TestAccAppAuth_basic
--- PASS: TestAccDataSourceApiAssociatedThrottlingPolicies_basic (638.12s)
=== CONT  TestAccApplicationAcl_basic
--- PASS: TestAccDataSourceApplicationAcl_basic (542.82s)
=== CONT  TestAccDataSourceAppcodes_basic
--- PASS: TestAccApplicationQuotaAssociate_basic (597.93s)
=== CONT  TestAccAppcode_manuallyConfig
--- PASS: TestAccAppAuth_basic (671.21s)
=== CONT  TestAccAppcode_basic
--- PASS: TestAccApplicationAcl_basic (624.31s)
=== CONT  TestAccDataSourceApiBasicConfigurations_basic
--- PASS: TestAccAppcode_manuallyConfig (541.63s)
=== CONT  TestAccApi_functionGraph
--- PASS: TestAccDataSourceAppcodes_basic (554.74s)
=== CONT  TestAccDataSourceInstances_basic
--- PASS: TestAccAppcode_basic (510.99s)
=== CONT  TestAccAclPolicy_basic
--- PASS: TestAccDataSourceApiBasicConfigurations_basic (625.61s)
=== CONT  TestAccDataSourceSignatures_basic
--- PASS: TestAccDataSourceInstances_basic (541.05s)
=== CONT  TestAccApiPublishment_basic
--- PASS: TestAccApi_functionGraph (545.33s)
=== CONT  TestAccAclPolicyAssociate_basic
--- PASS: TestAccAclPolicy_basic (530.39s)
=== CONT  TestAccEnvironment_basic
--- PASS: TestAccDataSourceSignatures_basic (512.85s)
=== CONT  TestAccCustomAuthorizer_basic
--- PASS: TestAccApiPublishment_basic (611.33s)
=== CONT  TestAccInstance_basic
--- PASS: TestAccEnvironment_basic (544.26s)
=== CONT  TestAccEndpointWhiteList_basic
--- PASS: TestAccAclPolicyAssociate_basic (680.70s)
=== CONT  TestAccInstanceRoutes_basic
--- PASS: TestAccCustomAuthorizer_basic (568.31s)
=== CONT  TestAccInstanceFeature_basic
--- PASS: TestAccInstance_basic (564.88s)
=== CONT  TestAccEndpointConnectionManagement_basic
--- PASS: TestAccEndpointWhiteList_basic (556.81s)
=== CONT  TestAccGroup_DomainAccessEnabled
--- PASS: TestAccInstanceRoutes_basic (553.60s)
=== CONT  TestAccCustomAuthorizer_backend
--- PASS: TestAccInstanceFeature_basic (528.04s)
=== CONT  TestAccGroup_urlDomains
--- PASS: TestAccGroup_DomainAccessEnabled (517.07s)
=== CONT  TestAccDataSourceThrottlingPolicies_basic
--- PASS: TestAccEndpointConnectionManagement_basic (583.90s)
=== CONT  TestAccDataSourceApiAssociatedPlugins_basic
--- PASS: TestAccCustomAuthorizer_backend (542.85s)
=== CONT  TestAccGroup_variables
--- PASS: TestAccGroup_urlDomains (566.48s)
=== CONT  TestAccGroup_basic
--- PASS: TestAccDataSourceThrottlingPolicies_basic (637.40s)
=== CONT  TestAccEnvironmentVariable_basic
--- PASS: TestAccDataSourceApiAssociatedPlugins_basic (636.21s)
=== CONT  TestAccDataSourceApiAssociatedSignatures_basic
--- PASS: TestAccGroup_variables (631.57s)
=== CONT  TestAccDataSourceApiAssociatedApplications_basic
--- PASS: TestAccGroup_basic (552.48s)
=== CONT  TestAccChannel_basic
--- PASS: TestAccEnvironmentVariable_basic (575.68s)
=== CONT  TestAccDataSourceInstanceFeatures_basic
--- PASS: TestAccDataSourceApiAssociatedSignatures_basic (634.40s)
=== CONT  TestAccChannel_eipMembers
--- PASS: TestAccDataSourceApiAssociatedApplications_basic (649.61s)
=== CONT  TestAccDataSourceApiAssociatedAclPolicies_basic
--- PASS: TestAccChannel_basic (629.37s)
=== CONT  TestAccCertificate_instanceWithRootCA
--- PASS: TestAccDataSourceInstanceFeatures_basic (513.40s)
=== CONT  TestAccCertificate_instance
--- PASS: TestAccChannel_eipMembers (547.63s)
=== CONT  TestAccDataSourceInstanceSupportedFeatures_basic
--- PASS: TestAccDataSourceApiAssociatedAclPolicies_basic (635.34s)
--- PASS: TestAccCertificate_instanceWithRootCA (530.41s)
--- PASS: TestAccCertificate_instance (526.45s)
--- PASS: TestAccDataSourceInstanceSupportedFeatures_basic (514.50s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      10485.293s
```
