### PR TITLE
test(RDS): fix rds test

### DIFF
--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_error_log_link_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_error_log_link_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccRdsErrorLogLink_basic(t *testing.T) {
+func TestAccDataSourceRdsErrorLogLink_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	dataSource := "data.huaweicloud_rds_error_log_link.test"
 	dc := acceptance.InitDataSourceCheck(dataSource)
@@ -35,6 +35,30 @@ func TestAccRdsErrorLogLink_basic(t *testing.T) {
 	})
 }
 
+func testRdsErrorLogLink_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.n1.large.2"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+`, testAccRdsInstance_base(name), name)
+}
+
 func testRdsErrorLogLink_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -42,5 +66,5 @@ func testRdsErrorLogLink_basic(name string) string {
 data "huaweicloud_rds_error_log_link" "test" {
   instance_id = huaweicloud_rds_instance.test.id
 }
-`, testAccRdsInstance_basic(name))
+`, testRdsErrorLogLink_base(name))
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_binlog_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_mysql_binlog_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -13,8 +12,6 @@ import (
 func TestAccMysqlBinlogDataSource_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_mysql_binlog.test"
-	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),
-		acctest.RandStringFromCharSet(2, "!#%^*"), acctest.RandIntRange(10, 99))
 	dc := acceptance.InitDataSourceCheck(rName)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -22,7 +19,7 @@ func TestAccMysqlBinlogDataSource_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMysqlBinlogDataSource_basic(name, dbPwd),
+				Config: testAccMysqlBinlogDataSource_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(rName, "binlog_retention_hours"),
@@ -34,7 +31,7 @@ func TestAccMysqlBinlogDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccMysqlBinlogDataSource_basic(name string, dbPwd string) string {
+func testAccMysqlBinlogDataSource_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -43,5 +40,5 @@ data "huaweicloud_rds_mysql_binlog" "test" {
   instance_id = huaweicloud_rds_mysql_binlog.test.instance_id
 }
 
-`, testMysqlBinlog_basic(name, dbPwd))
+`, testMysqlBinlog_basic(name))
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_accounts_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_accounts_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourcePgAccounts_basic(t *testing.T) {
+func TestAccDataSourceRdsPgAccounts_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_pg_accounts.test"
 	dc := acceptance.InitDataSourceCheck(rName)
@@ -40,6 +40,38 @@ func TestAccDatasourcePgAccounts_basic(t *testing.T) {
 	})
 }
 
+func testAccDatasourcePgAccounts_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.n1.large.2"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+
+resource "huaweicloud_rds_pg_account" "test" {
+  instance_id = huaweicloud_rds_instance.test.id
+  name        = "%[2]s"
+  password    = "Test@12345678"
+  description = "test_description"
+}
+`, testAccRdsInstance_base(name), name)
+}
+
 func testAccDatasourcePgAccounts_basic(name string) string {
 	return fmt.Sprintf(`
 %s
@@ -66,5 +98,5 @@ output "user_name_filter_is_useful" {
   )
 }
 
