### PR TITLE
feat(dms): support new param for rocketmq consumer group

### DIFF
--- a/docs/resources/dms_rocketmq_consumer_group.md
+++ b/docs/resources/dms_rocketmq_consumer_group.md
@@ -11,6 +11,8 @@ Manages DMS RocketMQ consumer group resources within HuaweiCloud.
 
 ## Example Usage
 
+### Create consumer group for 4.8.0 version instance
+
 ```hcl
 variable "instance_id" {}
 
@@ -25,6 +27,22 @@ resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
 }
 ```
 
+### Create consumer group for 5.x version instance
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
+  instance_id     = var.instance_id
+  name            = "consumer_group_test"
+  enabled         = true
+  broadcast       = true
+  retry_max_times = 3
+  description     = "the description of the consumer group"
+  consume_orderly = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -36,21 +54,24 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `brokers` - (Required, List, ForceNew) Specifies the list of associated brokers of the consumer group.
-
-  Changing this parameter will create a new resource.
-
 * `name` - (Required, String, ForceNew) Specifies the name of the consumer group.
 
   Changing this parameter will create a new resource.
 
 * `retry_max_times` - (Required, Int) Specifies the maximum number of retry times.
 
-* `enabled` - (Optional, Bool) Specifies the consumer group is enabled or not. Default to true.
+* `enabled` - (Optional, Bool) Specifies the consumer group is enabled or not. Defaults to true.
 
 * `broadcast` - (Optional, Bool) Specifies whether to broadcast of the consumer group.
 
 * `description` - (Optional, String) Specifies the description of the consumer group.
+
+* `brokers` - (Optional, List, ForceNew) Specifies the list of associated brokers of the consumer group.
+  It's only valid when RocketMQ instance version is **4.8.0**.
+  Changing this parameter will create a new resource.
+
+* `consume_orderly` - (Optional, Bool) Specifies whether to consume orderly.
+  It's only valid when RocketMQ instance version is **5.x**.
 
 ## Attribute Reference
 

--- a/docs/resources/dms_rocketmq_instance.md
+++ b/docs/resources/dms_rocketmq_instance.md
@@ -44,10 +44,13 @@ The following arguments are supported:
   An instance name starts with a letter, consists of 4 to 64 characters, and can contain only letters,
   digits, underscores (_), and hyphens (-).
 
-* `engine_version` - (Required, String, ForceNew) Specifies the version of the RocketMQ engine. Value: 4.8.0.
+* `engine_version` - (Required, String, ForceNew) Specifies the version of the RocketMQ engine.
+  Valid values are **4.8.0** and **5.x**.
   Changing this parameter will create a new resource.
 
-* `storage_space` - (Required, Int) Specifies the message storage capacity, Unit: GB. Value range: 300-3000.
+* `storage_space` - (Required, Int) Specifies the message storage capacity, Unit: GB.
+  When `engine_version` is **4.8.0**, value ranges from **300** to **30000**.
+  When `engine_version` is **5.x**, value ranges from **200** to **60000**.
 
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC.
   Changing this parameter will create a new resource.
@@ -62,15 +65,7 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `flavor_id` - (Required, String) Specifies a product ID. The options are as follows:
-  + **c6.4u8g.cluster**: maximum number of topics on each broker: 4000; maximum number of consumer groups
-    on each broker: 4000
-  + **c6.8u16g.cluster**: maximum number of topics on each broker: 8000; maximum number of consumer groups
-    on each broker: 8000
-  + **c6.12u24g.cluster**: maximum number of topics on each broker: 12,000; maximum number of consumer groups
-    on each broker: 12,000
-  + **c6.16u32g.cluster**: maximum number of topics on each broker: 16,000; maximum number of consumer groups
-    on each broker: 16,000
+* `flavor_id` - (Required, String) Specifies the flavor ID.
 
 * `storage_spec_code` - (Required, String, ForceNew) Specifies the storage I/O specification.
   The options are as follows:
@@ -93,7 +88,8 @@ The following arguments are supported:
   multiple EIP IDs. This parameter is mandatory if public access is enabled (that is, enable_publicip is set to true).
   This parameter can not be updated if public access is disabled.
 
-* `broker_num` - (Optional, Int) Specifies the broker numbers. Defaults to **1**.
+* `broker_num` - (Optional, Int) Specifies the broker numbers.
+  It's only valid when `engine_version` is **4.8.0**, and defaults to **1**.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the instance.
 

