### PR TITLE
test(iam): improve iam tests

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -47,6 +47,7 @@ var (
 	HW_ENTERPRISE_PROJECT_ID  = os.Getenv("HW_ENTERPRISE_PROJECT_ID")
 	HW_ADMIN                  = os.Getenv("HW_ADMIN")
 	HW_IAM_V5                 = os.Getenv("HW_IAM_V5")
+	HW_RUNNER_PUBLIC_IP       = os.Getenv("HW_RUNNER_PUBLIC_IP")
 
 	HW_APIG_DEDICATED_INSTANCE_ID             = os.Getenv("HW_APIG_DEDICATED_INSTANCE_ID")
 	HW_APIG_DEDICATED_INSTANCE_USED_SUBNET_ID = os.Getenv("HW_APIG_DEDICATED_INSTANCE_USED_SUBNET_ID")
@@ -728,6 +729,13 @@ func TestAccPreCheckAdminOnly(t *testing.T) {
 func TestAccPreCheckIAMV5(t *testing.T) {
 	if HW_IAM_V5 == "" {
 		t.Skip("This environment does not support IAM v5 tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckRunnerPublicIP(t *testing.T) {
+	if HW_RUNNER_PUBLIC_IP == "" {
+		t.Skip("HW_RUNNER_PUBLIC_IP must be set for this acceptance test.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_acl_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_acl_test.go
@@ -54,10 +54,13 @@ func TestAccIdentitACL_basic(t *testing.T) {
 		getIdentitACLResourceFunc,
 	)
 
+	// the runner public IP must by set
+	// otherwise, when the ACL is applied, you can't access your account
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPreCheckRunnerPublicIP(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -77,7 +80,6 @@ func TestAccIdentitACL_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "type", "console"),
 					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ip_cidrs.#", "2"),
 				),
 			},
 		},
@@ -94,10 +96,13 @@ func TestAccIdentitACL_apiAccess(t *testing.T) {
 		getIdentitACLResourceFunc,
 	)
 
+	// the runner public IP must by set
+	// otherwise, when the ACL is applied, you can't access your account
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckAdminOnly(t)
+			acceptance.TestAccPreCheckRunnerPublicIP(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -117,7 +122,6 @@ func TestAccIdentitACL_apiAccess(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "type", "api"),
 					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ip_cidrs.#", "2"),
 				),
 			},
 		},
@@ -131,15 +135,15 @@ resource "huaweicloud_identity_acl" "test" {
 
   ip_ranges {
     range       = "172.16.0.0-172.16.255.255"
-    description = "This is a basic ip range 1 for %[1]s access"
+    description = "This is a basic ip range for %[1]s access"
   }
 
   ip_cidrs {
-    cidr        = "159.138.32.195/32"
-    description = "This is a basic ip address 1 for %[1]s access"
+    cidr        = "%[2]s/32"
+    description = "This is a basic ip address for %[1]s access"
   }
 }
-`, aclType)
+`, aclType, acceptance.HW_CODEARTS_PUBLIC_IP_ADDRESS)
 }
 
 func testAccIdentityACL_update(aclType string) string {
@@ -157,13 +161,9 @@ resource "huaweicloud_identity_acl" "test" {
   }
 
   ip_cidrs {
-    cidr        = "159.138.32.195/32"
-    description = "This is a update ip address 1 for %[1]s access"
-  }
-  ip_cidrs {
-    cidr        = "159.138.32.196/32"
-    description = "This is a update ip address 2 for %[1]s access"
+    cidr        = "%[2]s/32"
+    description = "This is a update ip address for %[1]s access"
   }
 }
-`, aclType)
+`, aclType, acceptance.HW_CODEARTS_PUBLIC_IP_ADDRESS)
 }

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_test.go
@@ -50,7 +50,7 @@ func TestAccIdentityUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "tested by terraform"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "pwd_reset", "true"),
-					resource.TestCheckResourceAttr(resourceName, "email", "user_1@abc.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", userName+"@abc.com"),
 					resource.TestCheckResourceAttr(resourceName, "password_strength", "Strong"),
 					resource.TestCheckResourceAttr(resourceName, "login_protect_verification_method", "email"),
 				),
@@ -71,7 +71,7 @@ func TestAccIdentityUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "updated by terraform"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "pwd_reset", "false"),
-					resource.TestCheckResourceAttr(resourceName, "email", "user_1@abcd.com"),
+					resource.TestCheckResourceAttr(resourceName, "email", userName+"@abcd.com"),
 					resource.TestCheckResourceAttr(resourceName, "login_protect_verification_method", ""),
 				),
 			},
