### PR TITLE
chore(dns): fix failed acceptance test and improve coverage

### DIFF
--- a/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_zones_test.go
+++ b/huaweicloud/services/acceptance/dns/data_source_huaweicloud_dns_zones_test.go
@@ -79,6 +79,30 @@ func TestAccDatasourceDNSZones_public(t *testing.T) {
 	})
 }
 
+func testAccDNSZone_private(zoneName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_vpc" "default" {
+  name = "vpc-default"
+}
+
+resource "huaweicloud_dns_zone" "zone_1" {
+  name        = "%s"
+  email       = "email@example.com"
+  description = "a private zone"
+  zone_type   = "private"
+
+  router {
+    router_id = data.huaweicloud_vpc.default.id
+  }
+
+  tags = {
+    zone_type = "private"
+    owner     = "terraform"
+  }
+}
+`, zoneName)
+}
+
 func testAccDatasourceDNSZones_basic(name string) string {
 	return fmt.Sprintf(`
 %s

--- a/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
+++ b/huaweicloud/services/acceptance/dns/resource_huaweicloud_dns_recordset_test.go
@@ -235,12 +235,22 @@ func TestAccDNSRecordset_privateZone(t *testing.T) {
 	})
 }
 
+func testAccRecordset_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dns_zone" "test" {
+  name        = "%s"
+  description = "Created by terraform script"
+  ttl         = 300
+}
+`, name)
+}
+
 func testDNSRecordset_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "huaweicloud_dns_recordset" "test" {
-  zone_id     = huaweicloud_dns_zone.zone_1.id
+  zone_id     = huaweicloud_dns_zone.test.id
   name        = "%s"
   type        = "A"
   description = "a recordset description"
@@ -255,7 +265,7 @@ resource "huaweicloud_dns_recordset" "test" {
     key2 = "value2"
   }
 }
-`, testAccDNSZone_basic(name), name)
+`, testAccRecordset_base(name), name)
 }
 
 func testDNSRecordset_basic_update(name string) string {
@@ -263,7 +273,7 @@ func testDNSRecordset_basic_update(name string) string {
 %s
 
 resource "huaweicloud_dns_recordset" "test" {
-  zone_id     = huaweicloud_dns_zone.zone_1.id
+  zone_id     = huaweicloud_dns_zone.test.id
   name        = "update.%s"
   type        = "TXT"
   description = "a recordset description update"
@@ -278,7 +288,7 @@ resource "huaweicloud_dns_recordset" "test" {
     key2 = "value2_update"
   }
 }
-`, testAccDNSZone_basic(name), name)
+`, testAccRecordset_base(name), name)
 }
 
 func testDNSRecordset_publicZone(name string) string {
@@ -286,7 +296,7 @@ func testDNSRecordset_publicZone(name string) string {
 %s
 
 resource "huaweicloud_dns_recordset" "test" {
-  zone_id     = huaweicloud_dns_zone.zone_1.id
+  zone_id     = huaweicloud_dns_zone.test.id
   name        = "%s"
   type        = "A"
   description = "a record set"
@@ -299,7 +309,7 @@ resource "huaweicloud_dns_recordset" "test" {
     key = "value"
   }
 }
-`, testAccDNSZone_basic(name), name)
+`, testAccRecordset_base(name), name)
 }
 
 func testDNSRecordset_publicZone_update(name string) string {
@@ -307,7 +317,7 @@ func testDNSRecordset_publicZone_update(name string) string {
 %s
 
 resource "huaweicloud_dns_recordset" "test" {
-  zone_id     = huaweicloud_dns_zone.zone_1.id
+  zone_id     = huaweicloud_dns_zone.test.id
   name        = "update.%s"
   type        = "TXT"
   description = "an updated record set"
@@ -320,7 +330,7 @@ resource "huaweicloud_dns_recordset" "test" {
     key = "value_updated"
   }
 }
-`, testAccDNSZone_basic(name), name)
+`, testAccRecordset_base(name), name)
 }
 
 func testDNSRecordset_privateZone(name string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix failed acceptance test and improve coverage.

![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/4e11caf8-4d10-43f7-be0c-7714e681a98c)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
 sh run-test.sh ./huaweicloud/services/acceptance/dns Test.*
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -run Test.* -timeout 360m -parallel 1

=== RUN   TestAccDataSourceCustomLines_basic
=== PAUSE TestAccDataSourceCustomLines_basic
=== RUN   TestAccDataSourceFloatingPtrrecords_basic
=== PAUSE TestAccDataSourceFloatingPtrrecords_basic
=== RUN   TestAccDataSourceLineGroups_basic
=== PAUSE TestAccDataSourceLineGroups_basic
=== RUN   TestAccDataSourceNameservers_basic
=== PAUSE TestAccDataSourceNameservers_basic
=== RUN   TestAccDataSourceQuotas_basic
=== PAUSE TestAccDataSourceQuotas_basic
=== RUN   TestAccDataSourceQuotas_expectError
=== PAUSE TestAccDataSourceQuotas_expectError
=== RUN   TestAccDatasourceDNSRecordsets_basic
=== PAUSE TestAccDatasourceDNSRecordsets_basic
=== RUN   TestAccDatasourceDNSRecordsets_private
=== PAUSE TestAccDatasourceDNSRecordsets_private
=== RUN   TestAccDatasourceDNSZones_basic
=== PAUSE TestAccDatasourceDNSZones_basic
=== RUN   TestAccDatasourceDNSZones_public
=== PAUSE TestAccDatasourceDNSZones_public
=== RUN   TestAccDNSCustomLine_basic
=== PAUSE TestAccDNSCustomLine_basic
=== RUN   TestAccDNSEndpoint_basic
=== PAUSE TestAccDNSEndpoint_basic
=== RUN   TestAccDNSLineGroup_basic
=== PAUSE TestAccDNSLineGroup_basic
=== RUN   TestAccDNSPtrRecord_basic
=== PAUSE TestAccDNSPtrRecord_basic
=== RUN   TestAccDNSPtrRecord_withEpsId
=== PAUSE TestAccDNSPtrRecord_withEpsId
=== RUN   TestAccDNSRecordset_basic
=== PAUSE TestAccDNSRecordset_basic
=== RUN   TestAccDNSRecordset_publicZone
=== PAUSE TestAccDNSRecordset_publicZone
=== RUN   TestAccDNSRecordset_privateZone
=== PAUSE TestAccDNSRecordset_privateZone
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== RUN   TestAccDNSV2RecordSet_readTTL
=== PAUSE TestAccDNSV2RecordSet_readTTL
=== RUN   TestAccDNSV2RecordSet_private
=== PAUSE TestAccDNSV2RecordSet_private
=== RUN   TestAccDNSResolverRuleAssociate_basic
=== PAUSE TestAccDNSResolverRuleAssociate_basic
=== RUN   TestAccDNSResolverRule_basic
=== PAUSE TestAccDNSResolverRule_basic
=== RUN   TestAccDNSZone_basic
=== PAUSE TestAccDNSZone_basic
=== RUN   TestAccDNSZone_private
=== PAUSE TestAccDNSZone_private
=== RUN   TestAccDNSZone_readTTL
=== PAUSE TestAccDNSZone_readTTL
=== RUN   TestAccDNSZone_withEpsId
=== PAUSE TestAccDNSZone_withEpsId
=== CONT  TestAccDataSourceCustomLines_basic
--- PASS: TestAccDataSourceCustomLines_basic (46.57s)
=== CONT  TestAccDNSPtrRecord_withEpsId
--- PASS: TestAccDNSPtrRecord_withEpsId (39.81s)
=== CONT  TestAccDNSZone_withEpsId
--- PASS: TestAccDNSZone_withEpsId (30.12s)
=== CONT  TestAccDNSZone_readTTL
--- PASS: TestAccDNSZone_readTTL (21.27s)
=== CONT  TestAccDNSZone_private
--- PASS: TestAccDNSZone_private (84.50s)
=== CONT  TestAccDNSZone_basic
--- PASS: TestAccDNSZone_basic (36.74s)
=== CONT  TestAccDNSResolverRule_basic
--- PASS: TestAccDNSResolverRule_basic (130.48s)
=== CONT  TestAccDNSResolverRuleAssociate_basic
--- PASS: TestAccDNSResolverRuleAssociate_basic (148.03s)
=== CONT  TestAccDNSV2RecordSet_private
--- PASS: TestAccDNSV2RecordSet_private (47.10s)
=== CONT  TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2RecordSet_readTTL (38.74s)
=== CONT  TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_basic (70.73s)
=== CONT  TestAccDNSRecordset_privateZone
--- PASS: TestAccDNSRecordset_privateZone (91.87s)
=== CONT  TestAccDNSRecordset_publicZone
--- PASS: TestAccDNSRecordset_publicZone (56.43s)
=== CONT  TestAccDNSRecordset_basic
--- PASS: TestAccDNSRecordset_basic (58.07s)
=== CONT  TestAccDatasourceDNSRecordsets_private
--- PASS: TestAccDatasourceDNSRecordsets_private (85.54s)
=== CONT  TestAccDNSPtrRecord_basic
--- PASS: TestAccDNSPtrRecord_basic (60.17s)
=== CONT  TestAccDNSLineGroup_basic
--- PASS: TestAccDNSLineGroup_basic (35.77s)
=== CONT  TestAccDNSEndpoint_basic
--- PASS: TestAccDNSEndpoint_basic (139.30s)
=== CONT  TestAccDNSCustomLine_basic
--- PASS: TestAccDNSCustomLine_basic (36.03s)
=== CONT  TestAccDatasourceDNSZones_public
--- PASS: TestAccDatasourceDNSZones_public (59.89s)
=== CONT  TestAccDatasourceDNSZones_basic
--- PASS: TestAccDatasourceDNSZones_basic (66.54s)
=== CONT  TestAccDataSourceQuotas_basic
--- PASS: TestAccDataSourceQuotas_basic (19.84s)
=== CONT  TestAccDatasourceDNSRecordsets_basic
--- PASS: TestAccDatasourceDNSRecordsets_basic (85.22s)
=== CONT  TestAccDataSourceQuotas_expectError
--- PASS: TestAccDataSourceQuotas_expectError (1.43s)
=== CONT  TestAccDataSourceLineGroups_basic
--- PASS: TestAccDataSourceLineGroups_basic (42.77s)
=== CONT  TestAccDataSourceNameservers_basic
--- PASS: TestAccDataSourceNameservers_basic (19.14s)
=== CONT  TestAccDataSourceFloatingPtrrecords_basic
--- PASS: TestAccDataSourceFloatingPtrrecords_basic (84.36s)
PASS
coverage: 3.9% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       1636.785s       coverage: 3.9% of statements in ./huaweicloud/...
```
