### PR TITLE
chore(nat): add checkDeleted logic to private NAT gateway resource

### DIFF
--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_gateway.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_gateway.go
@@ -162,7 +162,8 @@ func resourcePrivateGatewayRead(_ context.Context, d *schema.ResourceData, meta 
 
 	resp, err := gateways.Get(natClient, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Private NAT gateway")
+		// If the private NAT gateway does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving private NAT gateway")
 	}
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
@@ -228,7 +229,8 @@ func resourcePrivateGatewayDelete(_ context.Context, d *schema.ResourceData, met
 	gatewayId := d.Id()
 	err = gateways.Delete(client, gatewayId)
 	if err != nil {
-		return diag.Errorf("error deleting private NAT gateway (%s): %s", gatewayId, err)
+		// If the private NAT gateway does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting private NAT gateway")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add checkDeleted logic to private NAT gateway resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_private)$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateGateway_basic
=== PAUSE TestAccPrivateGateway_basic
=== CONT  TestAccPrivateGateway_basic
--- PASS: TestAccPrivateGateway_basic (103.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       103.937s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/5ab1f242-4107-4773-8231-60e7b0a7dd33)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/da1dfaa4-d2b1-471b-bc8c-eed80452696b)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
