### PR TITLE
fix(apig/group): fix update domain name access logic

### DIFF
--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
@@ -258,7 +258,8 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	// The API will not report an error if it is called repeatedly.
 	err = updateDomianAccessEnabled(client, instanceId, groupId, d.Get("domain_access_enabled").(bool))
 	if err != nil {
-		return diag.FromErr(err)
+		// This feature is not available in some region, so use log.Printf to record the error.
+		log.Printf("[ERROR] Update debugging domain name access status failed: %s", err)
 	}
 
 	return resourceGroupRead(ctx, d, meta)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Because the debugging domain name access feature is not available in some region, forcibly calling the interface will block normal business, so the logic was modified to use `log.Printf` to record log errors.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccGroup_DomainAccessEnabled'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccGroup_DomainAccessEnabled -timeout 360m -parallel 4
=== RUN   TestAccGroup_DomainAccessEnabled
=== PAUSE TestAccGroup_DomainAccessEnabled
=== CONT  TestAccGroup_DomainAccessEnabled
--- PASS: TestAccGroup_DomainAccessEnabled (575.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      575.208s

make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccDataSourceApiBasicConfigurations_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccDataSourceApiBasicConfigurations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceApiBasicConfigurations_basic
=== PAUSE TestAccDataSourceApiBasicConfigurations_basic
=== CONT  TestAccDataSourceApiBasicConfigurations_basic
--- PASS: TestAccDataSourceApiBasicConfigurations_basic (748.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      748.898s
```
