### PR TITLE
chore(dli): adjust acceptance test and  improve the ut coverage

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -125,6 +125,13 @@ var (
 	HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH     = os.Getenv("HW_DLI_DS_AUTH_KRB_TAB_OBS_PATH")
 	HW_DLI_AGENCY_FLAG                  = os.Getenv("HW_DLI_AGENCY_FLAG")
 	HW_DLI_OWNER                        = os.Getenv("HW_DLI_OWNER")
+	HW_DLI_ELASTIC_RESOURCE_POOL_NAMES  = os.Getenv("HW_DLI_ELASTIC_RESOURCE_POOL_NAMES")
+	HW_DLI_SQL_QUEUE_NAME               = os.Getenv("HW_DLI_SQL_QUEUE_NAME")
+	HW_DLI_GENERAL_QUEUE_NAME           = os.Getenv("HW_DLI_GENERAL_QUEUE_NAME")
+	HW_DLI_UPDATED_OWNER                = os.Getenv("HW_DLI_UPDATED_OWNER")
+	HW_DLI_FLINK_VERSION                = os.Getenv("HW_DLI_FLINK_VERSION")
+	HW_DLI_FLINK_STREAM_GRAPH           = os.Getenv("HW_DLI_FLINK_STREAM_GRAPH")
+	HW_DLI_ELASTIC_RESOURCE_POOL        = os.Getenv("HW_DLI_ELASTIC_RESOURCE_POOL")
 
 	HW_GITHUB_REPO_HOST        = os.Getenv("HW_GITHUB_REPO_HOST")        // Repository host (Github, Gitlab, Gitee)
 	HW_GITHUB_PERSONAL_TOKEN   = os.Getenv("HW_GITHUB_PERSONAL_TOKEN")   // Personal access token (Github, Gitlab, Gitee)
@@ -944,6 +951,65 @@ func TestAccPreCheckDliAgency(t *testing.T) {
 func TestAccPreCheckDliOwner(t *testing.T) {
 	if HW_DLI_OWNER == "" {
 		t.Skip("HW_DLI_OWNER must be set for DLI datasource DLI agency acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliElasticResourcePoolName(t *testing.T) {
+	// Elastic resource pools for associating DLI datasource enhanced connection.
+	// Therefore, two elastic resource pools are provided, one for initial binding and the other for updating binding.
+	// Using commas (,) to separate two elastic resource pools.
+	// The CU of the latter must be large and can be associated with multiple queues.
+	// In the test case, the HW_DLI_SQL_QUEUE_NAME and HW_DLI_GENERAL_QUEUE_NAME belong to the latter resource pool.
+	names := strings.Split(HW_DLI_ELASTIC_RESOURCE_POOL_NAMES, ",")
+	if len(names) < 2 {
+		t.Skip("Before running acceptance tests related to elastic resource pool, " +
+			"please ensure +the 'HW_DLI_ELASTIC_RESOURCE_POOL_NAMES' has been configured")
+	}
+
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliSQLQueueName(t *testing.T) {
+	if HW_DLI_SQL_QUEUE_NAME == "" {
+		t.Skip("HW_DLI_SQL_QUEUE_NAME must be set for DLI acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliGenaralQueueName(t *testing.T) {
+	if HW_DLI_GENERAL_QUEUE_NAME == "" {
+		t.Skip("HW_DLI_GENERAL_QUEUE_NAME must be set for DLI acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliUpdatedOwner(t *testing.T) {
+	if HW_DLI_UPDATED_OWNER == "" {
+		t.Skip("HW_DLI_UPDATED_OWNER must be set for DLI acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliFlinkVersion(t *testing.T) {
+	if HW_DLI_FLINK_VERSION == "" {
+		t.Skip("HW_DLI_FLINK_VERSION must be set for DLI acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDliFlinkStreamGraph(t *testing.T) {
+	if HW_DLI_FLINK_STREAM_GRAPH == "" {
+		t.Skip("HW_DLI_FLINK_STREAM_GRAPH must be set for DLI acceptance tests.")
+	}
+}
+
+// Since it takes at least one hour to execute the elastic resource pool resource test case,
+// this variable is provided to distinguish the full test cases.
+// lintignore:AT003
+func TestAccPreCheckDliElasticResourcePool(t *testing.T) {
+	if HW_DLI_ELASTIC_RESOURCE_POOL == "" {
+		t.Skip("HW_DLI_ELASTIC_RESOURCE_POOL must be set for DLI acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_datasource_connections_test.go
+++ b/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_datasource_connections_test.go
@@ -38,9 +38,8 @@ func TestAccDatasourceConnections_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "connections.0.created_at"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "connections.0.routes.#"),
 					resource.TestCheckResourceAttr(dataSourceName, "connections.0.routes.0.name", name),
-					resource.TestCheckResourceAttr(dataSourceName, "connections.0.routes.0.cidr", "10.169.0.0/24"),
+					resource.TestCheckResourceAttr(dataSourceName, "connections.0.routes.0.cidr", "10.169.0.0/16"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "connections.0.queues.#"),
-					resource.TestCheckResourceAttr(dataSourceName, "connections.0.queues.0.name", name),
 					resource.TestCheckResourceAttrSet(dataSourceName, "connections.0.hosts.#"),
 					resource.TestCheckResourceAttr(dataSourceName, "connections.0.hosts.0.ip", "172.0.0.2"),
 					resource.TestCheckResourceAttr(dataSourceName, "connections.0.hosts.0.name", name),
@@ -63,13 +62,6 @@ func testDatasourceConnections_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_dli_queue" "test" {
-  name          = "%[2]s"
-  cu_count      = 16
-  resource_mode = 1
-  vpc_cidr      = "10.169.0.0/16"
-}
-
 locals {
   tags = {
     foo  = "bar"
@@ -81,10 +73,9 @@ resource "huaweicloud_dli_datasource_connection" "test" {
   name      = "%[2]s"
   vpc_id    = huaweicloud_vpc.test.id
   subnet_id = huaweicloud_vpc_subnet.test.id
-  queues    = [huaweicloud_dli_queue.test.name]
 
   routes {
-    cidr = "10.169.0.0/24"
+    cidr = "10.169.0.0/16"
     name = "%[2]s"
   }
 
@@ -103,7 +94,7 @@ data "huaweicloud_dli_datasource_connections" "test" {
 }
 
 locals {
-  name = data.huaweicloud_dli_datasource_connections.test.connections[0].name
+  name = huaweicloud_dli_datasource_connection.test.name
 }
 
 data "huaweicloud_dli_datasource_connections" "filter_by_name" {

--- a/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_elastic_resource_pools_test.go
+++ b/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_elastic_resource_pools_test.go
@@ -12,7 +12,6 @@ import (
 func TestAccDataSourceDliElasticResourcePools_basic(t *testing.T) {
 	var (
 		dataSource = "data.huaweicloud_dli_elastic_resource_pools.test"
-		rName      = acceptance.RandomAccResourceName()
 		dc         = acceptance.InitDataSourceCheck(dataSource)
 
 		byName   = "data.huaweicloud_dli_elastic_resource_pools.filter_by_name"
@@ -26,30 +25,34 @@ func TestAccDataSourceDliElasticResourcePools_basic(t *testing.T) {
 
 		byTags   = "data.huaweicloud_dli_elastic_resource_pools.filter_by_tags"
 		dcByTags = acceptance.InitDataSourceCheck(byTags)
+
+		_, elasticResourceName = getElasticResourcePoolNames()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliElasticResourcePoolName(t)
+			acceptance.TestAccPreCheckDliSQLQueueName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceDliElasticPools_basic(rName),
+				Config: testDataSourceDataSourceDliElasticPools_basic(elasticResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 
 					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("is_name_filter_useful", "true"),
 					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.id"),
-					resource.TestCheckResourceAttr(byName, "elastic_resource_pools.0.name", rName),
-					resource.TestCheckResourceAttr(byName, "elastic_resource_pools.0.max_cu", "64"),
-					resource.TestCheckResourceAttr(byName, "elastic_resource_pools.0.min_cu", "64"),
-					resource.TestCheckResourceAttr(byName, "elastic_resource_pools.0.current_cu", "64"),
-					resource.TestCheckResourceAttr(byName, "elastic_resource_pools.0.cidr", "172.16.0.0/12"),
+					resource.TestCheckResourceAttr(byName, "elastic_resource_pools.0.name", elasticResourceName),
+					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.max_cu"),
+					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.min_cu"),
+					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.current_cu"),
+					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.cidr"),
 					resource.TestCheckResourceAttr(byName, "elastic_resource_pools.0.enterprise_project_id", "0"),
-					resource.TestCheckResourceAttr(byName, "elastic_resource_pools.0.queues.0", rName),
-					resource.TestCheckResourceAttr(byName, "elastic_resource_pools.0.description", "Created by terraform script"),
+					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.queues.0"),
+					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.description"),
 					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.resource_id"),
 					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.owner"),
 					resource.TestCheckResourceAttrSet(byName, "elastic_resource_pools.0.manager"),
@@ -66,15 +69,13 @@ func TestAccDataSourceDliElasticResourcePools_basic(t *testing.T) {
 
 					dcByTags.CheckResourceExists(),
 					resource.TestCheckOutput("is_tags_filter_useful", "true"),
-
-					waitForDeletionCooldownComplete(),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceDataSourceDliElasticPools_basic(name string) string {
+func testDataSourceDataSourceDliElasticPools_basic(elasticResourceName string) string {
 	return fmt.Sprintf(`
 locals {
   tags = {
@@ -82,40 +83,9 @@ locals {
     terraform = "elastic_resource_pool"
   }
 }
+data "huaweicloud_dli_elastic_resource_pools" "test" {}
 
-resource "huaweicloud_dli_elastic_resource_pool" "test" {
-  name                  = "%[1]s"
-  max_cu                = 64
-  min_cu                = 64
-  enterprise_project_id = "0"
-  description           = "Created by terraform script"
-  tags                  = local.tags
-}
-
-resource "huaweicloud_dli_queue" "test" {
-  depends_on = [
-    huaweicloud_dli_elastic_resource_pool.test,
-  ] 
-  
-  name                       = "%[1]s"
-  cu_count                   = 16
-  resource_mode              = 1
-  elastic_resource_pool_name = huaweicloud_dli_elastic_resource_pool.test.name
-}
-
-data "huaweicloud_dli_elastic_resource_pools" "test" {
-  depends_on = [
-    huaweicloud_dli_elastic_resource_pool.test,
-    huaweicloud_dli_queue.test
-  ]
-}
-  
 data "huaweicloud_dli_elastic_resource_pools" "filter_by_name" {
-  depends_on = [
-    huaweicloud_dli_elastic_resource_pool.test,
-    huaweicloud_dli_queue.test
-  ]
-
   name = "%[1]s"
 }
 
@@ -124,34 +94,24 @@ locals {
     for v in data.huaweicloud_dli_elastic_resource_pools.filter_by_name.elastic_resource_pools[*].name : v == "%[1]s"
   ]
 }
-    
+
 output "is_name_filter_useful" {
   value = length(local.name_filter_result) == 1 && alltrue(local.name_filter_result)
 }
-    
-data "huaweicloud_dli_elastic_resource_pools" "filter_by_name_not_found" {
-  depends_on = [
-    huaweicloud_dli_elastic_resource_pool.test,
-    huaweicloud_dli_queue.test
-  ]
 
+data "huaweicloud_dli_elastic_resource_pools" "filter_by_name_not_found" {
   name = "not_found"
 }
-    
+
 output "is_name_filter_useful_not_found" {
   value = length(data.huaweicloud_dli_elastic_resource_pools.filter_by_name_not_found.elastic_resource_pools) == 0
 }
 
 locals {
-  status = huaweicloud_dli_elastic_resource_pool.test.status
+  status = data.huaweicloud_dli_elastic_resource_pools.filter_by_name.elastic_resource_pools[0].status
 }
-    
+
 data "huaweicloud_dli_elastic_resource_pools" "filter_by_status" {
-  depends_on = [
-    huaweicloud_dli_elastic_resource_pool.test,
-    huaweicloud_dli_queue.test
-  ]
- 
    status = local.status
 }
 
@@ -160,22 +120,17 @@ locals {
     for v in data.huaweicloud_dli_elastic_resource_pools.filter_by_status.elastic_resource_pools[*].status : v == local.status
   ]
 }
-    
+
 output "is_status_filter_useful" {
   value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
 }
 
 data "huaweicloud_dli_elastic_resource_pools" "filter_by_tags" {
-  depends_on = [
-    huaweicloud_dli_elastic_resource_pool.test,
-    huaweicloud_dli_queue.test
-  ]
-
   tags = local.tags
 }
 
 output "is_tags_filter_useful" {
   value = length(data.huaweicloud_dli_elastic_resource_pools.filter_by_tags) >= 1
-}  
-`, name)
+}
+`, elasticResourceName)
 }

--- a/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_flinkjar_jobs_test.go
+++ b/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_flinkjar_jobs_test.go
@@ -10,14 +10,43 @@ import (
 )
 
 func TestAccDataSourceDliFlinkjarJobs_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_dli_flinkjar_jobs.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
-	rName := acceptance.RandomAccResourceName()
-	bucketName := acceptance.RandomAccResourceNameWithDash()
+	var (
+		dataSource = "data.huaweicloud_dli_flinkjar_jobs.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		rName      = acceptance.RandomAccResourceName()
+		bucketName = acceptance.RandomAccResourceNameWithDash()
+
+		byId   = "data.huaweicloud_dli_flinkjar_jobs.job_id_filter"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byQueueName   = "data.huaweicloud_dli_flinkjar_jobs.queue_name_filter"
+		dcByQueuename = acceptance.InitDataSourceCheck(byQueueName)
+
+		byCuNum   = "data.huaweicloud_dli_flinkjar_jobs.cu_num_filter"
+		dcByCuNum = acceptance.InitDataSourceCheck(byCuNum)
+
+		byParallelNum   = "data.huaweicloud_dli_flinkjar_jobs.parallel_num_filter"
+		dcByParallelNum = acceptance.InitDataSourceCheck(byParallelNum)
+
+		byManageCuNum   = "data.huaweicloud_dli_flinkjar_jobs.manager_cu_num_filter"
+		dcByManageCuNum = acceptance.InitDataSourceCheck(byManageCuNum)
+
+		byTmCuNum   = "data.huaweicloud_dli_flinkjar_jobs.tm_cu_num_filter"
+		dcByTmCuNum = acceptance.InitDataSourceCheck(byTmCuNum)
+
+		byTmSlotNum   = "data.huaweicloud_dli_flinkjar_jobs.tm_slot_num_filter"
+		dcByTmSlotNum = acceptance.InitDataSourceCheck(byTmSlotNum)
+
+		byTags   = "data.huaweicloud_dli_flinkjar_jobs.tags_filter"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliGenaralQueueName(t)
+			acceptance.TestAccPreCheckDliJarPath(t)
+			acceptance.TestAccPreCheckDliFlinkVersion(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -32,14 +61,22 @@ func TestAccDataSourceDliFlinkjarJobs_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.manager_cu_num"),
 					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.tm_cu_num"),
 					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.tm_slot_num"),
-
+					dcById.CheckResourceExists(),
 					resource.TestCheckOutput("job_id_filter_is_useful", "true"),
+					dcByQueuename.CheckResourceExists(),
 					resource.TestCheckOutput("queue_name_filter_is_useful", "true"),
+					dcByCuNum.CheckResourceExists(),
 					resource.TestCheckOutput("cu_num_filter_is_useful", "true"),
+					dcByParallelNum.CheckResourceExists(),
 					resource.TestCheckOutput("parallel_num_filter_is_useful", "true"),
+					dcByManageCuNum.CheckResourceExists(),
 					resource.TestCheckOutput("manager_cu_num_filter_is_useful", "true"),
+					dcByTmCuNum.CheckResourceExists(),
 					resource.TestCheckOutput("tm_cu_num_filter_is_useful", "true"),
+					dcByTmSlotNum.CheckResourceExists(),
 					resource.TestCheckOutput("tm_slot_num_filter_is_useful", "true"),
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
 				),
 			},
 		},
@@ -56,102 +93,135 @@ data "huaweicloud_dli_flinkjar_jobs" "test" {
   ]
 }
 
+locals {
+  job_id = huaweicloud_dli_flinkjar_job.test.id
+}
+
 data "huaweicloud_dli_flinkjar_jobs" "job_id_filter" {
   job_id = local.job_id
 }
-  
-locals {
-  job_id = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].id
-}
-  
+
 output "job_id_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinkjar_jobs.job_id_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinkjar_jobs.job_id_filter.jobs[*].id : v == local.job_id]
   )
 }
 
+locals {
+  queue_name = huaweicloud_dli_flinkjar_job.test.queue_name
+}
+
 data "huaweicloud_dli_flinkjar_jobs" "queue_name_filter" {
+  depends_on = [
+    huaweicloud_dli_flinkjar_job.test
+  ]
+
   queue_name = local.queue_name
 }
-  
-locals {
-  queue_name = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].queue_name
-}
-  
+
 output "queue_name_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinkjar_jobs.queue_name_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinkjar_jobs.queue_name_filter.jobs[*].queue_name : v == local.queue_name]
   )
 }
 
+locals {
+  cu_num = huaweicloud_dli_flinkjar_job.test.cu_num
+}
+
 data "huaweicloud_dli_flinkjar_jobs" "cu_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinkjar_job.test
+  ]
+
   cu_num = local.cu_num
 }
-  
-locals {
-  cu_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].cu_num
-}
-  
+
 output "cu_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinkjar_jobs.cu_num_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinkjar_jobs.cu_num_filter.jobs[*].cu_num : v == local.cu_num]
   )
 }
 
+locals {
+  parallel_num = huaweicloud_dli_flinkjar_job.test.parallel_num
+}
+
 data "huaweicloud_dli_flinkjar_jobs" "parallel_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinkjar_job.test
+  ]
+
   parallel_num = local.parallel_num
 }
-  
-locals {
-  parallel_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].parallel_num
-}
-  
+
 output "parallel_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinkjar_jobs.parallel_num_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinkjar_jobs.parallel_num_filter.jobs[*].parallel_num : v == local.parallel_num]
   )
 }
 
+locals {
+  manager_cu_num = huaweicloud_dli_flinkjar_job.test.manager_cu_num
+}
+
 data "huaweicloud_dli_flinkjar_jobs" "manager_cu_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinkjar_job.test
+  ]
+
   manager_cu_num = local.manager_cu_num
 }
-  
-locals {
-  manager_cu_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].manager_cu_num
-}
-  
+
 output "manager_cu_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinkjar_jobs.manager_cu_num_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinkjar_jobs.manager_cu_num_filter.jobs[*].manager_cu_num : v == local.manager_cu_num]
   )
 }
 
+locals {
+  tm_cu_num = huaweicloud_dli_flinkjar_job.test.tm_cu_num
+}
+
 data "huaweicloud_dli_flinkjar_jobs" "tm_cu_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinkjar_job.test
+  ]
+
   tm_cu_num = local.tm_cu_num
 }
-  
-locals {
-  tm_cu_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].tm_cu_num
-}
-  
+
 output "tm_cu_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinkjar_jobs.tm_cu_num_filter.jobs) > 0 && alltrue(
-    [for v in data.huaweicloud_dli_flinkjar_jobs.tm_cu_num_filter.jobs[*].tm_cu_num: v == local.tm_cu_num]
+    [for v in data.huaweicloud_dli_flinkjar_jobs.tm_cu_num_filter.jobs[*].tm_cu_num : v == local.tm_cu_num]
   )
 }
 
+locals {
+  tm_slot_num = huaweicloud_dli_flinkjar_job.test.tm_slot_num
+}
+
 data "huaweicloud_dli_flinkjar_jobs" "tm_slot_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinkjar_job.test
+  ]
+
   tm_slot_num = local.tm_slot_num
 }
-  
-locals {
-  tm_slot_num = data.huaweicloud_dli_flinkjar_jobs.test.jobs[0].tm_slot_num
-}
-  
+
 output "tm_slot_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinkjar_jobs.tm_slot_num_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinkjar_jobs.tm_slot_num_filter.jobs[*].tm_slot_num : v == local.tm_slot_num]
   )
 }
-`, testAccFlinkJarJobResource_basic(name, bucketName))
+
+data "huaweicloud_dli_flinkjar_jobs" "tags_filter" {
+  tags = huaweicloud_dli_flinkjar_job.test.tags
+}
+
+output "tags_filter_is_useful" {
+  value = length(data.huaweicloud_dli_flinkjar_jobs.tags_filter.jobs) > 0
+}
+
+`, testAccDliFlinkJarJob_basic_step1(name, bucketName))
 }

--- a/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_flinksql_job_test.go
+++ b/huaweicloud/services/acceptance/dli/data_source_huaweicloud_dli_flinksql_job_test.go
@@ -10,13 +10,40 @@ import (
 )
 
 func TestAccDataSourceDliFlinkSQLJobs_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_dli_flinksql_jobs.test"
-	dc := acceptance.InitDataSourceCheck(dataSource)
-	rName := acceptance.RandomAccResourceName()
+	var (
+		dataSource = "data.huaweicloud_dli_flinksql_jobs.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+		rName      = acceptance.RandomAccResourceName()
 
+		byId   = "data.huaweicloud_dli_flinksql_jobs.job_id_filter"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byQueueName   = "data.huaweicloud_dli_flinksql_jobs.queue_name_filter"
+		dcByQueuename = acceptance.InitDataSourceCheck(byQueueName)
+
+		byCuNum   = "data.huaweicloud_dli_flinksql_jobs.cu_num_filter"
+		dcByCuNum = acceptance.InitDataSourceCheck(byCuNum)
+
+		byParallelNum   = "data.huaweicloud_dli_flinksql_jobs.parallel_num_filter"
+		dcByParallelNum = acceptance.InitDataSourceCheck(byParallelNum)
+
+		byManageCuNum   = "data.huaweicloud_dli_flinksql_jobs.manager_cu_num_filter"
+		dcByManageCuNum = acceptance.InitDataSourceCheck(byManageCuNum)
+
+		byTmCuNum   = "data.huaweicloud_dli_flinksql_jobs.tm_cu_num_filter"
+		dcByTmCuNum = acceptance.InitDataSourceCheck(byTmCuNum)
+
+		byTmSlotNum   = "data.huaweicloud_dli_flinksql_jobs.tm_slot_num_filter"
+		dcByTmSlotNum = acceptance.InitDataSourceCheck(byTmSlotNum)
+
+		byTags   = "data.huaweicloud_dli_flinksql_jobs.filter_by_tags"
+		dcByTags = acceptance.InitDataSourceCheck(byTags)
+	)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliGenaralQueueName(t)
+			acceptance.TestAccPreCheckDliFlinkVersion(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
@@ -31,14 +58,22 @@ func TestAccDataSourceDliFlinkSQLJobs_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.manager_cu_num"),
 					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.tm_cu_num"),
 					resource.TestCheckResourceAttrSet(dataSource, "jobs.0.tm_slot_num"),
-
+					dcById.CheckResourceExists(),
 					resource.TestCheckOutput("job_id_filter_is_useful", "true"),
+					dcByQueuename.CheckResourceExists(),
 					resource.TestCheckOutput("queue_name_filter_is_useful", "true"),
+					dcByCuNum.CheckResourceExists(),
 					resource.TestCheckOutput("cu_num_filter_is_useful", "true"),
+					dcByParallelNum.CheckResourceExists(),
 					resource.TestCheckOutput("parallel_num_filter_is_useful", "true"),
+					dcByManageCuNum.CheckResourceExists(),
 					resource.TestCheckOutput("manager_cu_num_filter_is_useful", "true"),
+					dcByTmCuNum.CheckResourceExists(),
 					resource.TestCheckOutput("tm_cu_num_filter_is_useful", "true"),
+					dcByTmSlotNum.CheckResourceExists(),
 					resource.TestCheckOutput("tm_slot_num_filter_is_useful", "true"),
+					dcByTags.CheckResourceExists(),
+					resource.TestCheckOutput("tags_filter_is_useful", "true"),
 				),
 			},
 		},
@@ -48,101 +83,166 @@ func TestAccDataSourceDliFlinkSQLJobs_basic(t *testing.T) {
 func testDataSourceDataSourceDliFlinkSQLJobs_basic(name string) string {
 	return fmt.Sprintf(`
 %s
+
+resource "huaweicloud_dli_flinksql_job" "test" {
+  name          = "%s"
+  type          = "flink_opensource_sql_job"
+  run_mode      = "exclusive_cluster"
+  sql           = local.opensourceSql
+  queue_name    = "%s"
+  flink_version = "%s"
+  restart_when_exception = true
+  cu_number         = 4
+  resume_checkpoint = true
+  manager_cu_number = 2
+  tm_cus            = 2
+  tm_slot_num       = 3
+  parallel_number   = 2
+
+  tags = {
+    foo = "bar"
+  }
+}
+
 data "huaweicloud_dli_flinksql_jobs" "test" {
   depends_on = [
     huaweicloud_dli_flinksql_job.test
   ]
 }
+
 data "huaweicloud_dli_flinksql_jobs" "job_id_filter" {
   job_id = local.job_id
 }
-  
+
 locals {
-  job_id = data.huaweicloud_dli_flinksql_jobs.test.jobs[0].id
+  job_id = huaweicloud_dli_flinksql_job.test.id
 }
-  
+
 output "job_id_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinksql_jobs.job_id_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinksql_jobs.job_id_filter.jobs[*].id : v == local.job_id]
   )
 }
+
+locals {
+  queue_name = huaweicloud_dli_flinksql_job.test.queue_name
+}
+
 data "huaweicloud_dli_flinksql_jobs" "queue_name_filter" {
+  depends_on = [
+    huaweicloud_dli_flinksql_job.test
+  ]
+
   queue_name = local.queue_name
 }
-  
-locals {
-  queue_name = data.huaweicloud_dli_flinksql_jobs.test.jobs[0].queue_name
-}
-  
+
 output "queue_name_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinksql_jobs.queue_name_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinksql_jobs.queue_name_filter.jobs[*].queue_name : v == local.queue_name]
   )
 }
+
+locals {
+  cu_num = huaweicloud_dli_flinksql_job.test.cu_number
+}
+
+
 data "huaweicloud_dli_flinksql_jobs" "cu_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinksql_job.test
+  ]
+
   cu_num = local.cu_num
 }
-  
-locals {
-  cu_num = data.huaweicloud_dli_flinksql_jobs.test.jobs[0].cu_num
-}
-  
+
 output "cu_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinksql_jobs.cu_num_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinksql_jobs.cu_num_filter.jobs[*].cu_num : v == local.cu_num]
   )
 }
+
+locals {
+  parallel_num = huaweicloud_dli_flinksql_job.test.parallel_number
+}
+
 data "huaweicloud_dli_flinksql_jobs" "parallel_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinksql_job.test
+  ]
+
   parallel_num = local.parallel_num
 }
-  
-locals {
-  parallel_num = data.huaweicloud_dli_flinksql_jobs.test.jobs[0].parallel_num
-}
-  
+
 output "parallel_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinksql_jobs.parallel_num_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinksql_jobs.parallel_num_filter.jobs[*].parallel_num : v == local.parallel_num]
   )
 }
+
+locals {
+  manager_cu_num = huaweicloud_dli_flinksql_job.test.manager_cu_number
+}
+
 data "huaweicloud_dli_flinksql_jobs" "manager_cu_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinksql_job.test
+  ]
+
   manager_cu_num = local.manager_cu_num
 }
-  
-locals {
-  manager_cu_num = data.huaweicloud_dli_flinksql_jobs.test.jobs[0].manager_cu_num
-}
-  
+
 output "manager_cu_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinksql_jobs.manager_cu_num_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinksql_jobs.manager_cu_num_filter.jobs[*].manager_cu_num : v == local.manager_cu_num]
   )
 }
+
+locals {
+  tm_cu_num = huaweicloud_dli_flinksql_job.test.tm_cus
+}
+
 data "huaweicloud_dli_flinksql_jobs" "tm_cu_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinksql_job.test
+  ]
+
   tm_cu_num = local.tm_cu_num
 }
-  
-locals {
-  tm_cu_num = data.huaweicloud_dli_flinksql_jobs.test.jobs[0].tm_cu_num
-}
-  
+
 output "tm_cu_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinksql_jobs.tm_cu_num_filter.jobs) > 0 && alltrue(
-    [for v in data.huaweicloud_dli_flinksql_jobs.tm_cu_num_filter.jobs[*].tm_cu_num: v == local.tm_cu_num]
+    [for v in data.huaweicloud_dli_flinksql_jobs.tm_cu_num_filter.jobs[*].tm_cu_num : v == local.tm_cu_num]
   )
 }
+
+locals {
+  tm_slot_num = huaweicloud_dli_flinksql_job.test.tm_slot_num
+}
+
 data "huaweicloud_dli_flinksql_jobs" "tm_slot_num_filter" {
+  depends_on = [
+    huaweicloud_dli_flinksql_job.test
+  ]
+
   tm_slot_num = local.tm_slot_num
 }
-  
-locals {
-  tm_slot_num = data.huaweicloud_dli_flinksql_jobs.test.jobs[0].tm_slot_num
-}
-  
+
 output "tm_slot_num_filter_is_useful" {
   value = length(data.huaweicloud_dli_flinksql_jobs.tm_slot_num_filter.jobs) > 0 && alltrue(
     [for v in data.huaweicloud_dli_flinksql_jobs.tm_slot_num_filter.jobs[*].tm_slot_num : v == local.tm_slot_num]
   )
 }
-`, testAccFlinkJobResource_basic(name, acceptance.HW_REGION_NAME))
+
+data "huaweicloud_dli_flinksql_jobs" "filter_by_tags" {
+  depends_on = [
+    huaweicloud_dli_flinksql_job.test
+  ]
+
+  tags = huaweicloud_dli_flinksql_job.test.tags
+}
+
+output "tags_filter_is_useful" {
+  value = length(data.huaweicloud_dli_flinksql_jobs.filter_by_tags.jobs) > 0
+}
+`, testAccFlinkJobResource_base(), name, acceptance.HW_DLI_GENERAL_QUEUE_NAME, acceptance.HW_DLI_FLINK_VERSION)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_database_test.go
@@ -39,18 +39,27 @@ func TestAccDliDatabase_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckDliUpdatedOwner(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliDatabase_basic(rName),
+				Config: testAccDliDatabase_basic_step1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "description", "For terraform acc test"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttrSet(resourceName, "owner"),
+				),
+			},
+			{
+				Config: testAccDliDatabase_basic_step2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "owner", acceptance.HW_DLI_UPDATED_OWNER),
 				),
 			},
 			{
@@ -80,7 +89,7 @@ func testAccDatabaseImportStateFunc(rName string) resource.ImportStateIdFunc {
 	}
 }
 
