### PR TITLE
feat(lts): log group and log stream supports tags

### DIFF
--- a/docs/resources/lts_stream.md
+++ b/docs/resources/lts_stream.md
@@ -42,6 +42,8 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.
   Changing this parameter will create a new resource.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs of the log stream.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -49,8 +51,6 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - The log stream ID.
 
 * `filter_count` - Number of log stream filters.
-
-* `tags` - The key/value pairs to associate with the log stream.
 
 * `created_at` - The creation time of the log stream.
 

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_group_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_group_test.go
@@ -104,7 +104,7 @@ resource "huaweicloud_lts_group" "test" {
   ttl_in_days = %d
 
   tags = {
-	owner = "terraform"
+    owner = "terraform"
   }
 }
 `, name, ttl)
@@ -119,7 +119,7 @@ resource "huaweicloud_lts_group" "test" {
   tags = {
     foo       = "bar"
     key       = "value"
-	terraform = ""
+    terraform = ""
   }
 }
 `, name, ttl)

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_group_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_group_test.go
@@ -67,7 +67,8 @@ func TestAccLtsGroup_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "ttl_in_days", "30"),
-				),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform")),
 			},
 			{
 				ResourceName:      resourceName,
@@ -86,8 +87,10 @@ func TestAccLtsGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "ttl_in_days", "60"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.terraform", ""),
 				),
 			},
 		},
@@ -99,6 +102,10 @@ func testAccLtsGroup_basic(name string, ttl int) string {
 resource "huaweicloud_lts_group" "test" {
   group_name  = "%s"
   ttl_in_days = %d
+
+  tags = {
+	owner = "terraform"
+  }
 }
 `, name, ttl)
 }
@@ -110,8 +117,9 @@ resource "huaweicloud_lts_group" "test" {
   ttl_in_days = %d
 
   tags = {
-    foo = "bar"
-    key = "value"
+    foo       = "bar"
+    key       = "value"
+	terraform = ""
   }
 }
 `, name, ttl)

--- a/huaweicloud/services/lts/common.go
+++ b/huaweicloud/services/lts/common.go
@@ -74,6 +74,7 @@ func updateTags(client *golangsdk.ServiceClient, resourceType, resourceId string
 	path = strings.ReplaceAll(path, "{resource_id}", resourceId)
 	opts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
 		OkCodes: []int{
 			// For log stream, the status code of deleting tags is 201.
 			200, 201,

--- a/huaweicloud/services/lts/common.go
+++ b/huaweicloud/services/lts/common.go
@@ -3,7 +3,9 @@ package lts
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
@@ -32,4 +34,74 @@ func parseQueryError500(err error, specErrors []string) error {
 		}
 	}
 	return err
+}
+
+// The tag field information.
+type TagsMap struct {
+	// The key of the tag.
+	Key string `json:"key" required:"true"`
+	// The value of the tag.
+	// The value can be an empty string.
+	Value string `json:"value"`
+	// Whether to apply to the log stream.
+	TagsToStreamsEnable bool `json:"tags_to_streams_enable"`
+}
+
+func expandTagsToList(tagRaw map[string]interface{}) []TagsMap {
+	var taglist []TagsMap
+
+	for k, v := range tagRaw {
+		tag := TagsMap{
+			Key:                 k,
+			Value:               v.(string),
+			TagsToStreamsEnable: false,
+		}
+		taglist = append(taglist, tag)
+	}
+
+	return taglist
+}
+
+func updateTags(client *golangsdk.ServiceClient, resourceType, resourceId string, d *schema.ResourceData) error {
+	oRaw, nRaw := d.GetChange("tags")
+	oMap := oRaw.(map[string]interface{})
+	nMap := nRaw.(map[string]interface{})
+
+	httpUrl := "v1/{project_id}/{resource_type}/{resource_id}/tags/action"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{resource_type}", resourceType)
+	path = strings.ReplaceAll(path, "{resource_id}", resourceId)
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			// For log stream, the status code of deleting tags is 201.
+			200, 201,
+		},
+	}
+	// remove old tags
+	if len(oMap) > 0 {
+		opts.JSONBody = map[string]interface{}{
+			"action": "delete",
+			"tags":   expandTagsToList(oMap),
+		}
+		_, err := client.Request("POST", path, &opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	// set new tags
+	if len(nMap) > 0 {
+		opts.JSONBody = map[string]interface{}{
+			"action": "create",
+			"tags":   expandTagsToList(nMap),
+		}
+
+		_, err := client.Request("POST", path, &opts)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_group.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_group.go
@@ -96,6 +96,12 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(id.(string))
 
+	if _, ok := d.GetOk("tags"); ok {
+		groupId := d.Id()
+		if err := updateTags(client, "groups", groupId, d); err != nil {
+			return diag.Errorf("error creating tags of log group %s: %s", groupId, err)
+		}
+	}
 	return resourceGroupRead(ctx, d, meta)
 }
 
@@ -103,7 +109,6 @@ func buildCreateGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
 		"log_group_name": d.Get("group_name"),
 		"ttl_in_days":    utils.ValueIgnoreEmpty(d.Get("ttl_in_days")),
-		"tags":           utils.ValueIgnoreEmpty(utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))),
 	}
 	return bodyParams
 }
