### PR TITLE
test(eip): fix acctest for geip associate

### DIFF
--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_internet_bandwidth_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_global_internet_bandwidth_test.go
@@ -91,7 +91,9 @@ func TestAccInternetBandwidth_basic(t *testing.T) {
 
 func testAccInternetBandwidth_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+data "huaweicloud_global_eip_pools" "all" {
+  access_site = "cn-north-beijing"
+}
 
 resource "huaweicloud_global_internet_bandwidth" "test" {
   access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
@@ -105,12 +107,14 @@ resource "huaweicloud_global_internet_bandwidth" "test" {
     foo = "bar"
   }
 }
-`, testAccGlobalEIPPoolsDataSource_basic, name)
+`, name)
 }
 
 func testAccInternetBandwidth_update(name string) string {
 	return fmt.Sprintf(`
-%s
+data "huaweicloud_global_eip_pools" "all" {
+  access_site = "cn-north-beijing"
+}
 
 resource "huaweicloud_global_internet_bandwidth" "test" {
   access_site           = data.huaweicloud_global_eip_pools.all.geip_pools[0].access_site
@@ -125,5 +129,5 @@ resource "huaweicloud_global_internet_bandwidth" "test" {
     key = "value"
   }
 }
-`, testAccGlobalEIPPoolsDataSource_basic, name)
+`, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix acctest for geip associate


## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/eip" TESTARGS="-run TestAccGEIPAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGEIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccGEIPAssociate_basic
=== PAUSE TestAccGEIPAssociate_basic
=== CONT  TestAccGEIPAssociate_basic
--- PASS: TestAccGEIPAssociate_basic (288.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       288.211s
```
