### PR TITLE
fix(lts/converge): management project id is required for first-time use

### DIFF
--- a/docs/resources/lts_log_converge.md
+++ b/docs/resources/lts_log_converge.md
@@ -65,6 +65,9 @@ The following arguments are supported:
 * `log_mapping_config` - (Required, List) Specifies the log converge configurations.  
   The [log_mapping_config](#converge_log_mapping_config) structure is documented below.
 
+* `management_project_id` - (Optional, String) Specifies the administrator project ID that required for
+  first-time use.
+
 <a name="converge_log_mapping_config"></a>
 The `log_mapping_config` block supports:
 

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_log_converge.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_log_converge.go
@@ -127,6 +127,12 @@ func ResourceLogConverge() *schema.Resource {
 				},
 				Description: `The log converge configurations.`,
 			},
+			"management_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The administrator project ID that required for first-time use.`,
+			},
 			"created_at": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -187,7 +193,8 @@ func buildModifyLogConvergeBodyParams(d *schema.ResourceData) map[string]interfa
 		"management_account_id": d.Get("management_account_id"),
 		"member_account_id":     d.Get("member_account_id"),
 		// Optional parameters
-		"log_mapping_config": buildLogMappingConfigsBodyParams(d.Get("log_mapping_config").(*schema.Set)),
+		"log_mapping_config":    buildLogMappingConfigsBodyParams(d.Get("log_mapping_config").(*schema.Set)),
+		"management_project_id": utils.ValueIgnoreEmpty(d.Get("management_project_id")),
 	}
 }
 
@@ -291,6 +298,7 @@ func resourceLogConvergeRead(_ context.Context, d *schema.ResourceData, meta int
 		d.Set("member_account_id", utils.PathSearch("member_account_id", respBody, nil)),
 		d.Set("management_account_id", utils.PathSearch("management_account_id", respBody, nil)),
 		d.Set("log_mapping_config", utils.PathSearch("log_mapping_config", respBody, nil)),
+		d.Set("management_project_id", utils.PathSearch("management_project_id", respBody, nil)),
 		// Attributes
 		d.Set("created_at", utils.FormatTimeStampRFC3339(
 			int64(utils.PathSearch("create_time", respBody, float64(0)).(float64))/1000, false)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new parameter `management_project_id`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  supports the management project id parameter that it is required for first-time use
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
NONE
```
![image](https://github.com/user-attachments/assets/c75ddedc-2433-4fbc-ae03-71b3026a722e)

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