-`, testPgAccount_basic(name), name)
+`, testAccDatasourcePgAccounts_base(name), name)
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_databases_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_databases_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourcePgDatabases_basic(t *testing.T) {
+func TestAccDataSourceRdsPgDatabases_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_pg_databases.test"
 	dc := acceptance.InitDataSourceCheck(rName)
@@ -38,6 +38,42 @@ func TestAccDatasourcePgDatabases_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccDatasourcePgDatabases_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.n1.large.2"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+
+resource "huaweicloud_rds_pg_database" "test" {
+  instance_id   = huaweicloud_rds_instance.test.id
+  name          = "%[2]s"
+  owner         = "root"
+  character_set = "UTF8"
+  template      = "template1"
+  lc_collate    = "en_US.UTF-8"
+  lc_ctype      = "en_US.UTF-8"
+}
+`, testAccRdsInstance_base(name), name)
 }
 
 func testAccDatasourcePgDatabases_basic(name string) string {
@@ -129,5 +165,5 @@ output "size_filter_is_useful" {
   )
 }
 
-`, testPgDatabase_basic(name))
+`, testAccDatasourcePgDatabases_base(name))
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_plugin_parameter_value_range_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_plugin_parameter_value_range_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourcePgPluginParameterValueRange_basic(t *testing.T) {
+func TestAccDataSourceRdsPgPluginParameterValueRange_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_pg_plugin_parameter_value_range.test"
 	dc := acceptance.InitDataSourceCheck(rName)
@@ -31,6 +31,30 @@ func TestAccDatasourcePgPluginParameterValueRange_basic(t *testing.T) {
 	})
 }
 
+func testAccDatasourcePgPluginParameterValueRange_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.n1.large.2"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+`, testAccRdsInstance_base(name), name)
+}
+
 func testAccDatasourcePgPluginParameterValueRange_basic(name string) string {
 	return fmt.Sprintf(`
 %s
@@ -39,5 +63,5 @@ data "huaweicloud_rds_pg_plugin_parameter_value_range" "test" {
   instance_id = huaweicloud_rds_instance.test.id
   name        = "shared_preload_libraries"
 }
-`, testAccRdsInstance_basic(name))
+`, testAccDatasourcePgPluginParameterValueRange_base(name))
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_plugin_parameter_values_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_plugin_parameter_values_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourcePgPluginParameterValues_basic(t *testing.T) {
+func TestAccDataSourceRdsPgPluginParameterValues_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_pg_plugin_parameter_values.test"
 	dc := acceptance.InitDataSourceCheck(rName)

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_plugins_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_plugins_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourcePgPlugins_basic(t *testing.T) {
+func TestAccDataSourceRdsPgPlugins_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_pg_plugins.test"
 	dc := acceptance.InitDataSourceCheck(rName)
@@ -36,6 +36,42 @@ func TestAccDatasourcePgPlugins_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccDatasourcePgPlugins_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.n1.large.2"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+
+resource "huaweicloud_rds_pg_database" "test" {
+  instance_id   = huaweicloud_rds_instance.test.id
+  name          = "%[2]s"
+  owner         = "root"
+  character_set = "UTF8"
+  template      = "template1"
+  lc_collate    = "en_US.UTF-8"
+  lc_ctype      = "en_US.UTF-8"
+}
+`, testAccRdsInstance_base(name), name)
 }
 
 func testAccDatasourcePgPlugins_basic(name string) string {
@@ -90,5 +126,5 @@ output "created_filter_is_useful" {
     [for v in data.huaweicloud_rds_pg_plugins.created_filter.plugins[*].created : v == local.created]
   )  
 }
-`, testPgDatabase_basic(name))
+`, testAccDatasourcePgPlugins_base(name))
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_roles_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_pg_roles_test.go
@@ -34,6 +34,32 @@ func TestAccDataSourceRdsPgRoles_basic(t *testing.T) {
 	})
 }
 
