### PR TITLE
test(dds): improve the UT coverage

### DIFF
--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_user_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_user_test.go
@@ -67,7 +67,7 @@ func TestAccDatabaseUser_basic(t *testing.T) {
 				Config: testAccDatabaseUser_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
 			{
@@ -140,8 +140,8 @@ resource "huaweicloud_dds_database_role" "test" {
 resource "huaweicloud_dds_database_user" "test" {
   instance_id = huaweicloud_dds_instance.test.id
 
-  name     = "%[2]s-update"
-  password = "HuaweiTest@12345678"
+  name     = "%[2]s"
+  password = "HuaweiTest@123"
   db_name  = "admin"
 
   roles {

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -1148,7 +1148,7 @@ resource "huaweicloud_dds_instance" "instance" {
   security_group_id = huaweicloud_networking_secgroup.test.id
   password          = "Terraform@1234"
   mode              = "ReplicaSet"
-  replica_set_name  = "replicaName"
+  replica_set_name  = "replicaNameUpdate"
   maintain_begin    = "02:00"
   maintain_end      = "03:00"
   description       = "test"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Improve the UT coverage for DDS.

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
./scripts/acc-test.sh 

run acceptance tests of huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_user_test.go:
=== RUN   TestAccDatabaseUser_basic
=== PAUSE TestAccDatabaseUser_basic
=== CONT  TestAccDatabaseUser_basic
--- PASS: TestAccDatabaseUser_basic (831.45s)
PASS
coverage: 18.1% of statements in ./huaweicloud/services/dds
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       831.500s        coverage: 18.1% of statements in ./huaweicloud/services/dds


### coverage of files in huaweicloud/services:

- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dds/resource_huaweicloud_dds_database_user.go (84.7%)


make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_withConfigurationReplicaSet"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_withConfigurationReplicaSet -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_withConfigurationReplicaSet
=== PAUSE TestAccDDSV3Instance_withConfigurationReplicaSet
=== CONT  TestAccDDSV3Instance_withConfigurationReplicaSet
--- PASS: TestAccDDSV3Instance_withConfigurationReplicaSet (3175.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       3175.590s
```