-func testAccDliDatabase_basic(rName string) string {
+func testAccDliDatabase_basic_step1(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_dli_database" "test" {
   name                  = "%s"
@@ -92,4 +101,19 @@ resource "huaweicloud_dli_database" "test" {
   }
 }
 `, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccDliDatabase_basic_step2(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dli_database" "test" {
+  name                  = "%s"
+  description           = "For terraform acc test"
+  enterprise_project_id = "%s"
+  owner                 = "%s"
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, acceptance.HW_DLI_UPDATED_OWNER)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_connection_associate_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_datasource_connection_associate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 )
 
@@ -26,29 +27,35 @@ func TestAccDatasourceConnectionAssociate_basic(t *testing.T) {
 		resourceName = "huaweicloud_dli_datasource_connection_associate.test"
 		name         = acceptance.RandomAccResourceName()
 		rc           = acceptance.InitResourceCheck(resourceName, &obj, getAssociatedElasticResourcePoolsFunc)
+
+		elasticResourceName, updateElasticResourceRoolName = getElasticResourcePoolNames()
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliElasticResourcePoolName(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAcDatasourceConnectionAssociatec_basic_step1(name),
+				Config: testAcDatasourceConnectionAssociatec_basic_step1(name, elasticResourceName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(resourceName, "connection_id",
 						"huaweicloud_dli_datasource_connection.test", "id"),
-					resource.TestCheckResourceAttr(resourceName, "elastic_resource_pools.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "elastic_resource_pools.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "elastic_resource_pools.0", elasticResourceName),
 				),
 			},
 			{
-				Config: testAcDatasourceConnectionAssociatec_basic_step2(name),
+				Config: testAcDatasourceConnectionAssociatec_basic_step2(name, updateElasticResourceRoolName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "elastic_resource_pools.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "elastic_resource_pools.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "elastic_resource_pools.0", updateElasticResourceRoolName),
 					// After elastic resource pool is created, it cannot be deleted within one hour.
-					waitForDeletionCooldownComplete(),
 				),
 			},
 			{
@@ -62,56 +69,34 @@ func TestAccDatasourceConnectionAssociate_basic(t *testing.T) {
 
 func testAcDatasourceConnectionAssociatec_base(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_vpc" "test" {
-  name = "%[1]s"
-  cidr = "192.168.0.0/16"
-}
-
-resource "huaweicloud_vpc_subnet" "test" {
-  vpc_id     = huaweicloud_vpc.test.id
-  name       = "%[1]s"
-  cidr       = cidrsubnet(huaweicloud_vpc.test.cidr, 3, 1)
-  gateway_ip = cidrhost(cidrsubnet(huaweicloud_vpc.test.cidr, 3, 1), 1)
-}
-
-resource "huaweicloud_dli_elastic_resource_pool" "test" {
-  count = 3
-
-  name                  = format("%[1]s_%%d", count.index)
-  min_cu                = 64
-  max_cu                = 64
-  enterprise_project_id = "0"
-
-  # The minimum CIDR range allowed for elastic resource pools is /19.
-  cidr = cidrsubnet(huaweicloud_vpc.test.cidr, 3, count.index+2)  # 192.168.x.0/19
-}
+%s
 
 resource "huaweicloud_dli_datasource_connection" "test" {
-  name      = "%[1]s"
+  name      = "%s"
   vpc_id    = huaweicloud_vpc.test.id
   subnet_id = huaweicloud_vpc_subnet.test.id
 }
-`, name)
+`, common.TestVpc(name), name)
 }
 
-func testAcDatasourceConnectionAssociatec_basic_step1(name string) string {
+func testAcDatasourceConnectionAssociatec_basic_step1(name, elasticResourceName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_dli_datasource_connection_associate" "test" {
   connection_id          = huaweicloud_dli_datasource_connection.test.id
-  elastic_resource_pools = slice(huaweicloud_dli_elastic_resource_pool.test[*].name, 0, 2)
+  elastic_resource_pools = ["%s"]
 }
-`, testAcDatasourceConnectionAssociatec_base(name), name)
+`, testAcDatasourceConnectionAssociatec_base(name), elasticResourceName)
 }
 
-func testAcDatasourceConnectionAssociatec_basic_step2(name string) string {
+func testAcDatasourceConnectionAssociatec_basic_step2(name, elasticResourceName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_dli_datasource_connection_associate" "test" {
   connection_id          = huaweicloud_dli_datasource_connection.test.id
-  elastic_resource_pools = slice(huaweicloud_dli_elastic_resource_pool.test[*].name, 1, 3)
+  elastic_resource_pools = ["%s"]
 }
-`, testAcDatasourceConnectionAssociatec_base(name), name)
+`, testAcDatasourceConnectionAssociatec_base(name), elasticResourceName)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_elastic_resource_pool_test.go
@@ -40,6 +40,7 @@ func TestAccElasticResourcePool_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckEpsID(t)
+			acceptance.TestAccPreCheckDliElasticResourcePool(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -69,7 +70,7 @@ func TestAccElasticResourcePool_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "min_cu", "64"),
 					resource.TestCheckResourceAttr(resourceName, "max_cu", "112"),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
 					waitForDeletionCooldownComplete(),
 					waitForCUModificationComplete(resourceName),
 				),
@@ -163,5 +164,5 @@ resource "huaweicloud_dli_elastic_resource_pool" "test" {
   min_cu                = 64
   enterprise_project_id = "%[2]s"
 }
-`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, name, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flink_template_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flink_template_test.go
@@ -95,8 +95,9 @@ func TestAccFlinkTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "sql", "select * from source_table2"),
 					resource.TestCheckResourceAttr(rName, "description", "This is a demo2"),
 					resource.TestCheckResourceAttr(rName, "type", "flink_sql_job"),
