### PR TITLE
feat(cce): support tag, label and taint policy on existing nodes

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -271,6 +271,15 @@ The following arguments are supported:
 * `taints` - (Optional, List) Specifies the taints configuration of the nodes to set anti-affinity.
   The structure is described below.
 
+* `tag_policy_on_existing_nodes` - (Optional, String) Specifies the tag policy on existing nodes.
+  The value can be **ignore** and **refresh**, defaults to **ignore**.
+
+* `label_policy_on_existing_nodes` - (Optional, String) Specifies the label policy on existing nodes.
+  The value can be **ignore** and **refresh**, defaults to **refresh**.
+
+* `taint_policy_on_existing_nodes` - (Optional, String) Specifies the taint policy on existing nodes.
+  The value can be **ignore** and **refresh**, defaults to **refresh**.
+
 The `root_volume` block supports:
 
 * `size` - (Required, Int, ForceNew) Specifies the disk size in GB. Changing this parameter will create a new resource.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240725031404-c60513eac6ef
+	github.com/chnsz/golangsdk v0.0.0-20240727071004-05a10c5e2c21
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240725031404-c60513eac6ef h1:smb24m2IIP7xqNCQUV1puaF6Wq4PnXXuddJkB6NZWHk=
-github.com/chnsz/golangsdk v0.0.0-20240725031404-c60513eac6ef/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240727071004-05a10c5e2c21 h1:87+38Hrzr3A8L6EpU7FMVCsculp3pmt2ZJil7ptMONs=
+github.com/chnsz/golangsdk v0.0.0-20240727071004-05a10c5e2c21/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -307,6 +307,9 @@ func TestAccNodePool_tagsLabelsTaints(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "taints.0.key", "test_key"),
 					resource.TestCheckResourceAttr(resourceName, "taints.0.value", "test_value"),
 					resource.TestCheckResourceAttr(resourceName, "taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "tag_policy_on_existing_nodes", "ignore"),
+					resource.TestCheckResourceAttr(resourceName, "label_policy_on_existing_nodes", "ignore"),
+					resource.TestCheckResourceAttr(resourceName, "taint_policy_on_existing_nodes", "ignore"),
 				),
 			},
 			{
@@ -324,6 +327,9 @@ func TestAccNodePool_tagsLabelsTaints(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "taints.1.key", "new_test_key"),
 					resource.TestCheckResourceAttr(resourceName, "taints.1.value", "new_test_value"),
 					resource.TestCheckResourceAttr(resourceName, "taints.1.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "tag_policy_on_existing_nodes", "refresh"),
+					resource.TestCheckResourceAttr(resourceName, "label_policy_on_existing_nodes", "refresh"),
+					resource.TestCheckResourceAttr(resourceName, "taint_policy_on_existing_nodes", "refresh"),
 				),
 			},
 		},
