### PR TITLE
chore: fix: test(er/ut): improve coverage of resource codes

### DIFF
--- a/docs/resources/er_static_route.md
+++ b/docs/resources/er_static_route.md
@@ -73,6 +73,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - The latest update time of the static route.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `update` - Default is 5 minutes.
+* `delete` - Default is 2 minutes.
+
 ## Import
 
 Static routes can be imported using the related `route_table_id` and their `id`, separated by a slash (/), e.g.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240624075804-edb862aaa73a
+	github.com/chnsz/golangsdk v0.0.0-20240628074404-f04cd77ad44a
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240624075804-edb862aaa73a h1:q+hV7Y6DEYO6CfQ6vQXydHZ0awa2/b3uXsx5yWkz/RI=
-github.com/chnsz/golangsdk v0.0.0-20240624075804-edb862aaa73a/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240628074404-f04cd77ad44a h1:3YjSSDC9ywWHhP+wC4c3ZEDIbqXElOjLV1onL2VTid4=
+github.com/chnsz/golangsdk v0.0.0-20240628074404-f04cd77ad44a/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_attachments_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_attachments_test.go
@@ -97,12 +97,12 @@ func testAccDataSourceAttachments_base() string {
 	)
 
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 
 %[1]s
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones    = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
   name                  = "%[2]s"
   asn                   = %[3]d
   enterprise_project_id = "0"

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_attachments_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_attachments_test.go
@@ -2,9 +2,9 @@ package er
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
-	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
@@ -12,34 +12,89 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func TestAccAttachmentsDataSource_basic(t *testing.T) {
+func TestAccDataSourceAttachments_basic(t *testing.T) {
 	var (
-		dName = "data.huaweicloud_er_attachments.filter_by_name"
-		name  = acceptance.RandomAccResourceName()
+		all = "data.huaweicloud_er_attachments.test"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-		dc = acceptance.InitDataSourceCheck(dName)
+		byAttachmentId   = "data.huaweicloud_er_attachments.filter_by_attachment_id"
+		dcByAttachmentId = acceptance.InitDataSourceCheck(byAttachmentId)
+
+		byType   = "data.huaweicloud_er_attachments.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byName   = "data.huaweicloud_er_attachments.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byResourceId   = "data.huaweicloud_er_attachments.filter_by_resource_id"
+		dcByResourceId = acceptance.InitDataSourceCheck(byResourceId)
+
+		byStatus   = "data.huaweicloud_er_attachments.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byTags   = "data.huaweicloud_er_attachments.filter_by_tags"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAttachmentsDataSource_filterByName(name),
+				Config: testAccDataSourceAttachments_basic_step1(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "attachments.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Check whether filter parameter 'attachment_id' is effective.
+					dcByAttachmentId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byAttachmentId, "attachments.#", "1"),
+					resource.TestCheckResourceAttrPair(byAttachmentId, "attachments.0.id",
+						"huaweicloud_er_vpc_attachment.test", "id"),
+					resource.TestCheckResourceAttrPair(byAttachmentId, "attachments.0.name",
+						"huaweicloud_er_vpc_attachment.test", "name"),
+					resource.TestCheckResourceAttrPair(byAttachmentId, "attachments.0.description",
+						"huaweicloud_er_vpc_attachment.test", "description"),
+					resource.TestCheckResourceAttrSet(byAttachmentId, "attachments.0.status"),
+					resource.TestCheckResourceAttrSet(byAttachmentId, "attachments.0.associated"),
+					resource.TestCheckResourceAttrPair(byAttachmentId, "attachments.0.resource_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestMatchResourceAttr(byAttachmentId, "attachments.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byAttachmentId, "attachments.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttr(byAttachmentId, "attachments.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(byAttachmentId, "attachments.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(byAttachmentId, "attachments.0.tags.key", "value"),
+					resource.TestCheckResourceAttr(byAttachmentId, "attachments.0.type", "vpc"),
+					resource.TestCheckOutput("is_attachment_id_filter_useful", "true"),
+					// Check whether filter parameter 'type' is effective.
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+					// Check whether filter parameter 'name' is effective.
+					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
-					resource.TestCheckOutput("not_found_validation_pass", "true"),
+					// Check whether filter parameter 'resource_id' is effective.
+					dcByResourceId.CheckResourceExists(),
+					resource.TestCheckOutput("is_resource_id_filter_useful", "true"),
+					// Check whether filter parameter 'status' is effective.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					// Check whether filter parameter 'tags' is effective.
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccAttachmentsDataSource_base(name string) string {
-	bgpAsNum := acctest.RandIntRange(64512, 65534)
+func testAccDataSourceAttachments_base() string {
+	var (
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+	)
 
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
@@ -65,374 +120,162 @@ resource "huaweicloud_er_vpc_attachment" "test" {
     key = "value"
   }
 }
+
+resource "huaweicloud_er_route_table" "test" {
+  instance_id = huaweicloud_er_instance.test.id
+  name        = "%[2]s"
+}
+
+resource "huaweicloud_er_static_route" "test" {
+  route_table_id = huaweicloud_er_route_table.test.id
+  destination    = huaweicloud_vpc.test.cidr
+  attachment_id  = huaweicloud_er_vpc_attachment.test.id
+}
 `, common.TestVpc(name), name, bgpAsNum)
 }
 
-func testAccAttachmentsDataSource_filterByName(name string) string {
+func testAccDataSourceAttachments_basic_step1() string {
 	return fmt.Sprintf(`
 %[1]s
 
-data "huaweicloud_er_attachments" "filter_by_name" {
-  // The behavior of parameter 'name' is 'Required', means this parameter does not have 'Know After Apply' behavior.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
-  ]
+data "huaweicloud_er_attachments" "test" {
+  depends_on = [huaweicloud_er_vpc_attachment.test]
 
   instance_id = huaweicloud_er_instance.test.id
-  name        = huaweicloud_er_vpc_attachment.test.name
 }
 
-data "huaweicloud_er_attachments" "not_found" {
-  // Since a specified name is used, there is no dependency relationship with resource attachment, and the dependency
-  // needs to be manually set.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
-  ]
-
-  instance_id = huaweicloud_er_instance.test.id
-  name        = "resource_not_found"
-}
-
+# Filter by attachment ID
 locals {
-  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_name.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
-}
-
-output "is_name_filter_useful" {
-  value = alltrue(local.filter_result) && length(local.filter_result) > 0
-}
-
-output "not_found_validation_pass" {
-  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
-}
-`, testAccAttachmentsDataSource_base(name))
-}
-
-func TestAccAttachmentsDataSource_filterById(t *testing.T) {
-	var (
-		dName = "data.huaweicloud_er_attachments.filter_by_id"
-		name  = acceptance.RandomAccResourceName()
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAttachmentsDataSource_filterById(name),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_id_filter_useful", "true"),
-					resource.TestCheckOutput("not_found_validation_pass", "true"),
-				),
-			},
-		},
-	})
-}
-
-func testAccAttachmentsDataSource_filterById(name string) string {
-	randUUID, _ := uuid.GenerateUUID()
-
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_attachments" "filter_by_id" {
-  instance_id   = huaweicloud_er_instance.test.id
   attachment_id = huaweicloud_er_vpc_attachment.test.id
 }
 
-data "huaweicloud_er_attachments" "not_found" {
-  // Since a random ID is used, there is no dependency relationship with resource attachment, and the dependency needs
-  // to be manually set.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
-  ]
+data "huaweicloud_er_attachments" "filter_by_attachment_id" {
+  depends_on = [huaweicloud_er_static_route.test]
 
   instance_id   = huaweicloud_er_instance.test.id
-  attachment_id = "%[2]s"
+  attachment_id = local.attachment_id
 }
 
 locals {
-  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_id.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
+  attachment_id_filter_result = [
+    for v in data.huaweicloud_er_attachments.filter_by_attachment_id.attachments[*].id : v == local.attachment_id
+  ]
 }
 
-output "is_id_filter_useful" {
-  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+output "is_attachment_id_filter_useful" {
+  value = length(local.attachment_id_filter_result) > 0 && alltrue(local.attachment_id_filter_result)
 }
 
-output "not_found_validation_pass" {
-  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
+# Filter by type
+locals {
+  # There is no attribute names 'type'.
+  attachment_type = "vpc"
 }
-`, testAccAttachmentsDataSource_base(name), randUUID)
-}
-
-func TestAccAttachmentsDataSource_filterByType(t *testing.T) {
-	var (
-		dName = "data.huaweicloud_er_attachments.filter_by_type"
-		name  = acceptance.RandomAccResourceName()
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAttachmentsDataSource_filterByType(name),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_type_filter_useful", "true"),
-					resource.TestCheckOutput("not_found_validation_pass", "true"),
-				),
-			},
-		},
-	})
-}
-
-func testAccAttachmentsDataSource_filterByType(name string) string {
-	randUUID, _ := uuid.GenerateUUID()
-
-	return fmt.Sprintf(`
-%[1]s
 
 data "huaweicloud_er_attachments" "filter_by_type" {
-  // Since a specified type is used, there is no dependency relationship with resource attachment, and the dependency
-  // needs to be manually set.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
-  ]
+  depends_on = [huaweicloud_er_vpc_attachment.test]
 
   instance_id = huaweicloud_er_instance.test.id
-  type        = "vpc"
-}
-
-data "huaweicloud_er_attachments" "not_found" {
-  // Since a specified type is used, there is no dependency relationship with resource attachment, and the dependency
-  // needs to be manually set.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
-  ]
-
-  instance_id = huaweicloud_er_instance.test.id
-  type        = "vgw"
+  type        = local.attachment_type
 }
 
 locals {
-  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_type.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
+  type_filter_result = [
+    for v in data.huaweicloud_er_attachments.filter_by_type.attachments[*].type : v == local.attachment_type
+  ]
 }
 
 output "is_type_filter_useful" {
-  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+  value = length(local.type_filter_result) > 0 && alltrue(local.type_filter_result)
 }
 
-output "not_found_validation_pass" {
-  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
-}
-`, testAccAttachmentsDataSource_base(name), randUUID)
-}
-
-func TestAccAttachmentsDataSource_filterByStatus(t *testing.T) {
-	var (
-		dName = "data.huaweicloud_er_attachments.filter_by_status"
-		name  = acceptance.RandomAccResourceName()
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAttachmentsDataSource_filterByStatus(name),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_status_filter_useful", "true"),
-					resource.TestCheckOutput("not_found_validation_pass", "true"),
-				),
-			},
-		},
-	})
+# Filter by name
+locals {
+  attachment_name = huaweicloud_er_vpc_attachment.test.name
 }
 
