### PR TITLE
chore(checkdeleted): supports more functions to handle errors

### DIFF
--- a/huaweicloud/common/errors.go
+++ b/huaweicloud/common/errors.go
@@ -54,3 +54,87 @@ func ConvertExpected400ErrInto404Err(err error, errCodeKey string, specErrCodes 
 	log.Printf("[WARN] Unable to recognize expected error code (%s), want %v", errCode, specErrCodes)
 	return err
 }
+
+// ConvertExpected403ErrInto404Err is a method used to parsing 403 error and try to convert it to 404 error according
+// to the right error code.
+// Arguments:
+// + err: The error response obtained through HTTP/HTTPS request.
+// + errCodeKey: The key name of the error code in the error response body, e.g. 'error_code', 'err_code'.
+// + specErrCodes: One or more error codes that you wish to match against the current error, e.g. 'APIGW.0001'.
+// Notes: If you missing specErrCodes input, this function will convert all 403 errors into 404 errors.
+// How to use it:
+// + For the general cases, their error code key is 'error_code', and we should call as follow:
+//   - utils.ConvertExpected403ErrInto404Err(err, "error_code")
+//   - utils.ConvertExpected403ErrInto404Err(err, "error_code", "DWS.0001")
+//   - utils.ConvertExpected403ErrInto404Err(err, "error_code", []string{"DWS.0001", "DLM.3028"}...)
+func ConvertExpected403ErrInto404Err(err error, errCodeKey string, specErrCodes ...string) error {
+	var err403 golangsdk.ErrDefault403
+	if !errors.As(err, &err403) {
+		log.Printf("[WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault403', but got '%s'",
+			reflect.TypeOf(err).String())
+		return err
+	}
+	var apiError interface{}
+	if jsonErr := json.Unmarshal(err403.Body, &apiError); jsonErr != nil {
+		return err
+	}
+
+	errCode, searchErr := jmespath.Search(errCodeKey, apiError)
+	if searchErr != nil || errCode == nil {
+		log.Printf("[WARN] Unable to find the expected error code key (%s)", errCodeKey)
+		return err
+	}
+
+	if len(specErrCodes) < 1 {
+		log.Printf("[INFO] Identified 403 error parsed it as 404 error (without the error code control)")
+		return golangsdk.ErrDefault404{}
+	}
+	if errCodeStr, ok := errCode.(string); ok && utils.StrSliceContains(specErrCodes, errCodeStr) {
+		log.Printf("[INFO] Identified 403 error with code '%s' and parsed it as 404 error", errCode)
+		return golangsdk.ErrDefault404{}
+	}
+	log.Printf("[WARN] Unable to recognize expected error code (%s), want %v", errCode, specErrCodes)
+	return err
+}
+
+// ConvertExpected500ErrInto404Err is a method used to parsing 500 error and try to convert it to 404 error according
+// to the right error code.
+// Arguments:
+// + err: The error response obtained through HTTP/HTTPS request.
+// + errCodeKey: The key name of the error code in the error response body, e.g. 'error_code', 'err_code'.
+// + specErrCodes: One or more error codes that you wish to match against the current error, e.g. 'APIGW.0001'.
+// Notes: If you missing specErrCodes input, this function will convert all 500 errors into 404 errors.
+// How to use it:
+// + For the general cases, their error code key is 'error_code', and we should call as follow:
+//   - utils.ConvertExpected500ErrInto404Err(err, "error_code")
+//   - utils.ConvertExpected500ErrInto404Err(err, "error_code", "SCM.0016")
+//   - utils.ConvertExpected500ErrInto404Err(err, "error_code", []string{"SCM.0016", "SCM.0017"}...)
+func ConvertExpected500ErrInto404Err(err error, errCodeKey string, specErrCodes ...string) error {
+	var err500 golangsdk.ErrDefault500
+	if !errors.As(err, &err500) {
+		log.Printf("[WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault500', but got '%s'",
+			reflect.TypeOf(err).String())
+		return err
+	}
+	var apiError interface{}
+	if jsonErr := json.Unmarshal(err500.Body, &apiError); jsonErr != nil {
+		return err
+	}
+
+	errCode, searchErr := jmespath.Search(errCodeKey, apiError)
+	if searchErr != nil || errCode == nil {
+		log.Printf("[WARN] Unable to find the expected error code key (%s)", errCodeKey)
+		return err
+	}
+
+	if len(specErrCodes) < 1 {
+		log.Printf("[INFO] Identified 500 error parsed it as 404 error (without the error code control)")
+		return golangsdk.ErrDefault404{}
+	}
+	if errCodeStr, ok := errCode.(string); ok && utils.StrSliceContains(specErrCodes, errCodeStr) {
+		log.Printf("[INFO] Identified 500 error with code '%s' and parsed it as 404 error", errCode)
+		return golangsdk.ErrDefault404{}
+	}
+	log.Printf("[WARN] Unable to recognize expected error code (%s), want %v", errCode, specErrCodes)
+	return err
+}

