### PR TITLE
feat(apig/instance): the instance supports custom ingress port

### DIFF
--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -112,6 +112,23 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the dedicated instance.
 
+* `custom_ingress_ports` - (Optional, List) Specified the list of the instance custom ingress ports.
+  The [custom_ingress_ports](#instance_custom_ingress_ports) structure is documented below.
+
+<a name="instance_custom_ingress_ports"></a>
+The `custom_ingress_ports` block supports:
+
+* `protocol` - (Required, String) Specified protocol of the custom ingress port.  
+  The valid values are as follows:
+  + **HTTP**
+  + **HTTPS**
+
+* `port` - (Required, Int) Specified port of the custom ingress port.
+  The valid value is range form `1,024` to `49,151`.
+
+  -> Currently, in the same dedicated instance, a maximum of `40` custom ingress ports can be created,
+     and one port can only support one protocol.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -131,6 +148,18 @@ In addition to all arguments above, the following attributes are exported:
 * `loadbalancer_provider` - The type of load balancer used by the dedicated instance.  
   The valid value is as follows:
   + **elb**: Elastic load balance.
+
+* `custom_ingress_ports` - Specified the list of the instance custom ingress ports.
+  The [custom_ingress_ports](#attr_custom_ingress_ports) structure is documented below.
+
+<a name="attr_custom_ingress_ports"></a>
+The `custom_ingress_ports` block supports:
+
+* `id` - The ID of the custom ingress port.
+
+* `status` - The current status of the custom ingress port.
+  + **normal**
+  + **abnormal**
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_instance_test.go
@@ -69,6 +69,11 @@ func TestAccInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_size", "0"),
 					resource.TestCheckResourceAttr(resourceName, "egress_address", ""),
 					resource.TestCheckResourceAttr(resourceName, "ingress_address", ""),
+					resource.TestCheckResourceAttr(resourceName, "custom_ingress_ports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "custom_ingress_ports.0.protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "custom_ingress_ports.0.port", "3662"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_ingress_ports.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "custom_ingress_ports.0.status"),
 				),
 			},
 			{
@@ -92,6 +97,7 @@ func TestAccInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "egress_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "custom_ingress_ports.#", "2"),
 				),
 			},
 			{
@@ -103,6 +109,7 @@ func TestAccInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ingress_bandwidth_size", "6"),
 					resource.TestCheckResourceAttrSet(resourceName, "egress_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "custom_ingress_ports.#", "0"),
 				),
 			},
 			{
@@ -147,6 +154,11 @@ resource "huaweicloud_apig_instance" "test" {
     foo = "bar"
     key = "value"
   }
+
+  custom_ingress_ports {
+    protocol = "HTTP"
+    port     = 3662
+  }
 }
 `, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }
@@ -181,6 +193,16 @@ resource "huaweicloud_apig_instance" "test" {
   tags = {
     foo    = "baar"
     newKey = "value"
+  }
+
+  custom_ingress_ports {
+    protocol = "HTTP"
+    port     = 3662
+  }
+
+  custom_ingress_ports {
+    protocol = "HTTPS"
+    port     = 3665
   }
 }
 `, common.TestBaseNetwork(rName), rName, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -35,6 +35,9 @@ import (
 // @API APIG POST /v2/{project_id}/apigw/instances{instance_id}/ingress-eip
 // @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/ingress-eip
 // @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/instance-tags
+// @API APIG POST /v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports
+// @API APIG GET /v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports
+// @API APIG DELETE /v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports/{ingress_port_id}
 func ResourceApigInstanceV2() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceInstanceCreate,
@@ -187,6 +190,35 @@ func ResourceApigInstanceV2() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `The address (full name) of the VPC endpoint service.`,
+			},
+			"custom_ingress_ports": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "Specified the list of the instance custom ingress ports.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Specified protocol of the custom ingress port.",
+						},
+						"port": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "Specified port of the custom ingress port.",
+						},
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the custom ingress port.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The current status of the custom ingress port.",
+						},
+					},
+				},
 			},
 			// Deprecated arguments
 			"available_zones": {
@@ -367,6 +399,12 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("error waiting for the status of dedicated instance (%s) to become running: %s", instanceId, err)
 	}
 
+	if v, ok := d.GetOk("custom_ingress_ports"); ok {
+		if err := addCustomIngressPorts(client, instanceId, v.(*schema.Set).List()); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceInstanceRead(ctx, d, meta)
 }
 
@@ -462,11 +500,35 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 		// Deprecated
 		d.Set("create_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", respBody, float64(0)).(float64))/1000, false)),
 	)
