### PR TITLE
chore(vpn): remove redundant code in VPN connection to improve code coverage

### DIFF
--- a/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_test.go
+++ b/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_test.go
@@ -161,7 +161,7 @@ func TestAccConnection_haRole(t *testing.T) {
 
 	name := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_vpn_connection.test"
-	ipAddress := "172.16.1.3"
+	ipAddress := "172.16.1.5"
 
 	rc := acceptance.InitResourceCheck(
 		rName,
@@ -215,6 +215,7 @@ resource "huaweicloud_vpn_connection" "test" {
   peer_subnets        = ["192.168.55.0/24"]
   vpn_type            = "static"
   psk                 = "Test@123"
+  enable_nqa          = true
 
   tags = {
     key = "val"

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
@@ -551,9 +551,6 @@ func createConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 
 			createConnectionWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
 			}
 			createConnectionWaitingResp, err := createConnectionWaitingClient.Request("GET", createConnectionWaitingPath, &createConnectionWaitingOpt)
 			if err != nil {
@@ -571,19 +568,16 @@ func createConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 
 			status := fmt.Sprintf("%v", statusRaw)
 
+			if status == "ERROR" {
+				return createConnectionWaitingRespBody, status, nil
+			}
+
 			targetStatus := []string{
 				"ACTIVE",
 				"DOWN",
 			}
 			if utils.StrSliceContains(targetStatus, status) {
 				return createConnectionWaitingRespBody, "COMPLETED", nil
-			}
-
-			unexpectedStatus := []string{
-				"ERROR",
-			}
-			if utils.StrSliceContains(unexpectedStatus, status) {
-				return createConnectionWaitingRespBody, status, nil
 			}
 
 			return createConnectionWaitingRespBody, "PENDING", nil
@@ -618,9 +612,6 @@ func resourceConnectionRead(_ context.Context, d *schema.ResourceData, meta inte
 
 	getConnectionOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getConnectionResp, err := getConnectionClient.Request("GET", getConnectionPath, &getConnectionOpt)
 
@@ -774,9 +765,6 @@ func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		updateConnectionOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
 		}
 		updateConnectionOpt.JSONBody = utils.RemoveNil(buildUpdateConnectionBodyParams(d))
 		_, err = updateConnectionClient.Request("PUT", updateConnectionPath, &updateConnectionOpt)
@@ -900,9 +888,6 @@ func updateConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 
 			updateConnectionWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
 			}
 			updateConnectionWaitingResp, err := updateConnectionWaitingClient.Request("GET", updateConnectionWaitingPath, &updateConnectionWaitingOpt)
 			if err != nil {
@@ -920,19 +905,16 @@ func updateConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 
 			status := fmt.Sprintf("%v", statusRaw)
 
+			if status == "ERROR" {
+				return updateConnectionWaitingRespBody, status, nil
+			}
+
 			targetStatus := []string{
 				"ACTIVE",
 				"DOWN",
 			}
 			if utils.StrSliceContains(targetStatus, status) {
 				return updateConnectionWaitingRespBody, "COMPLETED", nil
-			}
-
-			unexpectedStatus := []string{
-				"ERROR",
-			}
-			if utils.StrSliceContains(unexpectedStatus, status) {
-				return updateConnectionWaitingRespBody, status, nil
 			}
 
 			return updateConnectionWaitingRespBody, "PENDING", nil
@@ -1004,9 +986,6 @@ func deleteConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 
 			deleteConnectionWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
 			}
 			deleteConnectionWaitingResp, err := deleteConnectionWaitingClient.Request("GET", deleteConnectionWaitingPath, &deleteConnectionWaitingOpt)
 			if err != nil {
@@ -1029,10 +1008,7 @@ func deleteConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 
 			status := fmt.Sprintf("%v", statusRaw)
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
-			if utils.StrSliceContains(unexpectedStatus, status) {
+			if status == "ERROR" {
 				return deleteConnectionWaitingRespBody, status, nil
 			}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
remove redundant code in VPN connection to improve code coverage
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove redundant code in VPN connection to improve code coverage
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccConnection_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccConnection_ -timeout 360m -parallel 1
=== RUN   TestAccConnection_basic
=== PAUSE TestAccConnection_basic
=== RUN   TestAccConnection_policy
=== PAUSE TestAccConnection_policy
=== RUN   TestAccConnection_haRole
=== PAUSE TestAccConnection_haRole
=== CONT  TestAccConnection_basic
--- PASS: TestAccConnection_basic (513.25s)
=== CONT  TestAccConnection_haRole
--- PASS: TestAccConnection_haRole (409.72s)
=== CONT  TestAccConnection_policy
--- PASS: TestAccConnection_policy (493.02s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       1416.048s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