--- a/huaweicloud/common/errors_test.go
+++ b/huaweicloud/common/errors_test.go
@@ -28,19 +28,19 @@ func TestErrorFunc_ConvertExpected400ErrInto404Err(t *testing.T) {
 		t.Fatalf("Unable to convert 400 error to 404 error, the result type of the convert function is: %s",
 			reflect.TypeOf(parseResult1).String())
 	}
-	// Step1: Check whether the function can normally recognize unexpected 403 error under follow input and
+	// Step2: Check whether the function can normally recognize unexpected 403 error under follow input and
 	// terminate subsequent processing, and directly return error.
 	parseResult2 := common.ConvertExpected400ErrInto404Err(input403Err, "error_code", "TESTERR.0002")
 	if _, ok := parseResult2.(golangsdk.ErrDefault404); ok {
 		t.Fatalf("The expected 403 error was not recognized and was incorrectly converted")
 	}
-	// Step2: Check whether the function can normally recognize unexpected error code key under follow input and
+	// Step3: Check whether the function can normally recognize unexpected error code key under follow input and
 	// terminate subsequent processing, and directly return error.
 	parseResult3 := common.ConvertExpected400ErrInto404Err(input400Err, "err_code", "TESTERR.0002")
 	if !reflect.DeepEqual(parseResult3, input400Err) {
 		t.Fatalf("Illegal recognition of unexpected error code key and convert the error to other type")
 	}
-	// Step1: Check whether the function can normally identify the expected error code (during a expected code list)
+	// Step4: Check whether the function can normally identify the expected error code (during a expected code list)
 	// under follow input and convert the 400 error into a 404 error.
 	parseResult4 := common.ConvertExpected400ErrInto404Err(input400Err, "error_code",
 		[]string{"TESTERR.0001", "TESTERR.0002"}...)
@@ -48,11 +48,107 @@ func TestErrorFunc_ConvertExpected400ErrInto404Err(t *testing.T) {
 		t.Fatalf("Unable to convert 400 error to 404 error, the result type of the convert function is: %s",
 			reflect.TypeOf(parseResult1).String())
 	}
