### PR TITLE
test(iam): improve iam test cases

### DIFF
--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_provider_test.go
@@ -86,18 +86,28 @@ func TestAccIdentityProvider_oidc(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "oidc"),
 					resource.TestCheckResourceAttr(resourceName, "access_config.0.access_type", "program_console"),
-					resource.TestCheckResourceAttr(resourceName, "access_config.0.client_id", "client_id_example"),
+					resource.TestCheckResourceAttr(resourceName, "access_config.0.client_id", "client_id_example1"),
 				),
 			},
 			{
-				Config: testAccIdentityProvider_oidc_update(name),
+				Config: testAccIdentityProvider_oidc_update_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "oidc"),
+					resource.TestCheckResourceAttr(resourceName, "access_config.0.access_type", "program_console"),
+					resource.TestCheckResourceAttr(resourceName, "access_config.0.client_id", "client_id_example2"),
+				),
+			},
+			{
+				Config: testAccIdentityProvider_oidc_update_2(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "oidc"),
 					resource.TestCheckResourceAttr(resourceName, "status", "false"),
 					resource.TestCheckResourceAttr(resourceName, "access_config.0.access_type", "program"),
-					resource.TestCheckResourceAttr(resourceName, "access_config.0.client_id", "client_id_demo"),
+					resource.TestCheckResourceAttr(resourceName, "access_config.0.client_id", "client_id_example3"),
 				),
 			},
 		},
