### PR TITLE
feat(dataarts): add resource supports starting/stopping factory job

### DIFF
--- a/docs/resources/dataarts_factory_job_action.md
+++ b/docs/resources/dataarts_factory_job_action.md
@@ -1,0 +1,75 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dataarts_factory_job_action"
+description:|-
+  Manages a job action resource of DataArts Factory within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_factory_job_action
+
+Manages a job action resource of DataArts Factory within HuaweiCloud.
+
+-> Destroying resources does not change the current action status of the job.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "job_name" {}
+
+resource "huaweicloud_dataarts_factory_job_action" "test" {
+  workspace_id = var.workspace_id
+  action       = "start"
+  job_name     = var.job_name
+  process_type = "BATCH"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `workspace_id` - (Optional, String, ForceNew) Specified the ID of the workspace to which the job belongs.
+  Changing this creates a new resource.
+  If this parameter is not set, the default workspace is used by default.
+
+* `job_name` - (Required, String, ForceNew) Specified the name of the job.
+  Changing this creates a new resource.
+  The name contains a maximum of  `128` characters, including only letters, numbers, hyphens (-),
+  underscores (_), and periods (.).
+
+* `process_type` - (Required, String, ForceNew) Specified the type of the job.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **REAL_TIME**: Real-time processing.
+  + **BATCH**: Batch processing.
+
+* `action` - (Required, String) Specified the action type of the job.  
+  The valid values are as follows:
+  + **start**
+  + **stop**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals the `job_name`.
+
+* `status` - The current status of the job.
+  + **NORMAL**
+  + **STOPPED**
+  + **SCHEDULING**
+  + **PAUSED**
+  + **EXCEPTION**
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `update` - Default is 20 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1541,9 +1541,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_data_standard_template": dataarts.ResourceDataStandardTemplate(),
 			"huaweicloud_dataarts_architecture_reviewer":               dataarts.ResourceDataArtsArchitectureReviewer(),
 			// DataArts Factory
-			"huaweicloud_dataarts_factory_resource": dataarts.ResourceFactoryResource(),
-			"huaweicloud_dataarts_factory_job":      dataarts.ResourceFactoryJob(),
-			"huaweicloud_dataarts_factory_script":   dataarts.ResourceDataArtsFactoryScript(),
+			"huaweicloud_dataarts_factory_resource":   dataarts.ResourceFactoryResource(),
+			"huaweicloud_dataarts_factory_job_action": dataarts.ResourceFactoryJobAction(),
+			"huaweicloud_dataarts_factory_job":        dataarts.ResourceFactoryJob(),
+			"huaweicloud_dataarts_factory_script":     dataarts.ResourceDataArtsFactoryScript(),
 			// DataArts Security
 			"huaweicloud_dataarts_security_data_recognition_rule":    dataarts.ResourceSecurityRule(),
 			"huaweicloud_dataarts_security_data_secrecy_level":       dataarts.ResourceSecurityDataSecrecyLevel(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_action_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_factory_job_action_test.go
@@ -1,0 +1,268 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccFactoryJobAction_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dataarts_factory_job_action.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getFactoryJobResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testFactoryJobAction_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "job_name", name),
+					resource.TestCheckResourceAttr(rName, "process_type", "REAL_TIME"),
+					resource.TestCheckResourceAttr(rName, "action", "start"),
+					resource.TestCheckResourceAttr(rName, "status", "NORMAL"),
+				),
+			},
+			{
+				Config: testFactoryJobAction_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "job_name", name),
+					resource.TestCheckResourceAttr(rName, "process_type", "REAL_TIME"),
+					resource.TestCheckResourceAttr(rName, "action", "stop"),
+					resource.TestCheckResourceAttr(rName, "status", "STOPPED"),
+				),
+			},
+		},
+	})
+}
+
+func testFactoryJobAction_realTime_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_smn_topic" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_dataarts_factory_job" "test" {
+  name         = "%[1]s"
+  workspace_id = "%[2]s"
+  process_type = "REAL_TIME"
+
+  nodes {
+    name = "SMN_%[1]s"
+    type = "SMN"
+
+    location {
+      x = 10
+      y = 11
+    }
+
+    properties {
+      name  = "topic"
+      value = huaweicloud_smn_topic.test.topic_urn
+    }
+
+    properties {
+      name  = "messageType"
+      value = "NORMAL"
+    }
+
+    properties {
+      name  = "message"
+      value = "terraform acceptance test"
+    }
+  }
+
+  schedule {
+    type = "EXECUTE_ONCE"
+  }
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testFactoryJobAction_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_factory_job_action" "test" {
+  depends_on = [
+    "huaweicloud_dataarts_factory_job.test"
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "start"
+  job_name     = huaweicloud_dataarts_factory_job.test.name
+  process_type = huaweicloud_dataarts_factory_job.test.process_type
+}
+`, testFactoryJobAction_realTime_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testFactoryJobAction_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_factory_job_action" "test" {
+  depends_on = [
+    "huaweicloud_dataarts_factory_job.test"
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "stop"
+  job_name     = huaweicloud_dataarts_factory_job.test.name
+  process_type = huaweicloud_dataarts_factory_job.test.process_type
+}
+`, testFactoryJobAction_realTime_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func TestAccFactoryJobAction_batchJob(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_dataarts_factory_job_action.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getFactoryJobResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsCdmName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testFactoryJobAction_batchPinelineJob_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "job_name", name),
+					resource.TestCheckResourceAttr(rName, "process_type", "BATCH"),
+					resource.TestCheckResourceAttr(rName, "action", "start"),
+					resource.TestCheckResourceAttr(rName, "status", "SCHEDULING"),
+				),
+			},
+			{
+				Config: testFactoryJobAction_batchPinelineJob_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "job_name", name),
+					resource.TestCheckResourceAttr(rName, "process_type", "BATCH"),
+					resource.TestCheckResourceAttr(rName, "action", "stop"),
+					resource.TestCheckResourceAttr(rName, "status", "STOPPED"),
+				),
+			},
+		},
+	})
+}
+
+func testFactoryJobAction_batchPinelineJob_base(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_factory_job" "test" {
+  name         = "%[1]s"
+  workspace_id = "%[2]s"
+  process_type = "BATCH"
+
+  nodes {
+    name = "Rest_client_%[1]s"
+    type = "RESTAPI"
+
+    location {
+      x = 10
+      y = 11
+    }
+
+    properties {
+      name  = "url"
+      value = "https://www.huaweicloud.com/"
+    }
+
+    properties {
+      name  = "method"
+      value = "GET"
+    }
+
+    properties {
+      name  = "retry"
+      value = "false"
+    }
+
+    properties {
+      name  = "requestMode"
+      value = "sync"
+    }
+
+    properties {
+      name  = "securityAuthentication"
+      value = "NONE"
+    }
+
+    properties {
+      name  = "agentName"
+      value = "%[3]s"
+    }
+  }
+
+  schedule {
+    type = "CRON"
+    cron {
+      expression = "0 0 0 * * ?"
+      start_time = "2024-07-24T16:14:04+08"
+    }
+  }
+}
+`, name, acceptance.HW_DATAARTS_WORKSPACE_ID, acceptance.HW_DATAARTS_CDM_NAME)
+}
+
+func testFactoryJobAction_batchPinelineJob_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_factory_job_action" "test" {
+  depends_on = [
+    "huaweicloud_dataarts_factory_job.test"
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "start"
+  job_name     = huaweicloud_dataarts_factory_job.test.name
+  process_type = huaweicloud_dataarts_factory_job.test.process_type
+}
+`, testFactoryJobAction_batchPinelineJob_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testFactoryJobAction_batchPinelineJob_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_factory_job_action" "test" {
+  depends_on = [
+    "huaweicloud_dataarts_factory_job.test"
+  ]
+
+  workspace_id = "%[2]s"
+  action       = "stop"
+  job_name     = huaweicloud_dataarts_factory_job.test.name
+  process_type = huaweicloud_dataarts_factory_job.test.process_type
+}
+`, testFactoryJobAction_batchPinelineJob_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job_action.go
@@ -1,0 +1,266 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var actionResourceNotFoundCodes = "DLF.0819" // The workspace ID does not exist.
+
+// @API DataArtsStudio POST /v1/{project_id}/jobs/{job_name}/start
+// @API DataArtsStudio POST /v1/{project_id}/jobs/{job_name}/stop
+// @API DataArtsStudio GET /v1/{project_id}/jobs
+func ResourceFactoryJobAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceFactoryJobActionCreate,
+		ReadContext:   resourceFactoryJobActionRead,
+		UpdateContext: resourceFactoryJobActionUpdate,
+		DeleteContext: resourceFactoryJobActionDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specified the ID of the workspace.`,
+			},
+			"job_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specified the name of the job.`,
+			},
+			"process_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specified the type of the job.`,
+			},
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specified the action type of the job.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The current status of the job.`,
+			},
+		},
+	}
+}
+
+func resourceFactoryJobActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dataarts-dlf", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	jobName := d.Get("job_name").(string)
+	workspaceId := d.Get("workspace_id").(string)
+	_, err = doActionJob(client, workspaceId, jobName, d.Get("action").(string))
+	if err != nil {
+		return diag.Errorf("unable to operate status of the job (%s): %s", jobName, err)
+	}
+
+	d.SetId(jobName)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      jobStateRefreshFunc(client, workspaceId, jobName, d.Get("process_type").(string)),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        10 * time.Second,
+		PollInterval: 20 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the status of job (%s) to become running: %s", jobName, err)
+	}
+	return resourceFactoryJobActionRead(ctx, d, meta)
+}
+
+func doActionJob(client *golangsdk.ServiceClient, workspaceId, jobName, action string) (*http.Response, error) {
+	httpUrl := "v1/{project_id}/jobs/{job_name}/{action}"
+	actionPath := client.Endpoint + httpUrl
+	actionPath = strings.ReplaceAll(actionPath, "{project_id}", client.ProjectID)
+	actionPath = strings.ReplaceAll(actionPath, "{job_name}", jobName)
+	actionPath = strings.ReplaceAll(actionPath, "{action}", action)
+
+	actionOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"workspace": workspaceId,
+		},
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	return client.Request("POST", actionPath, &actionOpts)
+}
+
+func jobStateRefreshFunc(client *golangsdk.ServiceClient, workspaceId, jobName, jobType string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := getJobByName(client, workspaceId, jobName, jobType)
+		if err != nil {
+			return respBody, "ERROR", err
+		}
+
+		statusResp := utils.PathSearch("status", respBody, "").(string)
+		if utils.StrSliceContains([]string{"EXCEPTION"}, statusResp) {
+			return respBody, "ERROR", fmt.Errorf("unexpect status (%s)", statusResp)
+		}
+
+		if utils.StrSliceContains([]string{"NORMAL", "STOPPED", "SCHEDULING"}, statusResp) {
+			return respBody, "COMPLETED", nil
+		}
+		// Intermediate state: "STARTING" "STOPPING"
+		return respBody, "PENDING", nil
+	}
+}
+
+func getJobByName(client *golangsdk.ServiceClient, workspaceId, jobName, jobType string) (interface{}, error) {
+	// The maximum value of limit is 100.
+	httpUrl := "v1/{project_id}/jobs?limit=100"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	// The job_name field supports fuzzy matching.
+	getPath = fmt.Sprintf("%s&jobName=%v&jobType=%v", getPath, jobName, jobType)
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"workspace": workspaceId,
+		},
+	}
+
+	offset := 0
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", getPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &getOpt)
+		if err != nil {
+			return nil, err
+		}
+
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+
+		jobs := utils.PathSearch("jobs", respBody, make([]interface{}, 0)).([]interface{})
+		if len(jobs) < 1 {
+			break
+		}
+
+		job := utils.PathSearch(fmt.Sprintf("[?name=='%s']|[0]", jobName), jobs, nil)
+		if job != nil {
+			return job, nil
+		}
+		offset += len(jobs)
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func resourceFactoryJobActionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("dataarts-dlf", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	jobName := d.Get("job_name").(string)
+	job, err := getJobByName(client, d.Get("workspace_id").(string), jobName, d.Get("process_type").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", actionResourceNotFoundCodes),
+			fmt.Sprintf("job (%s) not found: %s", jobName, err))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("job_name", utils.PathSearch("name", job, nil)),
+		d.Set("status", utils.PathSearch("status", job, nil)),
+		d.Set("action", paserAction(utils.PathSearch("status", job, "").(string))),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving the fields of the job action: %s", err)
+	}
+	return nil
+}
+
+func paserAction(action string) string {
+	if utils.StrSliceContains([]string{"NORMAL", "SCHEDULING"}, action) {
+		return "start"
+	}
+	return "stop"
+}
+
+func resourceFactoryJobActionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dataarts-dlf", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DataArts client: %s", err)
+	}
+
+	if d.HasChange("action") {
+		jobName := d.Get("job_name").(string)
+		workspaceId := d.Get("workspace_id").(string)
+		_, err = doActionJob(client, workspaceId, jobName, d.Get("action").(string))
+		if err != nil {
+			return diag.Errorf("error updating DataArts job (%s) status: %s", jobName, err)
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending:      []string{"PENDING"},
+			Target:       []string{"COMPLETED"},
+			Refresh:      jobStateRefreshFunc(client, workspaceId, jobName, d.Get("process_type").(string)),
+			Timeout:      d.Timeout(schema.TimeoutUpdate),
+			Delay:        10 * time.Second,
+			PollInterval: 20 * time.Second,
+		}
+		_, err = stateConf.WaitForStateContext(ctx)
+		if err != nil {
+			return diag.Errorf("error waiting for the status of job (%s) to become running: %s", jobName, err)
+		}
+	}
+	return resourceFactoryJobActionRead(ctx, d, meta)
+}
+
+func resourceFactoryJobActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for changing job status. Deleting this resource will
+not change the current status, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Add new resource supports starting/stopping factory job.
![image](https://github.com/user-attachments/assets/0dadd98b-b5b4-4296-92e3-bfec839bd99c)

2. This resource is only a one-time action resource，there is no deletion logic, and the following message will be prompted when deleting.
  ![image](https://github.com/user-attachments/assets/9322be58-4d4b-4705-a47a-be1a41ef8200)



**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add corresponding to document and acceptance test.
3. this resource does not require deletion logic.

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 sh scripts/acc-test.sh
>>> Start to test
=== RUN   TestAccFactoryJobAction_basic
=== PAUSE TestAccFactoryJobAction_basic
=== RUN   TestAccFactoryJobAction_batchJob
=== PAUSE TestAccFactoryJobAction_batchJob
=== CONT  TestAccFactoryJobAction_basic
=== CONT  TestAccFactoryJobAction_batchJob
--- PASS: TestAccFactoryJobAction_batchJob (78.11s)
--- PASS: TestAccFactoryJobAction_basic (116.74s)
PASS
coverage: 10.2% of statements in ../../dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  116.800s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa.Resource not found
![image](https://github.com/user-attachments/assets/4dae7f37-7656-4a12-a5d4-7b2930fc9230)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
      -->
    ab. Related resources (workspace ID) not found
![image](https://github.com/user-attachments/assets/c9c61a02-1014-4207-ad58-65cc9aad378d)


  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
```
