### PR TITLE
test(iam): update precheck of iam tests

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -46,6 +46,7 @@ var (
 	HW_SECURITY_GROUP_ID      = os.Getenv("HW_SECURITY_GROUP_ID")
 	HW_ENTERPRISE_PROJECT_ID  = os.Getenv("HW_ENTERPRISE_PROJECT_ID")
 	HW_ADMIN                  = os.Getenv("HW_ADMIN")
+	HW_IAM_V5                 = os.Getenv("HW_IAM_V5")
 
 	HW_CAE_ENVIRONMENT_ID     = os.Getenv("HW_CAE_ENVIRONMENT_ID")
 	HW_CAE_APPLICATION_ID     = os.Getenv("HW_CAE_APPLICATION_ID")
@@ -703,6 +704,13 @@ func TestAccPreCheckOmsInstance(t *testing.T) {
 func TestAccPreCheckAdminOnly(t *testing.T) {
 	if HW_ADMIN == "" {
 		t.Skip("Skipping test because it requires the admin privileges")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckIAMV5(t *testing.T) {
+	if HW_IAM_V5 == "" {
+		t.Skip("This environment does not support IAM v5 tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_agency_test.go
@@ -36,6 +36,7 @@ func TestAccIdentityAgency_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPrecheckDomainName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_service_agency_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_service_agency_test.go
@@ -49,6 +49,7 @@ func TestAccIdentityServiceAgency_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPreCheckIAMV5(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_trust_agency_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_trust_agency_test.go
@@ -48,6 +48,7 @@ func TestAccIdentityTrustAgency_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPreCheckIAMV5(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
./coverage-test.sh 
>>> Start to test
=== RUN   TestAccIdentityAgenciesDataSource_basic
=== PAUSE TestAccIdentityAgenciesDataSource_basic
=== RUN   TestAccIdentityAgenciesDataSource_byName
=== PAUSE TestAccIdentityAgenciesDataSource_byName
=== RUN   TestAccIdentityAgenciesDataSource_byTrustDomainId
=== PAUSE TestAccIdentityAgenciesDataSource_byTrustDomainId
=== RUN   TestAccIdentityCustomRoleDataSource_basic
=== PAUSE TestAccIdentityCustomRoleDataSource_basic
=== RUN   TestAccIdentityGroupDataSource_basic
=== PAUSE TestAccIdentityGroupDataSource_basic
=== RUN   TestAccIdentityGroupDataSource_with_user
=== PAUSE TestAccIdentityGroupDataSource_with_user
=== RUN   TestAccIdentityPermissionsDataSource_basic
=== PAUSE TestAccIdentityPermissionsDataSource_basic
=== RUN   TestAccIdentityProjectsDataSource_basic
=== PAUSE TestAccIdentityProjectsDataSource_basic
=== RUN   TestAccIdentityProjectsDataSource_subProject
=== PAUSE TestAccIdentityProjectsDataSource_subProject
=== RUN   TestAccDataSourceIamIdentityProvider_basic
=== PAUSE TestAccDataSourceIamIdentityProvider_basic
=== RUN   TestAccIdentityRoleDataSource_basic
=== PAUSE TestAccIdentityRoleDataSource_basic
=== RUN   TestAccIdentityUsersDataSource_basic
=== PAUSE TestAccIdentityUsersDataSource_basic
=== RUN   TestAccDataSourceIamIdentityVirtualMfaDevices_basic
=== PAUSE TestAccDataSourceIamIdentityVirtualMfaDevices_basic
=== RUN   TestAccIdentityAccessKey_basic
=== PAUSE TestAccIdentityAccessKey_basic
=== RUN   TestAccIdentityAccessKey_secret
=== PAUSE TestAccIdentityAccessKey_secret
=== RUN   TestAccIdentitACL_basic
=== PAUSE TestAccIdentitACL_basic
=== RUN   TestAccIdentitACL_apiAccess
=== PAUSE TestAccIdentitACL_apiAccess
=== RUN   TestAccIdentityAgency_basic
=== PAUSE TestAccIdentityAgency_basic
=== RUN   TestAccIdentityGroupMembership_basic
=== PAUSE TestAccIdentityGroupMembership_basic
=== RUN   TestAccIdentityGroupRoleAssignment_basic
=== PAUSE TestAccIdentityGroupRoleAssignment_basic
=== RUN   TestAccIdentityGroupRoleAssignment_project
=== PAUSE TestAccIdentityGroupRoleAssignment_project
=== RUN   TestAccIdentityGroupRoleAssignment_allProjects
=== PAUSE TestAccIdentityGroupRoleAssignment_allProjects
=== RUN   TestAccIdentityGroupRoleAssignment_epsID
=== PAUSE TestAccIdentityGroupRoleAssignment_epsID
=== RUN   TestAccIdentityGroupRoleAssignment_old
=== PAUSE TestAccIdentityGroupRoleAssignment_old
=== RUN   TestAccIdentityGroup_basic
=== PAUSE TestAccIdentityGroup_basic
=== RUN   TestAccLoginPolicy_basic
=== PAUSE TestAccLoginPolicy_basic
=== RUN   TestAccPasswordPolicy_basic
=== PAUSE TestAccPasswordPolicy_basic
=== RUN   TestAccIdentityProject_basic
=== PAUSE TestAccIdentityProject_basic
=== RUN   TestAccProtectionPolicy_basic
=== PAUSE TestAccProtectionPolicy_basic
=== RUN   TestAccIdentityProviderConversion_basic
=== PAUSE TestAccIdentityProviderConversion_basic
=== RUN   TestAccIdentityProvider_basic
=== PAUSE TestAccIdentityProvider_basic
=== RUN   TestAccIdentityProvider_oidc
=== PAUSE TestAccIdentityProvider_oidc
=== RUN   TestAccIdentityRole_basic
=== PAUSE TestAccIdentityRole_basic
=== RUN   TestAccIdentityRole_agency
=== PAUSE TestAccIdentityRole_agency
=== RUN   TestAccIdentityServiceAgency_basic
=== PAUSE TestAccIdentityServiceAgency_basic
=== RUN   TestAccIdentityTrustAgency_basic
=== PAUSE TestAccIdentityTrustAgency_basic
=== RUN   TestAccIdentityUserRoleAssignment_basic
=== PAUSE TestAccIdentityUserRoleAssignment_basic
=== RUN   TestAccIdentityUser_basic
=== PAUSE TestAccIdentityUser_basic
=== RUN   TestAccIdentityUser_external
=== PAUSE TestAccIdentityUser_external
=== RUN   TestAccIdentityUserToken_basic
=== PAUSE TestAccIdentityUserToken_basic
=== RUN   TestAccIdentityVirtualMFADevice_basic
=== PAUSE TestAccIdentityVirtualMFADevice_basic
=== CONT  TestAccIdentityAgenciesDataSource_basic
=== CONT  TestAccIdentityGroupRoleAssignment_allProjects
--- PASS: TestAccIdentityAgenciesDataSource_basic (16.44s)
=== CONT  TestAccIdentityProvider_oidc
--- PASS: TestAccIdentityGroupRoleAssignment_allProjects (37.82s)
=== CONT  TestAccIdentityVirtualMFADevice_basic
--- PASS: TestAccIdentityProvider_oidc (30.80s)
=== CONT  TestAccIdentityUserToken_basic
--- PASS: TestAccIdentityVirtualMFADevice_basic (18.95s)
=== CONT  TestAccIdentityUser_external
--- PASS: TestAccIdentityUserToken_basic (26.22s)
=== CONT  TestAccIdentityUser_basic
--- PASS: TestAccIdentityUser_external (32.05s)
=== CONT  TestAccIdentityUserRoleAssignment_basic
--- PASS: TestAccIdentityUser_basic (45.11s)
=== CONT  TestAccIdentityTrustAgency_basic
    acceptance.go:713: This environment does not support IAM v5 tests
--- SKIP: TestAccIdentityTrustAgency_basic (0.01s)
=== CONT  TestAccIdentityServiceAgency_basic
    acceptance.go:713: This environment does not support IAM v5 tests
--- SKIP: TestAccIdentityServiceAgency_basic (0.01s)
=== CONT  TestAccIdentityRole_agency
--- PASS: TestAccIdentityUserRoleAssignment_basic (37.69s)
=== CONT  TestAccIdentityRole_basic
--- PASS: TestAccIdentityRole_agency (18.92s)
=== CONT  TestAccIdentityUsersDataSource_basic
--- PASS: TestAccIdentityUsersDataSource_basic (17.87s)
=== CONT  TestAccIdentityGroupRoleAssignment_project
    acceptance.go:1059: HW_PROJECT_ID must be set for acceptance tests
--- SKIP: TestAccIdentityGroupRoleAssignment_project (0.01s)
=== CONT  TestAccIdentityGroupRoleAssignment_basic
--- PASS: TestAccIdentityRole_basic (31.52s)
=== CONT  TestAccIdentityGroupMembership_basic
--- PASS: TestAccIdentityGroupRoleAssignment_basic (37.93s)
=== CONT  TestAccIdentityAgency_basic
--- PASS: TestAccIdentityGroupMembership_basic (92.96s)
=== CONT  TestAccIdentitACL_apiAccess
--- PASS: TestAccIdentitACL_apiAccess (27.41s)
=== CONT  TestAccIdentitACL_basic
--- PASS: TestAccIdentityAgency_basic (107.83s)
=== CONT  TestAccIdentityAccessKey_secret
--- PASS: TestAccIdentitACL_basic (27.41s)
=== CONT  TestAccIdentityAccessKey_basic
--- PASS: TestAccIdentityAccessKey_secret (26.72s)
=== CONT  TestAccDataSourceIamIdentityVirtualMfaDevices_basic
--- PASS: TestAccIdentityAccessKey_basic (48.32s)
=== CONT  TestAccIdentityProviderConversion_basic
--- PASS: TestAccDataSourceIamIdentityVirtualMfaDevices_basic (34.45s)
=== CONT  TestAccIdentityProvider_basic
--- PASS: TestAccIdentityProvider_basic (32.59s)
=== CONT  TestAccProtectionPolicy_basic
--- PASS: TestAccIdentityProviderConversion_basic (48.94s)
=== CONT  TestAccIdentityProject_basic
    acceptance.go:741: This environment does not support project tests
--- SKIP: TestAccIdentityProject_basic (0.01s)
=== CONT  TestAccIdentityGroup_basic
--- PASS: TestAccIdentityGroup_basic (31.44s)
=== CONT  TestAccLoginPolicy_basic
--- PASS: TestAccProtectionPolicy_basic (44.22s)
=== CONT  TestAccIdentityPermissionsDataSource_basic
--- PASS: TestAccLoginPolicy_basic (29.53s)
=== CONT  TestAccIdentityRoleDataSource_basic
--- PASS: TestAccIdentityRoleDataSource_basic (21.83s)
=== CONT  TestAccDataSourceIamIdentityProvider_basic
--- PASS: TestAccDataSourceIamIdentityProvider_basic (41.46s)
=== CONT  TestAccIdentityProjectsDataSource_subProject
--- PASS: TestAccIdentityProjectsDataSource_subProject (12.12s)
=== CONT  TestAccIdentityProjectsDataSource_basic
--- PASS: TestAccIdentityProjectsDataSource_basic (12.08s)
=== CONT  TestAccIdentityCustomRoleDataSource_basic
--- PASS: TestAccIdentityCustomRoleDataSource_basic (24.07s)
=== CONT  TestAccIdentityGroupDataSource_with_user
--- PASS: TestAccIdentityGroupDataSource_with_user (42.27s)
=== CONT  TestAccIdentityGroupDataSource_basic
--- PASS: TestAccIdentityGroupDataSource_basic (23.47s)
=== CONT  TestAccPasswordPolicy_basic
--- PASS: TestAccIdentityPermissionsDataSource_basic (216.76s)
=== CONT  TestAccIdentityAgenciesDataSource_byTrustDomainId
--- PASS: TestAccPasswordPolicy_basic (31.18s)
=== CONT  TestAccIdentityGroupRoleAssignment_epsID
--- PASS: TestAccIdentityAgenciesDataSource_byTrustDomainId (37.45s)
=== CONT  TestAccIdentityGroupRoleAssignment_old
--- PASS: TestAccIdentityGroupRoleAssignment_epsID (36.98s)
=== CONT  TestAccIdentityAgenciesDataSource_byName
--- PASS: TestAccIdentityGroupRoleAssignment_old (37.94s)
--- PASS: TestAccIdentityAgenciesDataSource_byName (39.61s)
PASS
```
