### PR TITLE
chore(AS): make `checkDeleted` logic in bandwidth policy resource stronger

### DIFF
--- a/huaweicloud/services/as/resource_huaweicloud_as_bandwidth_policy.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_bandwidth_policy.go
@@ -284,6 +284,7 @@ func resourceASBandWidthPolicyRead(_ context.Context, d *schema.ResourceData, me
 
 	getBandwidthPolicyResp, err := client.Request("GET", getBandwidthPolicyPath, &getBandwidthPolicyOpt)
 	if err != nil {
+		// When the resource does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving AS bandwidth policy")
 	}
 


### PR DESCRIPTION
…urce more reliable

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Make the `checkDeleted` logic in resource **huaweicloud_as_bandwidth_policy** more reliable.
- add `checkDeleted` logic in delete function(#5157).
- check `checkDeleted` logic in both read and delete function.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASBandWidthPolicy_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASBandWidthPolicy_ -timeout 360m -parallel 4
=== RUN   TestAccASBandWidthPolicy_basic
=== PAUSE TestAccASBandWidthPolicy_basic
=== RUN   TestAccASBandWidthPolicy_alarm
=== PAUSE TestAccASBandWidthPolicy_alarm
=== CONT  TestAccASBandWidthPolicy_basic
=== CONT  TestAccASBandWidthPolicy_alarm
--- PASS: TestAccASBandWidthPolicy_alarm (38.17s)
--- PASS: TestAccASBandWidthPolicy_basic (54.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        54.566s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/53122a7d-75a9-4d10-9b67-f13a3c6f90b2)
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    
    ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/fd937eff-4283-4c6d-8904-96c6be92342e)

