### PR TITLE
test(lts): improve the ut coverage and using env to reduce test time

### DIFF
--- a/docs/resources/lts_keywords_alarm_rule.md
+++ b/docs/resources/lts_keywords_alarm_rule.md
@@ -180,3 +180,21 @@ The keywords alarm rule can be imported using the `id`, e.g.
 ```bash
 $ terraform import huaweicloud_lts_keywords_alarm_rule.test ed8a4e02-b017-4c22-919d-8877b10cf505
 ```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `notification_rule`.
+It is generally recommended running `terraform plan` after importing a certificate.
+You can then decide if changes should be applied to the certificate, or the resource definition should be updated to
+align with the certificate. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_lts_keywords_alarm_rule" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      notification_rule,
+    ]
+  }
+}
+```

--- a/docs/resources/lts_sql_alarm_rule.md
+++ b/docs/resources/lts_sql_alarm_rule.md
@@ -181,3 +181,21 @@ The sql alarm rule can be imported using the `id`, e.g.
 ```bash
 $ terraform import huaweicloud_lts_sql_alarm_rule.test ed8a4e02-b017-4c22-919d-8877b10cf505
 ```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `notification_rule`.
+It is generally recommended running `terraform plan` after importing a certificate.
+You can then decide if changes should be applied to the certificate, or the resource definition should be updated to
+align with the certificate. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_lts_sql_alarm_rule" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      notification_rule,
+    ]
+  }
+}
+```

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -4,6 +4,7 @@ package acceptance
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -360,9 +361,9 @@ var (
 	HW_LTS_AGENCY_PROJECT_ID  = os.Getenv("HW_LTS_AGENCY_PROJECT_ID")
 	HW_LTS_AGENCY_DOMAIN_NAME = os.Getenv("HW_LTS_AGENCY_DOMAIN_NAME")
 	HW_LTS_AGENCY_NAME        = os.Getenv("HW_LTS_AGENCY_NAME")
-
-	HW_LTS_CCE_HOST_GROUP_ID = os.Getenv("HW_LTS_CCE_HOST_GROUP_ID")
-	HW_LTS_CCE_CLUSTER_ID    = os.Getenv("HW_LTS_CCE_CLUSTER_ID")
+	// The ID list of the LTS hosts. Using commas (,) to separate multiple IDs (At least two UUIDs we need).
+	HW_LTS_HOST_IDS       = os.Getenv("HW_LTS_HOST_IDS")
+	HW_LTS_CCE_CLUSTER_ID = os.Getenv("HW_LTS_CCE_CLUSTER_ID")
 
 	HW_LTS_LOG_CONVERGE_ORGANIZATION_ID       = os.Getenv("HW_LTS_LOG_CONVERGE_ORGANIZATION_ID")
 	HW_LTS_LOG_CONVERGE_MANAGEMENT_ACCOUNT_ID = os.Getenv("HW_LTS_LOG_CONVERGE_MANAGEMENT_ACCOUNT_ID")
@@ -1474,10 +1475,17 @@ func TestAccPreCheckLTSCrossAccountAccess(t *testing.T) {
 
 // lintignore:AT003
 func TestAccPreCheckLTSCCEAccess(t *testing.T) {
-	if HW_LTS_LOG_STREAM_ID == "" || HW_LTS_LOG_GROUP_ID == "" ||
-		HW_LTS_CCE_CLUSTER_ID == "" || HW_LTS_CCE_HOST_GROUP_ID == "" {
-		t.Skip("The cce access config of HW_LTS_LOG_STREAM_ID, HW_LTS_LOG_GROUP_ID, HW_LTS_CCE_CLUSTER_ID" +
-			" and HW_LTS_CCE_HOST_GROUP_ID must be set for the acceptance test")
+	if HW_LTS_CCE_CLUSTER_ID == "" {
+		t.Skip("The cce access config of HW_LTS_CCE_CLUSTER_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckLTSHostGroup(t *testing.T) {
+	// LTS host groups support updating associated hosts, so at least one host is required to create and update each host group.
+	hostIds := strings.Split(HW_LTS_HOST_IDS, ",")
+	if len(hostIds) < 2 {
+		t.Skip("The length of HW_LTS_HOST_IDS must be at least 2 for the host group acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_aom_accesses_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_aom_accesses_test.go
@@ -125,7 +125,7 @@ locals {
 output "is_log_stream_name_filter_useful" {
   value = length(local.log_stream_name_filter_result) > 0 && alltrue(local.log_stream_name_filter_result)
 }
-`, testAOMAccess_allWorkloads(name))
+`, testAOMAccess_basic_step1(name))
 }
 
 func testDataSourceDataSourceAOMAccesses_logGroupNotExist() string {

--- a/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_host_groups_test.go
+++ b/huaweicloud/services/acceptance/lts/data_source_huaweicloud_lts_host_groups_test.go
@@ -35,6 +35,7 @@ func TestAccDataSourceHostGroups_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckLTSHostGroup(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
@@ -72,22 +73,18 @@ func TestAccDataSourceHostGroups_basic(t *testing.T) {
 
 func testDataSourceHostGroups_base(name string) string {
 	return fmt.Sprintf(`
-%s
-
 resource "huaweicloud_lts_host_group" "test" {
-  depends_on = [null_resource.test]
-
   name = "%s"
   type = "linux"
 
-  host_ids = huaweicloud_compute_instance.test[*].id
+  host_ids = split(",", "%s")
 
   tags = {
     foo = "bar"
     key = "value"
   }
 }
-`, testHostGroup_base(name), name)
+`, name, acceptance.HW_LTS_HOST_IDS)
 }
 
 func testDataSourceHostGroups_basic(name string) string {
@@ -121,10 +118,14 @@ output "is_id_filter_useful" {
 
 # Filter by name
 locals {
-  group_name = data.huaweicloud_lts_host_groups.test.groups[0].name
+  group_name = huaweicloud_lts_host_group.test.name
 }
 
 data "huaweicloud_lts_host_groups" "filter_by_name" {
+  depends_on = [
+    huaweicloud_lts_host_group.test
+  ]
+
   name = local.group_name
 }
 
@@ -144,6 +145,10 @@ locals {
 }
 
 data "huaweicloud_lts_host_groups" "filter_by_not_found_name" {
+  depends_on = [
+    huaweicloud_lts_host_group.test
+  ]
+
   name = local.not_found_name
 }
 
@@ -159,10 +164,14 @@ output "is_name_not_found_filter_useful" {
 
 # Filter by type
 locals {
-  group_type = data.huaweicloud_lts_host_groups.test.groups[0].type
+  group_type = huaweicloud_lts_host_group.test.type
 }
 
 data "huaweicloud_lts_host_groups" "filter_by_type" {
+  depends_on = [
+    huaweicloud_lts_host_group.test
+  ]
+
   type = local.group_type
 }
 
@@ -182,6 +191,10 @@ locals {
 }
 
 data "huaweicloud_lts_host_groups" "filter_by_tags" {
+  depends_on = [
+    huaweicloud_lts_host_group.test
+  ]
+
   tags = local.tags
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Using environment variable `HW_LTS_HOST_ID`, `HW_LTS_HOST_ANOTHER_ID` and `HW_LTS_CCE_CLUSTER_ID` to reduce the test time.
2. Adding ignored fields to documents.
3. Adjust some acceptance test scripts to improve the ut coverage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. improve the UT coverage and using env to reduce test time.
```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/150208787/7125f66f-fae7-46dc-80f5-763f197bd6a7)

```
=== RUN   TestAccDataSourceAOMAccesses_basic
=== PAUSE TestAccDataSourceAOMAccesses_basic
=== RUN   TestAccDatasourceCceAccesses_basic
=== PAUSE TestAccDatasourceCceAccesses_basic
=== RUN   TestAccDataSourceGroups_basic
=== PAUSE TestAccDataSourceGroups_basic
=== RUN   TestAccDataSourceHostGroups_basic
=== PAUSE TestAccDataSourceHostGroups_basic
=== RUN   TestAccDataSourceNotificationTemplates_basic
=== PAUSE TestAccDataSourceNotificationTemplates_basic
=== RUN   TestAccDataSourcSearchCriteria_basic
=== PAUSE TestAccDataSourcSearchCriteria_basic
=== RUN   TestAccDataSourceStreams_basic
=== PAUSE TestAccDataSourceStreams_basic
=== RUN   TestAccDatasourceCustomTemplates_basic
=== PAUSE TestAccDatasourceCustomTemplates_basic
=== RUN   TestAccDatasourceTransfers_basic
=== PAUSE TestAccDatasourceTransfers_basic
=== RUN   TestAccessRule_basic
=== PAUSE TestAccessRule_basic
=== RUN   TestAccAOMAccess_basic
=== PAUSE TestAccAOMAccess_basic
=== RUN   TestAccAOMAccess_withCCICluster
=== PAUSE TestAccAOMAccess_withCCICluster
=== RUN   TestAccCceAccessConfig_containerFile
=== PAUSE TestAccCceAccessConfig_containerFile
=== RUN   TestAccCceAccessConfig_containerStdout
=== PAUSE TestAccCceAccessConfig_containerStdout
=== RUN   TestAccCceAccessConfig_hostFile
=== PAUSE TestAccCceAccessConfig_hostFile
=== RUN   TestAccCrossAccountAccess_basic
=== PAUSE TestAccCrossAccountAccess_basic
=== RUN   TestAccDashboard_basic
=== PAUSE TestAccDashboard_basic
=== RUN   TestAccLtsElbComp_basic
=== PAUSE TestAccLtsElbComp_basic
=== RUN   TestAccLtsGroup_basic
=== PAUSE TestAccLtsGroup_basic
=== RUN   TestAccHostAccessConfig_basic
=== PAUSE TestAccHostAccessConfig_basic
=== RUN   TestAccHostAccessConfig_windows
=== PAUSE TestAccHostAccessConfig_windows
=== RUN   TestAccHostGroup_basic
=== PAUSE TestAccHostGroup_basic
=== RUN   TestAccKeywordsAlarmRule_basic
=== PAUSE TestAccKeywordsAlarmRule_basic
=== RUN   TestAccLogConvergeSwitch_basic
=== PAUSE TestAccLogConvergeSwitch_basic
=== RUN   TestAccLogConverge_basic
=== PAUSE TestAccLogConverge_basic
=== RUN   TestAccNotificationTemplate_basic
=== PAUSE TestAccNotificationTemplate_basic
=== RUN   TestAccSearchCriteria_basic
=== PAUSE TestAccSearchCriteria_basic
=== RUN   TestAccSQLAlarmRule_basic
=== PAUSE TestAccSQLAlarmRule_basic
=== RUN   TestAccLtsStream_basic
=== PAUSE TestAccLtsStream_basic
=== RUN   TestAccLtsStream_epsId
=== PAUSE TestAccLtsStream_epsId
=== RUN   TestAccLtsStructTemplate_basic
=== PAUSE TestAccLtsStructTemplate_basic
=== RUN   TestAccStructConfig_basic
=== PAUSE TestAccStructConfig_basic
=== RUN   TestAccStructConfig_customTemplate
=== PAUSE TestAccStructConfig_customTemplate
=== RUN   TestAccStructCustomConfig_basic
=== PAUSE TestAccStructCustomConfig_basic
=== RUN   TestAccLtsTransfer_basic
=== PAUSE TestAccLtsTransfer_basic
=== RUN   TestAccLtsTransfer_dis
=== PAUSE TestAccLtsTransfer_dis
=== RUN   TestAccLtsTransfer_agency
=== PAUSE TestAccLtsTransfer_agency
=== RUN   TestAccWAFAccess_basic
=== PAUSE TestAccWAFAccess_basic
=== RUN   TestAccWAFAccess_withEpsId
=== PAUSE TestAccWAFAccess_withEpsId
=== CONT  TestAccDataSourceAOMAccesses_basic
=== CONT  TestAccHostAccessConfig_windows
=== CONT  TestAccLtsStructTemplate_basic
=== CONT  TestAccAOMAccess_basic
=== CONT  TestAccHostAccessConfig_basic
=== CONT  TestAccLtsStream_epsId
--- PASS: TestAccLtsStream_epsId (66.38s)
=== CONT  TestAccLtsGroup_basic
--- PASS: TestAccLtsStructTemplate_basic (101.21s)
=== CONT  TestAccLtsElbComp_basic
--- PASS: TestAccHostAccessConfig_windows (116.45s)
=== CONT  TestAccDashboard_basic
=== CONT  TestAccLtsElbComp_basic
    resource_huaweicloud_lts_elb_log_test.go:48: Step 1/2 error: Error running apply: exit status 1

        Error: error creating LogTank fields f93f9fe0-de75-49c7-8eaf-a490b7ed202f: Resource not found: [POST https://elb.cn-north-4.myhuaweicloud.com/v3/0970dd7a1300f5672ff2c003c60ae115/elb/logtanks], request_id: 3ed56627194831f5b0f2f57e4eaf1c87, error message: {"error_msg":"loadbalancer d2b7a742-fb38-49f2-b2d8-473a97a18434 could not be found.","error_code":"ELB.8904","request_id":"3ed56627194831f5b0f2f57e4eaf1c87"}

          with huaweicloud_elb_log.elb_1,
          on terraform_plugin_test.tf line 2, in resource "huaweicloud_elb_log" "elb_1":
           2: resource "huaweicloud_elb_log" "elb_1" {

--- FAIL: TestAccLtsElbComp_basic (18.26s)
=== CONT  TestAccCrossAccountAccess_basic
    acceptance.go:1448: The delegator account config of HW_LTS_AGENCY_STREAM_NAME, HW_LTS_AGENCY_STREAM_ID, HW_LTS_AGENCY_GROUP_NAME, HW_LTS_AGENCY_GROUP_ID, HW_LTS_AGENCY_PROJECT_ID, HW_LTS_AGENCY_DOMAIN_NAME and HW_LTS_AGENCY_NAME must be set for the acceptance test
--- SKIP: TestAccCrossAccountAccess_basic (0.01s)
=== CONT  TestAccCceAccessConfig_hostFile
=== CONT  TestAccDashboard_basic
    resource_huaweicloud_lts_dashboard_test.go:52: Step 1/2 error: Error running apply: exit status 1

        Error: error creating LtsDashBoard fields 9ac33c09-7f00-4eed-b9a0-0ffaad7a64d1: Bad request with: [POST https://lts.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/lts/template-dashboard], request_id: f5a76e157c2ad8ca6704c0c62cb5461e, error message: {"message":{"code":"LTS.0603","details":"group or stream not exist"}}

          with huaweicloud_lts_dashboard.dashboard_1,
          on terraform_plugin_test.tf line 2, in resource "huaweicloud_lts_dashboard" "dashboard_1":
           2: resource "huaweicloud_lts_dashboard" "dashboard_1" {

--- FAIL: TestAccDashboard_basic (17.53s)
=== CONT  TestAccCceAccessConfig_containerStdout
--- PASS: TestAccHostAccessConfig_basic (191.39s)
=== CONT  TestAccCceAccessConfig_containerFile
--- PASS: TestAccDataSourceAOMAccesses_basic (207.59s)
=== CONT  TestAccAOMAccess_withCCICluster
--- PASS: TestAccLtsGroup_basic (147.78s)
=== CONT  TestAccLtsTransfer_dis
--- PASS: TestAccAOMAccess_basic (239.68s)
=== CONT  TestAccWAFAccess_withEpsId
--- PASS: TestAccCceAccessConfig_hostFile (188.36s)
=== CONT  TestAccWAFAccess_basic
--- PASS: TestAccCceAccessConfig_containerStdout (194.21s)
=== CONT  TestAccLtsTransfer_agency
=== CONT  TestAccWAFAccess_withEpsId
    resource_huaweicloud_lts_waf_access_test.go:132: Step 1/2 error: Error running apply: exit status 1

        Error: error creating WAF dedicated : Action forbidden: [POST https://waf.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/premium-waf/instance?enterprise_project_id=0], request_id: d004d3239d97f3264f28b0a3bc03f979, error message: {"error_code":"WAF.00012006","error_msg":"User: iam::0970d7b7d400f2470fbec00316a03560:user:tf-user13 is not authorized to perform: waf:premiumInstance:create on resource: waf:cn-north-4:0970d7b7d400f2
        ...

          with huaweicloud_waf_dedicated_instance.test,
          on terraform_plugin_test.tf line 60, in resource "huaweicloud_waf_dedicated_instance" "test":
          60: resource "huaweicloud_waf_dedicated_instance" "test" {

--- PASS: TestAccCceAccessConfig_containerFile (189.58s)
=== CONT  TestAccNotificationTemplate_basic
--- PASS: TestAccAOMAccess_withCCICluster (183.93s)
=== CONT  TestAccLtsStream_basic
--- FAIL: TestAccWAFAccess_withEpsId (156.06s)
=== CONT  TestAccSQLAlarmRule_basic
--- PASS: TestAccLtsTransfer_dis (204.52s)
=== CONT  TestAccSearchCriteria_basic
=== CONT  TestAccWAFAccess_basic
    resource_huaweicloud_lts_waf_access_test.go:71: Step 1/4 error: Error running apply: exit status 1

        Error: error creating WAF dedicated : Action forbidden: [POST https://waf.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/premium-waf/instance], request_id: c753cd06f4ac4e63ab737a3802de87a9, error message: {"error_code":"WAF.00012006","error_msg":"User: iam::0970d7b7d400f2470fbec00316a03560:user:tf-user13 is not authorized to perform: waf:premiumInstance:create on resource: waf:cn-north-4:0970d7b7d400f2
        ...

          with huaweicloud_waf_dedicated_instance.test,
          on terraform_plugin_test.tf line 75, in resource "huaweicloud_waf_dedicated_instance" "test":
          75: resource "huaweicloud_waf_dedicated_instance" "test" {

--- PASS: TestAccNotificationTemplate_basic (102.91s)
=== CONT  TestAccLogConvergeSwitch_basic
--- FAIL: TestAccWAFAccess_basic (180.03s)
=== CONT  TestAccLogConverge_basic
    acceptance.go:1479: The cce access config of HW_LTS_LOG_CONVERGE_ORGANIZATION_ID, HW_LTS_LOG_CONVERGE_MANAGEMENT_ACCOUNT_ID, HW_LTS_LOG_CONVERGE_MEMBER_ACCOUNT_ID must be set for the log converge configuration acceptance test
--- SKIP: TestAccLogConverge_basic (0.06s)
=== CONT  TestAccKeywordsAlarmRule_basic
=== CONT  TestAccLogConvergeSwitch_basic
    resource_huaweicloud_lts_log_converge_switch_test.go:31: Step 1/1 error: Error running apply: exit status 1

        Error: failed to enable log receiving status (target: true): Bad request with: [PUT https://lts.cn-north-4.myhuaweicloud.com/v1/0970dd7a1300f5672ff2c003c60ae115/lts/log-converge-config/switch?log_converge_switch=true], request_id: f6d331005d69c5a00ed5cb14b6a16b96, error message: {"error_code":"LTS.2503","error_msg":"The LTS service is not trusted."}

          with huaweicloud_lts_log_converge_switch.test,
          on terraform_plugin_test.tf line 2, in resource "huaweicloud_lts_log_converge_switch" "test":
           2: resource "huaweicloud_lts_log_converge_switch" "test" {}

--- FAIL: TestAccLogConvergeSwitch_basic (20.94s)
=== CONT  TestAccHostGroup_basic
--- PASS: TestAccLtsStream_basic (127.95s)
=== CONT  TestAccDataSourcSearchCriteria_basic
--- PASS: TestAccSearchCriteria_basic (108.81s)
=== CONT  TestAccessRule_basic
    resource_huaweicloud_lts_access_rule_test.go:50: Step 1/2 error: Error running apply: exit status 1

        Error: error creating AomMappingRule cui-rule-1: Bad request with: [POST https://lts.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/lts/aom-mapping?isBatch=false], request_id: e8762eccd1bb76a2d437eb160853e259, error message: {"message":{"code":"LTS.0742","details":"AOM mapping rule log group id does not exsit"}}

          with huaweicloud_lts_access_rule.accessrule_1,
          on terraform_plugin_test.tf line 2, in resource "huaweicloud_lts_access_rule" "accessrule_1":
           2: resource "huaweicloud_lts_access_rule" "accessrule_1" {

--- FAIL: TestAccessRule_basic (23.65s)
=== CONT  TestAccDatasourceTransfers_basic
--- PASS: TestAccDataSourcSearchCriteria_basic (133.78s)
=== CONT  TestAccDatasourceCustomTemplates_basic
--- PASS: TestAccHostGroup_basic (171.68s)
=== CONT  TestAccDataSourceStreams_basic
--- PASS: TestAccSQLAlarmRule_basic (324.90s)
=== CONT  TestAccDataSourceHostGroups_basic
--- PASS: TestAccLtsTransfer_agency (399.98s)
=== CONT  TestAccDataSourceNotificationTemplates_basic
--- PASS: TestAccDatasourceTransfers_basic (189.57s)
=== CONT  TestAccDataSourceGroups_basic
--- PASS: TestAccDatasourceCustomTemplates_basic (135.87s)
=== CONT  TestAccStructCustomConfig_basic
--- PASS: TestAccDataSourceNotificationTemplates_basic (71.43s)
=== CONT  TestAccLtsTransfer_basic
--- PASS: TestAccDataSourceGroups_basic (83.93s)
=== CONT  TestAccStructConfig_customTemplate
--- PASS: TestAccKeywordsAlarmRule_basic (339.51s)
=== CONT  TestAccStructConfig_basic
--- PASS: TestAccDataSourceHostGroups_basic (160.35s)
=== CONT  TestAccDatasourceCceAccesses_basic
--- PASS: TestAccDataSourceStreams_basic (243.60s)
--- PASS: TestAccStructConfig_customTemplate (158.91s)
--- PASS: TestAccStructConfig_basic (161.57s)
--- PASS: TestAccLtsTransfer_basic (199.60s)
--- PASS: TestAccDatasourceCceAccesses_basic (152.21s)
--- PASS: TestAccStructCustomConfig_basic (268.51s)

```
