### PR TITLE
test(DCS): fix dcs test

### DIFF
--- a/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_instances_test.go
+++ b/huaweicloud/services/acceptance/dcs/data_source_huaweicloud_dcs_instances_test.go
@@ -38,8 +38,9 @@ func testAccDatasourceDcsInstance_basic(name string) string {
 %s
 
 data "huaweicloud_dcs_instances" "test" {
-  name   = huaweicloud_dcs_instance.instance_1.name
-  status = "RUNNING"
+  name     = huaweicloud_dcs_instance.instance_1.name
+  status   = "RUNNING"
+  capacity = 0.125
 }
 `, testAccDcsV1Instance_basic(name))
 }

--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_account_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_account_test.go
@@ -66,7 +66,6 @@ func TestAccDcsAccount_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckDCSAccountWhitelist(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -79,7 +78,8 @@ func TestAccDcsAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "account_role", "read"),
 					resource.TestCheckResourceAttr(rName, "account_type", "normal"),
 					resource.TestCheckResourceAttr(rName, "description", "add account"),
-					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_dcs_instance.instance_1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_dcs_instance.instance_1", "id"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
 				),
 			},
@@ -90,7 +90,8 @@ func TestAccDcsAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "account_role", "write"),
 					resource.TestCheckResourceAttr(rName, "account_type", "normal"),
 					resource.TestCheckResourceAttr(rName, "description", ""),
-					resource.TestCheckResourceAttrPair(rName, "instance_id", "huaweicloud_dcs_instance.instance_1", "id"),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"huaweicloud_dcs_instance.instance_1", "id"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
 				),
 			},

--- a/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
+++ b/huaweicloud/services/acceptance/dcs/resource_huaweicloud_dcs_instance_test.go
@@ -58,6 +58,8 @@ func TestAccDcsInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.id", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "timeout"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "100"),
+					resource.TestCheckResourceAttrPair(resourceName, "enterprise_project_id",
+						"huaweicloud_enterprise_project.test.0", "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "private_ip"),
 					resource.TestCheckResourceAttrSet(resourceName, "domain_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
@@ -85,10 +87,10 @@ func TestAccDcsInstances_basic(t *testing.T) {
 			{
 				Config: testAccDcsV1Instance_updated(instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "port", "6388"),
+					resource.TestCheckResourceAttr(resourceName, "port", "6389"),
 					resource.TestCheckResourceAttrPair(resourceName, "flavor",
 						"data.huaweicloud_dcs_flavors.test", "flavors.0.name"),
-					resource.TestCheckResourceAttr(resourceName, "capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "0.5"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "06:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "07:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_policy.0.begin_at", "01:00-02:00"),
@@ -97,6 +99,8 @@ func TestAccDcsInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.id", "10"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "latency-monitor-threshold"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "120"),
+					resource.TestCheckResourceAttrPair(resourceName, "enterprise_project_id",
+						"huaweicloud_enterprise_project.test.1", "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "launched_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_cidr"),
@@ -801,47 +805,6 @@ func TestAccDcsInstances_cluster_expand_replica(t *testing.T) {
 	})
 }
 
-func TestAccDcsInstances_withEpsId(t *testing.T) {
-	var instance instances.DcsInstance
-	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
-	resourceName := "huaweicloud_dcs_instance.instance_1"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getDcsResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckMigrateEpsID(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDcsV1Instance_epsId(instanceName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
-						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-				),
-			},
-			{
-				Config: testAccDcsV1Instance_epsId(instanceName, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
-						acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
-				),
-			},
-		},
-	})
-}
-
 func TestAccDcsInstances_whitelists(t *testing.T) {
 	var instance instances.DcsInstance
 	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
@@ -970,7 +933,7 @@ func TestAccDcsInstances_prePaid(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDcsInstance_prePaid(rName, false),
+				Config: testAccDcsInstance_prePaid(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -978,7 +941,7 @@ func TestAccDcsInstances_prePaid(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDcsInstance_prePaid(rName, true),
+				Config: testAccDcsInstance_prePaid_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
 				),
@@ -1073,8 +1036,15 @@ data "huaweicloud_dcs_flavors" "test" {
   engine_version = "5.0"
 }
 
+resource "huaweicloud_enterprise_project" "test" {
+  count = 2
+
+  name        = "%[1]s_${count.index}"
+  description = "terraform test"
+}
+
 resource "huaweicloud_dcs_instance" "instance_1" {
-  name               = "%s"
+  name               = "%[1]s"
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
@@ -1086,6 +1056,8 @@ resource "huaweicloud_dcs_instance" "instance_1" {
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "22:00:00"
   maintain_end       = "23:00:00"
+
+  enterprise_project_id = huaweicloud_enterprise_project.test[0].id
 
   backup_policy {
     backup_type = "auto"
@@ -1130,23 +1102,32 @@ data "huaweicloud_vpc_subnet" "test" {
 
 data "huaweicloud_dcs_flavors" "test" {
   cache_mode     = "ha"
-  capacity       = 1
+  capacity       = 0.5
   engine_version = "5.0"
 }
 
+resource "huaweicloud_enterprise_project" "test" {
+  count = 2
+
+  name        = "%[1]s_${count.index}"
+  description = "terraform test"
+}
+
 resource "huaweicloud_dcs_instance" "instance_1" {
-  name               = "%s"
+  name               = "%[1]s"
   engine_version     = "5.0"
   password           = "Huawei_test"
   engine             = "Redis"
-  port               = 6388
-  capacity           = 1
+  port               = 6389
+  capacity           = 0.5
   vpc_id             = data.huaweicloud_vpc.test.id
   subnet_id          = data.huaweicloud_vpc_subnet.test.id
   availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
   flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
   maintain_begin     = "06:00:00"
   maintain_end       = "07:00:00"
+
+  enterprise_project_id = huaweicloud_enterprise_project.test[1].id
 
   backup_policy {
     backup_type = "auto"
@@ -1842,45 +1823,6 @@ resource "huaweicloud_dcs_instance" "instance_1" {
 }`, instanceName)
 }
 