-func testAccAttachmentsDataSource_filterByStatus(name string) string {
-	return fmt.Sprintf(`
-%[1]s
+data "huaweicloud_er_attachments" "filter_by_name" {
+  # The behavior of parameter 'name' is 'Required', means this parameter does not have 'Know After Apply' behavior.
+  depends_on = [huaweicloud_er_vpc_attachment.test]
 
-data "huaweicloud_er_attachments" "filter_by_status" {
   instance_id = huaweicloud_er_instance.test.id
-  status      = huaweicloud_er_vpc_attachment.test.status
-}
-
-data "huaweicloud_er_attachments" "not_found" {
-  // Since a specified status is used, there is no dependency relationship with resource attachment, and the dependency needs
-  // to be manually set.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
-  ]
-
-  instance_id   = huaweicloud_er_instance.test.id
-  status        = "failed"
+  name        = local.attachment_name
 }
 
 locals {
-  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_status.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
-}
-
-output "is_status_filter_useful" {
-  value = alltrue(local.filter_result) && length(local.filter_result) > 0
-}
-
-output "not_found_validation_pass" {
-  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
-}
-`, testAccAttachmentsDataSource_base(name))
-}
-
-func TestAccAttachmentsDataSource_filterByTags(t *testing.T) {
-	var (
-		dName = "data.huaweicloud_er_attachments.filter_by_tags"
-		name  = acceptance.RandomAccResourceName()
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAttachmentsDataSource_filterByTags(name),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_tags_filter_is_useful", "true"),
-					resource.TestCheckOutput("not_found_validation_pass", "true"),
-				),
-			},
-		},
-	})
-}
-
-func testAccAttachmentsDataSource_filterByTags(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_attachments" "filter_by_tags" {
-  // Since a specified key/value pair is used, there is no dependency relationship with resource attachment, and the
-  // dependency needs to be manually set.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
+  name_filter_result = [
+    for v in data.huaweicloud_er_attachments.filter_by_name.attachments[*].name : v == local.attachment_name
   ]
-
-  instance_id = huaweicloud_er_instance.test.id
-
-  tags = {
-    foo = "bar"
-  }
 }
 
-data "huaweicloud_er_attachments" "not_found" {
-  // Since a specified key/value pair is used, there is no dependency relationship with resource attachment, and the
-  // dependency needs to be manually set.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
-  ]
-
-  instance_id = huaweicloud_er_instance.test.id
-
-  tags = {
-    owner = "terraform"
-  }
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
 }
 
