### PR TITLE
fix(AS): Fix some problems with AS group resource and add new fields

### DIFF
--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -196,6 +196,13 @@ The following arguments are supported:
     `yearly/monthly` basis, they will not be released when the ECSs are removed.
   + **false**: The EIPs bound to ECSs will be unbound but will not be released when the ECSs are removed.
 
+* `delete_volume` - (Optional, Bool) Specifies whether to delete the data disks attached to ECSs when the ECSs are removed.
+  Defaults to **false**.
+
+  + **true**: The data disks attached to ECSs will be released when the ECSs are removed. If the data disks are billed a
+    `yearly/monthly` basis, they will not be deleted when ECSs are removed.
+  + **false**: The data disks attached to ECSs will be detached but will not be released when the ECSs are removed.
+
 * `delete_instances` - (Optional, String) Specifies whether to delete the instances in the AS group when deleting
   the AS group. The options are **yes** and **no**.
 
@@ -236,6 +243,16 @@ The `lbaas_listeners` block supports:
 * `weight` - (Optional, Int) Specifies the weight, which determines the portion of requests a backend ECS processes
   compared to other backend ECSs added to the same listener. The value of this parameter ranges from **0** to **100**.
   Defaults to **1**.
+
+* `protocol_version` - (Optional, String) Specifies the version of instance IP addresses to be associated with the
+  load balancer. The value can be **ipv4** or **ipv6**. Defaults to **ipv4**.
+
+  -> 1. Instances in an AS group do not support IPv4/IPv6 dual-stack on multiple NICs. IPv4/IPv6 dual-stack is only
+  available for the first NIC that supports both IPv4 and IPv6. The NIC may be a primary NIC or an extension NIC.
+  <br/>2. Only ECSs with flavors that support IPv6 can use IPv4/IPv6 dual-stack networks. If you want to select IPv6 for
+  this parameter, make sure that you have selected such ECS flavors in a supported region.
+  <br/>3. If you add two or more load balancers whose pool_id, protocol_port, and protocol_version settings are totally
+  same, deduplication will be performed.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240614072804-903a1a5d0f98
+	github.com/chnsz/golangsdk v0.0.0-20240618022207-775fb17e64e9
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240614072804-903a1a5d0f98 h1:XjE/C5YSdQoN2U3l9AwJJtZmftxEjYm/39n03f6DH4E=
-github.com/chnsz/golangsdk v0.0.0-20240614072804-903a1a5d0f98/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240618022207-775fb17e64e9 h1:8HfuICiNSdlWJVe+jFFuXXSDMQHYH8cW8NltZKqKVuY=
+github.com/chnsz/golangsdk v0.0.0-20240618022207-775fb17e64e9/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
@@ -51,7 +51,14 @@ func TestAccASGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "desire_instance_number", "0"),
 					resource.TestCheckResourceAttr(resourceName, "min_instance_number", "0"),
 					resource.TestCheckResourceAttr(resourceName, "max_instance_number", "5"),
-					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "delete_publicip", "false"),
+					resource.TestCheckResourceAttr(resourceName, "delete_volume", "true"),
+					resource.TestCheckResourceAttrPair(resourceName, "lbaas_listeners.0.pool_id",
+						"huaweicloud_lb_pool.pool_1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "lbaas_listeners.0.protocol_port",
+						"huaweicloud_lb_listener.listener_1", "protocol_port"),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.weight", "20"),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_version", "ipv4"),
 					resource.TestCheckResourceAttr(resourceName, "networks.0.source_dest_check", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
@@ -70,6 +77,14 @@ func TestAccASGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "this is an updated AS group"),
 					resource.TestCheckResourceAttr(resourceName, "min_instance_number", "0"),
 					resource.TestCheckResourceAttr(resourceName, "max_instance_number", "5"),
+					resource.TestCheckResourceAttr(resourceName, "delete_publicip", "true"),
+					resource.TestCheckResourceAttr(resourceName, "delete_volume", "false"),
+					resource.TestCheckResourceAttrPair(resourceName, "lbaas_listeners.0.pool_id",
+						"huaweicloud_lb_pool.pool_1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "lbaas_listeners.0.protocol_port",
+						"huaweicloud_lb_listener.listener_1", "protocol_port"),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.weight", "30"),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_version", "ipv4"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 					resource.TestCheckResourceAttr(resourceName, "agency_name", "ims_admin"),
@@ -89,6 +104,7 @@ func TestAccASGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "status", "PAUSED"),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.weight", "1"),
 				),
 			},
 			{
@@ -132,6 +148,8 @@ func TestAccASGroup_withEpsId(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.weight", "1"),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_version", "ipv4"),
 				),
 			},
 		},
