### PR TITLE
chore(dc): make `checkDeleted` logic in virtual gateway stronger

### DIFF
--- a/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_gateway.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_gateway.go
@@ -128,7 +128,8 @@ func resourceVirtualGatewayRead(_ context.Context, d *schema.ResourceData, meta 
 	gatewayId := d.Id()
 	resp, err := gateways.Get(client, gatewayId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "virtual gateway")
+		// When the gateway does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving DC virtual gateway")
 	}
 
 	mErr := multierror.Append(nil,
@@ -189,7 +190,8 @@ func resourceVirtualGatewayDelete(_ context.Context, d *schema.ResourceData, met
 	gatewayId := d.Id()
 	err = gateways.Delete(client, gatewayId)
 	if err != nil {
-		return diag.Errorf("error deleting virtual gateway (%s): %s", gatewayId, err)
+		// When the gateway does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting DC virtual gateway")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

make `checkDeleted` logic in virtual gateway stronger
- add `checkDeleted` logic in deletion method.
- check `checkDeleted` logic in both read and deletion methods.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dc' TESTARGS='-run TestAccVirtualGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc -v -run TestAccVirtualGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccVirtualGateway_basic
=== PAUSE TestAccVirtualGateway_basic
=== CONT  TestAccVirtualGateway_basic
--- PASS: TestAccVirtualGateway_basic (54.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        54.588s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
   
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/64b5eade-e038-4e74-baca-2bdd577e3749)


  - **b. During delete/disassociate/unbind operation (Delete Context)**

![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/5de5963b-8f1c-485f-a67a-39f62adaa462)