+# Filter by resource ID
 locals {
-  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_tags.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
-}
-
-output "is_tags_filter_is_useful" {
-  value = alltrue(local.filter_result) && length(local.filter_result) > 0
-}
-
-output "not_found_validation_pass" {
-  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
-}
-`, testAccAttachmentsDataSource_base(name))
-}
-
-func TestAccAttachmentsDataSource_filterByResourceId(t *testing.T) {
-	var (
-		dName = "data.huaweicloud_er_attachments.filter_by_resource_id"
-		name  = acceptance.RandomAccResourceName()
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAttachmentsDataSource_filterByResourceId(name),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_resource_id_filter_useful", "true"),
-					resource.TestCheckOutput("not_found_validation_pass", "true"),
-				),
-			},
-		},
-	})
-}
-
-func testAccAttachmentsDataSource_filterByResourceId(name string) string {
-	randUUID, _ := uuid.GenerateUUID()
-
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_attachments" "filter_by_resource_id" {
-  // Since a specified resource ID is used, there is no dependency relationship with resource attachment, and the
-  // dependency needs to be manually set.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
-  ]
-
-  instance_id = huaweicloud_er_instance.test.id
   resource_id = huaweicloud_vpc.test.id
 }
 
-data "huaweicloud_er_attachments" "not_found" {
-  // Since a specified resource ID is used, there is no dependency relationship with resource attachment, and the
-  // dependency needs to be manually set.
-  depends_on = [
-    huaweicloud_er_vpc_attachment.test,
-  ]
+data "huaweicloud_er_attachments" "filter_by_resource_id" {
+  # The behavior of parameter 'type' is 'Required', means this parameter does not have 'Know After Apply' behavior.
+  depends_on = [huaweicloud_er_vpc_attachment.test]
 
   instance_id = huaweicloud_er_instance.test.id
-  resource_id = "%[2]s"
+  resource_id = local.resource_id
 }
 
 locals {
-  filter_result = [for v in data.huaweicloud_er_attachments.filter_by_resource_id.attachments[*].id : v == huaweicloud_er_vpc_attachment.test.id]
+  resource_id_filter_result = [
+    for v in data.huaweicloud_er_attachments.filter_by_resource_id.attachments[*].resource_id : v == local.resource_id
+  ]
 }
 
 output "is_resource_id_filter_useful" {
-  value = alltrue(local.filter_result) && length(local.filter_result) > 0
+  value = length(local.resource_id_filter_result) > 0 && alltrue(local.resource_id_filter_result)
 }
 
-output "not_found_validation_pass" {
-  value = length(data.huaweicloud_er_attachments.not_found.attachments) == 0
+# Filter by status
+locals {
+  attachment_status = huaweicloud_er_vpc_attachment.test.status
 }
-`, testAccAttachmentsDataSource_base(name), randUUID)
+
+data "huaweicloud_er_attachments" "filter_by_status" {
+  instance_id = huaweicloud_er_instance.test.id
+  status      = local.attachment_status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_er_attachments.filter_by_status.attachments[*].status : v == local.attachment_status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by tags
+locals {
+  attachment_tags = huaweicloud_er_vpc_attachment.test.tags
+}
+
+data "huaweicloud_er_attachments" "filter_by_tags" {
+  depends_on = [huaweicloud_er_vpc_attachment.test]
+
+  instance_id = huaweicloud_er_instance.test.id
+  tags        = local.attachment_tags
+}
+
+locals {
+  tags_filter_result = [
+    for v in data.huaweicloud_er_attachments.filter_by_tags.attachments[*].tags : length(v) == length(local.attachment_tags) &&
+    length(v) == length(merge(v, local.attachment_tags))
+  ]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.tags_filter_result) > 0 && alltrue(local.tags_filter_result)
+}
+`, testAccDataSourceAttachments_base())
 }

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_available_routes_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_available_routes_test.go
@@ -27,7 +27,7 @@ func TestAccDataSourceAvailableRoutes_basic(t *testing.T) {
 		dcByResourceType = acceptance.InitDataSourceCheck(byResourceType)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_flow_logs_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_flow_logs_test.go
@@ -43,7 +43,7 @@ func TestAccDatasourceFlowLogs_basic(t *testing.T) {
 		dcByLogStreamId = acceptance.InitDataSourceCheck(byLogStreamId)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_instances_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_instances_test.go
@@ -2,6 +2,7 @@ package er
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -10,33 +11,89 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccInstancesDataSource_basic(t *testing.T) {
+func TestAccDataSourceInstances_basic(t *testing.T) {
 	var (
-		dName    = "data.huaweicloud_er_instances.filter_by_name"
-		name     = acceptance.RandomAccResourceName()
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
+		all = "data.huaweicloud_er_instances.test"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-		dc = acceptance.InitDataSourceCheck(dName)
+		byInstanceId   = "data.huaweicloud_er_instances.filter_by_instance_id"
+		dcByInstanceId = acceptance.InitDataSourceCheck(byInstanceId)
+
+		byName   = "data.huaweicloud_er_instances.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byEpsId   = "data.huaweicloud_er_instances.filter_by_eps_id"
+		dcByEpsId = acceptance.InitDataSourceCheck(byEpsId)
+
+		byOwnedBySelf   = "data.huaweicloud_er_instances.filter_by_owned_by_self"
+		dcByOwnedBySelf = acceptance.InitDataSourceCheck(byOwnedBySelf)
+
+		byStatus   = "data.huaweicloud_er_instances.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byTags   = "data.huaweicloud_er_instances.filter_by_tags"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstancesDataSource_filterByName(name, bgpAsNum),
+				Config: testAccDataSourceInstances_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "instances.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Check whether filter parameter 'instance_id' is effective.
+					dcByInstanceId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byInstanceId, "instances.#", "1"),
+					resource.TestCheckResourceAttrPair(byInstanceId, "instances.0.id", "huaweicloud_er_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(byInstanceId, "instances.0.asn", "huaweicloud_er_instance.test", "asn"),
+					resource.TestCheckResourceAttrPair(byInstanceId, "instances.0.name", "huaweicloud_er_instance.test", "name"),
+					resource.TestCheckResourceAttrPair(byInstanceId, "instances.0.description", "huaweicloud_er_instance.test", "description"),
+					resource.TestCheckResourceAttrPair(byInstanceId, "instances.0.enterprise_project_id",
+						"huaweicloud_er_instance.test", "enterprise_project_id"),
+					resource.TestCheckResourceAttr(byInstanceId, "instances.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(byInstanceId, "instances.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(byInstanceId, "instances.0.tags.key", "value"),
+					resource.TestMatchResourceAttr(byInstanceId, "instances.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttr(byInstanceId, "instances.0.enable_default_propagation", "true"),
+					resource.TestCheckResourceAttr(byInstanceId, "instances.0.enable_default_association", "true"),
+					resource.TestCheckResourceAttr(byInstanceId, "instances.0.auto_accept_shared_attachments", "true"),
+					resource.TestCheckResourceAttrSet(byInstanceId, "instances.0.default_propagation_route_table_id"),
+					resource.TestCheckResourceAttrSet(byInstanceId, "instances.0.default_association_route_table_id"),
+					resource.TestMatchResourceAttr(byInstanceId, "instances.0.availability_zones.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("is_instance_id_filter_useful", "true"),
+					// Check whether filter parameter 'name' is effective.
+					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					// Check whether filter parameter 'enterprise_project_id' is effective.
+					dcByEpsId.CheckResourceExists(),
+					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
+					// Check whether filter parameter 'owned_by_self' is effective.
+					dcByOwnedBySelf.CheckResourceExists(),
+					resource.TestCheckOutput("is_owned_by_self_filter_useful", "true"),
+					// Check whether filter parameter 'status' is effective.
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+					// Check whether filter parameter 'tags' is effective.
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccInstancesDataSource_base(name string, bgpAsNum int) string {
+func testAccDataSourceInstances_base() string {
+	var (
+		name     = acceptance.RandomAccResourceName()
+		bgpAsNum = acctest.RandIntRange(64512, 65534)
+	)
+
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
 
@@ -44,204 +101,140 @@ resource "huaweicloud_er_instance" "test" {
   availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
   name                  = "%[1]s"
   asn                   = %[2]d
-  description           = "Created by terraform test"
+  description           = "Created by script"
   enterprise_project_id = "0"
 
-  tags = {
-    foo   = "bar"
-    key   = "value"
-    owner = "terraform"
-  }
-}
-`, name, bgpAsNum)
-}
-
-func testAccInstancesDataSource_filterByName(name string, bgpAsNum int) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_instances" "filter_by_name" {
-  depends_on = [
-    huaweicloud_er_instance.test,
-  ]
-
-  name = huaweicloud_er_instance.test.name
-}
-
-output "is_name_filter_useful" {
-  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_name.instances[*].id : v == huaweicloud_er_instance.test.id])
-}
-`, testAccInstancesDataSource_base(name, bgpAsNum))
-}
-
-func TestAccInstancesDataSource_filterById(t *testing.T) {
-	var (
-		dName    = "data.huaweicloud_er_instances.filter_by_id"
-		name     = acceptance.RandomAccResourceName()
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstancesDataSource_filterById(name, bgpAsNum),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_id_filter_useful", "true"),
-				),
-			},
-		},
-	})
-}
-
-func testAccInstancesDataSource_filterById(name string, bgpAsNum int) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_instances" "filter_by_id" {
-  instance_id = huaweicloud_er_instance.test.id
-}
-
-output "is_id_filter_useful" {
-  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_id.instances[*].id : v == huaweicloud_er_instance.test.id])
-}
-`, testAccInstancesDataSource_base(name, bgpAsNum))
-}
-
-func TestAccInstancesDataSource_filterByStatus(t *testing.T) {
-	var (
-		dName    = "data.huaweicloud_er_instances.filter_by_status"
-		name     = acceptance.RandomAccResourceName()
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstancesDataSource_filterByStatus(name, bgpAsNum),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_status_filter_useful", "true"),
-				),
-			},
-		},
-	})
-}
-
-func testAccInstancesDataSource_filterByStatus(name string, bgpAsNum int) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_instances" "filter_by_status" {
-  status = huaweicloud_er_instance.test.status
-}
-
-output "is_status_filter_useful" {
-  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_status.instances[*].id : v == huaweicloud_er_instance.test.id])
-}
-`, testAccInstancesDataSource_base(name, bgpAsNum))
-}
-
-func TestAccInstancesDataSource_filterByEpsId(t *testing.T) {
-	var (
-		dName    = "data.huaweicloud_er_instances.filter_by_eps_id"
-		name     = acceptance.RandomAccResourceName()
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstancesDataSource_filterByEpsId(name, bgpAsNum),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
-				),
-			},
-		},
-	})
-}
-
-func testAccInstancesDataSource_filterByEpsId(name string, bgpAsNum int) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_instances" "filter_by_eps_id" {
-  depends_on = [
-    huaweicloud_er_instance.test,
-  ]
-
-  // Query all instances belonging to the default enterprise project.
-  enterprise_project_id = "0"
-}
-
-output "is_eps_id_filter_useful" {
-  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_eps_id.instances[*].id : v == huaweicloud_er_instance.test.id])
-}
-`, testAccInstancesDataSource_base(name, bgpAsNum))
-}
-
-func TestAccInstancesDataSource_filterByTags(t *testing.T) {
-	var (
-		dName    = "data.huaweicloud_er_instances.filter_by_tags"
-		name     = acceptance.RandomAccResourceName()
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstancesDataSource_filterByTags(name, bgpAsNum),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("is_tags_filter_is_useful", "true"),
-				),
-			},
-		},
-	})
-}
-
-func testAccInstancesDataSource_filterByTags(name string, bgpAsNum int) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_instances" "filter_by_tags" {
-  depends_on = [
-    huaweicloud_er_instance.test,
-  ]
+  enable_default_propagation     = true
+  enable_default_association     = true
+  auto_accept_shared_attachments = true
 
   tags = {
     foo = "bar"
     key = "value"
   }
 }
