### PR TITLE
chore(cbh/instance): supplement the relevant content of `checkDeleted`

### DIFF
--- a/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
+++ b/huaweicloud/services/cbh/resource_huaweicloud_cbh_instance.go
@@ -1138,7 +1138,9 @@ func resourceCBHInstanceDelete(ctx context.Context, d *schema.ResourceData, meta
 	expression := fmt.Sprintf("[?server_id == '%s']|[0]", d.Id())
 	instance := utils.PathSearch(expression, instances, nil)
 	if instance == nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+		// Before deleting the CBH instance, it is necessary to first call the query API to obtain the resource_id of
+		// the instance. If the instance cannot be found, then execute the logic of checkDeleted.
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error deleting the CBH instance")
 	}
 
 	resourceId := utils.PathSearch("resource_info.resource_id", instance, "").(string)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Supplement the relevant content of `checkDeleted`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Supplement the relevant content of `checkDeleted`

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/cbh" TESTARGS="-run TestAccCBHInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbh -v -run TestAccCBHInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccCBHInstance_basic
=== PAUSE TestAccCBHInstance_basic
=== CONT  TestAccCBHInstance_basic
--- PASS: TestAccCBHInstance_basic (2394.90s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbh       2394.959s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/20efefcc-2c98-48f1-af09-00892f0da4ff)
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/ee6832ff-8c48-4f00-9aba-507cca6a6540)

