### PR TITLE
chore(AS): make checkDeleted logic in planned task resource stronger

### DIFF
--- a/huaweicloud/services/as/resource_huaweicloud_as_planned_task.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_planned_task.go
@@ -277,7 +277,10 @@ func resourcePlannedTaskRead(_ context.Context, d *schema.ResourceData, meta int
 	)
 	plannedTasksResp, err := scheduledtasks.List(client, listOpts)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "AS planned task")
+		// When the group does not exist, the API response body is an empty list.
+		// It seems that `CheckDeletedDiag` here has no practical significance.
+		// In order to avoid unknown problems, this part of the code is retained.
+		return common.CheckDeletedDiag(d, err, "error retrieving AS planned task")
 	}
 
 	var mErr *multierror.Error
@@ -365,7 +368,8 @@ func resourcePlannedTaskDelete(_ context.Context, d *schema.ResourceData, meta i
 		taskId  = d.Id()
 	)
 	if err := scheduledtasks.Delete(asClient, groupID, taskId); err != nil {
-		return diag.Errorf("error deleting AS planned task (%s): %s", taskId, err)
+		// When the group or task does not exist, the response HTTP status code of the delete API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting AS planned task")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Make the `checkDeleted` logic in resource `huaweicloud_as_planned_task` more reliable.
- add `checkDeleted` logic in deletion method.
- check `checkDeleted` logic in both read and delete methods.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccPlannedTask_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccPlannedTask_ -timeout 360m -parallel 4
=== RUN   TestAccPlannedTask_basic
=== PAUSE TestAccPlannedTask_basic
=== RUN   TestAccPlannedTask_timedTask
=== PAUSE TestAccPlannedTask_timedTask
=== CONT  TestAccPlannedTask_basic
=== CONT  TestAccPlannedTask_timedTask
--- PASS: TestAccPlannedTask_timedTask (185.37s)
--- PASS: TestAccPlannedTask_basic (240.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        241.034s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/2a39838f-7d75-44ab-9ee1-c56233ba7242)


    ab. Related resources (parent resources) not found
    
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/8639d46c-6029-4ff6-acee-72490a3c7e8b)


  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/b1d5483e-f60e-4aab-a146-47e6bfb5e670)


    bb. Related resources (parent resources) not found

![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/c5c49308-8591-4664-9913-503477b41631)


