### PR TITLE
fix(dns): data cannot be queried on the international site

### DIFF
--- a/docs/data-sources/dns_nameservers.md
+++ b/docs/data-sources/dns_nameservers.md
@@ -22,6 +22,9 @@ data "huaweicloud_dns_nameservers" "test" {
 
 The following arguments are supported:
 
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
 * `type` - (Optional, String) Specifies the type of the name server.
   The valid values are as follows:
    + **public**

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_floating_ptrrecords.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_floating_ptrrecords.go
@@ -149,7 +149,7 @@ func dataSourceFloatingPtrrecordsRead(_ context.Context, d *schema.ResourceData,
 
 // @API DNS GET /v2/reverse/floatingips
 func (w *FloatingPtrrecordsDSWrapper) ListPtrRecords() (*gjson.Result, error) {
-	client, err := w.NewClient(w.Config, "dns")
+	client, err := w.NewClient(w.Config, "dns_region")
 	if err != nil {
 		return nil, err
 	}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_line_groups.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_line_groups.go
@@ -121,7 +121,7 @@ func dataSourceLineGroupsRead(_ context.Context, d *schema.ResourceData, meta in
 
 // @API DNS GET /v2.1/linegroups
 func (w *LineGroupsDSWrapper) ListLineGroups() (*gjson.Result, error) {
-	client, err := w.NewClient(w.Config, "dns")
+	client, err := w.NewClient(w.Config, "dns_region")
 	if err != nil {
 		return nil, err
 	}

--- a/huaweicloud/services/dns/data_source_huaweicloud_dns_nameservers.go
+++ b/huaweicloud/services/dns/data_source_huaweicloud_dns_nameservers.go
@@ -21,6 +21,12 @@ func DataSourceNameservers() *schema.Resource {
 		ReadContext: dataSourceNameserversRead,
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
 			"type": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -113,7 +119,7 @@ func dataSourceNameserversRead(_ context.Context, d *schema.ResourceData, meta i
 
 // @API DNS GET /v2/nameservers
 func (w *NameserversDSWrapper) ListNameServers() (*gjson.Result, error) {
-	client, err := w.NewClient(w.Config, "dns")
+	client, err := w.NewClient(w.Config, "dns_region")
 	if err != nil {
 		return nil, err
 	}
@@ -135,6 +141,7 @@ func (w *NameserversDSWrapper) ListNameServers() (*gjson.Result, error) {
 func (w *NameserversDSWrapper) listNameServersToSchema(body *gjson.Result) error {
 	d := w.ResourceData
 	mErr := multierror.Append(nil,
+		d.Set("region", w.Config.GetRegion(w.ResourceData)),
 		d.Set("nameservers", schemas.SliceToList(body.Get("nameservers"),
 			func(nameserver gjson.Result) any {
 				return map[string]any{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 Fixed the problem that data cannot be queried on the international site.
 Cause of the problem: the global domain name used by the client when querying data.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDataSourceFloatingPtrrecords_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDataSourceFloatingPtrrecords_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceFloatingPtrrecords_basic
=== PAUSE TestAccDataSourceFloatingPtrrecords_basic
=== CONT  TestAccDataSourceFloatingPtrrecords_basic
--- PASS: TestAccDataSourceFloatingPtrrecords_basic (93.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       93.157s

make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDataSourceLineGroups_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDataSourceLineGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceLineGroups_basic
=== PAUSE TestAccDataSourceLineGroups_basic
=== CONT  TestAccDataSourceLineGroups_basic
--- PASS: TestAccDataSourceLineGroups_basic (49.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       49.681s

make testacc TEST='./huaweicloud/services/acceptance/dns' TESTARGS='-run TestAccDataSourceNameservers_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dns -v -run TestAccDataSourceNameservers_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceNameservers_basic
=== PAUSE TestAccDataSourceNameservers_basic
=== CONT  TestAccDataSourceNameservers_basic
--- PASS: TestAccDataSourceNameservers_basic (22.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dns       22.110s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
