### PR TITLE
refactor(common|cae): using general function to handle 400 errors

### DIFF
--- a/huaweicloud/common/errors.go
+++ b/huaweicloud/common/errors.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"reflect"
+
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// ConvertExpected400ErrInto404Err is a method used to parsing 400 error and try to convert it to 404 error according
+// to the right error code.
+// Arguments:
+// + err: The error response obtained through HTTP/HTTPS request.
+// + errCodeKey: The key name of the error code in the error response body, e.g. 'error_code', 'err_code'.
+// + specErrCodes: One or more error codes that you wish to match against the current error, e.g. 'APIGW.0001'.
+// Notes: If you missing specErrCodes input, this function will convert all 400 errors into 404 errors.
+// How to use it:
+// + For the general cases, their error code key is 'error_code', and we should call as follow:
+//   - utils.ConvertExpected400ErrInto404Err(err, "error_code")
+//   - utils.ConvertExpected400ErrInto404Err(err, "error_code", "DLM.3027")
+//   - utils.ConvertExpected400ErrInto404Err(err, "error_code", []string{"DLM.3027", "DLM.3028"}...)
+func ConvertExpected400ErrInto404Err(err error, errCodeKey string, specErrCodes ...string) error {
+	var err400 golangsdk.ErrDefault400
+	if !errors.As(err, &err400) {
+		log.Printf("[WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault400', but got '%s'",
+			reflect.TypeOf(err).String())
+		return err
+	}
+	var apiError interface{}
+	if jsonErr := json.Unmarshal(err400.Body, &apiError); jsonErr != nil {
+		return err
+	}
+
+	errCode, searchErr := jmespath.Search(errCodeKey, apiError)
+	if searchErr != nil || errCode == nil {
+		log.Printf("[WARN] Unable to find the expected error code key (%s)", errCodeKey)
+		return err
+	}
+
+	if len(specErrCodes) < 1 {
+		log.Printf("[INFO] Identified 400 error parsed it as 404 error (without the error code control)")
+		return golangsdk.ErrDefault404{}
+	}
+	if errCodeStr, ok := errCode.(string); ok && utils.StrSliceContains(specErrCodes, errCodeStr) {
+		log.Printf("[INFO] Identified 400 error with code '%s' and parsed it as 404 error", errCode)
+		return golangsdk.ErrDefault404{}
+	}
+	log.Printf("[WARN] Unable to recognize expected error code (%s), want %v", errCode, specErrCodes)
+	return err
+}

--- a/huaweicloud/common/errors_test.go
+++ b/huaweicloud/common/errors_test.go
@@ -1,0 +1,58 @@
+package common_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+)
+
+func TestErrorFunc_ConvertExpected400ErrInto404Err(t *testing.T) {
+	input400Err := golangsdk.ErrDefault400{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte("{\"error_code\": \"TESTERR.0002\", \"error_msg\": \"Resource not found\"}"),
+		},
+	}
+	input403Err := golangsdk.ErrDefault403{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte("{\"error_code\": \"TESTERR.0003\", \"error_msg\": \"Authentication Failed\"}"),
+		},
+	}
+
+	// Step1: Check whether the function can normally identify the expected error code under follow input and convert
+	// the 400 error into a 404 error.
+	parseResult1 := common.ConvertExpected400ErrInto404Err(input400Err, "error_code", "TESTERR.0002")
+	if _, ok := parseResult1.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 400 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult1).String())
+	}
+	// Step1: Check whether the function can normally recognize unexpected 403 error under follow input and
+	// terminate subsequent processing, and directly return error.
+	parseResult2 := common.ConvertExpected400ErrInto404Err(input403Err, "error_code", "TESTERR.0002")
+	if _, ok := parseResult2.(golangsdk.ErrDefault404); ok {
+		t.Fatalf("The expected 403 error was not recognized and was incorrectly converted")
+	}
+	// Step2: Check whether the function can normally recognize unexpected error code key under follow input and
+	// terminate subsequent processing, and directly return error.
+	parseResult3 := common.ConvertExpected400ErrInto404Err(input400Err, "err_code", "TESTERR.0002")
+	if !reflect.DeepEqual(parseResult3, input400Err) {
+		t.Fatalf("Illegal recognition of unexpected error code key and convert the error to other type")
+	}
+	// Step1: Check whether the function can normally identify the expected error code (during a expected code list)
+	// under follow input and convert the 400 error into a 404 error.
+	parseResult4 := common.ConvertExpected400ErrInto404Err(input400Err, "error_code",
+		[]string{"TESTERR.0001", "TESTERR.0002"}...)
+	if _, ok := parseResult4.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 400 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult1).String())
+	}
+	// Step1: Check whether the function can normally recognize unexpected error code under (during a unmatched code
+	// list) follow input and terminate subsequent processing, and directly return error.
+	parseResult5 := common.ConvertExpected400ErrInto404Err(input400Err, "error_code",
+		[]string{"TESTERR.0001", "TESTERR.0003"}...)
+	if !reflect.DeepEqual(parseResult5, input400Err) {
+		t.Fatalf("error converting 400 error to 404 error via a non-exist error code")
+	}
+}

--- a/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_configurations_test.go
+++ b/huaweicloud/services/acceptance/cae/resource_huaweicloud_cae_component_configurations_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/chnsz/golangsdk"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cae"
@@ -39,7 +40,7 @@ func getComponentConfigurationsFunc(cfg *config.Config, state *terraform.Resourc
 	}
 	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return nil, cae.ParseQueryError400(err, cae.ConfigRelatedResourcesNotFoundCodes)
