### PR TITLE
feat: test(apig/api): supports new params and rewrite the UT

### DIFF
--- a/docs/data-sources/apig_api.md
+++ b/docs/data-sources/apig_api.md
@@ -55,6 +55,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `authorizer_id` - The ID of the authorizer to which the API request used.
 
+* `tags` - The list of tags configuration.
+
 * `group_id` - The group ID corresponding to the API.
 
 * `group_name` - The group name corresponding to the API.
@@ -142,6 +144,10 @@ The `request_params` block supports:
 
 * `default` - The default value of the parameter.
 
+* `valid_enable` - Whether to enable the parameter validation.
+  + **1**: enable
+  + **2**: disable
+
 <a name="api_backend_params"></a>
 The `backend_params` block supports:
 
@@ -166,6 +172,8 @@ The `mock` block supports:
 
 * `id` - The ID of the mock backend configuration.
 
+* `status_code` - The custom status code of the mock response.
+
 * `response` - The response of the mock backend configuration.
 
 * `authorizer_id` - The ID of the backend custom authorization.
@@ -176,6 +184,8 @@ The `mock_policy` block supports:
 * `id` - The ID of the mock backend policy.
 
 * `name` - The backend policy name.
+
+* `status_code` - The custom status code of the mock response.
 
 * `response` - The response of the backend policy.
 
@@ -196,6 +206,16 @@ The `func_graph` block supports:
 
 * `function_urn` - The URN of the FunctionGraph function.
 
+* `version` - The version of the FunctionGraph function.
+
+* `function_alias_urn` - The alias URN of the FunctionGraph function.  
+
+* `network_type` - The network architecture (framework) type of the FunctionGraph function.
+  **V1**: Non-VPC network framework.
+  **V2**: VPC network framework.
+
+* `request_protocol` - The request protocol of the FunctionGraph function.  
+
 * `timeout` - The timeout for API requests to backend service.
 
 * `version` - The version of the FunctionGraph function.
@@ -213,6 +233,16 @@ The `func_graph_policy` block supports:
 
 * `function_urn` - The URN of the FunctionGraph function.
 
