### PR TITLE
chore: test(apig/throttle): adjust the codes and imporve the UT coverage 

### DIFF
--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
@@ -2,8 +2,10 @@ package apig
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -26,16 +28,15 @@ func TestAccThrottlingPolicy_basic(t *testing.T) {
 	var (
 		policy throttles.ThrottlingPolicy
 
-		rName      = "huaweicloud_apig_throttling_policy.test"
 		name       = acceptance.RandomAccResourceName()
 		updateName = acceptance.RandomAccResourceName()
 		baseConfig = testAccApigThrottlingPolicy_base(name)
-	)
 
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&policy,
-		getThrottlingPolicyFunc,
+		rName = "huaweicloud_apig_throttling_policy.test"
+		rc    = acceptance.InitResourceCheck(rName, &policy, getThrottlingPolicyFunc)
+
+		rNamePre = "huaweicloud_apig_throttling_policy.pre_test"
+		rcPre    = acceptance.InitResourceCheck(rNamePre, &policy, getThrottlingPolicyFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -46,7 +47,58 @@ func TestAccThrottlingPolicy_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccApigThrottlingPolicy_basic_step1(baseConfig, name),
+				// Check whether illegal type values ​​can be intercepted normally (create phase).
+				Config:      testAccApigThrottlingPolicy_basic_step1(baseConfig, name),
+				ExpectError: regexp.MustCompile("invalid throttling policy type: NON-Exist-Type"),
+			},
+			{
+				// Check whether illegal application ID ​​can be intercepted normally (create phase).
+				Config:      testAccApigThrottlingPolicy_basic_step2(baseConfig, name),
+				ExpectError: regexp.MustCompile("error creating special application throttling policy"),
+			},
+			{
+				// Check whether illegal call limit ​​can be intercepted normally (create phase).
+				// The API does not check whether the value or format of the user ID is legal.
+				Config:      testAccApigThrottlingPolicy_basic_step3(baseConfig, name),
+				ExpectError: regexp.MustCompile("The parameter value is too small"),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_basic_step4(baseConfig, name),
+				Check: resource.ComposeTestCheckFunc(
+					rcPre.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rNamePre, "name", name),
+					resource.TestCheckResourceAttr(rNamePre, "description", "Created by script"),
+					resource.TestCheckResourceAttr(rNamePre, "type", "API-based"),
+					resource.TestCheckResourceAttr(rNamePre, "period", "15000"),
+					resource.TestCheckResourceAttr(rNamePre, "period_unit", "SECOND"),
+					resource.TestCheckResourceAttr(rNamePre, "max_api_requests", "100"),
+					resource.TestCheckResourceAttr(rNamePre, "max_user_requests", "60"),
+					resource.TestCheckResourceAttr(rNamePre, "max_app_requests", "60"),
+					resource.TestCheckResourceAttr(rNamePre, "max_ip_requests", "60"),
+					resource.TestCheckResourceAttr(rNamePre, "app_throttles.#", "0"),
+					resource.TestCheckResourceAttr(rNamePre, "user_throttles.#", "0"),
+					resource.TestMatchResourceAttr(rNamePre, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				// Check whether illegal type values ​​can be intercepted normally (update phase).
+				Config:      testAccApigThrottlingPolicy_basic_step5(baseConfig, name),
+				ExpectError: regexp.MustCompile("invalid throttling policy type: NON-Exist-Type"),
+			},
+			{
+				// Check whether illegal application ID ​​can be intercepted normally (update phase).
+				Config:      testAccApigThrottlingPolicy_basic_step6(baseConfig, name),
+				ExpectError: regexp.MustCompile("error updating special app throttles"),
+			},
+			{
+				// Check whether illegal call limit ​​can be intercepted normally (update phase).
+				// The API does not check whether the value or format of the user ID is legal.
+				Config:      testAccApigThrottlingPolicy_basic_step7(baseConfig, name),
+				ExpectError: regexp.MustCompile("The parameter value is too small"),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_basic_step8(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
@@ -58,10 +110,12 @@ func TestAccThrottlingPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "max_user_requests", "60"),
 					resource.TestCheckResourceAttr(rName, "max_app_requests", "60"),
 					resource.TestCheckResourceAttr(rName, "max_ip_requests", "60"),
+					resource.TestCheckResourceAttr(rName, "app_throttles.#", "2"),
+					resource.TestCheckResourceAttr(rName, "user_throttles.#", "2"),
 				),
 			},
 			{
-				Config: testAccApigThrottlingPolicy_basic_step2(baseConfig, updateName),
+				Config: testAccApigThrottlingPolicy_basic_step9(baseConfig, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", updateName),
@@ -73,28 +127,132 @@ func TestAccThrottlingPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "max_user_requests", "45"),
 					resource.TestCheckResourceAttr(rName, "max_app_requests", "45"),
 					resource.TestCheckResourceAttr(rName, "max_ip_requests", "45"),
+					resource.TestCheckResourceAttr(rName, "app_throttles.#", "2"),
+					resource.TestCheckResourceAttr(rName, "user_throttles.#", "2"),
 				),
 			},
 			{
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccThrottlingPolicyImportStateFunc(),
+				ImportStateIdFunc: testAccThrottlingPolicyImportStateFunc(rName),
 			},
 		},
 	})
