### PR TITLE
chore(AS): Remove `checkDeleted` logic in the AS datasource

### DIFF
--- a/huaweicloud/services/as/data_source_huaweicloud_as_activity_logs.go
+++ b/huaweicloud/services/as/data_source_huaweicloud_as_activity_logs.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/activitylogs"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -117,7 +116,7 @@ func dataSourceActivityLogsRead(_ context.Context, d *schema.ResourceData, meta 
 
 	activityLogList, err := activitylogs.List(client, groupID, opts)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "AS activity logs")
+		return diag.Errorf("error retrieving activity logs in AS group %s: %s", groupID, err)
 	}
 
 	randUUID, err := uuid.GenerateUUID()

--- a/huaweicloud/services/as/data_source_huaweicloud_as_lifecycle_hooks.go
+++ b/huaweicloud/services/as/data_source_huaweicloud_as_lifecycle_hooks.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -103,7 +102,7 @@ func dataSourceLifeCycleHooksRead(_ context.Context, d *schema.ResourceData, met
 
 	lifecycleHookList, err := lifecyclehooks.List(client, groupID).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "AS lifecycle hooks")
+		return diag.Errorf("error retrieving lifecycle hooks in AS group %s: %s", groupID, err)
 	}
 
 	lifecycleHooks, err := flattenLifecycleHooks(d, lifecycleHookList)

--- a/huaweicloud/services/as/data_source_huaweicloud_as_policies.go
+++ b/huaweicloud/services/as/data_source_huaweicloud_as_policies.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/policies"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -176,7 +175,7 @@ func dataSourceASPoliciesRead(_ context.Context, d *schema.ResourceData, meta in
 
 	policyResp, err := policies.List(client, opts).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "AS policies")
+		return diag.Errorf("error retrieving AS policies: %s", err)
 	}
 
 	randUUID, err := uuid.GenerateUUID()

--- a/huaweicloud/services/as/data_source_huaweicloud_as_policy_execute_logs.go
+++ b/huaweicloud/services/as/data_source_huaweicloud_as_policy_execute_logs.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/policyexecutelogs"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 )
 
@@ -190,7 +189,7 @@ func dataSourcePolicyExecuteLogsRead(_ context.Context, d *schema.ResourceData, 
 
 	executeLogList, err := policyexecutelogs.List(client, opts)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "AS policy execute logs")
+		return diag.Errorf("error retrieving AS policy execute logs: %s", err)
 	}
 
 	randUUID, err := uuid.GenerateUUID()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove `checkDeleted` logic in the AS datasource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccActivityLogsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccActivityLogsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccActivityLogsDataSource_basic
=== PAUSE TestAccActivityLogsDataSource_basic
=== CONT  TestAccActivityLogsDataSource_basic
--- PASS: TestAccActivityLogsDataSource_basic (26.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        26.553s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourceLifecycleHooks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceLifecycleHooks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceLifecycleHooks_basic
=== PAUSE TestAccDataSourceLifecycleHooks_basic
=== CONT  TestAccDataSourceLifecycleHooks_basic
--- PASS: TestAccDataSourceLifecycleHooks_basic (216.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        216.192s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccPoliciesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccPoliciesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccPoliciesDataSource_basic
=== PAUSE TestAccPoliciesDataSource_basic
=== CONT  TestAccPoliciesDataSource_basic
--- PASS: TestAccPoliciesDataSource_basic (133.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        133.694s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccPolicyExecuteLogsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccPolicyExecuteLogsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccPolicyExecuteLogsDataSource_basic
=== PAUSE TestAccPolicyExecuteLogsDataSource_basic
=== CONT  TestAccPolicyExecuteLogsDataSource_basic
--- PASS: TestAccPolicyExecuteLogsDataSource_basic (30.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        30.279s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
