### PR TITLE
test(cts): enhance the coverage of the data source CTS notifications test case by adding more filters

### DIFF
--- a/huaweicloud/services/acceptance/cts/data_source_huaweicloud_cts_notifications_test.go
+++ b/huaweicloud/services/acceptance/cts/data_source_huaweicloud_cts_notifications_test.go
@@ -31,6 +31,8 @@ func TestAccDatasourceCTSNotifications_basic(t *testing.T) {
 					resource.TestCheckOutput("is_default_useful", "true"),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
 					resource.TestCheckOutput("is_topic_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					resource.TestCheckOutput("is_operation_type_filter_useful", "true"),
 				),
 			},
 		},
@@ -127,6 +129,46 @@ data "huaweicloud_cts_notifications" "filter_by_topic_id" {
 output "is_topic_id_filter_useful" {
   value = length(data.huaweicloud_cts_notifications.filter_by_topic_id.notifications) > 0 && alltrue(
     [for v in data.huaweicloud_cts_notifications.filter_by_topic_id.notifications[*].topic_id : v == local.topic_id]
+  )
+}
+
+locals {
+  status = huaweicloud_cts_notification.notify.status
+}
+
+data "huaweicloud_cts_notifications" "filter_by_status" {
+  type   = "smn"
+  status = local.status
+
+  depends_on = [
+    huaweicloud_cts_notification.test,
+    huaweicloud_cts_notification.notify
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(data.huaweicloud_cts_notifications.filter_by_status.notifications) >= 1 && alltrue(
+    [for v in data.huaweicloud_cts_notifications.filter_by_status.notifications[*].status : v == local.status]
+  )
+}
+
+locals {
+  operation_type = huaweicloud_cts_notification.notify.operation_type
+}
+
+data "huaweicloud_cts_notifications" "filter_by_operation_type" {
+  type           = "smn"
+  operation_type = local.operation_type
+
+  depends_on = [
+    huaweicloud_cts_notification.test,
+    huaweicloud_cts_notification.notify,
+  ]
+}
+
+output "is_operation_type_filter_useful" {
+  value = length(data.huaweicloud_cts_notifications.filter_by_operation_type.notifications) >= 1 && alltrue(
+    [for v in data.huaweicloud_cts_notifications.filter_by_operation_type.notifications[*].operation_type : v == local.operation_type]
   )
 }
 `, config)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
enhance the coverage of the data source CTS notifications test case by adding filters for operation type and status
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. enhance the coverage of the data source CTS notifications test case by adding filters for operation type and status
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 make testacc TEST="./huaweicloud/services/acceps_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccDatasourceCTSNotifications_basic -timeout 360m -parallel
=== RUN   TestAccDatasourceCTSNotifications_basic
=== PAUSE TestAccDatasourceCTSNotifications_basic
=== CONT  TestAccDatasourceCTSNotifications_basic
--- PASS: TestAccDatasourceCTSNotifications_basic (74.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       74.542s

```
