### PR TITLE
feat(hss/host_protection): support `is_wait_host_available` parameter

### DIFF
--- a/docs/resources/hss_host_protection.md
+++ b/docs/resources/hss_host_protection.md
@@ -51,6 +51,12 @@ The following arguments are supported:
   If omitted, randomly select quota for the corresponding version.
   This field is valid only when `charging_mode` is set to **prePaid**.
 
+* `is_wait_host_available` - (Optional, Bool) Specifies whether to wait for the host agent status to become **online**.
+  The value can be **true** or **false**. Defaults to **false**.
+
+  -> If this field is set to **true**, the program will wait for a maximum of `30` minutes until the host's agent status
+  becomes **online**, and then enable host protection.
+
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the host
   protection belongs. Changing this parameter will create a new resource.
 
@@ -82,6 +88,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `open_time` - The time to enable host protection.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+
 ## Import
 
 The host protection can be imported using the `id`, e.g.
@@ -91,7 +103,7 @@ $ terraform import huaweicloud_hss_host_protection.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `quota_id`.
+API response, security or some other reason. The missing attributes include: `quota_id`, `is_wait_host_available`.
 It is generally recommended running `terraform plan` after importing a resource.
 You can then decide if changes should be applied to the resource, or the resource definition
 should be updated to align with the resource. Also, you can ignore changes as below.
@@ -102,7 +114,7 @@ resource "huaweicloud_hss_host_protection" "test" {
   
   lifecycle {
     ignore_changes = [
-      quota_id,
+      quota_id, is_wait_host_available,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_protection_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_protection_test.go
@@ -67,14 +67,15 @@ func TestAccHostProtection_basic(t *testing.T) {
 		getHostProtectionFunc,
 	)
 
+	// Because after closing the protection, the ECS instance will automatically switch to free basic protection,
+	// so avoid CheckDestroy here.
+	// lintignore:AT001
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
-			acceptance.TestAccPreCheckHSSHostProtectionQuotaId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccHostProtection_basic(),
@@ -83,8 +84,7 @@ func TestAccHostProtection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "host_id", acceptance.HW_HSS_HOST_PROTECTION_HOST_ID),
 					resource.TestCheckResourceAttr(rName, "version", "hss.version.basic"),
 					resource.TestCheckResourceAttr(rName, "charging_mode", "prePaid"),
-					resource.TestCheckResourceAttr(rName, "quota_id", acceptance.HW_HSS_HOST_PROTECTION_QUOTA_ID),
-					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 					resource.TestCheckResourceAttrSet(rName, "host_name"),
 					resource.TestCheckResourceAttrSet(rName, "host_status"),
 					resource.TestCheckResourceAttrSet(rName, "private_ip"),
@@ -95,6 +95,7 @@ func TestAccHostProtection_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "detect_result"),
 					resource.TestCheckResourceAttrSet(rName, "asset_value"),
 					resource.TestCheckResourceAttrSet(rName, "open_time"),
+					resource.TestCheckResourceAttrPair(rName, "quota_id", "huaweicloud_hss_quota.test", "id"),
 				),
 			},
 			{
@@ -104,7 +105,7 @@ func TestAccHostProtection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "host_id", acceptance.HW_HSS_HOST_PROTECTION_HOST_ID),
 					resource.TestCheckResourceAttr(rName, "version", "hss.version.enterprise"),
 					resource.TestCheckResourceAttr(rName, "charging_mode", "postPaid"),
-					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrSet(rName, "enterprise_project_id"),
 					resource.TestCheckResourceAttrSet(rName, "host_name"),
 					resource.TestCheckResourceAttrSet(rName, "host_status"),
 					resource.TestCheckResourceAttrSet(rName, "private_ip"),
@@ -122,34 +123,42 @@ func TestAccHostProtection_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"quota_id",
+					"quota_id", "is_wait_host_available",
 				},
 			},
 		},
 	})
 }
 
+func testAccHostProtection_base() string {
+	return `
+resource "huaweicloud_hss_quota" "test" {
+  version     = "hss.version.basic"
+  period_unit = "month"
+  period      = 1
+}`
+}
+
 func testAccHostProtection_basic() string {
 	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_hss_host_protection" "test" {
-  host_id               = "%[1]s"
-  version               = "hss.version.basic"
-  charging_mode         = "prePaid"
-  quota_id              = "%[2]s"
-  enterprise_project_id = "%[3]s"
+  host_id                = "%[2]s"
+  version                = "hss.version.basic"
+  charging_mode          = "prePaid"
+  quota_id               = huaweicloud_hss_quota.test.id
+  is_wait_host_available = true
 }
-`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID, acceptance.HW_HSS_HOST_PROTECTION_QUOTA_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccHostProtection_base(), acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
 }
 
 func testAccHostProtection_update() string {
 	return fmt.Sprintf(`
-
 resource "huaweicloud_hss_host_protection" "test" {
-  host_id               = "%[1]s"
-  version               = "hss.version.enterprise"
-  charging_mode         = "postPaid"
-  enterprise_project_id = "%[2]s"
+  host_id       = "%[1]s"
+  version       = "hss.version.enterprise"
+  charging_mode = "postPaid"
 }
-`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Support `is_wait_host_available` parameter to control whether to wait for the host agent status to become online.
2. `enterprise_project_id` parameter add Computed attribute.
3. Update test cases.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
5. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ export HW_HSS_HOST_PROTECTION_HOST_ID=xxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccHostProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccHostProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccHostProtection_basic
=== PAUSE TestAccHostProtection_basic
=== CONT  TestAccHostProtection_basic
--- PASS: TestAccHostProtection_basic (269.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       269.450s

```