-	// Step1: Check whether the function can normally recognize unexpected error code under (during a unmatched code
+	// Step5: Check whether the function can normally recognize unexpected error code under (during a unmatched code
 	// list) follow input and terminate subsequent processing, and directly return error.
 	parseResult5 := common.ConvertExpected400ErrInto404Err(input400Err, "error_code",
 		[]string{"TESTERR.0001", "TESTERR.0003"}...)
 	if !reflect.DeepEqual(parseResult5, input400Err) {
 		t.Fatalf("error converting 400 error to 404 error via a non-exist error code")
+	}
+}
+
+func TestErrorFunc_ConvertExpected403ErrInto404Err(t *testing.T) {
+	input403Err := golangsdk.ErrDefault403{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte("{\"error_code\": \"TESTERR.0002\", \"error_msg\": \"Resource not found\"}"),
+		},
+	}
+	input400Err := golangsdk.ErrDefault400{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte("{\"error_code\": \"TESTERR.0003\", \"error_msg\": \"Authentication Failed\"}"),
+		},
+	}
+
+	// Step1: Check whether the function can normally identify the expected error code under follow input and convert
+	// the 403 error into a 404 error.
+	parseResult1 := common.ConvertExpected403ErrInto404Err(input403Err, "error_code", "TESTERR.0002")
+	if _, ok := parseResult1.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 403 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult1).String())
+	}
+	// Step2: Check whether the function can normally recognize unexpected 400 error under follow input and
+	// terminate subsequent processing, and directly return error.
+	parseResult2 := common.ConvertExpected403ErrInto404Err(input400Err, "error_code", "TESTERR.0002")
+	if _, ok := parseResult2.(golangsdk.ErrDefault404); ok {
+		t.Fatalf("The expected 403 error was not recognized and was incorrectly converted")
+	}
+	// Step3: Check whether the function can normally recognize unexpected error code key under follow input and
+	// terminate subsequent processing, and directly return error.
+	parseResult3 := common.ConvertExpected403ErrInto404Err(input403Err, "err_code", "TESTERR.0002")
+	if !reflect.DeepEqual(parseResult3, input403Err) {
+		t.Fatalf("Illegal recognition of unexpected error code key and convert the error to other type")
+	}
+	// Step4: Check whether the function can normally identify the expected error code (during a expected code list)
+	// under follow input and convert the 403 error into a 404 error.
+	parseResult4 := common.ConvertExpected403ErrInto404Err(input403Err, "error_code",
+		[]string{"TESTERR.0001", "TESTERR.0002"}...)
+	if _, ok := parseResult4.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 403 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult1).String())
+	}
+	// Step5: Check whether the function can normally recognize unexpected error code under (during a unmatched code
+	// list) follow input and terminate subsequent processing, and directly return error.
+	parseResult5 := common.ConvertExpected403ErrInto404Err(input403Err, "error_code",
+		[]string{"TESTERR.0001", "TESTERR.0003"}...)
+	if !reflect.DeepEqual(parseResult5, input403Err) {
+		t.Fatalf("error converting 403 error to 404 error via a non-exist error code")
+	}
+}
+
+func TestErrorFunc_ConvertExpected500ErrInto404Err(t *testing.T) {
+	input500Err := golangsdk.ErrDefault500{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte("{\"error_code\": \"TESTERR.0002\", \"error_msg\": \"Resource not found\"}"),
+		},
+	}
+	input400Err := golangsdk.ErrDefault400{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte("{\"error_code\": \"TESTERR.0003\", \"error_msg\": \"Authentication Failed\"}"),
+		},
+	}
+
+	// Step1: Check whether the function can normally identify the expected error code under follow input and convert
+	// the 500 error into a 404 error.
+	parseResult1 := common.ConvertExpected500ErrInto404Err(input500Err, "error_code", "TESTERR.0002")
+	if _, ok := parseResult1.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 500 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult1).String())
+	}
+	// Step2: Check whether the function can normally recognize unexpected 400 error under follow input and
+	// terminate subsequent processing, and directly return error.
+	parseResult2 := common.ConvertExpected500ErrInto404Err(input400Err, "error_code", "TESTERR.0002")
+	if _, ok := parseResult2.(golangsdk.ErrDefault404); ok {
+		t.Fatalf("The expected 500 error was not recognized and was incorrectly converted")
+	}
+	// Step3: Check whether the function can normally recognize unexpected error code key under follow input and
+	// terminate subsequent processing, and directly return error.
+	parseResult3 := common.ConvertExpected500ErrInto404Err(input500Err, "err_code", "TESTERR.0002")
+	if !reflect.DeepEqual(parseResult3, input500Err) {
+		t.Fatalf("Illegal recognition of unexpected error code key and convert the error to other type")
+	}
+	// Step4: Check whether the function can normally identify the expected error code (during a expected code list)
+	// under follow input and convert the 500 error into a 404 error.
+	parseResult4 := common.ConvertExpected500ErrInto404Err(input500Err, "error_code",
+		[]string{"TESTERR.0001", "TESTERR.0002"}...)
+	if _, ok := parseResult4.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 500 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult1).String())
+	}
+	// Step5: Check whether the function can normally recognize unexpected error code under (during a unmatched code
+	// list) follow input and terminate subsequent processing, and directly return error.
+	parseResult5 := common.ConvertExpected500ErrInto404Err(input500Err, "error_code",
+		[]string{"TESTERR.0001", "TESTERR.0003"}...)
+	if !reflect.DeepEqual(parseResult5, input500Err) {
+		t.Fatalf("error converting 500 error to 404 error via a non-exist error code")
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Except 400 error, the 403 error and 500 error also needs the related functions to handle the errors.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports more functions to handle errors
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
go test -v -run=TestErrorFunc
=== RUN   TestErrorFunc_ConvertExpected400ErrInto404Err
2024/07/30 15:59:35 [INFO] Identified 400 error with code 'TESTERR.0002' and parsed it as 404 error
2024/07/30 15:59:35 [WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault400', but got 'golangsdk.ErrDefault403'
2024/07/30 15:59:35 [WARN] Unable to find the expected error code key (err_code)
2024/07/30 15:59:35 [INFO] Identified 400 error with code 'TESTERR.0002' and parsed it as 404 error
2024/07/30 15:59:35 [WARN] Unable to recognize expected error code (TESTERR.0002), want [TESTERR.0001 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertExpected400ErrInto404Err (0.00s)
=== RUN   TestErrorFunc_ConvertExpected403ErrInto404Err
2024/07/30 15:59:35 [INFO] Identified 403 error with code 'TESTERR.0002' and parsed it as 404 error
2024/07/30 15:59:35 [WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault403', but got 'golangsdk.ErrDefault400'
2024/07/30 15:59:35 [WARN] Unable to find the expected error code key (err_code)
2024/07/30 15:59:35 [INFO] Identified 403 error with code 'TESTERR.0002' and parsed it as 404 error
2024/07/30 15:59:35 [WARN] Unable to recognize expected error code (TESTERR.0002), want [TESTERR.0001 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertExpected403ErrInto404Err (0.00s)
=== RUN   TestErrorFunc_ConvertExpected500ErrInto404Err
2024/07/30 15:59:35 [INFO] Identified 500 error with code 'TESTERR.0002' and parsed it as 404 error
2024/07/30 15:59:35 [WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault500', but got 'golangsdk.ErrDefault400'
2024/07/30 15:59:35 [WARN] Unable to find the expected error code key (err_code)
2024/07/30 15:59:35 [INFO] Identified 500 error with code 'TESTERR.0002' and parsed it as 404 error
2024/07/30 15:59:35 [WARN] Unable to recognize expected error code (TESTERR.0002), want [TESTERR.0001 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertExpected500ErrInto404Err (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common        0.131s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
