### PR TITLE
feat(SecMaster): add resource playbook approval

### DIFF
--- a/docs/resources/secmaster_playbook_approval.md
+++ b/docs/resources/secmaster_playbook_approval.md
@@ -1,0 +1,49 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_playbook_approval"
+description: |-
+  Manages a SecMaster playbook approval resource within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_playbook_approval
+
+Manages a SecMaster playbook approval resource within HuaweiCloud.
+
+-> Destroying this resource will not change the status of the playbook approval resource.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "version_id" {}
+
+resource "huaweicloud_secmaster_playbook_approval" "test" {
+  workspace_id = var.workspace_id
+  version_id   = var.version_id
+  result       = "PASS"
+  content      = "ok"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the playbook belongs.
+
+* `version_id` - (Required, String, NonUpdatable) Specifies the version ID of the playbook.
+
+* `result` - (Optional, String) Specifies the result of playbook approval. The value can be **PASS** and **UN_PASS**.
+
+* `content` - (Optional, String) Specifies the content of the playbook approval.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1689,6 +1689,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_playbook_version":      secmaster.ResourcePlaybookVersion(),
 			"huaweicloud_secmaster_playbook_rule":         secmaster.ResourcePlaybookRule(),
 			"huaweicloud_secmaster_playbook_action":       secmaster.ResourcePlaybookAction(),
+			"huaweicloud_secmaster_playbook_approval":     secmaster.ResourcePlaybookApproval(),
 
 			"huaweicloud_servicestage_application":                 servicestage.ResourceApplication(),
 			"huaweicloud_servicestage_component_instance":          servicestage.ResourceComponentInstance(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -260,6 +260,7 @@ var (
 	// The SecMaster indicator ID
 	HW_SECMASTER_INDICATOR_TYPE_ID        = os.Getenv("HW_SECMASTER_INDICATOR_TYPE_ID")
 	HW_SECMASTER_INDICATOR_TYPE_ID_UPDATE = os.Getenv("HW_SECMASTER_INDICATOR_TYPE_ID_UPDATE")
+	HW_SECMASTER_UNAUDITED_VERSION_ID     = os.Getenv("HW_SECMASTER_UNAUDITED_VERSION_ID")
 
 	// The SecMaster workspace ID
 	HW_SECMASTER_PIPELINE_ID = os.Getenv("HW_SECMASTER_PIPELINE_ID")
@@ -1426,6 +1427,13 @@ func TestAccPreCheckSecMaster(t *testing.T) {
 		HW_SECMASTER_INDICATOR_TYPE_ID_UPDATE == "" {
 		t.Skip("HW_SECMASTER_WORKSPACE_ID, HW_SECMASTER_INDICATOR_TYPE_ID and HW_SECMASTER_INDICATOR_TYPE_ID_UPDATE" +
 			" must be set for SecMaster acceptance tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckSecMasterPlaybookApproval(t *testing.T) {
+	if HW_SECMASTER_WORKSPACE_ID == "" || HW_SECMASTER_UNAUDITED_VERSION_ID == "" {
+		t.Skip("HW_SECMASTER_WORKSPACE_ID and HW_SECMASTER_UNAUDITED_VERSION_ID must be set for SecMaster acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_playbook_approval_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_playbook_approval_test.go
@@ -1,0 +1,37 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccPlaybookApproval_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterPlaybookApproval(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testPlaybookApproval_basic(),
+			},
+		},
+	})
+}
+
+func testPlaybookApproval_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_secmaster_playbook_approval" "test" {
+  workspace_id = "%[1]s"
+  version_id   = "%[2]s"
+  result       = "PASS"
+  content      = "ok"
+}
+`, acceptance.HW_SECMASTER_WORKSPACE_ID, acceptance.HW_SECMASTER_UNAUDITED_VERSION_ID)
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_playbook_approval.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_playbook_approval.go
@@ -1,0 +1,114 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableParamsApproval = []string{"workspace_id", "version_id"}
+
+// @API SecMaster POST /v1/{project_id}/workspaces/{workspace_id}/soc/playbooks/versions/{version_id}/approval
+func ResourcePlaybookApproval() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePlaybookApprovalCreate,
+		UpdateContext: resourcePlaybookApprovalUpdate,
+		ReadContext:   resourcePlaybookApprovalRead,
+		DeleteContext: resourcePlaybookApprovalDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableParamsApproval),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the workspace to which the playbook belongs.`,
+			},
+			"version_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the version ID of the playbook.`,
+			},
+			"result": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the result of playbook approval.`,
+			},
+			"content": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the content of the playbook approval.`,
+			},
+		},
+	}
+}
+
+func resourcePlaybookApprovalCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		createPlaybookApprovalHttpUrl = "v1/{project_id}/workspaces/{workspace_id}/soc/playbooks/versions/{version_id}/approval"
+		createPlaybookApprovalProduct = "secmaster"
+	)
+	createPlaybookApprovalClient, err := cfg.NewServiceClient(createPlaybookApprovalProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	createPlaybookApprovalPath := createPlaybookApprovalClient.Endpoint + createPlaybookApprovalHttpUrl
+	createPlaybookApprovalPath = strings.ReplaceAll(createPlaybookApprovalPath, "{project_id}", createPlaybookApprovalClient.ProjectID)
+	createPlaybookApprovalPath = strings.ReplaceAll(createPlaybookApprovalPath, "{workspace_id}", d.Get("workspace_id").(string))
+	createPlaybookApprovalPath = strings.ReplaceAll(createPlaybookApprovalPath, "{version_id}", d.Get("version_id").(string))
+
+	createPlaybookApprovalOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	createPlaybookApprovalOpt.JSONBody = map[string]interface{}{
+		"result":  utils.ValueIgnoreEmpty(d.Get("result")),
+		"content": utils.ValueIgnoreEmpty(d.Get("content")),
+	}
+
+	_, err = createPlaybookApprovalClient.Request("POST", createPlaybookApprovalPath, &createPlaybookApprovalOpt)
+	if err != nil {
+		return diag.Errorf("error creating playbook approval: %s", err)
+	}
+
+	d.SetId(d.Get("version_id").(string))
+
+	return nil
+}
+
+func resourcePlaybookApprovalRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourcePlaybookApprovalUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourcePlaybookApprovalDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for playbook approval resource. Deleting this resource will
+		not change the status of the currently playbook approval resource, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

1.  add a new resource to support playbook approval
2. The acceptance test coverage of the resource is *86.4%*.
![image](https://github.com/user-attachments/assets/a90d8fe4-ed8c-4744-b903-b73e71d82368)
3. This resource is only a one-time action resource，there is no **ReadContext**, **UpdateContext** and **DeleteContext** logical, and the following message will be prompted when deleting.
![image](https://github.com/user-attachments/assets/7dd9caea-c6fa-40d2-8bd2-17a35aef0f63)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
add resource playbook approval
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/secmaster" TESTARGS="-run TestAccPlaybookApproval_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccPlaybookApproval_basic -timeout 360m -parallel 4
=== RUN   TestAccPlaybookApproval_basic
=== PAUSE TestAccPlaybookApproval_basic
=== CONT  TestAccPlaybookApproval_basic
--- PASS: TestAccPlaybookApproval_basic (22.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 22.642s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

