### PR TITLE
chore(waf): remove WAF datasource checkDeleted logic

### DIFF
--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_dedicated_instances.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_dedicated_instances.go
@@ -10,7 +10,6 @@ import (
 
 	instances "github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_instances"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 )
@@ -143,7 +142,7 @@ func dataSourceWafDedicatedInstanceRead(_ context.Context, d *schema.ResourceDat
 
 		rst, err := instances.ListInstance(client, opts)
 		if err != nil {
-			return common.CheckDeletedDiag(d, err, "Error obtain WAF dedicated instance information.")
+			return diag.Errorf("error retrieving WAF dedicated instances %s", err)
 		}
 		items = rst.Items
 	}

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_reference_tables.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/valuelists"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -85,7 +84,7 @@ func dataSourceWafReferenceTablesRead(_ context.Context, d *schema.ResourceData,
 	}
 	r, err := valuelists.List(client, opts)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error obtain WAF reference table information")
+		return diag.Errorf("error retrieving WAF reference tables %s", err)
 	}
 
 	if len(r.Items) == 0 {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove WAF service datasource checkDeleted logic.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```

root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_waf)$ sh run-testacc.sh ./huaweicloud/services/acceptance/waf TestAccDataSourceReferenceTablesV1.*
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -run TestAccDataSourceReferenceTablesV1.* -timeout 360m -parallel 4

=== RUN   TestAccDataSourceReferenceTablesV1_basic
--- PASS: TestAccDataSourceReferenceTablesV1_basic (441.63s)
=== RUN   TestAccDataSourceReferenceTablesV1_withEpsID
--- PASS: TestAccDataSourceReferenceTablesV1_withEpsID (408.32s)
PASS
coverage: 2.7% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       850.344s
```
```
$ sh run-testacc.sh ./huaweicloud/services/acceptance/waf TestAccDataSourceWafDedicatedInstances.*
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -run TestAccDataSourceWafDedicatedInstances.* -timeout 360m -parallel 4

=== RUN   TestAccDataSourceWafDedicatedInstances_basic
=== PAUSE TestAccDataSourceWafDedicatedInstances_basic
=== RUN   TestAccDataSourceWafDedicatedInstances_withEpsId
=== PAUSE TestAccDataSourceWafDedicatedInstances_withEpsId
=== CONT  TestAccDataSourceWafDedicatedInstances_basic
=== CONT  TestAccDataSourceWafDedicatedInstances_withEpsId
--- PASS: TestAccDataSourceWafDedicatedInstances_withEpsId (414.46s)
--- PASS: TestAccDataSourceWafDedicatedInstances_basic (479.68s)
PASS
coverage: 2.7% of statements in ./huaweicloud/...
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       480.185s 
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
