### PR TITLE
chore(AS): make checkDeleted logic in notification resource stronger

### DIFF
--- a/huaweicloud/services/as/resource_huaweicloud_as_notification.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_notification.go
@@ -130,7 +130,9 @@ func resourceAsNotificationRead(_ context.Context, d *schema.ResourceData, meta 
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving AS notification")
+		// When the group does not exist, the response error information of the detailed API is as follows:
+		// {"error": {"code": "AS.2007","message": "The AS group does not exist."}}.
+		return common.CheckDeletedDiag(d, parseGroupResponseError(err), "error retrieving AS notification")
 	}
 
 	getASNotificationRespBody, err := utils.FlattenResponse(getResp)
@@ -139,6 +141,10 @@ func resourceAsNotificationRead(_ context.Context, d *schema.ResourceData, meta 
 	}
 
 	notificationMap := filterTargetASNotificationByTopicUrn(getASNotificationRespBody, d.Id())
+	if len(notificationMap) == 0 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
@@ -193,7 +199,10 @@ func resourceAsNotificationDelete(_ context.Context, d *schema.ResourceData, met
 	}
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting AS notification: %s", err)
+		// When the group does not exist, the response error message of the delete API is:
+		// {"error": {"code": "AS.2007","message": "The AS group does not exist."}}.
+		// When AS notification does not exist, the response HTTP status code of the delete API is 404
+		return common.CheckDeletedDiag(d, parseGroupResponseError(err), "error deleting AS notification")
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Make the `checkDeleted` logic in the notification resource more reliable.
- when the group does not exist or the notification does not exist, the read and delete methods are enhanced to support checkDeleted judgment.
- check `checkDeleted` logic in both read and delete method.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccAsNotification_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccAsNotification_basic -timeout 360m -parallel 4
=== RUN   TestAccAsNotification_basic
=== PAUSE TestAccAsNotification_basic
=== CONT  TestAccAsNotification_basic
--- PASS: TestAccAsNotification_basic (240.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        240.181s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found

    ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/b624365c-84a4-4b23-a846-45512ccfa955)

    ab. Related resources (parent resources) not found
    
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/4fb637d6-9ca5-436c-831e-c68681e9f60d)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found

   ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/9b279dbb-8383-43c9-94ec-814b60f65c5b)

    bb. Related resources (parent resources) not found
    
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/9755b739-17c2-4d11-b766-abed8897f8c0)

