### PR TITLE
feat(dms): support new params for rocketmq topic

### DIFF
--- a/docs/resources/dms_rocketmq_topic.md
+++ b/docs/resources/dms_rocketmq_topic.md
@@ -11,6 +11,20 @@ Manages DMS RocketMQ topic resources within HuaweiCloud.
 
 ## Example Usage
 
+### Create a topic for 5.x version instance
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_rocketmq_topic" "test" {
+  instance_id  = var.instance_id
+  name         = "topic_test"
+  message_type = "NORMAL"
+}
+```
+
+### Create a topic with brokers for 4.8.0 version instance
+
 ```hcl
 variable "instance_id" {}
 
@@ -26,6 +40,23 @@ resource "huaweicloud_dms_rocketmq_topic" "test" {
 }
 ```
 
+### Create a topic with queues for 4.8.0 version instance
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_dms_rocketmq_topic" "test" {
+  instance_id = var.instance_id
+  name        = "topic_test"
+  permission  = "all"
+
+  queues {
+    broker    = "broker-0"
+    queue_num = 3
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -34,42 +65,62 @@ The following arguments are supported:
   If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
 * `instance_id` - (Required, String, ForceNew) Specifies the ID of the rocketMQ instance.
-
   Changing this parameter will create a new resource.
 
 * `name` - (Required, String, ForceNew) Specifies the name of the topic.
+  Changing this parameter will create a new resource.
+
+* `message_type` - (Optional, String, ForceNew) Specifies the message type of the topic.
+  It's only valid when RocketMQ instance version is **5.x**. Valid values are:
+  + **NORMAL**: Normal messages.
+  + **FIFO**: Ordered messages.
+  + **DELAY**: Scheduled messages.
+  + **TRANSACTION**: Transactional messages.
 
   Changing this parameter will create a new resource.
 
-* `brokers` - (Required, List, ForceNew) Specifies the list of associated brokers of the topic.
-
+* `brokers` - (Optional, List, ForceNew) Specifies the list of associated brokers of the topic.
+  It's only valid when RocketMQ instance version is **4.8.0**.
   Changing this parameter will create a new resource.
-  The [BrokerRef](#DmsRocketMQTopic_BrokerRef) structure is documented below.
+  The [brokers](#DmsRocketMQTopic_BrokerRef) structure is documented below.
 
-* `queue_num` - (Optional, Int, ForceNew) Specifies the number of queues. Default to 8.
+* `queue_num` - (Optional, Int, ForceNew) Specifies the number of queues. Default to **8**.
+  It's only valid when RocketMQ instance version is **4.8.0**.
+  Changing this parameter will create a new resource.
 
+* `queues` - (Optional, List, ForceNew) Specifies the queues information of the topic.
+  It's only valid when RocketMQ instance version is **4.8.0**.
+  The [queues](#DmsRocketMQTopic_QueueRef) structure is documented below.
   Changing this parameter will create a new resource.
 
 * `permission` - (Optional, String) Specifies the permissions of the topic.
-  Value options: **all**, **sub**, **pub**. Default to all.
+  Value options: **all**, **sub**, **pub**. Default to **all**.
+  It's only valid when RocketMQ instance version is **4.8.0**.
 
 * `total_read_queue_num` - (Optional, Int) Specifies the total number of read queues.
 
 * `total_write_queue_num` - (Optional, Int) Specifies the total number of write queues.
 
 <a name="DmsRocketMQTopic_BrokerRef"></a>
-The `BrokerRef` block supports:
+The `brokers` block supports:
 
-* `name` - (Optional, String) Indicates the name of the broker.
+* `name` - (Optional, String) Specifies the name of the broker.
+
+<a name="DmsRocketMQTopic_QueueRef"></a>
+The `queues` block supports:
+
+* `broker` - (Optional, String) Specifies the associated broker.
+
+* `queue_num` - (Optional, Int) Specifies the number of the queues.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
-  
+
 <a name="DmsRocketMQTopic_BrokerRef"></a>
-  The `BrokerRef` block supports:
+  The `brokers` block supports:
 
 * `read_queue_num` - Indicates the read queues number of the broker. It's useless when create a topic.
 

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_topic_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rocketmq_topic_test.go
@@ -101,6 +101,80 @@ func TestAccDmsRocketMQTopic_basic(t *testing.T) {
 	})
 }
 
+func TestAccDmsRocketMQTopic_withQueues(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dms_rocketmq_topic.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDmsRocketMQTopicResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsRocketMQTopic_with_queues(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "permission", "sub"),
+					resource.TestCheckResourceAttr(rName, "total_read_queue_num", "3"),
+					resource.TestCheckResourceAttr(rName, "total_write_queue_num", "3"),
+					resource.TestCheckResourceAttr(rName, "brokers.0.write_queue_num", "3"),
+					resource.TestCheckResourceAttr(rName, "brokers.0.write_queue_num", "3"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_id", "queues"},
+			},
+		},
+	})
+}
+
+func TestAccDmsRocketMQTopic_version5(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dms_rocketmq_topic.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDmsRocketMQTopicResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDmsRocketMQTopic_verison5(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "message_type", "NORMAL"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_id"},
+			},
+		},
+	})
+}
+
 func testAccDmsRocketmqTopic_Base(rName string) string {
 	return fmt.Sprintf(`
 %s