-
-output "is_tags_filter_is_useful" {
-  value = alltrue([for v in data.huaweicloud_er_instances.filter_by_tags.instances[*].id : v == huaweicloud_er_instance.test.id])
+`, name, bgpAsNum)
 }
-`, testAccInstancesDataSource_base(name, bgpAsNum))
+
+func testAccDataSourceInstances_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_er_instances" "test" {
+  depends_on = [huaweicloud_er_instance.test]
+}
+
+# Filter by instance ID
+locals {
+  instance_id = huaweicloud_er_instance.test.id
+}
+
+data "huaweicloud_er_instances" "filter_by_instance_id" {
+  instance_id = local.instance_id
+}
+
+locals {
+  instance_id_filter_result = [
+    for v in data.huaweicloud_er_instances.filter_by_instance_id.instances[*].id : v == local.instance_id
+  ]
+}
+
+output "is_instance_id_filter_useful" {
+  value = length(local.instance_id_filter_result) > 0 && alltrue(local.instance_id_filter_result)
+}
+
+# Filter by name
+locals {
+  instance_name = huaweicloud_er_instance.test.name
+}
+
+data "huaweicloud_er_instances" "filter_by_name" {
+  depends_on = [huaweicloud_er_instance.test]
+
+  name = local.instance_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_er_instances.filter_by_name.instances[*].name : v == local.instance_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by enterprise project ID
+locals {
+  eps_id = huaweicloud_er_instance.test.enterprise_project_id
+}
+
+data "huaweicloud_er_instances" "filter_by_eps_id" {
+  depends_on = [huaweicloud_er_instance.test]
+  
+  enterprise_project_id = local.eps_id
+}
+
+locals {
+  eps_id_filter_result = [
+    for v in data.huaweicloud_er_instances.filter_by_eps_id.instances[*].enterprise_project_id : v == local.eps_id
+  ]
+}
+
+output "is_eps_id_filter_useful" {
+  value = length(local.eps_id_filter_result) > 0 && alltrue(local.eps_id_filter_result)
+}
+
+# Filter by owned_by_self param
+data "huaweicloud_er_instances" "filter_by_owned_by_self" {
+  depends_on = [huaweicloud_er_instance.test]
+
+  owned_by_self = true
+}
+
+output "is_owned_by_self_filter_useful" {
+  value = contains(data.huaweicloud_er_instances.filter_by_owned_by_self.instances[*].id, local.instance_id)
+}
+
+# Filter by status
+locals {
+  instance_status = huaweicloud_er_instance.test.status
+}
+
+data "huaweicloud_er_instances" "filter_by_status" {
+  status = local.instance_status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_er_instances.filter_by_status.instances[*].status : v == local.instance_status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+
+# Filter by tags
+locals {
+  instance_tags = huaweicloud_er_instance.test.tags
+}
+
+data "huaweicloud_er_instances" "filter_by_tags" {
+  depends_on = [huaweicloud_er_instance.test]
+
+  tags = local.instance_tags
+}
+
+locals {
+  tags_filter_result = [
+    for v in data.huaweicloud_er_instances.filter_by_tags.instances[*].tags : length(v) == length(local.instance_tags) &&
+    length(v) == length(merge(v, local.instance_tags))
+  ]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.tags_filter_result) > 0 && alltrue(local.tags_filter_result)
+}
+`, testAccDataSourceInstances_base())
 }

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_instances_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_instances_test.go
@@ -95,10 +95,10 @@ func testAccDataSourceInstances_base() string {
 	)
 
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones    = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones    = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
   name                  = "%[1]s"
   asn                   = %[2]d
   description           = "Created by script"

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_propagations_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_propagations_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -15,8 +14,7 @@ import (
 func TestAccDataSourcePropagations_basic(t *testing.T) {
 	var (
 		name       = acceptance.RandomAccResourceName()
-		bgpAsNum   = acctest.RandIntRange(64512, 65534)
-		baseConfig = testAccPropagation_basic(name, bgpAsNum)
+		baseConfig = testAccDataSourcePropagations_base(name)
 
 		all = "data.huaweicloud_er_propagations.test"
 		dc  = acceptance.InitDataSourceCheck(all)
@@ -34,53 +32,67 @@ func TestAccDataSourcePropagations_basic(t *testing.T) {
 		dcByNotFoundInstanceId = acceptance.InitDataSourceCheck(byNotFoundInstanceId)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourcePropagations_basic(baseConfig),
+				Config: testAccDataSourcePropagations_basic_step1(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(all, "propagations.#"),
 					resource.TestCheckResourceAttrSet(all, "propagations.0.resource_id"),
-					resource.TestCheckResourceAttrSet(all, "propagations.0.created_at"),
-					resource.TestCheckResourceAttrSet(all, "propagations.0.updated_at"),
-
-					dcByStatus.CheckResourceExists(),
-					resource.TestCheckOutput("is_status_filter_useful", "true"),
-
+					resource.TestMatchResourceAttr(all, "propagations.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(all, "propagations.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					// Check whether filter parameter 'status' is effective.
 					dcByAttachmentId.CheckResourceExists(),
 					resource.TestCheckOutput("is_attachment_id_filter_useful", "true"),
-
+					// Check whether filter parameter 'attachment_type' is effective.
 					dcByAttachmentType.CheckResourceExists(),
 					resource.TestCheckOutput("is_attachment_type_filter_useful", "true"),
-
+					// Check whether filter parameter 'status' is effective.
 					dcByStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
 				),
 			},
-			// If the instance ID does not exist, the data source will not report the error.
-			// Just return an empty list.
 			{
-				Config: testAccDatasourcePropagations_instanceIdNotFound(baseConfig),
+				// Checks whether the resource returns the expected empty list when the instance ID does not exist.
+				Config: testAccDataSourcePropagations_basic_step2(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					dcByNotFoundInstanceId.CheckResourceExists(),
+					// If the instance ID does not exist, the data source will not report the error.
+					// Just return an empty list.
 					resource.TestCheckResourceAttr(byNotFoundInstanceId, "propagations.#", "0"),
 				),
 			},
-			// If the routing table ID does not exist, the data source will report an error: 'route table {uuid} not found'.
 			{
-				Config:      testAccDatasourcePropagations_routeTableIdNotFound(baseConfig),
+				// Checks whether the resource returns the expected error when the route table ID does not exist.
+				// Please ensure that the test account has 'ER FullAccess' permission for version 5.0.
+				Config: testAccDataSourcePropagations_basic_step3(baseConfig),
+				// If the routing table ID does not exist, the data source will report an error: 'route table {uuid} not found'.
 				ExpectError: regexp.MustCompile(`route table [a-f0-9-]+ not found`),
 			},
 		},
 	})
 }
 
-func testAccDatasourcePropagations_basic(baseConfig string) string {
+func testAccDataSourcePropagations_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_er_propagation" "test" {
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  attachment_id  = huaweicloud_er_vpc_attachment.test.id
+}
+`, testAccPropagation_base(name))
+}
+
+func testAccDataSourcePropagations_basic_step1(baseConfig string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -169,7 +181,7 @@ output "is_status_filter_useful" {
 `, baseConfig)
 }
 
-func testAccDatasourcePropagations_instanceIdNotFound(baseConfig string) string {
+func testAccDataSourcePropagations_basic_step2(baseConfig string) string {
 	randUUID, _ := uuid.GenerateUUID()
 
 	return fmt.Sprintf(`
@@ -186,7 +198,7 @@ data "huaweicloud_er_propagations" "instance_id_not_found" {
 `, baseConfig, randUUID)
 }
 
-func testAccDatasourcePropagations_routeTableIdNotFound(baseConfig string) string {
+func testAccDataSourcePropagations_basic_step3(baseConfig string) string {
 	randUUID, _ := uuid.GenerateUUID()
 
 	return fmt.Sprintf(`

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_quotas_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_quotas_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceQuotas_basic(t *testing.T) {
 		dcByNotFoundRouteTableId = acceptance.InitDataSourceCheck(byNotFoundRouteTableId)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
@@ -2,220 +2,246 @@ package er
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func TestAccRouteTablesDataSource_basic(t *testing.T) {
+func TestAccDataSourceRouteTables_basic(t *testing.T) {
 	var (
-		dName    = "data.huaweicloud_er_route_tables.test"
-		name     = acceptance.RandomAccResourceName()
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
+		all = "data.huaweicloud_er_route_tables.test"
+		dc  = acceptance.InitDataSourceCheck(all)
 
-		dc = acceptance.InitDataSourceCheck(dName)
+		byRouteTableId   = "data.huaweicloud_er_route_tables.filter_by_route_table_id"
+		dcByRouteTableId = acceptance.InitDataSourceCheck(byRouteTableId)
+
+		byName   = "data.huaweicloud_er_route_tables.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byTags   = "data.huaweicloud_er_route_tables.filter_by_tags"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRouteTablesDataSource_basic(name, bgpAsNum),
+				Config: testAccDataSourceRouteTables_basic_step1(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dName, "route_tables.#", "2"),
+					resource.TestMatchResourceAttr(all, "route_tables.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					// Check whether filter parameter 'route_table_id' is effective.
+					dcByRouteTableId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.id",
+						"huaweicloud_er_route_table.test", "id"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.name",
+						"huaweicloud_er_route_table.test", "name"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.description",
+						"huaweicloud_er_route_table.test", "description"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.associations.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.associations.0.id",
+						"huaweicloud_er_association.test", "id"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.associations.0.attachment_id",
+						"huaweicloud_er_vpc_attachment.test", "id"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.associations.0.attachment_type", "vpc"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.propagations.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.propagations.0.id",
+						"huaweicloud_er_propagation.test", "id"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.propagations.0.attachment_id",
+						"huaweicloud_er_vpc_attachment.test", "id"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.propagations.0.attachment_type", "vpc"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.routes.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.routes.0.id",
+						"huaweicloud_er_static_route.test", "id"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.routes.0.destination",
+						"huaweicloud_er_static_route.test", "destination"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.routes.0.is_blackhole", "false"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.routes.0.attachments.#", "1"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.routes.0.attachments.0.attachment_id",
+						"huaweicloud_er_vpc_attachment.test", "id"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.routes.0.attachments.0.attachment_type", "vpc"),
+					resource.TestCheckResourceAttrPair(byRouteTableId, "route_tables.0.routes.0.attachments.0.resource_id",
+						"huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.is_default_association", "false"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.is_default_propagation", "false"),
+					resource.TestCheckResourceAttrSet(byRouteTableId, "route_tables.0.routes.0.status"),
+					resource.TestCheckResourceAttrSet(byRouteTableId, "route_tables.0.status"),
+					resource.TestMatchResourceAttr(byRouteTableId, "route_tables.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byRouteTableId, "route_tables.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(byRouteTableId, "route_tables.0.tags.key", "value"),
+					resource.TestCheckOutput("is_route_table_id_filter_useful", "true"),
+					// Check whether filter parameter 'name' is effective.
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					// Check whether filter parameter 'tags' is effective.
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("is_tags_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccRouteTablesDataSource_byName(t *testing.T) {
+func testAccDataSourceRouteTables_base() string {
 	var (
-		dName    = "data.huaweicloud_er_route_tables.test"
 		name     = acceptance.RandomAccResourceName()
 		bgpAsNum = acctest.RandIntRange(64512, 65534)
-
-		dc = acceptance.InitDataSourceCheck(dName)
 	)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRouteTablesDataSource_byName(name, bgpAsNum),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("route_tables_count", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccRouteTablesDataSource_byId(t *testing.T) {
-	var (
-		dName    = "data.huaweicloud_er_route_tables.test"
-		name     = acceptance.RandomAccResourceName()
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRouteTablesDataSource_byId(name, bgpAsNum),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("route_tables_count", "1"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccRouteTablesDataSource_byTags(t *testing.T) {
-	var (
-		dName    = "data.huaweicloud_er_route_tables.test"
-		name     = acceptance.RandomAccResourceName()
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
-
-		dc = acceptance.InitDataSourceCheck(dName)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRouteTablesDataSource_byTags(name, bgpAsNum),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckOutput("route_tables_count", "2"),
-				),
-			},
-		},
-	})
-}
-
-func testAccRouteTablesDataSource_base(name string, bgpAsNum int) string {
 	return fmt.Sprintf(`
 data "huaweicloud_availability_zones" "test" {}
+
+%[1]s
 
 resource "huaweicloud_er_instance" "test" {
   availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
 
-  name = "%[1]s"
-  asn  = %[2]d
+  name = "%[2]s"
+  asn  = %[3]d
 }
 
 resource "huaweicloud_er_route_table" "test" {
   instance_id = huaweicloud_er_instance.test.id
-  name        = "%[1]s"
+  name        = "%[2]s"
+  description = "Created by script"
 
   tags = {
-    foo   = "bar"
-    owner = "terraform"
+    foo = "bar"
+    key = "value"
   }
 }
 
-resource "huaweicloud_er_route_table" "another" {
+resource "huaweicloud_er_vpc_attachment" "test" {
   instance_id = huaweicloud_er_instance.test.id
-  name        = "%[1]s_another"
-
-  tags = {
-    owner = "terraform"
-  }
-}
-`, name, bgpAsNum)
-}
-
-func testAccRouteTablesDataSource_basic(name string, bgpAsNum int) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_route_tables" "test" {
-  depends_on = [
-    huaweicloud_er_route_table.test
-  ]
-
-  instance_id = huaweicloud_er_instance.test.id
-}
-`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
-}
-
-func testAccRouteTablesDataSource_byName(name string, bgpAsNum int) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_route_tables" "test" {
-  depends_on = [
-    huaweicloud_er_route_table.test
-  ]
-
-  instance_id = huaweicloud_er_instance.test.id
+  vpc_id      = huaweicloud_vpc.test.id
+  subnet_id   = huaweicloud_vpc_subnet.test.id
   name        = "%[2]s"
 }
 
-output "route_tables_count" {
-  value = length(data.huaweicloud_er_route_tables.test.route_tables)
+resource "huaweicloud_er_static_route" "test" {
+  route_table_id = huaweicloud_er_route_table.test.id
+  destination    = huaweicloud_vpc.test.cidr
+  attachment_id  = huaweicloud_er_vpc_attachment.test.id
 }
-`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
-}
 
-func testAccRouteTablesDataSource_byId(name string, bgpAsNum int) string {
-	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_er_route_tables" "test" {
-  depends_on = [
-    huaweicloud_er_route_table.test
-  ]
-
+resource "huaweicloud_er_association" "test" {
   instance_id    = huaweicloud_er_instance.test.id
   route_table_id = huaweicloud_er_route_table.test.id
+  attachment_id  = huaweicloud_er_vpc_attachment.test.id
 }
 
-output "route_tables_count" {
-  value = length(data.huaweicloud_er_route_tables.test.route_tables)
+resource "huaweicloud_er_propagation" "test" {
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = huaweicloud_er_route_table.test.id
+  attachment_id  = huaweicloud_er_vpc_attachment.test.id
 }
-`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+`, common.TestVpc(name), name, bgpAsNum)
 }
 
-func testAccRouteTablesDataSource_byTags(name string, bgpAsNum int) string {
+func testAccDataSourceRouteTables_basic_step1() string {
 	return fmt.Sprintf(`
 %[1]s
 
 data "huaweicloud_er_route_tables" "test" {
   depends_on = [
-    huaweicloud_er_route_table.test
+    huaweicloud_er_static_route.test,
+    huaweicloud_er_association.test,
+    huaweicloud_er_propagation.test,
   ]
 
   instance_id = huaweicloud_er_instance.test.id
-
-  tags = {
-    owner = "terraform"
-  }
 }
 
-output "route_tables_count" {
-  value = length(data.huaweicloud_er_route_tables.test.route_tables)
+# Filter by route table ID
+locals {
+  route_table_id = huaweicloud_er_route_table.test.id
 }
-`, testAccRouteTablesDataSource_base(name, bgpAsNum), name)
+
+data "huaweicloud_er_route_tables" "filter_by_route_table_id" {
+  depends_on = [
+    huaweicloud_er_static_route.test,
+    huaweicloud_er_association.test,
+    huaweicloud_er_propagation.test,
+  ]
+
+  instance_id    = huaweicloud_er_instance.test.id
+  route_table_id = local.route_table_id
+}
+
+locals {
+  route_table_id_filter_result = [
+    for v in data.huaweicloud_er_route_tables.filter_by_route_table_id.route_tables[*].id : v == local.route_table_id
+  ]
+}
+
+output "is_route_table_id_filter_useful" {
+  value = length(local.route_table_id_filter_result) > 0 && alltrue(local.route_table_id_filter_result)
+}
+
+# Filter by name
+locals {
+  route_table_name = huaweicloud_er_route_table.test.name
+}
+
+data "huaweicloud_er_route_tables" "filter_by_name" {
+  depends_on = [
+    huaweicloud_er_static_route.test,
+    huaweicloud_er_association.test,
+    huaweicloud_er_propagation.test,
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+  name        = local.route_table_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_er_route_tables.filter_by_route_table_id.route_tables[*].name : v == local.route_table_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by tags
+locals {
+  route_table_tags = huaweicloud_er_route_table.test.tags
+}
+
+data "huaweicloud_er_route_tables" "filter_by_tags" {
+  depends_on = [
+    huaweicloud_er_static_route.test,
+    huaweicloud_er_association.test,
+    huaweicloud_er_propagation.test,
+  ]
+
+  instance_id = huaweicloud_er_instance.test.id
+  tags        = local.route_table_tags
+}
+
+locals {
+  tags_filter_result = [
+    for v in data.huaweicloud_er_route_tables.filter_by_tags.route_tables[*].tags : length(v) == length(local.route_table_tags) &&
+    length(v) == length(merge(v, local.route_table_tags))
+  ]
+}
+
+output "is_tags_filter_useful" {
+  value = length(local.tags_filter_result) > 0 && alltrue(local.tags_filter_result)
+}
+`, testAccDataSourceRouteTables_base())
 }

--- a/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
+++ b/huaweicloud/services/acceptance/er/data_source_huaweicloud_er_route_table_test.go
@@ -102,12 +102,12 @@ func testAccDataSourceRouteTables_base() string {
 	)
 
 	return fmt.Sprintf(`
-data "huaweicloud_availability_zones" "test" {}
+data "huaweicloud_er_availability_zones" "test" {}
 
 %[1]s
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
 
   name = "%[2]s"
   asn  = %[3]d

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_association_test.go
@@ -2,6 +2,7 @@ package er
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -29,9 +30,8 @@ func TestAccAssociation_basic(t *testing.T) {
 	var (
 		obj associations.Association
 
-		rName    = "huaweicloud_er_association.test"
-		name     = acceptance.RandomAccResourceName()
-		bgpAsNum = acctest.RandIntRange(64512, 65534)
+		rName = "huaweicloud_er_association.test"
+		name  = acceptance.RandomAccResourceName()
 	)
 
 	rc := acceptance.InitResourceCheck(
@@ -40,13 +40,13 @@ func TestAccAssociation_basic(t *testing.T) {
 		getAssociationResourceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAssociation_basic(name, bgpAsNum),
+				Config: testAccAssociation_basic_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "instance_id",
@@ -57,40 +57,44 @@ func TestAccAssociation_basic(t *testing.T) {
 						"huaweicloud_er_vpc_attachment.test", "id"),
 					resource.TestCheckResourceAttr(rName, "attachment_type", "vpc"),
 					resource.TestCheckResourceAttrSet(rName, "status"),
-					resource.TestCheckResourceAttrSet(rName, "created_at"),
-					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(rName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
 				),
 			},
 			{
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccAssociationImportStateFunc(),
+				ImportStateIdFunc: testAccAssociationImportStateFunc(rName),
 			},
 		},
 	})
 }
 
-func testAccAssociationImportStateFunc() resource.ImportStateIdFunc {
+func testAccAssociationImportStateFunc(rsName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
 		var instanceId, routeTableId, associationId string
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type == "huaweicloud_er_association" {
-				instanceId = rs.Primary.Attributes["instance_id"]
-				routeTableId = rs.Primary.Attributes["route_table_id"]
-				associationId = rs.Primary.ID
-			}
+		rs, ok := s.RootModule().Resources[rsName]
+		if !ok {
+			return "", fmt.Errorf("the resource (%s) of ER association is not found in the tfstate", rsName)
 		}
+		instanceId = rs.Primary.Attributes["instance_id"]
+		routeTableId = rs.Primary.Attributes["route_table_id"]
+		associationId = rs.Primary.ID
 		if instanceId == "" || routeTableId == "" || associationId == "" {
 			return "", fmt.Errorf("some import IDs are missing, want "+
-				"'<instance_id>/<route_table_id>/<association_id>', but '%s/%s/%s'",
+				"'<instance_id>/<route_table_id>/<id>', but got '%s/%s/%s'",
 				instanceId, routeTableId, associationId)
 		}
 		return fmt.Sprintf("%s/%s/%s", instanceId, routeTableId, associationId), nil
 	}
 }
 
-func testAccAssociation_base(name string, bgpAsNum int) string {
+func testAccAssociation_base(name string) string {
+	bgpAsNum := acctest.RandIntRange(64512, 65534)
+
 	return fmt.Sprintf(`
 data "huaweicloud_er_availability_zones" "test" {}
 
@@ -131,7 +135,7 @@ resource "huaweicloud_er_route_table" "test" {
 `, name, bgpAsNum)
 }
 
-func testAccAssociation_basic(name string, bgpAsNum int) string {
+func testAccAssociation_basic_step1(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -140,5 +144,5 @@ resource "huaweicloud_er_association" "test" {
   route_table_id = huaweicloud_er_route_table.test.id
   attachment_id  = huaweicloud_er_vpc_attachment.test.id
 }
-`, testAccAssociation_base(name, bgpAsNum))
+`, testAccAssociation_base(name))
 }

--- a/huaweicloud/services/acceptance/er/resource_huaweicloud_er_instance_test.go
+++ b/huaweicloud/services/acceptance/er/resource_huaweicloud_er_instance_test.go
@@ -58,7 +58,7 @@ func TestAccInstance_basic(t *testing.T) {
 		getInstanceResourceFunc,
 	)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 		},
@@ -91,6 +91,8 @@ func TestAccInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "availability_zones.0",
+						"data.huaweicloud_er_availability_zones.test", "names.1"),
 					resource.TestCheckResourceAttr(rName, "asn", fmt.Sprintf("%v", bgpAsNum)),
 					resource.TestCheckResourceAttr(rName, "description", ""),
 					resource.TestCheckResourceAttr(rName, "enable_default_propagation", "false"),
@@ -137,7 +139,7 @@ func testInstance_basic_step2(name string, bgpAsNum int) string {
 data "huaweicloud_er_availability_zones" "test" {}
 
 resource "huaweicloud_er_instance" "test" {
-  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 0, 1)
+  availability_zones = slice(data.huaweicloud_er_availability_zones.test.names, 1, 2)
 
   name = "%[1]s"
   asn  = %[2]d
@@ -169,7 +171,7 @@ func TestAccInstance_updateWithEpsId(t *testing.T) {
 	srcEPS := acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
 	destEPS := acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckMigrateEpsID(t)

--- a/huaweicloud/services/er/data_source_huaweicloud_er_associations.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_associations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/er/v3/associations"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/associations
@@ -127,8 +128,9 @@ func flattenAssociations(all []associations.Association) []map[string]interface{
 			"resource_id":     propagation.ResourceId,
 			"route_policy_id": propagation.RoutePolicy.ExportPoilicyId,
 			"status":          propagation.Status,
-			"created_at":      propagation.CreatedAt,
-			"updated_at":      propagation.UpdatedAt,
+			// The time results are not the time in RF3339 format without milliseconds.
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(propagation.CreatedAt)/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(propagation.UpdatedAt)/1000, false),
 		}
 	}
 	return result

--- a/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go
@@ -181,14 +181,15 @@ func flattenAttachments(all []attachments.Attachment) []map[string]interface{} {
 	result := make([]map[string]interface{}, len(all))
 	for i, attachment := range all {
 		result[i] = map[string]interface{}{
-			"id":             attachment.ID,
-			"name":           attachment.Name,
-			"description":    attachment.Description,
-			"status":         attachment.Status,
-			"associated":     attachment.Associated,
-			"resource_id":    attachment.ResourceId,
-			"created_at":     attachment.CreatedAt,
-			"updated_at":     attachment.UpdatedAt,
+			"id":          attachment.ID,
+			"name":        attachment.Name,
+			"description": attachment.Description,
+			"status":      attachment.Status,
+			"associated":  attachment.Associated,
+			"resource_id": attachment.ResourceId,
+			// The time results are not the time in RF3339 format without milliseconds.
+			"created_at":     utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(attachment.CreatedAt)/1000, false),
+			"updated_at":     utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(attachment.UpdatedAt)/1000, false),
 			"tags":           utils.TagsToMap(attachment.Tags),
 			"type":           attachment.ResourceType,
 			"route_table_id": attachment.RouteTableId,

--- a/huaweicloud/services/er/data_source_huaweicloud_er_flow_logs.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_flow_logs.go
@@ -214,10 +214,13 @@ func flattenListTransitIpsResponseBody(resp interface{}) []interface{} {
 			"log_group_id":   utils.PathSearch("log_group_id", v, nil),
 			"log_stream_id":  utils.PathSearch("log_stream_id", v, nil),
 			"log_store_type": utils.PathSearch("log_store_type", v, nil),
-			"created_at":     utils.PathSearch("created_at", v, nil),
-			"updated_at":     utils.PathSearch("updated_at", v, nil),
-			"status":         utils.PathSearch("state", v, nil),
-			"enabled":        utils.PathSearch("enabled", v, nil),
+			// The time results are not the time in RF3339 format without milliseconds.
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("created_at",
+				v, "").(string))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("updated_at",
+				v, "").(string))/1000, false),
+			"status":  utils.PathSearch("state", v, nil),
+			"enabled": utils.PathSearch("enabled", v, nil),
 		})
 	}
 	return rst

--- a/huaweicloud/services/er/data_source_huaweicloud_er_instances.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_instances.go
@@ -182,15 +182,16 @@ func flattenInstances(all []instances.Instance) []map[string]interface{} {
 	result := make([]map[string]interface{}, len(all))
 	for i, instance := range all {
 		result[i] = map[string]interface{}{
-			"id":                                 instance.ID,
-			"asn":                                instance.ASN,
-			"name":                               instance.Name,
-			"description":                        instance.Description,
-			"status":                             instance.Status,
-			"enterprise_project_id":              instance.EnterpriseProjectId,
-			"tags":                               utils.TagsToMap(instance.Tags),
-			"created_at":                         instance.CreatedAt,
-			"updated_at":                         instance.UpdatedAt,
+			"id":                    instance.ID,
+			"asn":                   instance.ASN,
+			"name":                  instance.Name,
+			"description":           instance.Description,
+			"status":                instance.Status,
+			"enterprise_project_id": instance.EnterpriseProjectId,
+			"tags":                  utils.TagsToMap(instance.Tags),
+			// The time results are not the time in RF3339 format without milliseconds.
+			"created_at":                         utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(instance.CreatedAt)/1000, false),
+			"updated_at":                         utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(instance.UpdatedAt)/1000, false),
 			"enable_default_propagation":         instance.EnableDefaultPropagation,
 			"enable_default_association":         instance.EnableDefaultAssociation,
 			"auto_accept_shared_attachments":     instance.AutoAcceptSharedAttachments,

--- a/huaweicloud/services/er/data_source_huaweicloud_er_propagations.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_propagations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/er/v3/propagations"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API ER GET /v3/{project_id}/enterprise-router/{er_id}/route-tables/{route_table_id}/propagations
@@ -132,8 +133,9 @@ func flattenPropagations(all []propagations.Propagation) []map[string]interface{
 			"resource_id":     propagation.ResourceId,
 			"route_policy_id": propagation.RoutePolicy.ImportPoilicyId,
 			"status":          propagation.Status,
-			"created_at":      propagation.CreatedAt,
-			"updated_at":      propagation.UpdatedAt,
+			// The time results are not the time in RF3339 format without milliseconds.
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(propagation.CreatedAt)/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(propagation.UpdatedAt)/1000, false),
 		}
 	}
 	return result

--- a/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go
+++ b/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go
@@ -273,8 +273,8 @@ func queryRouteTableRoutes(client *golangsdk.ServiceClient, routeTableId string)
 		for i, attachment := range route.Attachments {
 			attachments[i] = map[string]interface{}{
 				"attachment_id":   attachment.AttachmentId,
-				"attachment_type": attachment.AttachmentId,
-				"resource_id":     attachment.AttachmentId,
+				"attachment_type": attachment.ResourceType,
+				"resource_id":     attachment.ResourceId,
 			}
 		}
 		rr["attachments"] = attachments
@@ -323,6 +323,7 @@ func flattenRouteTables(client *golangsdk.ServiceClient, instanceId string,
 
 		result[i] = map[string]interface{}{
 			"id":                     routeTableId,
+			"name":                   routeTable.Name,
 			"description":            routeTable.Description,
 			"associations":           associationList,
 			"propagations":           propagationList,
@@ -330,9 +331,10 @@ func flattenRouteTables(client *golangsdk.ServiceClient, instanceId string,
 			"is_default_association": routeTable.IsDefaultAssociation,
 			"is_default_propagation": routeTable.IsDefaultPropagation,
 			"status":                 routeTable.Status,
-			"created_at":             routeTable.CreatedAt,
-			"updated_at":             routeTable.UpdatedAt,
-			"tags":                   utils.TagsToMap(routeTable.Tags),
+			// The time results are not the time in RF3339 format without milliseconds.
+			"created_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(routeTable.CreatedAt)/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(routeTable.UpdatedAt)/1000, false),
+			"tags":       utils.TagsToMap(routeTable.Tags),
 		}
 	}
 	return result

--- a/huaweicloud/services/er/resource_huaweicloud_er_association.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_association.go
@@ -111,10 +111,11 @@ func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(resp.ID)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"PENDING"},
-		Target:       []string{"COMPLETED"},
-		Refresh:      associationStatusRefreshFunc(client, instanceId, routeTableId, d.Id(), []string{"available"}),
-		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: associationStatusRefreshFunc(client, instanceId, routeTableId, d.Id(), []string{"available"}),
+		Timeout: d.Timeout(schema.TimeoutDelete),
+		// After the creation request is sent, it will briefly enter the pending status.
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
 	}
@@ -129,6 +130,7 @@ func resourceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta
 // QueryAssociationById is a method to query association details from a specified route table using given parameters.
 func QueryAssociationById(client *golangsdk.ServiceClient, instanceId, routeTableId,
 	associationId string) (*associations.Association, error) {
+	// The query parameter list does not contain the ID parameter, so can only filter it manually.
 	resp, err := associations.List(client, instanceId, routeTableId, associations.ListOpts{})
 	if err != nil {
 		return nil, err
@@ -152,8 +154,7 @@ func QueryAssociationById(client *golangsdk.ServiceClient, instanceId, routeTabl
 	log.Printf("[DEBUG] The result filtered by resource ID (%s) is: %#v", associationId, result)
 	association, ok := result[0].(associations.Association)
 	if !ok {
-		return nil, fmt.Errorf("the element type of filter result is incorrect, want 'associations.Association', "+
-			"but got '%T'", result[0])
+		return nil, fmt.Errorf("the element type of filter result is incorrect, want 'associations.Association', but got '%T'", result[0])
 	}
 
 	return &association, nil
@@ -207,8 +208,9 @@ func resourceAssociationRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("attachment_id", resp.AttachmentId),
 		d.Set("attachment_type", resp.ResourceType),
 		d.Set("status", resp.Status),
-		d.Set("created_at", resp.CreatedAt),
-		d.Set("updated_at", resp.UpdatedAt),
+		// The time results are not the time in RF3339 format without milliseconds.
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.CreatedAt)/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.UpdatedAt)/1000, false)),
 	)
 
 	if mErr.ErrorOrNil() != nil {
@@ -240,10 +242,11 @@ func resourceAssociationDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"PENDING"},
-		Target:       []string{"COMPLETED"},
-		Refresh:      associationStatusRefreshFunc(client, instanceId, routeTableId, associationId, nil),
-		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: associationStatusRefreshFunc(client, instanceId, routeTableId, associationId, nil),
+		Timeout: d.Timeout(schema.TimeoutDelete),
+		// After the creation request is sent, it will briefly enter the pending status.
 		Delay:        5 * time.Second,
 		PollInterval: 10 * time.Second,
 	}
@@ -259,8 +262,7 @@ func resourceAssociationImportState(_ context.Context, d *schema.ResourceData, _
 	error) {
 	parts := strings.SplitN(d.Id(), "/", 3)
 	if len(parts) != 3 {
-		return nil, fmt.Errorf("Invalid format for import ID, want '<instance_id>/<route_table_id>/<association_id>', "+
-			"but '%s'", d.Id())
+		return nil, fmt.Errorf("invalid format for import ID, want '<instance_id>/<route_table_id>/<association_id>', but got '%s'", d.Id())
 	}
 
 	d.SetId(parts[2])

--- a/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go
@@ -231,8 +231,11 @@ func resourceFlowLogRead(_ context.Context, d *schema.ResourceData, meta interfa
 		d.Set("resource_type", utils.PathSearch("flow_log.resource_type", getFlowLogRespBody, nil)),
 		d.Set("resource_id", utils.PathSearch("flow_log.resource_id", getFlowLogRespBody, nil)),
 		d.Set("state", utils.PathSearch("flow_log.state", getFlowLogRespBody, nil)),
-		d.Set("created_at", utils.PathSearch("flow_log.created_at", getFlowLogRespBody, nil)),
-		d.Set("updated_at", utils.PathSearch("flow_log.updated_at", getFlowLogRespBody, nil)),
+		// The time results are not the time in RF3339 format without milliseconds.
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("flow_log.created_at",
+			getFlowLogRespBody, "").(string))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("flow_log.updated_at",
+			getFlowLogRespBody, "").(string))/1000, false)),
 		d.Set("enabled", utils.PathSearch("flow_log.enabled", getFlowLogRespBody, nil)),
 	)
 

