### PR TITLE
fix(hss): add forceNew attribute to the quota ID of resource and fix data source test cases

### DIFF
--- a/docs/resources/hss_webtamper_protection.md
+++ b/docs/resources/hss_webtamper_protection.md
@@ -38,8 +38,8 @@ The following arguments are supported:
 
   -> Before using HSS web tamper protection, it is necessary to ensure that the agent status of the host is **online**.
 
-* `quota_id` - (Optional, String) Specifies quota ID (yearly/monthly billing mode) for web tamper protection.
-  If omitted, an existing quota will be randomly selected.
+* `quota_id` - (Optional, String, ForceNew) Specifies quota ID (yearly/monthly billing mode) for web tamper protection.
+  If omitted, an existing quota will be randomly selected. Changing this parameter will create a new resource.
 
 * `is_dynamics_protect` - (Optional, Bool) Specifies whether to enable dynamic web tamper protection.
   Setting to **true** means enabling dynamic protection, while leaving it blank or setting to **false** means disabling

--- a/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_hosts_test.go
+++ b/huaweicloud/services/acceptance/hss/data_source_huaweicloud_hss_webtamper_hosts_test.go
@@ -1,6 +1,7 @@
 package hss
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -45,8 +46,12 @@ func TestAccDataSourceWebTamperHosts_basic(t *testing.T) {
 }
 
 func testDataSourceWebTamperHosts_basic() string {
-	return `
-data "huaweicloud_hss_webtamper_hosts" "test" {}
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_hss_webtamper_hosts" "test" {
+  depends_on = [huaweicloud_hss_webtamper_protection.test]
+}
 
 # Filter using host ID.
 locals {
@@ -101,5 +106,5 @@ data "huaweicloud_hss_webtamper_hosts" "not_found" {
 output "not_found_validation_pass" {
   value = length(data.huaweicloud_hss_webtamper_hosts.not_found.hosts) == 0
 }
-`
+`, testAccWebTamperProtection_basic())
 }

--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_webtamper_protection_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_webtamper_protection_test.go
@@ -72,9 +72,7 @@ func TestAccWebTamperProtection_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckEpsID(t)
 			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
-			acceptance.TestAccPreCheckHSSHostProtectionQuotaId(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -117,24 +115,121 @@ func TestAccWebTamperProtection_basic(t *testing.T) {
 	})
 }
 
+func testAccWebTamperProtection_base() string {
+	return `
+resource "huaweicloud_hss_quota" "test" {
+  version     = "hss.version.wtp"
+  period_unit = "month"
+  period      = 1
+}`
+}
+
 func testAccWebTamperProtection_basic() string {
 	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_hss_webtamper_protection" "test" {
-  host_id               = "%[1]s"
-  quota_id              = "%[2]s"
+  host_id               = "%[2]s"
+  quota_id              = huaweicloud_hss_quota.test.id
   is_dynamics_protect   = true
-  enterprise_project_id = "%[3]s"
+  enterprise_project_id = "0"
 }
-`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID, acceptance.HW_HSS_HOST_PROTECTION_QUOTA_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccWebTamperProtection_base(), acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
 }
 
 func testAccWebTamperProtection_update() string {
 	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_hss_webtamper_protection" "test" {
-  host_id               = "%[1]s"
-  enterprise_project_id = "%[2]s"
+  host_id               = "%[2]s"
+  quota_id              = huaweicloud_hss_quota.test.id
+  enterprise_project_id = "0"
 }
