### PR TITLE
test(er): fix the failure UT design

### DIFF
--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_associations_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_associations_test.go
@@ -2,6 +2,7 @@ package er
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-uuid"
@@ -13,16 +14,12 @@ import (
 
 func TestAccDataSourceAssociations_basic(t *testing.T) {
 	var (
-		dcName   = "data.huaweicloud_er_associations.test"
-		name     = acceptance.RandomAccResourceName()
-		dc       = acceptance.InitDataSourceCheck(dcName)
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
+		name       = acceptance.RandomAccResourceName()
+		bgpAsNum   = acctest.RandIntRange(64512, 65534)
+		baseConfig = testAccAssociation_basic(name, bgpAsNum)
 
-		byInstanceId   = "data.huaweicloud_er_associations.not_found_instance_id"
-		dcByInstanceId = acceptance.InitDataSourceCheck(byInstanceId)
-
-		byRouteTableId   = "data.huaweicloud_er_associations.not_found_route_table_id"
-		dcByRouteTableId = acceptance.InitDataSourceCheck(byRouteTableId)
+		all = "data.huaweicloud_er_associations.test"
+		dc  = acceptance.InitDataSourceCheck(all)
 
 		byAttachmentId   = "data.huaweicloud_er_associations.filter_by_attachment_id"
 		dcByAttachmentId = acceptance.InitDataSourceCheck(byAttachmentId)
@@ -32,6 +29,9 @@ func TestAccDataSourceAssociations_basic(t *testing.T) {
 
 		byStatus   = "data.huaweicloud_er_associations.filter_by_status"
 		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byNotFoundInstanceId   = "data.huaweicloud_er_associations.instance_id_not_found"
+		dcByNotFoundInstanceId = acceptance.InitDataSourceCheck(byNotFoundInstanceId)
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -41,19 +41,13 @@ func TestAccDataSourceAssociations_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceAssociations_basic(name, bgpAsNum),
+				Config: testAccDatasourceAssociations_basic(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dcName, "associations.#"),
-					resource.TestCheckResourceAttrSet(dcName, "associations.0.resource_id"),
-					resource.TestCheckResourceAttrSet(dcName, "associations.0.created_at"),
-					resource.TestCheckResourceAttrSet(dcName, "associations.0.updated_at"),
-
-					dcByInstanceId.CheckResourceExists(),
-					resource.TestCheckOutput("instance_id_not_found", "true"),
-
-					dcByRouteTableId.CheckResourceExists(),
-					resource.TestCheckOutput("route_table_id_not_found", "true"),
+					resource.TestCheckResourceAttrSet(all, "associations.#"),
+					resource.TestCheckResourceAttrSet(all, "associations.0.resource_id"),
+					resource.TestCheckResourceAttrSet(all, "associations.0.created_at"),
+					resource.TestCheckResourceAttrSet(all, "associations.0.updated_at"),
 
 					dcByStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
@@ -68,41 +62,27 @@ func TestAccDataSourceAssociations_basic(t *testing.T) {
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
 				),
 			},
+			// If the instance ID does not exist, the data source will not report the error.
+			// Just return an empty list.
+			{
+				Config: testAccDatasourceAssociations_instanceIdNotFound(baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					dcByNotFoundInstanceId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byNotFoundInstanceId, "associations.#", "0"),
+				),
+			},
+			// If the routing table ID does not exist, the data source will report an error: 'route table {uuid} not found'.
+			{
+				Config:      testAccDatasourceAssociations_routeTableIdNotFound(baseConfig),
+				ExpectError: regexp.MustCompile(`route table [a-f0-9-]+ not found`),
+			},
 		},
 	})
 }
 
