### PR TITLE
feat(Organizations): add organizations account invite decliner resource

### DIFF
--- a/docs/resources/organizations_account_invite_decliner.md
+++ b/docs/resources/organizations_account_invite_decliner.md
@@ -1,0 +1,35 @@
+---
+subcategory: "Organizations"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_organizations_account_invite_decliner"
+description: |-
+  Manages an Organizations account invite decliner resource within HuaweiCloud.
+---
+
+# huaweicloud_organizations_account_invite_decliner
+
+Manages an Organizations account invite decliner resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable invitation_id {}
+
+resource "huaweicloud_organizations_account_invite_decliner" "test"{
+  invitation_id = var.invitation_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `invitation_id` - (Required, String, ForceNew) Specifies the unique ID of an invitation (handshake).
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1927,6 +1927,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_organizations_account_associate":       organizations.ResourceAccountAssociate(),
 			"huaweicloud_organizations_account_invite":          organizations.ResourceAccountInvite(),
 			"huaweicloud_organizations_account_invite_accepter": organizations.ResourceAccountInviteAccepter(),
+			"huaweicloud_organizations_account_invite_decliner": organizations.ResourceAccountInviteDecliner(),
 			"huaweicloud_organizations_trusted_service":         organizations.ResourceTrustedService(),
 			"huaweicloud_organizations_policy":                  organizations.ResourcePolicy(),
 			"huaweicloud_organizations_policy_attach":           organizations.ResourcePolicyAttach(),

--- a/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_decliner_test.go
+++ b/huaweicloud/services/acceptance/organizations/resource_huaweicloud_organizations_account_invite_decliner_test.go
@@ -1,0 +1,37 @@
+package organizations
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccAccountInviteDecliner_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckMultiAccount(t)
+			acceptance.TestAccPreCheckOrganizationsOpen(t)
+			acceptance.TestAccPreCheckOrganizationsInvitationId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccountInviteDecliner_basic(),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func testAccountInviteDecliner_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_organizations_account_invite_decliner" "test" {
+  invitation_id = "%s"
+}
+`, acceptance.HW_ORGANIZATIONS_INVITATION_ID)
+}

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_decliner.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_decliner.go
@@ -1,0 +1,86 @@
+package organizations
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API Organizations POST /v1/received-handshakes/{handshake_id}/decline
+func ResourceAccountInviteDecliner() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAccountInviteDeclinerCreate,
+		ReadContext:   resourceAccountInviteDeclinerRead,
+		DeleteContext: resourceAccountInviteDeclinerDelete,
+
+		Schema: map[string]*schema.Schema{
+			"invitation_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `Specifies the unique ID of an invitation (handshake).`,
+			},
+		},
+	}
+}
+
+func resourceAccountInviteDeclinerCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v1/received-handshakes/{handshake_id}/decline"
+		product = "organizations"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Organizations client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{handshake_id}", d.Get("invitation_id").(string))
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating Organizations account invite decliner: %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := jmespath.Search("handshake.id", createRespBody)
+	if err != nil {
+		return diag.Errorf("error creating Organizations account invite decliner: ID is not found in API response")
+	}
+	d.SetId(id.(string))
+
+	return nil
+}
+
+func resourceAccountInviteDeclinerRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAccountInviteDeclinerDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting Organizations account invite decliner resource is not supported. The Organizations account " +
+		"invite decliner resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add organizations account invite decliner resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
  
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add organizations account invite decliner resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
