### PR TITLE
chore(nat): add checkDeleted logic

### DIFF
--- a/huaweicloud/services/nat/resource_huaweicloud_nat_dnat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_dnat_rule.go
@@ -214,7 +214,8 @@ func resourcePublicDnatRuleRead(_ context.Context, d *schema.ResourceData, meta 
 	ruleId := d.Id()
 	resp, err := dnats.Get(client, ruleId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "DNAT rule")
+		// If the DNAT rule does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving DNAT rule")
 	}
 
 	mErr := multierror.Append(nil,
@@ -301,7 +302,8 @@ func resourcePublicDnatRuleDelete(ctx context.Context, d *schema.ResourceData, m
 	)
 	err = dnats.Delete(client, gatewayId, ruleId)
 	if err != nil {
-		return diag.Errorf("error deleting DNAT rule (%s): %s", ruleId, err)
+		// If the DNAT rule does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting DNAT rule")
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_gateway.go
@@ -212,7 +212,8 @@ func resourcePublicGatewayRead(_ context.Context, d *schema.ResourceData, meta i
 	gatewayId := d.Id()
 	resp, err := gateways.Get(client, gatewayId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "NAT Gateway")
+		// If the NAT gateway does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving NAT Gateway")
 	}
 
 	mErr := multierror.Append(nil,
@@ -296,8 +297,10 @@ func resourcePublicGatewayDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	gatewayId := d.Id()
-	if err = gateways.Delete(client, gatewayId); err != nil {
-		return diag.Errorf("unable to delete NAT gateway (%s): %s", gatewayId, err)
+	err = gateways.Delete(client, gatewayId)
+	if err != nil {
+		// If the NAT gateway does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "err deleting NAT gateway")
 	}
 
 	stateConf := &resource.StateChangeConf{

--- a/huaweicloud/services/nat/resource_huaweicloud_nat_snat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_snat_rule.go
@@ -154,7 +154,7 @@ func buildPublicSnatRuleCreateOpts(d *schema.ResourceData) (snats.CreateOpts, er
 
 	sourceType := d.Get("source_type").(int)
 	if sourceType == 1 && subnetId != "" {
-		return result, fmt.Errorf("In the DC (Direct Connect) scenario (source_type is 1), only the parameter 'cidr' " +
+		return result, fmt.Errorf("in the DC (Direct Connect) scenario (source_type is 1), only the parameter 'cidr' " +
 			"is valid, and the parameter 'subnet_id' must be empty")
 	}
 	result.SourceType = sourceType
@@ -226,7 +226,8 @@ func resourcePublicSnatRuleRead(_ context.Context, d *schema.ResourceData, meta 
 
 	resp, err := snats.Get(natClient, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Public SNAT rule")
+		// If the SNAT rule does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving SNAT rule")
 	}
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
@@ -320,7 +321,8 @@ func resourcePublicSnatRuleDelete(ctx context.Context, d *schema.ResourceData, m
 	gatewayId := d.Get("nat_gateway_id").(string)
 	err = snats.Delete(client, gatewayId, ruleId)
 	if err != nil {
-		return diag.Errorf("error deleting public SNAT rule (%s): %s", ruleId, err)
+		// If the SNAT rule does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting SNAT rule")
 	}
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"PENDING"},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add checkDeleted logic.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add checkDeleted logic to NAT resource
2.add checkDeleted logic to SNAT resource
3.add checkDeleted logic to DNAT resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_basic
--- PASS: TestAccPublicGateway_basic (126.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       126.833s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicSnatRule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicSnatRule -timeout 360m -parallel 4
=== RUN   TestAccPublicSnatRule_basic
=== PAUSE TestAccPublicSnatRule_basic
=== RUN   TestAccPublicSnatRule_associatedGlobalEIP
=== PAUSE TestAccPublicSnatRule_associatedGlobalEIP
=== RUN   TestAccPublicSnatRule_netWorkId
=== PAUSE TestAccPublicSnatRule_netWorkId
=== CONT  TestAccPublicSnatRule_basic
=== CONT  TestAccPublicSnatRule_netWorkId
=== CONT  TestAccPublicSnatRule_associatedGlobalEIP
--- PASS: TestAccPublicSnatRule_netWorkId (140.46s)
--- PASS: TestAccPublicSnatRule_basic (204.92s)
--- PASS: TestAccPublicSnatRule_associatedGlobalEIP (310.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       310.188s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPublicDnatRule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPublicDnatRule -timeout 360m -parallel 4
=== RUN   TestAccPublicDnatRule_basic
=== PAUSE TestAccPublicDnatRule_basic
=== RUN   TestAccPublicDnatRule_withPort
=== PAUSE TestAccPublicDnatRule_withPort
=== CONT  TestAccPublicDnatRule_basic
=== CONT  TestAccPublicDnatRule_withPort
--- PASS: TestAccPublicDnatRule_withPort (321.70s)
--- PASS: TestAccPublicDnatRule_basic (713.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       713.849s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
    1.NAT resource
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/148871570/3428ac96-f5e1-4121-86b0-d676d5baf0f3)
    2.SNAT resource
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/148871570/3e212e06-2d82-4fa6-ae9f-dc1b5ad2fb9b)
    3.DNAT resource
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/148871570/c6515abf-7d6e-4579-93a2-f91c1d2e8ae0)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
    1.NAT resource
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/148871570/7d0cefe4-d814-4716-8e25-c27585dc44ee)
    2.SNAT resource
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/148871570/876acbfe-8820-4fa1-a75c-e7cd1d19e0d7)
    3.DNAT resource
![image](https://github.com/huaweicloud/terraform-provider-huaweicloud/assets/148871570/d6d0f80f-214f-4b66-a731-e6aef3759edb)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
