### PR TITLE
feat(dns/zone): the public zone supports modifying status

### DIFF
--- a/docs/resources/dns_zone.md
+++ b/docs/resources/dns_zone.md
@@ -66,6 +66,13 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the zone. Changing this creates a
   new zone.
 
+* `status` - (Optional, String) Specifies the status of the zone.  
+  The valid values are as follows:
+  + **ENABLE**
+  + **DISABLE**
+
+  -> This parameter is only supported by the public zone, and it is a one-time action.
+
 The `router` block supports:
 
 * `router_id` - (Required, String) ID of the associated VPC.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240612024006-fff9ea1aeb14
+	github.com/chnsz/golangsdk v0.0.0-20240613025804-cb6baaa08a61
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240612024006-fff9ea1aeb14 h1:dimpWURK5Xv3ahc1QdyKv2MP0J/eZbpFYeW5p+Cjwdk=
-github.com/chnsz/golangsdk v0.0.0-20240612024006-fff9ea1aeb14/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240613025804-cb6baaa08a61 h1:HgOc8ilof4Fmt0/yxAENP/sAbh++GGCWe0F7/e4Oito=
+github.com/chnsz/golangsdk v0.0.0-20240613025804-cb6baaa08a61/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_zone_test.go
@@ -55,6 +55,7 @@ func TestAccDNSZone_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.zone_type", "public"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttrSet(resourceName, "email"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DISABLE"),
 				),
 			},
 			{
@@ -70,6 +71,7 @@ func TestAccDNSZone_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.zone_type", "public"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc"),
 					resource.TestCheckResourceAttrSet(resourceName, "email"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ENABLE"),
 				),
 			},
 		},
@@ -171,6 +173,7 @@ resource "huaweicloud_dns_zone" "zone_1" {
   name        = "%s"
   description = "a zone"
   ttl         = 300
+  status      = "DISABLE"
 
   tags = {
     zone_type = "public"
@@ -186,6 +189,7 @@ resource "huaweicloud_dns_zone" "zone_1" {
   name        = "%s"
   description = "an updated zone"
   ttl         = 600
+  status      = "ENABLE"
 
   tags = {
     zone_type = "public"

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/zones/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/zones/requests.go
@@ -221,3 +221,25 @@ func DisassociateZone(client *golangsdk.ServiceClient, zoneID string, opts Route
 	_, r.Err = client.Post(disassociateURL(client, zoneID), b, nil, nil)
 	return
 }
+
+// UpdateStatusOpts is a struct that is used as parameter of the UpdateZoneStatus method.
+type UpdateStatusOpts struct {
+	// The ID of the public zone.
+	ZoneId string `json:"-" required:"true"`
+	// The status of the public zone.
+	// The valid values are as follows:
+	// + ENABLE
+	// + DISABLE
+	Status string `json:"status" required:"true"`
+}
+
+// UpdateZoneStatus is a method to set status of the public zone using given parameters.
+func UpdateZoneStatus(c *golangsdk.ServiceClient, opts UpdateStatusOpts) error {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+	var r UpdateStatusOpts
+	_, err = c.Put(setStatusURL(c, opts.ZoneId), b, &r, nil)
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/zones/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dns/v2/zones/urls.go
@@ -17,3 +17,7 @@ func associateURL(client *golangsdk.ServiceClient, zoneID string) string {
 func disassociateURL(client *golangsdk.ServiceClient, zoneID string) string {
 	return client.ServiceURL("zones", zoneID, "disassociaterouter")
 }
+
+func setStatusURL(client *golangsdk.ServiceClient, zoneId string) string {
+	return client.ServiceURL("zones", zoneId, "statuses")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240612024006-fff9ea1aeb14
+# github.com/chnsz/golangsdk v0.0.0-20240613025804-cb6baaa08a61
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 The public zone supports modifying status.

The endpoint of client is https://dns.myhuaweicloud.com/ instead of https://dns.{region}.myhuaweicloud.com/. 
If the latter is used, some areas will report errors, such as `la-north-2`.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/9d6510d4-5c56-4fe0-a7fa-25fc978fedb1)



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dns TESTARGS='-run TestAccDNSZone_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDNSZone_basic -timeout 360m -parallel 4
=== RUN   TestAccDNSZone_basic
=== PAUSE TestAccDNSZone_basic
=== CONT  TestAccDNSZone_basic
--- PASS: TestAccDNSZone_basic (47.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       47.371s```
