### PR TITLE
chore(nat): add checkDeleted logic to private DNAT rule resource

### DIFF
--- a/huaweicloud/services/nat/resource_huaweicloud_nat_private_dnat_rule.go
+++ b/huaweicloud/services/nat/resource_huaweicloud_nat_private_dnat_rule.go
@@ -147,7 +147,8 @@ func resourcePrivateDnatRuleRead(_ context.Context, d *schema.ResourceData, meta
 
 	resp, err := dnats.Get(client, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Private DNAT rule")
+		// If the private DNAT rule does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving private DNAT rule")
 	}
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
@@ -225,7 +226,8 @@ func resourcePrivateDnatRuleDelete(_ context.Context, d *schema.ResourceData, me
 	ruleId := d.Id()
 	err = dnats.Delete(client, ruleId)
 	if err != nil {
-		return diag.Errorf("error deleting DNAT rule (Private NAT) (%s): %s", ruleId, err)
+		// If the private DNAT rule does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting private DNAT rule")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add checkDeleted logic to private DNAT rule resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/nat" TESTARGS="-run TestAccPrivateDnatRule"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccPrivateDnatRule -timeout 360m -parallel 4
=== RUN   TestAccPrivateDnatRule_basic
=== PAUSE TestAccPrivateDnatRule_basic
=== RUN   TestAccPrivateDnatRule_elbBackend
=== PAUSE TestAccPrivateDnatRule_elbBackend
=== RUN   TestAccPrivateDnatRule_vipBackend
=== PAUSE TestAccPrivateDnatRule_vipBackend
=== RUN   TestAccPrivateDnatRule_customIpAddress
=== PAUSE TestAccPrivateDnatRule_customIpAddress
=== CONT  TestAccPrivateDnatRule_basic
=== CONT  TestAccPrivateDnatRule_vipBackend
=== CONT  TestAccPrivateDnatRule_elbBackend
=== CONT  TestAccPrivateDnatRule_customIpAddress
--- PASS: TestAccPrivateDnatRule_vipBackend (446.08s)
--- PASS: TestAccPrivateDnatRule_customIpAddress (501.12s)
--- PASS: TestAccPrivateDnatRule_basic (661.99s)
--- PASS: TestAccPrivateDnatRule_elbBackend (790.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       790.064s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/9295e390-48b5-4ce6-abee-084df2c1a9ca)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/d3a9ad00-a5ee-4580-876a-95172f01bed2)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