+func testDataSourceDataSourceRdsPgRoles_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name               = "%[2]s"
+  flavor             = "rds.pg.n1.large.2"
+  availability_zone  = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id  = huaweicloud_networking_secgroup.test.id
+  subnet_id          = data.huaweicloud_vpc_subnet.test.id
+  vpc_id             = data.huaweicloud_vpc.test.id
+  time_zone          = "UTC+08:00"
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+`, testAccRdsInstance_base(name), name)
+}
+
 func testDataSourceDataSourceRdsPgRoles_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -50,5 +76,5 @@ data "huaweicloud_rds_pg_roles" "test" {
   instance_id = huaweicloud_rds_instance.test.id
   account     = "root"
 }
-`, testAccRdsInstance_basic(name), name)
+`, testDataSourceDataSourceRdsPgRoles_base(name), name)
 }

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_restore_time_ranges_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_restore_time_ranges_test.go
@@ -16,6 +16,7 @@ func TestAccDataSourceRdsRestoreTimeRanges_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRdsInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sqlserver_accounts_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sqlserver_accounts_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccSQLServerAccounts_basic(t *testing.T) {
+func TestAccDatasourceSQLServerAccounts_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_sqlserver_accounts.test"
 	dbPwd := fmt.Sprintf("%s%s%d", acctest.RandString(5),

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sqlserver_database_privileges_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sqlserver_database_privileges_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccSQLServerDatabasePrivileges_basic(t *testing.T) {
+func TestAccDatasourceSQLServerDatabasePrivileges_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_sqlserver_database_privileges.test"
 

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sqlserver_databases_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_sqlserver_databases_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccSQLServerDatabases_basic(t *testing.T) {
+func TestAccDatasourceSQLServerDatabases_basic(t *testing.T) {
 	name := acceptance.RandomAccResourceName()
 	rName := "data.huaweicloud_rds_sqlserver_databases.test"
 	dc := acceptance.InitDataSourceCheck(rName)

--- a/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_storage_types_test.go
+++ b/huaweicloud/services/acceptance/rds/data_source_huaweicloud_rds_storage_types_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccDatasourceStoragetype_basic(t *testing.T) {
+func TestAccDatasourceStorageType_basic(t *testing.T) {
 	rName := "data.huaweicloud_rds_storage_types.test"
 	dc := acceptance.InitDataSourceCheck(rName)
 

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_extend_log_link_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_extend_log_link_test.go
@@ -74,7 +74,6 @@ func TestAccRdsExtendLogLink_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckRdsInstanceId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      nil,

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_privilege_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_privilege_test.go
@@ -75,7 +75,7 @@ func buildGetMysqlDatabasePrivilegeQueryParams(dbName string) string {
 	return fmt.Sprintf("?db-name=%s&page=1&limit=100", dbName)
 }
 
-func TestAccRdsDatabasePrivilege_basic(t *testing.T) {
+func TestAccMysqlDatabasePrivilege_basic(t *testing.T) {
 	var obj interface{}
 
 	name := acceptance.RandomAccResourceName()

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_table_restore_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_mysql_database_table_restore_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccRdsInstanceMysqlDatabaseTableRestore_basic(t *testing.T) {
+func TestAccMysqlDatabaseTableRestore_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
@@ -25,7 +25,7 @@ func TestAccRdsInstanceMysqlDatabaseTableRestore_basic(t *testing.T) {
 	})
 }
 
-func TestAccRdsInstanceMysqlDatabaseTableRestore_table(t *testing.T) {
+func TestAccMysqlDatabaseTableRestore_table(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_account_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_account_test.go
@@ -129,6 +129,33 @@ func TestAccPgAccount_basic(t *testing.T) {
 	})
 }
 
+func testPgAccount_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  description       = "test_description"
+  flavor            = "rds.pg.n1.large.2"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+`, testAccRdsInstance_base(name), name)
+}
+
 func testPgAccount_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -147,7 +174,7 @@ resource "huaweicloud_rds_pg_account" "test" {
   description = "test_description"
   memberof    = [huaweicloud_rds_pg_account.member.name]
 }
-`, testAccRdsInstance_basic(name), name)
+`, testPgAccount_base(name), name)
 }
 
 func testPgAccount_update(name string) string {
@@ -174,5 +201,5 @@ resource "huaweicloud_rds_pg_account" "test" {
   description = "test_description_update"
   memberof    = [huaweicloud_rds_pg_account.member_update.name]
 }
-`, testAccRdsInstance_basic(name), name)
+`, testPgAccount_base(name), name)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_database_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_database_test.go
@@ -124,6 +124,33 @@ func TestAccPgDatabase_basic(t *testing.T) {
 	})
 }
 
