### PR TITLE
test(waf): fix test case to improve UT coverage

### DIFF
--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_domains_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_domains_test.go
@@ -86,5 +86,5 @@ output "enterprise_project_id_filter_is_useful" {
     [for v in data.huaweicloud_waf_domains.enterprise_project_id_filter.domains[*].enterprise_project_id : v == local.enterprise_project_id]
   )  
 }
-`, testAccWafDomainV1_update2(name, domainName))
+`, testAccWafDomainV1_policy(name, domainName))
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -596,11 +596,19 @@ resource "huaweicloud_waf_domain" "domain_1" {
 
 func testAccWafDomainV1_base_withEpsID(randName, epsID string) string {
 	return fmt.Sprintf(`
-%s
+resource "huaweicloud_waf_cloud_instance" "test" {
+  resource_spec_code    = "enterprise"
+  enterprise_project_id = "%[2]s"
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = 1
+  auto_renew    = "false"
+}
 
 resource "huaweicloud_waf_certificate" "certificate_1" {
-  name                  = "%s"
-  enterprise_project_id = "%s"
+  name                  = "%[1]s"
+  enterprise_project_id = "%[2]s"
 
   certificate = <<EOT
 -----BEGIN CERTIFICATE-----
@@ -662,7 +670,7 @@ EOT
   ]
 
 }
-`, testAccCloudInstance_basic_withEpsID(epsID), randName, epsID)
+`, randName, epsID)
 }
 
 func testAccWafDomainV1_basic_withEpsID(randName, domainName, epsID string) string {

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_cc_protection_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_rule_cc_protection_test.go
@@ -160,7 +160,7 @@ func TestAccRuleCCProtection_withEpsID(t *testing.T) {
 					resource.TestCheckResourceAttrPair(rName, "policy_id", "huaweicloud_waf_policy.policy_1", "id"),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-					resource.TestCheckResourceAttr(rName, "protective_action", "log"),
+					resource.TestCheckResourceAttr(rName, "protective_action", "block"),
 					resource.TestCheckResourceAttr(rName, "rate_limit_mode", "other"),
 					resource.TestCheckResourceAttr(rName, "other_user_identifier", "test_referer"),
 					resource.TestCheckResourceAttr(rName, "limit_num", "20"),
@@ -272,7 +272,7 @@ resource "huaweicloud_waf_rule_cc_protection" "test" {
   policy_id             = huaweicloud_waf_policy.policy_1.id
   name                  = "%s"
   enterprise_project_id = "%s"
-  protective_action     = "log"
+  protective_action     = "block"
   rate_limit_mode       = "other"
   other_user_identifier = "test_referer"
   limit_num             = 20


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix test case to improve UT coverage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ sh run-testacc.sh ./huaweicloud/services/acceptance/waf TestAccDatasourceWAFDomains_basic
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -run TestAccDatasourceWAFDomains_basic -timeout 360m -parallel 4

=== RUN   TestAccDatasourceWAFDomains_basic
=== PAUSE TestAccDatasourceWAFDomains_basic
=== CONT  TestAccDatasourceWAFDomains_basic
--- PASS: TestAccDatasourceWAFDomains_basic (155.04s)
PASS
coverage: 2.5% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       155.584s
```
```
$ sh run-testacc.sh ./huaweicloud/services/acceptance/waf TestAccWafDomainV1_withEpsID
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -run TestAccWafDomainV1_withEpsID -timeout 360m -parallel 4

=== RUN   TestAccWafDomainV1_withEpsID
=== PAUSE TestAccWafDomainV1_withEpsID
=== CONT  TestAccWafDomainV1_withEpsID
--- PASS: TestAccWafDomainV1_withEpsID (147.82s)
PASS
coverage: 2.4% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       148.244s
```
```
$ sh run-testacc.sh ./huaweicloud/services/acceptance/waf TestAccRuleCCProtection.*
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -run TestAccRuleCCProtection.* -timeout 360m -parallel 4

=== RUN   TestAccRuleCCProtection_basic
=== PAUSE TestAccRuleCCProtection_basic
=== RUN   TestAccRuleCCProtection_withEpsID
=== PAUSE TestAccRuleCCProtection_withEpsID
=== CONT  TestAccRuleCCProtection_basic
=== CONT  TestAccRuleCCProtection_withEpsID
--- PASS: TestAccRuleCCProtection_withEpsID (437.55s)
--- PASS: TestAccRuleCCProtection_basic (495.75s)
PASS
coverage: 2.9% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       496.220s 
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
