### PR TITLE
fix(cbr/vaults): param auto_expand_enabled is unavailable

### DIFF
--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
@@ -223,6 +223,10 @@ func filterVaults(all []interface{}, d *schema.ResourceData) []interface{} {
 			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("billing.size", v, nil)) {
 			continue
 		}
+		if param, ok := d.GetOk("auto_expand_enabled"); ok &&
+			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("auto_expand", v, nil)) {
+			continue
+		}
 
 		rst = append(rst, v)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supplement the filter parameter 'auto_expand_enabled'.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supplement the filter parameter 'auto_expand_enabled'.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cbr' TESTARGS='-run=TestAccDataVaults_backupServer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cbr -v -run=TestAccDataVaults_backupServer -timeout 360m -parallel 4
=== RUN   TestAccDataVaults_backupServer
=== PAUSE TestAccDataVaults_backupServer
=== CONT  TestAccDataVaults_backupServer
--- PASS: TestAccDataVaults_backupServer (430.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       430.250s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