+					// The tags is ForceNew.
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(rName, "tags.key", "value2"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 				),
 			},
 			{
@@ -135,7 +136,7 @@ resource "huaweicloud_dli_flink_template" "test" {
 
   tags = {
     foo = "bar"
-    key = "value2"
+    key = "value"
   }
 }
 `, name)

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinkjar_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_flinkjar_job_test.go
@@ -23,7 +23,7 @@ func getDliFlinkJarJobResourceFunc(config *config.Config, state *terraform.Resou
 	return flinkjob.Get(client, jobId)
 }
 
-func TestAccResourceDliFlinkJarJob_basic(t *testing.T) {
+func TestAccDliFlinkJarJob_basic(t *testing.T) {
 	var obj flinkjob.CreateJarJobOpts
 	resourceName := "huaweicloud_dli_flinkjar_job.test"
 	name := acceptance.RandomAccResourceName()
@@ -39,33 +39,53 @@ func TestAccResourceDliFlinkJarJob_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckDliJarPath(t)
+			acceptance.TestAccPreCheckDliGenaralQueueName(t)
+			acceptance.TestAccPreCheckDliFlinkVersion(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlinkJarJobResource_basic(name, bucketName),
+				Config: testAccDliFlinkJarJob_basic_step1(name, bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "status", "job_running"),
+					resource.TestCheckResourceAttr(resourceName, "queue_name", acceptance.HW_DLI_GENERAL_QUEUE_NAME),
+					resource.TestCheckResourceAttrPair(resourceName, "obs_bucket", "huaweicloud_obs_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "log_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "description", "description of dli job"),
+					// resource.TestCheckResourceAttr(resourceName, "main_class", "com.huaweicloud.dli.obs.Main"),
+					resource.TestCheckResourceAttr(resourceName, "feature", "basic"),
+					resource.TestCheckResourceAttr(resourceName, "flink_version", acceptance.HW_DLI_FLINK_VERSION),
+					resource.TestCheckResourceAttr(resourceName, "cu_num", "6"),
+					resource.TestCheckResourceAttr(resourceName, "manager_cu_num", "2"),
+					resource.TestCheckResourceAttr(resourceName, "parallel_num", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tm_slot_num", "1"),
+					resource.TestCheckResourceAttr(resourceName, "smn_topic", name),
+					resource.TestCheckResourceAttr(resourceName, "restart_when_exception", "true"),
+					resource.TestCheckResourceAttr(resourceName, "resume_max_num", "2"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_config.max_records_per_file", "10"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 			{
-				Config: testAccFlinkJarJobResource_update(name, bucketName),
+				Config: testAccFlinkJarJobResource_basic_step2(name, bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Update description of dli job."),
+					resource.TestCheckResourceAttr(resourceName, "resume_checkpoint", "false"),
+					resource.TestCheckResourceAttr(resourceName, "resume_max_num", "1"),
+					resource.TestCheckResourceAttr(resourceName, "runtime_config.max_records_per_file", "5"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -102,109 +122,10 @@ resource "huaweicloud_dli_package" "test" {
   type        = "jar"
   object_path = var.jarObsPath
 }
-
-resource "huaweicloud_dli_queue" "test" {
-  name       = "%[5]s"
-  cu_count   = 16
-  queue_type = "general"
-
-  tags = {
-    foo = "bar"
-  }
-}
 `, acceptance.HW_ACCESS_KEY, acceptance.HW_SECRET_KEY, acceptance.HW_DLI_FLINK_JAR_OBS_PATH, bucketName, name)
 }
 
