### PR TITLE
feat(dataarts/api): add new resource to debug APIs

### DIFF
--- a/docs/resources/dataarts_dataservice_api_debug.md
+++ b/docs/resources/dataarts_dataservice_api_debug.md
@@ -1,0 +1,74 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_api_debug"
+description: |-
+  Use this resource to debug API for DataArts Data Service within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_api_debug
+
+Use this resource to debug API for DataArts Data Service within HuaweiCloud.
+
+-> 1. Only exclusive API can be debugged.
+   <br>2. This resource is only a one-time action resource for debugging the API. Deleting this resource will not clear
+   the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "debug_api_id" {}
+variable "exclusive_cluster_id" {}
+
+# The API already has an request parameter and names 'test_request_field'.
+resource "huaweicloud_dataarts_dataservice_api_debug" "test" {
+  workspace_id = var.workspace_id
+  api_id       = var.debug_api_id
+  instance_id  = var.exclusive_cluster_id
+
+  params = jsonencode({
+    "page_num": "1",     # Default parameter
+    "page_size": "100",  # Default parameter
+    "test_request_field": "{\"foo\": \"bar\"}"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the ID of workspace where the API is located.
+
+  Changing this parameter will create a new resource.
+
+* `api_id` - (Required, String, ForceNew) Specifies the ID of the catalog where the API is located.
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the exclusive cluster ID.
+  Changing this parameter will create a new resource.
+
+* `params` - (Optional, String, ForceNew) Specifies the request parameters in which to debug the API, in JSON format.
+  Changing this parameter will create a new resource.
+
+  -> There are two default and required parameter `page_num` and `page_size` that need to be defined.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also request ID for this debug operation.
+
+* `url` - The result detail of this API debug.
+
+* `result` - The ID of the catalog where the API is located.
+
+* `timeout` - The timeout of this API debug.
+
+* `request_header` - The request header of this API debug result, in JSON format.
+
+* `response_header` - The response header of this API debug result, in JSON format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1576,9 +1576,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_security_permission_set_member":    dataarts.ResourceSecurityPermissionSetMember(),
 			"huaweicloud_dataarts_security_permission_set_privilege": dataarts.ResourceSecurityPermissionSetPrivilege(),
 			// DataArts DataService
-			"huaweicloud_dataarts_dataservice_api":     dataarts.ResourceDataServiceApi(),
-			"huaweicloud_dataarts_dataservice_app":     dataarts.ResourceDataServiceApp(),
-			"huaweicloud_dataarts_dataservice_catalog": dataarts.ResourceDatatServiceCatalog(),
+			"huaweicloud_dataarts_dataservice_api":       dataarts.ResourceDataServiceApi(),
+			"huaweicloud_dataarts_dataservice_api_debug": dataarts.ResourceDataServiceApiDebug(),
+			"huaweicloud_dataarts_dataservice_app":       dataarts.ResourceDataServiceApp(),
+			"huaweicloud_dataarts_dataservice_catalog":   dataarts.ResourceDatatServiceCatalog(),
 
 			"huaweicloud_mpc_transcoding_template":       mpc.ResourceTranscodingTemplate(),
 			"huaweicloud_mpc_transcoding_template_group": mpc.ResourceTranscodingTemplateGroup(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -331,6 +331,7 @@ var (
 	HW_AS_INSTANCE_ID          = os.Getenv("HW_AS_INSTANCE_ID")
 	HW_AS_LIFECYCLE_HOOK_NAME  = os.Getenv("HW_AS_LIFECYCLE_HOOK_NAME")
 
+	// Common
 	HW_DATAARTS_WORKSPACE_ID                               = os.Getenv("HW_DATAARTS_WORKSPACE_ID")
 	HW_DATAARTS_CDM_NAME                                   = os.Getenv("HW_DATAARTS_CDM_NAME")
 	HW_DATAARTS_MANAGER_ID                                 = os.Getenv("HW_DATAARTS_MANAGER_ID")
@@ -343,11 +344,16 @@ var (
 	HW_DATAARTS_BUILTIN_RULE_ID                            = os.Getenv("HW_DATAARTS_BUILTIN_RULE_ID")
 	HW_DATAARTS_BUILTIN_RULE_NAME                          = os.Getenv("HW_DATAARTS_BUILTIN_RULE_NAME")
 	HW_DATAARTS_SUBJECT_ID                                 = os.Getenv("HW_DATAARTS_SUBJECT_ID")
-	HW_DATAARTS_CONNECTION_NAME                            = os.Getenv("HW_DATAARTS_CONNECTION_NAME")
 	HW_DATAARTS_ARCHITECTURE_USER_ID                       = os.Getenv("HW_DATAARTS_ARCHITECTURE_USER_ID")
 	HW_DATAARTS_ARCHITECTURE_USER_NAME                     = os.Getenv("HW_DATAARTS_ARCHITECTURE_USER_NAME")
 	HW_DATAARTS_SECURITY_PERMISSSIONSET_MEMBER_OBJECT_ID   = os.Getenv("HW_DATAARTS_SECURITY_PERMISSSIONSET_MEMBER_OBJECT_ID")
 	HW_DATAARTS_SECURITY_PERMISSSIONSET_MEMBER_OBJECT_NAME = os.Getenv("HW_DATAARTS_SECURITY_PERMISSSIONSET_MEMBER_OBJECT_NAME")
+	// Management Center
+	HW_DATAARTS_CONNECTION_ID   = os.Getenv("HW_DATAARTS_CONNECTION_ID")
+	HW_DATAARTS_CONNECTION_NAME = os.Getenv("HW_DATAARTS_CONNECTION_NAME")
+	// Data Service
+	HW_DATAARTS_REVIEWER_NAME  = os.Getenv("HW_DATAARTS_REVIEWER_NAME")
+	HW_DATAARTS_LTS_QUEUE_NAME = os.Getenv("HW_DATAARTS_LTS_QUEUE_NAME")
 
 	HW_EVS_AVAILABILITY_ZONE_GPSSD2 = os.Getenv("HW_EVS_AVAILABILITY_ZONE_GPSSD2")
 	HW_EVS_AVAILABILITY_ZONE_ESSD2  = os.Getenv("HW_EVS_AVAILABILITY_ZONE_ESSD2")
@@ -1740,6 +1746,20 @@ func TestAccPreCheckDataArtsWorkSpaceID(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckDataArtsReviewerName(t *testing.T) {
+	if HW_DATAARTS_REVIEWER_NAME == "" {
+		t.Skip("HW_DATAARTS_REVIEWER_NAME must be set for DataService tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDataArtsRelatedLtsQueueName(t *testing.T) {
+	if HW_DATAARTS_LTS_QUEUE_NAME == "" {
+		t.Skip("HW_DATAARTS_LTS_QUEUE_NAME must be set for the DataService tests")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckDataArtsManagerID(t *testing.T) {
 	if HW_DATAARTS_MANAGER_ID == "" {
 		t.Skip("This environment does not support DataArts Studio permission set tests")
@@ -1796,6 +1816,13 @@ func TestAccPreCheckDataArtsSubjectID(t *testing.T) {
 func TestAccPreCheckDataArtsConnectionName(t *testing.T) {
 	if HW_DATAARTS_CONNECTION_NAME == "" {
 		t.Skip("HW_DATAARTS_CONNECTION_NAME must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDataArtsConnectionID(t *testing.T) {
+	if HW_DATAARTS_CONNECTION_ID == "" {
+		t.Skip("HW_DATAARTS_CONNECTION_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_api_debug_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_api_debug_test.go
@@ -1,0 +1,141 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataServiceApiDebug_basic(t *testing.T) {
+	rName := "huaweicloud_dataarts_dataservice_api_debug.test"
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsReviewerName(t)
+			acceptance.TestAccPreCheckDataArtsRelatedLtsQueueName(t)
+		},
+
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataServiceApiDebug_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "url", "/demo"),
+					resource.TestCheckResourceAttrSet(rName, "result"),
+					resource.TestCheckResourceAttrSet(rName, "timeout"),
+					resource.TestCheckResourceAttrSet(rName, "request_header"),
+					resource.TestCheckResourceAttrSet(rName, "response_header"),
+				),
+			},
+		},
+	})
+}
+
+// Deploy an API that can be used for debugging, publishing, and authorization.
+func testAccDataServiceApi_develop() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_dataservice_instances" "test" {
+  workspace_id = "%[1]s"
+}
+
+# Under root path.
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  dlm_type     = "EXCLUSIVE"
+}
+
+resource "huaweicloud_dli_database" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_dli_table" "test" {
+  database_name = huaweicloud_dli_database.test.name
+  name          = "%[2]s"
+  data_location = "DLI"
+
+  columns {
+    name = "test_request_field"
+    type = "string"
+  }
+  columns {
+    name = "test_response_field"
+    type = "string"
+  }
+}
+
+resource "huaweicloud_dataarts_dataservice_api" "test" {
+  workspace_id = "%[1]s"
+  dlm_type     = "EXCLUSIVE"
+
+  type         = "API_SPECIFIC_TYPE_CONFIGURATION"
+  catalog_id   = huaweicloud_dataarts_dataservice_catalog.test.id
+  name         = "%[2]s"
+  auth_type    = "NONE"
+  manager      = "%[3]s"
+  path         = "/demo"
+  protocol     = "PROTOCOL_TYPE_HTTPS"
+  request_type = "REQUEST_TYPE_POST"
+  visibility   = "WORKSPACE"
+
+  request_params {
+    name      = "test_request_field"
+    position  = "REQUEST_PARAMETER_POSITION_BODY"
+    type      = "REQUEST_PARAMETER_TYPE_STRING"
+    necessary = true
+  }
+
+  datasource_config {
+    type          = "DLI"
+    connection_id = "%[4]s"
+    queue         = "%[5]s"
+    database      = huaweicloud_dli_database.test.name
+    datatable     = huaweicloud_dli_table.test.name
+
+    backend_params {
+      name     = "test_request_field"
+      mapping  = "test_request_field"
+      condition = "CONDITION_TYPE_EQ"
+    }
+
+    response_params {
+      name  = "test_response_field"
+      type  = "REQUEST_PARAMETER_TYPE_STRING"
+      field = "test_response_field"
+    }
+  }
+}
+
+`, acceptance.HW_DATAARTS_WORKSPACE_ID,
+		name,
+		acceptance.HW_DATAARTS_REVIEWER_NAME,
+		acceptance.HW_DATAARTS_CONNECTION_ID,
+		acceptance.HW_DATAARTS_LTS_QUEUE_NAME)
+}
+
+func testAccDataServiceApiDebug_basic() string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_debug" "test" {
+  workspace_id = "%[2]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+
+  params = jsonencode({
+    "page_num": "1",
+    "page_size": "100",
+    "test_request_field": "{\"foo\": \"bar\"}"
+  })
+}
+`, testAccDataServiceApi_develop(), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_debug.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_debug.go
@@ -1,0 +1,237 @@
+package dataarts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio POST /v1/{project_id}/service/apis/{api_id}/instances/{instance_id}/test
+func ResourceDataServiceApiDebug() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDataServiceApiDebugCreate,
+		ReadContext:   resourceDataServiceApiDebugRead,
+		DeleteContext: resourceDataServiceApiDebugDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the API is located.`,
+			},
+
+			// Parameters in request header
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the workspace to which the API belongs.`,
+			},
+
+			// Arguments
+			"api_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the catalog where the API is located.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The exclusive cluster ID.`,
+			},
+			"params": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  `The request parameters in which to debug the API, in JSON format.`,
+				ValidateFunc: validation.StringIsJSON,
+			},
+			// Sometimes, debug requests may be affected by network fluctuations and time out.
+			// Retry as appropriate to resolve the issue.
+			"max_retries": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  3,
+				Description: utils.SchemaDesc(
+					`The maximum retry number of the API debug operation.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+
+			// Attributes
+			"url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The request URL of this API debug operation.`,
+			},
+			"result": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The result detail of this API debug operation.`,
+			},
+			"timeout": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The timeout of this API debug operation.`,
+			},
+			"request_header": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The request header of this API debug operation.`,
+			},
+			"response_header": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The response header of this API debug operation.`,
+			},
+		},
+	}
+}
+
+func buildApiDebugBodyParams(params string) map[string]interface{} {
+	parsedParams := make(map[string]interface{})
+	err := json.Unmarshal([]byte(params), &parsedParams)
+	if err != nil {
+		log.Printf("[ERROR] Invalid type of the debug parameters, not json format")
+	}
+	return map[string]interface{}{
+		"paras": parsedParams,
+	}
+}
+
+func debugApi(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl     = "v1/{project_id}/service/apis/{api_id}/instances/{instance_id}/test"
+		workspaceId = d.Get("workspace_id").(string)
+		apiId       = d.Get("api_id").(string)
+		instanceId  = d.Get("instance_id").(string)
+	)
+	debugPath := client.Endpoint + httpUrl
+	debugPath = strings.ReplaceAll(debugPath, "{project_id}", client.ProjectID)
+	debugPath = strings.ReplaceAll(debugPath, "{api_id}", apiId)
+	debugPath = strings.ReplaceAll(debugPath, "{instance_id}", instanceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    workspaceId,
+			"Dlm-Type":     "EXCLUSIVE",
+		},
+		JSONBody: buildApiDebugBodyParams(d.Get("params").(string)),
+	}
+
+	requestResp, err := client.Request("POST", debugPath, &opt)
+	if err != nil {
+		return nil, fmt.Errorf("error debugging API (%s): %s", apiId, err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving API debug result: %s", err)
+	}
+	return respBody, nil
+}
+
+func parseApiDebugHeaders(headers interface{}) interface{} {
+	jsonFilter, err := json.Marshal(headers)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert the header content, not json format")
+		return nil
+	}
+	return string(jsonFilter)
+}
+
+func apiDebugRetryFunc(client *golangsdk.ServiceClient, d *schema.ResourceData) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := debugApi(client, d)
+		if err != nil {
+			// After an error is identified, the log is recorded immediately and a retry is initiated.
+			// Returns the error at this time will cause the retry to be interrupted.
+			log.Printf("[ERROR] Failed to debug API, the error is: %s", err)
+			return nil, "DEBUG_FAILED", nil
+		}
+		return resp, "SUCCESS", nil
+	}
+}
+
+func resourceDataServiceApiDebugCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		maxRetries = d.Get("max_retries").(int)
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:        []string{"DEBUG_FAILED"},
+		Target:         []string{"SUCCESS"},
+		Refresh:        apiDebugRetryFunc(client, d),
+		Timeout:        d.Timeout(schema.TimeoutCreate),
+		PollInterval:   3 * time.Second,
+		NotFoundChecks: maxRetries,
+	}
+	resp, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error debugging API, %d retries have been made, the error messages has been recorded to the log file", maxRetries)
+	}
+	d.SetId(utils.PathSearch("requestId", resp, "").(string))
+
+	// Saving debug result in the CreateContext because of this resource do not have any query API to obtain the result.
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("url", utils.PathSearch("url", resp, "")),
+		d.Set("result", utils.PathSearch("result", resp, "")),
+		d.Set("timeout", utils.PathSearch("timecost", resp, "")),
+		d.Set("request_header", parseApiDebugHeaders(utils.PathSearch("requestHeader", resp, make(map[string]interface{})))),
+		d.Set("response_header", parseApiDebugHeaders(utils.PathSearch("responseHeader", resp, make(map[string]interface{})))),
+	)
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving API debug resource fields: %s", err)
+	}
+	return resourceDataServiceApiDebugRead(ctx, d, meta)
+}
+
+func resourceDataServiceApiDebugRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// This resource is only a one-time action resource for debugging the API.
+	// There is no API for the provider to query the API debug history.
+	return nil
+}
+
+func resourceDataServiceApiDebugDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for debugging the API. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We needs a resource to provide the available debug operation for DataService API.

For the retry logic, I has been validated as follows:
From 09:40 to 11:40, only two failed for one API during total 300 time tests (0.6%).
![image](https://github.com/user-attachments/assets/273a4558-3a02-456d-9e2a-55bfac75d063)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to debug APIs.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o dataarts -f TestAccDataServiceApiDebug_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataServiceApiDebug_basic -timeout 360m -parallel 5
=== RUN   TestAccDataServiceApiDebug_basic
=== PAUSE TestAccDataServiceApiDebug_basic
=== CONT  TestAccDataServiceApiDebug_basic
--- PASS: TestAccDataServiceApiDebug_basic (64.17s)
PASS
coverage: 11.0% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  64.220s coverage: 11.0% of statements in ./huaweicloud/services/dataarts
```

![image](https://github.com/user-attachments/assets/40464e50-fa63-468d-9f06-e506bf9ef249)

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