+func testPgDatabase_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  description       = "test_description"
+  flavor            = "rds.pg.n1.large.2"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+`, testAccRdsInstance_base(name), name)
+}
+
 func testPgDatabase_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -139,7 +166,7 @@ resource "huaweicloud_rds_pg_database" "test" {
   is_revoke_public_privilege = false
   description                = "test_description"
 }
-`, testAccRdsInstance_basic(name), name)
+`, testPgDatabase_base(name), name)
 }
 
 func testPgDatabase_update(name string) string {
@@ -165,5 +192,5 @@ resource "huaweicloud_rds_pg_database" "test" {
   is_revoke_public_privilege = false
   description                = ""
 }
-`, testAccRdsInstance_basic(name), name)
+`, testPgDatabase_base(name), name)
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_hba_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_hba_test.go
@@ -146,6 +146,30 @@ func TestAccPgHba_basic(t *testing.T) {
 	})
 }
 
+func testPgHba_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = "rds.pg.n1.large.2"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+`, testAccRdsInstance_base(name), name)
+}
+
 func testPgHba_basic(name string) string {
 	return fmt.Sprintf(`
 %s
@@ -169,7 +193,7 @@ resource "huaweicloud_rds_pg_hba" "test" {
     method   = "scram-sha-256"
   }
 }
-`, testAccRdsInstance_basic(name))
+`, testPgHba_base(name))
 }
 
 func testPgHba_basic_update(name string) string {
@@ -204,5 +228,5 @@ resource "huaweicloud_rds_pg_hba" "test" {
     method   = "reject"
   }
 }
-`, testAccRdsInstance_basic(name))
+`, testPgHba_base(name))
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_plugin_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_pg_plugin_test.go
@@ -90,6 +90,33 @@ func TestAccPgPlugin_basic(t *testing.T) {
 	})
 }
 
+func testPgPlugin_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  description       = "test_description"
+  flavor            = "rds.pg.n1.large.2"
+  availability_zone = [data.huaweicloud_availability_zones.test.names[0]]
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    type    = "PostgreSQL"
+    version = "12"
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 50
+  }
+}
+`, testAccRdsInstance_base(name), name)
+}
+
 func testPgPlugin_basic(randName string) string {
 	return fmt.Sprintf(`
 %s
@@ -99,5 +126,5 @@ resource "huaweicloud_rds_pg_plugin" "test" {
   name          = "pgl_ddl_deploy"
   database_name = "postgres"
 }
-`, testAccRdsInstance_basic(randName))
+`, testPgPlugin_base(randName))
 }

--- a/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
+++ b/huaweicloud/services/acceptance/rds/resource_huaweicloud_rds_read_replica_instance_test.go
@@ -36,7 +36,9 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 						"data.huaweicloud_rds_flavors.replica", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "type", "Replica"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
-						"huaweicloud_networking_secgroup.test", "id"),
+						"huaweicloud_networking_secgroup.test_secgroup.0", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "enterprise_project_id",
+						"huaweicloud_enterprise_project.test.0", "id"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8888"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
@@ -63,7 +65,9 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 						"data.huaweicloud_rds_flavors.replica", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "type", "Replica"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
-						"huaweicloud_networking_secgroup.test", "id"),
+						"huaweicloud_networking_secgroup.test_secgroup.1", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "enterprise_project_id",
+						"huaweicloud_enterprise_project.test.1", "id"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "db.0.port", "8889"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.type", "CLOUDSSD"),
@@ -90,43 +94,73 @@ func TestAccReadReplicaInstance_basic(t *testing.T) {
 	})
 }
 
-func TestAccReadReplicaInstance_withEpsId(t *testing.T) {
+func TestAccReadReplicaInstance_prePaid(t *testing.T) {
 	var replica instances.RdsInstanceResponse
 	name := acceptance.RandomAccResourceName()
 	resourceType := "huaweicloud_rds_read_replica_instance"
 	resourceName := "huaweicloud_rds_read_replica_instance.test"
-	srcEPS := acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
-	destEPS := acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckMigrateEpsID(t)
-		},
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckRdsInstanceDestroy(resourceType),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccReadReplicaInstance_withEpsId(name, srcEPS),
+				Config: testAccReadReplicaInstance_prePaid(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &replica),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", srcEPS),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "true"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "50"),
 				),
 			},
 			{
-				Config: testAccReadReplicaInstance_withEpsId(name, destEPS),
+				Config: testAccReadReplicaInstance_prePaid_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceExists(resourceName, &replica),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", destEPS),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
 				),
 			},
 		},
 	})
 }
 
+func testAccReadReplicaInstance_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_rds_flavors" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+  group_type    = "dedicated"
+  vcpus         = 4
+}
+
+resource "huaweicloud_rds_instance" "test" {
+  name              = "%[2]s"
+  flavor            = data.huaweicloud_rds_flavors.test.flavors[0].name
+  security_group_id = huaweicloud_networking_secgroup.test.id
+  subnet_id         = data.huaweicloud_vpc_subnet.test.id
+  vpc_id            = data.huaweicloud_vpc.test.id
+  availability_zone = slice(sort(data.huaweicloud_rds_flavors.test.flavors[0].availability_zones), 0, 1)
+
+  db {
+    type    = "MySQL"
+    version = "8.0"
+  }
+
+  volume {
+    type = "CLOUDSSD"
+    size = 40
+  }
+}
+`, testAccRdsInstance_base(name), name)
+}
+
 func testAccReadReplicaInstance_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_rds_flavors" "replica" {
   db_type       = "MySQL"