-func testAccFlinkJarJobResource_basic(name, bucketName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_dli_flinkjar_job" "test" {
-  name            = "%[2]s"
-  queue_name      = "common_test"
-  entrypoint      = "${huaweicloud_dli_package.test.group_name}/${huaweicloud_dli_package.test.object_name}"
-  entrypoint_args = "--output.path obs://${var.ak}:${var.sk}@obs.%[3]s.myhuaweicloud.com/${huaweicloud_obs_bucket.test.bucket}/output"
-  obs_bucket      = huaweicloud_obs_bucket.test.bucket
-  log_enabled     = true
-
-  tags = {
-    foo = "bar"
-  }
-}
-`, testAccFlinkJarJobResource_base(bucketName, name), name, acceptance.HW_REGION_NAME)
-}
-
-func testAccFlinkJarJobResource_update(name, bucketName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_dli_flinkjar_job" "test" {
-  name            = "%[2]s"
-  queue_name      = huaweicloud_dli_queue.test.name
-  entrypoint      = "${huaweicloud_dli_package.test.group_name}/${huaweicloud_dli_package.test.object_name}"
-  entrypoint_args = "--output.path obs://${var.ak}:${var.sk}@obs.%[3]s.myhuaweicloud.com/${huaweicloud_obs_bucket.test.bucket}/output"
-  obs_bucket      = huaweicloud_obs_bucket.test.bucket
-  log_enabled     = true
-
-  tags = {
-    owner = "terraform"
-  }
-}
-`, testAccFlinkJarJobResource_base(bucketName, name), name, acceptance.HW_REGION_NAME)
-}
-
-func TestAccResourceDliFlinkJarJob_all(t *testing.T) {
-	var obj flinkjob.CreateJarJobOpts
-	resourceName := "huaweicloud_dli_flinkjar_job.test"
-	name := acceptance.RandomAccResourceName()
-	bucketName := acceptance.RandomAccResourceNameWithDash()
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getDliFlinkJarJobResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckDliJarPath(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFlinkJarJobResource_all(name, bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "status", "job_running"),
-					resource.TestCheckResourceAttr(resourceName, "queue_name", name),
-					resource.TestCheckResourceAttrPair(resourceName, "obs_bucket", "huaweicloud_obs_bucket.test", "bucket"),
-					resource.TestCheckResourceAttr(resourceName, "log_enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "description", "description of dli job"),
-					resource.TestCheckResourceAttr(resourceName, "main_class", "com.huaweicloud.dli.obs.Main"),
-					resource.TestCheckResourceAttr(resourceName, "feature", "basic"),
-					resource.TestCheckResourceAttr(resourceName, "flink_version", "1.10"),
-					resource.TestCheckResourceAttr(resourceName, "cu_num", "6"),
-					resource.TestCheckResourceAttr(resourceName, "manager_cu_num", "2"),
-					resource.TestCheckResourceAttr(resourceName, "parallel_num", "2"),
-					resource.TestCheckResourceAttr(resourceName, "tm_slot_num", "1"),
-					resource.TestCheckResourceAttr(resourceName, "smn_topic", name),
-					resource.TestCheckResourceAttr(resourceName, "restart_when_exception", "true"),
-					resource.TestCheckResourceAttr(resourceName, "resume_max_num", "2"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func testAccFlinkJarJobResource_all(name, bucketName string) string {
+func testAccDliFlinkJarJob_basic_step1(name, bucketName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -215,16 +136,14 @@ resource "huaweicloud_smn_topic" "test" {
 
 resource "huaweicloud_dli_flinkjar_job" "test" {
   name                   = "%[2]s"
-  queue_name             = huaweicloud_dli_queue.test.name
+  queue_name             = "%[4]s"
   entrypoint             = "${huaweicloud_dli_package.test.group_name}/${huaweicloud_dli_package.test.object_name}"
   entrypoint_args        = "--output.path obs://${var.ak}:${var.sk}@obs.%[3]s.myhuaweicloud.com/${huaweicloud_obs_bucket.test.bucket}/output"
   obs_bucket             = huaweicloud_obs_bucket.test.bucket
   log_enabled            = true
   description            = "description of dli job"
-  main_class             = "com.huaweicloud.dli.obs.Main"
-  dependency_files       = ["jar_package/user.csv"]
   feature                = "basic"
-  flink_version          = "1.10"
+  flink_version          = "%[5]s"
   cu_num                 = 6
   manager_cu_num         = 2
   parallel_num           = 2
@@ -235,6 +154,57 @@ resource "huaweicloud_dli_flinkjar_job" "test" {
   resume_checkpoint      = true
   resume_max_num         = 2
   checkpoint_path        = "${huaweicloud_obs_bucket.test.bucket}/checkpoint/"
+
+  runtime_config = {
+    "max_records_per_file" = "10"
+  }
+
+  tags = {
+    foo = "bar"
+  }
 }
-`, testAccFlinkJarJobResource_base(bucketName, name), name, acceptance.HW_REGION_NAME)
+`, testAccFlinkJarJobResource_base(bucketName, name), name, acceptance.HW_REGION_NAME, acceptance.HW_DLI_GENERAL_QUEUE_NAME,
+		acceptance.HW_DLI_FLINK_VERSION)
+}
+
+func testAccFlinkJarJobResource_basic_step2(name, bucketName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_smn_topic" "test" {
+  name         = "%[2]s"
+  display_name = "The display name of topic_1"
+}
+
+resource "huaweicloud_dli_flinkjar_job" "test" {
+  name                   = "%[2]s"
+  queue_name             = "%[4]s"
+  entrypoint             = "${huaweicloud_dli_package.test.group_name}/${huaweicloud_dli_package.test.object_name}"
+  entrypoint_args        = "--output.path obs://${var.ak}:${var.sk}@obs.%[3]s.myhuaweicloud.com/${huaweicloud_obs_bucket.test.bucket}/output"
+  obs_bucket             = huaweicloud_obs_bucket.test.bucket
+  log_enabled            = true
+  description            = "Update description of dli job."
+  feature                = "basic"
+  flink_version          = "%[5]s"
+  cu_num                 = 6
+  manager_cu_num         = 2
+  parallel_num           = 2
+  tm_cu_num              = 2
+  tm_slot_num            = 1
+  smn_topic              = huaweicloud_smn_topic.test.name
+  restart_when_exception = "true"
+  resume_checkpoint      = false
+  resume_max_num         = 1
+  checkpoint_path        = "${huaweicloud_obs_bucket.test.bucket}/checkpoint/"
+
+  runtime_config = {
+    "max_records_per_file" = "5"
+  }
+
+  tags = {
+    owner = "terraform"
+  }
+}
+`, testAccFlinkJarJobResource_base(bucketName, name), name, acceptance.HW_REGION_NAME, acceptance.HW_DLI_GENERAL_QUEUE_NAME,
+		acceptance.HW_DLI_FLINK_VERSION)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_package_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_package_test.go
@@ -186,7 +186,10 @@ func TestAccDliPackage_not_groupName(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliUpdatedOwner(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
@@ -201,6 +204,7 @@ func TestAccDliPackage_not_groupName(t *testing.T) {
 						name, acceptance.HW_REGION_NAME)),
 					resource.TestCheckResourceAttr(resourceName, "object_name", "simple_pyspark_test_DLF_refresh.py"),
 					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "owner", acceptance.HW_DLI_UPDATED_OWNER),
 				),
 			},
 			{
@@ -210,6 +214,7 @@ func TestAccDliPackage_not_groupName(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "group_name"),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "owner", acceptance.HW_DLI_OWNER),
 				),
 			},
 		},
@@ -224,12 +229,13 @@ resource "huaweicloud_dli_package" "test" {
   depends_on  = [huaweicloud_obs_bucket_object.test]
   type        = "modelFile"
   object_path = "https://${huaweicloud_obs_bucket.test.bucket_domain_name}/dli/packages/simple_pyspark_test_DLF_refresh.py"
+  owner       = "%s"
 
   tags = {
     foo = "bar"
   }
 }
-`, testAccDliPackage_base(name))
+`, testAccDliPackage_base(name), acceptance.HW_DLI_UPDATED_OWNER)
 }
 
 func testAccDliPackage_not_groupName_update(name string) string {
@@ -240,56 +246,11 @@ resource "huaweicloud_dli_package" "test" {
   depends_on  = [huaweicloud_obs_bucket_object.test]
   type        = "modelFile"
   object_path = "https://${huaweicloud_obs_bucket.test.bucket_domain_name}/dli/packages/simple_pyspark_test_DLF_refresh.py"
+  owner       = "%s"
 
   tags = {
     owner = "terraform"
   }
 }
-`, testAccDliPackage_base(name))
-}
-
-func TestAccDliPackage_owner(t *testing.T) {
-	var (
-		pkg          resources.Resource
-		name         = acceptance.RandomAccResourceNameWithDash()
-		resourceName = "huaweicloud_dli_package.test"
-	)
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&pkg,
-		getPackageResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckDliOwner(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDliPackage_owner(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "owner", acceptance.HW_DLI_OWNER),
-				),
-			},
-		},
-	})
-}
-
-func testAccDliPackage_owner(name string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dli_package" "test" {
-  depends_on  = [huaweicloud_obs_bucket_object.test]
-  group_name  = "%s"
-  type        = "pyFile"
-  object_path = "https://${huaweicloud_obs_bucket.test.bucket_domain_name}/dli/packages/simple_pyspark_test_DLF_refresh.py"
-  owner       = "%s"
-}
-`, testAccDliPackage_base(name), name, acceptance.HW_DLI_OWNER)
+`, testAccDliPackage_base(name), acceptance.HW_DLI_OWNER)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_permission_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_permission_test.go
@@ -43,25 +43,28 @@ func TestAccResourceDliAuth_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliAuthorizedUserConfigured(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliAuthResource_basic(name, acceptance.HW_PROJECT_ID, "SELECT"),
+				Config: testAccDliAuthResource_basic(name, "SELECT"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
 					resource.TestCheckResourceAttr(resourceName, "object", fmt.Sprintf("databases.%s", name)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "SELECT"),
 					resource.TestCheckResourceAttrSet(resourceName, "is_admin"),
 				),
 			},
 			{
-				Config: testAccDliAuthResource_basic(name, acceptance.HW_PROJECT_ID, "CREATE_TABLE"),
+				Config: testAccDliAuthResource_basic(name, "CREATE_TABLE"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
 					resource.TestCheckResourceAttr(resourceName, "object", fmt.Sprintf("databases.%s", name)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "CREATE_TABLE"),
 					resource.TestCheckResourceAttrSet(resourceName, "is_admin"),
@@ -76,20 +79,18 @@ func TestAccResourceDliAuth_basic(t *testing.T) {
 	})
 }
 
