### PR TITLE
fix(apig/instance): fix the reference of the data source attr

### DIFF
--- a/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instances_test.go
+++ b/huaweicloud/services/acceptance/apig/data_source_huaweicloud_apig_instances_test.go
@@ -41,6 +41,7 @@ func TestAccDataSourceInstances_basic(t *testing.T) {
 					dc.CheckResourceExists(),
 					resource.TestMatchResourceAttr(dataSource, "instances.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
 					resource.TestCheckResourceAttrSet(dataSource, "instances.0.id"),
+					resource.TestCheckResourceAttrSet(dataSource, "instances.0.edition"),
 					resource.TestCheckResourceAttrSet(dataSource, "instances.0.name"),
 					resource.TestCheckResourceAttrSet(dataSource, "instances.0.status"),
 					resource.TestCheckResourceAttrSet(dataSource, "instances.0.enterprise_project_id"),

--- a/huaweicloud/services/apig/data_source_huaweicloud_apig_instances.go
+++ b/huaweicloud/services/apig/data_source_huaweicloud_apig_instances.go
@@ -197,7 +197,7 @@ func flattenInstances(instances []interface{}) []interface{} {
 			"name":                  utils.PathSearch("instance_name", authorizer, nil),
 			"type":                  utils.PathSearch("type", authorizer, nil),
 			"status":                utils.PathSearch("status", authorizer, nil),
-			"edition":               utils.PathSearch("edition", authorizer, nil),
+			"edition":               utils.PathSearch("spec", authorizer, nil),
 			"enterprise_project_id": utils.PathSearch("enterprise_project_id", authorizer, nil),
 			"eip_address":           utils.PathSearch("eip_address", authorizer, nil),
 			"loadbalancer_provider": utils.PathSearch("loadbalancer_provider", authorizer, nil),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The key mapping of attribute 'edition' is incorrect, the key name should be 'spec', not 'edition'.

tfstate content while key mapping is incorrect:
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/fc5ebc79-4394-4b08-be08-9df02bfb6199)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the key mapping of attribute 'edition'
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccDataSourceInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccDataSourceInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceInstances_basic
=== PAUSE TestAccDataSourceInstances_basic
=== CONT  TestAccDataSourceInstances_basic
--- PASS: TestAccDataSourceInstances_basic (562.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      562.584s
```
