### PR TITLE
chore(as): improve test case coverage of AS services

### DIFF
--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_activity_logs_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_activity_logs_test.go
@@ -27,8 +27,7 @@ func TestAccActivityLogsDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "scaling_group_id", acceptance.HW_AS_SCALING_GROUP_ID),
-					resource.TestCheckOutput("is_start_time_filter_useful", "true"),
-					resource.TestCheckOutput("is_end_time_filter_useful", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.#"),
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
 				),
 			},
@@ -40,32 +39,6 @@ func testAccActivityLogsDataSource_basic() string {
 	return fmt.Sprintf(`
 data "huaweicloud_as_activity_logs" "test" {
   scaling_group_id = "%[1]s"
-}
-
-locals {
-  start_time = data.huaweicloud_as_activity_logs.test.activity_logs[0].start_time
-}
-data "huaweicloud_as_activity_logs" "start_time_filter" {
-  scaling_group_id = "%[1]s"
-  start_time       = local.start_time
-}
-output "is_start_time_filter_useful" {
-  value = length(data.huaweicloud_as_activity_logs.start_time_filter.activity_logs) > 0 && alltrue( 
-    [for v in data.huaweicloud_as_activity_logs.start_time_filter.activity_logs[*].start_time : v == local.start_time]
-  )  
-}
-
-locals {
-  end_time = data.huaweicloud_as_activity_logs.test.activity_logs[0].end_time
-}
-data "huaweicloud_as_activity_logs" "end_time_filter" {
-  scaling_group_id = "%[1]s"
-  end_time         = local.end_time
-}
-output "is_end_time_filter_useful" {
-  value = length(data.huaweicloud_as_activity_logs.end_time_filter.activity_logs) >= 0 && alltrue( 
-    [for v in data.huaweicloud_as_activity_logs.end_time_filter.activity_logs[*].end_time : v != local.end_time]
-  )  
 }
 
 locals {

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_group_test.go
@@ -2,6 +2,7 @@ package as
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -216,6 +217,11 @@ func TestAccASGroup_sourceDestCheck(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "networks.0.source_dest_check", "false"),
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
 				),
+			},
+			{
+				Config: testASGroup_sourceDestErrorCheck(rName),
+				ExpectError: regexp.MustCompile("invalid parameters: it should be min_instance_number <=" +
+					" desire_instance_number <= max_instance_number"),
 			},
 		},
 	})
@@ -456,7 +462,35 @@ func testASGroup_sourceDestCheck(rName string) string {
 resource "huaweicloud_as_group" "acc_as_group"{
   scaling_group_name       = "%s"
   scaling_configuration_id = huaweicloud_as_configuration.acc_as_config.id
+  min_instance_number      = 0
+  max_instance_number      = 2
+  desire_instance_number   = 2
   vpc_id                   = huaweicloud_vpc.test.id
+  delete_instances         = "yes"
+
+  networks {
+    id                = huaweicloud_vpc_subnet.test.id
+    source_dest_check = false
+  }
+  security_groups {
+    id = huaweicloud_networking_secgroup.test.id
+  }
+}
+`, testASGroup_Base(rName), rName)
+}
+
+func testASGroup_sourceDestErrorCheck(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_as_group" "acc_as_group"{
+  scaling_group_name       = "%s"
+  scaling_configuration_id = huaweicloud_as_configuration.acc_as_config.id
+  min_instance_number      = 0
+  max_instance_number      = 0
+  desire_instance_number   = 2
+  vpc_id                   = huaweicloud_vpc.test.id
+  delete_instances         = "yes"
 
   networks {
     id                = huaweicloud_vpc_subnet.test.id

--- a/huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_callback_test.go
+++ b/huaweicloud/services/acceptance/as/resource_huaweicloud_as_lifecycle_hook_callback_test.go
@@ -15,6 +15,7 @@ func TestAccLifecycleHookCallBack_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckASScalingGroupID(t)
 			acceptance.TestAccPreCheckASLifecycleActionKey(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -41,6 +42,7 @@ func TestAccLifecycleHookCallBack_withInstanceIdAndHookName(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckASScalingGroupID(t)
 			acceptance.TestAccPreCheckASINSTANCEID(t)
 			acceptance.TestAccPreCheckASLifecycleHookName(t)
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

improve test case coverage of AS services.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccActivityLogsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccActivityLogsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccActivityLogsDataSource_basic
=== PAUSE TestAccActivityLogsDataSource_basic
=== CONT  TestAccActivityLogsDataSource_basic
--- PASS: TestAccActivityLogsDataSource_basic (20.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        21.016s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASGroup_ -timeout 360m -parallel 4
=== RUN   TestAccASGroup_basic
=== PAUSE TestAccASGroup_basic
=== RUN   TestAccASGroup_withEpsId
=== PAUSE TestAccASGroup_withEpsId
=== RUN   TestAccASGroup_forceDelete
=== PAUSE TestAccASGroup_forceDelete
=== RUN   TestAccASGroup_sourceDestCheck
=== PAUSE TestAccASGroup_sourceDestCheck
=== CONT  TestAccASGroup_basic
=== CONT  TestAccASGroup_forceDelete
=== CONT  TestAccASGroup_sourceDestCheck
=== CONT  TestAccASGroup_withEpsId
--- PASS: TestAccASGroup_withEpsId (196.69s)
--- PASS: TestAccASGroup_forceDelete (246.21s)
--- PASS: TestAccASGroup_sourceDestCheck (330.59s)
--- PASS: TestAccASGroup_basic (397.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        397.821s
```

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccASInstanceAttach_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccASInstanceAttach_basic -timeout 360m -parallel 4
=== RUN   TestAccASInstanceAttach_basic
=== PAUSE TestAccASInstanceAttach_basic
=== CONT  TestAccASInstanceAttach_basic
--- PASS: TestAccASInstanceAttach_basic (569.70s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        569.748s
```
* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