-func testAccDliAuthResource_basic(name string, projectId string, privileges string) string {
-	database := testAccDliDatabase_basic(name)
-	userConfig := testAccDliAuthUserConfig(name, projectId)
-
+func testAccDliAuthResource_basic(name string, privileges string) string {
 	return fmt.Sprintf(`
-%s
-%s
+resource "huaweicloud_dli_database" "test" {
+  name = "%s"
+}
 
 resource "huaweicloud_dli_permission" "test" {
-  user_name  = huaweicloud_identity_user.test.name
+  user_name  = "%s"
   object     = "databases.${huaweicloud_dli_database.test.name}"
   privileges = ["%s"]
 }
-`, database, userConfig, privileges)
+`, name, acceptance.HW_DLI_AUTHORIZED_USER_NAME, privileges)
 }
 
 func TestAccResourceDliAuth_flink(t *testing.T) {
@@ -104,25 +105,29 @@ func TestAccResourceDliAuth_flink(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliAuthorizedUserConfigured(t)
+			acceptance.TestAccPreCheckDliFlinkVersion(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliAuthResource_flink(name, acceptance.HW_PROJECT_ID, acceptance.HW_REGION_NAME, "GET"),
+				Config: testAccDliAuthResource_flink(name, "GET"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
 					resource.TestMatchResourceAttr(resourceName, "object", regexp.MustCompile(`jobs\.flink\.\d*`)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "GET"),
 					resource.TestCheckResourceAttrSet(resourceName, "is_admin"),
 				),
 			},
 			{
-				Config: testAccDliAuthResource_flink(name, acceptance.HW_PROJECT_ID, acceptance.HW_REGION_NAME, "START"),
+				Config: testAccDliAuthResource_flink(name, "START"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
 					resource.TestMatchResourceAttr(resourceName, "object", regexp.MustCompile(`jobs\.flink\.\d*`)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "START"),
 					resource.TestCheckResourceAttrSet(resourceName, "is_admin"),
@@ -137,20 +142,18 @@ func TestAccResourceDliAuth_flink(t *testing.T) {
 	})
 }
 
-func testAccDliAuthResource_flink(name, projectId, region string, privileges string) string {
-	flinkJob := testAccFlinkJobResource_basic(name, region)
-	userConfig := testAccDliAuthUserConfig(name, projectId)
+func testAccDliAuthResource_flink(name, privileges string) string {
+	flinkJob := testAccFlinkJobResource_basic(name)
 
 	return fmt.Sprintf(`
 %s
-%s
 
 resource "huaweicloud_dli_permission" "test" {
-  user_name  = huaweicloud_identity_user.test.name
+  user_name  = "%s"
   object     = "jobs.flink.${huaweicloud_dli_flinksql_job.test.id}"
   privileges = ["%s"]
 }
-`, flinkJob, userConfig, privileges)
+`, flinkJob, acceptance.HW_DLI_AUTHORIZED_USER_NAME, privileges)
 }
 
 func TestAccResourceDliAuth_table(t *testing.T) {
@@ -165,15 +168,18 @@ func TestAccResourceDliAuth_table(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliAuthorizedUserConfigured(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliAuthResource_table(name, acceptance.HW_PROJECT_ID, "SELECT"),
+				Config: testAccDliAuthResource_table(name, "SELECT"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
 					resource.TestCheckResourceAttr(resourceName, "object",
 						fmt.Sprintf("databases.%s.tables.%s", name, name)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "SELECT"),
@@ -181,10 +187,10 @@ func TestAccResourceDliAuth_table(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDliAuthResource_table(name, acceptance.HW_PROJECT_ID, "DROP_TABLE"),
+				Config: testAccDliAuthResource_table(name, "DROP_TABLE"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
 					resource.TestCheckResourceAttr(resourceName, "object",
 						fmt.Sprintf("databases.%s.tables.%s", name, name)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "DROP_TABLE"),
@@ -200,26 +206,23 @@ func TestAccResourceDliAuth_table(t *testing.T) {
 	})
 }
 
-func testAccDliAuthResource_table(name string, projectId string, privileges string) string {
+func testAccDliAuthResource_table(name, privileges string) string {
 	table := testAccDliTableResource_basic(name)
-	userConfig := testAccDliAuthUserConfig(name, projectId)
 
 	return fmt.Sprintf(`
 %s
-%s
 
 resource "huaweicloud_dli_permission" "test" {
-  user_name  = huaweicloud_identity_user.test.name
+  user_name  = "%s"
   object     = "databases.${huaweicloud_dli_database.test.name}.tables.${huaweicloud_dli_table.test.name}"
   privileges = ["%s"]
 }
-`, table, userConfig, privileges)
+`, table, acceptance.HW_DLI_AUTHORIZED_USER_NAME, privileges)
 }
 
 func TestAccResourceDliAuth_package(t *testing.T) {
 	var obj auth.Privilege
 	resourceName := "huaweicloud_dli_permission.test"
-	name := acceptance.RandomAccResourceName()
 	packageGroupName := acceptance.RandomAccResourceNameWithDash()
 
 	rc := acceptance.InitResourceCheck(
@@ -232,25 +235,26 @@ func TestAccResourceDliAuth_package(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckOBS(t)
+			acceptance.TestAccPreCheckDliAuthorizedUserConfigured(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliAuthResource_package(name, acceptance.HW_PROJECT_ID, packageGroupName, "USE_GROUP"),
+				Config: testAccDliAuthResource_package(packageGroupName, "USE_GROUP"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
 					resource.TestCheckResourceAttr(resourceName, "object", fmt.Sprintf("groups.%s", packageGroupName)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "USE_GROUP"),
 					resource.TestCheckResourceAttrSet(resourceName, "is_admin"),
 				),
 			},
 			{
-				Config: testAccDliAuthResource_package(name, acceptance.HW_PROJECT_ID, packageGroupName, "GET_GROUP"),
+				Config: testAccDliAuthResource_package(packageGroupName, "GET_GROUP"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
 					resource.TestCheckResourceAttr(resourceName, "object", fmt.Sprintf("groups.%s", packageGroupName)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "GET_GROUP"),
 					resource.TestCheckResourceAttrSet(resourceName, "is_admin"),
@@ -265,27 +269,24 @@ func TestAccResourceDliAuth_package(t *testing.T) {
 	})
 }
 
-func testAccDliAuthResource_package(name, projectId, packageGroupName string, privileges string) string {
+func testAccDliAuthResource_package(packageGroupName string, privileges string) string {
 	group := testAccDliPackage_basic(packageGroupName)
-	userConfig := testAccDliAuthUserConfig(name, projectId)
 
 	return fmt.Sprintf(`
 %s
-%s
 
 resource "huaweicloud_dli_permission" "test" {
-  user_name  = huaweicloud_identity_user.test.name
+  user_name  = "%s"
   object     = "groups.${huaweicloud_dli_package.test.group_name}"
   privileges = ["%s"]
 }
 
-`, group, userConfig, privileges)
+`, group, acceptance.HW_DLI_AUTHORIZED_USER_NAME, privileges)
 }
 
 func TestAccResourceDliAuth_queue(t *testing.T) {
 	var obj auth.Privilege
 	resourceName := "huaweicloud_dli_permission.test"
-	name := acceptance.RandomAccResourceName()
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -294,26 +295,30 @@ func TestAccResourceDliAuth_queue(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliAuthorizedUserConfigured(t)
+			acceptance.TestAccPreCheckDliSQLQueueName(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliAuthResource_queue(name, acceptance.HW_PROJECT_ID, "DROP_QUEUE"),
+				Config: testAccDliAuthResource_queue("DROP_QUEUE"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
-					resource.TestCheckResourceAttr(resourceName, "object", fmt.Sprintf("queues.%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
+					resource.TestCheckResourceAttr(resourceName, "object", fmt.Sprintf("queues.%s", acceptance.HW_DLI_SQL_QUEUE_NAME)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "DROP_QUEUE"),
 					resource.TestCheckResourceAttrSet(resourceName, "is_admin"),
 				),
 			},
 			{
-				Config: testAccDliAuthResource_queue(name, acceptance.HW_PROJECT_ID, "SUBMIT_JOB"),
+				Config: testAccDliAuthResource_queue("SUBMIT_JOB"),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "user_name", name),
-					resource.TestCheckResourceAttr(resourceName, "object", fmt.Sprintf("queues.%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "user_name", acceptance.HW_DLI_AUTHORIZED_USER_NAME),
+					resource.TestCheckResourceAttr(resourceName, "object", fmt.Sprintf("queues.%s", acceptance.HW_DLI_SQL_QUEUE_NAME)),
 					resource.TestCheckResourceAttr(resourceName, "privileges.0", "SUBMIT_JOB"),
 					resource.TestCheckResourceAttrSet(resourceName, "is_admin"),
 				),
@@ -327,80 +332,12 @@ func TestAccResourceDliAuth_queue(t *testing.T) {
 	})
 }
 
-func testAccDliAuthResource_queue(name string, projectId string, privileges string) string {
-	queue := testAccDliQueue_basic(name, dli.CU16)
-	userConfig := testAccDliAuthUserConfig(name, projectId)
-
+func testAccDliAuthResource_queue(privileges string) string {
 	return fmt.Sprintf(`
-%s
-%s
 resource "huaweicloud_dli_permission" "test" {
-  user_name  = huaweicloud_identity_user.test.name
-  object     = "queues.${huaweicloud_dli_queue.test.name}"
+  user_name  = "%s"
+  object     = "queues.%s"
   privileges = ["%s"]
 }
-`, queue, userConfig, privileges)
-}
-
-func testAccDliAuthUserConfig(name string, projectId string) string {
-	return fmt.Sprintf(`
-resource "huaweicloud_identity_group" "group_1" {
-  name = "%s"
-}
-
-resource "huaweicloud_identity_user" "test" {
-  name        = "%s"
-  password    = "password123@!"
-  enabled     = true
-}
-
-resource "huaweicloud_identity_role" "role_1" {
-  name        = "%s"
-  description = "DLI readOnly role created by terraform"
-  type        = "AX"
-  policy      = <<EOF
-{
-    "Version": "1.1",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "dli:jobs:get",
-                "dli:queue:show_privileges",
-                "dli:database:show_functions",
-                "dli:table:show_segments",
-                "dli:table:describe_table",
-                "dli:table:show_privileges",
-                "dli:table:select",
-                "dli:database:displayAllDatabases",
-                "dli:database:show_roles",
-                "dli:database:show_users",
-                "dli:datasourceauth:show_privileges",
-                "dli:database:show_privileges",
-                "dli:database:show_all_roles",
-                "dli:column:select",
-                "dli:datasourceauth:use_auth",
-                "dli:table:show_partitions",
-                "dli:database:displayAllTables",
-                "dli:table:show_table_properties",
-                "dli:table:show_create_table"
-            ]
-        }
-    ]
-}
-EOF
-}
-
-resource "huaweicloud_identity_role_assignment" "role_assignment_1" {
-  role_id    = huaweicloud_identity_role.role_1.id
-  group_id   = huaweicloud_identity_group.group_1.id
-  project_id = "%s"
-}
-
-resource "huaweicloud_identity_group_membership" "membership_1" {
-  group = huaweicloud_identity_group.group_1.id
-  users = [huaweicloud_identity_user.test.id]
-}
-
-`, name, name, name, projectId)
+`, acceptance.HW_DLI_AUTHORIZED_USER_NAME, acceptance.HW_DLI_SQL_QUEUE_NAME, privileges)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_queue_test.go
@@ -2,6 +2,7 @@ package dli
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -11,8 +12,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	act "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 )
 
@@ -26,29 +25,40 @@ func getDliQueueResourceFunc(cfg *config.Config, state *terraform.ResourceState)
 	return result.Body, result.Err
 }
 
+func getElasticResourcePoolNames() (name string, updateName string) {
+	elasticResourceNames := strings.Split(acceptance.HW_DLI_ELASTIC_RESOURCE_POOL_NAMES, ",")
+	if len(elasticResourceNames) >= 2 {
+		return elasticResourceNames[0], elasticResourceNames[1]
+	}
+	return "", ""
+}
+
 func TestAccDliQueue_basic(t *testing.T) {
 	var (
 		obj   interface{}
-		rName = act.RandomAccResourceName()
+		rName = acceptance.RandomAccResourceName()
 
 		typeSQL     = "huaweicloud_dli_queue.default"
 		typeGeneral = "huaweicloud_dli_queue.general"
 
-		rcForTypeSQL     = acceptance.InitResourceCheck(typeSQL, &obj, getDliQueueResourceFunc)
-		rcForTypeGeneral = acceptance.InitResourceCheck(typeGeneral, &obj, getDliQueueResourceFunc)
+		rcForTypeSQL           = acceptance.InitResourceCheck(typeSQL, &obj, getDliQueueResourceFunc)
+		rcForTypeGeneral       = acceptance.InitResourceCheck(typeGeneral, &obj, getDliQueueResourceFunc)
+		elasticResourceName, _ = getElasticResourcePoolNames()
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { act.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliElasticResourcePoolName(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rcForTypeSQL.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliQueue_basic(rName, dli.CU16),
+				Config: testAccDliQueue_basic_step1(elasticResourceName, rName, dli.CU16),
 				Check: resource.ComposeTestCheckFunc(
 					rcForTypeSQL.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(typeSQL, "elastic_resource_pool_name",
-						"huaweicloud_dli_elastic_resource_pool.test", "name"),
+					resource.TestCheckResourceAttr(typeSQL, "elastic_resource_pool_name", elasticResourceName),
 					resource.TestCheckResourceAttr(typeSQL, "name", rName+"_sql"),
 					resource.TestCheckResourceAttr(typeSQL, "queue_type", dli.QueueTypeSQL),
 					resource.TestCheckResourceAttr(typeSQL, "cu_count", fmt.Sprintf("%d", dli.CU16)),
@@ -56,14 +66,12 @@ func TestAccDliQueue_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(typeSQL, "resource_mode", "1"),
 					resource.TestCheckResourceAttrSet(typeSQL, "create_time"),
 					rcForTypeGeneral.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(typeSQL, "elastic_resource_pool_name",
-						"huaweicloud_dli_elastic_resource_pool.test", "name"),
+					resource.TestCheckResourceAttr(typeGeneral, "elastic_resource_pool_name", elasticResourceName),
 					resource.TestCheckResourceAttr(typeGeneral, "name", rName+"_general"),
 					resource.TestCheckResourceAttr(typeGeneral, "queue_type", dli.QueueTypeGeneral),
 					resource.TestCheckResourceAttr(typeGeneral, "cu_count", fmt.Sprintf("%d", dli.CU16)),
-					resource.TestCheckResourceAttr(typeSQL, "resource_mode", "1"),
+					resource.TestCheckResourceAttr(typeGeneral, "resource_mode", "1"),
 					resource.TestCheckResourceAttrSet(typeGeneral, "create_time"),
-					waitForDeletionCooldownComplete(),
 				),
 			},
 			{
@@ -95,28 +103,11 @@ func testAccQueueImportStateFunc(rName string) resource.ImportStateIdFunc {
 	}
 }
 
-func testAccDliQueue_base(rName string, cuCount int) string {
+func testAccDliQueue_basic_step1(elasticResourceName, rName string, cuCount int) string {
 	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_dli_elastic_resource_pool" "test" {
-  name   = "%[2]s"
-  min_cu = %[3]d
-  max_cu = %[3]d
-  cidr   = cidrsubnet(huaweicloud_vpc.test.cidr, 3, 1)
-
-  enterprise_project_id = "0"
-}
-`, common.TestVpc(rName), rName, cuCount)
-}
-
-func testAccDliQueue_basic(rName string, cuCount int) string {
-	return fmt.Sprintf(`
-%[1]s
-
 # The default type is SQL
 resource "huaweicloud_dli_queue" "default" {
-  elastic_resource_pool_name = huaweicloud_dli_elastic_resource_pool.test.name
+  elastic_resource_pool_name = "%[1]s"
   resource_mode              = 1
 
   name     = "%[2]s_sql"
@@ -128,153 +119,64 @@ resource "huaweicloud_dli_queue" "default" {
 }
 
 resource "huaweicloud_dli_queue" "general" {
-  elastic_resource_pool_name = huaweicloud_dli_elastic_resource_pool.test.name
+  elastic_resource_pool_name = "%[1]s"
   resource_mode              = 1
 
   name       = "%[2]s_general"
   cu_count   = %[3]d
   queue_type = "general"
-}
-`, testAccDliQueue_base(rName, cuCount*4), // Prevent resource creation failure due to insufficient total resource CUs
-		rName, cuCount)
+}`, elasticResourceName, rName, cuCount)
 }
 
-func TestAccDliQueue_scalingPolicies(t *testing.T) {
+func TestAccDliQueue_another(t *testing.T) {
 	var (
-		obj          queues.CreateOpts
-		rName        = acceptance.RandomAccResourceName()
-		resourceName = "huaweicloud_dli_queue.test"
-		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDliQueueResourceFunc)
+		obj                    queues.CreateOpts
+		rName                  = acceptance.RandomAccResourceName()
+		resourceName           = "huaweicloud_dli_queue.test"
+		rc                     = acceptance.InitResourceCheck(resourceName, &obj, getDliQueueResourceFunc)
+		_, elasticResourceName = getElasticResourcePoolNames()
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccQueue_scalingPolicies_step1(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(resourceName, "elastic_resource_pool_name",
-						"huaweicloud_dli_elastic_resource_pool.test", "name"),
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policies.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.%", "5"),
-				),
-			},
-			{
-				Config: testAccQueue_scalingPolicies_step2(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policies.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.priority", "1"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.impact_start_time", "00:00"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.impact_stop_time", "24:00"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.min_cu", "16"),
-					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.max_cu", "16"),
-					waitForDeletionCooldownComplete(),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccQueueImportStateFunc(resourceName),
-			},
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliElasticResourcePoolName(t)
 		},
-	})
-}
-
-func testAccQueue_scalingPolicies_step1(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_dli_queue" "test" {
-  elastic_resource_pool_name = huaweicloud_dli_elastic_resource_pool.test.name
-  resource_mode              = 1
-
-  name     = "%[2]s"
-  cu_count = 16
-
-  scaling_policies {
-    priority          = 1
-    impact_start_time = "00:00"
-    impact_stop_time  = "24:00"
-    min_cu            = 16
-    max_cu            = 16
-  }
-  
-  scaling_policies {
-    priority          = 2
-    impact_start_time = "00:00"
-    impact_stop_time  = "01:00"
-    min_cu            = 20
-    max_cu            = 28
-  }
-}`, testAccDliQueue_base(rName, 64), rName)
-}
-
-func testAccQueue_scalingPolicies_step2(rName string) string {
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_dli_queue" "test" {
-  elastic_resource_pool_name = huaweicloud_dli_elastic_resource_pool.test.name
-  resource_mode              = 1
-
-  name     = "%[2]s"
-  cu_count = 16
-
-  scaling_policies {
-    priority          = 1
-    impact_start_time = "00:00"
-    impact_stop_time  = "24:00"
-    max_cu            = 16
-    min_cu            = 16
-  }
-}`, testAccDliQueue_base(rName, 64), rName)
-}
-
-func TestAccDliQueue_sparkDriver(t *testing.T) {
-	var (
-		obj          queues.CreateOpts
-		rName        = act.RandomAccResourceName()
-		resourceName = "huaweicloud_dli_queue.test"
-		rc           = acceptance.InitResourceCheck(resourceName, &obj, getDliQueueResourceFunc)
-	)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { act.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDliQueue_sparkDriver_step1(rName),
+				Config: testAccDliQueue_another_step1(elasticResourceName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(resourceName, "elastic_resource_pool_name",
-						"huaweicloud_dli_elastic_resource_pool.test", "name"),
+					resource.TestCheckResourceAttr(resourceName, "elastic_resource_pool_name", elasticResourceName),
 					resource.TestCheckResourceAttr(resourceName, "spark_driver.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spark_driver.0.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "spark_driver.0.max_instance", "2"),
 					resource.TestCheckResourceAttr(resourceName, "spark_driver.0.max_concurrent", "1"),
 					resource.TestCheckResourceAttr(resourceName, "spark_driver.0.max_prefetch_instance", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policies.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.%", "5"),
 				),
 			},
 			{
-				Config: testAccDliQueue_sparkDriver_step2(rName),
+				Config: testAccDliQueue_another_step2(elasticResourceName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "spark_driver.0.max_prefetch_instance", "4"),
+					resource.TestCheckResourceAttr(resourceName, "spark_driver.0.max_prefetch_instance", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.impact_start_time", "00:00"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.impact_stop_time", "24:00"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.min_cu", "16"),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policies.0.max_cu", "16"),
 				),
 			},
 			{
-				Config: testAccDliQueue_sparkDriver_step3(rName),
+				Config: testAccDliQueue_another_step3(elasticResourceName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "spark_driver.#", "0"),
-					waitForDeletionCooldownComplete(),
+					resource.TestCheckResourceAttr(resourceName, "scaling_policies.#", "1"),
 				),
 			},
 			{
@@ -290,53 +192,71 @@ func TestAccDliQueue_sparkDriver(t *testing.T) {
 	})
 }
 
-func testAccDliQueue_sparkDriver_step1(rName string) string {
+func testAccDliQueue_another_step1(elasticResourceName, rName string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_dli_queue" "test" {
-  elastic_resource_pool_name = huaweicloud_dli_elastic_resource_pool.test.name
+  elastic_resource_pool_name = "%[1]s"
   resource_mode              = 1
 
   name     = "%[2]s"
-  cu_count = 64
+  cu_count = 16
 
   spark_driver {
     max_instance          = 2
     max_concurrent        = 1
     max_prefetch_instance = "0"
   }
-}`, testAccDliQueue_base(rName, 64), rName)
+
+  scaling_policies {
+    priority          = 1
+    impact_start_time = "00:00"
+    impact_stop_time  = "24:00"
+    min_cu            = 16
+    max_cu            = 16
+  }
+
+  scaling_policies {
+    priority          = 2
+    impact_start_time = "00:00"
+    impact_stop_time  = "01:00"
+    min_cu            = 20
+    max_cu            = 28
+  }
+}`, elasticResourceName, rName)
 }
 
-// Modify "max_prefetch_instance" parameter, and remove the "max_instance" and "max_concurrent" parameters。
-func testAccDliQueue_sparkDriver_step2(rName string) string {
+func testAccDliQueue_another_step2(elasticResourceName, rName string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_dli_queue" "test" {
-  elastic_resource_pool_name = huaweicloud_dli_elastic_resource_pool.test.name
+  elastic_resource_pool_name = "%[1]s"
   resource_mode              = 1
 
   name     = "%[2]s"
-  cu_count = 64
+  cu_count = 16
 
+  # Modify "max_prefetch_instance" parameter, and remove the "max_instance" and "max_concurrent" parameters。
   spark_driver {
-    max_prefetch_instance = "4"
+    max_prefetch_instance = "1"
   }
-}`, testAccDliQueue_base(rName, 64), rName)
+
+  scaling_policies {
+    priority          = 1
+    impact_start_time = "00:00"
+    impact_stop_time  = "24:00"
+    max_cu            = 16
+    min_cu            = 16
+  }
+}`, elasticResourceName, rName)
 }
 
 // Remove spark_driver parameters
-func testAccDliQueue_sparkDriver_step3(rName string) string {
+func testAccDliQueue_another_step3(elasticResourceName, rName string) string {
 	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_dli_queue" "test" {
-  elastic_resource_pool_name = huaweicloud_dli_elastic_resource_pool.test.name
+  elastic_resource_pool_name = "%s"
   resource_mode              = 1
 
   name     = "%s"
-  cu_count = 64
-}`, testAccDliQueue_base(rName, 64), rName)
+  cu_count = 16
+}`, elasticResourceName, rName)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_spark_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_spark_job_test.go
@@ -37,6 +37,7 @@ func TestAccDliSparkJobV2_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliGenaralQueueName(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckDliSparkJobDestroy,
@@ -45,8 +46,7 @@ func TestAccDliSparkJobV2_basic(t *testing.T) {
 				Config: testAccDliSparkJob_basic(rName, dashName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					acceptance.TestCheckResourceAttrWithVariable(resourceName, "queue_name",
-						"${huaweicloud_dli_queue.test.name}"),
+					resource.TestCheckResourceAttr(resourceName, "queue_name", acceptance.HW_DLI_GENERAL_QUEUE_NAME),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 				),
 			},
@@ -78,16 +78,10 @@ func testAccCheckDliSparkJobDestroy(s *terraform.State) error {
 
 func testAccDliSparkJob_basic(name, dashName string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_dli_queue" "test" {
-  name       = "%s"
-  cu_count   = 16
-  queue_type = "general"
-}
-
 %s
 
 resource "huaweicloud_dli_spark_job" "test" {
-  queue_name = huaweicloud_dli_queue.test.name
+  queue_name = "%s"
   name       = "%s"
   app_name   = "${huaweicloud_dli_package.test.group_name}/${huaweicloud_dli_package.test.object_name}"
   
@@ -96,5 +90,5 @@ resource "huaweicloud_dli_spark_job" "test" {
     huaweicloud_obs_bucket_object.test,
   ]
 }
-`, name, testAccDliPackage_basic(dashName), name)
+`, testAccDliPackage_basic(dashName), acceptance.HW_DLI_GENERAL_QUEUE_NAME, name)
 }

--- a/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
+++ b/huaweicloud/services/acceptance/dli/resource_huaweicloud_dli_sql_job_test.go
@@ -34,7 +34,10 @@ func TestAccResourceDliSqlJob_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDliSQLQueueName(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      testAccCheckDliSQLJobDestroy,
 		Steps: []resource.TestStep{
@@ -45,43 +48,7 @@ func TestAccResourceDliSqlJob_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "sql", fmt.Sprint("DESC ", name)),
 					resource.TestCheckResourceAttr(resourceName, "database_name", name),
 					resource.TestCheckResourceAttr(resourceName, "job_type", "DDL"),
-					resource.TestCheckResourceAttr(resourceName, "queue_name", name),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"rows", "schema"},
-			},
-		},
-	})
-}
-
-func TestAccResourceDliSqlJob_query(t *testing.T) {
-	var sqlJobObj sqljob.SqlJobOpts
-	resourceName := "huaweicloud_dli_sql_job.test"
-	name := acceptance.RandomAccResourceName()
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&sqlJobObj,
-		getDliSQLJobResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      testAccCheckDliSQLJobDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSQLJobBaseResource_query(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "sql", fmt.Sprint("SELECT * FROM ", name)),
-					resource.TestCheckResourceAttr(resourceName, "database_name", name),
-					resource.TestCheckResourceAttr(resourceName, "queue_name", "default"),
-					resource.TestCheckResourceAttr(resourceName, "job_type", "QUERY"),
+					resource.TestCheckResourceAttr(resourceName, "queue_name", acceptance.HW_DLI_SQL_QUEUE_NAME),
 				),
 			},
 			{
@@ -134,17 +101,12 @@ func testAccSqlJobBaseResource_basic(name string) string {
 	return fmt.Sprintf(`
 %s
 
