### PR TITLE
chore(nat): add checkDeleted logic to private SNAT rule resource

### DIFF
--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_snat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_snat_rule.go
@@ -135,7 +135,8 @@ func resourcePrivateSnatRuleRead(_ context.Context, d *schema.ResourceData, meta
 
 	resp, err := snats.Get(client, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Private SNAT rule")
+		// If the private SNAT rule does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving private SNAT rule")
 	}
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
@@ -188,7 +189,8 @@ func resourcePrivateSnatRuleDelete(_ context.Context, d *schema.ResourceData, me
 	ruleId := d.Id()
 	err = snats.Delete(client, ruleId)
 	if err != nil {
-		return diag.Errorf("error deleting private SNAT rule (%s): %s", ruleId, err)
+		// If the private SNAT rule does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting private SNAT rule")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add checkDeleted logic to private SNAT rule resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateSnatRule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateSnatRule -timeout 360m -parallel 4
=== RUN   TestAccPrivateSnatRule_basic
=== PAUSE TestAccPrivateSnatRule_basic
=== RUN   TestAccPrivateSnatRule_cidr
=== PAUSE TestAccPrivateSnatRule_cidr
=== CONT  TestAccPrivateSnatRule_basic
=== CONT  TestAccPrivateSnatRule_cidr
--- PASS: TestAccPrivateSnatRule_basic (204.50s)
--- PASS: TestAccPrivateSnatRule_cidr (205.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       205.305s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/5f81b4c9-b304-4c8e-a307-eeb68a9f44a8)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/3d8ea6b2-59fb-4720-8c02-45eab03717c5)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
