### PR TITLE
fix(dataarts): checkdeleted not be triggered for reviewer and subject

### DIFF
--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_reviewer.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_reviewer.go
@@ -17,6 +17,8 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var workspaceIdNotFound = "DLG.0818"
+
 // @API DataArtsStudio POST /v2/{project_id}/design/approvals/users
 // @API DataArtsStudio GET /v2/{project_id}/design/approvals/users
 // @API DataArtsStudio DELETE /v2/{project_id}/design/approvals/users
@@ -146,7 +148,8 @@ func resourceArchitectureReviewerRead(_ context.Context, d *schema.ResourceData,
 	}
 	getArchitectureReviewerResp, err := getArchitectureReviewerClient.Request("GET", getArchitectureReviewerPath, &getArchitectureReviewerOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "DataArts Studio architecture reviewer")
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "errors|[0].error_code", workspaceIdNotFound),
+			"DataArts Studio architecture reviewer")
 	}
 
 	getArchitectureReviewerRespBody, err := utils.FlattenResponse(getArchitectureReviewerResp)

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_subject.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_subject.go
@@ -190,7 +190,8 @@ func resourceArchitectureSubjectRead(_ context.Context, d *schema.ResourceData, 
 		path := fmt.Sprintf("%s&offset=%v", getSubjectPath, currentTotal)
 		getSubjectResp, err := getSubjectClient.Request("GET", path, &getSubjectOpt)
 		if err != nil {
-			return common.CheckDeletedDiag(d, err, "error retrieving DataArts Architecture subject")
+			return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "errors|[0].error_code", workspaceIdNotFound),
+				"error retrieving DataArts Architecture subject")
 		}
 		getSubjectRespBody, err := utils.FlattenResponse(getSubjectResp)
 		if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixed the issue that checkdeleted will not be triggered if the workspace ID does not exist.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dataarts TESTARGS='-run TestAccResourceArchitectureReviewer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceArchitectureReviewer_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceArchitectureReviewer_basic
=== PAUSE TestAccResourceArchitectureReviewer_basic
=== CONT  TestAccResourceArchitectureReviewer_basic
--- PASS: TestAccResourceArchitectureReviewer_basic (14.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  14.955s

make testacc TEST=./huaweicloud/services/acceptance/dataarts TESTARGS='-run TestAccResourceArchitectureSubject_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run TestAccResourceArchitectureSubject_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceArchitectureSubject_basic
=== PAUSE TestAccResourceArchitectureSubject_basic
=== CONT  TestAccResourceArchitectureSubject_basic
--- PASS: TestAccResourceArchitectureSubject_basic (24.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  24.646s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
     + **huaweicloud_dataarts_architecture_reviewer**
    ![image](https://github.com/user-attachments/assets/ecc27610-2ca7-4691-a7ec-a8dc9e64bc27)
     + **huaweicloud_dataarts_architecture_subject**
    ![image](https://github.com/user-attachments/assets/2a267eef-cfab-44bf-92a0-434beafaddc4)

    ab. Related resources (parent resources workspace ID) not found
    + **huaweicloud_dataarts_architecture_reviewer**
   ![image](https://github.com/user-attachments/assets/422e718c-722b-4c1b-94b9-76449436abf9)
    + **huaweicloud_dataarts_architecture_subject**
   ![image](https://github.com/user-attachments/assets/97ecd6c1-60c2-4f58-b900-90c2d64b4ddd)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
