### PR TITLE
feat(GaussDB): guassdb mysql proxy support connection pool type

### DIFF
--- a/docs/resources/gaussdb_mysql_proxy.md
+++ b/docs/resources/gaussdb_mysql_proxy.md
@@ -90,6 +90,12 @@ The following arguments are supported:
 
   Defaults to **eventual**.
 
+* `connection_pool_type` - (Optional, String) Specifies the connection pool type. Value options:
+  + **CLOSED**: The connection pool is not used.
+  + **SESSION**: The session-level connection pool is used.
+
+  Defaults to **CLOSED**.
+
 <a name="node_weight_struct"></a>
 The `master_node_weight` and `readonly_nodes_weight` block supports:
 
@@ -116,6 +122,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Indicates the resource ID.
 
 * `address` - Indicates the address of the proxy.
+
+* `switch_connection_pool_type_enabled` - Indicates whether the proxy supports session-level connection pool.
 
 * `nodes` - Indicates the node information of the proxy.
   The [nodes](#nodes_struct) structure is documented below.

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy_test.go
@@ -96,6 +96,8 @@ func TestAccGaussDBMySQLProxy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "new_node_auto_add_status", "OFF"),
 					resource.TestCheckResourceAttr(resourceName, "port", "3339"),
 					resource.TestCheckResourceAttr(resourceName, "transaction_split", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_type", "SESSION"),
+					resource.TestCheckResourceAttr(resourceName, "switch_connection_pool_type_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "master_node_weight.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "readonly_nodes_weight.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "multiStatementType"),
@@ -131,6 +133,8 @@ func TestAccGaussDBMySQLProxy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "new_node_weight", "20"),
 					resource.TestCheckResourceAttr(resourceName, "port", "3338"),
 					resource.TestCheckResourceAttr(resourceName, "transaction_split", "OFF"),
+					resource.TestCheckResourceAttr(resourceName, "connection_pool_type", "CLOSED"),
+					resource.TestCheckResourceAttr(resourceName, "switch_connection_pool_type_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "master_node_weight.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "readonly_nodes_weight.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "looseImciApThreshold"),
@@ -214,6 +218,7 @@ resource "huaweicloud_gaussdb_mysql_proxy" "test" {
   port                     = 3339
   transaction_split        = "ON"
   consistence_mode         = "session"
+  connection_pool_type     = "SESSION"
 
   master_node_weight {
     id     = local.sort_nodes[0].id
@@ -251,6 +256,7 @@ resource "huaweicloud_gaussdb_mysql_proxy" "test" {
   port                     = 3338
   transaction_split        = "OFF"
   consistence_mode         = "eventual"
+  connection_pool_type     = "CLOSED"
 
   master_node_weight {
     id     = local.sort_nodes[0].id
@@ -293,6 +299,7 @@ resource "huaweicloud_gaussdb_mysql_proxy" "test" {
   port                     = 3338
   transaction_split        = "OFF"
   consistence_mode         = "eventual"
+  connection_pool_type     = "CLOSED"
 
   master_node_weight {
     id     = local.sort_nodes[0].id


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  guassdb mysql proxy support connection pool type
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  guassdb mysql proxy support connection pool type
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBMySQLProxy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBMySQLProxy_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBMySQLProxy_basic
=== PAUSE TestAccGaussDBMySQLProxy_basic
=== CONT  TestAccGaussDBMySQLProxy_basic
--- PASS: TestAccGaussDBMySQLProxy_basic (4197.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   4198.019s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