+}
+
+func testAccThrottlingPolicyImportStateFunc(rsName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rsName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rsName, rs)
+		}
+		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["name"] == "" {
+			return "", fmt.Errorf("missing some attributes, want '{instance_id}/{name}', but '%s/%s'",
+				rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["name"])
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["name"]), nil
+	}
+}
+
+func testAccApigThrottlingPolicy_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_identity_users" "test" {}
+
+resource "huaweicloud_apig_instance" "test" {
+  name                  = "%[2]s"
+  edition               = "BASIC"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id = "0"
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0],
+  ]
+}
+
+# If you want to test a resource (huaweicloud_apig_throttling_policy) that does not contain app-specific throttling
+# policy after step 2, then the application resources must be retained.
+# If you delete this script (application resources definition), the application deletion operation and the special
+# throttling policies update operation will be executed in parallel.
+# If the APP is deleted before the throttling policies update operation complete, it will cause an error during the
+# update API. The order of the two operations cannot be controlled.
+resource "huaweicloud_apig_application" "test" {
+  count = 3
+
+  instance_id = huaweicloud_apig_instance.test.id
+  name        = "%[2]s_${count.index}"
+}
+`, common.TestBaseNetwork(name), name)
 }
 
 func testAccApigThrottlingPolicy_basic_step1(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_apig_application" "test" {
-  name        = "%[2]s"
-  instance_id = huaweicloud_apig_instance.test.id
+resource "huaweicloud_apig_throttling_policy" "invalid_type" {
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  type             = "NON-Exist-Type"
+  period           = 15000
+  period_unit      = "SECOND"
+  max_api_requests = 100
+}
+`, baseConfig, name)
 }
 
