### PR TITLE
fix(dms): fix updating broker nums when public IP enabled

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -141,6 +141,10 @@ The following arguments are supported:
 * `broker_num` - (Optional, Int) Specifies the broker numbers.
   It is required when creating an instance with `flavor_id`.
 
+* `new_tenant_ips` - (Optional, List) Specifies the IPv4 private IP addresses for the new brokers.
+
+  -> The number of specified IP addresses must be less than or equal to the number of new brokers.
+
 * `access_user` - (Optional, String, ForceNew) Specifies the username of SASL_SSL user. A username consists of 4
   to 64 characters and supports only letters, digits, and hyphens (-). Changing this creates a new instance resource.
 
@@ -180,7 +184,7 @@ The following arguments are supported:
   and `maintain_end` must be set in pairs. If parameter `maintain_end` is left blank, parameter
   `maintain_begin` is also blank. In this case, the system automatically allocates the default end time 06:00.
 
-* `public_ip_ids` - (Optional, List, ForceNew) Specifies the IDs of the elastic IP address (EIP)
+* `public_ip_ids` - (Optional, List) Specifies the IDs of the elastic IP address (EIP)
   bound to the DMS Kafka instance. Changing this creates a new instance resource.
   + If the instance is created with `flavor_id`, the total number of public IPs is equal to `broker_num`.
   + If the instance is created with `product_id`, the total number of public IPs must provide as follows:
@@ -191,6 +195,11 @@ The following arguments are supported:
   | 300MB | 3 |
   | 600MB | 4 |
   | 1,200MB | 8 |
+
+  -> Only support to **add** public IP nums when `broker_num` adding and the instance is **created** with public IP
+  **enabled** and using `flavor_id`.
+
+  ~> The parameter behavior of `public_ip_ids` has been changed from `list` to `set`.
 
 * `retention_policy` - (Optional, String) Specifies the action to be taken when the memory usage reaches the disk
   capacity threshold. The valid values are as follows:
@@ -262,6 +271,7 @@ In addition to all arguments above, the following attributes are exported:
 * `management_connect_address` - Indicates the Kafka Manager connection address of a Kafka instance.
 * `cross_vpc_accesses` - Indicates the Access information of cross-VPC. The structure is documented below.
 * `charging_mode` - Indicates the charging mode of the instance.
+* `public_ip_address` - Indicates the public IP addresses list of the instance.
 
 The `cross_vpc_accesses` block supports:
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240702061604-791e00a19973
+	github.com/chnsz/golangsdk v0.0.0-20240710014841-c6d07e14c758
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240702061604-791e00a19973 h1:V7UKkd3quQgjL4UvvY/ecPqgDtCGonOpTbb/+/pOwhU=
-github.com/chnsz/golangsdk v0.0.0-20240702061604-791e00a19973/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240710014841-c6d07e14c758 h1:NNYIBgrDoYutD+MeLhFOjNDnFis0pADQM4572YSVohs=
+github.com/chnsz/golangsdk v0.0.0-20240710014841-c6d07e14c758/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
@@ -295,12 +295,13 @@ func List(client *golangsdk.ServiceClient, opts ListOpsBuilder) pagination.Pager
 }
 
 type ResizeInstanceOpts struct {
-	NewSpecCode     *string `json:"new_spec_code,omitempty"`
-	NewStorageSpace *int    `json:"new_storage_space,omitempty"`
-	OperType        *string `json:"oper_type,omitempty"`
-	NewBrokerNum    *int    `json:"new_broker_num,omitempty"`
-	NewProductID    *string `json:"new_product_id,omitempty"`
-	PublicIpID      *string `json:"publicip_id,omitempty"`
+	NewSpecCode     *string  `json:"new_spec_code,omitempty"`
+	NewStorageSpace *int     `json:"new_storage_space,omitempty"`
+	OperType        *string  `json:"oper_type,omitempty"`
+	NewBrokerNum    *int     `json:"new_broker_num,omitempty"`
+	NewProductID    *string  `json:"new_product_id,omitempty"`
+	PublicIpID      *string  `json:"publicip_id,omitempty"`
+	TenantIps       []string `json:"tenant_ips,omitempty"`
 }
 
 func Resize(client *golangsdk.ServiceClient, id string, opts ResizeInstanceOpts) (string, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240702061604-791e00a19973
+# github.com/chnsz/golangsdk v0.0.0-20240710014841-c6d07e14c758
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix updating broker nums when public IP enabled

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dms" TESTARGS="-run  TestAccKafkaInstance_publicIp"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run  TestAccKafkaInstance_publicIp -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstance_publicIp
=== PAUSE TestAccKafkaInstance_publicIp
=== CONT  TestAccKafkaInstance_publicIp
--- PASS: TestAccKafkaInstance_publicIp (1562.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1563.025s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
