### PR TITLE
fix(apig/throttle): avoid the duplicate resource name

### DIFF
--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_throttling_policy_test.go
@@ -66,7 +66,7 @@ func TestAccThrottlingPolicy_basic(t *testing.T) {
 				Config: testAccApigThrottlingPolicy_basic_step4(baseConfig, name),
 				Check: resource.ComposeTestCheckFunc(
 					rcPre.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rNamePre, "name", name),
+					resource.TestCheckResourceAttr(rNamePre, "name", name+"_pre_test"),
 					resource.TestCheckResourceAttr(rNamePre, "description", "Created by script"),
 					resource.TestCheckResourceAttr(rNamePre, "type", "API-based"),
 					resource.TestCheckResourceAttr(rNamePre, "period", "15000"),
@@ -188,7 +188,7 @@ func testAccApigThrottlingPolicy_basic_step1(baseConfig, name string) string {
 
 resource "huaweicloud_apig_throttling_policy" "invalid_type" {
   instance_id      = local.instance_id
-  name             = "%[2]s"
+  name             = "%[2]s_invalid_type"
   type             = "NON-Exist-Type"
   period           = 15000
   period_unit      = "SECOND"
@@ -205,7 +205,7 @@ func testAccApigThrottlingPolicy_basic_step2(baseConfig, name string) string {
 
 resource "huaweicloud_apig_throttling_policy" "invalid_app_id" {
   instance_id      = local.instance_id
-  name             = "%[2]s"
+  name             = "%[2]s_invalid_app_id"
   type             = "API-based"
   period           = 15000
   period_unit      = "SECOND"
@@ -225,7 +225,7 @@ func testAccApigThrottlingPolicy_basic_step3(baseConfig, name string) string {
 
 resource "huaweicloud_apig_throttling_policy" "invalid_user_id" {
   instance_id      = local.instance_id
-  name             = "%[2]s"
+  name             = "%[2]s_invalid_user_id"
   type             = "API-based"
   period           = 15000
   period_unit      = "SECOND"
@@ -245,7 +245,7 @@ func testAccApigThrottlingPolicy_basic_step4(baseConfig, name string) string {
 
 resource "huaweicloud_apig_throttling_policy" "pre_test" {
   instance_id       = local.instance_id
-  name              = "%[2]s"
+  name              = "%[2]s_pre_test"
   type              = "API-based"
   period            = 15000
   period_unit       = "SECOND"
@@ -264,7 +264,7 @@ func testAccApigThrottlingPolicy_basic_step5(baseConfig, name string) string {
 
 resource "huaweicloud_apig_throttling_policy" "pre_test" {
   instance_id       = local.instance_id
-  name              = "%[2]s"
+  name              = "%[2]s_pre_test"
   type              = "NON-Exist-Type"
   period            = 15000
   period_unit       = "SECOND"
@@ -285,7 +285,7 @@ func testAccApigThrottlingPolicy_basic_step6(baseConfig, name string) string {
 
 resource "huaweicloud_apig_throttling_policy" "pre_test" {
   instance_id       = local.instance_id
-  name              = "%[2]s"
+  name              = "%[2]s_pre_test"
   type              = "API-based"
   period            = 15000
   period_unit       = "SECOND"
@@ -309,7 +309,7 @@ func testAccApigThrottlingPolicy_basic_step7(baseConfig, name string) string {
 
 resource "huaweicloud_apig_throttling_policy" "pre_test" {
   instance_id       = local.instance_id
-  name              = "%[2]s"
+  name              = "%[2]s_pre_test"
   type              = "API-based"
   period            = 15000
   period_unit       = "SECOND"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Make resource names difference and avoid the error of the duplicate name.
In some cases, the following errors may occur:
```
resource_huaweicloud_apig_throttling_policy_test.go:41: Step 4/10 error: Error running apply: exit status 1
        
        Error: throttling policy: Bad request with: [POST https://apig.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/apigw/instances/2500c7bd8d8d408f902713274a505589/throttles], request_id: fa9496bd0908bb2fe4bca567dce6979d, error message: {"error_code":"APIG.3204","error_msg":"The request throttling policy name already exists"}
        
          with huaweicloud_apig_throttling_policy.pre_test,
          on terraform_plugin_test.tf line 27, in resource "huaweicloud_apig_throttling_policy" "pre_test":
          27: resource "huaweicloud_apig_throttling_policy" "pre_test" {
```

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. make resource names difference and avoid the error of the duplicate name
```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./huaweicloud/services/acceptance/apig' TESTARGS='-run=TestAccThrottlingPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run=TestAccThrottlingPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccThrottlingPolicy_basic
=== PAUSE TestAccThrottlingPolicy_basic
=== CONT  TestAccThrottlingPolicy_basic
--- PASS: TestAccThrottlingPolicy_basic (148.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      148.849s
```