-resource "huaweicloud_apig_throttling_policy" "test" {
+func testAccApigThrottlingPolicy_basic_step2(baseConfig, name string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_throttling_policy" "invalid_app_id" {
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  type             = "API-based"
+  period           = 15000
+  period_unit      = "SECOND"
+  max_api_requests = 100
+
+  app_throttles {
+    max_api_requests     = 30
+    throttling_object_id = "%[3]s"
+  }
+}
+`, baseConfig, name, randUUID)
+}
+
+func testAccApigThrottlingPolicy_basic_step3(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_throttling_policy" "invalid_user_id" {
+  instance_id      = huaweicloud_apig_instance.test.id
+  name             = "%[2]s"
+  type             = "API-based"
+  period           = 15000
+  period_unit      = "SECOND"
+  max_api_requests = 100
+
+  user_throttles {
+    max_api_requests     = -1
+    throttling_object_id = "INVALID_OBJECT_ID_CONTENT"
+  }
+}
+`, baseConfig, name)
+}
+
+func testAccApigThrottlingPolicy_basic_step4(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_throttling_policy" "pre_test" {
   instance_id       = huaweicloud_apig_instance.test.id
   name              = "%[2]s"
   type              = "API-based"
@@ -109,14 +267,115 @@ resource "huaweicloud_apig_throttling_policy" "test" {
 `, baseConfig, name)
 }
 
-func testAccApigThrottlingPolicy_basic_step2(baseConfig, name string) string {
+func testAccApigThrottlingPolicy_basic_step5(baseConfig, name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_apig_application" "test" {
-  name        = "%[2]s"
-  instance_id = huaweicloud_apig_instance.test.id
+resource "huaweicloud_apig_throttling_policy" "pre_test" {
+  instance_id       = huaweicloud_apig_instance.test.id
+  name              = "%[2]s"
+  type              = "NON-Exist-Type"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Created by script"
 }
+`, baseConfig, name)
+}
+
+func testAccApigThrottlingPolicy_basic_step6(baseConfig, name string) string {
+	randUUID, _ := uuid.GenerateUUID()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_throttling_policy" "pre_test" {
+  instance_id       = huaweicloud_apig_instance.test.id
+  name              = "%[2]s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Created by script"
+
+  app_throttles {
+    max_api_requests     = 30
+    throttling_object_id = "%[3]s"
+  }
+}
+`, baseConfig, name, randUUID)
+}
+
+func testAccApigThrottlingPolicy_basic_step7(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_throttling_policy" "pre_test" {
+  instance_id       = huaweicloud_apig_instance.test.id
+  name              = "%[2]s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Created by script"
+
+  user_throttles {
+    max_api_requests     = -1
+    throttling_object_id = "INVALID_OBJECT_ID_CONTENT"
+  }
+}
+`, baseConfig, name)
+}
+
+func testAccApigThrottlingPolicy_basic_step8(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_apig_throttling_policy" "test" {
+  instance_id       = huaweicloud_apig_instance.test.id
+  name              = "%[2]s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Created by script"
+
+  dynamic "app_throttles" {
+    for_each = slice(huaweicloud_apig_application.test[*].id, 0, 2)
+
+    content {
+      max_api_requests     = 30
+      throttling_object_id = app_throttles.value
+    }
+  }
+
+  dynamic "user_throttles" {
+    for_each = slice(data.huaweicloud_identity_users.test.users[*].id, 0, 2)
+
+    content {
+      max_api_requests     = 30
+      throttling_object_id = user_throttles.value
+    }
+  }
+}
+`, baseConfig, name)
+}
+
+func testAccApigThrottlingPolicy_basic_step9(baseConfig, name string) string {
+	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_apig_throttling_policy" "test" {
   instance_id       = huaweicloud_apig_instance.test.id
@@ -129,174 +388,6 @@ resource "huaweicloud_apig_throttling_policy" "test" {
   max_app_requests  = 45
   max_ip_requests   = 45
   description       = "Updated by script"
-}
-`, baseConfig, name)
-}
-
-func TestAccThrottlingPolicy_spec(t *testing.T) {
-	var (
-		policy *throttles.ThrottlingPolicy
-
-		rName = "huaweicloud_apig_throttling_policy.test"
-		name  = acceptance.RandomAccResourceName()
-	)
-
-	rc := acceptance.InitResourceCheck(
-		rName,
-		&policy,
-		getThrottlingPolicyFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccApigThrottlingPolicy_spec_step1(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "name", name),
-					resource.TestCheckResourceAttr(rName, "type", "API-based"),
-					resource.TestCheckResourceAttr(rName, "period", "15000"),
-					resource.TestCheckResourceAttr(rName, "period_unit", "SECOND"),
-					resource.TestCheckResourceAttr(rName, "max_api_requests", "100"),
-					resource.TestCheckResourceAttr(rName, "app_throttles.#", "0"),
-				),
-			},
-			{
-				Config: testAccApigThrottlingPolicy_spec_step2(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "app_throttles.#", "2"),
-				),
-			},
-			{
-				Config: testAccApigThrottlingPolicy_spec_step3(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "app_throttles.#", "2"),
-				),
-			},
-			{
-				Config: testAccApigThrottlingPolicy_spec_step4(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "app_throttles.#", "0"),
-				),
-			},
-			{
-				ResourceName:      rName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccThrottlingPolicyImportStateFunc(),
-			},
-		},
-	})
-}
-
-func testAccThrottlingPolicyImportStateFunc() resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rName := "huaweicloud_apig_throttling_policy.test"
-		rs, ok := s.RootModule().Resources[rName]
-		if !ok {
-			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
-		}
-		if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["name"] == "" {
-			return "", fmt.Errorf("missing some attributes, want '{instance_id}/{name}', but '%s/%s'",
-				rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["name"])
-		}
-		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["name"]), nil
-	}
-}
-
-func testAccApigThrottlingPolicy_base(name string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_availability_zones" "test" {}
-
-resource "huaweicloud_apig_instance" "test" {
-  name                  = "%s"
-  edition               = "BASIC"
-  vpc_id                = huaweicloud_vpc.test.id
-  subnet_id             = huaweicloud_vpc_subnet.test.id
-  security_group_id     = huaweicloud_networking_secgroup.test.id
-  enterprise_project_id = "0"
-
-  availability_zones = [
-    data.huaweicloud_availability_zones.test.names[0],
-  ]
-}
-`, common.TestBaseNetwork(name), name)
-}
-
-func testAccApigThrottlingPolicy_spec_step1(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_apig_throttling_policy" "test" {
-  instance_id      = huaweicloud_apig_instance.test.id
-  name             = "%[2]s"
-  type             = "API-based"
-  period           = 15000
-  period_unit      = "SECOND"
-  max_api_requests = 100
-}
-`, testAccApigThrottlingPolicy_base(name), name)
-}
-
-func testAccApigThrottlingPolicy_spec_step2(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_apig_application" "test" {
-  count = 3
-
-  name        = "%[2]s_${count.index}"
-  instance_id = huaweicloud_apig_instance.test.id
-}
-
-resource "huaweicloud_apig_throttling_policy" "test" {
-  instance_id      = huaweicloud_apig_instance.test.id
-  name             = "%[2]s"
-  type             = "API-based"
-  period           = 15000
-  period_unit      = "SECOND"
-  max_api_requests = 100
-
-  dynamic "app_throttles" {
-    for_each = slice(huaweicloud_apig_application.test[*].id, 0, 2)
-
-    content {
-      max_api_requests     = 30
-      throttling_object_id = app_throttles.value
-    }
-  }
-}
-`, testAccApigThrottlingPolicy_base(name), name)
-}
-
-func testAccApigThrottlingPolicy_spec_step3(name string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_apig_application" "test" {
-  count = 3
-
-  name        = "%[2]s_${count.index}"
-  instance_id = huaweicloud_apig_instance.test.id
-}
-
-resource "huaweicloud_apig_throttling_policy" "test" {
-  instance_id      = huaweicloud_apig_instance.test.id
-  name             = "%[2]s"
-  type             = "API-based"
-  period           = 15000
-  period_unit      = "SECOND"
-  max_api_requests = 100
 
   dynamic "app_throttles" {
     for_each = slice(huaweicloud_apig_application.test[*].id, 1, 3)
@@ -306,28 +397,15 @@ resource "huaweicloud_apig_throttling_policy" "test" {
       throttling_object_id = app_throttles.value
     }
   }
-}
-`, testAccApigThrottlingPolicy_base(name), name)
-}
 