-func testAccDcsV1Instance_epsId(instanceName, epsId string) string {
-	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
-
-data "huaweicloud_vpc" "test" {
-  name = "vpc-default"
-}
-
-data "huaweicloud_vpc_subnet" "test" {
-  name = "subnet-default"
-}
-
-data "huaweicloud_dcs_flavors" "test" {
-  cache_mode = "ha"
-  capacity   = 0.125
-}
-
-resource "huaweicloud_dcs_instance" "instance_1" {
-  name               = "%s"
-  engine_version     = "5.0"
-  password           = "Huawei_test"
-  engine             = "Redis"
-  capacity           = 0.125
-  vpc_id             = data.huaweicloud_vpc.test.id
-  subnet_id          = data.huaweicloud_vpc_subnet.test.id
-  availability_zones = [data.huaweicloud_availability_zones.test.names[0]]
-  flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
-
-  backup_policy {
-    backup_type = "auto"
-    begin_at    = "00:00-01:00"
-    period_type = "weekly"
-    backup_at   = [1]
-    save_days   = 1
-  }
-  enterprise_project_id = "%s"
-}`, instanceName, epsId)
-}
-
 func testAccDcsV1Instance_tiny(instanceName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
@@ -2035,7 +1977,7 @@ resource "huaweicloud_dcs_instance" "instance_1" {
 }`, instanceName)
 }
 
