### PR TITLE
feat(dms): support new params and attrs for kafka instance

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -116,6 +116,9 @@ The following arguments are supported:
 
   ~> The parameter behavior of `availability_zones` has been changed from `list` to `set`.
 
+* `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether to enable IPv6. Defaults to **false**.
+  Changing this creates a new instance resource.
+
 * `arch_type` - (Optional, String, ForceNew) Specifies the CPU architecture. Valid value is **X86**.
   Changing this creates a new instance resource.
 
@@ -219,8 +222,11 @@ The following arguments are supported:
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the Kafka instance.
 
-* `ssl_enable` - (Optional, Bool, ForceNew) Specifies whether the Kafka SASL_SSL is enabled.  
+* `ssl_enable` - (Optional, Bool, ForceNew) Specifies whether the Kafka SASL_SSL is enabled.
   Changing this creates a new resource.
+
+* `vpc_client_plain` - (Optional, Bool, ForceNew) Specifies whether the intra-VPC plaintext access is enabled.
+  Defaults to **false**. Changing this creates a new resource.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the DMS Kafka instance.
 
@@ -272,6 +278,20 @@ In addition to all arguments above, the following attributes are exported:
 * `cross_vpc_accesses` - Indicates the Access information of cross-VPC. The structure is documented below.
 * `charging_mode` - Indicates the charging mode of the instance.
 * `public_ip_address` - Indicates the public IP addresses list of the instance.
+* `extend_times` - Indicates the extend times. If the value exceeds **20**, disk expansion is no longer allowed.
+* `connector_id` - Indicates the connector ID.
+* `connector_node_num` - Indicates the number of connector node.
+* `storage_resource_id` - Indicates the storage resource ID.
+* `storage_type` - Indicates the storage type.
+* `ipv6_connect_addresses` - Indicates the IPv6 connect addresses list.
+* `created_at` - Indicates the create time.
+* `cert_replaced` - Indicates whether the certificate can be replaced.
+* `is_logical_volume` - Indicates whether the instance is a new instance.
+* `message_query_inst_enable` - Indicates whether message query is enabled.
+* `node_num` - Indicates the node quantity.
+* `pod_connect_address` - Indicates the connection address on the tenant side.
+* `public_bandwidth` - Indicates the public network access bandwidth.
+* `ssl_two_way_enable` - Indicates whether to enable two-way authentication.
 
 The `cross_vpc_accesses` block supports:
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240710014841-c6d07e14c758
+	github.com/chnsz/golangsdk v0.0.0-20240716014404-0fcfcbab0dac
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240710014841-c6d07e14c758 h1:NNYIBgrDoYutD+MeLhFOjNDnFis0pADQM4572YSVohs=
-github.com/chnsz/golangsdk v0.0.0-20240710014841-c6d07e14c758/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240716014404-0fcfcbab0dac h1:P7W3VqsjJj+OHYYtHKRQeFW0STJfvWm+Knlw3ftbKRA=
+github.com/chnsz/golangsdk v0.0.0-20240716014404-0fcfcbab0dac/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/requests.go
@@ -71,6 +71,9 @@ type CreateOps struct {
 	// Indicates the ID of a subnet.
 	SubnetID string `json:"subnet_id" required:"true"`
 
+	// Whether to enable the IPv6.
+	Ipv6Enable bool `json:"ipv6_enable,omitempty"`
+
 	// Indicates the ID of an AZ.
 	// The parameter value can be left blank or an empty array.
 	AvailableZones []string `json:"available_zones" required:"true"`
@@ -115,6 +118,9 @@ type CreateOps struct {
 
 	// Indicates whether to enable SSL-encrypted access.
 	SslEnable bool `json:"ssl_enable,omitempty"`
+
+	// Whether to enable vpc client plain
+	VpcClientPlain bool `json:"vpc_client_plain,omitempty"`
 
 	// Indicates the protocol to use after SASL is enabled.
 	KafkaSecurityProtocol string `json:"kafka_security_protocol,omitempty"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances/results.go
@@ -91,6 +91,7 @@ type Instance struct {
 	Ipv6ConnectAddresses       []string           `json:"ipv6_connect_addresses"`
 	ConnectorEnalbe            bool               `json:"connector_enable"`
 	ConnectorID                string             `json:"connector_id"`
+	ConnectorNodeNum           int                `json:"connector_node_num"`
 	RestEnable                 bool               `json:"rest_enable"`
 	RestConnectAddress         string             `json:"rest_connect_address"`
 	MessageQueryInstEnable     bool               `json:"message_query_inst_enable"`
@@ -104,6 +105,8 @@ type Instance struct {
 	CesVersion                 string             `json:"ces_version"`
 	AccessUser                 string             `json:"access_user"`
 	Tags                       []tags.ResourceTag `json:"tags"`
+	CertReplaced               bool               `json:"cert_replaced"`
+	SslTwoWayEnable            bool               `json:"ssl_two_way_enable"`
 }
 
 type Task struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240710014841-c6d07e14c758
+# github.com/chnsz/golangsdk v0.0.0-20240716014404-0fcfcbab0dac
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new params and attrs for kafka instance.


## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/acc-test.sh 

run acceptance tests of huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_kafka_instance_test.go:
=== RUN   TestAccKafkaInstance_basic
=== PAUSE TestAccKafkaInstance_basic
=== RUN   TestAccKafkaInstance_prePaid
=== PAUSE TestAccKafkaInstance_prePaid
=== RUN   TestAccKafkaInstance_withEpsId
=== PAUSE TestAccKafkaInstance_withEpsId
=== RUN   TestAccKafkaInstance_compatible
=== PAUSE TestAccKafkaInstance_compatible
=== RUN   TestAccKafkaInstance_newFormat
=== PAUSE TestAccKafkaInstance_newFormat
=== RUN   TestAccKafkaInstance_publicIp
=== PAUSE TestAccKafkaInstance_publicIp
=== CONT  TestAccKafkaInstance_basic
=== CONT  TestAccKafkaInstance_compatible
=== CONT  TestAccKafkaInstance_publicIp
=== CONT  TestAccKafkaInstance_newFormat
--- PASS: TestAccKafkaInstance_compatible (836.40s)
=== CONT  TestAccKafkaInstance_withEpsId
    acceptance.go:578: The environment variables does not support Enterprise Project ID for acc tests
--- SKIP: TestAccKafkaInstance_withEpsId (0.01s)
=== CONT  TestAccKafkaInstance_prePaid
--- PASS: TestAccKafkaInstance_prePaid (938.50s)
--- PASS: TestAccKafkaInstance_publicIp (1849.02s)
--- PASS: TestAccKafkaInstance_basic (1916.50s)
--- PASS: TestAccKafkaInstance_newFormat (2649.75s)
PASS
coverage: 18.1% of statements in ./huaweicloud/services/dms
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       2649.815s       coverage: 18.1% of statements in ./huaweicloud/services/dms

### coverage of files in huaweicloud/services:

- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_instance.go (77.3%)
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
