### PR TITLE
chore(nat): add checkDeleted logic to transit IP resource

### DIFF
--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_transit_ip.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_transit_ip.go
@@ -117,7 +117,8 @@ func resourcePrivateTransitIpRead(_ context.Context, d *schema.ResourceData, met
 
 	resp, err := transitips.Get(natClient, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Transit IP (Private NAT)")
+		// If the transit IP does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving transit IP (private NAT)")
 	}
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
@@ -163,7 +164,8 @@ func resourcePrivateTransitIpDelete(_ context.Context, d *schema.ResourceData, m
 	transitIpId := d.Id()
 	err = transitips.Delete(client, transitIpId)
 	if err != nil {
-		return diag.Errorf("error deleting transit IP (Private NAT) (%s): %s", transitIpId, err)
+		// If the transit IP does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting transit IP (private NAT)")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add checkDeleted logic to transit IP resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateTransitIp_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateTransitIp_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateTransitIp_basic
=== PAUSE TestAccPrivateTransitIp_basic
=== CONT  TestAccPrivateTransitIp_basic
--- PASS: TestAccPrivateTransitIp_basic (113.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       113.324s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/b301281d-f731-4c31-822b-28f0fff5447b)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/7356655f-1286-4a6f-8c48-14699b440c26)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
