### PR TITLE
chore: test(apig/plugin): adjust the codes and imporve the UT coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240628074404-f04cd77ad44a
+	github.com/chnsz/golangsdk v0.0.0-20240702013005-681dacd9cbbd
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240628074404-f04cd77ad44a h1:3YjSSDC9ywWHhP+wC4c3ZEDIbqXElOjLV1onL2VTid4=
-github.com/chnsz/golangsdk v0.0.0-20240628074404-f04cd77ad44a/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240702013005-681dacd9cbbd h1:M0xvkrKizd+kc3ovx1WBnZQr8FS1V/ok9Hwybpvs8pc=
+github.com/chnsz/golangsdk v0.0.0-20240702013005-681dacd9cbbd/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -47,6 +47,8 @@ var (
 	HW_ENTERPRISE_PROJECT_ID  = os.Getenv("HW_ENTERPRISE_PROJECT_ID")
 	HW_ADMIN                  = os.Getenv("HW_ADMIN")
 
+	HW_APIG_DEDICATED_INSTANCE_ID = os.Getenv("HW_APIG_DEDICATED_INSTANCE_ID")
+
 	HW_CAE_ENVIRONMENT_ID     = os.Getenv("HW_CAE_ENVIRONMENT_ID")
 	HW_CAE_APPLICATION_ID     = os.Getenv("HW_CAE_APPLICATION_ID")
 	HW_CAE_CODE_URL           = os.Getenv("HW_CAE_CODE_URL")
@@ -572,6 +574,13 @@ func TestAccPreCheckMigrateEpsID(t *testing.T) {
 func TestAccPreCheckUserId(t *testing.T) {
 	if HW_USER_ID == "" {
 		t.Skip("The environment variables does not support the user ID (HW_USER_ID) for acc tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckApigSubResourcesRelatedInfo(t *testing.T) {
+	if HW_APIG_DEDICATED_INSTANCE_ID == "" {
+		t.Skip("Before running APIG acceptance tests, please ensure the env 'HW_APIG_DEDICATED_INSTANCE_ID' has been configured")
 	}
 }
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_plugin.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_plugin.go
@@ -3,13 +3,11 @@ package apig
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins"
 
@@ -49,14 +47,8 @@ func ResourcePlugin() *schema.Resource {
 				Description: "The ID of the dedicated instance to which the plugin belongs.",
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ValidateFunc: validation.All(
-					validation.StringMatch(regexp.MustCompile(`^[\x{4E00}-\x{9FFC}A-Za-z]([\x{4E00}-\x{9FFC}\w-]*)?$`),
-						"Only Chinese characters, English letters, digits hyphens (-) and underscores (_) are "+
-							"allowed, and must start with an English letter or Chinese character."),
-					validation.StringLenBetween(3, 255),
-				),
+				Type:        schema.TypeString,
+				Required:    true,
 				Description: "The plugin name.",
 			},
 			"type": {

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/plugins/results.go
@@ -30,9 +30,9 @@ type Plugin struct {
 	// The valid length is limited from `3` to `255` characters.
 	Description string `json:"remark"`
 	// The creation time.
-	CreatedAt string `json:"created_at"`
+	CreatedAt string `json:"create_time"`
 	// The latest update time.
-	UpdatedAt string `json:"updated_at"`
+	UpdatedAt string `json:"update_time"`
 }
 
 // BindResp is the structure that represents the API response of the plugin binding.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240628074404-f04cd77ad44a
+# github.com/chnsz/golangsdk v0.0.0-20240702013005-681dacd9cbbd
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There are some incorrect coding:
- Validation is not recommand.
- Time result is not standard RFC3339 format.
- The coverage percentage of the resource codes less than 80%.
- All the test cases can be merged into one.
- Using environment variable 'HW_APIG_DEDICATED_INSTANCE_ID' to reduce the test time.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. adjust the codes and imporve the UT coverage
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
./coverage_test.sh 
>>> Start to test
=== RUN   TestAccPlugin_basic
=== PAUSE TestAccPlugin_basic
=== CONT  TestAccPlugin_basic
--- PASS: TestAccPlugin_basic (1007.93s)
PASS
coverage: 5.2% of statements in ../../apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      1007.998
```
