### PR TITLE
feat(cbh/asset_agency_authorization): support asset agency authorization resource

### DIFF
--- a/docs/resources/cbh_asset_agency_authorization.md
+++ b/docs/resources/cbh_asset_agency_authorization.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Cloud Bastion Host (CBH)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cbh_asset_agency_authorization"
+description: |-
+  Manages a CBH asset agency authorization resource within HuaweiCloud.
+---
+
+# huaweicloud_cbh_asset_agency_authorization
+
+Manages a CBH asset agency authorization resource within HuaweiCloud.
+
+-> After you enable CSMS credentials and KMS key agency authorization, you need to wait about `10` minutes, the CBH
+instance can obtain a token with agency permissions. Destroying resources will not change the current asset
+agency authorization status.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_cbh_asset_agency_authorization" "test" {
+  csms = true
+  kms  = true
+} 
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CBH asset agency authorization.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `csms` - (Required, Bool) Specifies whether to enable CSMS credential agency authorization. The value can be **true**
+  or **false**.  
+  If set to **true** to enable agency authorization, the CBH service will have the permission to query your CSMS
+  credential list. You can select credentials as resource accounts on the CBH instance.
+
+* `kms` - (Required, Bool) Specifies whether to enable KMS key agency authorization. The value can be **true** or
+  **false**.  
+  If set to **true** to enable agency authorization, the CBH service will have the permission to use the KMS interface
+  to obtain the CSMS credential value. You can use this credential value to log in to the managed host on the CBH
+  instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1040,8 +1040,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_cbr_policy":                cbr.ResourcePolicy(),
 			"huaweicloud_cbr_vault":                 cbr.ResourceVault(),
 
-			"huaweicloud_cbh_instance":    cbh.ResourceCBHInstance(),
-			"huaweicloud_cbh_ha_instance": cbh.ResourceCBHHAInstance(),
+			"huaweicloud_cbh_instance":                   cbh.ResourceCBHInstance(),
+			"huaweicloud_cbh_ha_instance":                cbh.ResourceCBHHAInstance(),
+			"huaweicloud_cbh_asset_agency_authorization": cbh.ResourceAssetAgencyAuthorization(),
 
 			"huaweicloud_cc_connection":                                     cc.ResourceCloudConnection(),
 			"huaweicloud_cc_network_instance":                               cc.ResourceNetworkInstance(),

--- a/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_asset_agency_authorization_test.go
+++ b/huaweicloud/services/acceptance/cbh/resource_huaweicloud_cbh_asset_agency_authorization_test.go
@@ -1,0 +1,107 @@
+package cbh
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAssetAgencyAuthorizationResourceFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	var (
+		region  = acceptance.HW_REGION_NAME
+		product = "cbh"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CBH client: %s", err)
+	}
+
+	basePath := client.Endpoint + "v2/{project_id}/cbs/agency/authorization"
+	basePath = strings.ReplaceAll(basePath, "{project_id}", client.ProjectID)
+	baseOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", basePath, &baseOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving CBH asset agency authorization: %s", err)
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccAssetAgencyAuthorization_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_cbh_asset_agency_authorization.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAssetAgencyAuthorizationResourceFunc,
+	)
+
+	// Avoid CheckDestroy, because there is nothing in the resource destroy method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAssetAgencyAuthorization_basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "csms", "true"),
+					resource.TestCheckResourceAttr(rName, "kms", "true"),
+				),
+			},
+			{
+				Config: testAccAssetAgencyAuthorization_update1,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "csms", "true"),
+					resource.TestCheckResourceAttr(rName, "kms", "false")),
+			},
+			{
+				Config: testAccAssetAgencyAuthorization_update2,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "csms", "false"),
+					resource.TestCheckResourceAttr(rName, "kms", "false")),
+			},
+		},
+	})
+}
+
+const testAccAssetAgencyAuthorization_basic = `
+resource "huaweicloud_cbh_asset_agency_authorization" "test" {
+  csms = true
+  kms  = true
+}
+`
+
+const testAccAssetAgencyAuthorization_update1 = `
+resource "huaweicloud_cbh_asset_agency_authorization" "test" {
+  csms = true
+  kms  = false
+}
+`
+
+const testAccAssetAgencyAuthorization_update2 = `
+resource "huaweicloud_cbh_asset_agency_authorization" "test" {
+  csms = false
+  kms  = false
+}
+`

--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_asset_agency_authorization.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_asset_agency_authorization.go
@@ -1,0 +1,152 @@
+package cbh
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CBH POST /v2/{project_id}/cbs/agency/authorization
+// @API CBH GET /v2/{project_id}/cbs/agency/authorization
+func ResourceAssetAgencyAuthorization() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAssetAgencyAuthorizationCreate,
+		UpdateContext: resourceAssetAgencyAuthorizationUpdate,
+		ReadContext:   resourceAssetAgencyAuthorizationRead,
+		DeleteContext: resourceAssetAgencyAuthorizationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"csms": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"kms": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+		},
+	}
+}
+
+func assetAgencyAuthorizationOperation(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	basePath := client.Endpoint + "v2/{project_id}/cbs/agency/authorization"
+	basePath = strings.ReplaceAll(basePath, "{project_id}", client.ProjectID)
+	baseOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	baseOpt.JSONBody = map[string]interface{}{
+		"authorization": map[string]interface{}{
+			"csms": d.Get("csms").(bool),
+			"kms":  d.Get("kms").(bool),
+		},
+	}
+
+	_, err := client.Request("POST", basePath, &baseOpt)
+
+	return err
+}
+
+func resourceAssetAgencyAuthorizationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cbh"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	err = assetAgencyAuthorizationOperation(client, d)
+	if err != nil {
+		return diag.Errorf("error creating CBH asset agency authorization: %s", err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(id)
+
+	return resourceAssetAgencyAuthorizationRead(ctx, d, meta)
+}
+
+func resourceAssetAgencyAuthorizationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cbh"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	basePath := client.Endpoint + "v2/{project_id}/cbs/agency/authorization"
+	basePath = strings.ReplaceAll(basePath, "{project_id}", client.ProjectID)
+	baseOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", basePath, &baseOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving CBH asset agency authorization: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("csms", utils.PathSearch("authorization.csms", getRespBody, false)),
+		d.Set("kms", utils.PathSearch("authorization.kms", getRespBody, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceAssetAgencyAuthorizationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "cbh"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CBH client: %s", err)
+	}
+
+	err = assetAgencyAuthorizationOperation(client, d)
+	if err != nil {
+		return diag.Errorf("error updating CBH asset agency authorization: %s", err)
+	}
+
+	return resourceAssetAgencyAuthorizationRead(ctx, d, meta)
+}
+
+func resourceAssetAgencyAuthorizationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support asset agency authorization resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
Support asset agency authorization resource
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccAssetAgencyAuthorization_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccAssetAgencyAuthorization_basic -timeout 360m -parallel 4
=== RUN   TestAccAssetAgencyAuthorization_basic
=== PAUSE TestAccAssetAgencyAuthorization_basic
=== CONT  TestAccAssetAgencyAuthorization_basic
--- PASS: TestAccAssetAgencyAuthorization_basic (21.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       21.613s


```
