### PR TITLE
chore(vpn): remove CheckDeleted from VPN data source and add CheckDeleted to VPN resource deletion

### DIFF
--- a/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_health_check_test.go
+++ b/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_connection_health_check_test.go
@@ -33,9 +33,6 @@ func getConnectionHealthCheckResourceFunc(cfg *config.Config, state *terraform.R
 
 	getConnectionHealthCheckOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getConnectionHealthCheckResp, err := getConnectionHealthCheckClient.Request("GET", getConnectionHealthCheckPath, &getConnectionHealthCheckOpt)
 	if err != nil {

--- a/huaweicloud/services/vpn/data_source_huaweicloud_vpn_gateway_availability_zones.go
+++ b/huaweicloud/services/vpn/data_source_huaweicloud_vpn_gateway_availability_zones.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -74,16 +73,13 @@ func resourceVpnGatewayAZsRead(_ context.Context, d *schema.ResourceData, meta i
 
 	getGatewayAZsOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 
 	getGatewayAZsResp, err := getGatewayAZsClient.Request("GET", getGatewayAZsPath, &getGatewayAZsOpt)
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving VPN gateway AZs")
+		return diag.Errorf("error retrieving VPN gateway AZs: %s", err)
 	}
 
 	getGatewayAZsRespBody, err := utils.FlattenResponse(getGatewayAZsResp)

--- a/huaweicloud/services/vpn/data_source_huaweicloud_vpn_gateways.go
+++ b/huaweicloud/services/vpn/data_source_huaweicloud_vpn_gateways.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -280,16 +279,13 @@ func dataSourceGatewaysRead(_ context.Context, d *schema.ResourceData, meta inte
 
 	getGatewaysOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
-		MoreHeaders: map[string]string{"Content-Type": "application/json"},
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 
 	getGatewaysResp, err := getGatewaysClient.Request("GET", getGatewaysPath, &getGatewaysOpt)
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving Gateway")
+		return diag.Errorf("error retrieving VPN gateway: %s", err)
 	}
 
 	getGatewaysRespBody, err := utils.FlattenResponse(getGatewaysResp)

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
@@ -379,9 +379,6 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	createConnectionOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
 	}
 	createConnectionOpt.JSONBody = utils.RemoveNil(buildCreateConnectionBodyParams(d))
 	createConnectionResp, err := createConnectionClient.Request("POST", createConnectionPath, &createConnectionOpt)
@@ -947,13 +944,10 @@ func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 	deleteConnectionOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
 	_, err = deleteConnectionClient.Request("DELETE", deleteConnectionPath, &deleteConnectionOpt)
 	if err != nil {
-		return diag.Errorf("error deleting VPN connection: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting VPN connection")
 	}
 
 	err = deleteConnectionWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection_health_check.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection_health_check.go
@@ -85,9 +85,6 @@ func resourceConnectionHealthCheckCreate(ctx context.Context, d *schema.Resource
 
 	createConnectionHealthCheckOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
 	}
 	createConnectionHealthCheckOpt.JSONBody = utils.RemoveNil(buildCreateConnectionHealthCheckBodyParams(d))
 	createConnectionHealthCheckResp, err := createConnectionHealthCheckClient.Request("POST",
@@ -142,9 +139,6 @@ func resourceConnectionHealthCheckRead(_ context.Context, d *schema.ResourceData
 
 	getConnectionHealthCheckOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getConnectionHealthCheckResp, err := getConnectionHealthCheckClient.Request("GET",
 		getConnectionHealthCheckPath, &getConnectionHealthCheckOpt)
@@ -191,14 +185,14 @@ func resourceConnectionHealthCheckDelete(_ context.Context, d *schema.ResourceDa
 
 	deleteConnectionHealthCheckOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
 	_, err = deleteConnectionHealthCheckClient.Request("DELETE", deleteConnectionHealthCheckPath,
 		&deleteConnectionHealthCheckOpt)
 	if err != nil {
-		return diag.Errorf("error deleting ConnectionHealthCheck: %s", err)
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "VPN.0001"),
+			"error deleting ConnectionHealthCheck",
+		)
 	}
 
 	return nil

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_customer_gateway.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_customer_gateway.go
@@ -176,9 +176,6 @@ func resourceCustomerGatewayCreate(ctx context.Context, d *schema.ResourceData, 
 
 	createCustomerGatewayOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
 	}
 	createCustomerGatewayOpt.JSONBody = utils.RemoveNil(buildCreateCustomerGatewayBodyParams(d))
 	createCustomerGatewayResp, err := createCustomerGatewayClient.Request("POST", createCustomerGatewayPath, &createCustomerGatewayOpt)
@@ -252,9 +249,6 @@ func resourceCustomerGatewayRead(_ context.Context, d *schema.ResourceData, meta
 
 	getCustomerGatewayOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getCustomerGatewayResp, err := getCustomerGatewayClient.Request("GET", getCustomerGatewayPath, &getCustomerGatewayOpt)
 
@@ -318,9 +312,6 @@ func resourceCustomerGatewayUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		updateCustomerGatewayOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
 		}
 		updateCustomerGatewayOpt.JSONBody = utils.RemoveNil(buildUpdateCustomerGatewayBodyParams(d))
 		_, err = updateCustomerGatewayClient.Request("PUT", updateCustomerGatewayPath, &updateCustomerGatewayOpt)
@@ -378,13 +369,10 @@ func resourceCustomerGatewayDelete(_ context.Context, d *schema.ResourceData, me
 
 	deleteCustomerGatewayOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
 	_, err = deleteCustomerGatewayClient.Request("DELETE", deleteCustomerGatewayPath, &deleteCustomerGatewayOpt)
 	if err != nil {
-		return diag.Errorf("error deleting VPN customer gateway: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting VPN customer gateway")
 	}
 
 	return nil

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_gateway.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_gateway.go
@@ -450,9 +450,6 @@ func resourceGatewayCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	createGatewayOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
 	}
 	createGatewayOpt.JSONBody = utils.RemoveNil(buildCreateGatewayBodyParams(d, cfg))
 	createGatewayResp, err := createGatewayClient.Request("POST", createGatewayPath, &createGatewayOpt)
@@ -662,9 +659,6 @@ func createGatewayWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 
 			createGatewayWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
 			}
 			createGatewayWaitingResp, err := createGatewayWaitingClient.Request("GET", createGatewayWaitingPath, &createGatewayWaitingOpt)
 			if err != nil {
@@ -729,9 +723,6 @@ func resourceGatewayRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 	getGatewayOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getGatewayResp, err := getGatewayClient.Request("GET", getGatewayPath, &getGatewayOpt)
 
@@ -886,9 +877,6 @@ func resourceGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		updateGatewayOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
 		}
 		updateGatewayOpt.JSONBody = utils.RemoveNil(buildUpdateGatewayBodyParams(d))
 		_, err = updateGatewayClient.Request("PUT", updateGatewayPath, &updateGatewayOpt)
@@ -1009,9 +997,6 @@ func updateGatewayWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 
 			updateGatewayWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
 			}
 			updateGatewayWaitingResp, err := updateGatewayWaitingClient.Request("GET", updateGatewayWaitingPath, &updateGatewayWaitingOpt)
 			if err != nil {
@@ -1073,13 +1058,10 @@ func resourceGatewayDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	deleteGatewayOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
 	_, err = deleteGatewayClient.Request("DELETE", deleteGatewayPath, &deleteGatewayOpt)
 	if err != nil {
-		return diag.Errorf("error deleting VPN gateway: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting VPN gateway")
 	}
 
 	err = deleteGatewayWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
@@ -1112,9 +1094,6 @@ func deleteGatewayWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 
 			deleteGatewayWaitingOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
 			}
 			deleteGatewayWaitingResp, err := deleteGatewayWaitingClient.Request("GET", deleteGatewayWaitingPath, &deleteGatewayWaitingOpt)
 			if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
