### PR TITLE
chore(nat): remove checkDeleted logic in the NAT datasource

### DIFF
--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_dnat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_dnat_rules.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/chnsz/golangsdk/pagination"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -213,7 +212,7 @@ func dataSourceDnatRulesRead(_ context.Context, d *schema.ResourceData, meta int
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving private DNAT rule")
+		return diag.Errorf("error retrieving DNAT rules %s", err)
 	}
 
 	listDnatRulesRespJson, err := json.Marshal(listDnatRulesResp)

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_gateways.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_gateways.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -166,7 +165,7 @@ func dataSourcePublicGatewaysRead(_ context.Context, d *schema.ResourceData, met
 	listGatewaysResp, err := listGatewaysClient.Request("GET", listGatewaysPath, &listGatewaysOpt)
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving NAT Gateway")
+		return diag.Errorf("error retrieving NAT gateways %s", err)
 	}
 
 	listGatewaysRespBody, err := utils.FlattenResponse(listGatewaysResp)

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_private_dnat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_private_dnat_rules.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/chnsz/golangsdk/pagination"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -193,7 +192,7 @@ func dataSourcePrivateDnatRulesRead(_ context.Context, d *schema.ResourceData, m
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving private DNAT rule")
+		return diag.Errorf("error retrieving private DNAT rules %s", err)
 	}
 
 	listDnatRulesRespJson, err := json.Marshal(listDnatRulesResp)

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_private_gateways.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_private_gateways.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/chnsz/golangsdk/pagination"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -176,7 +175,7 @@ func dataSourcePrivateGatewaysRead(_ context.Context, d *schema.ResourceData, me
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving private NAT Gateway")
+		return diag.Errorf("error retrieving private NAT gateways %s", err)
 	}
 
 	listGatewaysRespJson, err := json.Marshal(listGatewaysResp)

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_private_snat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_private_snat_rules.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/chnsz/golangsdk/pagination"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -163,7 +162,7 @@ func dataSourcePrivateSnatRulesRead(_ context.Context, d *schema.ResourceData, m
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving private SNAT rule")
+		return diag.Errorf("error retrieving private SNAT rules %s", err)
 	}
 
 	listSnatRulesRespJson, err := json.Marshal(listSnatRulesResp)

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_private_transit_ips.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_private_transit_ips.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/chnsz/golangsdk/pagination"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -160,7 +159,7 @@ func dataSourcePrivateTransitIpsRead(_ context.Context, d *schema.ResourceData, 
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving transit IPs")
+		return diag.Errorf("error retrieving transit IPs %s", err)
 	}
 
 	listTransitIpsRespJson, err := json.Marshal(listTransitIpsResp)

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_snat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_snat_rules.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/chnsz/golangsdk/pagination"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -188,7 +187,7 @@ func dataSourceSnatRulesRead(_ context.Context, d *schema.ResourceData, meta int
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving SNAT rules")
+		return diag.Errorf("error retrieving SNAT rules %s", err)
 	}
 
 	listSnatRulesRespJson, err := json.Marshal(listSnatRulesResp)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove checkDeleted logic in the NAT datasource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccDatasource"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccDatasource -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDnatRules_basic
=== PAUSE TestAccDatasourceDnatRules_basic
=== RUN   TestAccDatasourcePublicGateways_basic
=== PAUSE TestAccDatasourcePublicGateways_basic
=== RUN   TestAccDatasourcePrivateDnatRules_basic
=== PAUSE TestAccDatasourcePrivateDnatRules_basic
=== RUN   TestAccDatasourcePrivateGateways_basic
=== PAUSE TestAccDatasourcePrivateGateways_basic
=== RUN   TestAccDatasourcePrivateSnatRules_basic
=== PAUSE TestAccDatasourcePrivateSnatRules_basic
=== RUN   TestAccDatasourcePrivateTransitIps_basic
=== PAUSE TestAccDatasourcePrivateTransitIps_basic
=== RUN   TestAccDatasourceSnatRules_basic
=== PAUSE TestAccDatasourceSnatRules_basic
=== RUN   TestAccDatasourceSnatRules_direct
=== PAUSE TestAccDatasourceSnatRules_direct
=== CONT  TestAccDatasourceDnatRules_basic
=== CONT  TestAccDatasourcePrivateSnatRules_basic
=== CONT  TestAccDatasourcePrivateDnatRules_basic
=== CONT  TestAccDatasourcePrivateGateways_basic
--- PASS: TestAccDatasourcePrivateGateways_basic (232.44s)
=== CONT  TestAccDatasourceSnatRules_basic
--- PASS: TestAccDatasourcePrivateSnatRules_basic (270.10s)
=== CONT  TestAccDatasourceSnatRules_direct
--- PASS: TestAccDatasourceDnatRules_basic (469.84s)
=== CONT  TestAccDatasourcePublicGateways_basic
--- PASS: TestAccDatasourcePrivateDnatRules_basic (496.34s)
=== CONT  TestAccDatasourcePrivateTransitIps_basic
--- PASS: TestAccDatasourceSnatRules_basic (271.93s)
--- PASS: TestAccDatasourceSnatRules_direct (247.39s)
--- PASS: TestAccDatasourcePrivateTransitIps_basic (160.38s)
--- PASS: TestAccDatasourcePublicGateways_basic (195.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       665.715s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