--- a/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_consumer_groups_test.go
+++ b/huaweicloud/services/acceptance/dms/data_source_huaweicloud_dms_rocketmq_consumer_groups_test.go
@@ -118,5 +118,5 @@ output "retry_max_times_filter_is_useful" {
   )
 }
 
-`, testAccDmsRocketmqConsumerGroup_Base(name), name)
+`, testAccDmsRocketmqConsumerGroup_version4(name), name)
 }

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumer_group_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_consumer_group_test.go
@@ -25,7 +25,7 @@ func getDmsRocketMQConsumerGroupResourceFunc(cfg *config.Config, state *terrafor
 	)
 	getRocketmqConsumerGroupClient, err := cfg.NewServiceClient(getRocketmqConsumerGroupProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+		return nil, fmt.Errorf("error creating DMS client: %s", err)
 	}
 
 	// Split instance_id and group from resource id
@@ -43,9 +43,6 @@ func getDmsRocketMQConsumerGroupResourceFunc(cfg *config.Config, state *terrafor
 
 	getRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getRocketmqConsumerGroupResp, err := getRocketmqConsumerGroupClient.Request("GET", getRocketmqConsumerGroupPath,
 		&getRocketmqConsumerGroupOpt)
@@ -80,6 +77,7 @@ func TestAccDmsRocketMQConsumerGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "broadcast", "true"),
 					resource.TestCheckResourceAttr(resourceName, "retry_max_times", "3"),
 					resource.TestCheckResourceAttr(resourceName, "description", "add description."),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 				),
 			},
 			{
@@ -102,7 +100,52 @@ func TestAccDmsRocketMQConsumerGroup_basic(t *testing.T) {
 	})
 }
 
-func testAccDmsRocketmqConsumerGroup_Base(rName string) string {
+func TestAccDmsRocketMQConsumerGroup_version5(t *testing.T) {
+	var obj interface{}
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_rocketmq_consumer_group.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDmsRocketMQConsumerGroupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsRocketMQConsumerGroup_version5(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "broadcast", "true"),
+					resource.TestCheckResourceAttr(resourceName, "retry_max_times", "3"),
+					resource.TestCheckResourceAttr(resourceName, "description", "add description."),
+					resource.TestCheckResourceAttr(resourceName, "consume_orderly", "true"),
+				),
+			},
+			{
+				Config: testDmsRocketMQConsumerGroup_version5(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "consume_orderly", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDmsRocketmqConsumerGroup_version4(rName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -122,7 +165,31 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
 
   flavor_id         = "c6.4u8g.cluster"
   storage_spec_code = "dms.physical.storage.high.v2"
-  broker_num        = 1
+  broker_num        = 2
+}
+`, common.TestBaseNetwork(rName), rName)
+}
+
+func testAccDmsRocketmqConsumerGroup_version5(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%s"
+  engine_version    = "5.x"
+  storage_space     = 200
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  flavor_id         = "rocketmq.b1.large.1"
+  storage_spec_code = "dms.physical.storage.high.v2"
 }
 `, common.TestBaseNetwork(rName), rName)
 }
@@ -136,14 +203,15 @@ resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
   broadcast   = true
 
   brokers = [
-    "broker-0"
+    "broker-0",
+    "broker-1"
   ]
 
   name            = "%s"
   retry_max_times = "3"
   description     = "add description."
 }
-`, testAccDmsRocketmqConsumerGroup_Base(name), name)
+`, testAccDmsRocketmqConsumerGroup_version4(name), name)
 }
 
 func testDmsRocketMQConsumerGroup_basic_update(name string) string {
@@ -155,7 +223,8 @@ resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
   broadcast   = false
 
   brokers = [
-    "broker-0"
+    "broker-0",
+    "broker-1"
   ]
 
   name            = "%s"
@@ -163,5 +232,20 @@ resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
   enabled         = false
   description     = ""
 }