@@ -137,16 +171,31 @@ data "huaweicloud_rds_flavors" "replica" {
   vcpus         = 2
 }
 
+resource "huaweicloud_networking_secgroup" "test_secgroup" {
+  count = 2
+
+  name                 = "%[2]s_${count.index}"
+  delete_default_rules = true
+}
+
+resource "huaweicloud_enterprise_project" "test" {
+  count = 2
+
+  name        = "%[2]s_${count.index}"
+  description = "terraform test"
+}
+
 resource "huaweicloud_rds_read_replica_instance" "test" {
-  name                = "%s"
-  description         = "test_description"
-  flavor              = data.huaweicloud_rds_flavors.replica.flavors[0].name
-  primary_instance_id = huaweicloud_rds_instance.test.id
-  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
-  security_group_id   = huaweicloud_networking_secgroup.test.id
-  ssl_enable          = true
-  maintain_begin      = "06:00"
-  maintain_end        = "09:00"
+  name                  = "%[2]s"
+  description           = "test_description"
+  flavor                = data.huaweicloud_rds_flavors.replica.flavors[0].name
+  primary_instance_id   = huaweicloud_rds_instance.test.id
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  security_group_id     = huaweicloud_networking_secgroup.test_secgroup[0].id
+  ssl_enable            = true
+  maintain_begin        = "06:00"
+  maintain_end          = "09:00"
+  enterprise_project_id = huaweicloud_enterprise_project.test[0].id
 
   db {
     port = 8888
@@ -169,12 +218,12 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
     foo = "bar"
   }
 }
-`, testAccRdsInstance_mysql_step1(name), name)
+`, testAccReadReplicaInstance_base(name), name)
 }
 
 func testAccReadReplicaInstance_update(name, updateName string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_rds_flavors" "replica" {
   db_type       = "MySQL"
@@ -185,16 +234,31 @@ data "huaweicloud_rds_flavors" "replica" {
   vcpus         = 2
 }
 
+resource "huaweicloud_networking_secgroup" "test_secgroup" {
+  count = 2
+
+  name                 = "%[2]s_${count.index}"
+  delete_default_rules = true
+}
+
+resource "huaweicloud_enterprise_project" "test" {
+  count = 2
+
+  name        = "%[2]s_${count.index}"
+  description = "terraform test"
+}
+
 resource "huaweicloud_rds_read_replica_instance" "test" {
-  name                = "%s"
-  description         = "test_description_update"
-  flavor              = data.huaweicloud_rds_flavors.replica.flavors[0].name
-  primary_instance_id = huaweicloud_rds_instance.test.id
-  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
-  security_group_id   = huaweicloud_networking_secgroup.test.id
-  ssl_enable          = false
-  maintain_begin      = "15:00"
-  maintain_end        = "17:00"
+  name                  = "%[2]s"
+  description           = "test_description_update"
+  flavor                = data.huaweicloud_rds_flavors.replica.flavors[0].name
+  primary_instance_id   = huaweicloud_rds_instance.test.id
+  availability_zone     = data.huaweicloud_availability_zones.test.names[0]
+  security_group_id     = huaweicloud_networking_secgroup.test_secgroup[1].id
+  ssl_enable            = false
+  maintain_begin        = "15:00"
+  maintain_end          = "17:00"
+  enterprise_project_id = huaweicloud_enterprise_project.test[1].id
 
   db {
     port = 8889
@@ -217,12 +281,12 @@ resource "huaweicloud_rds_read_replica_instance" "test" {
     foo_update = "bar_update"
   }
 }
-`, testAccRdsInstance_mysql_step1(name), updateName)
+`, testAccReadReplicaInstance_base(name), updateName)
 }
 
