### PR TITLE
chore(CDN): make `checkDeleted` logic in the cdn service stronger

### DIFF
--- a/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_statistics.go
+++ b/huaweicloud/services/cdn/data_source_huaweicloud_cdn_domain_statistics.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -125,7 +124,7 @@ func resourceStatisticsRead(_ context.Context, d *schema.ResourceData, meta inte
 	domainStatisticsResp, err := domainStatisticsClient.Request("GET", domainStatisticsPath, &domainStatisticsOpt)
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving Statistics")
+		return diag.Errorf("error retrieving CDN statistics: %s", err)
 	}
 
 	domainStatisticsRespBody, err := utils.FlattenResponse(domainStatisticsResp)

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_billing_option.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_billing_option.go
@@ -136,6 +136,7 @@ func resourceBillingOptionRead(_ context.Context, d *schema.ResourceData, meta i
 
 	resp, err := hcCdnClient.ShowChargeModes(&request)
 	if err != nil {
+		// The billing model is always valuable and there is no need to pay attention to scenarios where resources do not exist.
 		return diag.Errorf("error retrieving CDN billing option: %s", err)
 	}
 

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -2539,6 +2539,10 @@ func resourceCdnDomainDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 	_, err = domains.Delete(cdnClient, d.Id(), opts).Extract()
 	if err != nil {
+		// When the domain does not exist, the deletion API will report an error and return the following information:
+		// {"error": {"error_code": "CDN.0000","error_msg": "domain is null or more than one."}}.
+		// The error code "CDN.0000" indicates an internal system error and cannot be used to prove that the resource
+		// no longer exists, so the logic of checkDeleted is not added.
 		return diag.Errorf("error deleting CDN domain (%s): %s", d.Id(), err)
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

make `checkDeleted` logic in the cdn service stronger.
- remove `checkDeleted` logic in datasources.
- add comments and reasons for methods that do not support `checkDeleted`.
- check `checkDeleted` logic in resources (Currently, in the CDN service, only the resource `huaweicloud_cdn_domain` supports `checkDeleted`).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceStatistics_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceStatistics_basic
=== PAUSE TestAccDatasourceStatistics_basic
=== CONT  TestAccDatasourceStatistics_basic
--- PASS: TestAccDatasourceStatistics_basic (9.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       9.862s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccBillingOption_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccBillingOption_basic -timeout 360m -parallel 4
=== RUN   TestAccBillingOption_basic
=== PAUSE TestAccBillingOption_basic
=== CONT  TestAccBillingOption_basic
--- PASS: TestAccBillingOption_basic (19.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       19.088s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/4785b5a5-5a47-4959-bb4a-4825d08061c6)
