### PR TITLE
feat(DDM): add ddm instance restart resource

### DIFF
--- a/docs/resources/ddm_instance_restart.md
+++ b/docs/resources/ddm_instance_restart.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Distributed Database Middleware (DDM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ddm_instance_restart"
+description: |-
+  Manages a DDM instance restart resource within HuaweiCloud.
+---
+
+# huaweicloud_ddm_instance_restart
+
+Manages a DDM instance restart resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable instance_id {}
+
+resource "huaweicloud_ddm_instance_restart" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of a DDM instance.
+  Changing this creates a new resource.
+
+* `type` - (Optional, String, ForceNew) Specifies the restart type. Value options:
+  + **soft**: Only the process is restarted.
+  + **hard**: The instance VM is forcibly restarted.
+
+## Attribute Reference
+
+* `id` - The resource ID. The value is the instance ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1231,6 +1231,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dds_instance_parameters_modify":  dds.ResourceDDSInstanceParametersModify(),
 
 			"huaweicloud_ddm_instance":               ddm.ResourceDdmInstance(),
+			"huaweicloud_ddm_instance_restart":       ddm.ResourceDdmInstanceRestart(),
 			"huaweicloud_ddm_schema":                 ddm.ResourceDdmSchema(),
 			"huaweicloud_ddm_account":                ddm.ResourceDdmAccount(),
 			"huaweicloud_ddm_instance_read_strategy": ddm.ResourceDdmInstanceReadStrategy(),

--- a/huaweicloud/services/acceptance/ddm/resource_huaweicloud_ddm_instance_restart_test.go
+++ b/huaweicloud/services/acceptance/ddm/resource_huaweicloud_ddm_instance_restart_test.go
@@ -1,0 +1,48 @@
+package ddm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDDMInstanceRestart_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_ddm_instance_restart.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDdmInstanceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDDMInstanceRestart_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccDDMInstanceRestart_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_ddm_instance_restart" "test" {
+  depends_on = [huaweicloud_ddm_instance.test]
+
+  instance_id = huaweicloud_ddm_instance.test.id
+  type        = "soft"
+}`, testDdmInstance_basic(rName))
+}

--- a/huaweicloud/services/ddm/resource_huaweicloud_ddm_instance_restart.go
+++ b/huaweicloud/services/ddm/resource_huaweicloud_ddm_instance_restart.go
@@ -1,0 +1,83 @@
+package ddm
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API DDM POST /v1/{project_id}/instances/{instance_id}/action
+// @API DDM GET /v1/{project_id}/instances/{instance_id}
+func ResourceDdmInstanceRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDDMInstanceRestartCreate,
+		ReadContext:   resourceDDMInstanceRestartRead,
+		DeleteContext: resourceDDMInstanceRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceDDMInstanceRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		product = "ddm"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating DDM Client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	restartType := d.Get("type").(string)
+	err = restartDdmInstance(ctx, client, instanceID, restartType, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error restarting instance: %s", err)
+	}
+
+	d.SetId(instanceID)
+
+	return nil
+}
+
+func resourceDDMInstanceRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceDDMInstanceRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restart resource is not supported. The restart resource is only removed from the state," +
+		" the instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add ddm instance restart resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add ddm instance restart resource
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/ddm/ TESTARGS='-run TestAccDdmInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ddm/ -v -run TestAccDdmInstance_ -timeout 360m -parallel 4
=== RUN   TestAccDdmInstance_basic
=== PAUSE TestAccDdmInstance_basic
=== RUN   TestAccDdmInstance_prepaid
=== PAUSE TestAccDdmInstance_prepaid
=== RUN   TestAccDdmInstance_updateWithEpsId
=== PAUSE TestAccDdmInstance_updateWithEpsId
=== CONT  TestAccDdmInstance_basic
=== CONT  TestAccDdmInstance_updateWithEpsId
=== CONT  TestAccDdmInstance_prepaid
=== CONT  TestAccDdmInstance_updateWithEpsId
    acceptance.go:564: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccDdmInstance_updateWithEpsId (0.00s)
--- PASS: TestAccDdmInstance_prepaid (766.07s)
--- PASS: TestAccDdmInstance_basic (1592.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ddm       1592.232s

make testacc TEST=./huaweicloud/services/acceptance/ddm/ TESTARGS='-run TestAccDDMInstanceRestart_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ddm/ -v -run TestAccDDMInstanceRestart_basic -timeout 360m -parallel 4
=== RUN   TestAccDDMInstanceRestart_basic
=== PAUSE TestAccDDMInstanceRestart_basic
=== CONT  TestAccDDMInstanceRestart_basic
--- PASS: TestAccDDMInstanceRestart_basic (509.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ddm       509.291s
```