+		return nil, common.ConvertExpected400ErrInto404Err(err, "error_code", cae.ConfigRelatedResourcesNotFoundCodes...)
 	}
 
 	respBody, err := utils.FlattenResponse(requestResp)

--- a/huaweicloud/services/cae/common.go
+++ b/huaweicloud/services/cae/common.go
@@ -2,39 +2,8 @@ package cae
 
 import (
 	"encoding/json"
-	"errors"
 	"log"
-
-	"github.com/jmespath/go-jmespath"
-
-	"github.com/chnsz/golangsdk"
 )
-
-// ParseQueryError400 is a method used to parse whether a 404 error message means the resources not found.
-// For the CAE service, there are some known 404 error codes:
-// + CAE.01500208: application or component does not found.
-// + CAE.01500404: environment does not found.
-func ParseQueryError400(err error, specErrors []string) error {
-	var err400 golangsdk.ErrDefault400
-	if errors.As(err, &err400) {
-		var apiError interface{}
-		if jsonErr := json.Unmarshal(err400.Body, &apiError); jsonErr != nil {
-			return err
-		}
-
-		errCode, searchErr := jmespath.Search("error_code", apiError)
-		if searchErr != nil {
-			return err
-		}
-
-		for _, v := range specErrors {
-			if errCode == v {
-				return golangsdk.ErrDefault404{}
-			}
-		}
-	}
-	return err
-}
 
 func unmarshalJsonFormatParamster(paramName, paramVal string) map[string]interface{} {
 	parseResult := make(map[string]interface{})

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_component.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_component.go
@@ -18,8 +18,8 @@ import (
 )
 
 var ComponentResourceNotFoundCodes = []string{
-	"CAE.01500404",
-	"CAE.01500208",
+	"CAE.01500208", // Application or component does not found.
+	"CAE.01500404", // Environment does not found.
 }
 
 // @API CAE POST /v1/{project_id}/cae/applications/{application_id}/components
@@ -330,7 +330,7 @@ func GetComponentById(cfg *config.Config, region, environmentId, applicationId, 
 	}
 	resp, err := client.Request("GET", getPath, &getComponentOpt)
 	if err != nil {
-		return nil, ParseQueryError400(err, ComponentResourceNotFoundCodes)
+		return nil, err
 	}
 
 	getComponentRespBody, err := utils.FlattenResponse(resp)
@@ -347,7 +347,7 @@ func resourceComponentRead(_ context.Context, d *schema.ResourceData, meta inter
 	componentId := d.Id()
 	componentRespBody, err := GetComponentById(cfg, region, d.Get("environment_id").(string), d.Get("application_id").(string), componentId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, ParseQueryError400(err, ComponentResourceNotFoundCodes),
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", ComponentResourceNotFoundCodes...),
 			fmt.Sprintf("error retrieving CAE component (%s): %s", componentId, err))
 	}
 

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_component_configurations.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_component_configurations.go
@@ -18,8 +18,8 @@ import (
 )
 
 var ConfigRelatedResourcesNotFoundCodes = []string{
-	"CAE.01500208",
-	"CAE.01500404",
+	"CAE.01500208", // Application or component does not found.
+	"CAE.01500404", // Environment does not found.
 }
 
 // ListNode is the structure of linked list node.
@@ -251,7 +251,7 @@ func resourceComponentConfigurationsRead(_ context.Context, d *schema.ResourceDa
 	}
 	requestResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, ParseQueryError400(err, ConfigRelatedResourcesNotFoundCodes),
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", ConfigRelatedResourcesNotFoundCodes...),
 			fmt.Sprintf("error querying configurations for the specified component (%s): %s", componentId, err))
 	}
 	respBody, err := utils.FlattenResponse(requestResp)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supports a new general function that unified 400 errors handle and replace all resource's usage for CAE service.

Notes: the configuration resource is using component ID as the resource ID and the CheckDeleted logic does not use the d.Id as the check object, we will fixed in the next PR.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. unified function for handling 400 errors.
2. replace the references of checkdeleted func.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
go test -v -run=Test
=== RUN   TestErrorFunc_ConvertExpected400ErrsTo404Err
2024/07/11 16:48:40 [INFO] Identified 400 error with code 'TESTERR.0002' and parsed it as 404 error
2024/07/11 16:48:40 [INFO] Unable to recognize expected error type, want 'golangsdk.ErrDefault400', but got 'golangsdk.ErrDefault403'
2024/07/11 16:48:40 [INFO] Unable to find the expected error code key ('err_code'): %!s(<nil>)
2024/07/11 16:48:40 [INFO] Identified 400 error with code 'TESTERR.0002' and parsed it as 404 error
2024/07/11 16:48:40 [INFO] Unable to recognize expected error code (TESTERR.0002), want [TESTERR.0001 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertExpected400ErrsTo404Err (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common        0.039s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    (component)
    ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/a7f2f9dd-d42a-4ec3-aefc-34db31118019)
    (configurations)
    ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/cce86c88-bd68-4c57-b8e5-096d38b0f7f6)

    ab. Related resources (parent resources) not found
    (component: environment not found)
    ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/0031ee50-5f03-46f4-a644-d8eaa6ee9af1)
    (component: application not found)
    ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/19e9cc1a-c710-408b-8014-9bb5c44bdd9e)
    (configurations: environment not found)
    ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/a30e7e2f-0eda-485c-b23a-6d2fe1ea81cf)
    (configurations: environment not found)
    ![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/74246744/a34b9396-3852-4b30-8811-52e0b7e540f4)

