### PR TITLE
chore(css): css cluster engine_version and availability_zone field set non updatable

### DIFF
--- a/docs/resources/css_cluster.md
+++ b/docs/resources/css_cluster.md
@@ -120,9 +120,8 @@ The following arguments are supported:
 * `engine_type` - (Optional, String, ForceNew) Specifies the engine type. The valid value is **elasticsearch**.
   Defaults to **elasticsearch**. Changing this parameter will create a new resource.
 
-* `engine_version` - (Required, String, ForceNew) Specifies the engine version.
+* `engine_version` - (Required, String, NonUpdatable) Specifies the engine version.
   For details, see [Supported Cluster Versions](https://support.huaweicloud.com/intl/en-us/api-css/css_03_0056.html).
-  Changing this parameter will create a new resource.
 
 * `security_mode` - (Optional, Bool) Specifies whether to enable authentication.
   The value can be **true** or **false**. Authentication is disabled by default.
@@ -165,12 +164,11 @@ The following arguments are supported:
 
 * `security_group_id` - (Required, String) Specifies the security group ID.
 
-* `availability_zone` - (Required, String, ForceNew) Specifies the availability zone name.
+* `availability_zone` - (Required, String, NonUpdatable) Specifies the availability zone name.
   Separate multiple AZs with commas (,), for example, az1,az2. AZs must be unique. The number of nodes must be greater
   than or equal to the number of AZs. If the number of nodes is a multiple of the number of AZs, the nodes are evenly
   distributed to each AZ. If the number of nodes is not a multiple of the number of AZs, the absolute difference
   between node quantity in any two AZs is **1** at most.
-  Changing this parameter will create a new resource.
 
 * `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
 

--- a/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_cluster.go
@@ -40,6 +40,8 @@ const (
 	ClusterStatusUnavailable = "303"
 )
 
+var clusterNonUpdatableParams = []string{"engine_version", "availability_zone"}
+
 // @API CSS POST /v1.0/{project_id}/clusters/{cluster_id}/role_extend
 // @API CSS POST /v1.0/{project_id}/clusters
 // @API CSS POST /v1.0/{project_id}/{resource_type}/{cluster_id}/tags
@@ -94,6 +96,8 @@ func ResourceCssCluster() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 
+		CustomizeDiff: config.FlexibleForceNew(clusterNonUpdatableParams),
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -116,7 +120,6 @@ func ResourceCssCluster() *schema.Resource {
 			"engine_version": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"security_mode": {
 				Type:     schema.TypeBool,
@@ -165,7 +168,6 @@ func ResourceCssCluster() *schema.Resource {
 			"availability_zone": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				RequiredWith: []string{"vpc_id", "subnet_id", "security_group_id"},
 				Computed:     true,
 				Description:  "schema: Required",
@@ -485,6 +487,12 @@ func ResourceCssCluster() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "schema: Deprecated; use created_at instead",
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
 			},
 		},
 	}


### PR DESCRIPTION
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
css cluster engine_version and availability_zone field set non updatable

Replace `forceNew` with `non-updatable` to avoid accidentally deleting the cluster by triggering forceNew after using the following two action resources.
huaweicloud_css_es_core_upgrade:
Running `terraform plan` after the resource is successfully executed, the cluster engine_version field ForceNew will be triggered.

huaweicloud_css_cluster_node_replace:
Running `terraform plan` after the resource is successfully executed, the cluster availability_zone field ForceNew will be triggered.

**Special notes for your reviewer**:

**Release note**:


```
css cluster engine_version and availability_zone field set non updatable
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