@@ -122,6 +196,30 @@ resource "huaweicloud_dms_rocketmq_instance" "test" {
   flavor_id         = "c6.4u8g.cluster"
   storage_spec_code = "dms.physical.storage.high.v2"
   broker_num        = 1
+}
+`, common.TestBaseNetwork(rName), rName)
+}
+
+func testAccDmsRocketmqTopic_verison5(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_dms_rocketmq_instance" "test" {
+  name              = "%s"
+  engine_version    = "5.x"
+  storage_space     = 200
+  vpc_id            = huaweicloud_vpc.test.id
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  security_group_id = huaweicloud_networking_secgroup.test.id
+
+  availability_zones = [
+    data.huaweicloud_availability_zones.test.names[0]
+  ]
+
+  flavor_id         = "rocketmq.b1.large.1"
+  storage_spec_code = "dms.physical.storage.high.v2"
 }
 `, common.TestBaseNetwork(rName), rName)
 }
@@ -154,4 +252,33 @@ resource "huaweicloud_dms_rocketmq_topic" "test" {
   total_write_queue_num = "5"
 }
 `, testAccDmsRocketmqTopic_Base(name), name)
+}
+
+func testDmsRocketMQTopic_with_queues(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_rocketmq_topic" "test" {
+  instance_id = huaweicloud_dms_rocketmq_instance.test.id
+  name        = "%s"
+  permission  = "sub"
+
+  queues {
+    broker    = "broker-0"
+    queue_num = 3
+  }
+}
+`, testAccDmsRocketmqTopic_Base(name), name)
+}
+
+func testDmsRocketMQTopic_verison5(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_dms_rocketmq_topic" "test" {
+  instance_id  = huaweicloud_dms_rocketmq_instance.test.id
+  name         = "%s"
+  message_type = "NORMAL"
+}
+`, testAccDmsRocketmqTopic_verison5(name), name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new params for rocketmq topic.

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run TestAccDmsRocketMQTopic_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsRocketMQTopic_ -timeout 360m -parallel 4
=== RUN   TestAccDmsRocketMQTopic_basic
=== PAUSE TestAccDmsRocketMQTopic_basic
=== RUN   TestAccDmsRocketMQTopic_withQueues
=== PAUSE TestAccDmsRocketMQTopic_withQueues
=== RUN   TestAccDmsRocketMQTopic_version5
=== PAUSE TestAccDmsRocketMQTopic_version5
=== CONT  TestAccDmsRocketMQTopic_basic
=== CONT  TestAccDmsRocketMQTopic_version5
=== CONT  TestAccDmsRocketMQTopic_withQueues
--- PASS: TestAccDmsRocketMQTopic_version5 (662.33s)
--- PASS: TestAccDmsRocketMQTopic_withQueues (796.34s)
--- PASS: TestAccDmsRocketMQTopic_basic (967.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       967.580s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
