### PR TITLE
chore(dc): make `checkDeleted` logic in virtual interface stronger

### DIFF
--- a/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_virtual_interface.go
@@ -365,7 +365,8 @@ func resourceVirtualInterfaceRead(_ context.Context, d *schema.ResourceData, met
 	interfaceId := d.Id()
 	resp, err := interfaces.Get(client, interfaceId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "virtual interface")
+		// When the interface does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving DC virtual interface")
 	}
 	log.Printf("[DEBUG] The response of virtual interface is: %#v", resp)
 
@@ -543,7 +544,8 @@ func resourceVirtualInterfaceDelete(_ context.Context, d *schema.ResourceData, m
 	interfaceId := d.Id()
 	err = interfaces.Delete(client, interfaceId)
 	if err != nil {
-		return diag.Errorf("error deleting virtual interface (%s): %s", interfaceId, err)
+		// When the interface does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting DC virtual interface")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

make `checkDeleted` logic in virtual interface stronger
- add `checkDeleted` logic in deletion method.
- check `checkDeleted` logic in both read and deletion methods.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dc' TESTARGS='-run TestAccVirtualInterface_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dc -v -run TestAccVirtualInterface_basic -timeout 360m -parallel 4
=== RUN   TestAccVirtualInterface_basic
=== PAUSE TestAccVirtualInterface_basic
=== CONT  TestAccVirtualInterface_basic
--- PASS: TestAccVirtualInterface_basic (68.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dc        68.223s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
   
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/f53044a9-57aa-481d-83ba-132af8abcc26)


  - **b. During delete/disassociate/unbind operation (Delete Context)**

![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/75192204/da3ec265-b230-4634-b03a-d5e5bd8c9b8c)