-resource "huaweicloud_dli_queue" "test" {
-  name     = "%s"
-  cu_count = 16
-}
-
 resource "huaweicloud_dli_sql_job" "test" {
   sql           = "DESC ${huaweicloud_dli_table.test.name}"
   database_name = huaweicloud_dli_database.test.name
-  queue_name    = huaweicloud_dli_queue.test.name
+  queue_name    = "%s"
 }
-`, testAccSQLJobBaseResource(name), name)
+`, testAccSQLJobBaseResource(name), acceptance.HW_DLI_SQL_QUEUE_NAME)
 }
 
 func testAccSQLJobBaseResource(name string) string {
@@ -174,18 +136,6 @@ resource "huaweicloud_dli_table" "test" {
 `, name, name)
 }
 
-func testAccSQLJobBaseResource_query(name string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_dli_sql_job" "test" {
-  sql           = "SELECT * FROM ${huaweicloud_dli_table.test.name}"
-  database_name = huaweicloud_dli_database.test.name
-
-}
-`, testAccSQLJobBaseResource(name))
-}
-
 func testAccSQLJobResource_aync(name string) string {
 	return fmt.Sprintf(`
 %s
@@ -195,7 +145,14 @@ resource "huaweicloud_dli_sql_job" "test" {
   database_name = huaweicloud_dli_database.test.name
 
   conf {
-    dli_sql_sqlasync_enabled = true
+	spark_sql_max_records_per_file                = 1
+    spark_sql_auto_broadcast_join_threshold       = -1
+    spark_sql_shuffle_partitions                  = 4096
+    spark_sql_dynamic_partition_overwrite_enabled = true
+    spark_sql_files_max_partition_bytes           = 134216704
+    spark_sql_bad_records_path                    = "test"
+    dli_sql_sqlasync_enabled                      = true
+    dli_sql_job_timeout                           = 300
   }
 }
 `, testAccSQLJobBaseResource(name))

--- a/huaweicloud/services/dli/data_source_huaweicloud_dli_flinkjar_jobs.go
+++ b/huaweicloud/services/dli/data_source_huaweicloud_dli_flinkjar_jobs.go
@@ -136,10 +136,10 @@ func DataSourceDliFlinkjarJobs() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						// The runtime_config is a json string.
 						"runtime_config": {
-							Type:     schema.TypeMap,
+							Type:     schema.TypeString,
 							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"resume_max_num": {
 							Type:     schema.TypeInt,
@@ -218,8 +218,10 @@ func (w *FlinkjarJobsDSWrapper) ListFlinkJobs() (*gjson.Result, error) {
 
 	uri := "/v1.0/{project_id}/streaming/jobs"
 	params := map[string]any{
-		"queue_name": w.Get("queue_name"),
-		"tags":       w.getTags(),
+		"queue_name":  w.Get("queue_name"),
+		"tags":        w.getTags(),
+		"job_type":    "flink_jar_job",
+		"show_detail": true,
 	}
 	params = utils.RemoveNil(params)
 	return httphelper.New(client).

--- a/huaweicloud/services/dli/data_source_huaweicloud_dli_flinksql_jobs.go
+++ b/huaweicloud/services/dli/data_source_huaweicloud_dli_flinksql_jobs.go
@@ -173,10 +173,10 @@ func DataSourceDliFlinkSQLJobs() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						// The runtime_config is a json string.
 						"runtime_config": {
-							Type:     schema.TypeMap,
+							Type:     schema.TypeString,
 							Computed: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"operator_config": {
 							Type:     schema.TypeString,
@@ -235,8 +235,9 @@ func (w *FlinkSQLJobsDSWrapper) ListFlinkJobs() (*gjson.Result, error) {
 
 	uri := "/v1.0/{project_id}/streaming/jobs"
 	params := map[string]any{
-		"queue_name": w.Get("queue_name"),
-		"tags":       w.getTags(),
+		"queue_name":  w.Get("queue_name"),
+		"tags":        w.getTags(),
+		"show_detail": true,
 	}
 	params = utils.RemoveNil(params)
 	return httphelper.New(client).

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flinksql_job.go
@@ -427,7 +427,8 @@ func resourceFlinkSqlJobRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	if d.Get("type").(string) == flinkjob.JobTypeFlinkOpenSourceSql {
+	_, ok := d.GetOk("graph_type")
+	if d.Get("type").(string) == flinkjob.JobTypeFlinkOpenSourceSql && ok {
 		v3Client, err := config.DliV3Client(region)
 		if err != nil {
 			return diag.Errorf("error creating DLI v3 client: %s", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Adjust some acceptance test scripts to improve the ut coverage.
2.  fix the issure that the flink SQL and flink JAR data sources cannot be queried.

![image](https://github.com/user-attachments/assets/63b9b76c-a751-41b7-a933-2e9fa75c0b8e)
![image](https://github.com/user-attachments/assets/ebfa2128-0cf3-4b00-8ee5-b2e5970d8691)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
>>> Start to test
=== RUN   TestAccDatasourceAuths_basic
=== PAUSE TestAccDatasourceAuths_basic
=== RUN   TestAccDatasourceAuths_CSS
=== PAUSE TestAccDatasourceAuths_CSS
=== RUN   TestAccDatasourceAuths_Kafka_SSL
=== PAUSE TestAccDatasourceAuths_Kafka_SSL
=== RUN   TestAccDatasourceAuths_KRB
=== PAUSE TestAccDatasourceAuths_KRB
=== RUN   TestAccDatasourceConnections_basic
=== PAUSE TestAccDatasourceConnections_basic
=== RUN   TestAccDataSourceDliElasticResourcePools_basic
=== PAUSE TestAccDataSourceDliElasticResourcePools_basic
=== RUN   TestAccDataSourceDliFlinkTemplates_basic
=== PAUSE TestAccDataSourceDliFlinkTemplates_basic
=== RUN   TestAccDataSourceDliFlinkjarJobs_basic
=== PAUSE TestAccDataSourceDliFlinkjarJobs_basic
=== RUN   TestAccDataSourceDliFlinkSQLJobs_basic
=== PAUSE TestAccDataSourceDliFlinkSQLJobs_basic
=== RUN   TestAccDataSourceDliQuotas_basic
=== PAUSE TestAccDataSourceDliQuotas_basic
=== RUN   TestAccDataSourceDliSparkTemplates_basic
=== PAUSE TestAccDataSourceDliSparkTemplates_basic
=== RUN   TestAccDataSourceDliSqlJobs_basic
=== PAUSE TestAccDataSourceDliSqlJobs_basic
=== RUN   TestAccDataSourceDliSqlTemplates_basic
=== PAUSE TestAccDataSourceDliSqlTemplates_basic
=== RUN   TestAccDliAgency_basic
=== PAUSE TestAccDliAgency_basic
=== RUN   TestAccDatabasePrivilege_basic
=== PAUSE TestAccDatabasePrivilege_basic
=== RUN   TestAccDatabasePrivilege_database
=== PAUSE TestAccDatabasePrivilege_database
=== RUN   TestAccDliDatabase_basic
=== PAUSE TestAccDliDatabase_basic
=== RUN   TestAccDatasourceAuth_basic
=== PAUSE TestAccDatasourceAuth_basic
=== RUN   TestAccDatasourceAuth_css
=== PAUSE TestAccDatasourceAuth_css
=== RUN   TestAccDatasourceAuth_Kafka_SSL
=== PAUSE TestAccDatasourceAuth_Kafka_SSL
=== RUN   TestAccDatasourceAuth_KRB
=== PAUSE TestAccDatasourceAuth_KRB
=== RUN   TestAccDatasourceConnectionAssociate_basic
=== PAUSE TestAccDatasourceConnectionAssociate_basic
=== RUN   TestAccDatasourceConnectionPrivilege_basic
=== PAUSE TestAccDatasourceConnectionPrivilege_basic
=== RUN   TestAccDatasourceConnection_basic
=== PAUSE TestAccDatasourceConnection_basic
=== RUN   TestAccElasticResourcePool_basic
=== PAUSE TestAccElasticResourcePool_basic
=== RUN   TestAccFlinkTemplate_basic
=== PAUSE TestAccFlinkTemplate_basic
=== RUN   TestAccDliFlinkJarJob_basic
=== PAUSE TestAccDliFlinkJarJob_basic
=== RUN   TestAccResourceDliFlinkJob_basic
=== PAUSE TestAccResourceDliFlinkJob_basic
=== RUN   TestAccResourceDliFlinkJob_streamGraph
=== PAUSE TestAccResourceDliFlinkJob_streamGraph
=== RUN   TestAccGlobalVariable_basic
=== PAUSE TestAccGlobalVariable_basic
=== RUN   TestAccDliPackage_basic
=== PAUSE TestAccDliPackage_basic
=== RUN   TestAccDliPackage_not_groupName
=== PAUSE TestAccDliPackage_not_groupName
=== RUN   TestAccResourceDliAuth_basic
=== PAUSE TestAccResourceDliAuth_basic
=== RUN   TestAccResourceDliAuth_flink
=== PAUSE TestAccResourceDliAuth_flink
=== RUN   TestAccResourceDliAuth_table
=== PAUSE TestAccResourceDliAuth_table
=== RUN   TestAccResourceDliAuth_package
=== PAUSE TestAccResourceDliAuth_package
=== RUN   TestAccResourceDliAuth_queue
=== PAUSE TestAccResourceDliAuth_queue
=== RUN   TestAccDliQueue_basic
--- PASS: TestAccDliQueue_basic (269.45s)
=== RUN   TestAccDliQueue_another
--- PASS: TestAccDliQueue_another (291.57s)
=== RUN   TestAccDliSparkJobV2_basic
=== PAUSE TestAccDliSparkJobV2_basic
=== RUN   TestAccSparkTemplate_basic
=== PAUSE TestAccSparkTemplate_basic
=== RUN   TestAccResourceDliSqlJob_basic
=== PAUSE TestAccResourceDliSqlJob_basic
=== RUN   TestAccResourceDliSqlJob_async
=== PAUSE TestAccResourceDliSqlJob_async
=== RUN   TestAccSQLTemplate_basic
=== PAUSE TestAccSQLTemplate_basic
=== RUN   TestAccResourceDliTable_basic
=== PAUSE TestAccResourceDliTable_basic
=== RUN   TestAccResourceDliTable_OBS
=== PAUSE TestAccResourceDliTable_OBS
=== CONT  TestAccDatasourceAuths_basic
=== CONT  TestAccDatasourceConnectionPrivilege_basic
=== CONT  TestAccResourceDliAuth_flink
=== CONT  TestAccResourceDliSqlJob_basic
=== CONT  TestAccDatasourceConnectionAssociate_basic
--- PASS: TestAccDatasourceAuths_basic (38.50s)
=== CONT  TestAccResourceDliAuth_basic
--- PASS: TestAccResourceDliAuth_basic (57.40s)
=== CONT  TestAccDliPackage_not_groupName
--- PASS: TestAccDatasourceConnectionPrivilege_basic (110.16s)
=== CONT  TestAccDliPackage_basic
--- PASS: TestAccResourceDliSqlJob_basic (159.61s)
=== CONT  TestAccGlobalVariable_basic
--- PASS: TestAccDatasourceConnectionAssociate_basic (167.88s)
=== CONT  TestAccResourceDliFlinkJob_streamGraph
    acceptance.go:1003: HW_DLI_FLINK_STREAM_GRAPH must be set for DLI acceptance tests.
--- SKIP: TestAccResourceDliFlinkJob_streamGraph (0.01s)
=== CONT  TestAccResourceDliFlinkJob_basic
--- PASS: TestAccResourceDliAuth_flink (167.93s)
=== CONT  TestAccDliFlinkJarJob_basic
--- PASS: TestAccDliPackage_not_groupName (117.45s)
=== CONT  TestAccFlinkTemplate_basic
--- PASS: TestAccGlobalVariable_basic (54.92s)
=== CONT  TestAccElasticResourcePool_basic
    acceptance.go:1012: HW_DLI_ELASTIC_RESOURCE_POOL must be set for DLI acceptance tests.
--- SKIP: TestAccElasticResourcePool_basic (0.01s)
=== CONT  TestAccDatasourceConnection_basic
--- PASS: TestAccDliPackage_basic (117.64s)
=== CONT  TestAccDataSourceDliSqlJobs_basic
--- PASS: TestAccFlinkTemplate_basic (104.05s)
=== CONT  TestAccDatasourceAuth_KRB
--- PASS: TestAccDatasourceAuth_KRB (35.41s)
=== CONT  TestAccDatasourceAuth_Kafka_SSL
--- PASS: TestAccDatasourceAuth_Kafka_SSL (45.12s)
=== CONT  TestAccDatasourceAuth_css
--- PASS: TestAccResourceDliFlinkJob_basic (244.82s)
=== CONT  TestAccDatasourceAuth_basic
--- PASS: TestAccDatasourceAuth_css (74.73s)
=== CONT  TestAccDliDatabase_basic
--- PASS: TestAccDatasourceAuth_basic (66.74s)
=== CONT  TestAccDatabasePrivilege_database
--- PASS: TestAccDliFlinkJarJob_basic (311.94s)
=== CONT  TestAccDatabasePrivilege_basic
--- PASS: TestAccDatasourceConnection_basic (270.83s)
=== CONT  TestAccDliAgency_basic
--- PASS: TestAccDliDatabase_basic (72.11s)
=== CONT  TestAccDataSourceDliSqlTemplates_basic
--- PASS: TestAccDliAgency_basic (127.44s)
=== CONT  TestAccResourceDliTable_basic
--- PASS: TestAccDataSourceDliSqlJobs_basic (423.52s)
=== CONT  TestAccResourceDliTable_OBS
--- PASS: TestAccDatabasePrivilege_database (179.98s)
=== CONT  TestAccDataSourceDliFlinkTemplates_basic
--- PASS: TestAccResourceDliTable_basic (86.81s)
=== CONT  TestAccDataSourceDliSparkTemplates_basic
--- PASS: TestAccDatabasePrivilege_basic (224.31s)
=== CONT  TestAccDataSourceDliQuotas_basic
--- PASS: TestAccDataSourceDliSqlTemplates_basic (185.73s)
=== CONT  TestAccDataSourceDliFlinkSQLJobs_basic
--- PASS: TestAccDataSourceDliQuotas_basic (77.69s)
=== CONT  TestAccDataSourceDliFlinkjarJobs_basic
--- PASS: TestAccResourceDliTable_OBS (148.12s)
=== CONT  TestAccResourceDliAuth_queue
--- PASS: TestAccDataSourceDliFlinkTemplates_basic (168.82s)
=== CONT  TestAccSparkTemplate_basic
--- PASS: TestAccDataSourceDliSparkTemplates_basic (159.69s)
=== CONT  TestAccDliSparkJobV2_basic
--- PASS: TestAccSparkTemplate_basic (88.25s)
=== CONT  TestAccSQLTemplate_basic
--- PASS: TestAccResourceDliAuth_queue (118.66s)
=== CONT  TestAccResourceDliSqlJob_async
--- PASS: TestAccSQLTemplate_basic (107.27s)
=== CONT  TestAccDatasourceAuths_KRB
--- PASS: TestAccDataSourceDliFlinkSQLJobs_basic (303.46s)
=== CONT  TestAccDataSourceDliElasticResourcePools_basic
--- PASS: TestAccDliSparkJobV2_basic (190.26s)
=== CONT  TestAccDatasourceConnections_basic
--- PASS: TestAccDatasourceAuths_KRB (56.88s)
=== CONT  TestAccResourceDliAuth_package
--- PASS: TestAccResourceDliSqlJob_async (169.83s)
=== CONT  TestAccDatasourceAuths_Kafka_SSL
--- PASS: TestAccDataSourceDliElasticResourcePools_basic (73.95s)
=== CONT  TestAccDatasourceAuths_CSS
--- PASS: TestAccDataSourceDliFlinkjarJobs_basic (331.63s)
=== CONT  TestAccResourceDliAuth_table
--- PASS: TestAccDatasourceAuths_Kafka_SSL (53.77s)
--- PASS: TestAccDatasourceAuths_CSS (49.87s)
--- PASS: TestAccResourceDliAuth_package (121.13s)
--- PASS: TestAccDatasourceConnections_basic (153.50s)
--- PASS: TestAccResourceDliAuth_table (99.22s)
PASS
coverage: 70.5% of statements in ../../dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       1773.801s```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
