### PR TITLE
feat(lts/access): new data source to query cce access configs

### DIFF
--- a/docs/data-sources/lts_cce_accesses.md
+++ b/docs/data-sources/lts_cce_accesses.md
@@ -1,0 +1,171 @@
+---
+subcategory: "Log Tank Service (LTS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lts_cce_accesses"
+description: |-
+  Using this data source to query the list of CCE access configurations within HuaweiCloud.
+---
+
+# huaweicloud_lts_cce_accesses
+
+Using this data source to query the list of CCE access configurations within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "access_config_name" {}
+
+data "huaweicloud_lts_cce_accesses" "test" {
+  name = var.access_config_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query CCE access configurations.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the CCE access to be queried.
+
+* `host_group_name` - (Optional, String) Specifies the name of the host group to be queried.
+
+* `log_group_name` - (Optional, String) Specifies the name of the log group to which the access configurations and log
+  streams belong.
+
+* `log_stream_name` - (Optional, String) Specifies the name of the log stream to which the access configurations belong.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CCE access.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `accesses` - The list of CCE access configurations.
+  The [accesses](#data_accesses_attr) structure is documented below.
+
+<a name="data_accesses_attr"></a>
+The `accesses` block supports:
+
+* `id` - The ID of the CCE access.
+
+* `name` - The name of the CCE access.
+
+* `log_group_id` - The ID of the log group.
+
+* `log_group_name` - The name of the log group.
+
+* `log_stream_id` - The ID of the log stream.
+
+* `log_stream_name` - The name of the log stream.
+
+* `access_config` - The configuration detail of the CCE access.  
+  The [access_config](#data_accesses_elem_access_config) structure is documented below.
+
+* `cluster_id` - The ID of the cluster corresponding to CCE access.
+
+* `host_group_ids` - The ID list of the log access host groups.
+
+* `tags` - The key/value pairs to associate with the CCE access.
+
+* `binary_collect` - Whether collect in binary format.
+
+* `log_split` - Whether to split log.
+
+* `access_type` - The type of the log access.
+
+* `created_at` - The creation time of the CCE access, in RFC3339 format.
+
+<a name="data_accesses_elem_access_config"></a>
+The `access_config` block supports:
+
+* `path_type` - The type of the CCE access.
+  + **container_stdout**
+  + **container_file**
+  + **host_file**
+
+* `paths` - The collection paths.
+
+* `black_paths` - The collection path blacklist.
+
+* `windows_log_info` - The configuration of Windows event logs.  
+  The [windows_log_info](#data_access_config_elem_windows_log_info) structure is documented below.
+
+* `single_log_format` - The configuration single-line logs.  
+  The [single_log_format](#data_access_config_elem_single_log_format) structure is documented below.
+
+* `multi_log_format` - The configuration multi-line logs.  
+  The [multi_log_format](#data_access_config_elem_multi_log_format) structure is documented below.
+
+* `stdout` - Whether output is standard.
+
+* `stderr` - Whether error output is standard.
+
+* `name_space_regex` - The regular expression matching of kubernetes namespaces.
+
+* `pod_name_regex` - The regular expression matching of kubernetes pods.
+
+* `container_name_regex` - The regular expression matching of kubernetes container names.
+
+* `log_labels` - The container label log tag.
+
+* `include_labels` - The container label whitelist.
+
+* `exclude_labels` - The container label blacklist.
+
+* `log_envs` - The environment variable tag.
+
+* `include_envs` - The environment variable whitelist.
+
+* `exclude_envs` - The environment variable blacklist.
+
+* `log_k8s` - The kubernetes label log tag.
+
+* `include_k8s_labels` - The kubernetes label whitelist.
+
+* `exclude_k8s_labels` - The kubernetes label blacklist.
+
+<a name="data_access_config_elem_windows_log_info"></a>
+The `windows_log_info` block supports:
+
+* `categorys` - The types of Windows event logs to be collected.
+  + **Application**
+  + **System**
+  + **Security**
+  + **Setup**
+
+* `event_level` - The list of Windows event levels.  
+  The element includes:
+  + **information**
+  + **warning**
+  + **error**
+  + **critical**
+  + **verbose**
+
+* `time_offset_unit` - The collection time offset unit.
+  + **day**
+  + **hour**
+  + **sec**
+
+* `time_offset` - The collection time offset.
+
+<a name="data_access_config_elem_single_log_format"></a>
+The `single_log_format` block supports:
+
+* `mode` - The mode of single-line log format.
+  + **system**: the system time.
+  + **wildcard**: the time wildcard.
+
+* `value` - The value of single-line log format.
+
+<a name="data_access_config_elem_multi_log_format"></a>
+The `multi_log_format` block supports:
+
+* `mode` - The mode of multi-line log format.
+  + **time**: the time wildcard.
+  + **regular**: the regular expression.
+
+* `value` - The value of multi-line log format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -733,6 +733,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_certificate":  lb.DataSourceLBCertificateV2(),
 			"huaweicloud_lb_pools":        lb.DataSourcePools(),
 
+			"huaweicloud_lts_cce_accesses":                 lts.DataSourceCceAccesses(),
 			"huaweicloud_lts_groups":                       lts.DataSourceLtsGroups(),
 			"huaweicloud_lts_host_groups":                  lts.DataSourceLtsHostGroups(),
 			"huaweicloud_lts_notification_templates":       lts.DataSourceLtsNotificationTemplates(),

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_cce_accesses_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_cce_accesses_test.go
@@ -1,0 +1,385 @@
+package lts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDatasourceCceAccesses_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		byName   = "data.huaweicloud_lts_cce_accesses.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNameNotFound   = "data.huaweicloud_lts_cce_accesses.filter_by_not_found_name"
+		dcbyNameNotFound = acceptance.InitDataSourceCheck(byNameNotFound)
+
+		byLogGroupName   = "data.huaweicloud_lts_cce_accesses.filter_by_log_group_name"
+		dcByLogGroupName = acceptance.InitDataSourceCheck(byLogGroupName)
+
+		byLogStreamName   = "data.huaweicloud_lts_cce_accesses.filter_by_log_stream_name"
+		dcByLogStreamName = acceptance.InitDataSourceCheck(byLogStreamName)
+
+		byTags   = "data.huaweicloud_lts_cce_accesses.filter_by_tags"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckProjectID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"null": {
+				Source:            "hashicorp/null",
+				VersionConstraint: "3.2.1",
+			},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceCceAccesses_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestMatchResourceAttr(byName, "accesses.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttr(byName, "accesses.0.name", name),
+					resource.TestCheckResourceAttrPair(byName, "accesses.0.log_group_id", "huaweicloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(byName, "accesses.0.log_stream_id", "huaweicloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.host_group_ids.#", "1"),
+					resource.TestCheckResourceAttrPair(byName, "accesses.0.host_group_ids.0", "huaweicloud_lts_host_group.test", "id"),
+					resource.TestCheckResourceAttrPair(byName, "accesses.0.cluster_id", "huaweicloud_cce_cluster.test", "id"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.#", "1"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.path_type", "container_file"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.paths.#", "1"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.paths.0", "/var"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.black_paths.#", "1"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.black_paths.0", "/var/a.log"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.name_space_regex", "test"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.pod_name_regex", "test"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.container_name_regex", "test"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.windows_log_info.0.categorys.#", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.windows_log_info.0.event_level.#", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.windows_log_info.0.time_offset_unit", "day"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.windows_log_info.0.time_offset", "7"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.single_log_format.#", "1"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.single_log_format.0.mode", "system"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_labels.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_labels.log_label_key_name", "foo"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_labels.log_label_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_labels.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_labels.include_label_key_name", "foo"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_labels.include_label_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_labels.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_labels.exclude_label_key_name", "foo"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_labels.exclude_label_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_envs.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_envs.log_env_key_name", "foo"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_envs.log_env_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_envs.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_envs.include_env_key_name", "foo"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_envs.include_env_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_envs.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_envs.exclude_env_key_name", "foo"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_envs.exclude_env_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_k8s.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_k8s.log_k8s_key_name", "foo"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.log_k8s.log_k8s_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_k8s_labels.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_k8s_labels.include_k8s_label_key_name", "foo"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.include_k8s_labels.include_k8s_label_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_k8s_labels.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_k8s_labels.exclude_k8s_label_key_name", "foo"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.access_config.0.exclude_k8s_labels.exclude_k8s_label_key_value", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(byName, "accesses.0.tags.key", "value"),
+					resource.TestMatchResourceAttr(byName, "accesses.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+
+					dcbyNameNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_name_filter_useful", "true"),
+					dcByLogGroupName.CheckResourceExists(),
+					resource.TestCheckOutput("is_log_group_name_filter_useful", "true"),
+					dcByLogStreamName.CheckResourceExists(),
+					resource.TestCheckOutput("is_log_stream_name_filter_useful", "true"),
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceCceAccesses_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_images_images" "test" {
+  visibility   = "public"
+  architecture = "x86"
+  os           = "Ubuntu"
+}
+
+%[1]s
+
+resource "huaweicloud_networking_secgroup" "test" {
+  # install ICAgent needs the access rule with port 22 and cannot delete the default rules.
+  # Without using EIP, that is a safe way to using SSH access rule.
+  name = "%[2]s"
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name                = "%[2]s"
+  image_id            = data.huaweicloud_images_images.test.images[0].id
+  flavor_id           = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids  = [huaweicloud_networking_secgroup.test.id]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+
+  system_disk_type = "SAS"
+  system_disk_size = 50
+
+  data_disks {
+    type = "SAS"
+    size = "10"
+  }
+
+  # install IC agent
+  user_data = <<EOF
+#! /bin/bash
+set +o history;
+curl https://icagent-cn-north-4.obs.cn-north-4.myhuaweicloud.com/ICAgent_linux/apm_agent_install.sh > \
+apm_agent_install.sh && REGION=cn-north-4 bash apm_agent_install.sh -ak %[3]s -sk %[4]s -region cn-north-4 -projectid %[5]s \
+-accessip 100.125.12.150 -obsdomain obs.cn-north-4.myhuaweicloud.com -accessdomain lts-access.cn-north-4.myhuaweicloud.com;
+set -o history;
+EOF
+}
+
+# wait 2 minutes for the lts service to discover the server
+resource "null_resource" "test" {
+  depends_on = [huaweicloud_compute_instance.test]
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = "sleep 120;"
+  }
+}
+
+resource "huaweicloud_lts_host_group" "test" {
+  depends_on = [null_resource.test]
+
+  name     = "%[2]s"
+  type     = "linux"
+  host_ids = [
+    huaweicloud_compute_instance.test.id
+  ]
+}
+
+resource "huaweicloud_cce_cluster" "test" {
+  name                   = replace("%[2]s", "_", "-")
+  flavor_id              = "cce.s1.small"
+  vpc_id                 = huaweicloud_vpc.test.id
+  subnet_id              = huaweicloud_vpc_subnet.test.id
+  container_network_type = "overlay_l2"
+}
+
+resource "huaweicloud_lts_group" "test" {
+  group_name  = "%[2]s"
+  ttl_in_days = 30
+}
+
+resource "huaweicloud_lts_stream" "test" {
+  group_id    = huaweicloud_lts_group.test.id
+  stream_name = "%[2]s"
+}
+
+resource "huaweicloud_lts_cce_access" "test" {
+  name           = "%[2]s"
+  log_group_id   = huaweicloud_lts_group.test.id
+  log_stream_id  = huaweicloud_lts_stream.test.id
+  host_group_ids = [huaweicloud_lts_host_group.test.id]
+  cluster_id     = huaweicloud_cce_cluster.test.id
+
+  access_config {
+    path_type            = "container_file"
+    paths                = ["/var"]
+    black_paths          = ["/var/a.log"]
+    name_space_regex     = "test"
+    pod_name_regex       = "test"
+    container_name_regex = "test"
+
+    windows_log_info {
+      categorys        = ["System", "Application"]
+      event_level      = ["warning", "error"]
+      time_offset_unit = "day"
+      time_offset      = 7
+    }
+
+    single_log_format {
+      mode = "system"
+    }
+
+    log_labels = {
+      log_label_key_name = "foo"
+      log_label_key_value = "bar"
+    }
+
+    include_labels = {
+      include_label_key_name = "foo"
+      include_label_key_value = "bar"
+    }
+
+    exclude_labels = {
+      exclude_label_key_name = "foo"
+      exclude_label_key_value = "bar"
+    }
+
+    log_envs = {
+      log_env_key_name = "foo"
+      log_env_key_value = "bar"
+    }
+
+    include_envs = {
+      include_env_key_name = "foo"
+      include_env_key_value = "bar"
+    }
+
+    exclude_envs = {
+      exclude_env_key_name = "foo"
+      exclude_env_key_value = "bar"
+    }
+
+    log_k8s = {
+      log_k8s_key_name = "foo"
+      log_k8s_key_value = "bar"
+    }
+
+    include_k8s_labels = {
+      include_k8s_label_key_name = "foo"
+      include_k8s_label_key_value = "bar"
+    }
+
+    exclude_k8s_labels = {
+      exclude_k8s_label_key_name = "foo"
+      exclude_k8s_label_key_value = "bar"
+    }
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}`, common.TestVpc(name), name, acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY, acceptance.HW_PROJECT_ID)
+}
+
+func testAccDatasourceCceAccesses_basic(name string) string {
+	baseConfig := testAccDatasourceCceAccesses_base(name)
+
+	return fmt.Sprintf(`
+%[1]s
+
+# In order to ensure that the filtering of the data source UT is not affected by the related resource UT and can
+# correctly filter according to the attributes of the resources created by this UT, the name filtering is used as the
+# basis for subsequent filtering.
+# Filter by access config name
+data "huaweicloud_lts_cce_accesses" "filter_by_name" {
+  name = huaweicloud_lts_cce_access.test.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_lts_cce_accesses.filter_by_name.accesses[*].name : v == huaweicloud_lts_cce_access.test.name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by access config name and the name is not exist
+data "huaweicloud_lts_cce_accesses" "filter_by_not_found_name" {
+  depends_on = [huaweicloud_lts_cce_access.test]
+
+  name = "not_found"
+}
+
+output "is_not_found_name_filter_useful" {
+  value = length(data.huaweicloud_lts_cce_accesses.filter_by_not_found_name.accesses) == 0
+}
+
+# Filter by log group name
+locals {
+  log_group_name = data.huaweicloud_lts_cce_accesses.filter_by_name.accesses[0].log_group_name
+}
+
+data "huaweicloud_lts_cce_accesses" "filter_by_log_group_name" {
+  log_group_name = local.log_group_name
+}
+
+locals {
+  log_group_name_filter_result = [
+    for v in data.huaweicloud_lts_cce_accesses.filter_by_log_group_name.accesses[*].log_group_name : v == local.log_group_name
+  ]
+}
+
+output "is_log_group_name_filter_useful" {
+  value = length(local.log_group_name_filter_result) > 0 && alltrue(local.log_group_name_filter_result)
+}
+
+# Filter by log stream name
+locals {
+  log_stream_name = data.huaweicloud_lts_cce_accesses.filter_by_name.accesses[0].log_stream_name
+}
+
+data "huaweicloud_lts_cce_accesses" "filter_by_log_stream_name" {
+  log_stream_name = local.log_stream_name
+}
+
+locals {
+  log_stream_name_filter_result = [
+    for v in data.huaweicloud_lts_cce_accesses.filter_by_log_stream_name.accesses[*].log_stream_name : v == local.log_stream_name
+  ]
+}
+
+output "is_log_stream_name_filter_useful" {
+  value = length(local.log_stream_name_filter_result) > 0 && alltrue(local.log_stream_name_filter_result)
+}
+
+# Filter by tags
+locals {
+  tags = data.huaweicloud_lts_cce_accesses.filter_by_name.accesses[0].tags
+}
+
+data "huaweicloud_lts_cce_accesses" "filter_by_tags" {
+  tags = local.tags
+}
+
+locals {
+  log_tags_filter_result = [
+    for t in data.huaweicloud_lts_cce_accesses.filter_by_tags.accesses[*].tags : length(t) > 1 &&
+	  alltrue([for k, v in t: lookup(local.tags, k, "not_found") == v])
+  ]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.log_tags_filter_result) > 0 && alltrue(local.log_tags_filter_result)
+}
+`, baseConfig)
+}

--- a/huaweicloud/services/lts/data_source_huaweicloud_lts_cce_accesses.go
+++ b/huaweicloud/services/lts/data_source_huaweicloud_lts_cce_accesses.go
@@ -1,0 +1,385 @@
+package lts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LTS POST /v3/{project_id}/lts/access-config-list
+func DataSourceCceAccesses() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCceAccessesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to query CCE access configurations.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the CCE access.`,
+			},
+			"log_group_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the log group to which the access configurations and log streams belong.`,
+			},
+			"log_stream_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the log stream to which the access configurations belong.`,
+			},
+			"tags": common.TagsSchema(),
+			"accesses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the CCE access.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the CCE access.`,
+						},
+						"log_group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the log group.`,
+						},
+						"log_group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the log group.`,
+						},
+						"log_stream_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the log stream.`,
+						},
+						"log_stream_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the log stream.`,
+						},
+						"access_config": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataCceAccessConfigDeatilSchema(),
+							Description: `The configuration of the CCE access.`,
+						},
+						"cluster_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the cluster corresponding to CCE access.`,
+						},
+						"host_group_ids": {
+							Type:        schema.TypeList,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Computed:    true,
+							Description: `The ID list of the log access host groups.`,
+						},
+						"tags": common.TagsComputedSchema(),
+						"binary_collect": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether collect in binary format.`,
+						},
+						"log_split": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether to split log.`,
+						},
+						"access_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the log access.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the CCE access, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `The list of CCE access configurations.`,
+			},
+		},
+	}
+}
+
+func dataCceAccessConfigDeatilSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"path_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the CCE access.`,
+			},
+			"paths": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: `The collection paths.`,
+			},
+			"black_paths": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: `The collection path blacklist.`,
+			},
+			"windows_log_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"categorys": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The collection path blacklist.`,
+						},
+						"event_level": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of Windows event levels.`,
+						},
+						"time_offset": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The collection time offset unit.`,
+						},
+						"time_offset_unit": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The collection time offset.`,
+						},
+					},
+				},
+				Description: `The configuration of Windows event logs.`,
+			},
+			"single_log_format": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The mode of single-line log format.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The value of single-line log format.`,
+						},
+					},
+				},
+				Description: `The configuration single-line logs.`,
+			},
+			"multi_log_format": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The mode of multi-line log format.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The value of multi-line log format.`,
+						},
+					},
+				},
+				Description: `The configuration multi-line logs.`,
+			},
+			"stdout": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether output is standard.`,
+			},
+			"stderr": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether error output is standard.`,
+			},
+			"name_space_regex": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The regular expression matching of kubernetes namespaces.`,
+			},
+			"pod_name_regex": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The regular expression matching of kubernetes pods.`,
+			},
+			"container_name_regex": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The regular expression matching of kubernetes container names.`,
+			},
+			"log_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The container label log tag.`,
+			},
+			"include_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The container label whitelist.`,
+			},
+			"exclude_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The container label blacklist.`,
+			},
+			"log_envs": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The environment variable tag.`,
+			},
+			"include_envs": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The environment variable whitelist.`,
+			},
+			"exclude_envs": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The environment variable blacklist.`,
+			},
+			"log_k8s": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The kubernetes label log tag.`,
+			},
+			"include_k8s_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The kubernetes label whitelist.`,
+			},
+			"exclude_k8s_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The kubernetes label blacklist.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildQueryCceAccessConfigsBodyParams(d *schema.ResourceData) map[string]interface{} {
+	queryOpts := make(map[string]interface{})
+
+	if accessConfigName, ok := d.GetOk("name"); ok {
+		queryOpts["access_config_name_list"] = []interface{}{accessConfigName}
+	}
+	if logGroupName, ok := d.GetOk("log_group_name"); ok {
+		queryOpts["log_group_name_list"] = []interface{}{logGroupName}
+	}
+	if logStreamName, ok := d.GetOk("log_stream_name"); ok {
+		queryOpts["log_stream_name_list"] = []interface{}{logStreamName}
+	}
+	if tagsConfig, ok := d.GetOk("tags"); ok {
+		queryOpts["access_config_tag_list"] = utils.ExpandResourceTags(tagsConfig.(map[string]interface{}))
+	}
+
+	return queryOpts
+}
+
+func dataSourceCceAccessesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                        = meta.(*config.Config)
+		region                     = cfg.GetRegion(d)
+		listCceAccessConfigHttpUrl = "v3/{project_id}/lts/access-config-list"
+	)
+	ltsClient, err := cfg.NewServiceClient("lts", region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	listCceAccessConfigPath := ltsClient.Endpoint + listCceAccessConfigHttpUrl
+	listCceAccessConfigPath = strings.ReplaceAll(listCceAccessConfigPath, "{project_id}", ltsClient.ProjectID)
+
+	listCceAccessConfigOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildQueryCceAccessConfigsBodyParams(d),
+	}
+
+	requestResp, err := ltsClient.Request("POST", listCceAccessConfigPath, &listCceAccessConfigOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CCE access configs")
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	flattenedAccesses := flattenAccessConfigDetails(utils.PathSearch("result", respBody, make([]interface{}, 0)).([]interface{}))
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("accesses", flattenedAccesses),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAccessConfigDetails(accesses []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(accesses))
+	for _, v := range accesses {
+		result = append(result, map[string]interface{}{
+			"id":              utils.PathSearch("access_config_id", v, nil),
+			"name":            utils.PathSearch("access_config_name", v, nil),
+			"log_group_id":    utils.PathSearch("log_info.log_group_id", v, nil),
+			"log_group_name":  utils.PathSearch("log_info.log_group_name", v, nil),
+			"log_stream_id":   utils.PathSearch("log_info.log_stream_id", v, nil),
+			"log_stream_name": utils.PathSearch("log_info.log_stream_name", v, nil),
+			"access_config":   flattenCceAccessConfigDetail(v),
+			"cluster_id":      utils.PathSearch("cluster_id", v, nil),
+			"host_group_ids":  utils.PathSearch("host_group_info.host_group_id_list", v, nil),
+			"tags":            utils.FlattenTagsToMap(utils.PathSearch("access_config_tag", v, nil)),
+			"binary_collect":  utils.PathSearch("binary_collect", v, nil),
+			"log_split":       utils.PathSearch("log_split", v, nil),
+			"access_type":     utils.PathSearch("access_config_type", v, nil),
+			"created_at":      utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", v, float64(0)).(float64))/1000, false),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source that used to query the CCE access configurations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new data source that used to query the CCE access configurations.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/lts' TESTARGS='-run=TestAccDatasourceCceAccesses_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run=TestAccDatasourceCceAccesses_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCceAccesses_basic
=== PAUSE TestAccDatasourceCceAccesses_basic
=== CONT  TestAccDatasourceCceAccesses_basic
--- PASS: TestAccDatasourceCceAccesses_basic (596.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       596.528s
```
