### PR TITLE
fix(dns/recordset): remove state while zone id not found

### DIFF
--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
@@ -253,7 +253,7 @@ func resourceDNSRecordsetRead(_ context.Context, d *schema.ResourceData, meta in
 
 	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error creating DNS client")
 	}
 
 	version := getApiVersionByZoneType(zoneType)
@@ -329,7 +329,7 @@ func resourceDNSRecordsetUpdate(ctx context.Context, d *schema.ResourceData, met
 
 	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error creating DNS client")
 	}
 
 	if zoneType == "private" {
@@ -457,7 +457,7 @@ func resourceDNSRecordsetDelete(ctx context.Context, d *schema.ResourceData, met
 
 	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error creating DNS client")
 	}
 
 	version := getApiVersionByZoneType(zoneType)

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset_v2.go
@@ -167,7 +167,7 @@ func resourceDNSRecordSetV2Read(_ context.Context, d *schema.ResourceData, meta 
 
 	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error creating DNS client")
 	}
 
 	n, err := recordsets.Get(dnsClient, zoneID, recordsetID).Extract()
@@ -216,7 +216,7 @@ func resourceDNSRecordSetV2Update(ctx context.Context, d *schema.ResourceData, m
 
 	dnsClient, zoneType, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error creating DNS client")
 	}
 
 	if d.HasChanges("description", "ttl", "records") {
@@ -285,7 +285,7 @@ func resourceDNSRecordSetV2Delete(ctx context.Context, d *schema.ResourceData, m
 
 	dnsClient, _, err := chooseDNSClientbyZoneID(d, zoneID, meta)
 	if err != nil {
-		return diag.FromErr(err)
+		return common.CheckDeletedDiag(d, err, "error creating DNS client")
 	}
 
 	err = recordsets.Delete(dnsClient, zoneID, recordsetID).ExtractErr()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The resource state info should be removed if the resource ID or parent resource ID not found.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
Before querying resource detail, the provider trys to build a client according to the zone type.
For this logic, there is a bug that it does not handle the 404 error.
![image](https://github.com/user-attachments/assets/3129e4a5-594d-4bd3-9862-aafe0582826c)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. provider should remove the recordset state while zone id not found.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
NONE
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    NONE

    ab. Related resources (parent resources) not found
    (Public zone)
    ![image](https://github.com/user-attachments/assets/cef394d6-b521-443d-b53f-91508e8016ca)

    (Private zone)
    ![image](https://github.com/user-attachments/assets/717447f6-d3f9-46af-ac94-7d0fb6e4cbef)