+* `version` - The version of the FunctionGraph function.
+
+* `function_alias_urn` - The alias URN of the FunctionGraph function.  
+
+* `network_type` - The network architecture (framework) type of the FunctionGraph function.
+  **V1**: Non-VPC network framework.
+  **V2**: VPC network framework.
+
+* `request_protocol` - The request protocol of the FunctionGraph function.  
+
 * `conditions` - The policy conditions.
   The [conditions](#policy_conditions) structure is documented below.
   
@@ -221,8 +251,6 @@ The `func_graph_policy` block supports:
 * `effective_mode` - The effective mode of the backend policy.
 
 * `timeout` - The timeout for API requests to backend service.
-
-* `version` - The version of the FunctionGraph function.
 
 * `backend_params` - The configaiton list of the backend parameters.
   The [backend_params](#api_backend_params) structure is documented below.

--- a/docs/data-sources/apig_api_basic_configurations.md
+++ b/docs/data-sources/apig_api_basic_configurations.md
@@ -118,6 +118,8 @@ The `configurations` block supports:
 
 * `description` - The description of the API.
 
+* `tags` - The list of tags configuration.
+
 * `registered_at` - The registered time of the API, in RFC3339 format.
 
 * `updated_at` - The latest update time of the API, in RFC3339 format.

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_basic_configurations_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_basic_configurations_test.go
@@ -80,6 +80,7 @@ func TestAccDataSourceApiBasicConfigurations_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(byId, "configurations.0.simple_authentication", "false"),
 					resource.TestCheckResourceAttr(byId, "configurations.0.cors", "true"),
 					resource.TestCheckResourceAttr(byId, "configurations.0.matching", "Exact"),
+					resource.TestCheckResourceAttr(byId, "configurations.0.description", "Created by script"),
 					resource.TestMatchResourceAttr(byId, "configurations.0.registered_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 					resource.TestMatchResourceAttr(byId, "configurations.0.updated_at",
@@ -127,7 +128,7 @@ func testAccDataSourceApiBasicConfigurations_base() string {
 resource "huaweicloud_apig_custom_authorizer" "frontEnd" {
   instance_id      = huaweicloud_apig_instance.test.id
   name             = "%[2]s_front"
-  function_urn     = huaweicloud_fgs_function.test.urn
+  function_urn     = huaweicloud_fgs_function.test[1].urn
   function_version = "latest"
   type             = "FRONTEND"
 }
@@ -144,7 +145,7 @@ resource "huaweicloud_apig_api" "test" {
   matching                = "Exact"
   authorizer_id           = huaweicloud_apig_custom_authorizer.frontEnd.id
   cors                    = true
-  description             = "Updated by script"
+  description             = "Created by script"
   tags                    = ["foo"]
   
   request_params {
@@ -158,7 +159,7 @@ resource "huaweicloud_apig_api" "test" {
 
   web {
     path             = "/"
-    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
     request_method   = "GET"
     request_protocol = "HTTP"
     timeout          = 30000
@@ -432,7 +433,7 @@ data "huaweicloud_apig_api_basic_configurations" "filter_by_vpc_channel_name" {
   ]
 
   instance_id      = huaweicloud_apig_instance.test.id
-  vpc_channel_name = huaweicloud_apig_vpc_channel.test.name
+  vpc_channel_name = huaweicloud_apig_channel.test.name
 }
 
 output "is_vpc_channel_name_filter_useful" {

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_basic_configurations_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_basic_configurations_test.go
@@ -72,6 +72,8 @@ func TestAccDataSourceApiBasicConfigurations_basic(t *testing.T) {
 					dcById.CheckResourceExists(),
 					resource.TestCheckOutput("is_id_filter_useful", "true"),
 					resource.TestCheckResourceAttrSet(byId, "configurations.0.group_name"),
+					resource.TestCheckResourceAttr(byId, "configurations.0.tags.#", "1"),
+					resource.TestCheckResourceAttr(byId, "configurations.0.tags.0", "foo"),
 					resource.TestCheckResourceAttrSet(byId, "configurations.0.group_version"),
 					resource.TestCheckResourceAttrSet(byId, "configurations.0.publish_id"),
 					resource.TestCheckResourceAttrSet(byId, "configurations.0.backend_type"),
@@ -143,6 +145,7 @@ resource "huaweicloud_apig_api" "test" {
   authorizer_id           = huaweicloud_apig_custom_authorizer.frontEnd.id
   cors                    = true
   description             = "Updated by script"
+  tags                    = ["foo"]
   
   request_params {
     name     = "%[2]s"

--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_api_test.go
@@ -8,77 +8,185 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccDataSourceApi_basic(t *testing.T) {
-	name := acceptance.RandomAccResourceName()
-	dataSource := "data.huaweicloud_apig_api.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		webBackend       = "data.huaweicloud_apig_api.web"
+		dcWithWebBackend = acceptance.InitDataSourceCheck(webBackend)
+		fgsBackend       = "data.huaweicloud_apig_api.func_graph"
+		dcWithFgsBackend = acceptance.InitDataSourceCheck(fgsBackend)
+		mockBackend      = "data.huaweicloud_apig_api.mock"
+		dcWithMock       = acceptance.InitDataSourceCheck(mockBackend)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Before running acceptance test for each kind of APIs, please make sure the agency already assign the FGS service.
+			acceptance.TestAccPreCheckFgsAgency(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceApi_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSource, "name", name),
-					resource.TestCheckResourceAttr(dataSource, "type", "Public"),
-					resource.TestCheckResourceAttr(dataSource, "request_method", "GET"),
-					resource.TestCheckResourceAttr(dataSource, "request_path", "/user_info/{user_age}"),
-					resource.TestCheckResourceAttr(dataSource, "request_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(dataSource, "security_authentication", "APP"),
-					resource.TestCheckResourceAttr(dataSource, "simple_authentication", "false"),
-					resource.TestCheckResourceAttrPair(dataSource, "group_id", "huaweicloud_apig_group.test", "id"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.#", "2"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.0.%", "12"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.0.name", "X-TEST-ENUM"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.0.passthrough", "true"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.0.type", "STRING"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.0.minimum", "10"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.0.maximum", "20"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.1.name", "user_age"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.1.required", "true"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.1.minimum", "0"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.1.maximum", "200"),
-					resource.TestCheckResourceAttr(dataSource, "request_params.1.location", "PATH"),
-					resource.TestCheckResourceAttr(dataSource, "backend_params.#", "2"),
-					resource.TestCheckResourceAttr(dataSource, "backend_params.0.%", "8"),
-					resource.TestCheckResourceAttr(dataSource, "backend_params.0.name", "userAge"),
-					resource.TestCheckResourceAttr(dataSource, "backend_params.1.name", "x-test-id"),
-					resource.TestCheckResourceAttr(dataSource, "backend_params.1.system_param_type", "backend"),
-					resource.TestCheckResourceAttr(dataSource, "description", "Created by script"),
-					resource.TestCheckResourceAttr(dataSource, "matching", "Exact"),
-					resource.TestCheckResourceAttr(dataSource, "success_response", "Success response"),
-					resource.TestCheckResourceAttr(dataSource, "failure_response", "Failed response"),
-					resource.TestCheckResourceAttr(dataSource, "web.0.%", "11"),
-					resource.TestCheckResourceAttr(dataSource, "web.0.path", "/getUserAge/{userAge}"),
-					resource.TestCheckResourceAttr(dataSource, "web.0.request_method", "GET"),
-					resource.TestCheckResourceAttr(dataSource, "web.0.request_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(dataSource, "web.0.timeout", "30000"),
-					resource.TestCheckResourceAttr(dataSource, "web.0.retry_count", "1"),
-					resource.TestCheckResourceAttrPair(dataSource, "web.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
-					resource.TestCheckResourceAttrPair(dataSource, "web.0.vpc_channel_id", "huaweicloud_apig_vpc_channel.test", "id"),
-					resource.TestCheckResourceAttr(dataSource, "web_policy.0.backend_params.#", "3"),
-					resource.TestCheckResourceAttr(dataSource, "web_policy.#", "1"),
-					resource.TestCheckResourceAttr(dataSource, "web_policy.0.%", "14"),
-					resource.TestCheckResourceAttr(dataSource, "web_policy.0.effective_mode", "ANY"),
-					resource.TestCheckResourceAttr(dataSource, "web_policy.0.conditions.#", "1"),
-					resource.TestCheckResourceAttr(dataSource, "web_policy.0.conditions.0.source", "param"),
-					resource.TestCheckResourceAttr(dataSource, "web_policy.0.conditions.0.type", "Equal"),
-					resource.TestCheckResourceAttr(dataSource, "web_policy.0.conditions.0.value", "28"),
-					resource.TestCheckResourceAttrPair(dataSource, "web_policy.0.vpc_channel_id", "huaweicloud_apig_vpc_channel.test", "id"),
-					resource.TestCheckResourceAttr(dataSource, "mock.#", "0"),
-					resource.TestCheckResourceAttr(dataSource, "mock_policy.#", "0"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph.#", "0"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.#", "0"),
-					resource.TestMatchResourceAttr(dataSource, "registered_at",
+					// Query the API with Web backend
+					dcWithWebBackend.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(webBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "api_id", "huaweicloud_apig_api.web", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "name", name+"_web"),
+					resource.TestCheckResourceAttr(webBackend, "type", "Public"),
+					resource.TestCheckResourceAttr(webBackend, "request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(webBackend, "request_method", "GET"),
+					resource.TestCheckResourceAttr(webBackend, "request_path", "/web/test"),
+					resource.TestCheckResourceAttr(webBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(webBackend, "simple_authentication", "true"),
+					resource.TestCheckResourceAttr(webBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(webBackend, "success_response", "Success response"),
+					resource.TestCheckResourceAttr(webBackend, "failure_response", "Failed response"),
+					resource.TestCheckResourceAttr(webBackend, "description", "Created by script"),
+					resource.TestCheckResourceAttr(webBackend, "tags.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "tags.0", "foo"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.name", "X-Service-Num"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.type", "STRING"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.location", "HEADER"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.maximum", "20"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.minimum", "10"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.example", "TERRAFORM01"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.passthrough", "true"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.valid_enable", "1"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.type", "REQUEST"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.name", "SerivceNum"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.location", "HEADER"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.value", "X-Service-Num"),
+					resource.TestCheckResourceAttr(webBackend, "web.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.path", "/web/test/backend"),
+					resource.TestCheckResourceAttrPair(webBackend, "web.0.vpc_channel_id", "huaweicloud_apig_channel.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.timeout", "30000"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.retry_count", "1"),
+					resource.TestCheckResourceAttrPair(webBackend, "web.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.name", name+"_web_policy"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.effective_mode", "ANY"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.path", "/web/test/backend"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.timeout", "30000"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.retry_count", "1"),
+					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.vpc_channel_id", "huaweicloud_apig_channel.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.type", "SYSTEM"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.name", "SerivceNum"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.location", "HEADER"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.value", "X-Service-Num"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.system_param_type", "backend"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.source", "param"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.param_name", "X-Service-Num"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.type", "Equal"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.value", "0001"),
+					resource.TestCheckResourceAttr(webBackend, "mock.#", "0"),
+					resource.TestCheckResourceAttr(webBackend, "func_graph.#", "0"),
+					resource.TestCheckResourceAttr(webBackend, "mock_policy.#", "0"),
+					resource.TestCheckResourceAttr(webBackend, "func_graph_policy.#", "0"),
+					resource.TestMatchResourceAttr(webBackend, "registered_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
-					resource.TestMatchResourceAttr(dataSource, "updated_at",
+					resource.TestMatchResourceAttr(webBackend, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Query the API with FunctionGraph backend
+					dcWithFgsBackend.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(fgsBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "api_id", "huaweicloud_apig_api.func_graph", "id"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(fgsBackend, "name", name+"_fgs"),
+					resource.TestCheckResourceAttr(fgsBackend, "type", "Public"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_protocol", "GRPCS"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_method", "POST"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_path", "/fgs/test"),
+					resource.TestCheckResourceAttr(fgsBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(fgsBackend, "simple_authentication", "true"),
+					resource.TestCheckResourceAttr(fgsBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_params.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "backend_params.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.#", "1"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.function_urn", "huaweicloud_fgs_function.test.1", "urn"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.version", "huaweicloud_fgs_function.test.1", "versions.0.name"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.network_type", "V2"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.request_protocol", "GRPCS"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.timeout", "5000"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.invocation_type", "sync"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.#", "1"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.name", name+"_fgs_policy"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.function_urn", "huaweicloud_fgs_function.test.1", "urn"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.version",
+						"huaweicloud_fgs_function.test.1", "versions.0.name"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.network_type", "V2"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.request_protocol", "GRPCS"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.timeout", "5000"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.invocation_type", "sync"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.effective_mode", "ANY"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.authorizer_id",
+						"huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.source", "cookie"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.cookie_name", "regex_test"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.type", "Matching"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.value", fmt.Sprintf("^%s:\\w+$", name)),
+					resource.TestCheckResourceAttr(fgsBackend, "web.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "mock.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "web_policy.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "mock_policy.#", "0"),
+					resource.TestMatchResourceAttr(fgsBackend, "registered_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(fgsBackend, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Query the API with mock configuration
+					dcWithMock.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(mockBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "api_id", "huaweicloud_apig_api.mock", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(mockBackend, "name", name+"_mock"),
+					resource.TestCheckResourceAttr(mockBackend, "type", "Public"),
+					resource.TestCheckResourceAttr(mockBackend, "request_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(mockBackend, "request_method", "POST"),
+					resource.TestCheckResourceAttr(mockBackend, "request_path", "/mock/test"),
+					resource.TestCheckResourceAttr(mockBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(mockBackend, "simple_authentication", "true"),
+					resource.TestCheckResourceAttr(mockBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(mockBackend, "request_params.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "backend_params.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "mock.#", "1"),
+					resource.TestCheckResourceAttr(mockBackend, "mock.0.status_code", "201"),
+					resource.TestCheckResourceAttr(mockBackend, "mock.0.response", "{'message':'hello world'}"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.#", "1"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.name", name+"_mock_policy"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.status_code", "201"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.response", "{'message':'hello world'}"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.effective_mode", "ANY"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.source", "system"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.type", "Equal"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.value", "user"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.sys_name", "reqPath"),
+					resource.TestCheckResourceAttr(mockBackend, "web.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "func_graph.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "web_policy.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "func_graph_policy.#", "0"),
+					resource.TestMatchResourceAttr(mockBackend, "registered_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(mockBackend, "updated_at",
 						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
@@ -88,194 +196,157 @@ func TestAccDataSourceApi_basic(t *testing.T) {
 
 func testAccDataSourceApi_basic(name string) string {
 	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_apig_api" "test" {
-  instance_id = huaweicloud_apig_instance.test.id
-  api_id      = huaweicloud_apig_api.test.id
-}
-`, testAccApi_basic(testAccApi_base(name), name))
-}
-
-func TestAccDataSourceApi_functionGraph(t *testing.T) {
-	name := acceptance.RandomAccResourceName()
-	dataSource := "data.huaweicloud_apig_api.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataSourceApi_functionGraph(name),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSource, "name", name),
-					resource.TestCheckResourceAttr(dataSource, "type", "Public"),
-					resource.TestCheckResourceAttr(dataSource, "request_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(dataSource, "request_method", "POST"),
-					resource.TestCheckResourceAttr(dataSource, "request_path", fmt.Sprintf("/test/function/%s", name)),
-					resource.TestCheckResourceAttr(dataSource, "backend_type", "FUNCTION"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph.#", "1"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph.0.invocation_type", "async"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph.0.timeout", "6000"),
-					resource.TestCheckResourceAttrPair(dataSource, "func_graph.0.function_urn", "huaweicloud_fgs_function.test", "urn"),
-					resource.TestCheckResourceAttrPair(dataSource, "func_graph.0.version", "huaweicloud_fgs_function.test", "version"),
-					resource.TestCheckResourceAttrPair(dataSource, "func_graph.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.#", "1"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.invocation_type", "async"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.backend_params.#", "1"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.backend_params.0.%", "8"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.backend_params.0.description", "created by terraform script"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.backend_params.0.location", "QUERY"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.backend_params.0.type", "CONSTANT"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.conditions.#", "1"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.conditions.0.%", "10"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.conditions.0.source", "system"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.conditions.0.sys_name", "reqPath"),
-					resource.TestCheckResourceAttr(dataSource, "func_graph_policy.0.conditions.0.type", "Equal"),
-					resource.TestCheckResourceAttr(dataSource, "web.#", "0"),
-					resource.TestCheckResourceAttr(dataSource, "web_policy.#", "0"),
-					resource.TestCheckResourceAttr(dataSource, "mock.#", "0"),
-					resource.TestCheckResourceAttr(dataSource, "mock_policy.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-func testAccDataSourceApi_functionGraph(name string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_apig_api" "test" {
-  instance_id = huaweicloud_apig_instance.test.id
-  api_id      = huaweicloud_apig_api.test.id
-}
-`, testAccApi_functionGraph(name))
-}
-
-func TestAccDataSourceApi_mock(t *testing.T) {
-	var (
-		name       = acceptance.RandomAccResourceName()
-		dataSource = "data.huaweicloud_apig_api.test"
-		dc         = acceptance.InitDataSourceCheck(dataSource)
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataSourceApi_mock(name),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSource, "name", name),
-					resource.TestCheckResourceAttr(dataSource, "type", "Private"),
-					resource.TestCheckResourceAttr(dataSource, "request_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(dataSource, "backend_type", "MOCK"),
-					resource.TestCheckResourceAttr(dataSource, "matching", "Prefix"),
-					resource.TestCheckResourceAttrPair(dataSource, "response_id", "huaweicloud_apig_response.test", "id"),
-					resource.TestCheckResourceAttrPair(dataSource, "authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
-					resource.TestCheckResourceAttr(dataSource, "body_description", "This is request body description"),
-					resource.TestCheckResourceAttr(dataSource, "cors", "true"),
-					resource.TestCheckResourceAttr(dataSource, "mock.#", "1"),
-					resource.TestCheckResourceAttr(dataSource, "mock.0.response", "Mock backend description"),
-					resource.TestCheckResourceAttr(dataSource, "mock_policy.#", "1"),
-					resource.TestCheckResourceAttr(dataSource, "mock_policy.0.effective_mode", "ALL"),
-					resource.TestCheckResourceAttr(dataSource, "mock_policy.0.conditions.0.sys_name", "reqMethod"),
-					resource.TestCheckResourceAttrPair(dataSource, "publish_id", "huaweicloud_apig_api_publishment.test", "publish_id"),
-					resource.TestMatchResourceAttr(dataSource, "published_at",
-						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`))),
-			},
-		},
-	})
-}
-
-func testAccDataSourceApi_mock(name string) string {
-	return fmt.Sprintf(`
 %[1]s
 
-data "huaweicloud_availability_zones" "test" {}
+resource "huaweicloud_apig_api" "web" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_web"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/web/test"
+  security_authentication = "APP"
+  simple_authentication   = true
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+  tags                    = ["foo"]
 
-resource "huaweicloud_apig_instance" "test" {
-  name                  = "%[2]s"
-  edition               = "BASIC"
-  vpc_id                = huaweicloud_vpc.test.id
-  subnet_id             = huaweicloud_vpc_subnet.test.id
-  security_group_id     = huaweicloud_networking_secgroup.test.id
-  enterprise_project_id = "0"
-  availability_zones    = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
-}
+  request_params {
+    name         = "X-Service-Num"
+    type         = "STRING"
+    location     = "HEADER"
+    maximum      = 20
+    minimum      = 10
+    example      = "TERRAFORM01"
+    passthrough  = true
+    valid_enable = 1 # enable
+  }
 
-resource "huaweicloud_apig_group" "test" {
-  instance_id = huaweicloud_apig_instance.test.id
-  name        = "%[2]s"
-}
+  backend_params {
+    type     = "REQUEST"
+    name     = "SerivceNum"
+    location = "HEADER"
+    value    = "X-Service-Num"
+  }
 
-resource "huaweicloud_apig_response" "test" {
-  name        = "%[2]s"
-  instance_id = huaweicloud_apig_instance.test.id
-  group_id    = huaweicloud_apig_group.test.id
+  web {
+    path             = "/web/test/backend"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+    retry_count      = 1
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+  }
 
-  rule {
-    error_type  = "AUTHORIZER_FAILURE"
-    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
-    status_code = 401
+  web_policy {
+    name             = "%[2]s_web_policy"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/web/test/backend"
+    timeout          = 30000
+    retry_count      = 1
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+
+    backend_params {
+      type              = "SYSTEM"
+      name              = "SerivceNum"
+      location          = "HEADER"
+      value             = "X-Service-Num"
+      system_param_type = "backend"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "X-Service-Num"
+      type       = "Equal"
+      value      = "0001"
+    }
   }
 }
 
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%[2]s"
-  app         = "default"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Python3.6"
-  code_type   = "inline"
-}
-
-resource "huaweicloud_apig_custom_authorizer" "test" {
-  instance_id      = huaweicloud_apig_instance.test.id
-  name             = "%[2]s"
-  function_urn     = huaweicloud_fgs_function.test.urn
-  function_version = "latest"
-  type             = "FRONTEND"
-}
-
-resource "huaweicloud_apig_api" "test" {
+resource "huaweicloud_apig_api" "func_graph" {
   instance_id             = huaweicloud_apig_instance.test.id
   group_id                = huaweicloud_apig_group.test.id
-  name                    = "%[2]s"
-  type                    = "Private"
-  request_protocol        = "HTTP"
+  name                    = "%[2]s_fgs"
+  type                    = "Public"
+  request_protocol        = "GRPCS"
   request_method          = "POST"
-  request_path            = "/test/mock"
-  security_authentication = "AUTHORIZER"
-  matching                = "Prefix"
-  response_id             = huaweicloud_apig_response.test.id
-  authorizer_id           = huaweicloud_apig_custom_authorizer.test.id
-  body_description        = "This is request body description"
-  cors                    = true
+  request_path            = "/fgs/test"
+  security_authentication = "APP"
+  simple_authentication   = true
+  matching                = "Exact"
+  description             = "Created by script"
+  tags                    = ["foo"]
+
+  func_graph {
+    function_urn     = huaweicloud_fgs_function.test[1].urn
+    version          = tolist(huaweicloud_fgs_function.test[1].versions)[0].name
+    network_type     = "V2"
+    request_protocol = "GRPCS"
+    timeout          = 5000
+    invocation_type  = "sync"
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+  }
+
+  func_graph_policy {
+    name             = "%[2]s_fgs_policy"
+    function_urn     = huaweicloud_fgs_function.test[1].urn
+    version          = tolist(huaweicloud_fgs_function.test[1].versions)[0].name
+    network_type     = "V2"
+    request_protocol = "GRPCS"
+    timeout          = 5000
+    invocation_type  = "sync"
+    effective_mode   = "ANY"
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+
+    conditions {
+      source      = "cookie"
+      cookie_name = "regex_test"
+      type        = "Matching"
+      value       = "^%[2]s:\\w+$"
+    }
+  }
+}
+
+resource "huaweicloud_apig_api" "mock" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_mock"
+  type                    = "Public"
+  request_protocol        = "HTTPS"
+  request_method          = "POST"
+  request_path            = "/mock/test"
+  security_authentication = "APP"
+  simple_authentication   = true
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
 
   mock {
-    response = "Mock backend description"
+    status_code   = 201
+    response      = "{'message':'hello world'}"
+    authorizer_id = huaweicloud_apig_custom_authorizer.test.id
   }
 
   mock_policy {
-    name           = "%[2]s"
-    response       = "Mock backend policy description"
-    effective_mode = "ALL"
+    name           = "%[2]s_mock_policy"
+    status_code    = 201
+    response       = "{'message':'hello world'}"
+    authorizer_id  = huaweicloud_apig_custom_authorizer.test.id
+    effective_mode = "ANY"
 
     conditions {
-    source   = "system"
-    type     = "Equal"
-    value    = "GET"
-    sys_name = "reqMethod"
+      source   = "system"
+      type     = "Equal"
+      value    = "user"
+      sys_name = "reqPath"
     }
   }
 }
@@ -285,19 +356,52 @@ resource "huaweicloud_apig_environment" "test" {
   name        = "%[2]s"
 }
 
-resource "huaweicloud_apig_api_publishment" "test" {
+# Publish the API (with Web backend) and query it
+resource "huaweicloud_apig_api_publishment" "web" {
   instance_id = huaweicloud_apig_instance.test.id
   env_id      = huaweicloud_apig_environment.test.id
-  api_id      = huaweicloud_apig_api.test.id
+  api_id      = huaweicloud_apig_api.web.id
 }
 
-data "huaweicloud_apig_api" "test" {
+data "huaweicloud_apig_api" "web" {
   depends_on = [
-    huaweicloud_apig_api_publishment.test
+    huaweicloud_apig_api_publishment.web
   ]
 
   instance_id = huaweicloud_apig_instance.test.id
-  api_id      = huaweicloud_apig_api.test.id
+  api_id      = huaweicloud_apig_api.web.id
 }
-`, common.TestBaseNetwork(name), name)
+
+# Publish the API (with FunctionGraph backend) and query it
+resource "huaweicloud_apig_api_publishment" "func_graph" {
+  instance_id = huaweicloud_apig_instance.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  api_id      = huaweicloud_apig_api.func_graph.id
+}
+
+data "huaweicloud_apig_api" "func_graph" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.func_graph
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.func_graph.id
+}
+
+# Publish the API (with Mock) and query it
+resource "huaweicloud_apig_api_publishment" "mock" {
+  instance_id = huaweicloud_apig_instance.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  api_id      = huaweicloud_apig_api.mock.id
+}
+
+data "huaweicloud_apig_api" "mock" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.mock
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.mock.id
+}
+`, testAccApi_base(name), name)
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_publishment_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_publishment_test.go
@@ -2,6 +2,7 @@ package apig
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -27,40 +28,69 @@ func TestAccApiPublishment_basic(t *testing.T) {
 	var (
 		histories []apis.ApiVersionInfo
 
-		rName        = acceptance.RandomAccResourceName()
-		resourceName = "huaweicloud_apig_api_publishment.test"
-	)
+		rName = acceptance.RandomAccResourceName()
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&histories,
-		getPublishmentResourceFunc,
+		webBackend       = "huaweicloud_apig_api_publishment.web"
+		rcWithWebBackend = acceptance.InitResourceCheck(webBackend, &histories, getPublishmentResourceFunc)
+		fgsBackend       = "huaweicloud_apig_api_publishment.func_graph"
+		rcWithFgsBackend = acceptance.InitResourceCheck(fgsBackend, &histories, getPublishmentResourceFunc)
+		mockBackend      = "huaweicloud_apig_api_publishment.mock"
+		rcWithMock       = acceptance.InitResourceCheck(mockBackend, &histories, getPublishmentResourceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Before running acceptance test for each kind of APIs, please make sure the agency already assign the FGS service.
+			acceptance.TestAccPreCheckFgsAgency(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy:      rcWithWebBackend.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApiPublishment_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "instance_id",
-						"${huaweicloud_apig_instance.test.id}"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "env_id",
-						"${huaweicloud_apig_environment.test.id}"),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "api_id",
-						"${huaweicloud_apig_api.test.id}"),
-					resource.TestCheckResourceAttrSet(resourceName, "env_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "published_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "publish_id"),
+					// Publish the API with Web backend
+					rcWithWebBackend.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(webBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "env_id", "huaweicloud_apig_environment.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "env_name", "huaweicloud_apig_environment.test", "name"),
+					resource.TestCheckResourceAttrPair(webBackend, "api_id", "huaweicloud_apig_api.web", "id"),
+					resource.TestMatchResourceAttr(webBackend, "published_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(webBackend, "publish_id"),
+					// Publish the API with FunctionGraph backend
+					rcWithFgsBackend.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(fgsBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "env_id", "huaweicloud_apig_environment.test", "id"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "env_name", "huaweicloud_apig_environment.test", "name"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "api_id", "huaweicloud_apig_api.func_graph", "id"),
+					resource.TestMatchResourceAttr(fgsBackend, "published_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(fgsBackend, "publish_id"),
+					// Publish the API with Mock configuration
+					rcWithMock.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(mockBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "env_id", "huaweicloud_apig_environment.test", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "env_name", "huaweicloud_apig_environment.test", "name"),
+					resource.TestCheckResourceAttrPair(mockBackend, "api_id", "huaweicloud_apig_api.mock", "id"),
+					resource.TestMatchResourceAttr(mockBackend, "published_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrSet(mockBackend, "publish_id"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      webBackend,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      fgsBackend,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      mockBackend,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -69,20 +99,211 @@ func TestAccApiPublishment_basic(t *testing.T) {
 }
 
 func testAccApiPublishment_basic(name string) string {
-	relatedConfig := testAccApi_basic(testAccApi_base(name), name)
-
 	return fmt.Sprintf(`
 %[1]s
+
+resource "huaweicloud_apig_api" "web" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_web"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/web/test"
+  security_authentication = "APP"
+  simple_authentication   = true
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+
+  request_params {
+    name         = "X-Service-Num"
+    type         = "STRING"
+    location     = "HEADER"
+    maximum      = 20
+    minimum      = 10
+    example      = "TERRAFORM01"
+    passthrough  = true
+    valid_enable = 1 # enable
+  }
+
+  backend_params {
+    type     = "REQUEST"
+    name     = "SerivceNum"
+    location = "HEADER"
+    value    = "X-Service-Num"
+  }
+
+  web {
+    path             = "/web/test/backend"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+    retry_count      = 1
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+  }
+
+  web_policy {
+    name             = "%[2]s_web_policy"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/web/test/backend"
+    timeout          = 30000
+    retry_count      = 1
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+
+    backend_params {
+      type              = "SYSTEM"
+      name              = "SerivceNum"
+      location          = "HEADER"
+      value             = "X-Service-Num"
+      system_param_type = "backend"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "X-Service-Num"
+      type       = "Equal"
+      value      = "0001"
+    }
+  }
+}
+
+resource "huaweicloud_apig_api" "func_graph" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_fgs"
+  type                    = "Public"
+  request_protocol        = "GRPCS"
+  request_method          = "POST"
+  request_path            = "/fgs/test"
+  security_authentication = "APP"
+  simple_authentication   = true
+  matching                = "Exact"
+  description             = "Created by script"
+
+  func_graph {
+    function_urn     = huaweicloud_fgs_function.test[1].urn
+    version          = tolist(huaweicloud_fgs_function.test[1].versions)[0].name
+    network_type     = "V2"
+    request_protocol = "GRPCS"
+    timeout          = 5000
+    invocation_type  = "sync"
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+  }
+
+  func_graph_policy {
+    name             = "%[2]s_fgs_policy"
+    function_urn     = huaweicloud_fgs_function.test[1].urn
+    version          = tolist(huaweicloud_fgs_function.test[1].versions)[0].name
+    network_type     = "V2"
+    request_protocol = "GRPCS"
+    timeout          = 5000
+    invocation_type  = "sync"
+    effective_mode   = "ANY"
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+
+    conditions {
+      source      = "cookie"
+      cookie_name = "regex_test"
+      type        = "Matching"
+      value       = "^%[2]s:\\w+$"
+    }
+  }
+}
+
+resource "huaweicloud_apig_api" "mock" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_mock"
+  type                    = "Public"
+  request_protocol        = "HTTPS"
+  request_method          = "POST"
+  request_path            = "/mock/test"
+  security_authentication = "APP"
+  simple_authentication   = true
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+
+  mock {
+    status_code   = 201
+    response      = "{'message':'hello world'}"
+    authorizer_id = huaweicloud_apig_custom_authorizer.test.id
+  }
+
+  mock_policy {
+    name           = "%[2]s_mock_policy"
+    status_code    = 201
+    response       = "{'message':'hello world'}"
+    authorizer_id  = huaweicloud_apig_custom_authorizer.test.id
+    effective_mode = "ANY"
+
+    conditions {
+      source   = "system"
+      type     = "Equal"
+      value    = "user"
+      sys_name = "reqPath"
+    }
+  }
+}
 
 resource "huaweicloud_apig_environment" "test" {
   instance_id = huaweicloud_apig_instance.test.id
   name        = "%[2]s"
 }
 
-resource "huaweicloud_apig_api_publishment" "test" {
+# Publish the API (with Web backend) and query it
+resource "huaweicloud_apig_api_publishment" "web" {
   instance_id = huaweicloud_apig_instance.test.id
   env_id      = huaweicloud_apig_environment.test.id
-  api_id      = huaweicloud_apig_api.test.id
+  api_id      = huaweicloud_apig_api.web.id
 }
-`, relatedConfig, name)
+
+data "huaweicloud_apig_api" "web" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.web
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.web.id
+}
+
+# Publish the API (with FunctionGraph backend) and query it
+resource "huaweicloud_apig_api_publishment" "func_graph" {
+  instance_id = huaweicloud_apig_instance.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  api_id      = huaweicloud_apig_api.func_graph.id
+}
+
+data "huaweicloud_apig_api" "func_graph" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.func_graph
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.func_graph.id
+}
+
+# Publish the API (with Mock) and query it
+resource "huaweicloud_apig_api_publishment" "mock" {
+  instance_id = huaweicloud_apig_instance.test.id
+  env_id      = huaweicloud_apig_environment.test.id
+  api_id      = huaweicloud_apig_api.mock.id
+}
+
+data "huaweicloud_apig_api" "mock" {
+  depends_on = [
+    huaweicloud_apig_api_publishment.mock
+  ]
+
+  instance_id = huaweicloud_apig_instance.test.id
+  api_id      = huaweicloud_apig_api.mock.id
+}
+`, testAccApi_base(name), name)
 }

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_api_test.go
@@ -26,98 +26,346 @@ func TestAccApi_basic(t *testing.T) {
 	var (
 		api apis.APIResp
 
-		rName       = "huaweicloud_apig_api.test"
+		webBackend       = "huaweicloud_apig_api.web"
+		rcWithWebBackend = acceptance.InitResourceCheck(webBackend, &api, getApiFunc)
+		fgsBackend       = "huaweicloud_apig_api.func_graph"
+		rcWithFgsBackend = acceptance.InitResourceCheck(fgsBackend, &api, getApiFunc)
+		mockBackend      = "huaweicloud_apig_api.mock"
+		rcWithMock       = acceptance.InitResourceCheck(mockBackend, &api, getApiFunc)
+
 		name        = acceptance.RandomAccResourceName()
 		updateName  = acceptance.RandomAccResourceName()
 		basicConfig = testAccApi_base(name)
 	)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&api,
-		getApiFunc,
-	)
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Before running acceptance test for each kind of APIs, please make sure the agency already assign the FGS service.
+			acceptance.TestAccPreCheckFgsAgency(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy:      rcWithWebBackend.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccApi_basic(basicConfig, name),
+				Config: testAccApi_basic_step1(basicConfig, name),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "type", "Public"),
-					resource.TestCheckResourceAttr(rName, "description", "Created by script"),
-					resource.TestCheckResourceAttr(rName, "request_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(rName, "request_method", "GET"),
-					resource.TestCheckResourceAttr(rName, "request_path", "/user_info/{user_age}"),
-					resource.TestCheckResourceAttr(rName, "security_authentication", "APP"),
-					resource.TestCheckResourceAttr(rName, "matching", "Exact"),
-					resource.TestCheckResourceAttr(rName, "success_response", "Success response"),
-					resource.TestCheckResourceAttr(rName, "failure_response", "Failed response"),
-					resource.TestCheckResourceAttr(rName, "request_params.#", "2"),
-					resource.TestCheckResourceAttr(rName, "backend_params.#", "2"),
-					resource.TestCheckResourceAttr(rName, "web.0.path", "/getUserAge/{userAge}"),
-					resource.TestCheckResourceAttr(rName, "web.0.request_method", "GET"),
-					resource.TestCheckResourceAttr(rName, "web.0.request_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(rName, "web.0.timeout", "30000"),
-					resource.TestCheckResourceAttr(rName, "web_policy.#", "1"),
-					resource.TestCheckResourceAttr(rName, "web_policy.0.conditions.#", "1"),
-					resource.TestCheckResourceAttr(rName, "mock.#", "0"),
-					resource.TestCheckResourceAttr(rName, "func_graph.#", "0"),
-					resource.TestCheckResourceAttr(rName, "mock_policy.#", "0"),
-					resource.TestCheckResourceAttr(rName, "func_graph_policy.#", "0"),
-					resource.TestCheckResourceAttrPair(rName, "web.0.authorizer_id",
+					// Web backend
+					rcWithWebBackend.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(webBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "name", name+"_web"),
+					resource.TestCheckResourceAttr(webBackend, "type", "Public"),
+					resource.TestCheckResourceAttr(webBackend, "request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(webBackend, "request_method", "GET"),
+					resource.TestCheckResourceAttr(webBackend, "request_path", "/web/test"),
+					resource.TestCheckResourceAttr(webBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(webBackend, "simple_authentication", "true"),
+					resource.TestCheckResourceAttr(webBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(webBackend, "success_response", "Success response"),
+					resource.TestCheckResourceAttr(webBackend, "failure_response", "Failed response"),
+					resource.TestCheckResourceAttr(webBackend, "description", "Created by script"),
+					resource.TestCheckResourceAttr(webBackend, "tags.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "tags.0", "foo"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.name", "X-Service-Num"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.type", "STRING"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.location", "HEADER"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.maximum", "20"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.minimum", "10"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.example", "TERRAFORM01"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.passthrough", "true"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.valid_enable", "1"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.type", "REQUEST"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.name", "SerivceNum"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.location", "HEADER"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.value", "X-Service-Num"),
+					resource.TestCheckResourceAttr(webBackend, "web.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.path", "/web/test/backend"),
+					resource.TestCheckResourceAttrPair(webBackend, "web.0.vpc_channel_id", "huaweicloud_apig_channel.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.timeout", "30000"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.retry_count", "1"),
+					resource.TestCheckResourceAttrPair(webBackend, "web.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.name", name+"_web_policy"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.effective_mode", "ANY"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.path", "/web/test/backend"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.timeout", "30000"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.retry_count", "1"),
+					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.vpc_channel_id", "huaweicloud_apig_channel.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.type", "SYSTEM"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.name", "SerivceNum"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.location", "HEADER"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.value", "X-Service-Num"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.system_param_type", "backend"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.source", "param"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.param_name", "X-Service-Num"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.type", "Equal"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.value", "0001"),
+					resource.TestCheckResourceAttr(webBackend, "mock.#", "0"),
+					resource.TestCheckResourceAttr(webBackend, "func_graph.#", "0"),
+					resource.TestCheckResourceAttr(webBackend, "mock_policy.#", "0"),
+					resource.TestCheckResourceAttr(webBackend, "func_graph_policy.#", "0"),
+					// FunctionGraph backend
+					rcWithFgsBackend.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(webBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(fgsBackend, "name", name+"_fgs"),
+					resource.TestCheckResourceAttr(fgsBackend, "type", "Public"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_protocol", "GRPCS"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_method", "POST"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_path", "/fgs/test"),
+					resource.TestCheckResourceAttr(fgsBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(fgsBackend, "simple_authentication", "true"),
+					resource.TestCheckResourceAttr(fgsBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_params.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "backend_params.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.#", "1"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.function_urn", "huaweicloud_fgs_function.test.1", "urn"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.version", "huaweicloud_fgs_function.test.1", "versions.0.name"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.network_type", "V2"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.request_protocol", "GRPCS"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.timeout", "5000"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.invocation_type", "sync"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.#", "1"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.name", name+"_fgs_policy"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.function_urn", "huaweicloud_fgs_function.test.1", "urn"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.version",
+						"huaweicloud_fgs_function.test.1", "versions.0.name"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.network_type", "V2"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.request_protocol", "GRPCS"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.timeout", "5000"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.invocation_type", "sync"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.effective_mode", "ANY"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.authorizer_id",
 						"huaweicloud_apig_custom_authorizer.test", "id"),
-					resource.TestCheckResourceAttr(rName, "web_policy.0.backend_params.#", "3"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.source", "cookie"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.cookie_name", "regex_test"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.type", "Matching"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.value", fmt.Sprintf("^%s:\\w+$", name)),
+					resource.TestCheckResourceAttr(fgsBackend, "web.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "mock.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "web_policy.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "mock_policy.#", "0"),
+					// Mock configuration
+					rcWithMock.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(webBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(mockBackend, "name", name+"_mock"),
+					resource.TestCheckResourceAttr(mockBackend, "type", "Public"),
+					resource.TestCheckResourceAttr(mockBackend, "request_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(mockBackend, "request_method", "POST"),
+					resource.TestCheckResourceAttr(mockBackend, "request_path", "/mock/test"),
+					resource.TestCheckResourceAttr(mockBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(mockBackend, "simple_authentication", "true"),
+					resource.TestCheckResourceAttr(mockBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(mockBackend, "request_params.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "backend_params.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "mock.#", "1"),
+					resource.TestCheckResourceAttr(mockBackend, "mock.0.status_code", "201"),
+					resource.TestCheckResourceAttr(mockBackend, "mock.0.response", "{'message':'hello world'}"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.#", "1"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.name", name+"_mock_policy"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.status_code", "201"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.response", "{'message':'hello world'}"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.effective_mode", "ANY"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.source", "system"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.type", "Equal"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.value", "user"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.sys_name", "reqPath"),
+					resource.TestCheckResourceAttr(mockBackend, "web.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "func_graph.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "web_policy.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "func_graph_policy.#", "0"),
 				),
 			},
 			{
-				Config: testAccApi_update(basicConfig, updateName),
+				Config: testAccApi_basic_step2(basicConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", updateName),
-					resource.TestCheckResourceAttr(rName, "type", "Public"),
-					resource.TestCheckResourceAttr(rName, "description", "Updated by script"),
-					resource.TestCheckResourceAttr(rName, "request_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(rName, "request_method", "GET"),
-					resource.TestCheckResourceAttr(rName, "request_path", "/user_info/{user_name}"),
-					resource.TestCheckResourceAttr(rName, "security_authentication", "APP"),
-					resource.TestCheckResourceAttr(rName, "matching", "Exact"),
-					resource.TestCheckResourceAttr(rName, "success_response", "Updated Success response"),
-					resource.TestCheckResourceAttr(rName, "failure_response", "Updated Failed response"),
-					resource.TestCheckResourceAttr(rName, "request_params.#", "2"),
-					resource.TestCheckResourceAttr(rName, "backend_params.#", "3"),
-					resource.TestCheckResourceAttr(rName, "web.0.path", "/getUserName/{userName}"),
-					resource.TestCheckResourceAttr(rName, "web.0.request_method", "GET"),
-					resource.TestCheckResourceAttr(rName, "web.0.request_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(rName, "web.0.timeout", "60000"),
-					resource.TestCheckResourceAttr(rName, "web_policy.#", "1"),
-					resource.TestCheckResourceAttr(rName, "web_policy.0.conditions.#", "2"),
-					resource.TestCheckResourceAttr(rName, "mock.#", "0"),
-					resource.TestCheckResourceAttr(rName, "func_graph.#", "0"),
-					resource.TestCheckResourceAttr(rName, "mock_policy.#", "0"),
-					resource.TestCheckResourceAttr(rName, "func_graph_policy.#", "0"),
-					resource.TestCheckResourceAttr(rName, "web_policy.0.backend_params.#", "3"),
+					// Web backend
+					rcWithWebBackend.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(webBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "name", updateName+"_web"),
+					resource.TestCheckResourceAttr(webBackend, "type", "Private"),
+					resource.TestCheckResourceAttr(webBackend, "request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(webBackend, "request_method", "GET"),
+					resource.TestCheckResourceAttr(webBackend, "request_path", "/web/new/test"),
+					resource.TestCheckResourceAttr(webBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(webBackend, "simple_authentication", "false"),
+					resource.TestCheckResourceAttr(webBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(webBackend, "success_response", "Updated success response"),
+					resource.TestCheckResourceAttr(webBackend, "failure_response", "Updated failed response"),
+					resource.TestCheckResourceAttr(webBackend, "description", ""),
+					resource.TestCheckResourceAttr(webBackend, "tags.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "tags.0", "key"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.name", "X-Service-Name"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.type", "STRING"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.location", "HEADER"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.maximum", "30"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.minimum", "5"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.example", "XF"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.passthrough", "false"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.enumeration", "AF,RF"),
+					resource.TestCheckResourceAttr(webBackend, "request_params.0.valid_enable", "2"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.type", "REQUEST"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.name", "ServiceName"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.location", "HEADER"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.value", "X-Service-Name"),
+					resource.TestCheckResourceAttr(webBackend, "backend_params.0.system_param_type", "backend"),
+					resource.TestCheckResourceAttr(webBackend, "web.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.path", "/web/new/test/backend"),
+					resource.TestCheckResourceAttrPair(webBackend, "web.0.vpc_channel_id", "huaweicloud_apig_channel.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.timeout", "40000"),
+					resource.TestCheckResourceAttr(webBackend, "web.0.retry_count", "2"),
+					resource.TestCheckResourceAttrPair(webBackend, "web.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.name", updateName+"_web_policy"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.effective_mode", "ALL"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.path", "/web/new/test/backend"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.timeout", "40000"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.retry_count", "2"),
+					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.vpc_channel_id", "huaweicloud_apig_channel.test", "id"),
+					resource.TestCheckResourceAttrPair(webBackend, "web_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.type", "SYSTEM"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.name", "ServiceName"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.location", "HEADER"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.value", "X-Service-Name"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.backend_params.0.system_param_type", "backend"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.source", "param"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.param_name", "X-Service-Name"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.type", "Equal"),
+					resource.TestCheckResourceAttr(webBackend, "web_policy.0.conditions.0.value", "TF"),
+					resource.TestCheckResourceAttr(webBackend, "mock.#", "0"),
+					resource.TestCheckResourceAttr(webBackend, "func_graph.#", "0"),
+					resource.TestCheckResourceAttr(webBackend, "mock_policy.#", "0"),
+					resource.TestCheckResourceAttr(webBackend, "func_graph_policy.#", "0"),
+					// FunctionGraph backend
+					rcWithFgsBackend.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(webBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(fgsBackend, "name", updateName+"_fgs"),
+					resource.TestCheckResourceAttr(fgsBackend, "type", "Private"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_protocol", "GRPCS"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_method", "POST"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_path", "/fgs/new/test"),
+					resource.TestCheckResourceAttr(fgsBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(fgsBackend, "simple_authentication", "false"),
+					resource.TestCheckResourceAttr(fgsBackend, "description", ""),
+					resource.TestCheckResourceAttr(fgsBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(fgsBackend, "request_params.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "backend_params.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.#", "1"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.function_urn", "huaweicloud_fgs_function.test.1", "urn"),
+					resource.TestCheckResourceAttrSet(fgsBackend, "func_graph.0.function_alias_urn"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.network_type", "V2"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.request_protocol", "GRPCS"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.timeout", "6000"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph.0.invocation_type", "sync"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.#", "1"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.name", updateName+"_fgs_policy"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.function_urn", "huaweicloud_fgs_function.test.1", "urn"),
+					resource.TestCheckResourceAttrSet(fgsBackend, "func_graph_policy.0.function_alias_urn"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.network_type", "V2"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.request_protocol", "GRPCS"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.timeout", "6000"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.invocation_type", "sync"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.effective_mode", "ALL"),
+					resource.TestCheckResourceAttrPair(fgsBackend, "func_graph_policy.0.authorizer_id",
+						"huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.source", "cookie"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.cookie_name", "regex_test"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.type", "Matching"),
+					resource.TestCheckResourceAttr(fgsBackend, "func_graph_policy.0.conditions.0.value", fmt.Sprintf("^cookie-%s:\\w+$", updateName)),
+					resource.TestCheckResourceAttr(fgsBackend, "web.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "mock.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "web_policy.#", "0"),
+					resource.TestCheckResourceAttr(fgsBackend, "mock_policy.#", "0"),
+					// Mock configuration
+					rcWithMock.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(webBackend, "instance_id", "huaweicloud_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(mockBackend, "group_id", "huaweicloud_apig_group.test", "id"),
+					resource.TestCheckResourceAttr(mockBackend, "name", updateName+"_mock"),
+					resource.TestCheckResourceAttr(mockBackend, "type", "Private"),
+					resource.TestCheckResourceAttr(mockBackend, "request_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(mockBackend, "request_method", "POST"),
+					resource.TestCheckResourceAttr(mockBackend, "request_path", "/mock/new/test"),
+					resource.TestCheckResourceAttr(mockBackend, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(mockBackend, "simple_authentication", "false"),
+					resource.TestCheckResourceAttr(mockBackend, "matching", "Exact"),
+					resource.TestCheckResourceAttr(webBackend, "success_response", "Updated success response"),
+					resource.TestCheckResourceAttr(webBackend, "failure_response", "Updated failed response"),
+					resource.TestCheckResourceAttr(webBackend, "description", ""),
+					resource.TestCheckResourceAttr(mockBackend, "request_params.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "backend_params.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "mock.#", "1"),
+					resource.TestCheckResourceAttr(mockBackend, "mock.0.status_code", "202"),
+					resource.TestCheckResourceAttr(mockBackend, "mock.0.response", "{'message':'hello world!'}"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.#", "1"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.name", updateName+"_mock_policy"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.status_code", "202"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.response", "{'message':'hello world!'}"),
+					resource.TestCheckResourceAttrPair(mockBackend, "mock_policy.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.effective_mode", "ALL"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.#", "1"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.source", "system"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.type", "Equal"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.value", "GET"),
+					resource.TestCheckResourceAttr(mockBackend, "mock_policy.0.conditions.0.sys_name", "reqMethod"),
+					resource.TestCheckResourceAttr(mockBackend, "web.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "func_graph.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "web_policy.#", "0"),
+					resource.TestCheckResourceAttr(mockBackend, "func_graph_policy.#", "0"),
 				),
 			},
 			{
-				ResourceName:      rName,
+				ResourceName:      webBackend,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApiResourceImportStateFunc(),
+				ImportStateIdFunc: testAccApiResourceImportStateFunc(webBackend),
+			},
+			{
+				ResourceName:      fgsBackend,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApiResourceImportStateFunc(fgsBackend),
+			},
+			{
+				ResourceName:      mockBackend,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApiResourceImportStateFunc(mockBackend),
 			},
 		},
 	})
 }
 
-func testAccApiResourceImportStateFunc() resource.ImportStateIdFunc {
+func testAccApiResourceImportStateFunc(rName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		rName := "huaweicloud_apig_api.test"
 		rs, ok := s.RootModule().Resources[rName]
 		if !ok {
 			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
@@ -134,10 +382,12 @@ func testAccApi_base(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
+// When the backend uses the load balance channel, the number of retry count cannot exceed the number of available
+// backend servers in the load balance channel.
 resource "huaweicloud_compute_instance" "test" {
-  count = 2
+  count = 3
 
-  name               = "%[2]s_${count.index}"
+  name               = format("%[2]s_%%d", count.index)
   image_id           = data.huaweicloud_images_image.test.id
   flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
   security_group_ids = [huaweicloud_networking_secgroup.test.id]
@@ -149,6 +399,29 @@ resource "huaweicloud_compute_instance" "test" {
   }
 }
 
+resource "huaweicloud_fgs_function" "test" {
+  count = 2
+
+  functiongraph_version = "v2"
+  agency                = "%[3]s"
+  name                  = format("%[2]s_http_%%d", count.index)
+  app                   = "default"
+  handler               = "bootstrap"
+  memory_size           = 128
+  timeout               = 3
+  runtime               = "http"
+  code_type             = "inline"
+  func_code             = "dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganN="
+
+  versions {
+    name = "%[2]s"
+
+    aliases {
+      name = "custom_alias"
+    }
+  }
+}
+
 resource "huaweicloud_apig_instance" "test" {
   name                  = "%[2]s"
   edition               = "BASIC"
@@ -164,430 +437,359 @@ resource "huaweicloud_apig_group" "test" {
   instance_id = huaweicloud_apig_instance.test.id
 }
 
-resource "huaweicloud_apig_vpc_channel" "test" {
-  name        = "%[2]s"
-  instance_id = huaweicloud_apig_instance.test.id
-  port        = 80
-  algorithm   = "WRR"
-  protocol    = "HTTP"
-  path        = "/"
-  http_code   = "201"
+resource "huaweicloud_apig_channel" "test" {
+  instance_id        = huaweicloud_apig_instance.test.id
+  name               = "%[2]s"
+  port               = 80
+  balance_strategy   = 1
+  member_type        = "ecs"
+  type               = 2
 
-  dynamic "members" {
-    for_each = huaweicloud_compute_instance.test[*].id
+  health_check {
+    protocol           = "TCP"
+    threshold_normal   = 1 # minimum value
+    threshold_abnormal = 1 # minimum value
+    interval           = 1 # minimum value
+    timeout            = 1 # minimum value
+  }
+
+  dynamic "member" {
+    for_each = huaweicloud_compute_instance.test[*]
 
     content {
-      id = members.value
+      id   = member.value.id
+      name = member.value.name
     }
   }
 }
 
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%[2]s"
-  app         = "default"
-  description = "API custom authorization test"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Python3.6"
-  code_type   = "inline"
-
-  func_code = <<EOF
-# -*- coding:utf-8 -*-
-import json
-def handler(event, context):
-    if event["headers"]["authorization"]=='Basic dXNlcjE6cGFzc3dvcmQ=':
-        return {
-            'statusCode': 200,
-            'body': json.dumps({
-                "status":"allow",
-                "context":{
-                    "user_name":"user1"
-                }
-            })
-        }
-    else:
-        return {
-            'statusCode': 200,
-            'body': json.dumps({
-                "status":"deny",
-                "context":{
-                    "code":"1001",
-                    "message":"incorrect username or password"
-                }
-            })
-        }
-EOF
-}
-
 resource "huaweicloud_apig_custom_authorizer" "test" {
-  instance_id      = huaweicloud_apig_instance.test.id
-  name             = "%[2]s"
-  function_urn     = huaweicloud_fgs_function.test.urn
-  function_version = "latest"
-  type             = "BACKEND"
-  cache_age        = 60
+  instance_id        = huaweicloud_apig_instance.test.id
+  name               = "%[2]s"
+  function_urn       = huaweicloud_fgs_function.test[0].urn
+  function_alias_uri = format("%%s:!%%s", huaweicloud_fgs_function.test[0].urn, tolist(huaweicloud_fgs_function.test[0].versions)[0].aliases[0].name)
+  network_type       = "V2"
+  type               = "BACKEND"
+  is_body_send       = true
+  user_data          = "Demo"
+  cache_age          = 15
 }
-`, common.TestBaseComputeResources(name), name)
+`, common.TestBaseComputeResources(name), name, acceptance.HW_FGS_AGENCY_NAME)
 }
 
-func testAccApi_basic(relatedConfig, name string) string {
+func testAccApi_basic_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_apig_api" "test" {
+resource "huaweicloud_apig_api" "web" {
   instance_id             = huaweicloud_apig_instance.test.id
   group_id                = huaweicloud_apig_group.test.id
-  name                    = "%[2]s"
+  name                    = "%[2]s_web"
   type                    = "Public"
   request_protocol        = "HTTP"
   request_method          = "GET"
-  request_path            = "/user_info/{user_age}"
+  request_path            = "/web/test"
   security_authentication = "APP"
+  simple_authentication   = true
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+  tags                    = ["foo"]
+
+  request_params {
+    name         = "X-Service-Num"
+    type         = "STRING"
+    location     = "HEADER"
+    maximum      = 20
+    minimum      = 10
+    example      = "TERRAFORM01"
+    passthrough  = true
+    valid_enable = 1 # enable
+  }
+
+  backend_params {
+    type     = "REQUEST"
+    name     = "SerivceNum"
+    location = "HEADER"
+    value    = "X-Service-Num"
+  }
+
+  web {
+    path             = "/web/test/backend"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+    retry_count      = 1
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+  }
+
+  web_policy {
+    name             = "%[2]s_web_policy"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/web/test/backend"
+    timeout          = 30000
+    retry_count      = 1
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+
+    backend_params {
+      type              = "SYSTEM"
+      name              = "SerivceNum"
+      location          = "HEADER"
+      value             = "X-Service-Num"
+      system_param_type = "backend"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "X-Service-Num"
+      type       = "Equal"
+      value      = "0001"
+    }
+  }
+}
+
+resource "huaweicloud_apig_api" "func_graph" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_fgs"
+  type                    = "Public"
+  request_protocol        = "GRPCS"
+  request_method          = "POST"
+  request_path            = "/fgs/test"
+  security_authentication = "APP"
+  simple_authentication   = true
+  matching                = "Exact"
+  description             = "Created by script"
+
+  func_graph {
+    function_urn     = huaweicloud_fgs_function.test[1].urn
+    version          = tolist(huaweicloud_fgs_function.test[1].versions)[0].name
+    network_type     = "V2"
+    request_protocol = "GRPCS"
+    timeout          = 5000
+    invocation_type  = "sync"
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+  }
+
+  func_graph_policy {
+    name             = "%[2]s_fgs_policy"
+    function_urn     = huaweicloud_fgs_function.test[1].urn
+    version          = tolist(huaweicloud_fgs_function.test[1].versions)[0].name
+    network_type     = "V2"
+    request_protocol = "GRPCS"
+    timeout          = 5000
+    invocation_type  = "sync"
+    effective_mode   = "ANY"
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+
+    conditions {
+      source      = "cookie"
+      cookie_name = "regex_test"
+      type        = "Matching"
+      value       = "^%[2]s:\\w+$"
+    }
+  }
+}
+
+resource "huaweicloud_apig_api" "mock" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_mock"
+  type                    = "Public"
+  request_protocol        = "HTTPS"
+  request_method          = "POST"
+  request_path            = "/mock/test"
+  security_authentication = "APP"
+  simple_authentication   = true
   matching                = "Exact"
   success_response        = "Success response"
   failure_response        = "Failed response"
   description             = "Created by script"
 
-  request_params {
-    name     = "user_age"
-    type     = "NUMBER"
-    location = "PATH"
-    required = true
-    maximum  = 200
-    minimum  = 0
-  }
-  request_params {
-    name        = "X-TEST-ENUM"
-    type        = "STRING"
-    location    = "HEADER"
-    maximum     = 20
-    minimum     = 10
-    example     = "ACC_TEST_XXX"
-    passthrough = true
-    enumeration = "ACC_TEST_A,ACC_TEST_B"
+  mock {
+    status_code   = 201
+    response      = "{'message':'hello world'}"
+    authorizer_id = huaweicloud_apig_custom_authorizer.test.id
   }
 
-  backend_params {
-    type     = "REQUEST"
-    name     = "userAge"
-    location = "PATH"
-    value    = "user_age"
-  }
-  backend_params {
-    type              = "SYSTEM"
-    name              = "x-test-id"
-    location          = "HEADER"
-    value             = "x-test-id"
-    system_param_type = "backend"
-  }
-
-  web {
-    path             = "/getUserAge/{userAge}"
-    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
-    request_method   = "GET"
-    request_protocol = "HTTP"
-    timeout          = 30000
-    retry_count      = 1
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
-  }
-
-  web_policy {
-    name             = "%[2]s_policy1"
-    request_protocol = "HTTP"
-    request_method   = "GET"
-    effective_mode   = "ANY"
-    path             = "/getUserAge/{userAge}"
-    timeout          = 30000
-    retry_count      = 1
-    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
-
-    backend_params {
-      type     = "REQUEST"
-      name     = "userAge"
-      location = "PATH"
-      value    = "user_age"
-    }
-    backend_params {
-      type              = "SYSTEM"
-      name              = "x-test-policy-id"
-      location          = "HEADER"
-      value             = "x-test-policy-id"
-      system_param_type = "backend"
-    }
-    backend_params {
-      type              = "SYSTEM"
-      name              = "%[2]s"
-      location          = "HEADER"
-      value             = "serverName"
-      system_param_type = "internal"
-    }
-
-    conditions {
-      source     = "param"
-      param_name = "user_age"
-      type       = "Equal"
-      value      = "28"
-    }
-  }
-}
-`, relatedConfig, name)
-}
-
-func testAccApi_update(relatedConfig, name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_apig_api" "test" {
-  instance_id             = huaweicloud_apig_instance.test.id
-  group_id                = huaweicloud_apig_group.test.id
-  name                    = "%[2]s"
-  type                    = "Public"
-  request_protocol        = "HTTP"
-  request_method          = "GET"
-  request_path            = "/user_info/{user_name}"
-  security_authentication = "APP"
-  matching                = "Exact"
-  success_response        = "Updated Success response"
-  failure_response        = "Updated Failed response"
-  description             = "Updated by script"
-
-  request_params {
-    name     = "user_name"
-    type     = "STRING"
-    location = "PATH"
-    required = true
-    maximum  = 64
-    minimum  = 3
-  }
-  request_params {
-    name        = "X-TEST-ENUM"
-    type        = "STRING"
-    location    = "HEADER"
-    maximum     = 20
-    minimum     = 10
-    example     = "ACC_TEST_XXXX"
-    passthrough = false
-    enumeration = "ACC_TEST_A,ACC_TEST_B,ACC_TEST_C"
-  }
-
-  backend_params {
-    type     = "REQUEST"
-    name     = "userName"
-    location = "PATH"
-    value    = "user_name"
-  }
-  backend_params {
-    type              = "SYSTEM"
-    name              = "x-update-policy-id"
-    location          = "HEADER"
-    value             = "x-update-policy-id"
-    system_param_type = "backend"
-  }
-  backend_params {
-    type              = "SYSTEM"
-    name              = "%[2]s"
-    location          = "HEADER"
-    value             = "serverName"
-    system_param_type = "internal"
-  }
-
-  web {
-    path             = "/getUserName/{userName}"
-    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
-    request_method   = "GET"
-    request_protocol = "HTTP"
-    timeout          = 60000
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
-  }
-
-  web_policy {
-    name             = "%[2]s_policy1"
-    request_protocol = "HTTP"
-    request_method   = "GET"
-    effective_mode   = "ANY"
-    path             = "/getAdminName/{adminName}"
-    timeout          = 60000
-    vpc_channel_id   = huaweicloud_apig_vpc_channel.test.id
-    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
-
-    backend_params {
-      type     = "REQUEST"
-      name     = "adminName"
-      location = "PATH"
-      value    = "user_name"
-    }
-    backend_params {
-      type              = "SYSTEM"
-      name              = "x-update-policy-id"
-      location          = "HEADER"
-      value             = "x-update-policy-id"
-      system_param_type = "backend"
-    }
-    backend_params {
-      type              = "SYSTEM"
-      name              = "%[2]s"
-      location          = "HEADER"
-      value             = "serverName"
-      system_param_type = "internal"
-    }
-
-    conditions {
-      source     = "param"
-      param_name = "user_name"
-      type       = "Equal"
-      value      = "Administrator"
-    }
-    conditions {
-      source      = "cookie"
-      cookie_name = "user_name"
-      type        = "Equal"
-      value       = "value_test"
-    }
-  }
-}
-`, relatedConfig, name)
-}
-
-func TestAccApi_functionGraph(t *testing.T) {
-	var (
-		api apis.APIResp
-
-		rName = "huaweicloud_apig_api.test"
-		name  = acceptance.RandomAccResourceName()
-	)
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&api,
-		getApiFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccApi_functionGraph(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "type", "Public"),
-					resource.TestCheckResourceAttr(rName, "request_protocol", "HTTP"),
-					resource.TestCheckResourceAttr(rName, "request_method", "POST"),
-					resource.TestCheckResourceAttr(rName, "request_path", fmt.Sprintf("/test/function/%s", name)),
-					resource.TestCheckResourceAttr(rName, "func_graph.#", "1"),
-					resource.TestCheckResourceAttr(rName, "func_graph.0.invocation_type", "async"),
-					resource.TestCheckResourceAttr(rName, "func_graph.0.timeout", "6000"),
-					resource.TestCheckResourceAttrPair(rName, "func_graph.0.function_urn", "huaweicloud_fgs_function.test", "urn"),
-					resource.TestCheckResourceAttrPair(rName, "func_graph.0.version", "huaweicloud_fgs_function.test", "version"),
-					resource.TestCheckResourceAttrPair(rName, "func_graph.0.authorizer_id", "huaweicloud_apig_custom_authorizer.test", "id"),
-					resource.TestCheckResourceAttr(rName, "func_graph_policy.#", "1"),
-					resource.TestCheckResourceAttr(rName, "func_graph_policy.0.invocation_type", "async"),
-					resource.TestCheckResourceAttr(rName, "func_graph_policy.0.backend_params.#", "1"),
-					resource.TestCheckResourceAttr(rName, "func_graph_policy.0.conditions.#", "1"),
-					resource.TestCheckResourceAttr(rName, "web.#", "0"),
-					resource.TestCheckResourceAttr(rName, "web_policy.#", "0"),
-					resource.TestCheckResourceAttr(rName, "mock.#", "0"),
-					resource.TestCheckResourceAttr(rName, "mock_policy.#", "0"),
-				),
-			},
-			{
-				ResourceName:      rName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccApiResourceImportStateFunc(),
-			},
-		},
-	})
-}
-
-func testAccApi_functionGraph(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_availability_zones" "test" {}
-
-resource "huaweicloud_apig_instance" "test" {
-  name                  = "%[2]s"
-  edition               = "BASIC"
-  vpc_id                = huaweicloud_vpc.test.id
-  subnet_id             = huaweicloud_vpc_subnet.test.id
-  security_group_id     = huaweicloud_networking_secgroup.test.id
-  enterprise_project_id = "0"
-  availability_zones    = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), null)
-}
-
-resource "huaweicloud_apig_group" "test" {
-  instance_id = huaweicloud_apig_instance.test.id
-  name        = "%[2]s"
-}
-  
-resource "huaweicloud_fgs_function" "test" {
-  name        = "%[2]s"
-  app         = "default"
-  handler     = "index.handler"
-  memory_size = 128
-  timeout     = 3
-  runtime     = "Python3.6"
-  code_type   = "inline"
-}
-
-resource "huaweicloud_apig_custom_authorizer" "test" {
-  instance_id      = huaweicloud_apig_instance.test.id
-  name             = "%[2]s"
-  function_urn     = huaweicloud_fgs_function.test.urn
-  function_version = "latest"
-  type             = "BACKEND"
-  cache_age        = 60
-}
-
-resource "huaweicloud_apig_api" "test" {
-  instance_id             = huaweicloud_apig_instance.test.id
-  group_id                = huaweicloud_apig_group.test.id
-  name                    = "%[2]s"
-  type                    = "Public"
-  request_protocol        = "HTTP"
-  request_method          = "POST"
-  request_path            = "/test/function/%[2]s"
-  security_authentication = "APP"
-  matching                = "Exact"
-
-  func_graph {
-    function_urn    = huaweicloud_fgs_function.test.urn
-    version         = huaweicloud_fgs_function.test.version
-    invocation_type = "async"
-    timeout         = 6000
-    authorizer_id   = huaweicloud_apig_custom_authorizer.test.id
-  }
-
-  func_graph_policy {
-    name            = "%[2]s"
-    function_urn    = huaweicloud_fgs_function.test.urn
-    invocation_type = "async"
-    timeout         = 6000
-    version         = huaweicloud_fgs_function.test.version
-    authorizer_id   = huaweicloud_apig_custom_authorizer.test.id
-
-    backend_params {
-      name        = "test_param"
-      type        = "CONSTANT"
-      location    = "QUERY"
-      value       = "%[2]s"
-      description = "created by terraform script"
-    }
+  mock_policy {
+    name           = "%[2]s_mock_policy"
+    status_code    = 201
+    response       = "{'message':'hello world'}"
+    authorizer_id  = huaweicloud_apig_custom_authorizer.test.id
+    effective_mode = "ANY"
 
     conditions {
       source   = "system"
       type     = "Equal"
-      value    = "get"
+      value    = "user"
       sys_name = "reqPath"
     }
   }
 }
-`, common.TestBaseNetwork(name), name)
+`, baseConfig, name)
+}
+
+func testAccApi_basic_step2(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_api" "web" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_web"
+  type                    = "Private"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/web/new/test"
+  security_authentication = "APP"
+  simple_authentication   = false
+  matching                = "Exact"
+  success_response        = "Updated success response"
+  failure_response        = "Updated failed response"
+  tags                    = ["key"]
+
+  request_params {
+    name         = "X-Service-Name"
+    type         = "STRING"
+    location     = "HEADER"
+    maximum      = 30
+    minimum      = 5
+    example      = "XF"
+    passthrough  = false
+    enumeration  = "AF,RF"
+    valid_enable = 2 # disable
+  }
+
+  backend_params {
+    type              = "REQUEST"
+    name              = "ServiceName"
+    location          = "HEADER"
+    value             = "X-Service-Name"
+    system_param_type = "backend"
+  }
+
+  web {
+    path             = "/web/new/test/backend"
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 40000
+    retry_count      = 2
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+  }
+
+  web_policy {
+    name             = "%[2]s_web_policy"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ALL"
+    path             = "/web/new/test/backend"
+    timeout          = 40000
+    retry_count      = 2
+    vpc_channel_id   = huaweicloud_apig_channel.test.id
+    authorizer_id    = huaweicloud_apig_custom_authorizer.test.id
+
+    backend_params {
+      type              = "SYSTEM"
+      name              = "ServiceName"
+      location          = "HEADER"
+      value             = "X-Service-Name"
+      system_param_type = "backend"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "X-Service-Name"
+      type       = "Equal"
+      value      = "TF"
+    }
+  }
+}
+
+resource "huaweicloud_apig_api" "func_graph" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_fgs"
+  type                    = "Private"
+  request_protocol        = "GRPCS"
+  request_method          = "POST"
+  request_path            = "/fgs/new/test"
+  security_authentication = "APP"
+  simple_authentication   = false
+  matching                = "Exact"
+
+  func_graph {
+    function_urn       = huaweicloud_fgs_function.test[1].urn
+    function_alias_urn = format("%%s:!%%s", huaweicloud_fgs_function.test[1].urn,
+	  tolist(huaweicloud_fgs_function.test[1].versions)[0].aliases[0].name)
+    network_type       = "V2"
+    request_protocol   = "GRPCS"
+    timeout            = 6000
+    invocation_type    = "sync"
+    authorizer_id      = huaweicloud_apig_custom_authorizer.test.id
+  }
+
+  func_graph_policy {
+    name               = "%[2]s_fgs_policy"
+    function_urn       = huaweicloud_fgs_function.test[1].urn
+    function_alias_urn = format("%%s:!%%s", huaweicloud_fgs_function.test[1].urn,
+	  tolist(huaweicloud_fgs_function.test[1].versions)[0].aliases[0].name)
+    network_type       = "V2"
+    request_protocol   = "GRPCS"
+    timeout            = 6000
+    invocation_type    = "sync"
+    effective_mode     = "ALL"
+    authorizer_id      = huaweicloud_apig_custom_authorizer.test.id
+
+    conditions {
+      source      = "cookie"
+      cookie_name = "regex_test"
+      type        = "Matching"
+      value       = "^cookie-%[2]s:\\w+$"
+    }
+  }
+}
+
+resource "huaweicloud_apig_api" "mock" {
+  instance_id             = huaweicloud_apig_instance.test.id
+  group_id                = huaweicloud_apig_group.test.id
+  name                    = "%[2]s_mock"
+  type                    = "Private"
+  request_protocol        = "HTTPS"
+  request_method          = "POST"
+  request_path            = "/mock/new/test"
+  security_authentication = "APP"
+  simple_authentication   = false
+  matching                = "Exact"
+  success_response        = "Updated success response"
+  failure_response        = "Updated failed response"
+
+  mock {
+    status_code   = 202
+    response      = "{'message':'hello world!'}"
+    authorizer_id = huaweicloud_apig_custom_authorizer.test.id
+  }
+
+  mock_policy {
+    name           = "%[2]s_mock_policy"
+    status_code    = 202
+    response       = "{'message':'hello world!'}"
+    authorizer_id  = huaweicloud_apig_custom_authorizer.test.id
+    effective_mode = "ALL"
+
+    conditions {
+      source   = "system"
+      type     = "Equal"
+      value    = "GET"
+      sys_name = "reqMethod"
+    }
+  }
+}
+`, baseConfig, name)
 }

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_api_basic_configurations.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_api_basic_configurations.go
@@ -198,6 +198,12 @@ func DataSourceApiBasicConfigurations() *schema.Resource {
 							Computed:    true,
 							Description: "The description of the API.",
 						},
+						"tags": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The list of tags configuration.",
+						},
 						// The format is `yyyy-MM-ddTHH:mm:ss{timezone}`, e.g. `2006-01-02 15:04:05+08:00`.
 						"registered_at": {
 							Type:        schema.TypeString,
@@ -372,6 +378,7 @@ func flattenApiBasicConfigurations(configurations []interface{}) []interface{} {
 			"cors":                    utils.PathSearch("cors", conf, nil),
 			"matching":                analyseApiMatchMode(utils.PathSearch("match_mode", conf, "").(string)),
 			"description":             utils.PathSearch("remark", conf, nil),
+			"tags":                    utils.PathSearch("tags", conf, nil),
 			"registered_at":           flattenTimeToRFC3339(utils.PathSearch("register_time", conf, "").(string)),
 			"updated_at":              flattenTimeToRFC3339(utils.PathSearch("update_time", conf, "").(string)),
 			"published_at":            flattenPulishTime(utils.PathSearch("publish_time", conf, "").(string)),

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/requests.go
@@ -105,6 +105,8 @@ type AuthOpt struct {
 type Mock struct {
 	// The ID of the backend configration.
 	ID string `json:"id,omitempty"`
+	// The custom status code of the mock response.
+	StatusCode int `json:"status_code,omitempty"`
 	// Description about the backend, which can contain a maximum of 255 characters.
 	// Chinese characters must be in UTF-8 or Unicode format.
 	Description *string `json:"remark,omitempty"`
@@ -129,6 +131,10 @@ type FuncGraph struct {
 	// Timeout, in ms, which allowed for API Gateway to request the backend service.
 	// The valid value is range from 1 to 600,000.
 	Timeout int `json:"timeout" required:"true"`
+	// The network architecture type of the function.
+	NetworkType string `json:"network_type,omitempty"`
+	// Function alias URN.
+	FunctionAliasUrn string `json:"alias_urn,omitempty"`
 	// Backend custom authorizer ID.
 	AuthorizerId *string `json:"authorizer_id,omitempty"`
 	// Description about the backend, which can contain a maximum of 255 characters.
@@ -137,6 +143,8 @@ type FuncGraph struct {
 	// Function version.
 	// Maximum: 64
 	Version string `json:"version,omitempty"`
+	// The request protocol of the function.
+	RequestProtocol string `json:"req_protocol,omitempty"`
 }
 
 // Web is an object which will be build up a http backend.
@@ -250,6 +258,8 @@ type PolicyMock struct {
 	// Backend name, which consists of 3 to 64 characters and must start with a letter and can contain letters, digits,
 	// and underscores (_).
 	Name string `json:"name" required:"true"`
+	// The custom status code of the mock response.
+	StatusCode int `json:"status_code,omitempty"`
 	// Authorizer ID.
 	AuthorizerId *string `json:"authorizer_id,omitempty"`
 	// Backend parameters.
@@ -275,6 +285,10 @@ type PolicyFuncGraph struct {
 	// The backend name consists of 3 to 64 characters, which must start with a letter and can contain letters, digits,
 	// and underscores (_).
 	Name string `json:"name" required:"true"`
+	// The network architecture type of the function.
+	NetworkType string `json:"network_type,omitempty"`
+	// Function alias URN.
+	FunctionAliasUrn string `json:"alias_urn,omitempty"`
 	// Authorizer ID.
 	AuthorizerId *string `json:"authorizer_id,omitempty"`
 	// Backend parameters.
@@ -284,6 +298,8 @@ type PolicyFuncGraph struct {
 	Timeout int `json:"timeout,omitempty"`
 	// Function version Ensure that the version does not exceed 64 characters.
 	Version string `json:"version,omitempty"`
+	// The request protocol of the function.
+	RequestProtocol string `json:"req_protocol,omitempty"`
 }
 
 // PolicyWeb is an object which will be build up a backend policy of the http.

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis/results.go
@@ -252,6 +252,8 @@ type PolicyMockResp struct {
 	// Backend name, which consists of 3 to 64 characters and must start with a letter and can contain letters, digits,
 	// and underscores (_).
 	Name string `json:"name" required:"true"`
+	// The custom status code of the mock response.
+	StatusCode int `json:"status_code"`
 	// Authorizer ID.
 	AuthorizerId string `json:"authorizer_id,omitempty"`
 	// Backend parameters.
@@ -272,6 +274,12 @@ type PolicyFuncGraphResp struct {
 	EffectMode string `json:"effect_mode" required:"true"`
 	// Function URN.
 	FunctionUrn string `json:"function_urn" required:"true"`
+	// Function alias URN.
+	FunctionAliasUrn string `json:"alias_urn"`
+	// Network architecture type.
+	NetworkType string `json:"network_type"`
+	// The request protocol of the function.
+	RequestProtocol string `json:"req_protocol"`
 	// Invocation mode. The valid modes are as following:
 	//   async: asynchronous
 	//   sync: synchronous


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Resource and data source supports these parameters/attributes:
- func_graph.function_alias_urn
- func_graph.network_type
- func_graph.request_protocol
- func_graph_policy.function_alias_urn
- func_graph_policy.network_type
- func_graph_policy.request_protocol
- mock.status_code
- mock_policy.status_code
- tags 

Which one? (resource and data source):
- huaweicloud_apig_api
- data.huaweicloud_apig_api
- data.huaweicloud_apig_api_basic_configuration

Rewrite/refactor the acceptance tests because these UT cost too many time (total 50+minutes).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports some parameters for API resource and related querying data source.
2. rewrite the acceptance tests and reduce the total time 30+minutes.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

API resource
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApi_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApi_basic -timeout 360m -parallel 4
=== RUN   TestAccApi_basic
=== PAUSE TestAccApi_basic
=== CONT  TestAccApi_basic
--- PASS: TestAccApi_basic (713.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      714.017s
```
API querying data source
```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccDataSourceApi_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccDataSourceApi_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceApi_basic
=== PAUSE TestAccDataSourceApi_basic
=== CONT  TestAccDataSourceApi_basic
--- PASS: TestAccDataSourceApi_basic (661.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      661.797s
```
publishment resource
```
 make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccApiPublishment_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccApiPublishment_basic -timeout 360m -parallel 4
=== RUN   TestAccApiPublishment_basic
=== PAUSE TestAccApiPublishment_basic
=== CONT  TestAccApiPublishment_basic
--- PASS: TestAccApiPublishment_basic (667.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      667.197s
```