-func testAccApigThrottlingPolicy_spec_step4(name string) string {
-	return fmt.Sprintf(`
-%[1]s
+  dynamic "user_throttles" {
+    for_each = slice(data.huaweicloud_identity_users.test.users[*].id, 1, 3)
 
-resource "huaweicloud_apig_application" "test" {
-  count = 3
-
-  name        = "%[2]s_${count.index}"
-  instance_id = huaweicloud_apig_instance.test.id
+    content {
+      max_api_requests     = 40
+      throttling_object_id = user_throttles.value
+    }
+  }
 }
-
-resource "huaweicloud_apig_throttling_policy" "test" {
-  instance_id       = huaweicloud_apig_instance.test.id
-  name              = "%[2]s"
-  type              = "API-based"
-  period            = 15000
-  period_unit       = "SECOND"
-  max_api_requests  = 100
-}
-`, testAccApigThrottlingPolicy_base(name), name)
+`, baseConfig, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There are some incorrect coding:
- Validation is not recommand.
- Time result is not format with timeout, now is the Zulu.
- The coverage percentage of the resource codes less than 80%.
- The two test cases can be merged into one.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the codes and imporve the UT coverage.
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccThrottlingPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccThrottlingPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccThrottlingPolicy_basic
=== PAUSE TestAccThrottlingPolicy_basic
=== CONT  TestAccThrottlingPolicy_basic
--- PASS: TestAccThrottlingPolicy_basic (728.26s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      728.302s
```