--- a/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_route_table.go
@@ -199,8 +199,9 @@ func resourceRouteTableRead(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("is_default_propagation", resp.IsDefaultPropagation),
 		d.Set("tags", utils.TagsToMap(resp.Tags)),
 		d.Set("status", resp.Status),
-		d.Set("created_at", resp.CreatedAt),
-		d.Set("updated_at", resp.UpdatedAt),
+		// The time results are not the time in RF3339 format without milliseconds.
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.CreatedAt)/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.UpdatedAt)/1000, false)),
 	)
 
 	if mErr.ErrorOrNil() != nil {

--- a/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
+++ b/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go
@@ -181,8 +181,9 @@ func resourceVpcAttachmentRead(_ context.Context, d *schema.ResourceData, meta i
 		d.Set("auto_create_vpc_routes", resp.AutoCreateVpcRoutes),
 		d.Set("tags", utils.TagsToMap(resp.Tags)),
 		d.Set("status", resp.Status),
-		d.Set("created_at", resp.CreatedAt),
-		d.Set("updated_at", resp.UpdatedAt),
+		// The time results are not the time in RF3339 format without milliseconds.
+		d.Set("created_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.CreatedAt)/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(utils.ConvertTimeStrToNanoTimestamp(resp.UpdatedAt)/1000, false)),
 	)
 
 	if mErr.ErrorOrNil() != nil {

--- a/vendor/github.com/chnsz/golangsdk/openstack/er/v3/attachments/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/er/v3/attachments/results.go
@@ -52,7 +52,7 @@ type Attachment struct {
 	// + vgw: virtual gateway of cloud private line.
 	// + peering: Peering connection, through the cloud connection (CC) to load enterprise routers in different regions
 	//   to create a peering connection.
-	ResourceType string `q:"resource_type"`
+	ResourceType string `json:"resource_type"`
 	// The project ID to which the attachment is belongs.
 	ResourceProjectId string `json:"resource_project_id"`
 	// Whether this attachment is associated.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240624075804-edb862aaa73a
+# github.com/chnsz/golangsdk v0.0.0-20240628074404-f04cd77ad44a
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Some resource logics is incorrect and the coding coverage of related acceptance tests are less than 70%.

Logics update:
1. Resource of the static route is missing refresh function to wait the status from 'pending' to 'available'
2. Time result needs to format to remove the millseconds.
3. Before instance and the custom route table creates complete, we cannot update the default route tables. So, the logic of update default route table after instance create complete will never be used.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. improve coverage of resource codes.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
./coverage_test.sh 
>>> Start to test
=== RUN   TestAccDataSourceAssociations_basic
=== PAUSE TestAccDataSourceAssociations_basic
=== RUN   TestAccDataSourceAttachments_basic
=== PAUSE TestAccDataSourceAttachments_basic
=== RUN   TestAccDataSourceAZs_basic
=== PAUSE TestAccDataSourceAZs_basic
=== RUN   TestAccDataSourceAvailableRoutes_basic
=== PAUSE TestAccDataSourceAvailableRoutes_basic
=== RUN   TestAccDatasourceFlowLogs_basic
=== PAUSE TestAccDatasourceFlowLogs_basic
=== RUN   TestAccDataSourceInstances_basic
=== PAUSE TestAccDataSourceInstances_basic
=== RUN   TestAccDataSourcePropagations_basic
=== PAUSE TestAccDataSourcePropagations_basic
=== RUN   TestAccDataSourceQuotas_basic
=== PAUSE TestAccDataSourceQuotas_basic
=== RUN   TestAccDataSourceRouteTables_basic
=== PAUSE TestAccDataSourceRouteTables_basic
=== RUN   TestAccAssociation_basic
=== PAUSE TestAccAssociation_basic
=== RUN   TestAccFlowLog_basic
=== PAUSE TestAccFlowLog_basic
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== RUN   TestAccInstance_updateWithEpsId
=== PAUSE TestAccInstance_updateWithEpsId
=== RUN   TestAccPropagation_basic
=== PAUSE TestAccPropagation_basic
=== RUN   TestAccRouteTable_basic
=== PAUSE TestAccRouteTable_basic
=== RUN   TestAccStaticRoute_basic
=== PAUSE TestAccStaticRoute_basic
=== RUN   TestAccVpcAttachment_basic
=== PAUSE TestAccVpcAttachment_basic
=== CONT  TestAccDataSourceAssociations_basic
=== CONT  TestAccAssociation_basic
--- PASS: TestAccAssociation_basic (181.74s)
=== CONT  TestAccDataSourceInstances_basic
--- PASS: TestAccDataSourceAssociations_basic (261.32s)
=== CONT  TestAccDataSourceRouteTables_basic
--- PASS: TestAccDataSourceInstances_basic (107.23s)
=== CONT  TestAccDataSourceQuotas_basic
--- PASS: TestAccDataSourceRouteTables_basic (221.43s)
=== CONT  TestAccDataSourceAvailableRoutes_basic
--- PASS: TestAccDataSourceQuotas_basic (215.06s)
=== CONT  TestAccDatasourceFlowLogs_basic
--- PASS: TestAccDataSourceAvailableRoutes_basic (206.01s)
=== CONT  TestAccDataSourceAZs_basic
--- PASS: TestAccDataSourceAZs_basic (12.39s)
=== CONT  TestAccDataSourceAttachments_basic
--- PASS: TestAccDatasourceFlowLogs_basic (235.74s)
=== CONT  TestAccPropagation_basic
--- PASS: TestAccDataSourceAttachments_basic (210.43s)
=== CONT  TestAccVpcAttachment_basic
--- PASS: TestAccPropagation_basic (187.21s)
=== CONT  TestAccStaticRoute_basic
--- PASS: TestAccVpcAttachment_basic (221.11s)
=== CONT  TestAccRouteTable_basic
--- PASS: TestAccStaticRoute_basic (305.25s)
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (118.10s)
=== CONT  TestAccInstance_updateWithEpsId
--- PASS: TestAccRouteTable_basic (236.33s)
=== CONT  TestAccFlowLog_basic
--- PASS: TestAccInstance_updateWithEpsId (88.31s)
=== CONT  TestAccDataSourcePropagations_basic
--- PASS: TestAccFlowLog_basic (277.15s)
--- PASS: TestAccDataSourcePropagations_basic (266.30s)
PASS
coverage: 81.2% of statements in ../../er
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/er        1704.998s
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_associations.go:18:            DataSourceAssociations                          100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_associations.go:56:            associationsSchema                              100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_associations.go:99:            buildAssociationsistOpts                        100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_associations.go:116:           flattenAssociations                             100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_associations.go:139:           dataSourceAssociationsRead                      86.7%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go:19:             DataSourceAttachments                           100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go:136:            filterAttachments                               92.9%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go:159:            filterAttachmentsByTags                         100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go:176:            flattenAttachments                              83.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go:201:            buildAttachmentListOpts                         100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_attachments.go:210:            dataSourceAttachmentsRead                       71.4%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_availability_zones.go:19:      DataSourceAvailabilityZones                     100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_availability_zones.go:39:      dataSourceAvailabilityZonesRead                 81.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_availability_zones.go:86:      flattenListAvailabilityZone                     87.5%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_available_routes.go:20:        DataSourceErAvailableRoutes                     100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_available_routes.go:108:       newAvailableRoutesDSWrapper                     100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_available_routes.go:115:       dataSourceErAvailableRoutesRead                 83.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_available_routes.go:137:       ListEffectiveRoutes                             87.5%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_available_routes.go:159:       listEffectiveRoutesToSchema                     100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_flow_logs.go:20:               DataSourceFlowLogs                              100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_flow_logs.go:84:               flowLogSchema                                   100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_flow_logs.go:152:              dataSourceFlowLogsRead                          83.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_flow_logs.go:199:              flattenListTransitIpsResponseBody               87.5%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_flow_logs.go:229:              filterListFlowLogsResponseBody                  62.5%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_flow_logs.go:263:              buildListFlowLogsQueryParams                    100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_instances.go:19:               DataSourceInstances                             100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_instances.go:152:              filterInstances                                 93.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_instances.go:177:              flattenInstances                                83.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_instances.go:206:              buildSliceIgnoreEmptyElement                    100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_instances.go:213:              buildInstanceListOpts                           100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_instances.go:223:              dataSourceInstancesRead                         72.2%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_propagations.go:18:            DataSourcePropagations                          100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_propagations.go:56:            propagationSchema                               100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_propagations.go:103:           buildPropagationListOpts                        100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_propagations.go:120:           flattenPropagations                             100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_propagations.go:144:           dataSourcePropagationsRead                      82.4%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_quotas.go:19:                  DataSourceErQuotas                              100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_quotas.go:83:                  newQuotasDSWrapper                              100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_quotas.go:90:                  dataSourceErQuotasRead                          75.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_quotas.go:112:                 ShowQuotas                                      85.7%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_quotas.go:133:                 showQuotasToSchema                              100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go:29:            DataSourceRouteTables                           100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go:185:           routeTableRelationshipSchemaResource            100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go:207:           queryRouteTableAssociations                     77.8%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go:228:           queryRouteTablePropagations                     77.8%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go:249:           queryRouteTableRoutes                           76.5%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go:286:           filterRouteTablesByTags                         84.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go:310:           flattenRouteTables                              90.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/data_source_huaweicloud_er_route_tables.go:343:           dataSourceRouteTablesRead                       75.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_association.go:26:                ResourceAssociation                             100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_association.go:91:                resourceAssociationCreate                       78.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_association.go:131:               QueryAssociationById                            85.7%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_association.go:163:               associationStatusRefreshFunc                    72.7%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_association.go:186:               resourceAssociationRead                         76.9%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_association.go:222:               resourceAssociationDelete                       78.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_association.go:261:               resourceAssociationImportState                  83.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:29:                   ResourceFlowLog                                 100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:112:                  buildCreateFlowLogBodyParams                    100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:127:                  resourceFlowLogCreate                           78.1%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:184:                  getFlowLogInfo                                  92.9%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:210:                  resourceFlowLogRead                             80.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:245:                  updateFlowLogState                              88.9%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:265:                  buildUpdateFlowLogBodyParams                    100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:273:                  resourceFlowLogUpdate                           79.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:325:                  resourceFlowLogDelete                           83.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:365:                  flowLogStatusRefreshFunc                        72.2%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:400:                  flowLogWaitingForStateCompleted                 100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_flow_log.go:413:                  resourceFlowLogImportState                      80.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:36:                   ResourceInstance                                100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:145:                  resourceInstanceCreate                          76.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:194:                  buildCreateInstanceBodyParams                   100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:201:                  buildCreateInstanceInstanceChildBody            100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:215:                  instanceWaitingForStateCompleted                81.8%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:263:                  resourceInstanceRead                            81.2%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:317:                  resourceInstanceUpdate                          82.9%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:412:                  buildUpdateInstanceBodyParams                   100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:419:                  buildUpdateInstanceInstanceChildBody            66.7%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:436:                  buildUpdateInstanceAvailabilityZonesBodyParams  100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:443:                  resourceInstanceDelete                          80.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_instance.go:476:                  deleteInstanceWaitingForStateCompleted          81.8%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_propagation.go:26:                ResourcePropagation                             100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_propagation.go:91:                resourcePropagationCreate                       78.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_propagation.go:131:               QueryPropagationById                            85.7%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_propagation.go:163:               propagationStatusRefreshFunc                    72.7%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_propagation.go:186:               resourcePropagationRead                         76.9%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_propagation.go:222:               resourcePropagationDelete                       78.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_propagation.go:261:               resourcePropagationImportState                  83.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:35:                ResourceRouteTable                              100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:117:               buildRouteTableCreateOpts                       100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:125:               resourceRouteTableCreate                        80.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:156:               routeTableStatusRefreshFunc                     75.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:179:               resourceRouteTableRead                          78.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:213:               updateRouteTableBasicInfo                       87.5%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:241:               resourceRouteTableUpdate                        76.9%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:265:               releaseRouteTableAssociations                   44.4%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:283:               releaseRouteTablePropagations                   44.4%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:301:               resourceRouteTableDelete                        76.2%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_route_table.go:342:               resourceRouteTableImportState                   80.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_static_route.go:26:               ResourceStaticRoute                             100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_static_route.go:98:               buildStaticRouteCreateOpts                      100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_static_route.go:106:              staticRouteStatusRefreshFunc                    88.9%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_static_route.go:124:              resourceStaticRouteCreate                       78.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_static_route.go:156:              resourceStaticRouteRead                         81.2%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_static_route.go:200:              resourceStaticRouteUpdate                       78.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_static_route.go:236:              resourceStaticRouteDelete                       78.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_static_route.go:267:              resourceStaticRouteImportState                  71.4%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go:29:             ResourceVpcAttachment                           100.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go:120:            resourceVpcAttachmentCreate                     80.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go:157:            resourceVpcAttachmentRead                       72.7%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go:195:            updateVpcAttachmentBasicInfo                    87.5%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go:223:            vpcAttachmentStatusRefreshFunc                  83.3%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go:246:            resourceVpcAttachmentUpdate                     75.0%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go:269:            resourceVpcAttachmentDelete                     78.6%
github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/er/resource_huaweicloud_er_vpc_attachment.go:299:            resourceVpcAttachmentImportState                80.0%
total:                                                                                                                                  (statements)                                    81.2%
```
