### PR TITLE
test(dds): add acctest for instance and user

### DIFF
--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_user_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_user_test.go
@@ -64,6 +64,13 @@ func TestAccDatabaseUser_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccDatabaseUser_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -108,6 +115,32 @@ resource "huaweicloud_dds_database_user" "test" {
   instance_id = huaweicloud_dds_instance.test.id
 
   name     = "%[2]s"
+  password = "HuaweiTest@12345678"
+  db_name  = "admin"
+
+  roles {
+    name    = huaweicloud_dds_database_role.test.name
+    db_name = "admin"
+  }
+}
+`, testAccDatabaseRole_base(rName), rName)
+}
+
+func testAccDatabaseUser_update(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dds_database_role" "test" {
+  instance_id = huaweicloud_dds_instance.test.id
+
+  name    = "%[2]s"
+  db_name = "admin"
+}
+
+resource "huaweicloud_dds_database_user" "test" {
+  instance_id = huaweicloud_dds_instance.test.id
+
+  name     = "%[2]s-update"
   password = "HuaweiTest@12345678"
   db_name  = "admin"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add acctest for instance and user

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run   TestAccDatabaseUser_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run   TestAccDatabaseUser_basic -timeout 360m -parallel 4
=== RUN   TestAccDatabaseUser_basic
=== PAUSE TestAccDatabaseUser_basic
=== CONT  TestAccDatabaseUser_basic
--- PASS: TestAccDatabaseUser_basic (960.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       960.484s
```

```
./scripts/acc-test.sh 

run acceptance tests of huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go:
=== RUN   TestAccDDSV3Instance_basic
=== PAUSE TestAccDDSV3Instance_basic
=== RUN   TestAccDDSV3Instance_withEpsId
=== PAUSE TestAccDDSV3Instance_withEpsId
=== RUN   TestAccDDSV3Instance_prePaid
=== PAUSE TestAccDDSV3Instance_prePaid
=== RUN   TestAccDDSV3Instance_withConfigurationSharding
=== PAUSE TestAccDDSV3Instance_withConfigurationSharding
=== RUN   TestAccDDSV3Instance_withConfigurationReplicaSet
=== PAUSE TestAccDDSV3Instance_withConfigurationReplicaSet
=== RUN   TestAccDDSV3Instance_withSecondLevelMonitoring
=== PAUSE TestAccDDSV3Instance_withSecondLevelMonitoring
=== RUN   TestAccDDSV3Instance_updateAZ
=== PAUSE TestAccDDSV3Instance_updateAZ
=== CONT  TestAccDDSV3Instance_basic
=== CONT  TestAccDDSV3Instance_withConfigurationReplicaSet
=== CONT  TestAccDDSV3Instance_updateAZ
=== CONT  TestAccDDSV3Instance_withSecondLevelMonitoring
--- PASS: TestAccDDSV3Instance_withSecondLevelMonitoring (927.82s)
=== CONT  TestAccDDSV3Instance_prePaid
--- PASS: TestAccDDSV3Instance_updateAZ (2254.70s)
=== CONT  TestAccDDSV3Instance_withConfigurationSharding
--- PASS: TestAccDDSV3Instance_prePaid (1922.55s)
=== CONT  TestAccDDSV3Instance_withEpsId
    acceptance.go:557: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccDDSV3Instance_withEpsId (0.01s)
--- PASS: TestAccDDSV3Instance_withConfigurationReplicaSet (3317.32s)
--- PASS: TestAccDDSV3Instance_basic (3590.16s)
--- PASS: TestAccDDSV3Instance_withConfigurationSharding (1762.71s)
PASS
coverage: 30.7% of statements in ./huaweicloud/services/dds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       4017.468s
```