@@ -348,6 +354,10 @@ resource "huaweicloud_cce_node_pool" "test" {
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+
+  tag_policy_on_existing_nodes   = "ignore"
+  label_policy_on_existing_nodes = "ignore"
+  taint_policy_on_existing_nodes = "ignore"
 
   root_volume {
     size       = 40
@@ -396,6 +406,10 @@ resource "huaweicloud_cce_node_pool" "test" {
   scale_down_cooldown_time = 0
   priority                 = 0
   type                     = "vm"
+
+  tag_policy_on_existing_nodes   = "refresh"
+  label_policy_on_existing_nodes = "refresh"
+  taint_policy_on_existing_nodes = "refresh"
 
   root_volume {
     size       = 40

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -196,6 +196,21 @@ func ResourceNodePool() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"label_policy_on_existing_nodes": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tag_policy_on_existing_nodes": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"taint_policy_on_existing_nodes": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"current_node_count": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -306,6 +321,9 @@ func buildNodePoolCreateOpts(d *schema.ResourceData) (*nodepools.CreateOpts, err
 			NodeManagement: nodepools.NodeManagementSpec{
 				ServerGroupReference: d.Get("ecs_group_id").(string),
 			},
+			LabelPolicyOnExistingNodes:   d.Get("label_policy_on_existing_nodes").(string),
+			UserTagPolicyOnExistingNodes: d.Get("tag_policy_on_existing_nodes").(string),
+			TaintPolicyOnExistingNodes:   d.Get("taint_policy_on_existing_nodes").(string),
 		},
 	}
 
@@ -417,6 +435,9 @@ func resourceNodePoolRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("data_volumes", flattenResourceNodeDataVolume(d, s.Spec.NodeTemplate.DataVolumes)),
 		d.Set("root_volume", flattenResourceNodeRootVolume(d, s.Spec.NodeTemplate.RootVolume)),
 		d.Set("initialized_conditions", s.Spec.NodeTemplate.InitializedConditions),
+		d.Set("label_policy_on_existing_nodes", s.Spec.LabelPolicyOnExistingNodes),
+		d.Set("tag_policy_on_existing_nodes", s.Spec.UserTagPolicyOnExistingNodes),
+		d.Set("taint_policy_on_existing_nodes", s.Spec.TaintPolicyOnExistingNodes),
 	)
 
 	if s.Spec.NodeTemplate.BillingMode != 0 {
@@ -461,6 +482,9 @@ func buildNodePoolUpdateOpts(d *schema.ResourceData) (*nodepools.UpdateOpts, err
 				Taints:                buildResourceNodeTaint(d),
 				InitializedConditions: utils.ExpandToStringList(d.Get("initialized_conditions").([]interface{})),
 			},
+			LabelPolicyOnExistingNodes:   d.Get("label_policy_on_existing_nodes").(string),
+			UserTagPolicyOnExistingNodes: d.Get("tag_policy_on_existing_nodes").(string),
+			TaintPolicyOnExistingNodes:   d.Get("taint_policy_on_existing_nodes").(string),
 		},
 	}
 	return &updateOpts, nil

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
@@ -123,6 +123,12 @@ type CreateSpec struct {
 	PodSecurityGroups []PodSecurityGroupSpec `json:"podSecurityGroups,omitempty"`
 	// Node security group configurations
 	CustomSecurityGroups []string `json:"customSecurityGroups,omitempty"`
+	// label (k8s tag) policy on existing nodes
+	LabelPolicyOnExistingNodes string `json:"labelPolicyOnExistingNodes,omitempty"`
+	// tag policy on existing nodes
+	UserTagPolicyOnExistingNodes string `json:"userTagsPolicyOnExistingNodes,omitempty"`
+	// taint policy on existing nodes
+	TaintPolicyOnExistingNodes string `json:"taintPolicyOnExistingNodes,omitempty"`
 }
 
 type PodSecurityGroupSpec struct {
@@ -241,6 +247,12 @@ type UpdateSpec struct {
 	InitialNodeCount *int `json:"initialNodeCount" required:"true"`
 	// Auto scaling parameters
 	Autoscaling AutoscalingSpec `json:"autoscaling"`
+	// label (k8s tag) policy on existing nodes
+	LabelPolicyOnExistingNodes string `json:"labelPolicyOnExistingNodes,omitempty"`
+	// tag policy on existing nodes
+	UserTagPolicyOnExistingNodes string `json:"userTagsPolicyOnExistingNodes,omitempty"`
+	// taint policy on existing nodes
+	TaintPolicyOnExistingNodes string `json:"taintPolicyOnExistingNodes,omitempty"`
 }
 
 // ToNodePoolUpdateMap builds an update body based on UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/results.go
@@ -61,6 +61,12 @@ type Spec struct {
 	PodSecurityGroups []PodSecurityGroupSpec `json:"podSecurityGroups"`
 	// Node security group configurations
 	CustomSecurityGroups []string `json:"customSecurityGroups"`
+	// label (k8s tag) policy on existing nodes
+	LabelPolicyOnExistingNodes string `json:"labelPolicyOnExistingNodes"`
+	// tag policy on existing nodes
+	UserTagPolicyOnExistingNodes string `json:"userTagsPolicyOnExistingNodes"`
+	// taint policy on existing nodes
+	TaintPolicyOnExistingNodes string `json:"taintPolicyOnExistingNodes"`
 }
 
 type AutoscalingSpec struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/smn/v2/subscriptions/results.go
@@ -11,13 +11,19 @@ type Subscription struct {
 }
 
 type SubscriptionGet struct {
-	TopicUrn        string `json:"topic_urn"`
-	Protocol        string `json:"protocol"`
-	SubscriptionUrn string `json:"subscription_urn"`
-	Owner           string `json:"owner"`
-	Endpoint        string `json:"endpoint"`
-	Remark          string `json:"remark"`
-	Status          int    `json:"status"`
+	TopicUrn        string         `json:"topic_urn"`
+	Protocol        string         `json:"protocol"`
+	SubscriptionUrn string         `json:"subscription_urn"`
+	Owner           string         `json:"owner"`
+	Endpoint        string         `json:"endpoint"`
+	Remark          string         `json:"remark"`
+	Status          int            `json:"status"`
+	FilterPolicies  []FilterPolicy `json:"filter_polices"`
+}
+
+type FilterPolicy struct {
+	Name         string   `json:"name"`
+	StringEquals []string `json:"string_equals"`
 }
 
 // Extract will get the subscription object out of the commonResult object.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240725031404-c60513eac6ef
+# github.com/chnsz/golangsdk v0.0.0-20240727071004-05a10c5e2c21
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodePool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodePool -timeout 360m -parallel 4
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== RUN   TestAccNodePool_tagsLabelsTaints
=== PAUSE TestAccNodePool_tagsLabelsTaints
=== RUN   TestAccNodePool_volume_encryption
=== PAUSE TestAccNodePool_volume_encryption
=== RUN   TestAccNodePool_prePaid
=== PAUSE TestAccNodePool_prePaid
=== RUN   TestAccNodePool_SecurityGroups
=== PAUSE TestAccNodePool_SecurityGroups
=== RUN   TestAccNodePool_serverGroup
=== PAUSE TestAccNodePool_serverGroup
=== RUN   TestAccNodePool_storage
=== PAUSE TestAccNodePool_storage
=== CONT  TestAccNodePool_basic
=== CONT  TestAccNodePool_SecurityGroups
=== CONT  TestAccNodePool_volume_encryption
=== CONT  TestAccNodePool_prePaid
=== CONT  TestAccNodePool_volume_encryption
    acceptance.go:1121: This environment does not support KMS tests
--- SKIP: TestAccNodePool_volume_encryption (0.01s)
=== CONT  TestAccNodePool_storage
=== CONT  TestAccNodePool_prePaid
    acceptance.go:821: This environment does not support prepaid tests
--- SKIP: TestAccNodePool_prePaid (0.01s)
=== CONT  TestAccNodePool_tagsLabelsTaints
--- PASS: TestAccNodePool_SecurityGroups (812.63s)
=== CONT  TestAccNodePool_serverGroup
--- PASS: TestAccNodePool_storage (832.67s)
--- PASS: TestAccNodePool_tagsLabelsTaints (918.63s)
--- PASS: TestAccNodePool_basic (1302.34s)
--- PASS: TestAccNodePool_serverGroup (801.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1614.086s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
