### PR TITLE
feat(evs/snapshot_rollback): support snapshot rollback resource

### DIFF
--- a/docs/resources/evs_snapshot_rollback.md
+++ b/docs/resources/evs_snapshot_rollback.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evs_snapshot_rollback"
+description: |-
+  Manages an EVS snapshot rollback resource within HuaweiCloud.
+---
+
+# huaweicloud_evs_snapshot_rollback
+
+Manages an EVS snapshot rollback resource within HuaweiCloud.
+
+-> 1. Snapshot rollback is only supported rollback to the source volume, rollback to other specified volume is not
+  supported.<br/>2. Snapshot rollback to the source volume is only allowed if the volume status is **available** or
+  **error_rollbacking**.<br/>3. Snapshots with names prefixed by **autobk_snapshot_** are automatically created by the
+  system when creating volume backups, please do not perform the rollback snapshot to volume operation on these
+  snapshots.<br/>4. Destroying resources does not change the current operation of the snapshot rollback.
+
+## Example Usage
+
+```hcl
+variable "volume_id" {}
+variable "snapshot_id" {}
+
+resource "huaweicloud_evs_snapshot_rollback" "test" {
+  volume_id   = var.volume_id
+  snapshot_id = var.snapshot_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `volume_id` - (Required, String, ForceNew) Specifies the target volume ID for snapshot rollback.
+  Changing this parameter will create a new resource.
+
+* `snapshot_id` - (Required, String, ForceNew) Specifies the ID of the snapshot.
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, same as `snapshot_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1356,8 +1356,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_er_vpc_attachment": er.ResourceVpcAttachment(),
 			"huaweicloud_er_flow_log":       er.ResourceFlowLog(),
 
-			"huaweicloud_evs_snapshot": evs.ResourceEvsSnapshotV2(),
-			"huaweicloud_evs_volume":   evs.ResourceEvsVolume(),
+			"huaweicloud_evs_snapshot":          evs.ResourceEvsSnapshotV2(),
+			"huaweicloud_evs_volume":            evs.ResourceEvsVolume(),
+			"huaweicloud_evs_snapshot_rollback": evs.ResourceSnapshotRollBack(),
 
 			"huaweicloud_fgs_application":                fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration": fgs.ResourceAsyncInvokeConfiguration(),

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_snapshot_rollback_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_snapshot_rollback_test.go
@@ -1,0 +1,64 @@
+package evs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSnapshotRollBack_basic(t *testing.T) {
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
+	// method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// One-time action resource do not need to be checked and no processing is performed in the Read method.
+				Config: testAccSnapshotRollBack_basic(),
+			},
+		},
+	})
+}
+
+func testAccSnapshotRollBack_base() string {
+	name := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%[1]s"
+  description       = "Created by acc test"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  volume_type       = "SAS"
+  size              = 12
+}
+
+resource "huaweicloud_evs_snapshot" "test" {
+  volume_id   = huaweicloud_evs_volume.test.id
+  name        = "%[1]s"
+  description = "Daily backup"
+  metadata    = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name)
+}
+
+func testAccSnapshotRollBack_basic() string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_evs_snapshot_rollback" "test" {
+  volume_id   = huaweicloud_evs_volume.test.id
+  snapshot_id = huaweicloud_evs_snapshot.test.id
+}
+`, testAccSnapshotRollBack_base())
+}

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_snapshot_rollback.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_snapshot_rollback.go
@@ -1,0 +1,92 @@
+package evs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API EVS GET /v2/{project_id}/cloudsnapshots/{snapshot_id}
+// ResourceSnapshotRollBack is a definition of the one-time action resource that used to manage snapshot rollback.
+func ResourceSnapshotRollBack() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSnapshotRollBackCreate,
+		ReadContext:   resourceSnapshotRollBackRead,
+		DeleteContext: resourceSnapshotRollBackDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"snapshot_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceSnapshotRollBackCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                     = meta.(*config.Config)
+		region                  = cfg.GetRegion(d)
+		rollbackSnapshotHttpUrl = "v2/{project_id}/cloudsnapshots/{snapshot_id}/rollback"
+		rollbackSnapshotProduct = "evs"
+	)
+	rollbackSnapshotClient, err := cfg.NewServiceClient(rollbackSnapshotProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	rollbackSnapshotPath := rollbackSnapshotClient.Endpoint + rollbackSnapshotHttpUrl
+	rollbackSnapshotPath = strings.ReplaceAll(rollbackSnapshotPath, "{project_id}",
+		rollbackSnapshotClient.ProjectID)
+	rollbackSnapshotPath = strings.ReplaceAll(rollbackSnapshotPath, "{snapshot_id}",
+		d.Get("snapshot_id").(string))
+
+	rollbackSnapshotBodyParams := map[string]interface{}{
+		"rollback": map[string]interface{}{
+			"volume_id": d.Get("volume_id"),
+		},
+	}
+
+	rollbackSnapshotOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         rollbackSnapshotBodyParams,
+	}
+
+	// The API response is the same as the request body, and we do not need to retrieve any content from the response,
+	// so ignore it here.
+	_, err = rollbackSnapshotClient.Request("POST", rollbackSnapshotPath, &rollbackSnapshotOpt)
+	if err != nil {
+		return diag.Errorf("failed to rollback snapshot to volume: %s", err)
+	}
+
+	d.SetId(d.Get("snapshot_id").(string))
+
+	return resourceSnapshotRollBackRead(ctx, d, meta)
+}
+
+func resourceSnapshotRollBackRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceSnapshotRollBackDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Delete()' method because the resource is a one-time action resource.
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support snapshot rollback resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

1. Support snapshot rollback resource.
2. This resource is a one-time operation resource, and there is no need to check the logic of checkDeleted.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccSnapshotRollBack_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccSnapshotRollBack_basic -timeout 360m -parallel 4
=== RUN   TestAccSnapshotRollBack_basic
=== PAUSE TestAccSnapshotRollBack_basic
=== CONT  TestAccSnapshotRollBack_basic
--- PASS: TestAccSnapshotRollBack_basic (57.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       57.563s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
