### PR TITLE
feat(AS): Change `key_name` to `Optional` in AS configuration resource

### DIFF
--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -153,9 +153,6 @@ The `instance_config` block supports:
   data disks are optional. The [disk](#instance_config_disk_object) structure is documented below.
   Changing this will create a new resource.
 
-* `key_name` - (Required, String, ForceNew) Specifies the name of the SSH key pair used to log in to the instance.
-  Changing this will create a new resource.
-
 * `security_group_ids` - (Required, List, ForceNew) Specifies an array of one or more security group IDs.
   Changing this will create a new resource.
 
@@ -188,8 +185,25 @@ The `instance_config` block supports:
   <br/>If this parameter is not specified, the system automatically selects the DeH with the maximum available memory
   size from the DeHs that meet specifications requirements to create the ECSs, thereby balancing load of the DeHs.
 
-* `user_data` - (Optional, String, ForceNew) Specifies the user data to provide when launching the instance.
-  The file content must be encoded with Base64. Changing this will create a new resource.
+* `key_name` - (Optional, String, ForceNew) Specifies the name of the SSH key pair used to log in to the instance.
+  Changing this will create a new resource.
+
+* `user_data` - (Optional, String, ForceNew) Specifies the user data to be injected during the ECS creation process.
+  Changing this will create a new resource. For more information, see
+  [Passing User Data to ECSs](https://support.huaweicloud.com/intl/en-us/usermanual-ecs/en-us_topic_0032380449.html).
+
+  -> 1. The content to be injected must be encoded with base64. The maximum size of the content to be injected
+  (before encoding) is `32` KB.
+  <br/>2. If `key_name` is not specified, the data injected by `user_data` is the password of user `root` for logging in
+  to the ECS by default.
+  <br/>3. If both `key_name` and `user_data` are specified, `user_data` only injects user data.
+  <br/>4. This parameter is mandatory when you create a Linux ECS using the password authentication mode. Its value is
+  the initial user `root` password.
+  <br/>5. When the value of this field is used as a password, the recommended complexity for the password is as follows:
+  (1) The value ranges from `8` to `26` characters. (2) The value contains at least three of the following character
+  types: uppercase letters, lowercase letters, digits, and special characters `!@$%^-_=+[{}]:,./?`.
+
+~> Fields `key_name` and `user_data` cannot be empty together.
 
 * `public_ip` - (Optional, List, ForceNew) Specifies the EIP of the ECS instance.
   The [public_ip](#instance_config_public_ip_object) structure is documented below.
@@ -304,6 +318,9 @@ The `bandwidth` block supports:
 The `personality` block supports:
 
 * `path` - (Required, String, ForceNew) Specifies the path of the injected file. Changing this creates a new resource.
+  + For Linux OSs, specify the path, for example, **/etc/foo.txt**, for storing the injected file.
+  + For Windows, the injected file is automatically stored in the root directory of drive `C`. You only need to specify
+    the file name, for example, **foo**. The file name contains only letters and digits.
 
 * `content` - (Required, String, ForceNew) Specifies the content of the injected file, which must be encoded with base64.
   Changing this creates a new resource.

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_configuration_test.go
@@ -98,8 +98,7 @@ func TestAccASConfiguration_spot(t *testing.T) {
 						"data.huaweicloud_images_image.test", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_config.0.flavor",
 						"data.huaweicloud_compute_flavors.test", "ids.0"),
-					resource.TestCheckResourceAttrPair(resourceName, "instance_config.0.key_name",
-						"huaweicloud_kps_keypair.acc_key", "id"),
+					resource.TestCheckResourceAttr(resourceName, "instance_config.0.key_name", ""),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_config.0.security_group_ids.0",
 						"huaweicloud_networking_secgroup.test", "id"),
 					resource.TestCheckResourceAttr(resourceName, "instance_config.0.charging_mode", "spot"),
@@ -420,7 +419,6 @@ resource "huaweicloud_as_configuration" "acc_as_config"{
   instance_config {
     image                  = data.huaweicloud_images_image.test.id
     flavor                 = data.huaweicloud_compute_flavors.test.ids[0]
-    key_name               = huaweicloud_kps_keypair.acc_key.id
     security_group_ids     = [huaweicloud_networking_secgroup.test.id]
     charging_mode          = "spot"
     flavor_priority_policy = "COST_FIRST"
@@ -429,9 +427,11 @@ resource "huaweicloud_as_configuration" "acc_as_config"{
     metadata = {
       some_key = "some_value"
     }
+
+# The data injected by user_data is the password of user root for logging in to the ECS by default.
     user_data = <<EOT
-#!/bin/sh
-echo "Hello World! The time is now $(date -R)!" | tee /root/output.txt
+#! /bin/bash
+echo 'root:$6$V6azyeLwcD3CHlpY$BN3VVq18fmCkj66B4zdHLWevqcxlig' | chpasswd -e
 EOT
 
     disk {

--- a/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
@@ -75,7 +75,8 @@ func ResourceASConfiguration() *schema.Resource {
 						},
 						"key_name": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
+							Computed: true,
 							ForceNew: true,
 						},
 						"security_group_ids": {


### PR DESCRIPTION
…uration resource

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Change `key_name` from `Required` to `Optional` in AS configuration resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Change field `key_name` from `Required` to `Optional`.
- After the field `key_name` is changed to non-required, the impact on the field `user_data` is documented.
- Added test cases for scenarios that do not use `key_name`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_basic
=== PAUSE TestAccASConfiguration_basic
=== CONT  TestAccASConfiguration_basic
--- PASS: TestAccASConfiguration_basic (82.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        82.249s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_spot'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_spot -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_spot
=== PAUSE TestAccASConfiguration_spot
=== CONT  TestAccASConfiguration_spot
--- PASS: TestAccASConfiguration_spot (84.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        84.426s
```