@@ -91,8 +91,8 @@ func TestAccIdentityUser_external(t *testing.T) {
 	var user users.User
 	userName := acceptance.RandomAccResourceName()
 	password := acceptance.RandomPassword()
-	initXUserID := "123456789-abcdefg"
-	newXUserID := "abcdefg-123456789"
+	initXUserID := userName + "-abcdefg"
+	newXUserID := userName + "-123456789"
 	resourceName := "huaweicloud_identity_user.user_1"
 
 	rc := acceptance.InitResourceCheck(
@@ -143,10 +143,10 @@ func TestAccIdentityUser_external(t *testing.T) {
 func testAccIdentityUser_basic(name, password string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_user" "user_1" {
-  name        = "%s"
-  password    = "%s"
+  name        = "%[1]s"
+  password    = "%[2]s"
   enabled     = true
-  email       = "user_1@abc.com"
+  email       = "%[1]s@abc.com"
   description = "tested by terraform"
   
   login_protect_verification_method = "email"
@@ -157,11 +157,11 @@ resource "huaweicloud_identity_user" "user_1" {
 func testAccIdentityUser_update(name, password string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_user" "user_1" {
-  name        = "%s"
-  password    = "%s"
+  name        = "%[1]s"
+  password    = "%[2]s"
   pwd_reset   = false
   enabled     = false
-  email       = "user_1@abcd.com"
+  email       = "%[1]s@abcd.com"
   description = "updated by terraform"
 }
 `, name, password)
@@ -170,11 +170,11 @@ resource "huaweicloud_identity_user" "user_1" {
 func testAccIdentityUser_no_desc(name, password string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_user" "user_1" {
-  name      = "%s"
-  password  = "%s"
+  name      = "%[1]s"
+  password  = "%[2]s"
   pwd_reset = false
   enabled   = false
-  email     = "user_1@abcd.com"
+  email     = "%[1]s@abcd.com"
 }
 `, name, password)
 }
@@ -182,10 +182,10 @@ resource "huaweicloud_identity_user" "user_1" {
 func testAccIdentityUser_external(name, password, xUserID string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_user" "user_1" {
-  name                 = "%s"
-  password             = "%s"
+  name                 = "%[1]s"
+  password             = "%[2]s"
   description          = "IAM user with external identity id"
-  external_identity_id = "%s"
+  external_identity_id = "%[3]s"
 }
 `, name, password, xUserID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
./coverage_test.sh
>>> Start to test
=== RUN   TestAccIdentityAgenciesDataSource_basic
=== PAUSE TestAccIdentityAgenciesDataSource_basic
=== RUN   TestAccIdentityAgenciesDataSource_byName
=== PAUSE TestAccIdentityAgenciesDataSource_byName
=== RUN   TestAccIdentityAgenciesDataSource_byTrustDomainId
=== PAUSE TestAccIdentityAgenciesDataSource_byTrustDomainId
=== RUN   TestAccIdentityCustomRoleDataSource_basic
=== PAUSE TestAccIdentityCustomRoleDataSource_basic
=== RUN   TestAccIdentityGroupDataSource_basic
=== PAUSE TestAccIdentityGroupDataSource_basic
=== RUN   TestAccIdentityGroupDataSource_with_user
=== PAUSE TestAccIdentityGroupDataSource_with_user
=== RUN   TestAccIdentityPermissionsDataSource_basic
=== PAUSE TestAccIdentityPermissionsDataSource_basic
=== RUN   TestAccIdentityProjectsDataSource_basic
=== PAUSE TestAccIdentityProjectsDataSource_basic
=== RUN   TestAccIdentityProjectsDataSource_subProject
=== PAUSE TestAccIdentityProjectsDataSource_subProject
=== RUN   TestAccDataSourceIamIdentityProvider_basic
=== PAUSE TestAccDataSourceIamIdentityProvider_basic
=== RUN   TestAccIdentityRoleDataSource_basic
=== PAUSE TestAccIdentityRoleDataSource_basic
=== RUN   TestAccIdentityUsersDataSource_basic
=== PAUSE TestAccIdentityUsersDataSource_basic
=== RUN   TestAccDataSourceIamIdentityVirtualMfaDevices_basic
=== PAUSE TestAccDataSourceIamIdentityVirtualMfaDevices_basic
=== RUN   TestAccIdentityAccessKey_basic
=== PAUSE TestAccIdentityAccessKey_basic
=== RUN   TestAccIdentityAccessKey_secret
=== PAUSE TestAccIdentityAccessKey_secret
=== RUN   TestAccIdentitACL_basic
=== PAUSE TestAccIdentitACL_basic
=== RUN   TestAccIdentitACL_apiAccess
=== PAUSE TestAccIdentitACL_apiAccess
=== RUN   TestAccIdentityAgency_basic
=== PAUSE TestAccIdentityAgency_basic
=== RUN   TestAccIdentityGroupMembership_basic
=== PAUSE TestAccIdentityGroupMembership_basic
=== RUN   TestAccIdentityGroupRoleAssignment_basic
=== PAUSE TestAccIdentityGroupRoleAssignment_basic
=== RUN   TestAccIdentityGroupRoleAssignment_project
=== PAUSE TestAccIdentityGroupRoleAssignment_project
=== RUN   TestAccIdentityGroupRoleAssignment_allProjects
=== PAUSE TestAccIdentityGroupRoleAssignment_allProjects
=== RUN   TestAccIdentityGroupRoleAssignment_epsID
=== PAUSE TestAccIdentityGroupRoleAssignment_epsID
=== RUN   TestAccIdentityGroupRoleAssignment_old
=== PAUSE TestAccIdentityGroupRoleAssignment_old
=== RUN   TestAccIdentityGroup_basic
=== PAUSE TestAccIdentityGroup_basic
=== RUN   TestAccLoginPolicy_basic
=== PAUSE TestAccLoginPolicy_basic
=== RUN   TestAccPasswordPolicy_basic
=== PAUSE TestAccPasswordPolicy_basic
=== RUN   TestAccIdentityProject_basic
=== PAUSE TestAccIdentityProject_basic
=== RUN   TestAccProtectionPolicy_basic
=== PAUSE TestAccProtectionPolicy_basic
=== RUN   TestAccIdentityProviderConversion_basic
=== PAUSE TestAccIdentityProviderConversion_basic
=== RUN   TestAccIdentityProvider_basic
=== PAUSE TestAccIdentityProvider_basic
=== RUN   TestAccIdentityProvider_oidc
=== PAUSE TestAccIdentityProvider_oidc
=== RUN   TestAccIdentityRole_basic
=== PAUSE TestAccIdentityRole_basic
=== RUN   TestAccIdentityRole_agency
=== PAUSE TestAccIdentityRole_agency
=== RUN   TestAccIdentityServiceAgency_basic
=== PAUSE TestAccIdentityServiceAgency_basic
=== RUN   TestAccIdentityTrustAgency_basic
=== PAUSE TestAccIdentityTrustAgency_basic
=== RUN   TestAccIdentityUserRoleAssignment_basic
=== PAUSE TestAccIdentityUserRoleAssignment_basic
=== RUN   TestAccIdentityUser_basic
=== PAUSE TestAccIdentityUser_basic
=== RUN   TestAccIdentityUser_external
=== PAUSE TestAccIdentityUser_external
=== RUN   TestAccIdentityUserToken_basic
=== PAUSE TestAccIdentityUserToken_basic
=== RUN   TestAccIdentityVirtualMFADevice_basic
=== PAUSE TestAccIdentityVirtualMFADevice_basic
=== CONT  TestAccIdentityAgenciesDataSource_basic
=== CONT  TestAccIdentityGroup_basic
--- PASS: TestAccIdentityAgenciesDataSource_basic (11.69s)
=== CONT  TestAccDataSourceIamIdentityVirtualMfaDevices_basic
--- PASS: TestAccIdentityGroup_basic (25.13s)
=== CONT  TestAccIdentityGroupRoleAssignment_old
--- PASS: TestAccDataSourceIamIdentityVirtualMfaDevices_basic (26.11s)
=== CONT  TestAccIdentityGroupRoleAssignment_epsID
--- PASS: TestAccIdentityGroupRoleAssignment_old (30.42s)
=== CONT  TestAccIdentityGroupRoleAssignment_allProjects
--- PASS: TestAccIdentityGroupRoleAssignment_epsID (29.87s)
=== CONT  TestAccIdentityGroupRoleAssignment_project
--- PASS: TestAccIdentityGroupRoleAssignment_allProjects (29.42s)
=== CONT  TestAccIdentityGroupRoleAssignment_basic
--- PASS: TestAccIdentityGroupRoleAssignment_project (30.24s)
=== CONT  TestAccIdentityGroupMembership_basic
--- PASS: TestAccIdentityGroupRoleAssignment_basic (29.88s)
=== CONT  TestAccIdentityAgency_basic
--- PASS: TestAccIdentityGroupMembership_basic (71.71s)
=== CONT  TestAccIdentitACL_apiAccess
    acceptance.go:738: HW_RUNNER_PUBLIC_IP must be set for acceptance test.
--- SKIP: TestAccIdentitACL_apiAccess (0.01s)
=== CONT  TestAccIdentitACL_basic
    acceptance.go:738: HW_RUNNER_PUBLIC_IP must be set for acceptance test.
--- SKIP: TestAccIdentitACL_basic (0.01s)
=== CONT  TestAccIdentityAccessKey_secret
--- PASS: TestAccIdentityAccessKey_secret (19.67s)
=== CONT  TestAccIdentityAccessKey_basic
--- PASS: TestAccIdentityAgency_basic (98.68s)
=== CONT  TestAccIdentityProviderConversion_basic
--- PASS: TestAccIdentityAccessKey_basic (33.87s)
=== CONT  TestAccIdentityRole_basic
--- PASS: TestAccIdentityRole_basic (25.27s)
=== CONT  TestAccIdentityProvider_oidc
--- PASS: TestAccIdentityProviderConversion_basic (38.65s)
=== CONT  TestAccIdentityProvider_basic
--- PASS: TestAccIdentityProvider_oidc (24.62s)
=== CONT  TestAccIdentityPermissionsDataSource_basic
--- PASS: TestAccIdentityProvider_basic (26.34s)
=== CONT  TestAccIdentityRole_agency
--- PASS: TestAccIdentityRole_agency (12.91s)
=== CONT  TestAccIdentityUsersDataSource_basic
--- PASS: TestAccIdentityUsersDataSource_basic (13.08s)
=== CONT  TestAccIdentityVirtualMFADevice_basic
--- PASS: TestAccIdentityVirtualMFADevice_basic (12.51s)
=== CONT  TestAccIdentityRoleDataSource_basic
--- PASS: TestAccIdentityRoleDataSource_basic (17.68s)
=== CONT  TestAccIdentityUserToken_basic
--- PASS: TestAccIdentityUserToken_basic (18.36s)
=== CONT  TestAccDataSourceIamIdentityProvider_basic
--- PASS: TestAccDataSourceIamIdentityProvider_basic (30.82s)
=== CONT  TestAccIdentityUser_external
--- PASS: TestAccIdentityUser_external (22.51s)
=== CONT  TestAccIdentityProjectsDataSource_subProject
--- PASS: TestAccIdentityProjectsDataSource_subProject (9.69s)
=== CONT  TestAccIdentityProjectsDataSource_basic
--- PASS: TestAccIdentityProjectsDataSource_basic (9.58s)
=== CONT  TestAccIdentityUser_basic
--- PASS: TestAccIdentityUser_basic (31.90s)
=== CONT  TestAccIdentityProject_basic
    acceptance.go:766: This environment does not support project tests
--- SKIP: TestAccIdentityProject_basic (0.01s)
=== CONT  TestAccProtectionPolicy_basic
--- PASS: TestAccProtectionPolicy_basic (31.38s)
=== CONT  TestAccIdentityUserRoleAssignment_basic
--- PASS: TestAccIdentityUserRoleAssignment_basic (25.17s)
=== CONT  TestAccIdentityTrustAgency_basic
    acceptance.go:731: This environment does not support IAM v5 tests
--- SKIP: TestAccIdentityTrustAgency_basic (0.01s)
=== CONT  TestAccIdentityServiceAgency_basic
    acceptance.go:731: This environment does not support IAM v5 tests
--- SKIP: TestAccIdentityServiceAgency_basic (0.01s)
=== CONT  TestAccIdentityCustomRoleDataSource_basic
--- PASS: TestAccIdentityCustomRoleDataSource_basic (19.31s)
=== CONT  TestAccIdentityGroupDataSource_basic
--- PASS: TestAccIdentityGroupDataSource_basic (18.82s)
=== CONT  TestAccIdentityGroupDataSource_with_user
--- PASS: TestAccIdentityGroupDataSource_with_user (33.84s)
=== CONT  TestAccLoginPolicy_basic
--- PASS: TestAccIdentityPermissionsDataSource_basic (327.98s)
=== CONT  TestAccPasswordPolicy_basic
--- PASS: TestAccLoginPolicy_basic (23.98s)
=== CONT  TestAccIdentityAgenciesDataSource_byTrustDomainId
--- PASS: TestAccPasswordPolicy_basic (23.70s)
=== CONT  TestAccIdentityAgenciesDataSource_byName
--- PASS: TestAccIdentityAgenciesDataSource_byTrustDomainId (31.69s)
--- PASS: TestAccIdentityAgenciesDataSource_byName (33.30s)
PASS
coverage: 62.6% of statements in ../../iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       658.091s
```