-func testAccDatasourceAssociations_basic(name string, bgpAsNum int) string {
-	randUUID, _ := uuid.GenerateUUID()
-
+func testAccDatasourceAssociations_basic(baseConfig string) string {
 	return fmt.Sprintf(`
 %[1]s
-
-data "huaweicloud_er_associations" "not_found_instance_id" {
-  depends_on = [
-    huaweicloud_er_association.test,
-  ]
-
-  instance_id    = "%[2]s"
-  route_table_id = huaweicloud_er_route_table.test.id
-}
-  
-output "instance_id_not_found" {
-  value = length(data.huaweicloud_er_associations.not_found_instance_id.associations) == 0
-}
-  
-data "huaweicloud_er_associations" "not_found_route_table_id" {
-  depends_on = [
-    huaweicloud_er_association.test,
-  ]
-
-  instance_id    = huaweicloud_er_instance.test.id
-  route_table_id = "%[2]s"
-}
-  
-output "route_table_id_not_found" {
-  value = length(data.huaweicloud_er_associations.not_found_route_table_id.associations) == 0
-}
 
 data "huaweicloud_er_associations" "test" {
   depends_on = [
@@ -186,5 +166,39 @@ locals {
 output "is_status_filter_useful" {
   value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
 }
-`, testAccAssociation_basic(name, bgpAsNum), randUUID)
+`, baseConfig)
+}
+
+func testAccDatasourceAssociations_instanceIdNotFound(baseConfig string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_associations" "instance_id_not_found" {
+  depends_on = [
+    huaweicloud_er_association.test,
+  ]
+
+  instance_id    = "%[2]s"
+  route_table_id = huaweicloud_er_route_table.test.id
+}
+`, baseConfig, randUUID)
+}
+
+func testAccDatasourceAssociations_routeTableIdNotFound(baseConfig string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_associations" "route_table_id_not_found" {
+  depends_on = [
+    huaweicloud_er_association.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = "%[2]s"
+}
+`, baseConfig, randUUID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update the step design of the ER acceptance tests and fix the follow errors:
```
data_source_huaweicloud_er_associations_test.go:37: Step 1/1 error: Error running apply: exit status 1
        
        Error: error retrieving associations: Resource not found: [GET https://er.cn-north-4.myhuaweicloud.com/v3/0970dd7a1300f5672ff2c003c60ae115/enterprise-router/2aef212b-dfea-403a-9fad-21a782009e2f/route-tables/d0b1062f-4ce5-b59d-8073-6bf5adffe399/associations], request_id: fd033df628b3b077cbbf2793567a2f4a, error message: {"error_code":"ER.04045001","error_msg":"route table d0b1062f-4ce5-b59d-8073-6bf5adffe399 not found","request_id":"fd033df628b3b077cbbf2793567a2f4a"}
        
          with data.huaweicloud_er_associations.not_found_route_table_id,
          on terraform_plugin_test.tf line 62, in data "huaweicloud_er_associations" "not_found_route_table_id":
          62: data "huaweicloud_er_associations" "not_found_route_table_id" {
```
```
data_source_huaweicloud_er_propagations_test.go:37: Step 1/1 error: Error running apply: exit status 1
        
        Error: error retrieving propagations: Resource not found: [GET https://er.cn-north-4.myhuaweicloud.com/v3/0970dd7a1300f5672ff2c003c60ae115/enterprise-router/6a7fc892-40db-4071-be98-4c4dd8161152/route-tables/a7c25c1f-8cab-0c03-82a2-95ce57a96364/propagations], request_id: 7983ee4dd32a613521281947780de41c, error message: {"error_code":"ER.04045001","error_msg":"route table a7c25c1f-8cab-0c03-82a2-95ce57a96364 not found","request_id":"7983ee4dd32a613521281947780de41c"}
        
          with data.huaweicloud_er_propagations.not_found_route_table_id,
          on terraform_plugin_test.tf line 62, in data "huaweicloud_er_propagations" "not_found_route_table_id":
          62: data "huaweicloud_er_propagations" "not_found_route_table_id" {
```
Because of the querying will report an error that route table ID is not exist

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update the step design of the ER acceptance tests.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccDataSourceAssociations_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccDataSourceAssociations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAssociations_basic
--- PASS: TestAccDataSourceAssociations_basic (270.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        270.750s
```
```
make testacc TEST='./huaweicloud/services/acceptance/er' TESTARGS='-run=TestAccDataSourcePropagations_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/er -v -run=TestAccDataSourcePropagations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePropagations_basic
--- PASS: TestAccDataSourcePropagations_basic (275.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        275.172s
```
