### PR TITLE
feat(vpn): enhance customer gateway resource with id_type, id_value, ca_certificate.id attributes and deprecate route_mode, ip attributes

### DIFF
--- a/docs/resources/vpn_customer_gateway.md
+++ b/docs/resources/vpn_customer_gateway.md
@@ -15,11 +15,11 @@ Manages a VPN customer gateway resource within HuaweiCloud.
 
 ```hcl
 variable "name" {}
-variable "ip" {}
+variable "id_value" {}
 
 resource "huaweicloud_vpn_customer_gateway" "test" {
-  name = var.name
-  ip   = var.ip
+  name     = var.name
+  id_value = var.id_value
 }
 ```
 
@@ -27,12 +27,12 @@ resource "huaweicloud_vpn_customer_gateway" "test" {
 
 ```hcl
 variable "name" {}
-variable "ip" {}
+variable "id_value" {}
 variable "certificate_content" {}
 
 resource "huaweicloud_vpn_customer_gateway" "test" {
   name                = var.name
-  ip                  = var.ip
+  id_value            = var.id_value
   certificate_content = var.certificate_content
 }
 ```
@@ -46,17 +46,19 @@ The following arguments are supported:
 
 * `name` - (Required, String) The customer gateway name.
 
-* `ip` - (Required, String, ForceNew) The IP address of the customer gateway.
+* `id_value` - (Required, String, ForceNew) Specifies the identifier of a customer gateway.
+  When `id_type` is set to **ip**, the value is an IPv4 address in dotted decimal notation, for example, 192.168.45.7.
+  When `id_type` is set to **fqdn**, the value is a string of characters that can contain uppercase letters, lowercase letters,
+  digits, and special characters. Spaces and the following special characters are not supported: & < > [ ] \ ?.
 
   Changing this parameter will create a new resource.
 
-* `route_mode` - (Optional, String, ForceNew) The route mode of the customer gateway. The value can be **static** and **bgp**.
-  Defaults to **bgp**.
+* `id_type` - (Optional, String, ForceNew) Specifies the identifier type of a customer gateway.
+  The value can be **ip** or **fqdn**. The default value is **ip**.
 
-  Changing this parameter will create a new resource.
-
-* `asn` - (Optional, Int, ForceNew) The BGP ASN number of the customer gateway, only works when the route_mode is
-  **bgp**. The value ranges from **1** to **4294967295**, the default value is **65000**.
+* `asn` - (Optional, Int, ForceNew) The BGP ASN number of the customer gateway.
+  The value ranges from **1** to **4294967295**, the default value is **65000**.
+  Set this parameter to **0** when `id_type` is set to **fqdn**.
 
   Changing this parameter will create a new resource.
 
@@ -69,6 +71,8 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
+* `certificate_id` - Indicates the ID of the customer gateway certificate.
 
 * `serial_number` - Indicates the serial number of the customer gateway certificate.
 
@@ -92,4 +96,20 @@ The customer gateway can be imported using the `id`, e.g.
 
 ```bash
 $ terraform import huaweicloud_vpn_customer_gateway.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attribute is `certificate_content`. It is generally recommended
+running `terraform plan` after importing the resource. You can then decide if changes should be applied to the instance,
+or the resource definition should be updated to align with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_vpn_customer_gateway" "test" {
+    ...
+  lifecycle {
+    ignore_changes = [
+      certificate_content,
+    ]
+  }
+}
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
enhance customer gateway resource with id_type, id_value, ca_certificate.id attributes and deprecate route_mode, ip attributes
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. enhance customer gateway resource with id_type, id_value, ca_certificate.id attributes and deprecate route_mode, ip attributes
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccCustomerGateway"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccCustomerGateway -timeout 360m -parallel 4
=== RUN   TestAccCustomerGateway_basic_withDeprecatedFields
=== PAUSE TestAccCustomerGateway_basic_withDeprecatedFields
=== RUN   TestAccCustomerGateway_certificate_withDeprecatedFields
=== PAUSE TestAccCustomerGateway_certificate_withDeprecatedFields
=== RUN   TestAccCustomerGateway_basic
=== PAUSE TestAccCustomerGateway_basic
=== RUN   TestAccCustomerGateway_certificate
=== PAUSE TestAccCustomerGateway_certificate
=== CONT  TestAccCustomerGateway_basic_withDeprecatedFields
=== CONT  TestAccCustomerGateway_basic
=== CONT  TestAccCustomerGateway_certificate
=== CONT  TestAccCustomerGateway_certificate_withDeprecatedFields
--- PASS: TestAccCustomerGateway_basic_withDeprecatedFields (48.21s)
--- PASS: TestAccCustomerGateway_basic (48.67s)
--- PASS: TestAccCustomerGateway_certificate_withDeprecatedFields (48.84s)
--- PASS: TestAccCustomerGateway_certificate (48.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       49.013s

```
