### PR TITLE
chore(AS): Make the `checkDeleted` logic in the AS policy resource more reliable

### DIFF
--- a/huaweicloud/services/as/resource_huaweicloud_as_policy.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_policy.go
@@ -255,7 +255,8 @@ func resourceASPolicyRead(_ context.Context, d *schema.ResourceData, meta interf
 	policyId := d.Id()
 	asPolicy, err := policies.Get(asClient, policyId).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "AS policy")
+		// When the resource does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving AS policy")
 	}
 
 	mErr := multierror.Append(nil,
@@ -367,7 +368,8 @@ func resourceASPolicyDelete(_ context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if delErr := policies.Delete(asClient, d.Id()).ExtractErr(); delErr != nil {
-		return diag.Errorf("error deleting AS policy: %s", delErr)
+		// When the resource does not exist, the response HTTP status code of the delete API is 404.
+		return common.CheckDeletedDiag(d, delErr, "error deleting AS policy")
 	}
 
 	return nil


### PR DESCRIPTION
…re reliable

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Make the `checkDeleted` logic in the AS policy resource more reliable.
- add `checkDeleted` logic in deletion method.
- test "checkDeleted" logic in read and delete methods.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_basic
=== PAUSE TestAccASPolicy_basic
=== CONT  TestAccASPolicy_basic
--- PASS: TestAccASPolicy_basic (196.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        196.884s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASPolicy_Alarm'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASPolicy_Alarm -timeout 360m -parallel 4
=== RUN   TestAccASPolicy_Alarm
=== PAUSE TestAccASPolicy_Alarm
=== CONT  TestAccASPolicy_Alarm
--- PASS: TestAccASPolicy_Alarm (114.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        115.031s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/9e3aeccd-a9cd-4878-84d7-a7d8f23f534e)

   
  
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/88a5eb76-47f2-4dea-8031-2c950a443cc5)