@@ -165,6 +183,8 @@ func TestAccASGroup_forceDelete(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_instance_number", "5"),
 					resource.TestCheckResourceAttr(resourceName, "instances.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "delete_publicip", "true"),
+					resource.TestCheckResourceAttr(resourceName, "delete_volume", "true"),
 				),
 			},
 		},
@@ -255,6 +275,8 @@ resource "huaweicloud_as_group" "acc_as_group"{
   vpc_id                   = huaweicloud_vpc.test.id
   max_instance_number      = 5
   description              = "this is a basic AS group"
+  delete_publicip          = false
+  delete_volume            = true
 
   networks {
     id = huaweicloud_vpc_subnet.test.id
@@ -263,8 +285,10 @@ resource "huaweicloud_as_group" "acc_as_group"{
     id = huaweicloud_networking_secgroup.test.id
   }
   lbaas_listeners {
-    pool_id       = huaweicloud_lb_pool.pool_1.id
-    protocol_port = huaweicloud_lb_listener.listener_1.protocol_port
+    pool_id          = huaweicloud_lb_pool.pool_1.id
+    protocol_port    = huaweicloud_lb_listener.listener_1.protocol_port
+    weight           = 20
+    protocol_version = "ipv4"
   }
   tags = {
     foo = "bar"
@@ -287,6 +311,8 @@ resource "huaweicloud_as_group" "acc_as_group"{
   max_instance_number      = 5
   description              = "this is an updated AS group"
   agency_name              = "ims_admin"
+  delete_publicip          = true
+  delete_volume            = false
 
   networks {
     id = huaweicloud_vpc_subnet.test.id
@@ -295,8 +321,10 @@ resource "huaweicloud_as_group" "acc_as_group"{
     id = huaweicloud_networking_secgroup.test.id
   }
   lbaas_listeners {
-    pool_id       = huaweicloud_lb_pool.pool_1.id
-    protocol_port = huaweicloud_lb_listener.listener_1.protocol_port
+    pool_id          = huaweicloud_lb_pool.pool_1.id
+    protocol_port    = huaweicloud_lb_listener.listener_1.protocol_port
+    weight           = 30
+    protocol_version = "ipv4"
   }
   tags = {
     foo   = "bar"
@@ -408,6 +436,8 @@ resource "huaweicloud_as_group" "acc_as_group"{
   max_instance_number      = 5
   force_delete             = true
   vpc_id                   = huaweicloud_vpc.test.id
+  delete_publicip          = true
+  delete_volume            = true
 
   networks {
     id = huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/as/resource_huaweicloud_as_group.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_group.go
@@ -377,29 +377,6 @@ func getInstancesIDs(allIns []instances.Instance) []string {
 	return allIDs
 }
 
-func getInstancesLifeStates(allIns []instances.Instance) []string {
-	var allStates = make([]string, len(allIns))
-	for i, ins := range allIns {
-		allStates[i] = ins.LifeCycleStatus
-	}
-
-	return allStates
-}
-
-func refreshGroupState(client *golangsdk.ServiceClient, groupID string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		asGroup, err := groups.Get(client, groupID).Extract()
-		if err != nil {
-			var errDefault404 golangsdk.ErrDefault404
-			if errors.As(parseGroupResponseError(err), &errDefault404) {
-				return asGroup, "DELETED", nil
-			}
-			return nil, "ERROR", err
-		}
-		return asGroup, asGroup.Status, nil
-	}
-}
-
 // When the AS group does not exist, the response body example of the details interface is as follows:
 // {"error":{"code":"AS.2007","message":"The AS group does not exist."}}
 func parseGroupResponseError(err error) error {
@@ -432,7 +409,7 @@ func isAllInstanceInService(allIns []instances.Instance) bool {
 	return true
 }
 
-func checkASGroupInstancesInService(ctx context.Context, client *golangsdk.ServiceClient, groupID string, insNum int,
+func waitingForAllInstancesInService(ctx context.Context, client *golangsdk.ServiceClient, groupID string, insNum int,
 	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
@@ -458,7 +435,7 @@ func checkASGroupInstancesInService(ctx context.Context, client *golangsdk.Servi
 	return err
 }
 
-func checkASGroupInstancesRemoved(ctx context.Context, client *golangsdk.ServiceClient, groupID string,
+func waitingForAllInstancesRemoved(ctx context.Context, client *golangsdk.ServiceClient, groupID string,
 	timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
@@ -484,7 +461,7 @@ func checkASGroupInstancesRemoved(ctx context.Context, client *golangsdk.Service
 	return err
 }
 
-func checkASGroupRemoved(ctx context.Context, client *golangsdk.ServiceClient, groupID string, timeout time.Duration) error {
+func waitingForASGroupDeleted(ctx context.Context, client *golangsdk.ServiceClient, groupID string, timeout time.Duration) error {
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
@@ -548,7 +525,7 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 		Description:               d.Get("description").(string),
 		IamAgencyName:             d.Get("agency_name").(string),
 		IsDeletePublicip:          d.Get("delete_publicip").(bool),
-		EnterpriseProjectID:       common.GetEnterpriseProjectID(d, conf),
+		EnterpriseProjectID:       conf.GetEnterpriseProjectID(d),
 	}
 
 	asgId, err := groups.Create(asClient, createOpts).Extract()
@@ -575,11 +552,10 @@ func resourceASGroupCreate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 	}
 
-	// check all instances are inservice
 	if desireNum > 0 {
-		err = checkASGroupInstancesInService(ctx, asClient, asgId, desireNum, d.Timeout(schema.TimeoutCreate))
+		err = waitingForAllInstancesInService(ctx, asClient, asgId, desireNum, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return diag.Errorf("error waiting for instances in the AS group %s to become inservice: %s", asgId, err)
+			return diag.Errorf("error waiting for all instances in the AS group %s to become INSERVICE: %s", asgId, err)
 		}
 	}
 
@@ -597,12 +573,12 @@ func resourceASGroupRead(_ context.Context, d *schema.ResourceData, meta interfa
 	groupID := d.Id()
 	asg, err := groups.Get(asClient, groupID).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseGroupResponseError(err), "AS group")
+		return common.CheckDeletedDiag(d, parseGroupResponseError(err), "error retrieving AS group")
 	}
 
 	allIns, err := getInstancesInGroup(asClient, groupID, nil)
 	if err != nil {
-		return diag.Errorf("can not get the instances in AS Group %s: %s", groupID, err)
+		return diag.Errorf("error retrieving the instances in AS Group %s: %s", groupID, err)
 	}
 	allIDs := getInstancesIDs(allIns)
 
@@ -639,11 +615,11 @@ func resourceASGroupRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 	// save group tags
 	if resourceTags, err := tags.Get(asClient, groupID).Extract(); err == nil {
-		tagmap := make(map[string]string)
+		tagMap := make(map[string]string)
 		for _, val := range resourceTags.Tags {
-			tagmap[val.Key] = val.Value
+			tagMap[val.Key] = val.Value
 		}
-		mErr = multierror.Append(mErr, d.Set("tags", tagmap))
+		mErr = multierror.Append(mErr, d.Set("tags", tagMap))
 	} else {
 		log.Printf("[WARN] Error fetching tags of AS group (%s): %s", groupID, err)
 	}
@@ -731,7 +707,7 @@ func resourceASGroupUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		MultiAZPriorityPolicy:     d.Get("multi_az_scaling_policy").(string),
 		IsDeletePublicip:          d.Get("delete_publicip").(bool),
 		Description:               utils.String(d.Get("description").(string)),
-		EnterpriseProjectID:       common.GetEnterpriseProjectID(d, conf),
+		EnterpriseProjectID:       conf.GetEnterpriseProjectID(d),
 	}
 
 	if d.HasChange("agency_name") {
@@ -788,8 +764,8 @@ func forceDeleteASGroup(ctx context.Context, asClient *golangsdk.ServiceClient, 
 		return fmt.Errorf("error deleting AS group %s: %s", d.Id(), err)
 	}
 
-	if err := checkASGroupRemoved(ctx, asClient, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return fmt.Errorf("error deleting AS group %s: %s", d.Id(), err)
+	if err := waitingForASGroupDeleted(ctx, asClient, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
+		return fmt.Errorf("error waiting for AS group deleted %s: %s", d.Id(), err)
 	}
 	return nil
 }
@@ -813,12 +789,12 @@ func deleteAllInstancesFromASGroup(ctx context.Context, asClient *golangsdk.Serv
 	deleteIns := d.Get("delete_instances").(string)
 	batchResult := instances.BatchDelete(asClient, d.Id(), allIDs, deleteIns)
 	if batchResult.Err != nil {
-		return fmt.Errorf("error removing instancess of AS group: %s", batchResult.Err)
+		return fmt.Errorf("error removing instances of AS group: %s", batchResult.Err)
 	}
 
-	err := checkASGroupInstancesRemoved(ctx, asClient, d.Id(), d.Timeout(schema.TimeoutDelete))
+	err := waitingForAllInstancesRemoved(ctx, asClient, d.Id(), d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return fmt.Errorf("error removing instances from AS group %s: %s", d.Id(), err)
+		return fmt.Errorf("error waiting for removing instances from AS group %s: %s", d.Id(), err)
 	}
 	return nil
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/requests.go
@@ -60,6 +60,8 @@ type LBaaSListenerOpts struct {
 	PoolID       string `json:"pool_id" required:"true"`
 	ProtocolPort int    `json:"protocol_port" required:"true"`
 	Weight       int    `json:"weight,omitempty"`
+	// Field `protocol_version` cannot be specified to empty string. This filed must be `IPv4` or `IPv6`
+	ProtocolVersion string `json:"protocol_version,omitempty"`
 }
 
 func (opts CreateOpts) ToGroupCreateMap() (map[string]interface{}, error) {
@@ -151,7 +153,8 @@ type UpdateOpts struct {
 	HealthPeriodicAuditGrace  int                 `json:"health_periodic_audit_grace_period,omitempty"`
 	InstanceTerminatePolicy   string              `json:"instance_terminate_policy,omitempty"`
 	Notifications             []string            `json:"notifications,omitempty"`
-	IsDeletePublicip          bool                `json:"delete_publicip,omitempty"`
+	IsDeletePublicip          *bool               `json:"delete_publicip,omitempty"`
+	IsDeleteVolume            *bool               `json:"delete_volume,omitempty"`
 	ConfigurationID           string              `json:"scaling_configuration_id,omitempty"`
 	MultiAZPriorityPolicy     string              `json:"multi_az_priority_policy,omitempty"`
 	Description               *string             `json:"description,omitempty"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/autoscaling/v1/groups/results.go
@@ -92,10 +92,11 @@ type SecurityGroup struct {
 }
 
 type LBaaSListener struct {
-	ListenerID   string `json:"listener_id"`
-	PoolID       string `json:"pool_id"`
-	ProtocolPort int    `json:"protocol_port"`
-	Weight       int    `json:"weight"`
+	ListenerID      string `json:"listener_id"`
+	PoolID          string `json:"pool_id"`
+	ProtocolPort    int    `json:"protocol_port"`
+	Weight          int    `json:"weight"`
+	ProtocolVersion string `json:"protocol_version"`
 }
 
 type GroupPage struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240614072804-903a1a5d0f98
+# github.com/chnsz/golangsdk v0.0.0-20240618022207-775fb17e64e9
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix some problems with AS group resource and add new fields

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Fix some lint error in AS group resource.
- Add new field `delete_volume` and `lbaas_listeners.0.protocol_version`.
- Support editing field `delete_publicip`.
- Added some test scenarios to the test cases.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== CONT  TestAccASGroup_basic
--- PASS: TestAccASGroup_basic (349.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        349.377s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_withEpsId'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_withEpsId -timeout 360m -parallel 4
=== RUN   TestAccASGroup_withEpsId
=== PAUSE TestAccASGroup_withEpsId
=== CONT  TestAccASGroup_withEpsId
--- PASS: TestAccASGroup_withEpsId (173.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        173.983s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_forceDelete'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_forceDelete -timeout 360m -parallel 4
=== RUN   TestAccASGroup_forceDelete
=== PAUSE TestAccASGroup_forceDelete
=== CONT  TestAccASGroup_forceDelete
--- PASS: TestAccASGroup_forceDelete (208.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        209.008s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_sourceDestCheck'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_sourceDestCheck -timeout 360m -parallel 4
=== RUN   TestAccASGroup_sourceDestCheck
=== PAUSE TestAccASGroup_sourceDestCheck
=== CONT  TestAccASGroup_sourceDestCheck
--- PASS: TestAccASGroup_sourceDestCheck (162.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        163.010s
```