### PR TITLE
chore(cts): remove CheckDeleted from CTS data source and add CheckDeleted to resource deletion

### DIFF
--- a/huaweicloud/services/cts/data_source_huaweicloud_cts_notifications.go
+++ b/huaweicloud/services/cts/data_source_huaweicloud_cts_notifications.go
@@ -10,7 +10,6 @@ import (
 
 	cts "github.com/huaweicloud/huaweicloud-sdk-go-v3/services/cts/v3/model"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -192,7 +191,7 @@ func dataSourceNotificationsRead(_ context.Context, d *schema.ResourceData, meta
 
 	response, err := ctsClient.ListNotifications(listOpts)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving CTS key event notification")
+		return diag.Errorf("error retrieving CTS key event notification: %s", err)
 	}
 	randUUID, err := uuid.GenerateUUID()
 	if err != nil {

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_data_tracker.go
@@ -478,7 +478,10 @@ func resourceCTSDataTrackerDelete(_ context.Context, d *schema.ResourceData, met
 
 	_, err = ctsClient.DeleteTracker(&deleteOpts)
 	if err != nil {
-		return diag.Errorf("error deleting CTS data tracker %s: %s", trackerName, err)
+		return common.CheckDeletedDiag(d,
+			convertExpected403ErrInto404Err(err, "CTS.0013"),
+			fmt.Sprintf("error deleting CTS data tracker %s", trackerName),
+		)
 	}
 
 	return nil

--- a/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
+++ b/huaweicloud/services/cts/resource_huaweicloud_cts_notification.go
@@ -406,7 +406,7 @@ func resourceCTSNotificationDelete(_ context.Context, d *schema.ResourceData, me
 
 	_, err = ctsClient.DeleteNotification(&deleteOpts)
 	if err != nil {
-		return diag.Errorf("error deleting CTS key events notification: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting CTS key events notification")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
remove CheckDeleted from CTS data source and add CheckDeleted to resource deletion
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove CheckDeleted from CTS data source and add CheckDeleted to resource deletion
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSTracker"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSTracker -timeout 360m -parallel 1
=== RUN   TestAccCTSTracker_keepTracker
=== PAUSE TestAccCTSTracker_keepTracker
=== RUN   TestAccCTSTracker_deleteTracker
=== PAUSE TestAccCTSTracker_deleteTracker
=== CONT  TestAccCTSTracker_keepTracker
--- PASS: TestAccCTSTracker_keepTracker (46.30s)
=== CONT  TestAccCTSTracker_deleteTracker
--- PASS: TestAccCTSTracker_deleteTracker (31.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       77.412s

 make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSDataTracker"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSDataTracker -timeout 360m -parallel 1
=== RUN   TestAccCTSDataTracker_basic
=== PAUSE TestAccCTSDataTracker_basic
=== CONT  TestAccCTSDataTracker_basic
--- PASS: TestAccCTSDataTracker_basic (77.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       77.729s

make testacc TEST="./huaweicloud/services/acceptance/cts" TESTARGS="-run TestAccCTSNotification"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cts -v -run TestAccCTSNotification -timeout 360m -parallel 1
=== RUN   TestAccCTSNotification_basic
=== PAUSE TestAccCTSNotification_basic
=== CONT  TestAccCTSNotification_basic
--- PASS: TestAccCTSNotification_basic (56.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cts       56.920s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found

    1.resource_huaweicloud_cts_tracker
![image](https://github.com/user-attachments/assets/40cff3ed-5b97-4468-96fc-30a4b43d3245)

    2.resource_huaweicloud_cts_data_tracker
![image](https://github.com/user-attachments/assets/e4fb36d6-45a3-45f7-9e8c-6bd82b5076a3)

    3.resource_huaweicloud_cts_notification
![image](https://github.com/user-attachments/assets/5840c1d5-0b41-4de4-b203-9e4be9345f06)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    1.resource_huaweicloud_cts_tracker
![image](https://github.com/user-attachments/assets/4bb7dd3e-e7ad-403f-b56f-38c561b1d80a)

    2.resource_huaweicloud_cts_data_tracker
![image](https://github.com/user-attachments/assets/612ef42f-eaf7-45dc-9ec8-316391bb6156)

    3.resource_huaweicloud_cts_notification    
![image](https://github.com/user-attachments/assets/e1eabe3f-e0f4-428a-93d1-c2f3875cbb0e)



    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