-func testAccReadReplicaInstance_withEpsId(name, epsId string) string {
+func testAccReadReplicaInstance_prePaid(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_rds_flavors" "replica" {
   db_type       = "MySQL"
@@ -234,18 +298,69 @@ data "huaweicloud_rds_flavors" "replica" {
 }
 
 resource "huaweicloud_rds_read_replica_instance" "test" {
-  name                  = "%s"
+  name                  = "%[2]s"
+  description           = "test_description"
   flavor                = data.huaweicloud_rds_flavors.replica.flavors[0].name
   primary_instance_id   = huaweicloud_rds_instance.test.id
   availability_zone     = data.huaweicloud_availability_zones.test.names[0]
-  enterprise_project_id = "%s"
+  security_group_id     = huaweicloud_networking_secgroup.test.id
+  ssl_enable            = true
+  maintain_begin        = "06:00"
+  maintain_end          = "09:00"
+
+  db {
+    port = 8888
+  }
 
   volume {
-    type              = "CLOUDSSD"
-    size              = 40
-    limit_size        = 300
-    trigger_threshold = 10
+    type       = "CLOUDSSD"
+    size       = 50
+    limit_size = 0
   }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = true
 }
-`, testAccRdsInstance_mysql_step1(name), name, epsId)
+`, testAccReadReplicaInstance_base(name), name)
+}
+
+func testAccReadReplicaInstance_prePaid_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_rds_flavors" "replica" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "replica"
+  group_type    = "dedicated"
+  memory        = 4
+  vcpus         = 2
+}
+
+resource "huaweicloud_rds_read_replica_instance" "test" {
+  name                = "%[2]s"
+  description         = "test_description_update"
+  flavor              = data.huaweicloud_rds_flavors.replica.flavors[0].name
+  primary_instance_id = huaweicloud_rds_instance.test.id
+  availability_zone   = data.huaweicloud_availability_zones.test.names[0]
+  security_group_id   = huaweicloud_networking_secgroup.test.id
+
+  db {
+    port = 8889
+  }
+
+  volume {
+    type       = "CLOUDSSD"
+    size       = 60
+    limit_size = 0
+  }
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = false
+}
+`, testAccReadReplicaInstance_base(name), name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix rds test
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix rds test
```

## PR Checklist

