### PR TITLE
fix(cts): add null check before using agency_name

### DIFF
--- a/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
@@ -402,8 +402,11 @@ func resourceCTSDataTrackerRead(_ context.Context, d *schema.ResourceData, meta 
 		d.Set("name", ctsTracker.TrackerName),
 		d.Set("lts_enabled", ctsTracker.Lts.IsLtsEnabled),
 		d.Set("validate_file", ctsTracker.IsSupportValidate),
-		d.Set("agency_name", ctsTracker.AgencyName.Value()),
 	)
+
+	if ctsTracker.AgencyName != nil {
+		mErr = multierror.Append(mErr, d.Set("agency_name", ctsTracker.AgencyName.Value()))
+	}
 
 	if ctsTracker.DataBucket != nil {
 		mErr = multierror.Append(mErr, d.Set("data_bucket", ctsTracker.DataBucket.DataBucketName))

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_tracker.go
@@ -298,8 +298,11 @@ func resourceCTSTrackerRead(_ context.Context, d *schema.ResourceData, meta inte
 		d.Set("organization_enabled", ctsTracker.IsOrganizationTracker),
 		d.Set("validate_file", ctsTracker.IsSupportValidate),
 		d.Set("kms_id", ctsTracker.KmsId),
-		d.Set("agency_name", ctsTracker.AgencyName.Value()),
 	)
+
+	if ctsTracker.AgencyName != nil {
+		mErr = multierror.Append(mErr, d.Set("agency_name", ctsTracker.AgencyName.Value()))
+	}
 
 	if ctsTracker.ObsInfo != nil {
 		bucketName := ctsTracker.ObsInfo.BucketName


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add null check before using agency_name
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add null check before using agency_name
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSTracker_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSTracker_ -timeout 360m -parallel 1
=== RUN   TestAccCTSTracker_keepTracker
=== PAUSE TestAccCTSTracker_keepTracker
=== RUN   TestAccCTSTracker_deleteTracker
=== PAUSE TestAccCTSTracker_deleteTracker
=== CONT  TestAccCTSTracker_keepTracker
--- PASS: TestAccCTSTracker_keepTracker (144.97s)
=== CONT  TestAccCTSTracker_deleteTracker
--- PASS: TestAccCTSTracker_deleteTracker (83.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       228.803s

 make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSDataTracker_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSDataTracker_ -timeout 360m -parallel 1
=== RUN   TestAccCTSDataTracker_basic
=== PAUSE TestAccCTSDataTracker_basic
=== CONT  TestAccCTSDataTracker_basic
--- PASS: TestAccCTSDataTracker_basic (215.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       215.695s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
