### PR TITLE
test(cc): optimize CC network instance test case to mitigate concurrency issues

### DIFF
--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_network_instance_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_network_instance_test.go
@@ -95,7 +95,7 @@ func TestAccNetworkInstance_multiple(t *testing.T) {
 	var obj interface{}
 
 	name := acceptance.RandomAccResourceName()
-	rName := "huaweicloud_cc_network_instance.test"
+	rName := "huaweicloud_cc_network_instance.test2"
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -111,24 +111,24 @@ func TestAccNetworkInstance_multiple(t *testing.T) {
 			{
 				Config: testNetworkInstance_multiple(name, 2),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckMultiResourcesExists(2),
-					resource.TestCheckResourceAttr("huaweicloud_cc_network_instance.test.0", "type", "vpc"),
-					resource.TestCheckResourceAttr("huaweicloud_cc_network_instance.test.1", "type", "vpc"),
-					resource.TestCheckResourceAttr("huaweicloud_cc_network_instance.test.0", "status", "ACTIVE"),
-					resource.TestCheckResourceAttr("huaweicloud_cc_network_instance.test.1", "status", "ACTIVE"),
-					resource.TestCheckResourceAttrSet("huaweicloud_cc_network_instance.test.0", "domain_id"),
-					resource.TestCheckResourceAttrSet("huaweicloud_cc_network_instance.test.1", "domain_id"),
-					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test.0", "instance_id",
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr("huaweicloud_cc_network_instance.test1", "type", "vpc"),
+					resource.TestCheckResourceAttr("huaweicloud_cc_network_instance.test2", "type", "vpc"),
+					resource.TestCheckResourceAttr("huaweicloud_cc_network_instance.test1", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("huaweicloud_cc_network_instance.test2", "status", "ACTIVE"),
+					resource.TestCheckResourceAttrSet("huaweicloud_cc_network_instance.test1", "domain_id"),
+					resource.TestCheckResourceAttrSet("huaweicloud_cc_network_instance.test2", "domain_id"),
+					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test1", "instance_id",
 						"huaweicloud_vpc.test.0", "id"),
-					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test.1", "instance_id",
+					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test2", "instance_id",
 						"huaweicloud_vpc.test.1", "id"),
-					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test.0", "region_id",
+					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test1", "region_id",
 						"huaweicloud_vpc.test.0", "region"),
-					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test.1", "region_id",
+					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test2", "region_id",
 						"huaweicloud_vpc.test.1", "region"),
-					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test.0", "cloud_connection_id",
+					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test1", "cloud_connection_id",
 						"huaweicloud_cc_connection.test", "id"),
-					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test.1", "cloud_connection_id",
+					resource.TestCheckResourceAttrPair("huaweicloud_cc_network_instance.test2", "cloud_connection_id",
 						"huaweicloud_cc_connection.test", "id"),
 				),
 			},
@@ -203,18 +203,32 @@ func testNetworkInstance_multiple(name string, count int) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_cc_network_instance" "test" {
-  count = %[2]d
-
+resource "huaweicloud_cc_network_instance" "test1" {
   type                = "vpc"
   cloud_connection_id = huaweicloud_cc_connection.test.id
-  instance_id         = huaweicloud_vpc.test[count.index].id
-  project_id          = "%[3]s"
-  region_id           = huaweicloud_vpc.test[count.index].region
-
+  instance_id         = huaweicloud_vpc.test[0].id
+  project_id          = "%[2]s"
+  region_id           = huaweicloud_vpc.test[0].region
+  
   cidrs = [
-    huaweicloud_vpc_subnet.test[count.index].cidr,
+    huaweicloud_vpc_subnet.test[0].cidr,
   ]
 }
-`, testNetworkInstanceRef(name, count), count, acceptance.HW_PROJECT_ID)
+  
+resource "huaweicloud_cc_network_instance" "test2" {
+  type                = "vpc"
+  cloud_connection_id = huaweicloud_cc_connection.test.id
+  instance_id         = huaweicloud_vpc.test[1].id
+  project_id          = "%[2]s"
+  region_id           = huaweicloud_vpc.test[1].region
+  
+  cidrs = [
+    huaweicloud_vpc_subnet.test[1].cidr,
+  ]
+
+  depends_on = [
+    huaweicloud_cc_network_instance.test1,
+  ]
+}
+`, testNetworkInstanceRef(name, count), acceptance.HW_PROJECT_ID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 optimize CFW network instance test case to mitigate concurrency issues
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  optimize CFW network instance test case to mitigate concurrency issues
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccNetworkInstance.*"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccNetworkInstance.* -timeout 360m -parallel 4
=== RUN   TestAccNetworkInstance_basic
=== PAUSE TestAccNetworkInstance_basic
=== RUN   TestAccNetworkInstance_multiple
=== PAUSE TestAccNetworkInstance_multiple
=== CONT  TestAccNetworkInstance_basic
=== CONT  TestAccNetworkInstance_multiple
--- PASS: TestAccNetworkInstance_multiple (139.99s)
--- PASS: TestAccNetworkInstance_basic (151.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        151.845s

```