-`, testAccDmsRocketmqConsumerGroup_Base(name), name)
+`, testAccDmsRocketmqConsumerGroup_version4(name), name)
+}
+
+func testDmsRocketMQConsumerGroup_version5(name string, orderly bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_rocketmq_consumer_group" "test" {
+  instance_id     = huaweicloud_dms_rocketmq_instance.test.id
+  broadcast       = true
+  name            = "%s"
+  retry_max_times = "3"
+  description     = "add description."
+  consume_orderly = %v
+}
+`, testAccDmsRocketmqConsumerGroup_version5(name), name, orderly)
 }

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
@@ -45,13 +45,6 @@ func ResourceDmsRocketMQConsumerGroup() *schema.Resource {
 				ForceNew:    true,
 				Description: `Specifies the ID of the rocketMQ instance.`,
 			},
-			"brokers": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Required:    true,
-				ForceNew:    true,
-				Description: `Specifies the list of associated brokers of the consumer group.`,
-			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -73,8 +66,22 @@ func ResourceDmsRocketMQConsumerGroup() *schema.Resource {
 			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Computed:    true,
+				Default:     true,
 				Description: `Specifies the consumer group is enabled or not. Default to true.`,
+			},
+			"brokers": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `Specifies the list of associated brokers of the consumer group.`,
+			},
+			"consume_orderly": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies whether to consume orderly.`,
 			},
 			"broadcast": {
 				Type:        schema.TypeBool,
@@ -102,7 +109,7 @@ func resourceDmsRocketMQConsumerGroupCreate(ctx context.Context, d *schema.Resou
 	)
 	createRocketmqConsumerGroupClient, err := cfg.NewServiceClient(createRocketmqConsumerGroupProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
 	instanceID := d.Get("instance_id").(string)
@@ -113,9 +120,6 @@ func resourceDmsRocketMQConsumerGroupCreate(ctx context.Context, d *schema.Resou
 
 	createRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	createRocketmqConsumerGroupOpt.JSONBody = utils.RemoveNil(buildCreateRocketmqConsumerGroupBodyParams(d, cfg))
 	createRocketmqConsumerGroupResp, err := createRocketmqConsumerGroupClient.Request("POST",
@@ -140,17 +144,14 @@ func resourceDmsRocketMQConsumerGroupCreate(ctx context.Context, d *schema.Resou
 }
 
 func buildCreateRocketmqConsumerGroupBodyParams(d *schema.ResourceData, _ *config.Config) map[string]interface{} {
-	var enabled interface{} = true
-	if v, ok := d.GetOk("enabled"); ok {
-		enabled = v
-	}
 	bodyParams := map[string]interface{}{
-		"enabled":        enabled,
-		"broadcast":      utils.ValueIgnoreEmpty(d.Get("broadcast")),
-		"brokers":        utils.ValueIgnoreEmpty(d.Get("brokers")),
-		"name":           utils.ValueIgnoreEmpty(d.Get("name")),
-		"retry_max_time": utils.ValueIgnoreEmpty(d.Get("retry_max_times")),
-		"group_desc":     utils.ValueIgnoreEmpty(d.Get("description")),
+		"enabled":         utils.ValueIgnoreEmpty(d.Get("enabled")),
+		"broadcast":       utils.ValueIgnoreEmpty(d.Get("broadcast")),
+		"brokers":         utils.ValueIgnoreEmpty(d.Get("brokers").(*schema.Set).List()),
+		"name":            utils.ValueIgnoreEmpty(d.Get("name")),
+		"retry_max_time":  utils.ValueIgnoreEmpty(d.Get("retry_max_times")),
+		"group_desc":      utils.ValueIgnoreEmpty(d.Get("description")),
+		"consume_orderly": utils.ValueIgnoreEmpty(d.Get("consume_orderly")),
 	}
 	return bodyParams
 }
@@ -164,6 +165,7 @@ func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.Resou
 		"broadcast",
 		"retry_max_times",
 		"description",
+		"consume_orderly",
 	}
 
 	if d.HasChanges(updateRocketmqConsumerGroupHasChanges...) {
@@ -174,7 +176,7 @@ func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.Resou
 		)
 		updateRocketmqConsumerGroupClient, err := cfg.NewServiceClient(updateRocketmqConsumerGroupProduct, region)
 		if err != nil {
-			return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+			return diag.Errorf("error creating DMS client: %s", err)
 		}
 
 		parts := strings.SplitN(d.Id(), "/", 2)
@@ -208,13 +210,11 @@ func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.Resou
 
 func buildUpdateRocketmqConsumerGroupBodyParams(d *schema.ResourceData) map[string]interface{} {
 	bodyParams := map[string]interface{}{
-		"broadcast":      utils.ValueIgnoreEmpty(d.Get("broadcast")),
-		"retry_max_time": utils.ValueIgnoreEmpty(d.Get("retry_max_times")),
-		"group_desc":     utils.ValueIgnoreEmpty(d.Get("description")),
-	}
-	enabled := utils.ValueIgnoreEmpty(d.Get("enabled"))
-	if enabled != nil {
-		bodyParams["enabled"] = enabled
+		"broadcast":       utils.ValueIgnoreEmpty(d.Get("broadcast")),
+		"retry_max_time":  utils.ValueIgnoreEmpty(d.Get("retry_max_times")),
+		"group_desc":      utils.ValueIgnoreEmpty(d.Get("description")),
+		"consume_orderly": utils.ValueIgnoreEmpty(d.Get("consume_orderly")),
+		"enabled":         utils.ValueIgnoreEmpty(d.Get("enabled")),
 	}
 	return bodyParams
 }
@@ -232,7 +232,7 @@ func resourceDmsRocketMQConsumerGroupRead(_ context.Context, d *schema.ResourceD
 	)
 	getRocketmqConsumerGroupClient, err := cfg.NewServiceClient(getRocketmqConsumerGroupProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
 	parts := strings.SplitN(d.Id(), "/", 2)
@@ -249,9 +249,6 @@ func resourceDmsRocketMQConsumerGroupRead(_ context.Context, d *schema.ResourceD
 
 	getRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getRocketmqConsumerGroupResp, err := getRocketmqConsumerGroupClient.Request("GET", getRocketmqConsumerGroupPath,
 		&getRocketmqConsumerGroupOpt)
@@ -275,6 +272,7 @@ func resourceDmsRocketMQConsumerGroupRead(_ context.Context, d *schema.ResourceD
 		d.Set("name", name),
 		d.Set("retry_max_times", utils.PathSearch("retry_max_time", getRocketmqConsumerGroupRespBody, nil)),
 		d.Set("description", utils.PathSearch("group_desc", getRocketmqConsumerGroupRespBody, nil)),
+		d.Set("consume_orderly", utils.PathSearch("consume_orderly", getRocketmqConsumerGroupRespBody, false)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -291,7 +289,7 @@ func resourceDmsRocketMQConsumerGroupDelete(_ context.Context, d *schema.Resourc
 	)
 	deleteRocketmqConsumerGroupClient, err := cfg.NewServiceClient(deleteRocketmqConsumerGroupProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating DmsRocketMQConsumerGroup Client: %s", err)
+		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
 	parts := strings.SplitN(d.Id(), "/", 2)
@@ -308,9 +306,6 @@ func resourceDmsRocketMQConsumerGroupDelete(_ context.Context, d *schema.Resourc
 
 	deleteRocketmqConsumerGroupOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
 	_, err = deleteRocketmqConsumerGroupClient.Request("DELETE", deleteRocketmqConsumerGroupPath, &deleteRocketmqConsumerGroupOpt)
 	if err != nil {

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_instance.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"time"
 
@@ -72,12 +71,6 @@ func ResourceDmsRocketMQInstance() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: `Specifies the name of the DMS RocketMQ instance`,
-				ValidateFunc: validation.All(
-					validation.StringMatch(regexp.MustCompile(`^[A-Za-z-_0-9]*$`),
-						"An instance name starts with a letter and can contain only letters,"+
-							"digits, underscores (_), and hyphens (-)"),
-					validation.StringLenBetween(4, 64),
-				),
 			},
 			"engine_version": {
 				Type:        schema.TypeString,
@@ -86,10 +79,9 @@ func ResourceDmsRocketMQInstance() *schema.Resource {
 				Description: `Specifies the version of the RocketMQ engine.`,
 			},
 			"storage_space": {
-				Type:         schema.TypeInt,
-				Required:     true,
-				Description:  `Specifies the message storage capacity, Unit: GB.`,
-				ValidateFunc: validation.IntBetween(300, 3000),
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `Specifies the message storage capacity, Unit: GB.`,
 			},
 			"vpc_id": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new param for rocketmq consumer group.
And update the docs for rocketmq for version 5.x.

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run  TestAccDmsRocketMQConsumerGroup_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run  TestAccDmsRocketMQConsumerGroup_ -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQConsumerGroup_basic
=== PAUSE TestAccDmsRocketMQConsumerGroup_basic
=== RUN   TestAccDmsRocketMQConsumerGroup_version5
=== PAUSE TestAccDmsRocketMQConsumerGroup_version5
=== CONT  TestAccDmsRocketMQConsumerGroup_basic
=== CONT  TestAccDmsRocketMQConsumerGroup_version5
--- PASS: TestAccDmsRocketMQConsumerGroup_version5 (674.39s)
--- PASS: TestAccDmsRocketMQConsumerGroup_basic (919.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       919.111s
```
