### PR TITLE
feat(evs/volume_transfer): support volume transfer resource

### DIFF
--- a/docs/resources/evs_volume_transfer.md
+++ b/docs/resources/evs_volume_transfer.md
@@ -1,0 +1,56 @@
+---
+subcategory: "Elastic Volume Service (EVS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_evs_volume_transfer"
+description: |-
+  Manages an EVS volume transfer resource within HuaweiCloud.
+---
+
+# huaweicloud_evs_volume_transfer
+
+Manages an EVS volume transfer resource within HuaweiCloud.
+
+-> The transfer can only be created when the EVS volume is in the **available** state, other constraints that do not
+   support transfer are as follows:
+   <br/>1. Volumes with the prePaid billing mode do not support transfer.
+   <br/>2. Frozen volumes do not support transfer.
+   <br/>3. Encrypted volumes do not support transfer.
+   <br/>4. Volumes with corresponding backups and snapshots do not support transfer.
+   <br/>5. Volumes with backup policies do not support transfer.
+   <br/>6. Volumes on DSS (Dedicated Storage Service) do not support transfer.
+   <br/>7. Volumes on DESS (Dedicated Enterprise Storage Service) do not support transfer.
+
+## Example Usage
+
+```hcl
+variable "volume_id" {}
+variable "name" {}
+
+resource "huaweicloud_evs_volume_transfer" "test" {
+  volume_id = var.volume_id
+  name      = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `volume_id` - (Required, String, ForceNew) Specifies the volume ID to be transferred.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the volume transfer record.
+  Supports a maximum of `64` characters. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `auth_key` - The identity authentication key for volume transfer.
+
+* `created_at` - The creation time of the volume transfer record, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1369,6 +1369,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_evs_snapshot":          evs.ResourceEvsSnapshotV2(),
 			"huaweicloud_evs_volume":            evs.ResourceEvsVolume(),
 			"huaweicloud_evs_snapshot_rollback": evs.ResourceSnapshotRollBack(),
+			"huaweicloud_evs_volume_transfer":   evs.ResourceVolumeTransfer(),
 
 			"huaweicloud_fgs_application":                fgs.ResourceApplication(),
 			"huaweicloud_fgs_async_invoke_configuration": fgs.ResourceAsyncInvokeConfiguration(),

--- a/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_transfer_test.go
+++ b/huaweicloud/services/acceptance/evs/resource_huaweicloud_evs_volume_transfer_test.go
@@ -1,0 +1,111 @@
+package evs
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getVolumeTransferFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	var (
+		region                   = acceptance.HW_REGION_NAME
+		id                       = state.Primary.ID
+		getVolumeTransferHttpUrl = "v2/{project_id}/os-volume-transfer/{transfer_id}"
+		product                  = "evs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating EVS client: %s", err)
+	}
+
+	getVolumeTransferPath := client.Endpoint + getVolumeTransferHttpUrl
+	getVolumeTransferPath = strings.ReplaceAll(getVolumeTransferPath, "{project_id}", client.ProjectID)
+	getVolumeTransferPath = strings.ReplaceAll(getVolumeTransferPath, "{transfer_id}", id)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResponse, err := client.Request("GET", getVolumeTransferPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving EVS volume transfer: %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	transfer := utils.PathSearch("transfer", getRespBody, nil)
+	return transfer, nil
+}
+func TestAccVolumeTransfer_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_evs_volume_transfer.test"
+		name  = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getVolumeTransferFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVolumeTransfer_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "volume_id", "huaweicloud_evs_volume.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "auth_key"),
+					resource.TestMatchResourceAttr(rName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccVolumeTransfer_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%s"
+  description       = "Created by acc test"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  volume_type       = "SAS"
+  size              = 12
+}
+`, name)
+}
+
+func testAccVolumeTransfer_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_evs_volume_transfer" "test" {
+  volume_id = huaweicloud_evs_volume.test.id
+  name      = "%[2]s"
+}
+`, testAccVolumeTransfer_base(name), name)
+}

--- a/huaweicloud/services/evs/resource_huaweicloud_evs_volume_transfer.go
+++ b/huaweicloud/services/evs/resource_huaweicloud_evs_volume_transfer.go
@@ -1,0 +1,189 @@
+package evs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API EVS POST /v2/{project_id}/os-volume-transfer
+// @API EVS GET /v2/{project_id}/os-volume-transfer/{transfer_id}
+// @API EVS DELETE /v2/{project_id}/os-volume-transfer/{transfer_id}
+func ResourceVolumeTransfer() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVolumeTransferCreate,
+		ReadContext:   resourceVolumeTransferRead,
+		DeleteContext: resourceVolumeTransferDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"auth_key": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceVolumeTransferCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                         = meta.(*config.Config)
+		region                      = cfg.GetRegion(d)
+		createVolumeTransferHttpUrl = "v2/{project_id}/os-volume-transfer"
+		product                     = "evs"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	createVolumeTransferPath := client.Endpoint + createVolumeTransferHttpUrl
+	createVolumeTransferPath = strings.ReplaceAll(createVolumeTransferPath, "{project_id}", client.ProjectID)
+	createVolumeTransferBodyParams := map[string]interface{}{
+		"transfer": map[string]interface{}{
+			"name":      d.Get("name"),
+			"volume_id": d.Get("volume_id"),
+		},
+	}
+	createVolumeTransferOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         createVolumeTransferBodyParams,
+	}
+
+	createResponse, err := client.Request("POST", createVolumeTransferPath, &createVolumeTransferOpt)
+	if err != nil {
+		return diag.Errorf("error creating EVS volume transfer: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResponse)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	transferId := utils.PathSearch("transfer.id", createRespBody, "").(string)
+	if transferId == "" {
+		return diag.Errorf("error creating EVS volume transfer: ID is not found in API response")
+	}
+
+	d.SetId(transferId)
+	// The `auth_key` field is an important attribute and will only be returned when calling the create API.
+	// So it is necessary to make a no null judgment and set value here.
+	authKey := utils.PathSearch("transfer.auth_key", createRespBody, "").(string)
+	if authKey == "" {
+		return diag.Errorf("error creating EVS volume transfer: auth_key is not found in API response")
+	}
+
+	if err := d.Set("auth_key", authKey); err != nil {
+		return diag.Errorf("error setting attribute `auth_key` after creating EVS volume transfer: %s", err)
+	}
+
+	return resourceVolumeTransferRead(ctx, d, meta)
+}
+
+func resourceVolumeTransferRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		mErr                     *multierror.Error
+		cfg                      = meta.(*config.Config)
+		region                   = cfg.GetRegion(d)
+		getVolumeTransferHttpUrl = "v2/{project_id}/os-volume-transfer/{transfer_id}"
+		product                  = "evs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	getVolumeTransferPath := client.Endpoint + getVolumeTransferHttpUrl
+	getVolumeTransferPath = strings.ReplaceAll(getVolumeTransferPath, "{project_id}", client.ProjectID)
+	getVolumeTransferPath = strings.ReplaceAll(getVolumeTransferPath, "{transfer_id}", d.Id())
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResponse, err := client.Request("GET", getVolumeTransferPath, &getOpt)
+	if err != nil {
+		// When the resource does not exist, calling the query API will return a `404` status code.
+		return common.CheckDeletedDiag(d, err, "error retrieving EVS volume transfer")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResponse)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	transfer := utils.PathSearch("transfer", getRespBody, nil)
+	createdAtStr := utils.PathSearch("created_at", transfer, "").(string)
+	// The `created_at` field return format is **2024-07-23T11:19:06.469300**,
+	// convert it into the standard RFC3339 format here.
+	createdAtTimestamp := utils.ConvertTimeStrToNanoTimestamp(createdAtStr, "2006-01-02T15:04:05.999999")
+	createdAt := utils.FormatTimeStampRFC3339(createdAtTimestamp/1000, false)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("volume_id", utils.PathSearch("volume_id", transfer, "").(string)),
+		d.Set("name", utils.PathSearch("name", transfer, "").(string)),
+		d.Set("created_at", createdAt),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceVolumeTransferDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                         = meta.(*config.Config)
+		region                      = cfg.GetRegion(d)
+		deleteVolumeTransferHttpUrl = "v2/{project_id}/os-volume-transfer/{transfer_id}"
+		product                     = "evs"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating EVS client: %s", err)
+	}
+
+	deleteVolumeTransferPath := client.Endpoint + deleteVolumeTransferHttpUrl
+	deleteVolumeTransferPath = strings.ReplaceAll(deleteVolumeTransferPath, "{project_id}", client.ProjectID)
+	deleteVolumeTransferPath = strings.ReplaceAll(deleteVolumeTransferPath, "{transfer_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", deleteVolumeTransferPath, &deleteOpt)
+	if err != nil {
+		// When the resource does not exist, calling the delete API will return a `404` status code.
+		return common.CheckDeletedDiag(d, err, "error deleting EVS volume transfer")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support volume transfer resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support volume transfer resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccVolumeTransfer_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccVolumeTransfer_basic -timeout 360m -parallel 4
=== RUN   TestAccVolumeTransfer_basic
=== PAUSE TestAccVolumeTransfer_basic
=== CONT  TestAccVolumeTransfer_basic
--- PASS: TestAccVolumeTransfer_basic (45.59s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       45.654s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/34edfa48-f73f-486e-8ca4-88c9035dbfef)
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/c30c0500-c133-44e1-9f80-3cdbd6ffa2ce)
