### PR TITLE
feat(apig/instance): resource supports update edition

### DIFF
--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -54,7 +54,7 @@ The following arguments are supported:
   The name can contain `3` to `64` characters, only letters, digits, hyphens (-) and underscores (_) are allowed, and
   must start with a letter.
 
-* `edition` - (Required, String, ForceNew) Specifies the edition of the dedicated instance.  
+* `edition` - (Required, String) Specifies the edition of the dedicated instance.  
   The valid values are as follows:
   + **BASIC**: Basic Edition instance.
   + **PROFESSIONAL**: Professional Edition instance.
@@ -64,8 +64,6 @@ The following arguments are supported:
   + **PROFESSIONAL_IPV6**: IPv6 instance of the Professional Edition.
   + **ENTERPRISE_IPV6**: IPv6 instance of the Enterprise Edition.
   + **PLATINUM_IPV6**: IPv6 instance of the Platinum Edition.
-  
-  Changing this will create a new resource.
 
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC used to create the dedicated instance.  
   Changing this will create a new resource.

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -76,7 +76,7 @@ func TestAccInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "edition", "BASIC"),
+					resource.TestCheckResourceAttr(resourceName, "edition", "PROFESSIONAL"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "18:00:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "22:00:00"),
@@ -168,7 +168,7 @@ resource "huaweicloud_apig_instance" "test" {
   availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
   vpcep_service_name = "new_custom_apig"
 
-  edition               = "BASIC"
+  edition               = "PROFESSIONAL"
   name                  = "%[2]s"
   enterprise_project_id = "%[3]s"
   maintain_begin        = "18:00:00"
@@ -203,7 +203,7 @@ resource "huaweicloud_apig_instance" "test" {
   availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
   vpcep_service_name = "new_custom_apig"
 
-  edition               = "BASIC"
+  edition               = "PROFESSIONAL"
   name                  = "%[2]s"
   enterprise_project_id = "%[3]s"
   maintain_begin        = "18:00:00"
@@ -238,7 +238,7 @@ resource "huaweicloud_apig_instance" "test" {
   availability_zones = slice(data.huaweicloud_availability_zones.test.names, 0, 1)
   vpcep_service_name = "new_custom_apig"
 
-  edition               = "BASIC"
+  edition               = "PROFESSIONAL"
   name                  = "%[2]s"
   enterprise_project_id = "%[3]s"
   maintain_begin        = "18:00:00"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Now, we can update the instance specification via OpenAPI:
https://support.huaweicloud.com/api-apig/CreatePostPayResizeOrder.html

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. resource supports update edition.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (1205.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      1205.677s
```
