### PR TITLE
feat(dataarts): add new data source to query apis

### DIFF
--- a/docs/data-sources/dataarts_dataservice_apis.md
+++ b/docs/data-sources/dataarts_dataservice_apis.md
@@ -1,0 +1,237 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_apis"
+description: |-
+  Use this data source to get the list of Data Service APIs within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_apis
+
+Use this data source to get the list of Data Service APIs within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "api_name_to_be_queried" {}
+
+data "huaweicloud_dataarts_dataservice_apis" "test" {
+  workspace_id = var.workspace_id
+  name         = var.api_name_to_be_queried
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of workspace where the APIs are located.
+
+* `dlm_type` - (Optional, String) Specifies the type of DLM engine.  
+  The valid values are as follows:
+  + **SHARED**: Shared data service.
+  + **EXCLUSIVE**: The exclusive data service.
+
+  Defaults to **SHARED**.
+
+* `api_id` - (Optional, String) Specifies the API ID to be queried.
+
+* `name` - (Optional, String) Specifies the API name to be fuzzy queried.  
+  The valid length is limited from `3` to `64`, only Chinese and English characters, digits and underscores (_) are
+  allowed.  
+  The name must start with a Chinese or English character, and the Chinese characters must be in **UTF-8**
+  or **Unicode** format.
+
+* `type` - (Optional, String) Specifies the API type to be queried.  
+  The valid values are as follows:
+  + **API_SPECIFIC_TYPE_CONFIGURATION**
+  + **API_SPECIFIC_TYPE_REGISTER**
+  + **API_SPECIFIC_TYPE_ORCHESTRATE**
+  + **API_SPECIFIC_TYPE_MYBATIS**
+  + **API_SPECIFIC_TYPE_SCRIPT**
+  + **API_SPECIFIC_TYPE_GROOVY**
+
+* `description` - (Optional, String) Specifies the API description to be fuzzy queried.  
+  Maximum of `255` characters are allowed.
+
+* `create_user` - (Optional, String) Specifies the API creator to be queried.
+
+* `datatable` - (Optional, String) Specifies the data table name used by API to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `apis` - All APIs that match the filter parameters.  
+  The [apis](#dataservice_apis_elem) structure is documented below.
+
+<a name="dataservice_apis_elem"></a>
+The `apis` block supports:
+
+* `id` - The API ID, in UUID format.
+
+* `name` - The name of the API.
+
+* `type` - The API type.
+
+* `description` - The description of the API.
+
+* `protocol` - The request protocol of the API.
+
+* `path` - The API request path.
+
+* `request_type` - The request type of the API.
+
+* `manager` - The API reviewer.
+
+* `datasource_config` - The configuration of the API data source.  
+  The [datasource_config](#dataservice_api_datasource_config_attr) structure is documented below.
+
+* `request_params` - The parameters of the API request.  
+  The [request_params](#dataservice_api_request_params_attr) structure is documented below.
+
+* `backend_config` - The configuration of the API backend.  
+  The [backend_config](#dataservice_api_backend_config_attr) structure is documented below.
+
+* `create_user` - The creator name.
+
+* `created_at` - The creation time of the API, in RFC3339 format.
+
+* `updated_at` - The latest update time of the API, in RFC3339 format.
+
+* `group_id` - The ID of the group to which the API belongs, for shared type.
+
+* `status` - The API status, for shared type.
+
+* `host` - The API host configuration, for shared type.
+
+* `hosts` - The API host configuration, for exclusive type.
+
+<a name="dataservice_api_datasource_config_attr"></a>
+The `datasource_config` block supports:
+
+* `type` - The type of the data source.
+
+* `connection_name` - The name of the data connection for the DataArts Studio service.
+
+* `connection_id` - The ID of the data connection for the DataArts Studio service.
+
+* `database` - The name of the database.
+
+* `datatable` - The name of the data table.
+
+* `table_id` - The ID of the data table.
+
+* `queue` - The ID of the DLI queue.
+
+* `access_mode` - The access mode for the data.
+
+* `sql` - The SQL statements in script access type.
+
+* `backend_params` - The backend parameters of the API.  
+  The [backend_params](#dataservice_api_datasource_config_backend_params) structure is documented below.
+
+* `response_params` - The response parameters of the API.  
+  The [response_params](#dataservice_api_datasource_config_response_params) structure is documented below.
+
+* `order_params` - The order parameters of the API.  
+  The [order_params](#dataservice_api_datasource_config_order_params) structure is documented below.
+
+<a name="dataservice_api_datasource_config_backend_params"></a>
+The `backend_params` block supports:
+
+* `name` - The name of the backend parameter.
+
+* `mapping` - The name of the mapping parameter.
+
+* `condition` - The condition character.
+
+<a name="dataservice_api_datasource_config_response_params"></a>
+The `response_params` block supports:
+
+* `name` - The name of the response parameter.
+
+* `type` - The type of the response parameter.
+
+* `field` - The bound table field for the response parameter.
+
+* `description` - The description of the response parameter.
+
+* `example_value` - The example value of the response parameter.
+
+<a name="dataservice_api_datasource_config_order_params"></a>
+The `order_params` block supports:
+
+* `name` - The name of the order parameter.
+
+* `field` - The corresponding parameter field for the order parameter.
+
+* `optional` - Whether this order parameter is the optional parameter.
+
+* `sort` - The sort type of the order parameter.
+
+* `order` - The order of the sorting parameters.
+
+<a name="dataservice_api_request_params_attr"></a>
+The `request_params` block supports:
+
+* `name` - The name of the request parameter.
+
+* `position` - The position of the request parameter.
+
+* `type` - The type of the request parameter.
+
+* `description` - The description of the request parameter.
+
+* `necessary` - Whether this parameter is the required parameter.
+
+* `example_value` - The example value of the request parameter.
+
+* `default_value` - The default value of the request parameter.
+
+<a name="dataservice_api_backend_config_attr"></a>
+The `backend_config` block supports:
+
+* `type` - The type of the backend request.
+
+* `protocol` - The protocol of the backend request.
+
+* `host` - The backend host.
+
+* `timeout` - The backend timeout.
+
+* `path` - The backend path.
+
+* `backend_params` - The backend parameters of the API.  
+  The [backend_params](#dataservice_api_backend_config_attr_backend_params) structure is documented below.
+
+* `constant_params` - The backend constant parameters of the API.  
+  The [constant_params](#dataservice_api_backend_config_attr_constant_params) structure is documented below.
+
+<a name="dataservice_api_backend_config_attr_backend_params"></a>
+The `backend_params` block supports:
+
+* `name` - The name of the request parameter.
+
+* `position` - The position of the request parameter.
+
+* `backend_param_name` - The name of the corresponding backend parameter.
+
+<a name="dataservice_api_backend_config_attr_constant_params"></a>
+The `constant_params` block supports:
+
+* `name` - The name of the constant parameter.
+
+* `type` - The type of the constant parameter.
+
+* `position` - The position of the constant parameter.
+
+* `value` - The value of the constant parameter.
+
+* `description` - The description of the constant parameter.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -541,6 +541,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_ds_template_optionals": dataarts.DataSourceTemplateOptionalFields(),
 			"huaweicloud_dataarts_studio_data_connections":            dataarts.DataSourceDataConnections(),
 			"huaweicloud_dataarts_studio_workspaces":                  dataarts.DataSourceDataArtsStudioWorkspaces(),
+			// DataArts DataService
+			"huaweicloud_dataarts_dataservice_apis": dataarts.DataSourceDataServiceApis(),
 
 			"huaweicloud_dbss_flavors": dbss.DataSourceDbssFlavors(),
 

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_apis_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_apis_test.go
@@ -1,0 +1,365 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDataServiceApis_basic(t *testing.T) {
+	var (
+		rName = "data.huaweicloud_dataarts_dataservice_apis.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+
+		byId   = "data.huaweicloud_dataarts_dataservice_apis.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byName   = "data.huaweicloud_dataarts_dataservice_apis.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNameNotFound   = "data.huaweicloud_dataarts_dataservice_apis.filter_by_name_not_found"
+		dcByNameNotFound = acceptance.InitDataSourceCheck(byNameNotFound)
+
+		byDesc   = "data.huaweicloud_dataarts_dataservice_apis.filter_by_desc"
+		dcByDesc = acceptance.InitDataSourceCheck(byDesc)
+
+		byCreator   = "data.huaweicloud_dataarts_dataservice_apis.filter_by_creator"
+		dcByCreator = acceptance.InitDataSourceCheck(byCreator)
+
+		byType   = "data.huaweicloud_dataarts_dataservice_apis.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byTableName   = "data.huaweicloud_dataarts_dataservice_apis.filter_by_datatable"
+		dcByTableName = acceptance.InitDataSourceCheck(byTableName)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsManagerName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDataServiceApis_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "apis.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcById.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byId, "apis.#", "1"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.id", "huaweicloud_dataarts_dataservice_api.test", "id"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.name", "huaweicloud_dataarts_dataservice_api.test", "name"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.type", "huaweicloud_dataarts_dataservice_api.test", "type"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.description", "huaweicloud_dataarts_dataservice_api.test", "description"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.protocol", "huaweicloud_dataarts_dataservice_api.test", "protocol"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.request_type", "huaweicloud_dataarts_dataservice_api.test", "request_type"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.manager", "huaweicloud_dataarts_dataservice_api.test", "manager"),
+					resource.TestCheckResourceAttr(byId, "apis.0.datasource_config.#", "1"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.datasource_config.0.type",
+						"huaweicloud_dataarts_dataservice_api.test", "datasource_config.0.type"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.datasource_config.0.connection_id",
+						"huaweicloud_dataarts_studio_data_connection.test", "id"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.datasource_config.0.database", "huaweicloud_dli_database.test", "name"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.datasource_config.0.datatable", "huaweicloud_dli_table.test", "name"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.datasource_config.0.queue", "huaweicloud_dli_queue.test", "name"),
+					resource.TestCheckResourceAttr(byId, "apis.0.datasource_config.0.response_params.#", "1"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.datasource_config.0.response_params.0.name",
+						"huaweicloud_dataarts_dataservice_api.test", "datasource_config.0.response_params.0.name"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.datasource_config.0.response_params.0.type",
+						"huaweicloud_dataarts_dataservice_api.test", "datasource_config.0.response_params.0.type"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.datasource_config.0.response_params.0.field",
+						"huaweicloud_dataarts_dataservice_api.test", "datasource_config.0.response_params.0.field"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.datasource_config.0.response_params.0.description",
+						"huaweicloud_dataarts_dataservice_api.test", "datasource_config.0.response_params.0.description"),
+					resource.TestCheckResourceAttr(byId, "apis.0.request_params.#", "1"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.request_params.0.name",
+						"huaweicloud_dataarts_dataservice_api.test", "request_params.0.name"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.request_params.0.position",
+						"huaweicloud_dataarts_dataservice_api.test", "request_params.0.position"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.request_params.0.type",
+						"huaweicloud_dataarts_dataservice_api.test", "request_params.0.type"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.request_params.0.description",
+						"huaweicloud_dataarts_dataservice_api.test", "request_params.0.description"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.request_params.0.necessary",
+						"huaweicloud_dataarts_dataservice_api.test", "request_params.0.necessary"),
+					resource.TestCheckResourceAttrPair(byId, "apis.0.request_params.0.example_value",
+						"huaweicloud_dataarts_dataservice_api.test", "request_params.0.example_value"),
+					resource.TestCheckResourceAttrSet(byId, "apis.0.create_user"),
+					resource.TestMatchResourceAttr(rName, "apis.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByNameNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_not_found_filter_useful", "true"),
+					dcByDesc.CheckResourceExists(),
+					resource.TestCheckOutput("is_desc_filter_useful", "true"),
+					dcByCreator.CheckResourceExists(),
+					resource.TestCheckOutput("is_creator_filter_useful", "true"),
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					dcByTableName.CheckResourceExists(),
+					resource.TestCheckOutput("is_datatable_filter_useful", "true"),
+					waitForDeletionCooldownComplete(),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDataServiceApis_base() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_studio_data_connection" "test" {
+  workspace_id = "%[1]s"
+  type         = "DLI"
+  env_type     = "0"
+  name         = "%[2]s"
+  config       = jsonencode({
+    "cdm_property_enable": "false"
+  })
+}
+
+resource "huaweicloud_dli_database" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_dli_table" "test" {
+  database_name = huaweicloud_dli_database.test.name
+  name          = "%[2]s_resource_vpc"
+  data_location = "DLI"
+
+  columns {
+    name        = "resource_id"
+    type        = "string"
+    description = "The resource ID, in UUID format"
+  }
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[2]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_dli_elastic_resource_pool" "test" {
+  name                  = "%[2]s"
+  min_cu                = 64
+  max_cu                = 64
+  cidr                  = cidrsubnet(huaweicloud_vpc.test.cidr, 3, 1)
+  enterprise_project_id = "0"
+}
+
+resource "huaweicloud_dli_queue" "test" {
+  elastic_resource_pool_name = huaweicloud_dli_elastic_resource_pool.test.name
+  resource_mode              = 1
+
+  # basic configuration
+  name     = "%[2]s"
+  cu_count = 16
+}
+
+// Under root path.
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+}
+
+resource "huaweicloud_dataarts_dataservice_api" "test" {
+  workspace_id = "%[1]s"
+  type         = "API_SPECIFIC_TYPE_CONFIGURATION"
+  catalog_id   = huaweicloud_dataarts_dataservice_catalog.test.id
+  name         = "%[2]s"
+  description  = "Created by terraform script"
+  auth_type    = "NONE"
+  manager      = "%[3]s"
+  path         = "/terraform/auto/resource_query/{resource_type}"
+  protocol     = "PROTOCOL_TYPE_HTTP"
+  request_type = "REQUEST_TYPE_GET"
+  visibility   = "PROJECT"
+
+  request_params {
+    name          = "resource_type"
+    position      = "REQUEST_PARAMETER_POSITION_PATH"
+    type          = "REQUEST_PARAMETER_TYPE_STRING"
+    description   = "The type of the terraform resource to be queried"
+    necessary     = true
+    example_value = "demo"
+  }
+
+  datasource_config {
+    type          = "DLI"
+    connection_id = huaweicloud_dataarts_studio_data_connection.test.id
+    database      = huaweicloud_dli_database.test.name
+    datatable     = huaweicloud_dli_table.test.name
+    queue         = huaweicloud_dli_queue.test.name
+
+    response_params {
+      name        = "resource_id"
+      type        = "REQUEST_PARAMETER_TYPE_STRING"
+      field       = "resource_id"
+      description = "The resource ID, in UUID format"
+    }
+  }
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name, acceptance.HW_DATAARTS_MANAGER_NAME)
+}
+
+func testAccDataSourceDataServiceApis_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dataarts_dataservice_apis" "test" {
+  depends_on = [
+    huaweicloud_dataarts_dataservice_api.test
+  ]
+
+  workspace_id = "%[2]s"
+}
+
+# Filter by ID
+locals {
+  api_id = data.huaweicloud_dataarts_dataservice_apis.test.apis[0].id
+}
+
+data "huaweicloud_dataarts_dataservice_apis" "filter_by_id" {
+  workspace_id = "%[2]s"
+  api_id       = local.api_id
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_dataarts_dataservice_apis.filter_by_id.apis[*].id : v == local.api_id
+  ]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+}
+
+# Filter by name
+locals {
+  name = data.huaweicloud_dataarts_dataservice_apis.test.apis[0].name
+}
+
+data "huaweicloud_dataarts_dataservice_apis" "filter_by_name" {
+  workspace_id = "%[2]s"
+  name         = local.name # Fuzzy search 
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_dataservice_apis.filter_by_name.apis[*].name : v == local.name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by name (not found)
+locals {
+  not_found_name = "not_found"
+}
+
+data "huaweicloud_dataarts_dataservice_apis" "filter_by_name_not_found" {
+  workspace_id = "%[2]s"
+  name         = local.not_found_name # This name is not exist 
+}
+
+locals {
+  name_not_found_filter_result = [
+    for v in data.huaweicloud_dataarts_dataservice_apis.filter_by_name_not_found.apis[*].name : strcontains(v, local.not_found_name)
+  ]
+}
+
+output "is_name_not_found_filter_useful" {
+  value = length(local.name_not_found_filter_result) == 0
+}
+
+# Filter by description
+locals {
+  description = data.huaweicloud_dataarts_dataservice_apis.test.apis[0].description
+}
+
+data "huaweicloud_dataarts_dataservice_apis" "filter_by_desc" {
+  workspace_id = "%[2]s"
+  description  = local.description # Fuzzy search 
+}
+
+locals {
+  desc_filter_result = [
+    for v in data.huaweicloud_dataarts_dataservice_apis.filter_by_desc.apis[*].description : strcontains(v, local.description)
+  ]
+}
+
+output "is_desc_filter_useful" {
+  value = length(local.desc_filter_result) > 0 && alltrue(local.desc_filter_result)
+}
+
+# Filter by create user
+locals {
+  create_user = data.huaweicloud_dataarts_dataservice_apis.test.apis[0].create_user
+}
+
+data "huaweicloud_dataarts_dataservice_apis" "filter_by_creator" {
+  workspace_id = "%[2]s"
+  create_user  = local.create_user
+}
+
+locals {
+  creator_filter_result = [
+    for v in data.huaweicloud_dataarts_dataservice_apis.filter_by_desc.apis[*].create_user : v == local.create_user
+  ]
+}
+
+output "is_creator_filter_useful" {
+  value = length(local.creator_filter_result) > 0 && alltrue(local.creator_filter_result)
+}
+
+# Filter by type
+locals {
+  type = data.huaweicloud_dataarts_dataservice_apis.test.apis[0].type
+}
+
+data "huaweicloud_dataarts_dataservice_apis" "filter_by_type" {
+  workspace_id = "%[2]s"
+  type         = local.type
+}
+
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_dataarts_dataservice_apis.filter_by_type.apis[*].type : v == local.type
+  ]
+}
+
+output "is_type_filter_useful" {
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
+}
+
+# Filter by datatable
+locals {
+  datatable = data.huaweicloud_dataarts_dataservice_apis.test.apis[0].datasource_config[0].datatable
+}
+
+data "huaweicloud_dataarts_dataservice_apis" "filter_by_datatable" {
+  workspace_id = "%[2]s"
+  datatable    = local.datatable
+}
+
+locals {
+  datatable_filter_result = [
+    for v in data.huaweicloud_dataarts_dataservice_apis.filter_by_type.apis : v.datasource_config[0].datatable == local.datatable
+  ]
+}
+
+output "is_datatable_filter_useful" {
+  value = length(local.datatable_filter_result) > 0 && alltrue(local.datatable_filter_result)
+}
+`, testAccDataSourceDataServiceApis_base(), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_apis.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_apis.go
@@ -1,0 +1,640 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/service/apis
+// @API DataArtsStudio GET /v1/{project_id}/service/apis/{api_id}
+func DataSourceDataServiceApis() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDataServiceApisRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the API is located.`,
+			},
+
+			// Parameters in request header
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the API belongs.`,
+			},
+			"dlm_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of DLM engine.`,
+			},
+
+			// Query arguments
+			"api_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The API ID to be queried.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The API name to be queried.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The API type to be queried.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The API description to be queried.`,
+			},
+			"create_user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The API creator to be queried.`,
+			},
+			"datatable": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The data table name used by API to be queried.`,
+			},
+
+			// Attributes
+			"apis": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataApisElem(),
+				Description: `All APIs that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataApisElem() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			// Public attributes.
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The API ID, in UUID format.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the API.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The API type.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the API.`,
+			},
+			"protocol": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The request protocol of the API.`,
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The API request path.`,
+			},
+			"request_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The request type of the API.`,
+			},
+			"manager": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The API reviewer.`,
+			},
+			"datasource_config": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataApisDataSourceConfigElemSchema(),
+				Description: `The configuration of the API data source.`,
+			},
+			"request_params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataApisRequestParamsElemSchema(),
+				Description: `The parameters of the API request.`,
+			},
+			"backend_config": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataApisBackendConfigElemSchema(),
+				Description: `The configuration of the API backend.`,
+			},
+			"create_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The API creator.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the API.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the API.`,
+			},
+			// Attribute for shared API.
+			"group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the API.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The API status.`,
+			},
+			"host": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The host configuration for shared API.`,
+			},
+			// Attribute for exclusvie API.
+			"hosts": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The host configuration for exclusive API.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataApisDataSourceConfigElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the data source.`,
+			},
+			"connection_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the data connection.`,
+			},
+			"connection_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the data connection.`,
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the database.`,
+			},
+			"datatable": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the data table.`,
+			},
+			"table_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the data table.`,
+			},
+			"queue": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the DLI queue.`,
+			},
+			"access_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The access mode for the data.`,
+			},
+			"sql": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The SQL statements in script access type.`,
+			},
+			"backend_params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataApisDataSourceConfigBackendParamsElemSchema(),
+				Description: `The backend parameters of the API.`,
+			},
+			"response_params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataApisDataSourceConfigResponseParamsElemSchema(),
+				Description: `The response parameters of the API.`,
+			},
+			"order_params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataApisDataSourceConfigOrderParamsElemSchema(),
+				Description: `The order parameters of the API.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataApisDataSourceConfigBackendParamsElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the backend parameter.`,
+			},
+			"mapping": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the mapping parameter.`,
+			},
+			"condition": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The condition character.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataApisDataSourceConfigResponseParamsElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the response parameter.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the response parameter.`,
+			},
+			"field": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The bound table field for the response parameter.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the response parameter.`,
+			},
+			"example_value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The example value of the response parameter.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataApisDataSourceConfigOrderParamsElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the order parameter.`,
+			},
+			"field": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The corresponding parameter field for the order parameter.`,
+			},
+			"optional": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether this order parameter is the optional parameter.`,
+			},
+			"sort": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The sort type of the order parameter.`,
+			},
+			"order": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The order of the sorting parameters.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataApisRequestParamsElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the request parameter.`,
+			},
+			"position": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The position of the request parameter.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the request parameter.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the request parameter.`,
+			},
+			"necessary": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether this parameter is the required parameter.`,
+			},
+			"example_value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The example value of the request parameter.`,
+			},
+			"default_value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The default value of the request parameter.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataApisBackendConfigElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the backend request.`,
+			},
+			"protocol": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The protocol of the backend request.`,
+			},
+			"host": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The backend host.`,
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The backend timeout.`,
+			},
+			"path": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The backend path.`,
+			},
+			"backend_params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataApisBackendConfigBackendParamsElemSchema(),
+				Description: `The backend parameters of the API.`,
+			},
+			"constant_params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataApisBackendConfigConstantParamsElemSchema(),
+				Description: `The backend constant parameters of the API.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataApisBackendConfigBackendParamsElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the request parameter.`,
+			},
+			"position": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The position of the request parameter.`,
+			},
+			"backend_param_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the corresponding backend parameter.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataApisBackendConfigConstantParamsElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the constant parameter.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the constant parameter.`,
+			},
+			"position": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The position of the constant parameter.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the constant parameter.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the constant parameter.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildDataServiceApisQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if apiName, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, apiName)
+	}
+	if apiType, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&api_type=%v", res, apiType)
+	}
+	if apiDesc, ok := d.GetOk("description"); ok {
+		res = fmt.Sprintf("%s&description=%v", res, apiDesc)
+	}
+	if apiCreateUser, ok := d.GetOk("create_user"); ok {
+		res = fmt.Sprintf("%s&create_user=%v", res, apiCreateUser)
+	}
+	if tableName, ok := d.GetOk("datatable"); ok {
+		res = fmt.Sprintf("%s&table_name=%v", res, tableName)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}
+
+func GetDataServiceApis(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		workspaceId = d.Get("workspace_id").(string)
+		dlmType     = d.Get("dlm_type").(string)
+		httpUrl     = "v1/{project_id}/service/apis"
+	)
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath += buildDataServiceApisQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    workspaceId,
+			"Dlm-Type":     dlmType,
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, ParseQueryError400(err, apiResourceNotFoundCodes)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	apiRecords := utils.PathSearch("records", respBody, make([]interface{}, 0))
+	if apiId, ok := d.GetOk("api_id"); ok {
+		apiRecords = utils.PathSearch(fmt.Sprintf("[?id == '%v']", apiId), apiRecords, make([]interface{}, 0))
+	}
+	result := make([]interface{}, 0, len(apiRecords.([]interface{})))
+	for _, apiRecord := range apiRecords.([]interface{}) {
+		apiId := utils.PathSearch("id", apiRecord, "id_not_found").(string)
+		apiDetail, err := GetDataServiceApiDetail(client, workspaceId, dlmType, apiId)
+		if err != nil {
+			log.Printf("error querying API configuration by its ID (%s)", apiId)
+			continue
+		}
+		result = append(result, map[string]interface{}{
+			"id": apiId,
+			// Public attributes.
+			"name":         utils.PathSearch("name", apiDetail, nil),
+			"type":         utils.PathSearch("type", apiDetail, nil),
+			"description":  utils.PathSearch("description", apiDetail, nil),
+			"protocol":     utils.PathSearch("protocol", apiDetail, nil),
+			"path":         utils.PathSearch("path", apiDetail, nil),
+			"request_type": utils.PathSearch("request_type", apiDetail, nil),
+			"manager":      utils.PathSearch("manager", apiDetail, nil),
+			"datasource_config": flattenApiDataSourceConfig(client, workspaceId, utils.PathSearch("datasource_config", apiDetail,
+				make(map[string]interface{})).(map[string]interface{})),
+			"request_params": flattenApiRequestParams(utils.PathSearch("request_paras", apiDetail, make([]interface{}, 0)).([]interface{})),
+			"backend_config": flattenApiBackendConfig(utils.PathSearch("backend_config", apiDetail, make([]interface{}, 0)).([]interface{})),
+			"create_user":    utils.PathSearch("create_user", apiRecord, nil),
+			"created_at":     utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", apiDetail, 0).(float64))/1000, false),
+			"updated_at":     utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", apiDetail, 0).(float64))/1000, false),
+			// Attribute for shared API.
+			"group_id": utils.PathSearch("group_id", apiDetail, nil),
+			"status":   utils.PathSearch("status", apiDetail, nil),
+			"host":     utils.PathSearch("host", apiDetail, nil),
+			// Attribute for exclusvie API.
+			"hosts": flattenExclusiveApiHosts(utils.PathSearch("hosts", apiDetail, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result, nil
+}
+
+func GetDataServiceApiDetail(client *golangsdk.ServiceClient, workspaceId, dlmType, apiId string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/service/apis/{api_id}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{api_id}", apiId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    workspaceId,
+			"Dlm-Type":     dlmType,
+		},
+	}
+
+	requestResp, err := client.Request("GET", getPath, &opt)
+	if err != nil {
+		return nil, ParseQueryError400(err, apiResourceNotFoundCodes)
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func dataSourceDataServiceApisRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	apiRecords, err := GetDataServiceApis(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err,
+			fmt.Sprintf("error getting Data Service API (%s) for DataArts Studio", d.Id()))
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("apis", apiRecords),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query Data Service APIs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query apis
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/dataarts' TESTARGS='-run=TestAccDataSourceDataServiceApis_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run=TestAccDataSourceDataServiceApis_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataServiceApis_basic
--- PASS: TestAccDataSourceDataServiceApis_basic (4610.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  4610.202s
```
