### PR TITLE
chore(AS): make `checkDeleted` logic in instance attach stronger

### DIFF
--- a/huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_instance_attach.go
@@ -168,7 +168,9 @@ func resourceInstanceAttachRead(_ context.Context, d *schema.ResourceData, meta 
 	instanceID := parts[1]
 	ins, err := getGroupInstanceByID(asClient, groupID, instanceID)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "AS instance attach")
+		// When the group does not exist or the instance is not in the group, the method `getGroupInstanceByID` will
+		// specially handle these two scenarios into a 404 error code.
+		return common.CheckDeletedDiag(d, err, "error retrieving AS instance attach")
 	}
 
 	mErr := multierror.Append(nil,
@@ -254,6 +256,10 @@ func resourceInstanceAttachDelete(ctx context.Context, d *schema.ResourceData, m
 		},
 	}
 	if err := doBatchAction(ctx, asClient, d.Timeout(schema.TimeoutDelete), groupID, createActions); err != nil {
+		// When removing a non-existing instance from the scaling group, the error_code is "AS.4030", which means that
+		// the batch deletion of cloud servers failed.
+		// This error message is ambiguous and cannot be regarded as successfully deleted, so the checkDeleted
+		// verification is not performed.
 		return diag.Errorf("error disattaching instance %s from AS group %s: %s", instanceID, groupID, err)
 	}
 
@@ -296,7 +302,10 @@ func doBatchAction(ctx context.Context, client *golangsdk.ServiceClient, timeout
 func getGroupInstanceByID(client *golangsdk.ServiceClient, groupID, instanceID string) (*instances.Instance, error) {
 	page, err := instances.List(client, groupID, nil).AllPages()
 	if err != nil {
-		return nil, err
+		// When the group does not exist, the query instance list API response reports the following error:
+		// {"error":{"code":"AS.2007","message":"The AS group does not exist."}.
+		// It needs to be specially processed into 404
+		return nil, parseGroupResponseError(err)
 	}
 
 	allInstances, err := page.(instances.InstancePage).Extract()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Make the `checkDeleted` logic in the resource `huaweicloud_as_instance_attach` more reliable.
- add annotations for the checkDeleted scenario.
- add logic that if the group does not exist, it will be processed as a 404 error code.
- the response error code of the delete method is ambiguous and is not suitable for adding `checkDeleted` logic.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASInstanceAttach_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASInstanceAttach_basic -timeout 360m -parallel 4
=== RUN   TestAccASInstanceAttach_basic
=== PAUSE TestAccASInstanceAttach_basic
=== CONT  TestAccASInstanceAttach_basic
--- PASS: TestAccASInstanceAttach_basic (472.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        472.327s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/a3caa35d-e8ac-443f-9cba-84f89980786b)



    ab. Related resources (parent resources) not found
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/53d2062a-24da-4299-860c-85f3eddd9a8c)

