### PR TITLE
feat(lts/aom_access): add datasource to query aom accesses

### DIFF
--- a/docs/data-sources/lts_aom_accesses.md
+++ b/docs/data-sources/lts_aom_accesses.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Log Tank Service (LTS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_lts_aom_accesses"
+description: |-
+  Use this data source to get the list of AOM accesses.
+---
+
+# huaweicloud_lts_aom_accesses
+
+Use this data source to get the list of AOM accesses.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_lts_aom_accesses" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `log_group_name` - (Optional, String) Specifies the ID of the log group name to be queried.
+
+* `log_stream_name` - (Optional, String) Specifies the log stream name to be queried.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `accesses` - All AOM access rules that match the filter parameters.
+  The [accesses](#accesses_struct) structure is documented below.
+
+<a name="accesses_struct"></a>
+The `accesses` block supports:
+
+* `access_rules` - The AOM access log details.
+  The [access_rules](#access_rules_struct) structure is documented below.
+
+* `id` - The ID of the AOM access rule.
+
+* `name` - The name of the AOM access rule.
+
+* `cluster_id` - The cluster ID corresponding to the AOM access rule.
+
+* `cluster_name` - The cluster name corresponding to the AOM access rule.
+
+* `namespace` - The namespace corresponding to the AOM access rule.
+
+* `workloads` - The list of the workloads corresponding to AOM access rule.
+
+* `container_name` - The name of the container corresponding to AOM access rule.
+
+<a name="access_rules_struct"></a>
+The `access_rules` block supports:
+
+* `file_name` - The name of the log path.
+
+* `log_group_id` - The ID of the log group.
+
+* `log_group_name` - The name of the log group.
+
+* `log_stream_id` - The ID of the log stream.
+
+* `log_stream_name` - The name of the stream.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -737,6 +737,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_lb_certificate":  lb.DataSourceLBCertificateV2(),
 			"huaweicloud_lb_pools":        lb.DataSourcePools(),
 
+			"huaweicloud_lts_aom_accesses":                 lts.DataSourceAOMAccesses(),
 			"huaweicloud_lts_cce_accesses":                 lts.DataSourceCceAccesses(),
 			"huaweicloud_lts_groups":                       lts.DataSourceLtsGroups(),
 			"huaweicloud_lts_host_groups":                  lts.DataSourceLtsHostGroups(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -207,10 +207,6 @@ var (
 	HW_CCE_CHART_PATH = os.Getenv("HW_CCE_CHART_PATH")
 	// The cluster name of the CCE
 	HW_CCE_CLUSTER_NAME = os.Getenv("HW_CCE_CLUSTER_NAME")
-	// The cluster ID of the CCE
-	HW_CCE_CLUSTER_ID_ANOTHER = os.Getenv("HW_CCE_CLUSTER_ID_ANOTHER")
-	// The cluster name of the CCE
-	HW_CCE_CLUSTER_NAME_ANOTHER = os.Getenv("HW_CCE_CLUSTER_NAME_ANOTHER")
 	// The partition az of the CCE
 	HW_CCE_PARTITION_AZ = os.Getenv("HW_CCE_PARTITION_AZ")
 	// The namespace of the workload is located
@@ -371,6 +367,11 @@ var (
 	HW_LTS_LOG_CONVERGE_SOURCE_LOG_STREAM_ID   = os.Getenv("HW_LTS_LOG_CONVERGE_SOURCE_LOG_STREAM_ID")
 	HW_LTS_LOG_CONVERGE_TARGET_LOG_STREAM_NAME = os.Getenv("HW_LTS_LOG_CONVERGE_TARGET_LOG_STREAM_NAME")
 	HW_LTS_LOG_CONVERGE_TARGET_LOG_STREAM_ID   = os.Getenv("HW_LTS_LOG_CONVERGE_TARGET_LOG_STREAM_ID")
+
+	HW_LTS_CLUSTER_ID           = os.Getenv("HW_LTS_CLUSTER_ID")
+	HW_LTS_CLUSTER_NAME         = os.Getenv("HW_LTS_CLUSTER_NAME")
+	HW_LTS_CLUSTER_ID_ANOTHER   = os.Getenv("HW_LTS_CLUSTER_ID_ANOTHER")
+	HW_LTS_CLUSTER_NAME_ANOTHER = os.Getenv("HW_LTS_CLUSTER_NAME_ANOTHER")
 
 	HW_VPCEP_SERVICE_ID = os.Getenv("HW_VPCEP_SERVICE_ID")
 
@@ -1390,15 +1391,15 @@ func TestAccPreCheckEgAgencyName(t *testing.T) {
 
 // lintignore:AT003
 func TestAccPreCheckLtsAomAccess(t *testing.T) {
-	if HW_CCE_CLUSTER_ID == "" || HW_CCE_CLUSTER_NAME == "" {
-		t.Skip("HW_CCE_CLUSTER_ID and HW_CCE_CLUSTER_NAME must be set for LTS AOM access acceptance tests")
+	if HW_LTS_CLUSTER_ID == "" || HW_LTS_CLUSTER_NAME == "" {
+		t.Skip("HW_LTS_CLUSTER_ID and HW_LTS_CLUSTER_NAME must be set for LTS AOM access acceptance tests")
 	}
 }
 
 // lintignore:AT003
 func TestAccPreCheckLtsAomAccessUpdate(t *testing.T) {
-	if HW_CCE_CLUSTER_ID_ANOTHER == "" || HW_CCE_CLUSTER_NAME_ANOTHER == "" {
-		t.Skip("HW_CCE_CLUSTER_ID_ANOTHER and HW_CCE_CLUSTER_NAME_ANOTHER must be set for LTS AOM access" +
+	if HW_LTS_CLUSTER_ID_ANOTHER == "" || HW_LTS_CLUSTER_NAME_ANOTHER == "" {
+		t.Skip("HW_LTS_CLUSTER_ID_ANOTHER and HW_LTS_CLUSTER_NAME_ANOTHER must be set for LTS AOM access" +
 			" acceptance tests")
 	}
 }

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_aom_accesses_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_aom_accesses_test.go
@@ -1,0 +1,145 @@
+package lts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAOMAccesses_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_lts_aom_accesses.test"
+		rName      = acceptance.RandomAccResourceName()
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+
+		byLogGroupName   = "data.huaweicloud_lts_aom_accesses.filter_by_log_group_name"
+		dcByLogGroupName = acceptance.InitDataSourceCheck(byLogGroupName)
+
+		byLogStreamName   = "data.huaweicloud_lts_aom_accesses.filter_by_log_stream_name"
+		dcByLogStreamName = acceptance.InitDataSourceCheck(byLogStreamName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLtsAomAccess(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testDataSourceDataSourceAOMAccesses_logGroupNotExist(),
+				ExpectError: regexp.MustCompile("The log group does not existed"),
+			},
+			{
+				Config:      testDataSourceDataSourceAOMAccesses_logStreamNotExist(),
+				ExpectError: regexp.MustCompile("The log stream does not existed"),
+			},
+			{
+				Config: testDataSourceDataSourceAOMAccesses_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					dcByLogGroupName.CheckResourceExists(),
+					resource.TestCheckOutput("is_log_group_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byLogGroupName, "accesses.0.id", "huaweicloud_lts_aom_access.test", "id"),
+					resource.TestCheckResourceAttr(byLogGroupName, "accesses.0.name", rName),
+					resource.TestCheckResourceAttr(byLogGroupName, "accesses.0.cluster_id", acceptance.HW_LTS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(byLogGroupName, "accesses.0.cluster_name", acceptance.HW_LTS_CLUSTER_NAME),
+					resource.TestCheckResourceAttr(byLogGroupName, "accesses.0.namespace", "default"),
+					resource.TestCheckResourceAttr(byLogGroupName, "accesses.0.workloads.0", "__ALL_DEPLOYMENTS__"),
+					resource.TestCheckResourceAttr(byLogGroupName, "accesses.0.container_name", "test_container"),
+					resource.TestCheckResourceAttr(byLogGroupName, "accesses.0.access_rules.0.file_name", "/test/*"),
+					resource.TestCheckResourceAttrPair(byLogGroupName, "accesses.0.access_rules.0.log_group_id",
+						"huaweicloud_lts_group.test", "id"),
+					resource.TestCheckResourceAttrPair(byLogGroupName, "accesses.0.access_rules.0.log_group_name",
+						"huaweicloud_lts_group.test", "group_name"),
+					resource.TestCheckResourceAttrPair(byLogGroupName, "accesses.0.access_rules.0.log_stream_id",
+						"huaweicloud_lts_stream.test", "id"),
+					resource.TestCheckResourceAttrPair(byLogGroupName, "accesses.0.access_rules.0.log_stream_name",
+						"huaweicloud_lts_stream.test", "stream_name"),
+					dcByLogStreamName.CheckResourceExists(),
+					resource.TestCheckOutput("is_log_stream_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceDataSourceAOMAccesses_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_lts_aom_accesses" "test" {
+  depends_on = [
+    huaweicloud_lts_aom_access.test
+  ]
+}
+
+# Filter by log group name
+locals {
+  log_group_name = huaweicloud_lts_group.test.group_name
+}
+
+data "huaweicloud_lts_aom_accesses" "filter_by_log_group_name" {
+  depends_on = [
+    huaweicloud_lts_aom_access.test
+  ]
+
+  log_group_name = local.log_group_name
+}
+
+locals {
+  log_group_name_filter_result = [
+    for v in flatten(data.huaweicloud_lts_aom_accesses.filter_by_log_group_name.accesses[*].access_rules[*].log_stream_name) :
+    v == local.log_group_name
+  ]
+}
+
+output "is_log_group_name_filter_useful" {
+  value = length(local.log_group_name_filter_result) > 0 && alltrue(local.log_group_name_filter_result)
+}
+
+# Filter by log stream name
+locals {
+  log_stream_name = huaweicloud_lts_stream.test.stream_name
+}
+
+data "huaweicloud_lts_aom_accesses" "filter_by_log_stream_name" {
+  depends_on = [
+    huaweicloud_lts_aom_access.test
+  ]
+
+  log_stream_name = local.log_stream_name
+}
+
+locals {
+  log_stream_name_filter_result = [
+    for v in flatten(data.huaweicloud_lts_aom_accesses.filter_by_log_stream_name.accesses[*].access_rules[*].log_stream_name) :
+   v == local.log_stream_name
+  ]
+}
+
+output "is_log_stream_name_filter_useful" {
+  value = length(local.log_stream_name_filter_result) > 0 && alltrue(local.log_stream_name_filter_result)
+}
+`, testAOMAccess_allWorkloads(name))
+}
+
+func testDataSourceDataSourceAOMAccesses_logGroupNotExist() string {
+	return `
+data "huaweicloud_lts_aom_accesses" "filter_by_log_stream_name" {
+  log_group_name = "not_found_log_group"
+}
+`
+}
+
+func testDataSourceDataSourceAOMAccesses_logStreamNotExist() string {
+	return `
+data "huaweicloud_lts_aom_accesses" "filter_by_log_stream_name" {
+  log_stream_name = "not_found_log_stream"
+}
+`
+}

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_aom_access_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_aom_access_test.go
@@ -81,8 +81,8 @@ func TestAccAOMAccess_allWorkloads(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CCE_CLUSTER_ID),
-					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.HW_CCE_CLUSTER_NAME),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_LTS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.HW_LTS_CLUSTER_NAME),
 					resource.TestCheckResourceAttr(rName, "namespace", "default"),
 					resource.TestCheckResourceAttr(rName, "workloads.0", "__ALL_DEPLOYMENTS__"),
 					resource.TestCheckResourceAttr(rName, "container_name", "test_container"),
@@ -103,8 +103,8 @@ func TestAccAOMAccess_allWorkloads(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", fmt.Sprintf("%s_update", name)),
-					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CCE_CLUSTER_ID_ANOTHER),
-					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.HW_CCE_CLUSTER_NAME_ANOTHER),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_LTS_CLUSTER_ID_ANOTHER),
+					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.HW_LTS_CLUSTER_NAME_ANOTHER),
 					resource.TestCheckResourceAttr(rName, "namespace", "test_namespace"),
 					resource.TestCheckResourceAttr(rName, "workloads.0", "__ALL_DEPLOYMENTS__"),
 					resource.TestCheckResourceAttr(rName, "container_name", "test_container_update"),
@@ -145,8 +145,8 @@ func TestAccAOMAccess_specifyWorkloads(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_CCE_CLUSTER_ID),
-					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.HW_CCE_CLUSTER_NAME),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_LTS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "cluster_name", acceptance.HW_LTS_CLUSTER_NAME),
 					resource.TestCheckResourceAttr(rName, "namespace", "default"),
 					resource.TestCheckResourceAttr(rName, "workloads.0", "WORKLOAD_1"),
 					resource.TestCheckResourceAttr(rName, "workloads.1", "WORKLOAD_2"),
@@ -270,7 +270,7 @@ resource "huaweicloud_lts_aom_access" "test" {
     log_stream_name = huaweicloud_lts_stream.test.stream_name
   }
 }
-`, testAccLtsStream_basic(name), name, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
+`, testAccLtsStream_basic(name), name, acceptance.HW_LTS_CLUSTER_ID, acceptance.HW_LTS_CLUSTER_NAME)
 }
 
 func testAOMAccess_allWorkloads_update(name string) string {
@@ -293,7 +293,7 @@ resource "huaweicloud_lts_aom_access" "test" {
     log_stream_name = huaweicloud_lts_stream.test.stream_name
   }
 }
-`, testAccLtsStream_basic(name), name, acceptance.HW_CCE_CLUSTER_ID_ANOTHER, acceptance.HW_CCE_CLUSTER_NAME_ANOTHER)
+`, testAccLtsStream_basic(name), name, acceptance.HW_LTS_CLUSTER_ID_ANOTHER, acceptance.HW_LTS_CLUSTER_NAME_ANOTHER)
 }
 
 func testAOMAccess_specifyWorkloads(name string) string {
@@ -316,7 +316,7 @@ resource "huaweicloud_lts_aom_access" "test" {
     log_stream_name = huaweicloud_lts_stream.test.stream_name
   }
 }
-`, testAccLtsStream_basic(name), name, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
+`, testAccLtsStream_basic(name), name, acceptance.HW_LTS_CLUSTER_ID, acceptance.HW_LTS_CLUSTER_NAME)
 }
 
 func testAOMAccess_specifyWorkloads_update(name string) string {
@@ -339,7 +339,7 @@ resource "huaweicloud_lts_aom_access" "test" {
     log_stream_name = huaweicloud_lts_stream.test.stream_name
   }
 }
-`, testAccLtsStream_basic(name), name, acceptance.HW_CCE_CLUSTER_ID, acceptance.HW_CCE_CLUSTER_NAME)
+`, testAccLtsStream_basic(name), name, acceptance.HW_LTS_CLUSTER_ID, acceptance.HW_LTS_CLUSTER_NAME)
 }
 
 func testAOMAccess_withCCICluster(name string) string {

--- a/huaweicloud/services/lts/data_source_huaweicloud_lts_aom_accesses.go
+++ b/huaweicloud/services/lts/data_source_huaweicloud_lts_aom_accesses.go
@@ -1,0 +1,207 @@
+package lts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API LTS GET /v2/{project_id}/lts/aom-mapping
+func DataSourceAOMAccesses() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: resourceAOMAccessesRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"log_group_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of the log group name to be queried.`,
+			},
+			"log_stream_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the log stream name to be queried.`,
+			},
+			"accesses": {
+				Type:        schema.TypeList,
+				Elem:        AOMAccesseschema(),
+				Computed:    true,
+				Description: `All AOM access rules that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func AOMAccesseschema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the AOM access rule.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the AOM access rule.`,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cluster ID corresponding to the AOM access rule.`,
+			},
+			"cluster_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The cluster name corresponding to the AOM access rule.`,
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The namespace corresponding to the AOM access rule.`,
+			},
+			"workloads": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Computed:    true,
+				Description: `The list of the workloads corresponding to AOM access rule.`,
+			},
+			"container_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the container corresponding to AOM access rule.`,
+			},
+			"access_rules": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The AOM access log details.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"file_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the log path.`,
+						},
+						"log_group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the log group.`,
+						},
+						"log_group_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the log group.`,
+						},
+						"log_stream_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the log stream.`,
+						},
+						"log_stream_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the stream.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAOMAccessesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr    *multierror.Error
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/lts/aom-mapping"
+		product = "lts"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating LTS client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildListAOMAccessesQueryParams(d)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving AOM accesses: %s", err)
+	}
+
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("accesses", flattenAndFilterAOMAccesses(listRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenAndFilterAOMAccesses(resp interface{}) []interface{} {
+	if resp == nil {
+		return nil
+	}
+	curArray := resp.([]interface{})
+	rst := make([]interface{}, len(curArray))
+	for i, v := range curArray {
+		rst[i] = map[string]interface{}{
+			"id":             utils.PathSearch("rule_id", v, nil),
+			"name":           utils.PathSearch("rule_name", v, nil),
+			"cluster_id":     utils.PathSearch("rule_info.cluster_id", v, nil),
+			"cluster_name":   utils.PathSearch("rule_info.cluster_name", v, nil),
+			"namespace":      utils.PathSearch("rule_info.namespace", v, nil),
+			"container_name": utils.PathSearch("rule_info.container_name", v, nil),
+			"workloads":      utils.PathSearch("rule_info.deployments", v, nil),
+			"access_rules":   flattenAccessRules(v),
+		}
+	}
+	return rst
+}
+
+func buildListAOMAccessesQueryParams(d *schema.ResourceData) string {
+	queryParam := ""
+	if v, ok := d.GetOk("log_group_name"); ok {
+		queryParam = fmt.Sprintf("%s&log_group_name=%v", queryParam, v)
+	}
+
+	if v, ok := d.GetOk("log_stream_name"); ok {
+		queryParam = fmt.Sprintf("%s&log_stream_name=%v", queryParam, v)
+	}
+
+	if queryParam != "" {
+		queryParam = "?" + queryParam[1:]
+	}
+	return queryParam
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Modify environment variables of acceptance test of the AOM access resource.
Add new datasource to get the list of the AOM access rules.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. modify environment variables of acceptance test of the AOM access resource.
2. add new datasource to get the list of the AOM access rules.
3. add data source related acceptance test and document.

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST=./huaweicloud/services/acceptance/lts TESTARGS='-run TestAccAOMAccess_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccAOMAccess_ -timeout 360m -parallel 4
=== RUN   TestAccAOMAccess_allWorkloads
=== PAUSE TestAccAOMAccess_allWorkloads
=== RUN   TestAccAOMAccess_specifyWorkloads
=== PAUSE TestAccAOMAccess_specifyWorkloads
=== RUN   TestAccAOMAccess_withCCICluster
=== PAUSE TestAccAOMAccess_withCCICluster
=== CONT  TestAccAOMAccess_allWorkloads
=== CONT  TestAccAOMAccess_withCCICluster
=== CONT  TestAccAOMAccess_specifyWorkloads
--- PASS: TestAccAOMAccess_specifyWorkloads (110.39s)
--- PASS: TestAccAOMAccess_withCCICluster (110.59s)
--- PASS: TestAccAOMAccess_allWorkloads (119.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       120.002s

make testacc TEST=./huaweicloud/services/acceptance/lts TESTARGS='-run TestAccDataSourceAOMAccesses_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lts -v -run TestAccDataSourceAOMAccesses_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAOMAccesses_basic
=== PAUSE TestAccDataSourceAOMAccesses_basic
=== CONT  TestAccDataSourceAOMAccesses_basic
--- PASS: TestAccDataSourceAOMAccesses_basic (69.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       69.839s

```