-`, acceptance.HW_HSS_HOST_PROTECTION_HOST_ID, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, testAccWebTamperProtection_base(), acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}
+
+func TestAccWebTamperProtection_noFillQuotaId(t *testing.T) {
+	var (
+		wtpProtectHost *hssv5model.WtpProtectHostResponseInfo
+		rName          = "huaweicloud_hss_webtamper_protection.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&wtpProtectHost,
+		getWebTamperProtectionFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHSSHostProtectionHostId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebTamperProtection_noFillQuotaId(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "host_id", acceptance.HW_HSS_HOST_PROTECTION_HOST_ID),
+					resource.TestCheckResourceAttrSet(rName, "host_name"),
+					resource.TestCheckResourceAttrSet(rName, "private_ip"),
+					resource.TestCheckResourceAttrSet(rName, "os_bit"),
+					resource.TestCheckResourceAttrSet(rName, "os_type"),
+					resource.TestCheckResourceAttr(rName, "protect_status", string(hss.ProtectStatusOpened)),
+					resource.TestCheckResourceAttr(rName, "rasp_protect_status", string(hss.ProtectStatusOpened)),
+				),
+			},
+			{
+				Config: testAccWebTamperProtection_noFillQuotaId_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "host_id", acceptance.HW_HSS_HOST_PROTECTION_HOST_ID),
+					resource.TestCheckResourceAttrSet(rName, "host_name"),
+					resource.TestCheckResourceAttrSet(rName, "private_ip"),
+					resource.TestCheckResourceAttrSet(rName, "os_bit"),
+					resource.TestCheckResourceAttrSet(rName, "os_type"),
+					resource.TestCheckResourceAttr(rName, "protect_status", string(hss.ProtectStatusOpened)),
+					resource.TestCheckResourceAttr(rName, "rasp_protect_status", string(hss.ProtectStatusClosed)),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"quota_id", "is_dynamics_protect", "enterprise_project_id",
+				},
+			},
+		},
+	})
+}
+
+func testAccWebTamperProtection_noFillQuotaId() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_hss_webtamper_protection" "test" {
+  depends_on = [huaweicloud_hss_quota.test]
+
+  host_id               = "%[2]s"
+  is_dynamics_protect   = true
+  enterprise_project_id = "0"
+}
+`, testAccWebTamperProtection_base(), acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
+}
+
+func testAccWebTamperProtection_noFillQuotaId_update() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_hss_webtamper_protection" "test" {
+  depends_on = [huaweicloud_hss_quota.test]
+
+  host_id               = "%[2]s"
+  enterprise_project_id = "0"
+}
+`, testAccWebTamperProtection_base(), acceptance.HW_HSS_HOST_PROTECTION_HOST_ID)
 }

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_webtamper_protection.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_webtamper_protection.go
@@ -48,6 +48,7 @@ func ResourceWebTamperProtection() *schema.Resource {
 			"quota_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"is_dynamics_protect": {
 				Type:     schema.TypeBool,
@@ -254,13 +255,6 @@ func resourceWebTamperProtectionUpdate(ctx context.Context, d *schema.ResourceDa
 	checkHostAvailableErr := checkHostAvailable(client, region, epsId, hostId)
 	if checkHostAvailableErr != nil {
 		return diag.FromErr(checkHostAvailableErr)
-	}
-
-	if d.HasChange("quota_id") {
-		err = openWebTamperProtection(client, cfg, hostId, d)
-		if err != nil {
-			return diag.Errorf("error updating HSS web tamper protection: %s", err)
-		}
 	}
 
 	if d.HasChange("is_dynamics_protect") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add the forceNew attribute to the quota ID of webtamper_protection resource and fix test cases.
Modify test cases for webtamper_hosts data source.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Commit1: Add the forceNew attribute to the quota ID of webtamper_protection resource and fix test cases.
Commit2: Modify test cases for webtamper_hosts data source.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### webtamper_protection resource test
```
$ export HW_HSS_HOST_PROTECTION_HOST_ID=xxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceWebTamperHosts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceWebTamperHosts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWebTamperHosts_basic
=== PAUSE TestAccDataSourceWebTamperHosts_basic
=== CONT  TestAccDataSourceWebTamperHosts_basic
--- PASS: TestAccDataSourceWebTamperHosts_basic (101.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       101.752s


$ export HW_HSS_HOST_PROTECTION_HOST_ID=xxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccWebTamperProtection_noFillQuotaId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccWebTamperProtection_noFillQuotaId -timeout 360m -parallel 4
=== RUN   TestAccWebTamperProtection_noFillQuotaId
=== PAUSE TestAccWebTamperProtection_noFillQuotaId
=== CONT  TestAccWebTamperProtection_noFillQuotaId
--- PASS: TestAccWebTamperProtection_noFillQuotaId (77.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       77.494s

```

### webtamper_hosts datasource test
```
$ export HW_HSS_HOST_PROTECTION_HOST_ID=xxxxxxxxxxx
$ make testacc TEST="./huaweicloud/services/acceptance/hss" TESTARGS="-run TestAccDataSourceWebTamperHosts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccDataSourceWebTamperHosts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWebTamperHosts_basic
=== PAUSE TestAccDataSourceWebTamperHosts_basic
=== CONT  TestAccDataSourceWebTamperHosts_basic
--- PASS: TestAccDataSourceWebTamperHosts_basic (87.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       87.358s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