-func testAccDcsInstance_prePaid(instanceName string, isAutoRenew bool) string {
+func testAccDcsInstance_prePaid(instanceName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -2066,8 +2008,43 @@ resource "huaweicloud_dcs_instance" "test" {
   charging_mode = "prePaid"
   period_unit   = "month"
   period        = 1
-  auto_renew    = "%v"
-}`, instanceName, isAutoRenew)
+  auto_renew    = "false"
+}`, instanceName)
+}
+
+func testAccDcsInstance_prePaid_update(instanceName string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_vpc" "test" {
+  name = "vpc-default"
+}
+
+data "huaweicloud_vpc_subnet" "test" {
+  name = "subnet-default"
+}
+
+data "huaweicloud_dcs_flavors" "test" {
+  cache_mode = "ha"
+  capacity   = 0.5
+}
+
+resource "huaweicloud_dcs_instance" "test" {
+  vpc_id             = data.huaweicloud_vpc.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
+  availability_zones = try(slice(data.huaweicloud_availability_zones.test.names, 0, 1), [])
+  name               = "%s"
+  engine             = "Redis"
+  engine_version     = "5.0"
+  flavor             = data.huaweicloud_dcs_flavors.test.flavors[0].name
+  capacity           = 0.5
+  password           = "Huawei_test"
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = "true"
+}`, instanceName)
 }
 
 func testAccDcsV1Instance_ssl(instanceName string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix dcs test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix dcs test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/dcs/ TEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dcs/ -v  -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDcsAccounts_basic
=== PAUSE TestAccDataSourceDcsAccounts_basic
=== RUN   TestAccDatasourceDcsBackups_basic
=== PAUSE TestAccDatasourceDcsBackups_basic
=== RUN   TestAccDataSourceDcsBigkeyAnalyses_basic
=== PAUSE TestAccDataSourceDcsBigkeyAnalyses_basic
=== RUN   TestAccDataSourceDcsDiagnosisTasks_basic
=== PAUSE TestAccDataSourceDcsDiagnosisTasks_basic
=== RUN   TestAccDataSourceDcsFlavorsV2_basic
=== PAUSE TestAccDataSourceDcsFlavorsV2_basic
=== RUN   TestAccDataSourceDcsHotkeyAnalyses_basic
=== PAUSE TestAccDataSourceDcsHotkeyAnalyses_basic
=== RUN   TestAccDatasourceDcsInstance_basic
=== PAUSE TestAccDatasourceDcsInstance_basic
=== RUN   TestAccDcsMaintainWindowDataSource_basic
=== PAUSE TestAccDcsMaintainWindowDataSource_basic
=== RUN   TestAccDatasourceTemplateDetail_basic
=== PAUSE TestAccDatasourceTemplateDetail_basic
=== RUN   TestAccDatasourceTemplates_basic
=== PAUSE TestAccDatasourceTemplates_basic
=== RUN   TestAccDcsAccount_basic
=== PAUSE TestAccDcsAccount_basic
=== RUN   TestAccDcsBackup_basic
=== PAUSE TestAccDcsBackup_basic
=== RUN   TestAccBigKeyAnalysis_basic
=== PAUSE TestAccBigKeyAnalysis_basic
=== RUN   TestAccCustomTemplate_basic
=== PAUSE TestAccCustomTemplate_basic
=== RUN   TestAccDiagnosisTask_basic
=== PAUSE TestAccDiagnosisTask_basic
=== RUN   TestAccHotKeyAnalysis_basic
=== PAUSE TestAccHotKeyAnalysis_basic
=== RUN   TestAccDcsRestore_basic
=== PAUSE TestAccDcsRestore_basic
=== RUN   TestAccDcsInstances_basic
=== PAUSE TestAccDcsInstances_basic
=== RUN   TestAccDcsInstances_ha_change_capacity
=== PAUSE TestAccDcsInstances_ha_change_capacity
=== RUN   TestAccDcsInstances_ha_expand_replica
=== PAUSE TestAccDcsInstances_ha_expand_replica
=== RUN   TestAccDcsInstances_ha_to_proxy
=== PAUSE TestAccDcsInstances_ha_to_proxy
=== RUN   TestAccDcsInstances_rw_change_capacity
=== PAUSE TestAccDcsInstances_rw_change_capacity
=== RUN   TestAccDcsInstances_rw_expand_replica
=== PAUSE TestAccDcsInstances_rw_expand_replica
=== RUN   TestAccDcsInstances_rw_to_proxy
=== PAUSE TestAccDcsInstances_rw_to_proxy
=== RUN   TestAccDcsInstances_proxy_change_capacity
=== PAUSE TestAccDcsInstances_proxy_change_capacity
=== RUN   TestAccDcsInstances_proxy_to_ha
=== PAUSE TestAccDcsInstances_proxy_to_ha
=== RUN   TestAccDcsInstances_proxy_to_rw
=== PAUSE TestAccDcsInstances_proxy_to_rw
=== RUN   TestAccDcsInstances_cluster_change_capacity
=== PAUSE TestAccDcsInstances_cluster_change_capacity
=== RUN   TestAccDcsInstances_cluster_expand_replica
=== PAUSE TestAccDcsInstances_cluster_expand_replica
=== RUN   TestAccDcsInstances_whitelists
=== PAUSE TestAccDcsInstances_whitelists
=== RUN   TestAccDcsInstances_tiny
=== PAUSE TestAccDcsInstances_tiny
=== RUN   TestAccDcsInstances_single
=== PAUSE TestAccDcsInstances_single
=== RUN   TestAccDcsInstances_prePaid
=== PAUSE TestAccDcsInstances_prePaid
=== RUN   TestAccDcsInstances_ssl
=== PAUSE TestAccDcsInstances_ssl
=== CONT  TestAccDataSourceDcsAccounts_basic
=== CONT  TestAccDcsInstances_cluster_expand_replica
=== CONT  TestAccDcsInstances_cluster_change_capacity
=== CONT  TestAccDcsInstances_ssl
=== CONT  TestAccDcsInstances_whitelists
=== CONT  TestAccDcsInstances_tiny
=== CONT  TestAccDcsInstances_prePaid
=== CONT  TestAccDcsInstances_single
=== CONT  TestAccDcsInstances_rw_to_proxy
--- PASS: TestAccDcsInstances_single (177.03s)
=== CONT  TestAccDcsAccount_basic
--- PASS: TestAccDcsInstances_ssl (279.73s)
=== CONT  TestAccDcsInstances_ha_change_capacity
--- PASS: TestAccDcsInstances_tiny (294.65s)
=== CONT  TestAccDcsInstances_basic
--- PASS: TestAccDcsInstances_whitelists (300.00s)
=== CONT  TestAccDcsRestore_basic
--- PASS: TestAccDataSourceDcsAccounts_basic (346.31s)
=== CONT  TestAccHotKeyAnalysis_basic
--- PASS: TestAccDcsInstances_ha_expand_replica (435.64s)
=== CONT  TestAccDiagnosisTask_basic
--- PASS: TestAccDiagnosisTask_basic (51.96s)
=== CONT  TestAccCustomTemplate_basic
--- PASS: TestAccDcsInstances_cluster_expand_replica (488.66s)
=== CONT  TestAccBigKeyAnalysis_basic
--- PASS: TestAccDcsRestore_basic (207.37s)
=== CONT  TestAccDcsBackup_basic
--- PASS: TestAccCustomTemplate_basic (37.08s)
=== CONT  TestAccDcsInstances_proxy_to_rw
--- PASS: TestAccHotKeyAnalysis_basic (213.33s)
=== CONT  TestAccDcsInstances_rw_change_capacity
=== CONT  TestAccDcsInstances_proxy_to_ha
--- PASS: TestAccDcsAccount_basic (393.18s)
=== CONT  TestAccDcsInstances_rw_expand_replica
--- PASS: TestAccDcsInstances_prePaid (578.45s)
=== CONT  TestAccDcsInstances_ha_to_proxy
--- PASS: TestAccDcsInstances_rw_to_proxy (639.57s)
=== CONT  TestAccDcsInstances_proxy_change_capacity
--- PASS: TestAccDcsInstances_ha_change_capacity (361.86s)
=== CONT  TestAccDataSourceDcsDiagnosisTasks_basic
--- PASS: TestAccBigKeyAnalysis_basic (205.24s)
=== CONT  TestAccDataSourceDcsFlavorsV2_basic
--- PASS: TestAccDataSourceDcsFlavorsV2_basic (14.34s)
=== CONT  TestAccDatasourceTemplateDetail_basic
--- PASS: TestAccDataSourceDcsDiagnosisTasks_basic (69.99s)
=== CONT  TestAccDatasourceTemplates_basic
--- PASS: TestAccDatasourceTemplateDetail_basic (43.67s)
=== CONT  TestAccDataSourceDcsBigkeyAnalyses_basic
--- PASS: TestAccDatasourceTemplates_basic (70.54s)
=== CONT  TestAccDatasourceDcsBackups_basic
--- PASS: TestAccDcsInstances_rw_expand_replica (298.26s)
=== CONT  TestAccDcsMaintainWindowDataSource_basic
--- PASS: TestAccDcsMaintainWindowDataSource_basic (12.11s)
=== CONT  TestAccDatasourceDcsInstance_basic
--- PASS: TestAccDcsBackup_basic (375.47s)
=== CONT  TestAccDataSourceDcsHotkeyAnalyses_basic
--- PASS: TestAccDatasourceDcsBackups_basic (241.93s)
--- PASS: TestAccDatasourceDcsInstance_basic (185.00s)
--- PASS: TestAccDataSourceDcsBigkeyAnalyses_basic (381.14s)
--- PASS: TestAccDataSourceDcsHotkeyAnalyses_basic (280.12s)
--- PASS: TestAccDcsInstances_proxy_to_rw (741.85s)
--- PASS: TestAccDcsInstances_ha_to_proxy (696.47s)
--- PASS: TestAccDcsInstances_proxy_to_ha (841.39s)
--- PASS: TestAccDcsInstances_rw_change_capacity (992.21s)
--- PASS: TestAccDcsInstances_cluster_change_capacity (1980.58s)
--- PASS: TestAccDcsInstances_proxy_change_capacity (2259.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dcs       2899.201s
```
