### PR TITLE
test(nat): improve the ut coverage

### DIFF
--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_private_gateway_test.go
@@ -108,6 +108,7 @@ func testAccPrivateGateway_basic_step_2(name, relatedConfig string) string {
 resource "huaweicloud_nat_private_gateway" "test" {
   subnet_id             = huaweicloud_vpc_subnet.test.id
   name                  = "%[2]s"
+  spec                  = "Medium"
   enterprise_project_id = "0"
 
   tags = {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Improve the NATservice ut coverage.
1.snat resource
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/148871570/02014f83-d409-40d1-84f4-f0d8d6c1e3e2)

2.private nat resource
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/148871570/5321dae2-1f6c-4c4b-a6e8-e5cba7c72965)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ sh run-testacc.sh ./huaweicloud/services/acceptance/nat TestAccPublicSnatRule_.*
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -run TestAccPublicSnatRule_.* -timeout 360m -parallel 4

=== RUN   TestAccPublicSnatRule_basic
=== PAUSE TestAccPublicSnatRule_basic
=== RUN   TestAccPublicSnatRule_associatedGlobalEIP
=== PAUSE TestAccPublicSnatRule_associatedGlobalEIP
=== RUN   TestAccPublicSnatRule_netWorkId
=== PAUSE TestAccPublicSnatRule_netWorkId
=== CONT  TestAccPublicSnatRule_basic
=== CONT  TestAccPublicSnatRule_associatedGlobalEIP
=== CONT  TestAccPublicSnatRule_netWorkId
--- PASS: TestAccPublicSnatRule_netWorkId (137.87s)
--- PASS: TestAccPublicSnatRule_basic (202.85s)
--- PASS: TestAccPublicSnatRule_associatedGlobalEIP (303.42s)
PASS
coverage: 3.0% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       303.850s 
```
```
$ sh run_testacc.sh ./huaweicloud/services/acceptance/nat TestAccPrivateGateway_basic
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -run TestAccPrivateGateway_basic -timeout 360m -parallel 4

=== RUN   TestAccPrivateGateway_basic
=== PAUSE TestAccPrivateGateway_basic
=== CONT  TestAccPrivateGateway_basic
--- PASS: TestAccPrivateGateway_basic (105.63s)
PASS
coverage: 2.6% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       106.050s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
