### PR TITLE
chore(cts): add the operation_users field to the test case to improve coverage

### DIFF
--- a/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
+++ b/huaweicloud/services/acceptance/cts/resource_huaweicloud_cts_notification_test.go
@@ -79,6 +79,9 @@ func TestAccCTSNotification_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "filter.0.rule.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "operations.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "operations.0.service", "ECS"),
+					resource.TestCheckResourceAttr(resourceName, "operation_users.0.group", "devops"),
+					resource.TestCheckResourceAttr(resourceName, "operation_users.0.users.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "operation_users.0.users.0", "tf-user10"),
 					resource.TestCheckResourceAttrPair(resourceName, "smn_topic",
 						"huaweicloud_smn_topic.topic_1", "id"),
 				),
@@ -139,6 +142,11 @@ resource "huaweicloud_cts_notification" "notify" {
     service     = "ECS"
     resource    = "ecs"
     trace_names = ["createServer", "deleteServer"]
+  }
+
+  operation_users {
+    group = "devops"
+    users = ["tf-user10"]
   }
 }
 `, rName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add the operation_users field to the test case to improve coverage
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add the operation_users field to the test case to improve coverage
```

## PR Checklist

* [x] Tests added/passed.
* [] Documentation updated.
* [] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSNotification_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSNotification_basic -timeout 360m -parallel 4
=== RUN   TestAccCTSNotification_basic
=== PAUSE TestAccCTSNotification_basic
=== CONT  TestAccCTSNotification_basic
--- PASS: TestAccCTSNotification_basic (65.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       65.757s
```