* [ ] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsErrorLogLink_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsErrorLogLink_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsErrorLogLink_basic
=== PAUSE TestAccDataSourceRdsErrorLogLink_basic
=== CONT  TestAccDataSourceRdsErrorLogLink_basic
--- PASS: TestAccDataSourceRdsErrorLogLink_basic (725.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       725.431s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlBinlogDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlBinlogDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlBinlogDataSource_basic
=== PAUSE TestAccMysqlBinlogDataSource_basic
=== CONT  TestAccMysqlBinlogDataSource_basic
--- PASS: TestAccMysqlBinlogDataSource_basic (743.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       743.161s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsPgAccounts_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsPgAccounts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsPgAccounts_basic
=== PAUSE TestAccDataSourceRdsPgAccounts_basic
=== CONT  TestAccDataSourceRdsPgAccounts_basic
--- PASS: TestAccDataSourceRdsPgAccounts_basic (631.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       631.851s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsPgDatabases_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsPgDatabases_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsPgDatabases_basic
=== PAUSE TestAccDataSourceRdsPgDatabases_basic
=== CONT  TestAccDataSourceRdsPgDatabases_basic
--- PASS: TestAccDataSourceRdsPgDatabases_basic (681.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       681.851s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsPgPluginParameterValueRange_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsPgPluginParameterValueRange_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsPgPluginParameterValueRange_basic
=== PAUSE TestAccDataSourceRdsPgPluginParameterValueRange_basic
=== CONT  TestAccDataSourceRdsPgPluginParameterValueRange_basic
--- PASS: TestAccDataSourceRdsPgPluginParameterValueRange_basic (638.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       638.819s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsPgPluginParameterValues_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsPgPluginParameterValues_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsPgPluginParameterValues_basic
=== PAUSE TestAccDataSourceRdsPgPluginParameterValues_basic
=== CONT  TestAccDataSourceRdsPgPluginParameterValues_basic
--- PASS: TestAccDataSourceRdsPgPluginParameterValues_basic (731.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       731.905s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsPgPlugins_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsPgPlugins_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsPgPlugins_basic
=== PAUSE TestAccDataSourceRdsPgPlugins_basic
=== CONT  TestAccDataSourceRdsPgPlugins_basic
--- PASS: TestAccDataSourceRdsPgPlugins_basic (636.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       636.060s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDataSourceRdsPgRoles_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDataSourceRdsPgRoles_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceRdsPgRoles_basic
=== PAUSE TestAccDataSourceRdsPgRoles_basic
=== CONT  TestAccDataSourceRdsPgRoles_basic
--- PASS: TestAccDataSourceRdsPgRoles_basic (616.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       616.488s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDatasourceSQLServerAccounts_basic'        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDatasourceSQLServerAccounts_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceSQLServerAccounts_basic
=== PAUSE TestAccDatasourceSQLServerAccounts_basic
=== CONT  TestAccDatasourceSQLServerAccounts_basic
--- PASS: TestAccDatasourceSQLServerAccounts_basic (1471.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1471.973s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDatasourceSQLServerDatabasePrivileges_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDatasourceSQLServerDatabasePrivileges_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceSQLServerDatabasePrivileges_basic
=== PAUSE TestAccDatasourceSQLServerDatabasePrivileges_basic
=== CONT  TestAccDatasourceSQLServerDatabasePrivileges_basic
--- PASS: TestAccDatasourceSQLServerDatabasePrivileges_basic (1789.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1789.663s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDatasourceSQLServerDatabases_basic'       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDatasourceSQLServerDatabases_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceSQLServerDatabases_basic
=== PAUSE TestAccDatasourceSQLServerDatabases_basic
=== CONT  TestAccDatasourceSQLServerDatabases_basic
--- PASS: TestAccDatasourceSQLServerDatabases_basic (1515.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1515.125s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccDatasourceStorageType_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccDatasourceStorageType_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceStorageType_basic
=== PAUSE TestAccDatasourceStorageType_basic
=== CONT  TestAccDatasourceStorageType_basic
--- PASS: TestAccDatasourceStorageType_basic (13.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       13.152s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsExtendLogLink_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsExtendLogLink_basic -timeout 360m -parallel 4
=== RUN   TestAccRdsExtendLogLink_basic
=== PAUSE TestAccRdsExtendLogLink_basic
=== CONT  TestAccRdsExtendLogLink_basic
--- PASS: TestAccRdsExtendLogLink_basic (1521.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       1521.807s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccRdsInstance_' TEST_PARALLELISM=10
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccRdsInstance_ -timeout 360m -parallel 10
=== RUN   TestAccRdsInstance_basic
=== PAUSE TestAccRdsInstance_basic
=== RUN   TestAccRdsInstance_ha
=== PAUSE TestAccRdsInstance_ha
=== RUN   TestAccRdsInstance_mysql
=== PAUSE TestAccRdsInstance_mysql
=== RUN   TestAccRdsInstance_mysql_power_action
=== PAUSE TestAccRdsInstance_mysql_power_action
=== RUN   TestAccRdsInstance_sqlserver
=== PAUSE TestAccRdsInstance_sqlserver
=== RUN   TestAccRdsInstance_sqlserver_msdtc_hosts
=== PAUSE TestAccRdsInstance_sqlserver_msdtc_hosts
=== RUN   TestAccRdsInstance_mariadb
=== PAUSE TestAccRdsInstance_mariadb
=== RUN   TestAccRdsInstance_prePaid
=== PAUSE TestAccRdsInstance_prePaid
=== RUN   TestAccRdsInstance_restore_mysql
=== PAUSE TestAccRdsInstance_restore_mysql
=== RUN   TestAccRdsInstance_restore_sqlserver
=== PAUSE TestAccRdsInstance_restore_sqlserver
=== RUN   TestAccRdsInstance_restore_pg
=== PAUSE TestAccRdsInstance_restore_pg
=== CONT  TestAccRdsInstance_basic
=== CONT  TestAccRdsInstance_mariadb
=== CONT  TestAccRdsInstance_mysql
=== CONT  TestAccRdsInstance_mysql_power_action
=== CONT  TestAccRdsInstance_sqlserver
=== CONT  TestAccRdsInstance_restore_mysql
=== CONT  TestAccRdsInstance_sqlserver_msdtc_hosts
=== CONT  TestAccRdsInstance_ha
=== CONT  TestAccRdsInstance_restore_sqlserver
=== CONT  TestAccRdsInstance_restore_pg
--- PASS: TestAccRdsInstance_mariadb (677.08s)
=== CONT  TestAccRdsInstance_prePaid
--- PASS: TestAccRdsInstance_ha (738.13s)
--- PASS: TestAccRdsInstance_basic (941.28s)
--- PASS: TestAccRdsInstance_mysql_power_action (1110.73s)
--- PASS: TestAccRdsInstance_restore_pg (1477.31s)
--- PASS: TestAccRdsInstance_sqlserver_msdtc_hosts (1537.30s)
--- PASS: TestAccRdsInstance_restore_mysql (1673.68s)
--- PASS: TestAccRdsInstance_mysql (1926.58s)
--- PASS: TestAccRdsInstance_sqlserver (2768.43s)
--- PASS: TestAccRdsInstance_restore_sqlserver (2865.08s)
--- PASS: TestAccRdsInstance_prePaid (2194.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2871.988s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlBinlog_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlBinlog_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlBinlog_basic
--- PASS: TestAccMysqlBinlog_basic (756.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       757.022s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccMysqlDatabasePrivilege_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccMysqlDatabasePrivilege_basic -timeout 360m -parallel 4
=== RUN   TestAccMysqlDatabasePrivilege_basic
=== PAUSE TestAccMysqlDatabasePrivilege_basic
=== CONT  TestAccMysqlDatabasePrivilege_basic
--- PASS: TestAccMysqlDatabasePrivilege_basic (843.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       843.915s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgAccount_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgAccount_basic -timeout 360m -parallel 4
=== RUN   TestAccPgAccount_basic
=== PAUSE TestAccPgAccount_basic
=== CONT  TestAccPgAccount_basic
--- PASS: TestAccPgAccount_basic (732.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       732.877s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgDatabase_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgDatabase_basic -timeout 360m -parallel 4
=== RUN   TestAccPgDatabase_basic
=== PAUSE TestAccPgDatabase_basic
=== CONT  TestAccPgDatabase_basic
--- PASS: TestAccPgDatabase_basic (671.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       671.066s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgHba_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgHba_basic -timeout 360m -parallel 4
=== RUN   TestAccPgHba_basic
=== PAUSE TestAccPgHba_basic
=== CONT  TestAccPgHba_basic
--- PASS: TestAccPgHba_basic (697.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       697.931s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccPgPlugin_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccPgPlugin_basic -timeout 360m -parallel 4
=== RUN   TestAccPgPlugin_basic
=== PAUSE TestAccPgPlugin_basic
=== CONT  TestAccPgPlugin_basic
--- PASS: TestAccPgPlugin_basic (777.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       777.092s

make testacc TEST=./huaweicloud/services/acceptance/rds/ TESTARGS='-run TestAccReadReplicaInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/rds/ -v -run TestAccReadReplicaInstance_ -timeout 360m -parallel 4
=== RUN   TestAccReadReplicaInstance_basic
=== PAUSE TestAccReadReplicaInstance_basic
=== RUN   TestAccReadReplicaInstance_prePaid
=== PAUSE TestAccReadReplicaInstance_prePaid
=== CONT  TestAccReadReplicaInstance_basic
=== CONT  TestAccReadReplicaInstance_prePaid
--- PASS: TestAccReadReplicaInstance_prePaid (1995.15s)
--- PASS: TestAccReadReplicaInstance_basic (2294.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/rds       2294.114s
```