@@ -133,7 +143,7 @@ resource "huaweicloud_identity_provider" "provider_1" {
   access_config {
     access_type            = "program_console"
     provider_url           = "https://accounts.example.com"
-    client_id              = "client_id_example"
+    client_id              = "client_id_example1"
     authorization_endpoint = "https://accounts.example.com/o/oauth2/v2/auth"
     scopes                 = ["openid"]
     signing_key            = jsonencode(
@@ -155,7 +165,39 @@ resource "huaweicloud_identity_provider" "provider_1" {
 `, name)
 }
 
-func testAccIdentityProvider_oidc_update(name string) string {
+func testAccIdentityProvider_oidc_update_1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_identity_provider" "provider_1" {
+  name        = "%s"
+  protocol    = "oidc"
+  description = "unit test"
+
+  access_config {
+    access_type            = "program_console"
+    provider_url           = "https://accounts.example.com"
+    client_id              = "client_id_example2"
+    authorization_endpoint = "https://accounts.example.com/o/oauth2/v2/auth"
+    scopes                 = ["openid"]
+    signing_key            = jsonencode(
+    {
+      keys = [
+        {
+          alg = "RS256"
+          e   = "AQAB"
+          kid = "d05ef20c4512645vv1..."
+          kty = "RSA"
+          n   = "cws_cnjiwsbvweolwn_-vnl..."
+          use = "sig"
+        },
+      ]
+    }
+    )
+  }
+}
+`, name)
+}
+
+func testAccIdentityProvider_oidc_update_2(name string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_identity_provider" "provider_1" {
   name        = "%s"
@@ -166,7 +208,7 @@ resource "huaweicloud_identity_provider" "provider_1" {
   access_config {
     access_type            = "program"
     provider_url           = "https://accounts.example.com"
-    client_id              = "client_id_demo"
+    client_id              = "client_id_example3"
     signing_key            = jsonencode(
     {
       keys = [

--- a/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_token_test.go
+++ b/huaweicloud/services/acceptance/iam/resource_huaweicloud_identity_user_token_test.go
@@ -36,12 +36,50 @@ func TestAccIdentityUserToken_basic(t *testing.T) {
 
 func testAccIdentityUserToken_basic(userName, initPassword string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "huaweicloud_identity_user_token" "test" {
-  account_name = "%s"
+  account_name = "%[2]s"
   user_name    = huaweicloud_identity_user.user_1.name
-  password     = "%s"
+  password     = "%[3]s"
 }
 `, testAccIdentityUser_basic(userName, initPassword), acceptance.HW_DOMAIN_NAME, initPassword)
+}
+
+func TestAccIdentityUserToken_project(t *testing.T) {
+	userName := acceptance.RandomAccResourceName()
+	initPassword := acceptance.RandomPassword()
+	resourceName := "huaweicloud_identity_user_token.test"
+
+	// Avoid CheckDestroy because the token can not be destroyed.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityUserToken_project(userName, initPassword),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "token"),
+					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIdentityUserToken_project(userName, initPassword string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_identity_user_token" "test" {
+  account_name = "%[2]s"
+  user_name    = huaweicloud_identity_user.user_1.name
+  password     = "%[3]s"
+  project_name = "%[4]s"
+}
+`, testAccIdentityUser_basic(userName, initPassword), acceptance.HW_DOMAIN_NAME, initPassword, acceptance.HW_REGION_NAME)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [ ] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
./coverage.sh 
>>> Start to test
=== RUN   TestAccIdentityAgenciesDataSource_basic
=== PAUSE TestAccIdentityAgenciesDataSource_basic
=== RUN   TestAccIdentityAgenciesDataSource_byName
=== PAUSE TestAccIdentityAgenciesDataSource_byName
=== RUN   TestAccIdentityAgenciesDataSource_byTrustDomainId
=== PAUSE TestAccIdentityAgenciesDataSource_byTrustDomainId
=== RUN   TestAccIdentityCustomRoleDataSource_basic
=== PAUSE TestAccIdentityCustomRoleDataSource_basic
=== RUN   TestAccIdentityGroupDataSource_basic
=== PAUSE TestAccIdentityGroupDataSource_basic
=== RUN   TestAccIdentityGroupDataSource_with_user
=== PAUSE TestAccIdentityGroupDataSource_with_user
=== RUN   TestAccIdentityPermissionsDataSource_basic
=== PAUSE TestAccIdentityPermissionsDataSource_basic
=== RUN   TestAccIdentityProjectsDataSource_basic
=== PAUSE TestAccIdentityProjectsDataSource_basic
=== RUN   TestAccIdentityProjectsDataSource_subProject
=== PAUSE TestAccIdentityProjectsDataSource_subProject
=== RUN   TestAccDataSourceIamIdentityProvider_basic
=== PAUSE TestAccDataSourceIamIdentityProvider_basic
=== RUN   TestAccIdentityRoleDataSource_basic
=== PAUSE TestAccIdentityRoleDataSource_basic
=== RUN   TestAccIdentityUsersDataSource_basic
=== PAUSE TestAccIdentityUsersDataSource_basic
=== RUN   TestAccDataSourceIamIdentityVirtualMfaDevices_basic
=== PAUSE TestAccDataSourceIamIdentityVirtualMfaDevices_basic
=== RUN   TestAccIdentityAccessKey_basic
=== PAUSE TestAccIdentityAccessKey_basic
=== RUN   TestAccIdentityAccessKey_secret
=== PAUSE TestAccIdentityAccessKey_secret
=== RUN   TestAccIdentitACL_basic
=== PAUSE TestAccIdentitACL_basic
=== RUN   TestAccIdentitACL_apiAccess
=== PAUSE TestAccIdentitACL_apiAccess
=== RUN   TestAccIdentityAgency_basic
=== PAUSE TestAccIdentityAgency_basic
=== RUN   TestAccIdentityGroupMembership_basic
=== PAUSE TestAccIdentityGroupMembership_basic
=== RUN   TestAccIdentityGroupRoleAssignment_basic
=== PAUSE TestAccIdentityGroupRoleAssignment_basic
=== RUN   TestAccIdentityGroupRoleAssignment_project
=== PAUSE TestAccIdentityGroupRoleAssignment_project
=== RUN   TestAccIdentityGroupRoleAssignment_allProjects
=== PAUSE TestAccIdentityGroupRoleAssignment_allProjects
=== RUN   TestAccIdentityGroupRoleAssignment_epsID
=== PAUSE TestAccIdentityGroupRoleAssignment_epsID
=== RUN   TestAccIdentityGroupRoleAssignment_old
=== PAUSE TestAccIdentityGroupRoleAssignment_old
=== RUN   TestAccIdentityGroup_basic
=== PAUSE TestAccIdentityGroup_basic
=== RUN   TestAccLoginPolicy_basic
=== PAUSE TestAccLoginPolicy_basic
=== RUN   TestAccPasswordPolicy_basic
=== PAUSE TestAccPasswordPolicy_basic
=== RUN   TestAccIdentityProject_basic
=== PAUSE TestAccIdentityProject_basic
=== RUN   TestAccProtectionPolicy_basic
=== PAUSE TestAccProtectionPolicy_basic
=== RUN   TestAccIdentityProviderConversion_basic
=== PAUSE TestAccIdentityProviderConversion_basic
=== RUN   TestAccIdentityProvider_basic
=== PAUSE TestAccIdentityProvider_basic
=== RUN   TestAccIdentityProvider_oidc
=== PAUSE TestAccIdentityProvider_oidc
=== RUN   TestAccIdentityRole_basic
=== PAUSE TestAccIdentityRole_basic
=== RUN   TestAccIdentityRole_agency
=== PAUSE TestAccIdentityRole_agency
=== RUN   TestAccIdentityServiceAgency_basic
=== PAUSE TestAccIdentityServiceAgency_basic
=== RUN   TestAccIdentityTrustAgency_basic
=== PAUSE TestAccIdentityTrustAgency_basic
=== RUN   TestAccIdentityUserRoleAssignment_basic
=== PAUSE TestAccIdentityUserRoleAssignment_basic
=== RUN   TestAccIdentityUser_basic
=== PAUSE TestAccIdentityUser_basic
=== RUN   TestAccIdentityUser_external
=== PAUSE TestAccIdentityUser_external
=== RUN   TestAccIdentityUserToken_basic
=== PAUSE TestAccIdentityUserToken_basic
=== RUN   TestAccIdentityUserToken_project
=== PAUSE TestAccIdentityUserToken_project
=== RUN   TestAccIdentityVirtualMFADevice_basic
=== PAUSE TestAccIdentityVirtualMFADevice_basic
=== CONT  TestAccIdentityAgenciesDataSource_basic
=== CONT  TestAccProtectionPolicy_basic
--- PASS: TestAccIdentityAgenciesDataSource_basic (11.54s)
=== CONT  TestAccIdentityVirtualMFADevice_basic
--- PASS: TestAccIdentityVirtualMFADevice_basic (14.82s)
=== CONT  TestAccIdentityUserToken_project
--- PASS: TestAccProtectionPolicy_basic (34.99s)
=== CONT  TestAccIdentityUserToken_basic
--- PASS: TestAccIdentityUserToken_project (20.56s)
=== CONT  TestAccIdentityUser_external
--- PASS: TestAccIdentityUserToken_basic (20.93s)
=== CONT  TestAccIdentityUser_basic
--- PASS: TestAccIdentityUser_external (25.83s)
=== CONT  TestAccIdentityUserRoleAssignment_basic
--- PASS: TestAccIdentityUser_basic (36.01s)
=== CONT  TestAccIdentityTrustAgency_basic
    acceptance.go:731: This environment does not support IAM v5 tests
--- SKIP: TestAccIdentityTrustAgency_basic (0.01s)
=== CONT  TestAccIdentityServiceAgency_basic
    acceptance.go:731: This environment does not support IAM v5 tests
--- SKIP: TestAccIdentityServiceAgency_basic (0.01s)
=== CONT  TestAccIdentityRole_agency
--- PASS: TestAccIdentityUserRoleAssignment_basic (29.25s)
=== CONT  TestAccIdentityRole_basic
--- PASS: TestAccIdentityRole_agency (14.83s)
=== CONT  TestAccIdentityProvider_oidc
--- PASS: TestAccIdentityRole_basic (25.00s)
=== CONT  TestAccIdentityProvider_basic
--- PASS: TestAccIdentityProvider_oidc (34.35s)
=== CONT  TestAccIdentityProviderConversion_basic
--- PASS: TestAccIdentityProvider_basic (25.55s)
=== CONT  TestAccIdentityGroupRoleAssignment_allProjects
--- PASS: TestAccIdentityProviderConversion_basic (38.40s)
=== CONT  TestAccIdentityProject_basic
    acceptance.go:766: This environment does not support project tests
--- SKIP: TestAccIdentityProject_basic (0.01s)
=== CONT  TestAccPasswordPolicy_basic
--- PASS: TestAccIdentityGroupRoleAssignment_allProjects (29.23s)
=== CONT  TestAccLoginPolicy_basic
--- PASS: TestAccPasswordPolicy_basic (24.57s)
=== CONT  TestAccIdentityAccessKey_secret
--- PASS: TestAccLoginPolicy_basic (24.40s)
=== CONT  TestAccIdentityGroup_basic
--- PASS: TestAccIdentityAccessKey_secret (20.78s)
=== CONT  TestAccIdentityGroupRoleAssignment_project
--- PASS: TestAccIdentityGroup_basic (24.64s)
=== CONT  TestAccIdentityGroupRoleAssignment_old
--- PASS: TestAccIdentityGroupRoleAssignment_project (30.68s)
=== CONT  TestAccIdentityGroupRoleAssignment_basic
--- PASS: TestAccIdentityGroupRoleAssignment_old (30.47s)
=== CONT  TestAccIdentityGroupMembership_basic
--- PASS: TestAccIdentityGroupRoleAssignment_basic (30.21s)
=== CONT  TestAccIdentityGroupRoleAssignment_epsID
--- PASS: TestAccIdentityGroupRoleAssignment_epsID (29.58s)
=== CONT  TestAccIdentityAgency_basic
--- PASS: TestAccIdentityGroupMembership_basic (75.36s)
=== CONT  TestAccIdentitACL_apiAccess
    acceptance.go:738: HW_RUNNER_PUBLIC_IP must be set for this acceptance test.
--- SKIP: TestAccIdentitACL_apiAccess (0.01s)
=== CONT  TestAccIdentitACL_basic
    acceptance.go:738: HW_RUNNER_PUBLIC_IP must be set for this acceptance test.
--- SKIP: TestAccIdentitACL_basic (0.01s)
=== CONT  TestAccIdentityProjectsDataSource_basic
--- PASS: TestAccIdentityProjectsDataSource_basic (9.93s)
=== CONT  TestAccIdentityRoleDataSource_basic
--- PASS: TestAccIdentityRoleDataSource_basic (18.48s)
=== CONT  TestAccDataSourceIamIdentityProvider_basic
--- PASS: TestAccDataSourceIamIdentityProvider_basic (32.63s)
=== CONT  TestAccIdentityUsersDataSource_basic
--- PASS: TestAccIdentityUsersDataSource_basic (13.14s)
=== CONT  TestAccIdentityAccessKey_basic
--- PASS: TestAccIdentityAgency_basic (98.73s)
=== CONT  TestAccIdentityProjectsDataSource_subProject
--- PASS: TestAccIdentityProjectsDataSource_subProject (11.15s)
=== CONT  TestAccDataSourceIamIdentityVirtualMfaDevices_basic
--- PASS: TestAccIdentityAccessKey_basic (37.73s)
=== CONT  TestAccIdentityPermissionsDataSource_basic
--- PASS: TestAccDataSourceIamIdentityVirtualMfaDevices_basic (26.46s)
=== CONT  TestAccIdentityAgenciesDataSource_byName
--- PASS: TestAccIdentityAgenciesDataSource_byName (32.60s)
=== CONT  TestAccIdentityAgenciesDataSource_byTrustDomainId
--- PASS: TestAccIdentityAgenciesDataSource_byTrustDomainId (30.16s)
=== CONT  TestAccIdentityCustomRoleDataSource_basic
--- PASS: TestAccIdentityCustomRoleDataSource_basic (19.36s)
=== CONT  TestAccIdentityGroupDataSource_with_user
--- PASS: TestAccIdentityGroupDataSource_with_user (33.25s)
=== CONT  TestAccIdentityGroupDataSource_basic
--- PASS: TestAccIdentityGroupDataSource_basic (20.59s)
--- PASS: TestAccIdentityPermissionsDataSource_basic (266.33s)
PASS
coverage: 62.8% of statements in ../../iam
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iam       714.961s
```
