### PR TITLE
test(vpc): improve vpc test coverage

### DIFF
--- a/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_traffic_mirror_filters_test.go
+++ b/huaweicloud/services/acceptance/vpc/data_source_huaweicloud_vpc_traffic_mirror_filters_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccDataSourceVpcTrafficMirrorFilters_basic(t *testing.T) {
-	dataSource := "data.huaweicloud_vpc_traffic_mirror_filters.test1"
+	dataSource := "data.huaweicloud_vpc_traffic_mirror_filters.test"
 	rName := acceptance.RandomAccResourceName()
 	dc := acceptance.InitDataSourceCheck(dataSource)
 
@@ -33,13 +33,39 @@ func TestAccDataSourceVpcTrafficMirrorFilters_basic(t *testing.T) {
 
 func testDataSourceDataSourceVpcTrafficMirrorFilters_basic(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_vpc_traffic_mirror_filter" "test1" {
+resource "huaweicloud_vpc_traffic_mirror_filter" "test" {
   name        = "%[1]s"
   description = "tf acc test filter"
 }
 
-data "huaweicloud_vpc_traffic_mirror_filters" "test1" {
+resource "huaweicloud_vpc_traffic_mirror_filter_rule" "test1" {
+  traffic_mirror_filter_id = huaweicloud_vpc_traffic_mirror_filter.test.id
+  ethertype                = "IPv4"
+  direction                = "ingress"
+  protocol                 = "tcp"
+  action                   = "accept"
+  priority                 = 1
+  description              = "create VPC traffic mirror filter rule"
+}
+
+resource "huaweicloud_vpc_traffic_mirror_filter_rule" "test2" {
+  traffic_mirror_filter_id = huaweicloud_vpc_traffic_mirror_filter.test.id
+  ethertype                = "IPv4"
+  direction                = "egress"
+  protocol                 = "all"
+  action                   = "accept"
+  priority                 = 20
+  source_cidr_block        = "192.168.1.0/24"
+}
+
+data "huaweicloud_vpc_traffic_mirror_filters" "test" {
   name = "%[1]s"
+
+  depends_on = [
+    huaweicloud_vpc_traffic_mirror_filter.test,
+    huaweicloud_vpc_traffic_mirror_filter_rule.test1,
+    huaweicloud_vpc_traffic_mirror_filter_rule.test2
+  ]
 }
 `, name)
 }

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_network_interface_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_network_interface_test.go
@@ -85,10 +85,11 @@ func testAccNetworkInterface_basic(rName string) string {
 %s
 
 resource "huaweicloud_vpc_network_interface" "test" {
-  name      = "%s"
-  subnet_id = huaweicloud_vpc_subnet.test.id
-  allowed_addresses  = ["192.168.1.5"]
-  dhcp_lease_time    = "2h"
+  name              = "%s"
+  subnet_id         = huaweicloud_vpc_subnet.test.id
+  fixed_ip_v4       = "192.168.0.111"
+  allowed_addresses = ["192.168.1.5"]
+  dhcp_lease_time   = "2h"
 }
 `, testAccNetwork_base(rName), rName)
 }
@@ -102,6 +103,7 @@ func testAccNetworkInterface_update(rName string) string {
 resource "huaweicloud_vpc_network_interface" "test" {
   subnet_id          = huaweicloud_vpc_subnet.test.id
   security_group_ids = [huaweicloud_networking_secgroup.secgroup_1.id]
+  dhcp_lease_time    = "1h"
 }
 `, testAccNetwork_base(rName), testAccSecGroup_basic(rName))
 }

--- a/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_test.go
+++ b/huaweicloud/services/acceptance/vpc/resource_huaweicloud_vpc_route_test.go
@@ -79,6 +79,13 @@ func TestAccVpcRTBRoute_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccVpcRTBRoute_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -127,7 +134,7 @@ func TestAccVpcRTBRoute_vip(t *testing.T) {
 	})
 }
 
-func testAccVpcRTBRoute_basic(rName string) string {
+func testAccVpcRTBRoute_base(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc" "test1" {
   name = "%s_1"
@@ -144,6 +151,12 @@ resource "huaweicloud_vpc_peering_connection" "test" {
   vpc_id      = huaweicloud_vpc.test1.id
   peer_vpc_id = huaweicloud_vpc.test2.id
 }
+`, rName, rName, rName)
+}
+
+func testAccVpcRTBRoute_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "huaweicloud_vpc_route" "test" {
   vpc_id      = huaweicloud_vpc.test1.id
@@ -152,7 +165,21 @@ resource "huaweicloud_vpc_route" "test" {
   nexthop     = huaweicloud_vpc_peering_connection.test.id
   description = "peering route"
 }
-`, rName, rName, rName)
+`, testAccVpcRTBRoute_base(rName))
+}
+
+func testAccVpcRTBRoute_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpc_route" "test" {
+  vpc_id      = huaweicloud_vpc.test1.id
+  destination = huaweicloud_vpc.test2.cidr
+  type        = "peering"
+  nexthop     = huaweicloud_vpc_peering_connection.test.id
+  description = ""
+}
+`, testAccVpcRTBRoute_base(rName))
 }
 
 func testAccVpcRTBRoute_vip(rName string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./coverage_test.sh
>>> Start to test
=== RUN   TestAccNetworkingV2PortDataSource_basic
=== PAUSE TestAccNetworkingV2PortDataSource_basic
=== RUN   TestAccNetworkingSecGroupRulesDataSource_basic
=== PAUSE TestAccNetworkingSecGroupRulesDataSource_basic
=== RUN   TestAccNetworkingSecGroupV3DataSource_basic
=== PAUSE TestAccNetworkingSecGroupV3DataSource_basic
=== RUN   TestAccNetworkingSecGroupV3DataSource_byID
=== PAUSE TestAccNetworkingSecGroupV3DataSource_byID
=== RUN   TestAccNetworkingSecGroupsDataSource_basic
=== PAUSE TestAccNetworkingSecGroupsDataSource_basic
=== RUN   TestAccNetworkingSecGroupsDataSource_description
=== PAUSE TestAccNetworkingSecGroupsDataSource_description
=== RUN   TestAccNetworkingSecGroupsDataSource_id
=== PAUSE TestAccNetworkingSecGroupsDataSource_id
=== RUN   TestAccDataSourceVpcAddressGroups_basic
=== PAUSE TestAccDataSourceVpcAddressGroups_basic
=== RUN   TestAccDataSourceVpcFlowLogs_basic
=== PAUSE TestAccDataSourceVpcFlowLogs_basic
=== RUN   TestAccVpcIdsDataSource_basic
=== PAUSE TestAccVpcIdsDataSource_basic
=== RUN   TestAccNetworkAclsDataSource_basic
=== PAUSE TestAccNetworkAclsDataSource_basic
=== RUN   TestAccVpcPeeringConnectionDataSource_basic
=== PAUSE TestAccVpcPeeringConnectionDataSource_basic
=== RUN   TestAccVpcPeeringConnectionDataSource_byVpcId
=== PAUSE TestAccVpcPeeringConnectionDataSource_byVpcId
=== RUN   TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== PAUSE TestAccVpcPeeringConnectionDataSource_byPeerVpcId
=== RUN   TestAccVpcPeeringConnectionDataSource_byVpcIds
=== PAUSE TestAccVpcPeeringConnectionDataSource_byVpcIds
=== RUN   TestAccVpcRouteIdsDataSource_basic
=== PAUSE TestAccVpcRouteIdsDataSource_basic
=== RUN   TestAccVpcRouteTableDataSource_basic
=== PAUSE TestAccVpcRouteTableDataSource_basic
=== RUN   TestAccVpcRouteDataSource_basic
=== PAUSE TestAccVpcRouteDataSource_basic
=== RUN   TestAccVpcRouteDataSource_byVpcId
=== PAUSE TestAccVpcRouteDataSource_byVpcId
=== RUN   TestAccDataSourceVpcRoutes_basic
=== PAUSE TestAccDataSourceVpcRoutes_basic
=== RUN   TestAccDataSourceVpcSubNetworkInterfaces_basic
=== PAUSE TestAccDataSourceVpcSubNetworkInterfaces_basic
=== RUN   TestAccVpcSubnetIdsDataSource_basic
=== PAUSE TestAccVpcSubnetIdsDataSource_basic
=== RUN   TestAccVpcSubnetDataSource_ipv4Basic
=== PAUSE TestAccVpcSubnetDataSource_ipv4Basic
=== RUN   TestAccVpcSubnetDataSource_ipv4ByCidr
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByCidr
=== RUN   TestAccVpcSubnetDataSource_ipv4ByName
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByName
=== RUN   TestAccVpcSubnetDataSource_ipv4ByVpcId
=== PAUSE TestAccVpcSubnetDataSource_ipv4ByVpcId
=== RUN   TestAccVpcSubnetDataSource_ipv6Basic
=== PAUSE TestAccVpcSubnetDataSource_ipv6Basic
=== RUN   TestAccVpcSubnetsDataSource_basic
=== PAUSE TestAccVpcSubnetsDataSource_basic
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByCidr
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByCidr
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByName
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByName
=== RUN   TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== PAUSE TestAccVpcSubnetsDataSource_ipv4ByVpcId
=== RUN   TestAccVpcSubnetsDataSource_ipv6Basic
=== PAUSE TestAccVpcSubnetsDataSource_ipv6Basic
=== RUN   TestAccVpcDataSource_basic
=== PAUSE TestAccVpcDataSource_basic
=== RUN   TestAccVpcDataSource_byCidr
=== PAUSE TestAccVpcDataSource_byCidr
=== RUN   TestAccVpcDataSource_byName
=== PAUSE TestAccVpcDataSource_byName
=== RUN   TestAccDataSourceVpcTrafficMirrorFilterRules_basic
=== PAUSE TestAccDataSourceVpcTrafficMirrorFilterRules_basic
=== RUN   TestAccDataSourceVpcTrafficMirrorFilters_basic
=== PAUSE TestAccDataSourceVpcTrafficMirrorFilters_basic
=== RUN   TestAccDataSourceVpcTrafficMirrorSessions_basic
=== PAUSE TestAccDataSourceVpcTrafficMirrorSessions_basic
=== RUN   TestAccVpcsDataSource_basic
=== PAUSE TestAccVpcsDataSource_basic
=== RUN   TestAccVpcsDataSource_byCidr
=== PAUSE TestAccVpcsDataSource_byCidr
=== RUN   TestAccVpcsDataSource_byName
=== PAUSE TestAccVpcsDataSource_byName
=== RUN   TestAccVpcsDataSource_byAll
=== PAUSE TestAccVpcsDataSource_byAll
=== RUN   TestAccVpcsDataSource_tags
=== PAUSE TestAccVpcsDataSource_tags
=== RUN   TestAccNetworkingSecGroupRule_basic
=== PAUSE TestAccNetworkingSecGroupRule_basic
=== RUN   TestAccNetworkingSecGroupRule_Egress
=== PAUSE TestAccNetworkingSecGroupRule_Egress
=== RUN   TestAccNetworkingSecGroupRule_oldPorts
=== PAUSE TestAccNetworkingSecGroupRule_oldPorts
=== RUN   TestAccNetworkingSecGroupRule_remoteGroup
=== PAUSE TestAccNetworkingSecGroupRule_remoteGroup
=== RUN   TestAccNetworkingSecGroupRule_lowerCaseCIDR
=== PAUSE TestAccNetworkingSecGroupRule_lowerCaseCIDR
=== RUN   TestAccNetworkingSecGroupRule_noPorts
=== PAUSE TestAccNetworkingSecGroupRule_noPorts
=== RUN   TestAccNetworkingSecGroupRule_remoteAddressGroup
=== PAUSE TestAccNetworkingSecGroupRule_remoteAddressGroup
=== RUN   TestAccNetworkingSecGroupRule_noRemote
=== PAUSE TestAccNetworkingSecGroupRule_noRemote
=== RUN   TestAccNetworkingSecGroupRule_action
=== PAUSE TestAccNetworkingSecGroupRule_action
=== RUN   TestAccNetworkingSecGroupRule_priority
=== PAUSE TestAccNetworkingSecGroupRule_priority
=== RUN   TestAccNetworkingV3SecGroup_basic
=== PAUSE TestAccNetworkingV3SecGroup_basic
=== RUN   TestAccNetworkingV3SecGroup_withEpsId
=== PAUSE TestAccNetworkingV3SecGroup_withEpsId
=== RUN   TestAccNetworkingV3SecGroup_noDefaultRules
=== PAUSE TestAccNetworkingV3SecGroup_noDefaultRules
=== RUN   TestAccNetworkingV2VIPAssociate_basic
=== PAUSE TestAccNetworkingV2VIPAssociate_basic
=== RUN   TestAccNetworkingVip_basic
=== PAUSE TestAccNetworkingVip_basic
=== RUN   TestAccNetworkingVip_ipv6
=== PAUSE TestAccNetworkingVip_ipv6
=== RUN   TestAccVpcAddressGroup_basic
=== PAUSE TestAccVpcAddressGroup_basic
=== RUN   TestAccVpcAddressGroup_ipv6
=== PAUSE TestAccVpcAddressGroup_ipv6
=== RUN   TestAccVpcAddressGroup_eps
=== PAUSE TestAccVpcAddressGroup_eps
=== RUN   TestAccFlowLog_basic
=== PAUSE TestAccFlowLog_basic
=== RUN   TestAccNetworkAcl_basic
=== PAUSE TestAccNetworkAcl_basic
=== RUN   TestAccVpcNetworkInterface_basic
=== PAUSE TestAccVpcNetworkInterface_basic
=== RUN   TestAccVpcPeeringConnectionAccepter_basic
=== PAUSE TestAccVpcPeeringConnectionAccepter_basic
=== RUN   TestAccVpcPeeringConnection_basic
=== PAUSE TestAccVpcPeeringConnection_basic
=== RUN   TestAccVpcRouteTable_basic
=== PAUSE TestAccVpcRouteTable_basic
=== RUN   TestAccVpcRouteTable_multiRoutes
=== PAUSE TestAccVpcRouteTable_multiRoutes
=== RUN   TestAccVpcRTBRoute_basic
=== PAUSE TestAccVpcRTBRoute_basic
=== RUN   TestAccVpcRTBRoute_vip
=== PAUSE TestAccVpcRTBRoute_vip
=== RUN   TestAccSubNetworkInterface_basic
=== PAUSE TestAccSubNetworkInterface_basic
=== RUN   TestAccVpcSubnetV1_basic
=== PAUSE TestAccVpcSubnetV1_basic
=== RUN   TestAccVpcSubnetV1_ipv6
=== PAUSE TestAccVpcSubnetV1_ipv6
=== RUN   TestAccVpcSubnetV1_dhcp
=== PAUSE TestAccVpcSubnetV1_dhcp
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== RUN   TestAccVpcV1_secondaryCIDR
=== PAUSE TestAccVpcV1_secondaryCIDR
=== RUN   TestAccVpcV1_secondaryCIDRs
=== PAUSE TestAccVpcV1_secondaryCIDRs
=== RUN   TestAccVpcV1_WithEpsId
=== PAUSE TestAccVpcV1_WithEpsId
=== RUN   TestAccVpcV1_WithCustomRegion
=== PAUSE TestAccVpcV1_WithCustomRegion
=== RUN   TestAccTrafficMirrorFilterRule_basic
=== PAUSE TestAccTrafficMirrorFilterRule_basic
=== RUN   TestAccTrafficMirrorFilterRule_egress
=== PAUSE TestAccTrafficMirrorFilterRule_egress
=== RUN   TestAccTrafficMirrorFilter_basic
=== PAUSE TestAccTrafficMirrorFilter_basic
=== RUN   TestAccTrafficMirrorSession_basic
=== PAUSE TestAccTrafficMirrorSession_basic
=== CONT  TestAccNetworkingV2PortDataSource_basic
=== CONT  TestAccVpcV1_basic
--- PASS: TestAccNetworkingV2PortDataSource_basic (22.27s)
=== CONT  TestAccVpcsDataSource_basic
--- PASS: TestAccVpcV1_basic (46.50s)
=== CONT  TestAccVpcSubnetV1_dhcp
--- PASS: TestAccVpcsDataSource_basic (40.82s)
=== CONT  TestAccVpcSubnetV1_ipv6
--- PASS: TestAccVpcSubnetV1_dhcp (90.11s)
=== CONT  TestAccVpcSubnetV1_basic
--- PASS: TestAccVpcSubnetV1_ipv6 (97.77s)
=== CONT  TestAccSubNetworkInterface_basic
--- PASS: TestAccVpcSubnetV1_basic (96.21s)
=== CONT  TestAccVpcRTBRoute_vip
--- PASS: TestAccVpcRTBRoute_vip (100.25s)
=== CONT  TestAccVpcRTBRoute_basic
--- PASS: TestAccSubNetworkInterface_basic (265.45s)
=== CONT  TestAccVpcRouteTable_multiRoutes
--- PASS: TestAccVpcRTBRoute_basic (104.76s)
=== CONT  TestAccVpcRouteTable_basic
--- PASS: TestAccVpcRouteTable_multiRoutes (116.96s)
=== CONT  TestAccVpcPeeringConnection_basic
--- PASS: TestAccVpcPeeringConnection_basic (85.28s)
=== CONT  TestAccVpcPeeringConnectionAccepter_basic
--- PASS: TestAccVpcRouteTable_basic (196.93s)
=== CONT  TestAccVpcNetworkInterface_basic
--- PASS: TestAccVpcPeeringConnectionAccepter_basic (51.47s)
=== CONT  TestAccNetworkAcl_basic
--- PASS: TestAccVpcNetworkInterface_basic (101.73s)
=== CONT  TestAccFlowLog_basic
--- PASS: TestAccNetworkAcl_basic (138.79s)
=== CONT  TestAccVpcAddressGroup_eps
--- PASS: TestAccVpcAddressGroup_eps (15.55s)
=== CONT  TestAccVpcAddressGroup_ipv6
--- PASS: TestAccFlowLog_basic (117.45s)
=== CONT  TestAccVpcAddressGroup_basic
--- PASS: TestAccVpcAddressGroup_ipv6 (22.86s)
=== CONT  TestAccNetworkingVip_ipv6
--- PASS: TestAccVpcAddressGroup_basic (24.54s)
=== CONT  TestAccNetworkingVip_basic
--- PASS: TestAccNetworkingVip_ipv6 (86.91s)
=== CONT  TestAccNetworkingV2VIPAssociate_basic
--- PASS: TestAccNetworkingVip_basic (107.08s)
=== CONT  TestAccNetworkingV3SecGroup_noDefaultRules
--- PASS: TestAccNetworkingV3SecGroup_noDefaultRules (22.06s)
=== CONT  TestAccNetworkingV3SecGroup_withEpsId
--- PASS: TestAccNetworkingV3SecGroup_withEpsId (21.77s)
=== CONT  TestAccNetworkingV3SecGroup_basic
--- PASS: TestAccNetworkingV3SecGroup_basic (36.78s)
=== CONT  TestAccDataSourceVpcRoutes_basic
--- PASS: TestAccDataSourceVpcRoutes_basic (101.11s)
=== CONT  TestAccDataSourceVpcTrafficMirrorSessions_basic
--- PASS: TestAccNetworkingV2VIPAssociate_basic (364.99s)
=== CONT  TestAccDataSourceVpcTrafficMirrorFilters_basic
--- PASS: TestAccDataSourceVpcTrafficMirrorFilters_basic (31.12s)
=== CONT  TestAccNetworkingSecGroupRule_priority
--- PASS: TestAccDataSourceVpcTrafficMirrorSessions_basic (208.29s)
=== CONT  TestAccDataSourceVpcTrafficMirrorFilterRules_basic
--- PASS: TestAccNetworkingSecGroupRule_priority (41.17s)
=== CONT  TestAccNetworkingSecGroupRule_action
--- PASS: TestAccDataSourceVpcTrafficMirrorFilterRules_basic (33.15s)
=== CONT  TestAccNetworkingSecGroupRule_noRemote
--- PASS: TestAccNetworkingSecGroupRule_action (52.76s)
=== CONT  TestAccVpcDataSource_byName
--- PASS: TestAccNetworkingSecGroupRule_noRemote (42.12s)
=== CONT  TestAccNetworkingSecGroupRule_remoteAddressGroup
--- PASS: TestAccVpcDataSource_byName (39.83s)
=== CONT  TestAccNetworkingSecGroupRule_noPorts
--- PASS: TestAccNetworkingSecGroupRule_remoteAddressGroup (49.78s)
=== CONT  TestAccVpcDataSource_byCidr
--- PASS: TestAccNetworkingSecGroupRule_noPorts (42.04s)
=== CONT  TestAccNetworkingSecGroupRule_lowerCaseCIDR
--- PASS: TestAccVpcDataSource_byCidr (41.41s)
=== CONT  TestAccVpcDataSource_basic
--- PASS: TestAccNetworkingSecGroupRule_lowerCaseCIDR (43.03s)
=== CONT  TestAccNetworkingSecGroupRule_remoteGroup
--- PASS: TestAccVpcDataSource_basic (41.77s)
=== CONT  TestAccVpcSubnetsDataSource_ipv6Basic
--- PASS: TestAccNetworkingSecGroupRule_remoteGroup (47.48s)
=== CONT  TestAccNetworkingSecGroupRule_oldPorts
--- PASS: TestAccNetworkingSecGroupRule_oldPorts (43.96s)
=== CONT  TestAccNetworkingSecGroupRule_Egress
--- PASS: TestAccVpcSubnetsDataSource_ipv6Basic (71.41s)
=== CONT  TestAccNetworkingSecGroupRule_basic
--- PASS: TestAccNetworkingSecGroupRule_Egress (44.94s)
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByVpcId
--- PASS: TestAccNetworkingSecGroupRule_basic (43.75s)
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByName
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByVpcId (67.70s)
=== CONT  TestAccVpcsDataSource_tags
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByName (67.53s)
=== CONT  TestAccVpcSubnetsDataSource_ipv4ByCidr
--- PASS: TestAccVpcsDataSource_tags (43.04s)
=== CONT  TestAccVpcsDataSource_byAll
--- PASS: TestAccVpcSubnetsDataSource_ipv4ByCidr (66.44s)
=== CONT  TestAccVpcsDataSource_byName
--- PASS: TestAccVpcsDataSource_byAll (46.25s)
=== CONT  TestAccVpcsDataSource_byCidr
--- PASS: TestAccVpcsDataSource_byName (40.90s)
=== CONT  TestAccVpcSubnetsDataSource_basic
--- PASS: TestAccVpcsDataSource_byCidr (40.81s)
=== CONT  TestAccVpcSubnetDataSource_ipv6Basic
--- PASS: TestAccVpcSubnetsDataSource_basic (66.21s)
=== CONT  TestAccVpcSubnetDataSource_ipv4ByVpcId
--- PASS: TestAccVpcSubnetDataSource_ipv6Basic (65.87s)
=== CONT  TestAccVpcRouteIdsDataSource_basic
    acceptance.go:561: This environment does not support deprecated tests
--- SKIP: TestAccVpcRouteIdsDataSource_basic (0.01s)
=== CONT  TestAccVpcSubnetDataSource_ipv4ByName
--- PASS: TestAccVpcSubnetDataSource_ipv4ByVpcId (62.96s)
=== CONT  TestAccVpcRouteDataSource_byVpcId
--- PASS: TestAccVpcSubnetDataSource_ipv4ByName (63.48s)
=== CONT  TestAccVpcSubnetDataSource_ipv4ByCidr
--- PASS: TestAccVpcRouteDataSource_byVpcId (77.46s)
=== CONT  TestAccVpcRouteDataSource_basic
    acceptance.go:561: This environment does not support deprecated tests
--- SKIP: TestAccVpcRouteDataSource_basic (0.01s)
=== CONT  TestAccVpcSubnetDataSource_ipv4Basic
--- PASS: TestAccVpcSubnetDataSource_ipv4ByCidr (64.90s)
=== CONT  TestAccVpcRouteTableDataSource_basic
--- PASS: TestAccVpcSubnetDataSource_ipv4Basic (64.48s)
=== CONT  TestAccVpcSubnetIdsDataSource_basic
--- PASS: TestAccVpcRouteTableDataSource_basic (107.04s)
=== CONT  TestAccVpcPeeringConnectionDataSource_byPeerVpcId
--- PASS: TestAccVpcSubnetIdsDataSource_basic (75.06s)
=== CONT  TestAccDataSourceVpcSubNetworkInterfaces_basic
--- PASS: TestAccVpcPeeringConnectionDataSource_byPeerVpcId (67.13s)
=== CONT  TestAccVpcPeeringConnectionDataSource_byVpcIds
--- PASS: TestAccVpcPeeringConnectionDataSource_byVpcIds (130.71s)
=== CONT  TestAccVpcPeeringConnectionDataSource_byVpcId
--- PASS: TestAccVpcPeeringConnectionDataSource_byVpcId (62.57s)
=== CONT  TestAccVpcPeeringConnectionDataSource_basic
--- PASS: TestAccDataSourceVpcSubNetworkInterfaces_basic (242.03s)
=== CONT  TestAccNetworkAclsDataSource_basic
--- PASS: TestAccVpcPeeringConnectionDataSource_basic (65.53s)
=== CONT  TestAccVpcV1_WithEpsId
    acceptance.go:587: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccVpcV1_WithEpsId (0.01s)
=== CONT  TestAccVpcV1_WithCustomRegion
    acceptance.go:554: HW_CUSTOM_REGION_NAME must be set for acceptance tests
--- SKIP: TestAccVpcV1_WithCustomRegion (0.01s)
=== CONT  TestAccTrafficMirrorFilterRule_basic
--- PASS: TestAccNetworkAclsDataSource_basic (113.66s)
=== CONT  TestAccTrafficMirrorFilter_basic
--- PASS: TestAccTrafficMirrorFilterRule_basic (56.11s)
=== CONT  TestAccNetworkingSecGroupsDataSource_description
--- PASS: TestAccTrafficMirrorFilter_basic (25.26s)
=== CONT  TestAccTrafficMirrorFilterRule_egress
--- PASS: TestAccNetworkingSecGroupsDataSource_description (30.77s)
=== CONT  TestAccNetworkingSecGroupV3DataSource_byID
--- PASS: TestAccTrafficMirrorFilterRule_egress (22.71s)
=== CONT  TestAccTrafficMirrorSession_basic
--- PASS: TestAccNetworkingSecGroupV3DataSource_byID (92.15s)
=== CONT  TestAccDataSourceVpcAddressGroups_basic
--- PASS: TestAccDataSourceVpcAddressGroups_basic (27.56s)
=== CONT  TestAccNetworkingSecGroupsDataSource_id
--- PASS: TestAccNetworkingSecGroupsDataSource_id (30.39s)
=== CONT  TestAccNetworkingSecGroupsDataSource_basic
--- PASS: TestAccNetworkingSecGroupsDataSource_basic (32.26s)
=== CONT  TestAccVpcV1_secondaryCIDRs
--- PASS: TestAccVpcV1_secondaryCIDRs (65.34s)
=== CONT  TestAccNetworkingSecGroupV3DataSource_basic
--- PASS: TestAccNetworkingSecGroupV3DataSource_basic (95.90s)
=== CONT  TestAccVpcIdsDataSource_basic
--- PASS: TestAccVpcIdsDataSource_basic (32.34s)
=== CONT  TestAccNetworkingSecGroupRulesDataSource_basic
--- PASS: TestAccTrafficMirrorSession_basic (360.47s)
=== CONT  TestAccVpcV1_secondaryCIDR
--- PASS: TestAccVpcV1_secondaryCIDR (64.72s)
=== CONT  TestAccDataSourceVpcFlowLogs_basic
--- PASS: TestAccNetworkingSecGroupRulesDataSource_basic (76.77s)
--- PASS: TestAccDataSourceVpcFlowLogs_basic (110.47s)
PASS
coverage: 73.8% of statements in ../../vpc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       3159.398s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
