### PR TITLE
test(ELB): fix elb test

### DIFF
--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_l7policies_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_l7policies_test.go
@@ -56,6 +56,8 @@ func testAccDatasourceL7Policies_basic(name string) string {
 
 data "huaweicloud_elb_l7policies" "test" {
   depends_on = [huaweicloud_elb_l7policy.test]
+
+  l7policy_id = huaweicloud_elb_l7policy.test.id
 }
 
 data "huaweicloud_elb_l7policies" "name_filter" {
@@ -198,6 +200,8 @@ func testAccDatasourceL7Policies_url(name string) string {
 
 data "huaweicloud_elb_l7policies" "test" {
   depends_on = [huaweicloud_elb_l7policy.test]
+
+  l7policy_id = huaweicloud_elb_l7policy.test.id
 }
 
 locals {
@@ -253,6 +257,8 @@ func testAccDatasourceL7Policies_fixed_response(name string) string {
 
 data "huaweicloud_elb_l7policies" "test" {
   depends_on = [huaweicloud_elb_l7policy.test]
+
+  l7policy_id = huaweicloud_elb_l7policy.test.id
 }
 
 locals {

--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_monitors_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_monitors_test.go
@@ -54,6 +54,8 @@ func testAccDatasourceMonitors_basic(name string) string {
 
 data "huaweicloud_elb_monitors" "test" {
   depends_on = [huaweicloud_elb_monitor.monitor_1]
+
+  monitor_id = huaweicloud_elb_monitor.monitor_1.id
 }
 
 locals {

--- a/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_pools_test.go
+++ b/huaweicloud/services/acceptance/elb/data_source_huaweicloud_elb_pools_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccDatasourcePools_basic(t *testing.T) {
@@ -36,10 +37,72 @@ func TestAccDatasourcePools_basic(t *testing.T) {
 						"huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttr(rName, "pools.0.protection_status", "nonProtection"),
 					resource.TestCheckResourceAttr(rName, "pools.0.slow_start_enabled", "false"),
+
+					resource.TestCheckOutput("name_filter_is_useful", "true"),
+					resource.TestCheckOutput("pool_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("description_filter_is_useful", "true"),
+					resource.TestCheckOutput("healthmonitor_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("protocol_filter_is_useful", "true"),
+					resource.TestCheckOutput("lb_method_filter_is_useful", "true"),
+					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckOutput("vpc_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("protection_status_filter_is_useful", "true"),
 				),
 			},
 		},
 	})
+}
+
+func testAccDatasourcePools_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_elb_loadbalancer" "test" {
+  name            = "%[2]s"
+  ipv4_subnet_id  = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+
+  availability_zone = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+}
+
+resource "huaweicloud_elb_listener" "test" {
+  name            = "%[2]s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+}
+
+resource "huaweicloud_elb_pool" "test" {
+  name            = "%[2]s"
+  protocol        = "HTTP"
+  lb_method       = "ROUND_ROBIN"
+  type            = "instance"
+  vpc_id          = huaweicloud_vpc.test.id
+  description     = "test pool description"
+  loadbalancer_id = huaweicloud_elb_loadbalancer.test.id
+  listener_id     = huaweicloud_elb_listener.test.id
+
+  minimum_healthy_member_count = 1
+}
+
+resource "huaweicloud_elb_monitor" "test" {
+  pool_id          = huaweicloud_elb_pool.test.id
+  name             = "%[2]s"
+  protocol         = "HTTP"
+  interval         = 20
+  timeout          = 10
+  max_retries      = 5
+  max_retries_down = 5
+  url_path         = "/aa"
+  domain_name      = "www.aa.com"
+  port             = "8000"
+  status_code      = "200,401-500,502"
+  enabled          = false
+}
+`, common.TestBaseNetwork(name), name)
 }
 
 func testAccDatasourcePools_basic(name string) string {
@@ -47,11 +110,149 @@ func testAccDatasourcePools_basic(name string) string {
 %s
 
 data "huaweicloud_elb_pools" "test" {
-  name = "%s"
+  depends_on = [huaweicloud_elb_monitor.test]
 
-  depends_on = [
-    huaweicloud_elb_pool.test
-  ]
+  pool_id = huaweicloud_elb_pool.test.id
 }
-`, testAccElbV3PoolConfig_basic(name), name)
+
+data "huaweicloud_elb_pools" "name_filter" {
+  depends_on = [huaweicloud_elb_monitor.test]
+
+  name = "%[2]s"
+}
+
+output "name_filter_is_useful" {
+  value = length(data.huaweicloud_elb_pools.name_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_pools.name_filter.pools[*].name :v == "%[2]s"]
+  )
+}
+
+locals {
+  pool_id = huaweicloud_elb_pool.test.id
+}
+
+data "huaweicloud_elb_pools" "pool_id_filter" {
+  depends_on = [huaweicloud_elb_monitor.test]
+
+  pool_id = huaweicloud_elb_pool.test.id
+}
+
+output "pool_id_filter_is_useful" {
+  value = length(data.huaweicloud_elb_pools.pool_id_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_pools.pool_id_filter.pools[*].id : v == local.pool_id]
+  )
+}
+
+locals {
+  description = huaweicloud_elb_pool.test.description
+}
+
+data "huaweicloud_elb_pools" "description_filter" {
+  depends_on = [huaweicloud_elb_monitor.test]
+
+  description = huaweicloud_elb_pool.test.description
+}
+
+output "description_filter_is_useful" {
+  value = length(data.huaweicloud_elb_pools.description_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_pools.description_filter.pools[*].description : v == local.description]
+  )
+}
+
+locals {
+  healthmonitor_id = huaweicloud_elb_monitor.test.id
+}
+
+data "huaweicloud_elb_pools" "healthmonitor_id_filter" {
+  depends_on = [huaweicloud_elb_monitor.test]
+
+  healthmonitor_id = huaweicloud_elb_monitor.test.id
+}
+
+output "healthmonitor_id_filter_is_useful" {
+  value = length(data.huaweicloud_elb_pools.healthmonitor_id_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_pools.healthmonitor_id_filter.pools[*].healthmonitor_id : v == local.healthmonitor_id]
+  )
+}
+
+locals {
+  protocol = huaweicloud_elb_pool.test.protocol
+}
+
+data "huaweicloud_elb_pools" "protocol_filter" {
+  depends_on = [huaweicloud_elb_monitor.test]
+
+  protocol = huaweicloud_elb_pool.test.protocol
+}
+
+output "protocol_filter_is_useful" {
+  value = length(data.huaweicloud_elb_pools.description_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_pools.description_filter.pools[*].protocol : v == local.protocol]
+  )
+}
+
+locals {
+  lb_method = huaweicloud_elb_pool.test.lb_method
+}
+
+data "huaweicloud_elb_pools" "lb_method_filter" {
+  depends_on = [huaweicloud_elb_monitor.test]
+
+  lb_method = huaweicloud_elb_pool.test.lb_method
+}
+
+output "lb_method_filter_is_useful" {
+  value = length(data.huaweicloud_elb_pools.lb_method_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_pools.lb_method_filter.pools[*].lb_method : v == local.lb_method]
+  )
+}
+
+locals {
+  type = huaweicloud_elb_pool.test.type
+}
+
+data "huaweicloud_elb_pools" "type_filter" {
+  depends_on = [huaweicloud_elb_monitor.test]
+
+  type = huaweicloud_elb_pool.test.type
+}
+
+output "type_filter_is_useful" {
+  value = length(data.huaweicloud_elb_pools.type_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_pools.type_filter.pools[*].type : v == local.type]
+  )
+}
+
+locals {
+  vpc_id = huaweicloud_elb_pool.test.vpc_id
+}
+
+data "huaweicloud_elb_pools" "vpc_id_filter" {
+  depends_on = [huaweicloud_elb_monitor.test]
+
+  vpc_id = huaweicloud_elb_pool.test.vpc_id
+}
+
+output "vpc_id_filter_is_useful" {
+  value = length(data.huaweicloud_elb_pools.vpc_id_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_pools.vpc_id_filter.pools[*].vpc_id : v == local.vpc_id]
+  )
+}
+
+locals {
+  protection_status = huaweicloud_elb_pool.test.protection_status
+}
+
+data "huaweicloud_elb_pools" "protection_status_filter" {
+  depends_on = [huaweicloud_elb_monitor.test]
+
+  protection_status = huaweicloud_elb_pool.test.protection_status
+}
+
+output "protection_status_filter_is_useful" {
+  value = length(data.huaweicloud_elb_pools.protection_status_filter.pools) > 0 && alltrue(
+  [for v in data.huaweicloud_elb_pools.protection_status_filter.pools[*].protection_status : v == local.protection_status]
+  )
+}
+`, testAccDatasourcePools_base(name), name)
 }

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_certificate_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccElbV3Certificate_basic(t *testing.T) {
 	var c certificates.Certificate
 	name := fmt.Sprintf("tf-cert-%s", acctest.RandString(5))
-	resourceName := "huaweicloud_elb_certificate.test"
+	resourceName := "huaweicloud_elb_certificate.server"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -30,12 +30,16 @@ func TestAccElbV3Certificate_basic(t *testing.T) {
 					testAccCheckElbV3CertificateExists(resourceName, &c),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "type", "server"),
+					resource.TestCheckResourceAttr(resourceName, "domain", "www.elb.com"),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test certificate"),
 				),
 			},
 			{
 				Config: testAccElbV3CertificateConfig_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_updated", name)),
+					resource.TestCheckResourceAttr(resourceName, "domain", "www.elbupdate.com"),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test certificate update"),
 				),
 			},
 			{
@@ -50,7 +54,7 @@ func TestAccElbV3Certificate_basic(t *testing.T) {
 func TestAccElbV3Certificate_client(t *testing.T) {
 	var c certificates.Certificate
 	name := fmt.Sprintf("tf-cert-%s", acctest.RandString(5))
-	resourceName := "huaweicloud_elb_certificate.test"
+	resourceName := "huaweicloud_elb_certificate.client"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
@@ -148,7 +152,7 @@ func testAccCheckElbV3CertificateExists(
 
 func testAccElbV3CertificateConfig_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_elb_certificate" "test" {
+resource "huaweicloud_elb_certificate" "server" {
   name        = "%s"
   description = "terraform test certificate"
   domain      = "www.elb.com"
@@ -212,10 +216,10 @@ EOT
 
 func testAccElbV3CertificateConfig_update(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_elb_certificate" "test" {
+resource "huaweicloud_elb_certificate" "server" {
   name        = "%s_updated"
-  description = "terraform test certificate"
-  domain      = "www.elb.com"
+  description = "terraform test certificate update"
+  domain      = "www.elbupdate.com"
   private_key = <<EOT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
@@ -276,7 +280,7 @@ EOT
 
 func testAccElbV3CertificateConfig_client(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_elb_certificate" "test" {
+resource "huaweicloud_elb_certificate" "client" {
   name        = "%s"
   description = "terraform CA certificate"
   type        = "client"

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7policy_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_l7policy_test.go
@@ -716,7 +716,7 @@ resource "huaweicloud_elb_listener" "test_redirect" {
   protocol_port               = 443
   loadbalancer_id             = huaweicloud_elb_loadbalancer.test.id
   advanced_forwarding_enabled = true
-  server_certificate          = huaweicloud_elb_certificate.test.id
+  server_certificate          = huaweicloud_elb_certificate.server.id
 }
 
 resource "huaweicloud_elb_l7policy" "test" {
@@ -741,7 +741,7 @@ resource "huaweicloud_elb_listener" "test_redirect" {
   protocol_port               = 443
   loadbalancer_id             = huaweicloud_elb_loadbalancer.test.id
   advanced_forwarding_enabled = true
-  server_certificate          = huaweicloud_elb_certificate.test.id
+  server_certificate          = huaweicloud_elb_certificate.server.id
 }
 
 resource "huaweicloud_elb_listener" "test_redirect_update" {
@@ -750,7 +750,7 @@ resource "huaweicloud_elb_listener" "test_redirect_update" {
   protocol_port               = 448
   loadbalancer_id             = huaweicloud_elb_loadbalancer.test.id
   advanced_forwarding_enabled = true
-  server_certificate          = huaweicloud_elb_certificate.test.id
+  server_certificate          = huaweicloud_elb_certificate.server.id
 }
 
 resource "huaweicloud_elb_l7policy" "test" {

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_loadbalancer_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_loadbalancer_test.go
@@ -66,7 +66,7 @@ func TestAccElbV3LoadBalancer_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "protection_status", "nonProtection"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
-					resource.TestCheckResourceAttr(resourceName, "charge_mode", "flavor"),
+					resource.TestCheckResourceAttr(resourceName, "charge_mode", "lcu"),
 					resource.TestCheckResourceAttr(resourceName, "guaranteed", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttr(resourceName, "waf_failure_action", "discard"),
@@ -434,11 +434,26 @@ resource "huaweicloud_vpc_subnet" "test_1" {
   gateway_ip = "192.168.1.1"
 }
 
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[2]s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
 resource "huaweicloud_elb_loadbalancer" "test" {
-  name               = "%[2]s"
-  vpc_id             = huaweicloud_vpc.test.id
-  ipv4_subnet_id     = huaweicloud_vpc_subnet.test.ipv4_subnet_id
-  waf_failure_action = "discard"
+  name                = "%[2]s"
+  vpc_id              = huaweicloud_vpc.test.id
+  ipv4_subnet_id      = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+  ipv4_eip_id         = huaweicloud_vpc_eip.test.id
+  waf_failure_action  = "discard"
+  autoscaling_enabled = true
 
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0]
@@ -471,12 +486,27 @@ resource "huaweicloud_vpc_subnet" "test_1" {
   gateway_ip = "192.168.1.1"
 }
 
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[2]s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
 resource "huaweicloud_elb_loadbalancer" "test" {
-  name               = "%[3]s"
-  cross_vpc_backend  = true
-  vpc_id             = huaweicloud_vpc.test.id
-  ipv4_subnet_id     = huaweicloud_vpc_subnet.test.ipv4_subnet_id
-  waf_failure_action = "forward"
+  name                = "%[3]s"
+  cross_vpc_backend   = true
+  vpc_id              = huaweicloud_vpc.test.id
+  ipv4_subnet_id      = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+  ipv4_eip_id         = huaweicloud_vpc_eip.test.id
+  waf_failure_action  = "forward"
+  autoscaling_enabled = true
 
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0]

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_pool_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_pool_test.go
@@ -49,6 +49,7 @@ func TestAccElbV3Pool_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "instance"),
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
 						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test pool description"),
 					resource.TestCheckResourceAttr(resourceName, "slow_start_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "protection_status", "nonProtection"),
 					resource.TestCheckResourceAttr(resourceName, "persistence.0.type", "APP_COOKIE"),
@@ -67,10 +68,10 @@ func TestAccElbV3Pool_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "vpc_id",
 						"huaweicloud_vpc.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "slow_start_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test pool description update"),
 					resource.TestCheckResourceAttr(resourceName, "slow_start_duration", "100"),
 					resource.TestCheckResourceAttr(resourceName, "protection_status", "consoleProtection"),
-					resource.TestCheckResourceAttr(resourceName, "protection_reason",
-						"test protection reason"),
+					resource.TestCheckResourceAttr(resourceName, "protection_reason", "test protection reason"),
 					resource.TestCheckResourceAttr(resourceName, "persistence.0.type", "APP_COOKIE"),
 					resource.TestCheckResourceAttr(resourceName, "persistence.0.cookie_name", "testCookie"),
 					resource.TestCheckResourceAttr(resourceName, "minimum_healthy_member_count", "0"),
@@ -348,11 +349,12 @@ func testAccElbV3PoolConfig_basic(rName string) string {
 %s
 
 resource "huaweicloud_elb_pool" "test" {
-  name      = "%s"
-  protocol  = "HTTP"
-  lb_method = "ROUND_ROBIN"
-  type      = "instance"
-  vpc_id    = huaweicloud_vpc.test.id
+  name        = "%s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  type        = "instance"
+  vpc_id      = huaweicloud_vpc.test.id
+  description = "test pool description"
 
   minimum_healthy_member_count = 1
 
@@ -369,11 +371,12 @@ func testAccElbV3PoolConfig_update(rName, rNameUpdate string) string {
 %s
 
 resource "huaweicloud_elb_pool" "test" {
-  name      = "%s"
-  protocol  = "HTTP"
-  lb_method = "LEAST_CONNECTIONS"
-  type      = "instance"
-  vpc_id    = huaweicloud_vpc.test.id
+  name        = "%s"
+  protocol    = "HTTP"
+  lb_method   = "LEAST_CONNECTIONS"
+  type        = "instance"
+  vpc_id      = huaweicloud_vpc.test.id
+  description = "test pool description update"
 
   slow_start_enabled  = true
   slow_start_duration = 100

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_slow_log_files_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_slow_log_files_test.go
@@ -16,6 +16,7 @@ func TestAccDataSourceRdsSlowLogFiles_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRdsInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix elb test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix elb test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TEST_PARALLELISM=8
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v  -timeout 360m -parallel 8
=== RUN   TestAccDatasourceActiveStandbyPools_basic
=== PAUSE TestAccDatasourceActiveStandbyPools_basic
=== RUN   TestAccDataSourceELbCertificateV3_basic
--- PASS: TestAccDataSourceELbCertificateV3_basic (17.19s)
=== RUN   TestAccElbFlavorsDataSource_basic
=== PAUSE TestAccElbFlavorsDataSource_basic
=== RUN   TestAccDatasourceIpGroups_basic
=== PAUSE TestAccDatasourceIpGroups_basic
=== RUN   TestAccDatasourceL7polices_basic
=== PAUSE TestAccDatasourceL7polices_basic
=== RUN   TestAccDatasourceL7polices_url
=== PAUSE TestAccDatasourceL7polices_url
=== RUN   TestAccDatasourceL7polices_fixed_response
=== PAUSE TestAccDatasourceL7polices_fixed_response
=== RUN   TestAccDatasourceL7rules_basic
=== PAUSE TestAccDatasourceL7rules_basic
=== RUN   TestAccDatasourceListeners_basic
=== PAUSE TestAccDatasourceListeners_basic
=== RUN   TestAccDatasourceLoadBalancers_basic
=== PAUSE TestAccDatasourceLoadBalancers_basic
=== RUN   TestAccDatasourceLogtanks_basic
=== PAUSE TestAccDatasourceLogtanks_basic
=== RUN   TestAccDatasourceMembers_basic
=== PAUSE TestAccDatasourceMembers_basic
=== RUN   TestAccDatasourceMonitors_basic
=== PAUSE TestAccDatasourceMonitors_basic
=== RUN   TestAccDatasourcePools_basic
=== PAUSE TestAccDatasourcePools_basic
=== RUN   TestAccDatasourceSecurityPolicies_basic
=== PAUSE TestAccDatasourceSecurityPolicies_basic
=== RUN   TestAccElbActiveStandbyPool_basic
=== PAUSE TestAccElbActiveStandbyPool_basic
=== RUN   TestAccElbV3Certificate_basic
=== PAUSE TestAccElbV3Certificate_basic
=== RUN   TestAccElbV3Certificate_client
=== PAUSE TestAccElbV3Certificate_client
=== RUN   TestAccElbV3Certificate_withEpsId
=== PAUSE TestAccElbV3Certificate_withEpsId
=== RUN   TestAccElbV3IpGroup_basic
=== PAUSE TestAccElbV3IpGroup_basic
=== RUN   TestAccElbV3IpGroup_withEpsId
=== PAUSE TestAccElbV3IpGroup_withEpsId
=== RUN   TestAccElbV3L7Policy_basic
=== PAUSE TestAccElbV3L7Policy_basic
=== RUN   TestAccElbV3L7Policy_pools_config
=== PAUSE TestAccElbV3L7Policy_pools_config
=== RUN   TestAccElbV3L7Policy_listener
=== PAUSE TestAccElbV3L7Policy_listener
=== RUN   TestAccElbV3L7Policy_url
=== PAUSE TestAccElbV3L7Policy_url
=== RUN   TestAccElbV3L7Policy_fixed_response
=== PAUSE TestAccElbV3L7Policy_fixed_response
=== RUN   TestAccElbV3L7Rule_basic
=== PAUSE TestAccElbV3L7Rule_basic
=== RUN   TestAccElbV3L7Rule_basic_with_conditions
=== PAUSE TestAccElbV3L7Rule_basic_with_conditions
=== RUN   TestAccElbV3Listener_basic
=== PAUSE TestAccElbV3Listener_basic
=== RUN   TestAccElbV3Listener_with_port_ranges
=== PAUSE TestAccElbV3Listener_with_port_ranges
=== RUN   TestAccElbV3Listener_with_default_pool
=== PAUSE TestAccElbV3Listener_with_default_pool
=== RUN   TestAccElbV3Listener_with_protocol_https
=== PAUSE TestAccElbV3Listener_with_protocol_https
=== RUN   TestAccElbV3Listener_with_protocol_tls
=== PAUSE TestAccElbV3Listener_with_protocol_tls
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_with_deletion_protection
=== PAUSE TestAccElbV3LoadBalancer_with_deletion_protection
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== PAUSE TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid
=== RUN   TestAccElbV3LoadBalancer_availabilityZone
=== PAUSE TestAccElbV3LoadBalancer_availabilityZone
=== RUN   TestAccElbV3LoadBalancer_updateChargingMode
=== PAUSE TestAccElbV3LoadBalancer_updateChargingMode
=== RUN   TestAccElbV3LoadBalancer_withIpv6
=== PAUSE TestAccElbV3LoadBalancer_withIpv6
=== RUN   TestAccElbLogTank_basic
=== PAUSE TestAccElbLogTank_basic
=== RUN   TestAccElbV3Member_basic
=== PAUSE TestAccElbV3Member_basic
=== RUN   TestAccElbV3Member_crossVpcBackend
=== PAUSE TestAccElbV3Member_crossVpcBackend
=== RUN   TestAccElbV3Member_without_protocol_port
=== PAUSE TestAccElbV3Member_without_protocol_port
=== RUN   TestAccElbV3Monitor_basic
=== PAUSE TestAccElbV3Monitor_basic
=== RUN   TestAccElbV3Pool_basic
=== PAUSE TestAccElbV3Pool_basic
=== RUN   TestAccElbV3Pool_basic_with_loadbalancer
=== PAUSE TestAccElbV3Pool_basic_with_loadbalancer
=== RUN   TestAccElbV3Pool_basic_with_listener
=== PAUSE TestAccElbV3Pool_basic_with_listener
=== RUN   TestAccElbV3Pool_basic_with_type_ip
=== PAUSE TestAccElbV3Pool_basic_with_type_ip
=== RUN   TestAccElbV3Pool_basic_with_protocol_tcp
=== PAUSE TestAccElbV3Pool_basic_with_protocol_tcp
=== RUN   TestAccElbV3Pool_basic_with_connection_drain
=== PAUSE TestAccElbV3Pool_basic_with_connection_drain
=== RUN   TestAccSecurityPoliciesV3_basic
=== PAUSE TestAccSecurityPoliciesV3_basic
=== CONT  TestAccDatasourceActiveStandbyPools_basic
=== CONT  TestAccElbV3Listener_basic
=== CONT  TestAccElbActiveStandbyPool_basic
=== CONT  TestAccElbLogTank_basic
=== CONT  TestAccElbV3LoadBalancer_withEpsId
=== CONT  TestAccElbV3Listener_with_protocol_tls
=== CONT  TestAccElbV3LoadBalancer_availabilityZone
=== CONT  TestAccElbV3Pool_basic_with_listener
--- PASS: TestAccElbV3LoadBalancer_withEpsId (58.19s)
=== CONT  TestAccElbV3Pool_basic_with_loadbalancer
--- PASS: TestAccElbActiveStandbyPool_basic (86.74s)
=== CONT  TestAccElbV3Pool_basic
--- PASS: TestAccElbV3Listener_with_protocol_tls (164.77s)
=== CONT  TestAccElbV3Monitor_basic
--- PASS: TestAccDatasourceActiveStandbyPools_basic (169.30s)
=== CONT  TestAccElbV3Member_without_protocol_port
--- PASS: TestAccElbV3Listener_basic (182.14s)
=== CONT  TestAccElbV3Member_crossVpcBackend
--- PASS: TestAccElbV3Pool_basic_with_listener (189.34s)
=== CONT  TestAccElbV3Member_basic
--- PASS: TestAccElbV3LoadBalancer_availabilityZone (205.26s)
=== CONT  TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
--- PASS: TestAccElbV3Pool_basic (119.66s)
=== CONT  TestAccElbV3LoadBalancer_prePaid
--- PASS: TestAccElbLogTank_basic (233.30s)
=== CONT  TestAccElbV3Pool_basic_with_connection_drain
--- PASS: TestAccElbV3Member_without_protocol_port (80.67s)
=== CONT  TestAccSecurityPoliciesV3_basic
--- PASS: TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id (73.18s)
=== CONT  TestAccDatasourceListeners_basic
--- PASS: TestAccElbV3Monitor_basic (114.69s)
=== CONT  TestAccDatasourceSecurityPolicies_basic
--- PASS: TestAccSecurityPoliciesV3_basic (33.20s)
=== CONT  TestAccDatasourcePools_basic
--- PASS: TestAccElbV3Pool_basic_with_loadbalancer (231.78s)
=== CONT  TestAccDatasourceMonitors_basic
--- PASS: TestAccElbV3Pool_basic_with_connection_drain (117.89s)
=== CONT  TestAccDatasourceMembers_basic
--- PASS: TestAccElbV3Member_crossVpcBackend (211.77s)
=== CONT  TestAccDatasourceLogtanks_basic
--- PASS: TestAccDatasourceSecurityPolicies_basic (125.11s)
=== CONT  TestAccDatasourceLoadBalancers_basic
--- PASS: TestAccElbV3Member_basic (224.82s)
=== CONT  TestAccElbV3LoadBalancer_with_deletion_protection
--- PASS: TestAccElbV3LoadBalancer_prePaid (273.17s)
=== CONT  TestAccDatasourceL7polices_url
--- PASS: TestAccDatasourceMonitors_basic (206.27s)
=== CONT  TestAccDatasourceL7rules_basic
--- PASS: TestAccDatasourceListeners_basic (263.52s)
=== CONT  TestAccDatasourceL7polices_fixed_response
--- PASS: TestAccDatasourcePools_basic (345.17s)
=== CONT  TestAccElbV3Pool_basic_with_protocol_tcp
--- PASS: TestAccDatasourceLogtanks_basic (243.11s)
=== CONT  TestAccElbV3Listener_with_default_pool
--- PASS: TestAccElbV3LoadBalancer_with_deletion_protection (223.02s)
=== CONT  TestAccElbV3Listener_with_protocol_https
--- PASS: TestAccDatasourceLoadBalancers_basic (257.65s)
=== CONT  TestAccElbV3Pool_basic_with_type_ip
--- PASS: TestAccDatasourceMembers_basic (314.68s)
=== CONT  TestAccElbV3L7Policy_pools_config
--- PASS: TestAccElbV3Pool_basic_with_protocol_tcp (46.27s)
=== CONT  TestAccElbV3L7Rule_basic_with_conditions
--- PASS: TestAccDatasourceL7polices_url (222.94s)
=== CONT  TestAccElbV3L7Rule_basic
--- PASS: TestAccElbV3Pool_basic_with_type_ip (53.75s)
=== CONT  TestAccElbV3L7Policy_fixed_response
--- PASS: TestAccDatasourceL7polices_fixed_response (231.57s)
=== CONT  TestAccElbV3L7Policy_url
--- PASS: TestAccDatasourceL7rules_basic (298.74s)
=== CONT  TestAccElbV3L7Policy_listener
--- PASS: TestAccElbV3Listener_with_protocol_https (200.60s)
=== CONT  TestAccElbV3Listener_with_port_ranges
--- PASS: TestAccElbV3Listener_with_default_pool (241.59s)
=== CONT  TestAccElbV3LoadBalancer_withIpv6
--- PASS: TestAccElbV3Listener_with_port_ranges (93.53s)
=== CONT  TestAccElbV3LoadBalancer_basic
--- PASS: TestAccElbV3L7Policy_pools_config (268.75s)
=== CONT  TestAccElbV3LoadBalancer_updateChargingMode
--- PASS: TestAccElbV3L7Policy_fixed_response (253.38s)
=== CONT  TestAccDatasourceIpGroups_basic
--- PASS: TestAccElbV3L7Rule_basic_with_conditions (295.31s)
=== CONT  TestAccDatasourceL7polices_basic
--- PASS: TestAccElbV3LoadBalancer_withIpv6 (97.65s)
=== CONT  TestAccElbV3LoadBalancer_withEIP
--- PASS: TestAccElbV3L7Rule_basic (293.64s)
=== CONT  TestAccElbV3IpGroup_basic
--- PASS: TestAccElbV3L7Policy_url (241.82s)
=== CONT  TestAccElbV3L7Policy_basic
--- PASS: TestAccElbV3IpGroup_basic (40.33s)
=== CONT  TestAccElbV3IpGroup_withEpsId
--- PASS: TestAccElbV3LoadBalancer_withEIP (61.44s)
=== CONT  TestAccElbV3Certificate_client
--- PASS: TestAccDatasourceIpGroups_basic (68.68s)
=== CONT  TestAccElbV3Certificate_withEpsId
--- PASS: TestAccElbV3IpGroup_withEpsId (17.13s)
=== CONT  TestAccElbFlavorsDataSource_basic
--- PASS: TestAccElbV3Certificate_client (16.58s)
=== CONT  TestAccElbV3Certificate_basic
--- PASS: TestAccElbV3Certificate_withEpsId (16.27s)
--- PASS: TestAccElbV3Certificate_basic (25.46s)
--- PASS: TestAccElbFlavorsDataSource_basic (36.36s)
--- PASS: TestAccElbV3L7Policy_listener (302.76s)
--- PASS: TestAccElbV3LoadBalancer_basic (205.12s)
--- PASS: TestAccElbV3LoadBalancer_updateChargingMode (241.24s)
--- PASS: TestAccDatasourceL7polices_basic (241.76s)
--- PASS: TestAccElbV3L7Policy_basic (242.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       1274.771s
```