@@ -144,7 +149,7 @@ func resourceGroupRead(_ context.Context, d *schema.ResourceData, meta interface
 
 	groupResult := utils.PathSearch(fmt.Sprintf("log_groups|[?log_group_id=='%s']|[0]", groupId), respBody, nil)
 	if groupResult == nil {
-		return common.CheckDeletedDiag(d, err, fmt.Sprintf("unable to find log group by its ID (%s)", groupId))
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, fmt.Sprintf("unable to find log group by its ID (%s)", groupId))
 	}
 
 	mErr := multierror.Append(nil,
@@ -169,33 +174,39 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.Errorf("error creating LTS client: %s", err)
 	}
-	updatePath := client.Endpoint + httpUrl
-	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
-	updatePath = strings.ReplaceAll(updatePath, "{log_group_id}", groupId)
 
-	updateOpts := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-		JSONBody:         utils.RemoveNil(buildUpdateGroupBodyParams(d)),
+	if d.HasChange("ttl_in_days") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{log_group_id}", groupId)
+
+		updateOpts := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+			JSONBody:         utils.RemoveNil(buildUpdateGroupBodyParams(d)),
+		}
+
+		_, err = client.Request("POST", updatePath, &updateOpts)
+		if err != nil {
+			return diag.Errorf("error updating log group (%s): %s", groupId, err)
+		}
 	}
 
-	_, err = client.Request("POST", updatePath, &updateOpts)
-	if err != nil {
-		return diag.Errorf("error updating log group (%s): %s", groupId, err)
+	if d.HasChange("tags") {
+		if _, ok := d.GetOk("tags"); ok {
+			if err := updateTags(client, "groups", groupId, d); err != nil {
+				return diag.Errorf("error updating tags of log group %s: %s", groupId, err)
+			}
+		}
 	}
 
 	return resourceGroupRead(ctx, d, meta)
 }
 
 func buildUpdateGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
-	result := make(map[string]interface{})
-	if d.HasChange("tags") {
-		result["tags"] = utils.ExpandResourceTags(d.Get("tags").(map[string]interface{}))
+	return map[string]interface{}{
+		"ttl_in_days": d.Get("ttl_in_days"),
 	}
-	if d.HasChange("ttl_in_days") {
-		result["ttl_in_days"] = d.Get("ttl_in_days")
-	}
-	return result
 }
 
 func resourceGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_group.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_group.go
@@ -21,6 +21,7 @@ import (
 // @API LTS GET /v2/{project_id}/groups
 // @API LTS POST /v2/{project_id}/groups/{log_group_id}
 // @API LTS DELETE /v2/{project_id}/groups/{log_group_id}
+// @API LTS POST /v1/{project_id}/{resource_type}/{resource_id}/tags/action
 func ResourceLTSGroup() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceGroupCreate,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. For log groups, the ability to create and delete tags modified to use a public interface implementation.
2. Fix CheckDeleted of log group.
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/cfc695b2-93ac-40eb-b4c4-3b911719533e)

3. The log stream supports creating and deleting tags.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST=./huaweicloud/services/acceptance/lts TESTARGS='-run TestAccLtsGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccLtsGroup_ -timeout 360m -parallel 4
=== RUN   TestAccLtsGroup_basic
=== PAUSE TestAccLtsGroup_basic
=== CONT  TestAccLtsGroup_basic
--- PASS: TestAccLtsGroup_basic (45.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       45.768s

make testacc TEST=./huaweicloud/services/acceptance/lts TESTARGS='-run TestAccLtsStream_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccLtsStream_ -timeout 360m -parallel 4
=== RUN   TestAccLtsStream_basic
=== PAUSE TestAccLtsStream_basic
=== RUN   TestAccLtsStream_ttl
=== PAUSE TestAccLtsStream_ttl
=== RUN   TestAccLtsStream_tags
=== PAUSE TestAccLtsStream_tags
=== CONT  TestAccLtsStream_basic
=== CONT  TestAccLtsStream_tags
=== CONT  TestAccLtsStream_ttl
--- PASS: TestAccLtsStream_ttl (37.67s)
--- PASS: TestAccLtsStream_basic (38.21s)
--- PASS: TestAccLtsStream_tags (56.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       56.818s
```
