### PR TITLE
test: chore(AS): Fix AS configuration resource errors

### DIFF
--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -174,7 +174,8 @@ The `instance_config` block supports:
 
 * `ecs_group_id` - (Optional, String, ForceNew) Specifies the ECS group ID. Changing this will create a new resource.
 
-  -> To ensure service reliability, an ECS group allows ECSs within in the group to be automatically allocated to different hosts.
+  -> To ensure service reliability, an ECS group allows ECSs within in the group to be automatically allocated to
+  different hosts.
 
 * `tenancy` - (Optional, String, ForceNew) Configure this field to **dedicated** to create ECS instances on DeHs.
   Before configuring this field, prepare DeHs. Changing this will create a new resource.

--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -128,7 +128,7 @@ The following arguments are supported:
   If omitted, the provider-level region will be used. Changing this will create a new resource.
 
 * `scaling_configuration_name` - (Required, String, ForceNew) Specifies the AS configuration name.
-  The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 64 characters.
+  The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed `64` characters.
   Changing this will create a new resource.
 
 * `instance_config` - (Required, List, ForceNew) Specifies the information about instance configuration.
@@ -144,7 +144,7 @@ The `instance_config` block supports:
   If this argument is not specified, `flavor`, `image`, and `disk` arguments are mandatory.
   Changing this will create a new resource.
 
-* `flavor` - (Optional, String, ForceNew) Specifies the ECS flavor name. A maximum of 10 flavors can be selected.
+* `flavor` - (Optional, String, ForceNew) Specifies the ECS flavor name. A maximum of `10` flavors can be selected.
   Use a comma (,) to separate multiple flavor names. Changing this will create a new resource.
 
 * `image` - (Optional, String, ForceNew) Specifies the ECS image ID. Changing this will create a new resource.
@@ -174,6 +174,8 @@ The `instance_config` block supports:
 
 * `ecs_group_id` - (Optional, String, ForceNew) Specifies the ECS group ID. Changing this will create a new resource.
 
+  -> To ensure service reliability, an ECS group allows ECSs within in the group to be automatically allocated to different hosts.
+
 * `tenancy` - (Optional, String, ForceNew) Configure this field to **dedicated** to create ECS instances on DeHs.
   Before configuring this field, prepare DeHs. Changing this will create a new resource.
 
@@ -189,22 +191,22 @@ The `instance_config` block supports:
   The file content must be encoded with Base64. Changing this will create a new resource.
 
 * `public_ip` - (Optional, List, ForceNew) Specifies the EIP of the ECS instance.
-  The [object](#instance_config_public_ip_object) structure is documented below.
+  The [public_ip](#instance_config_public_ip_object) structure is documented below.
   Changing this will create a new resource.
 
 * `metadata` - (Optional, Map, ForceNew) Specifies the key/value pairs to make available from within the instance.
   Changing this will create a new resource.
 
 * `personality` - (Optional, List, ForceNew) Specifies the customize personality of an instance by defining one or
-  more files and their contents. The [object](#instance_config_personality_object) structure is documented below.
+  more files and their contents. The [personality](#instance_config_personality_object) structure is documented below.
   Changing this will create a new resource.
 
 <a name="instance_config_disk_object"></a>
 The `disk` block supports:
 
 * `size` - (Required, Int, ForceNew) Specifies the disk size. The unit is GB.
-  The system disk size ranges from 1 to 1024, and not less than the minimum value of the system disk in the
-  instance image. The data disk size ranges from 10 to 32768.
+  The system disk size ranges from `1` to `1024`, and not less than the minimum value of the system disk in the
+  instance image. The data disk size ranges from `10` to `32,768`.
   Changing this will create a new resource.
 
 * `volume_type` - (Required, String, ForceNew) Specifies the disk type. Changing this will create a new resource.
@@ -291,7 +293,7 @@ The `bandwidth` block supports:
   + **traffic**: Billing by traffic.
 
 * `size` - (Optional, Int, ForceNew) Specifies the bandwidth (Mbit/s). The value range for bandwidth billed by bandwidth
-  is 1 to 2000 and that for bandwidth billed by traffic is 1 to 300.
+  is `1` to `2,000` and that for bandwidth billed by traffic is `1` to `300`.
   Changing this creates a new resource.
 
 * `id` - (Optional, String, ForceNew) Specifies the ID of the shared bandwidth.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix AS configuration resource errors.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Commit1: fix AS configuration lint error.
  - remove `validaFunc` function in schema.
  - simplify some code writing.
  - remove unnecessary log printing.

- Commit2: add some document field descriptions.
- Commit3: enhance test case capabilities.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_basic
=== PAUSE TestAccASConfiguration_basic
=== CONT  TestAccASConfiguration_basic
--- PASS: TestAccASConfiguration_basic (85.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        85.929s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_spot'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_spot -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_spot
=== PAUSE TestAccASConfiguration_spot
=== CONT  TestAccASConfiguration_spot
--- PASS: TestAccASConfiguration_spot (86.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        86.149s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_instance'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_instance -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_instance
=== PAUSE TestAccASConfiguration_instance
=== CONT  TestAccASConfiguration_instance
--- PASS: TestAccASConfiguration_instance (197.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        197.299s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_DEH'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_DEH -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_DEH
=== PAUSE TestAccASConfiguration_DEH
=== CONT  TestAccASConfiguration_DEH
--- PASS: TestAccASConfiguration_DEH (87.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        87.861s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_bandwidth_new_disk'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_bandwidth_new_disk -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_bandwidth_new_disk
=== PAUSE TestAccASConfiguration_bandwidth_new_disk
=== CONT  TestAccASConfiguration_bandwidth_new_disk
--- PASS: TestAccASConfiguration_bandwidth_new_disk (86.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        86.570s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_snapshot'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_snapshot -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_snapshot
=== PAUSE TestAccASConfiguration_snapshot
=== CONT  TestAccASConfiguration_snapshot
--- PASS: TestAccASConfiguration_snapshot (682.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        682.322s
```