remove CheckDeleted from VPN data source and add CheckDeleted to VPN resource deletion
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. remove CheckDeleted from VPN data source and add CheckDeleted to VPN resource deletion
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccDatasourceVpnGatewayAZs_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccDatasourceVpnGatewayAZs_basic -timeout 360m -parallel 1
=== RUN   TestAccDatasourceVpnGatewayAZs_basic
=== PAUSE TestAccDatasourceVpnGatewayAZs_basic
=== CONT  TestAccDatasourceVpnGatewayAZs_basic
--- PASS: TestAccDatasourceVpnGatewayAZs_basic (11.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       11.612s

 make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccDatasourceGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccDatasourceGateway_basic -timeout 360m -parallel 1
=== RUN   TestAccDatasourceGateway_basic
=== PAUSE TestAccDatasourceGateway_basic
=== CONT  TestAccDatasourceGateway_basic
--- PASS: TestAccDatasourceGateway_basic (415.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       415.566s

make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccConnection_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccConnection_ -timeout 360m -parallel 1
=== RUN   TestAccConnection_basic
=== PAUSE TestAccConnection_basic
=== RUN   TestAccConnection_policy
=== PAUSE TestAccConnection_policy
=== RUN   TestAccConnection_haRole
=== PAUSE TestAccConnection_haRole
=== CONT  TestAccConnection_basic
--- PASS: TestAccConnection_basic (565.93s)
=== CONT  TestAccConnection_haRole
--- PASS: TestAccConnection_haRole (408.92s)
=== CONT  TestAccConnection_policy
--- PASS: TestAccConnection_policy (427.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       1402.569s

make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run  TestAccCustomerGateway_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run  TestAccCustomerGateway_ -timeout 360m -parallel 1
=== RUN   TestAccCustomerGateway_basic_withDeprecatedFields
=== PAUSE TestAccCustomerGateway_basic_withDeprecatedFields
=== RUN   TestAccCustomerGateway_certificate_withDeprecatedFields
=== PAUSE TestAccCustomerGateway_certificate_withDeprecatedFields
=== RUN   TestAccCustomerGateway_basic
=== PAUSE TestAccCustomerGateway_basic
=== RUN   TestAccCustomerGateway_certificate
=== PAUSE TestAccCustomerGateway_certificate
=== CONT  TestAccCustomerGateway_basic_withDeprecatedFields
--- PASS: TestAccCustomerGateway_basic_withDeprecatedFields (42.23s)
=== CONT  TestAccCustomerGateway_basic
--- PASS: TestAccCustomerGateway_basic (41.01s)
=== CONT  TestAccCustomerGateway_certificate
--- PASS: TestAccCustomerGateway_certificate (43.60s)
=== CONT  TestAccCustomerGateway_certificate_withDeprecatedFields
--- PASS: TestAccCustomerGateway_certificate_withDeprecatedFields (39.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       166.741s

 make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run  TestAccGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run  TestAccGateway_basic -timeout 360m -parallel 1
=== RUN   TestAccGateway_basic
=== PAUSE TestAccGateway_basic
=== CONT  TestAccGateway_basic
--- PASS: TestAccGateway_basic (466.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       466.180s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
resource_huaweicloud_vpn_connection_health_check
![image](https://github.com/user-attachments/assets/80faf6ba-1597-43a4-b289-f108c3f3f9af)

resource_huaweicloud_vpn_connection
![image](https://github.com/user-attachments/assets/9ecedcaa-3b25-40fb-adeb-79521e0e8c25)

resource_huaweicloud_vpn_customer_gateway
![image](https://github.com/user-attachments/assets/8f116f01-03af-41b8-bbf0-9cdb2d5263de)

resource_huaweicloud_vpn_gateway
![image](https://github.com/user-attachments/assets/befad393-2968-44e9-a1ca-70af2438bcc0)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
resource_huaweicloud_vpn_connection_health_check
![image](https://github.com/user-attachments/assets/fe59ddd1-096d-49b1-8dfb-ca6991703ced)

resource_huaweicloud_vpn_connection
![image](https://github.com/user-attachments/assets/fdfe14b8-38c6-437a-901c-36c3cd4c6014)

resource_huaweicloud_vpn_customer_gateway
![image](https://github.com/user-attachments/assets/53d6758b-93c5-43e9-85aa-80403e2f3484)

resource_huaweicloud_vpn_gateway
![image](https://github.com/user-attachments/assets/40aa56f1-01c8-4368-8eba-3e14ecc7fa76)


 <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
