### PR TITLE
fix(host): fix the resource unexpected change problem

### DIFF
--- a/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_group_test.go
+++ b/huaweicloud/services/acceptance/hss/resource_huaweicloud_hss_host_group_test.go
@@ -72,6 +72,8 @@ func TestAccHostGroup_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccHostGroupImportStateIDFunc(rName),
+				// The field `unprotect_host_ids` will be filled in during the creation and editing operations.
+				// We only need to add ignore to the test case and do not need to make special instructions in the document.
 				ImportStateVerifyIgnore: []string{
 					"unprotect_host_ids",
 				},
@@ -116,12 +118,6 @@ resource "huaweicloud_hss_host_group" "test" {
   name                  = "%[2]s"
   host_ids              = slice(huaweicloud_compute_instance.test[*].id, 0, 1)
   enterprise_project_id = "%[3]s"
-
-  lifecycle {
-    ignore_changes = [
-      unprotect_host_ids,
-    ]
-  }
 }
 `, testAccHostGroup_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
@@ -134,12 +130,6 @@ resource "huaweicloud_hss_host_group" "test" {
   name                  = "%[2]s-update"
   host_ids              = huaweicloud_compute_instance.test[*].id
   enterprise_project_id = "%[3]s"
-
-  lifecycle {
-    ignore_changes = [
-      unprotect_host_ids,
-    ]
-  }
 }
 `, testAccHostGroup_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/hss/resource_huaweicloud_hss_host_group.go
+++ b/huaweicloud/services/hss/resource_huaweicloud_hss_host_group.go
@@ -298,6 +298,11 @@ func resourceHostGroupRead(_ context.Context, d *schema.ResourceData, meta inter
 		d.Set("unprotect_host_num", resp.UnprotectHostNum),
 	)
 
+	if len(d.Get("unprotect_host_ids").([]interface{})) == 0 {
+		// The reason for writing an empty array to `unprotect_host_ids` is to avoid unexpected changes
+		mErr = multierror.Append(mErr, d.Set("unprotect_host_ids", make([]string, 0)))
+	}
+
 	if err = mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error saving host group fields: %s", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix the resource unexpected change problem caused by the field `unprotect_host_ids`.
- Before fixing the problem, executing `terraform plan` after creating the resource will cause the resource fields to change, as follows:
![image](https://github.com/user-attachments/assets/6a18da76-dd44-4edf-bcfc-c6d5e587b171)
- After fixing the problem, executing `terraform plan` will not trigger any changes:
![image](https://github.com/user-attachments/assets/37f1a0a4-7e83-4a92-90e6-a2948c9c42c0)






**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/hss' TESTARGS='-run TestAccHostGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/hss -v -run TestAccHostGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccHostGroup_basic
=== PAUSE TestAccHostGroup_basic
=== CONT  TestAccHostGroup_basic
--- PASS: TestAccHostGroup_basic (378.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/hss       378.234s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
