### PR TITLE
feat(evs/volumes): support more filter parameters

### DIFF
--- a/docs/data-sources/evs_volumes.md
+++ b/docs/data-sources/evs_volumes.md
@@ -26,6 +26,13 @@ The following arguments are supported:
 * `region` - (Optional, String) Specifies the region in which to query the disk list.
   If omitted, the provider-level region will be used.
 
+* `volume_id` - (Optional, String) Specifies the ID for the disk.
+
+* `name` - (Optional, String) Specifies the name for the disks. This field will undergo a fuzzy matching query, the
+  query result is for all disks whose names contain this value.
+
+* `volume_type_id` - (Optional, String) Specifies the type ID for the disks.
+
 * `availability_zone` - (Optional, String) Specifies the availability zone for the disks.
 
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID for filtering.

--- a/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_volumes_test.go
+++ b/huaweicloud/services/acceptance/evs/data_source_huaweicloud_evs_volumes_test.go
@@ -24,6 +24,11 @@ func TestAccEvsVolumesDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "volumes.#", "5"),
+
+					resource.TestCheckOutput("is_volume_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_availability_zone_filter_useful", "true"),
+					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
 				),
 			},
 		},
@@ -101,6 +106,61 @@ data "huaweicloud_evs_volumes" "test" {
   availability_zone = data.huaweicloud_availability_zones.test.names[0]
   server_id         = huaweicloud_compute_instance.test.id
   status            = "in-use"
+}
+
+# Filter using volume ID
+data "huaweicloud_evs_volumes" "volume_id_filter" {
+  volume_id = data.huaweicloud_evs_volumes.test.volumes.0.id
+}
+
+locals {
+  volume_id = data.huaweicloud_evs_volumes.test.volumes.0.id
+}
+
+output "is_volume_id_filter_useful" {
+  value = length(data.huaweicloud_evs_volumes.volume_id_filter.volumes) > 0 && alltrue(
+    [for v in data.huaweicloud_evs_volumes.volume_id_filter.volumes[*].id : v == local.volume_id]
+  )
+}
+
+# Filter using name
+data "huaweicloud_evs_volumes" "name_filter" {
+  name = data.huaweicloud_evs_volumes.test.volumes.0.name
+}
+
+# The name parameter is a fuzzy query, so only the number of query results is verified
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_evs_volumes.name_filter.volumes) > 0
+}
+
+# Filter using availability_zone
+data "huaweicloud_evs_volumes" "availability_zone_filter" {
+  availability_zone = data.huaweicloud_evs_volumes.test.volumes.0.availability_zone
+}
+
+locals {
+  availability_zone = data.huaweicloud_evs_volumes.test.volumes.0.availability_zone
+}
+
+output "is_availability_zone_filter_useful" {
+  value = length(data.huaweicloud_evs_volumes.availability_zone_filter.volumes) > 0 && alltrue(
+    [for v in data.huaweicloud_evs_volumes.availability_zone_filter.volumes[*].availability_zone : v == local.availability_zone]
+  )
+}
+
+# Filter using enterprise_project_id
+data "huaweicloud_evs_volumes" "enterprise_project_id_filter" {
+  enterprise_project_id = data.huaweicloud_evs_volumes.test.volumes.0.enterprise_project_id
+}
+
+locals {
+  enterprise_project_id = data.huaweicloud_evs_volumes.test.volumes.0.enterprise_project_id
+}
+
+output "is_enterprise_project_id_filter_useful" {
+  value = length(data.huaweicloud_evs_volumes.enterprise_project_id_filter.volumes) > 0 && alltrue(
+    [for v in data.huaweicloud_evs_volumes.enterprise_project_id_filter.volumes[*].enterprise_project_id : v == local.enterprise_project_id]
+  )
 }
 `, testAccEvsVolumesDataSource_base(rName))
 }

--- a/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
+++ b/huaweicloud/services/evs/data_source_huaweicloud_evs_volumes.go
@@ -27,6 +27,18 @@ func DataSourceEvsVolumesV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"volume_type_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"availability_zone": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -163,6 +175,9 @@ func DataSourceEvsVolumesV2() *schema.Resource {
 
 func buildQueryOpts(d *schema.ResourceData, cfg *config.Config) cloudvolumes.ListOpts {
 	result := cloudvolumes.ListOpts{
+		ID:                  d.Get("volume_id").(string),
+		Name:                d.Get("name").(string),
+		VolumeTypeID:        d.Get("volume_type_id").(string),
 		AvailabilityZone:    d.Get("availability_zone").(string),
 		EnterpriseProjectID: cfg.DataGetEnterpriseProjectID(d),
 		ServerID:            d.Get("server_id").(string),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support more filter parameters

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support more filter parameters


```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/evs" TESTARGS="-run TestAccEvsVolumesDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/evs -v -run TestAccEvsVolumesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccEvsVolumesDataSource_basic
=== PAUSE TestAccEvsVolumesDataSource_basic
=== CONT  TestAccEvsVolumesDataSource_basic
--- PASS: TestAccEvsVolumesDataSource_basic (380.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/evs       380.442s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
