### PR TITLE
chore(cdn): improve test case coverage of CDN services

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -96,7 +96,9 @@ var (
 	HW_RAM_ENABLE_FLAG               = os.Getenv("HW_RAM_ENABLE_FLAG")
 	HW_RAM_SHARE_INVITATION_ID       = os.Getenv("HW_RAM_SHARE_INVITATION_ID")
 
-	HW_CDN_DOMAIN_NAME      = os.Getenv("HW_CDN_DOMAIN_NAME")
+	HW_CDN_DOMAIN_NAME = os.Getenv("HW_CDN_DOMAIN_NAME")
+	// `HW_CDN_CERT_DOMAIN_NAME` Configure the domain name environment variable of the certificate type.
+	HW_CDN_CERT_DOMAIN_NAME = os.Getenv("HW_CDN_CERT_DOMAIN_NAME")
 	HW_CDN_DOMAIN_URL       = os.Getenv("HW_CDN_DOMAIN_URL")
 	HW_CDN_CERT_PATH        = os.Getenv("HW_CDN_CERT_PATH")
 	HW_CDN_PRIVATE_KEY_PATH = os.Getenv("HW_CDN_PRIVATE_KEY_PATH")
@@ -1619,6 +1621,13 @@ func TestAccPreCheckCCINamespace(t *testing.T) {
 func TestAccPreCheckCDN(t *testing.T) {
 	if HW_CDN_DOMAIN_NAME == "" {
 		t.Skip("This environment does not support CDN tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCertCDN(t *testing.T) {
+	if HW_CDN_CERT_DOMAIN_NAME == "" {
+		t.Skip("HW_CDN_CERT_DOMAIN_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_statistics_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domain_statistics_test.go
@@ -1,6 +1,7 @@
 package cdn
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,7 +14,11 @@ func TestAccDatasourceStatistics_basic(t *testing.T) {
 	dc := acceptance.InitDataSourceCheck(rName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCDN(t)
+			acceptance.TestAccPrecheckCDNAnalytics(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -28,13 +33,19 @@ func TestAccDatasourceStatistics_basic(t *testing.T) {
 }
 
 func testAccDatasourceStatistics_basic() string {
-	return `
+	return fmt.Sprintf(`
 data "huaweicloud_cdn_domain_statistics" "test" {
-  action      = "location_detail"
-  start_time  = 1662019200000
-  end_time    = 1662021000000
-  domain_name = "terraform.test.huaweicloud.com"
-  stat_type   = "req_num"
+  domain_name           = "%[1]s"
+  stat_type             = "%[2]s"
+  start_time            = "%[3]s"
+  end_time              = "%[4]s"
+  action                = "location_detail"
+  interval              = 3600
+  group_by              = "domain"
+  country               = "cn"
+  province              = "beijing"
+  isp                   = "yidong"
+  enterprise_project_id = "0"
 }
-`
+`, acceptance.HW_CDN_DOMAIN_NAME, acceptance.HW_CDN_STAT_TYPE, acceptance.HW_CDN_START_TIME, acceptance.HW_CDN_END_TIME)
 }

--- a/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domains_test.go
+++ b/huaweicloud/services/acceptance/cdn/data_source_huaweicloud_cdn_domains_test.go
@@ -10,18 +10,20 @@ import (
 )
 
 func TestAccDatasourceCDNDomains_basic(t *testing.T) {
-	rName := "data.huaweicloud_cdn_domains.test"
-	dc := acceptance.InitDataSourceCheck(rName)
+	var (
+		rName      = "data.huaweicloud_cdn_domains.test"
+		dc         = acceptance.InitDataSourceCheck(rName)
+		domainName = generateDomainName()
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCDN(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceDomains_basic(),
+				Config: testAccDatasourceDomains_basic(domainName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(rName, "domains.0.id"),
@@ -45,7 +47,7 @@ func TestAccDatasourceCDNDomains_basic(t *testing.T) {
 	})
 }
 
-func testAccDatasourceDomains_basic() string {
+func testAccDatasourceDomains_basic(domainName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -124,5 +126,5 @@ output "enterprise_project_id_filter_is_useful" {
     [for v in data.huaweicloud_cdn_domains.enterprise_project_id_filter.domains[*].enterprise_project_id : v == local.enterprise_project_id]
   )  
 }
-`, testAccCdnDomain_basic)
+`, testAccCdnDomain_basic(domainName))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

improve test case coverage of CDN services.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceStatistics_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceStatistics_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceStatistics_basic
=== PAUSE TestAccDatasourceStatistics_basic
=== CONT  TestAccDatasourceStatistics_basic
--- PASS: TestAccDatasourceStatistics_basic (9.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       10.045s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccDatasourceCDNDomains_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccDatasourceCDNDomains_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCDNDomains_basic
=== PAUSE TestAccDatasourceCDNDomains_basic
=== CONT  TestAccDatasourceCDNDomains_basic
--- PASS: TestAccDatasourceCDNDomains_basic (436.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       436.827s
```
```
make testacc TEST='./huaweicloud/services/acceptance/cdn' TESTARGS='-run TestAccCdnDomain'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cdn -v -run TestAccCdnDomain -timeout 360m -parallel 4
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_configTypeWholeSite (635.33s)
=== CONT  TestAccCdnDomain_epsID_migrate
--- PASS: TestAccCdnDomain_basic (792.57s)
--- PASS: TestAccCdnDomain_configHttpSettings (913.54s)
--- PASS: TestAccCdnDomain_configs (943.98s)
--- PASS: TestAccCdnDomain_epsID_migrate (309.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       944.642s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
