### PR TITLE
feat(eps): add new resource to grant eps capability

### DIFF
--- a/docs/resources/enterprise_project_authority.md
+++ b/docs/resources/enterprise_project_authority.md
@@ -1,0 +1,25 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_enterprise_project"
+description: |-
+  Use this resource to grant the enterprise project capability for current account within HuaweiCloud.
+---
+
+# huaweicloud_enterprise_project_authority
+
+Use this resource to grant the enterprise project capability for current account within HuaweiCloud.
+
+-> **NOTE:** Deleting this resource will not reclaim the enterprise project authorization of the current account.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_enterprise_project_authority" "test" {}
+```
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1323,7 +1323,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_elb_logtank":             elb.ResourceLogTank(),
 			"huaweicloud_elb_security_policy":     elb.ResourceSecurityPolicy(),
 
-			"huaweicloud_enterprise_project": eps.ResourceEnterpriseProject(),
+			"huaweicloud_enterprise_project":           eps.ResourceEnterpriseProject(),
+			"huaweicloud_enterprise_project_authority": eps.ResourceAuthority(),
 
 			"huaweicloud_er_association":    er.ResourceAssociation(),
 			"huaweicloud_er_instance":       er.ResourceInstance(),

--- a/huaweicloud/services/eps/resource_huaweicloud_enterprise_project_authority.go
+++ b/huaweicloud/services/eps/resource_huaweicloud_enterprise_project_authority.go
@@ -1,0 +1,68 @@
+package eps
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API EPS POST /v2/enterprises/enterprise-projects/authority
+func ResourceAuthority() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAuthorityCreate,
+		ReadContext:   resourceAuthorityRead,
+		DeleteContext: resourceAuthorityDelete,
+	}
+}
+
+func resourceAuthorityCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("bss", cfg.Region)
+	if err != nil {
+		return diag.Errorf("error creating BSS client: %s", err)
+	}
+
+	httpUrl := "v2/enterprises/enterprise-projects/authority"
+	createPath := client.Endpoint + httpUrl
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	_, err = client.Request("POST", createPath, &opts)
+	if err != nil {
+		return diag.Errorf("error granting the enterprise project: %s", err)
+	}
+
+	randUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(randUUID)
+
+	return resourceAuthorityRead(ctx, d, meta)
+}
+
+func resourceAuthorityRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAuthorityDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `Unable to reclaim the enterprise project authorization of the current account during this resource delete.
+The authority info can only be removed from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, we don‘’t have any resources that used to grant enterprise project capability.

![d067a49d318ae6e792727ed699a1076](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/a30adea5-53ee-44dc-8a71-5e34249492f7)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to grant eps capability
```

## PR Checklist

* [ ] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
NONE
```
