### PR TITLE
chore(AS): make `checkDeleted` logic in configuration resource stronger

### DIFF
--- a/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_configuration.go
@@ -464,7 +464,8 @@ func resourceASConfigurationRead(_ context.Context, d *schema.ResourceData, meta
 	configId := d.Id()
 	asConfig, err := configurations.Get(asClient, configId).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "AS configuration")
+		// When the resource does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving AS configuration")
 	}
 
 	// update InstanceID if necessary
@@ -505,7 +506,8 @@ func resourceASConfigurationDelete(_ context.Context, d *schema.ResourceData, me
 	}
 
 	if delErr := configurations.Delete(asClient, configId).ExtractErr(); delErr != nil {
-		return diag.Errorf("error deleting AS configuration: %s", delErr)
+		// When the resource does not exist, the response HTTP status code of the delete API is 404.
+		return common.CheckDeletedDiag(d, delErr, "error deleting AS configuration")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Make the `checkDeleted` logic in resource **huaweicloud_as_configuration** more reliable.
- add `checkDeleted` logic in delete function.
- check `checkDeleted` logic in both read and delete function.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASConfiguration_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASConfiguration_ -timeout 360m -parallel 4
=== RUN   TestAccASConfiguration_basic
=== PAUSE TestAccASConfiguration_basic
=== RUN   TestAccASConfiguration_spot_ecsPassword
=== PAUSE TestAccASConfiguration_spot_ecsPassword
=== RUN   TestAccASConfiguration_windowsPassword
=== PAUSE TestAccASConfiguration_windowsPassword
=== RUN   TestAccASConfiguration_instance
=== PAUSE TestAccASConfiguration_instance
=== RUN   TestAccASConfiguration_DEH
=== PAUSE TestAccASConfiguration_DEH
=== RUN   TestAccASConfiguration_bandwidth_new_disk
=== PAUSE TestAccASConfiguration_bandwidth_new_disk
=== RUN   TestAccASConfiguration_snapshot
=== PAUSE TestAccASConfiguration_snapshot
=== RUN   TestAccASConfiguration_dataDiskImage
=== PAUSE TestAccASConfiguration_dataDiskImage
=== CONT  TestAccASConfiguration_basic
=== CONT  TestAccASConfiguration_DEH
=== CONT  TestAccASConfiguration_windowsPassword
=== CONT  TestAccASConfiguration_instance
=== NAME  TestAccASConfiguration_DEH
    acceptance.go:1916: HW_DEDICATED_HOST_ID must be set for the acceptance test
--- SKIP: TestAccASConfiguration_DEH (0.00s)
=== CONT  TestAccASConfiguration_spot_ecsPassword
--- PASS: TestAccASConfiguration_basic (99.34s)
=== CONT  TestAccASConfiguration_snapshot
--- PASS: TestAccASConfiguration_windowsPassword (102.81s)
=== CONT  TestAccASConfiguration_dataDiskImage
    acceptance.go:1923: HW_IMS_DATA_DISK_IMAGE_ID must be set for the acceptance test
--- SKIP: TestAccASConfiguration_dataDiskImage (0.01s)
=== CONT  TestAccASConfiguration_bandwidth_new_disk
--- PASS: TestAccASConfiguration_spot_ecsPassword (106.66s)
--- PASS: TestAccASConfiguration_bandwidth_new_disk (97.40s)
--- PASS: TestAccASConfiguration_instance (233.51s)
--- PASS: TestAccASConfiguration_snapshot (691.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        790.579s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
   
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/962337fe-6bc1-4d84-8413-598d1d3b57ec)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/c2c71b11-0520-4cee-b81b-808dd40273d3)