+	if resp, err := getCustomIngressPorts(client, instanceId); err != nil {
+		mErr = multierror.Append(mErr, err)
+	} else {
+		mErr = multierror.Append(mErr, d.Set("custom_ingress_ports", flattenCustomIngressPorts(resp)))
+	}
 
 	if mErr.ErrorOrNil() != nil {
 		return diag.Errorf("error saving resource fields of the dedicated instance: %s", mErr)
 	}
 	return nil
+}
+
+func flattenCustomIngressPorts(resp interface{}) []map[string]interface{} {
+	customIngressPorts := utils.PathSearch("ingress_port_infos", resp, make([]interface{}, 0)).([]interface{})
+	if len(customIngressPorts) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(customIngressPorts))
+	for i, v := range customIngressPorts {
+		result[i] = map[string]interface{}{
+			"protocol": utils.PathSearch("protocol", v, ""),
+			"port":     utils.PathSearch("ingress_port", v, 0),
+			"id":       utils.PathSearch("ingress_port_id", v, ""),
+			"status":   utils.PathSearch("status", v, ""),
+		}
+	}
+
+	return result
 }
 
 func buildUpdateInstanceBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -835,7 +897,93 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
+	if d.HasChange("custom_ingress_ports") {
+		oldRaws, newRaws := d.GetChange("custom_ingress_ports")
+		err = updateCustomIngressPorts(client, oldRaws, newRaws, instanceId)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceInstanceRead(ctx, d, meta)
+}
+
+func addCustomIngressPorts(client *golangsdk.ServiceClient, instanceId string, ingressPorts []interface{}) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	for _, ingressPort := range ingressPorts {
+		opts := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			JSONBody: map[string]interface{}{
+				"protocol":     utils.PathSearch("protocol", ingressPort, nil),
+				"ingress_port": utils.PathSearch("port", ingressPort, 0),
+			},
+		}
+		_, err := client.Request("POST", createPath, &opts)
+		if err != nil {
+			return fmt.Errorf("error adding custom ingerss port to the dedicated instance: %s", err)
+		}
+	}
+	return nil
+}
+
+func getCustomIngressPorts(client *golangsdk.ServiceClient, instanceId string) (interface{}, error) {
+	// Currently, a maximum of 40 custom ingress ports can be created. Limit default value is 20.
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports?limit=500"
+	httpPath := client.Endpoint + httpUrl
+	httpPath = strings.ReplaceAll(httpPath, "{project_id}", client.ProjectID)
+	httpPath = strings.ReplaceAll(httpPath, "{instance_id}", instanceId)
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	resp, err := client.Request("GET", httpPath, &opts)
+	if err != nil {
+		return nil, fmt.Errorf("error getting custom ingerss port form the instance (%s) : %s", instanceId, err)
+	}
+
+	return utils.FlattenResponse(resp)
+}
+
+func removeCustomIngressPorts(client *golangsdk.ServiceClient, instanceId string, customIngressPorts []interface{}) error {
+	httpUrl := "v2/{project_id}/apigw/instances/{instance_id}/custom-ingress-ports/{ingress_port_id}"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{instance_id}", instanceId)
+
+	for _, v := range customIngressPorts {
+		deletePath := strings.ReplaceAll(path, "{ingress_port_id}", utils.PathSearch("id", v, "").(string))
+		opts := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+		}
+		_, err := client.Request("DELETE", deletePath, &opts)
+		if err != nil {
+			return fmt.Errorf("error removing custom ingerss port form the instance (%s) : %s", instanceId, err)
+		}
+	}
+
+	return nil
+}
+
+func updateCustomIngressPorts(client *golangsdk.ServiceClient, oldRaws, newRaws interface{}, instanceId string) error {
+	var (
+		addRaws    = newRaws.(*schema.Set).Difference(oldRaws.(*schema.Set))
+		removeRaws = oldRaws.(*schema.Set).Difference(newRaws.(*schema.Set))
+	)
+	if removeRaws.Len() > 0 {
+		if err := removeCustomIngressPorts(client, instanceId, removeRaws.List()); err != nil {
+			return err
+		}
+	}
+
+	if addRaws.Len() > 0 {
+		if err := addCustomIngressPorts(client, instanceId, addRaws.List()); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The instance supports custom ingress port.
The acceptance test coverage is `76.4%`.
![image](https://github.com/user-attachments/assets/41bbae18-cf93-4b30-b066-5eab94d2bd27)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
 1. add custom ingress port logic to APIG instance resource.
 2. add corresponding document description and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
>>> Start to test
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (1058.53s)
PASS
coverage: 6.8% of statements in ../../apig
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      1058.611s```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
