### PR TITLE
feat(as): the AS policy resource supports new API

### DIFF
--- a/docs/resources/as_policy.md
+++ b/docs/resources/as_policy.md
@@ -115,6 +115,11 @@ The following arguments are supported:
   + **SCHEDULED**: indicates that the scaling action is triggered as scheduled.
   + **RECURRENCE**: indicates that the scaling action is triggered periodically.
 
+* `action` - (Optional, String) Specifies the operation for the AS policy.
+  The default value is **resume**. The valid values are as follows:
+  + **resume**: Enables the AS policy.
+  + **pause**: Disables the AS policy.
+
 * `alarm_id` - (Optional, String) Specifies the alarm rule ID. This parameter is mandatory when `scaling_policy_type`
   is set to `ALARM`. You can create an alarm rule with
   [huaweicloud_ces_alarmrule](https://registry.terraform.io/providers/huaweicloud/huaweicloud/latest/docs/resources/ces_alarmrule).

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_policy_test.go
@@ -28,7 +28,8 @@ func TestAccASPolicy_basic(t *testing.T) {
 				Config: testASPolicy_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASPolicyExists(resourceName, &asPolicy),
-					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "action", "pause"),
+					resource.TestCheckResourceAttr(resourceName, "status", "PAUSED"),
 					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "300"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "SCHEDULED"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.operation", "ADD"),
@@ -39,6 +40,7 @@ func TestAccASPolicy_basic(t *testing.T) {
 			{
 				Config: testASPolicy_update(rName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "action", "resume"),
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
 					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "900"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "SCHEDULED"),
@@ -49,7 +51,8 @@ func TestAccASPolicy_basic(t *testing.T) {
 			{
 				Config: testASPolicy_recurrence(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "action", "pause"),
+					resource.TestCheckResourceAttr(resourceName, "status", "PAUSED"),
 					resource.TestCheckResourceAttr(resourceName, "cool_down_time", "900"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_type", "RECURRENCE"),
 					resource.TestCheckResourceAttr(resourceName, "scaling_policy_action.0.operation", "ADD"),
@@ -202,6 +205,8 @@ resource "huaweicloud_as_policy" "acc_as_policy"{
   scheduled_policy {
     launch_time = "2099-12-22T12:00Z"
   }
+
+  action = "pause"
 }
 `, testASPolicy_base(rName), rName)
 }
@@ -223,6 +228,8 @@ resource "huaweicloud_as_policy" "acc_as_policy"{
   scheduled_policy {
     launch_time = "2099-12-22T12:00Z"
   }
+
+  action = "resume"
 }
 `, testASPolicy_base(rName), rName)
 }
@@ -246,6 +253,8 @@ resource "huaweicloud_as_policy" "acc_as_policy"{
     start_time      = "2099-11-22T12:00Z"
     end_time        = "2099-12-22T12:00Z"
   }
+
+  action = "pause"
 }
 `, testASPolicy_base(rName), rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The AS policy resource supports new API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
The API can be used to change the policy status.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_basic
=== PAUSE TestAccASPolicy_basic
=== CONT  TestAccASPolicy_basic
--- PASS: TestAccASPolicy_basic (276.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        276.652s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/as" TESTARGS="-run TestAccASPolicy_Alarm"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_Alarm -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_Alarm
=== PAUSE TestAccASPolicy_Alarm
=== CONT  TestAccASPolicy_Alarm
--- PASS: TestAccASPolicy_Alarm (153.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        153.136s
```