### PR TITLE
chore(CCM): chore private ca resource functions and specifications

### DIFF
--- a/docs/resources/ccm_private_ca.md
+++ b/docs/resources/ccm_private_ca.md
@@ -2,7 +2,8 @@
 subcategory: "Cloud Certificate Manager (CCM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ccm_private_ca"
-description: ""
+description: |
+  Manages CCM private CA resource within HuaweiCloud.
 ---
 
 # huaweicloud_ccm_private_ca
@@ -35,7 +36,7 @@ resource "huaweicloud_ccm_private_ca" "test_root" {
 }
 ```
 
-### create a suboridinate private CA
+### create a subordinate private CA
 
 ```hcl
 variable "root_issuer_id" {}
@@ -95,11 +96,11 @@ The following arguments are supported:
 * `issuer_id` - (Optional, String, ForceNew) Specifies the ID of the parent CA. It's **required** for subordinate CA.
   Changing this parameter will create a new resource.
 
-* `path_length` - (Optional, Int, ForceNew) Specifies the Length of the CA certificate path. The valid value is
+* `path_length` - (Optional, Int, ForceNew) Specifies the length of the CA certificate path. The valid value is
   limited between `0` to `6`. If you want to create a root CA, this parameter is **not required** by default and the
   value will be set to `7` in return. Changing this parameter will create a new resource.
 
-* `key_usages` - (Optional, List, ForceNew) Specifies the Key usage of private CA. It's a list of string.
+* `key_usages` - (Optional, List, ForceNew) Specifies the key usage of private CA. It's a list of string.
   Options are: **digitalSignature**, **nonRepudiation**, **keyEncipherment**, **dataEncipherment**, **keyAgreement**,
   **keyCertSign**, **cRLSign**, **encipherOnly**, **decipherOnly**.
   This parameter is [digitalSignature,keyCertSign,cRLSign] by default and only support to customize when you create a
@@ -125,7 +126,7 @@ The following arguments are supported:
   The valid values are **prePaid** and **postPaid**. Defaults to **postPaid**.
   Changing this parameter will create a new resource.
 
-* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto renew is enabled.
+* `auto_renew` - (Optional, String, ForceNew) Specifies whether auto-renew is enabled.
   Valid values are **true** and **false**. Defaults to **false**.
   Changing this parameter will create a new resource.
 
@@ -168,7 +169,9 @@ The `validity` block supports:
   and subordinate CA is no longer than 20 years. Changing this parameter will create a new resource. When creating a
   subordinate CA, the validity must less than the root CA.
 
-* `started_at` - (Optional, String, ForceNew) Specifies the start time of validity.
+* `started_at` - (Optional, String, ForceNew) Specifies the start time of validity. The value is a timestamp in milliseconds.
+  For example, `1722840237000` indicates `2024-08-05 14:43:57`. The value of `started_at` cannot be earlier than `5` minutes
+  from the current time.
   Changing this parameter will create a new resource.
 
 <a name="block-crl_configuration"></a>
@@ -200,17 +203,20 @@ In addition to all arguments above, the following attributes are exported:
 
 * `issuer_name` - The name of the parent CA. For a root CA, the value of this parameter is null.
 
-* `gen_mode` - The generation method of the private CA.
+* `gen_mode` - The generation method of the private CA. Valid values are as follows:
+  + **GENERATE**: The certificate is generated through the PCA system.
+  + **IMPORT**: The certificate is imported externally.
+  + **CSR**: The CSR is imported externally and issued by the internal CA. The private key is not managed in PCA.
 
 * `serial_number` - The serial number of the private CA.
 
-* `created_at` - The create time of the private CA.
+* `created_at` - The creation time of the private CA.
 
-* `expired_at` - The expire time of the private CA.
+* `expired_at` - The expiration time of the private CA.
 
 * `free_quota` - The free quota of the private certificate.
 
-* `crl_dis_point` - The address of the CRL file in the OBS bucket.
+* `crl_configuration/crl_dis_point` - The address of the CRL file in the OBS bucket.
 
 ## Timeouts
 
@@ -224,12 +230,12 @@ This resource provides the following timeouts configuration options:
 Private CA can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_ccm_private_ca.private_ca_1 bf30b49d-9d5e-4d91-bcf2-75bc73f67306
+$ terraform import huaweicloud_ccm_private_ca.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `validity`, `key_usages`, `pending_days`,
-`action`.
+`action`, `auto_renew`.
 It is generally recommended running `terraform plan` after importing a private CA. You can then decide if changes should
 be applied to it, also you can ignore changes as below.
 
@@ -239,7 +245,7 @@ resource "huaweicloud_ccm_private_ca" "test" {
 
   lifecycle {
     ignore_changes = [
-      validity, key_usages, pending_days, action,
+      validity, key_usages, pending_days, action, auto_renew,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_ca_export_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_ca_export_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourcePrivateCaExport_basic(t *testing.T) {
 	var (
 		dataSource = "data.huaweicloud_ccm_private_ca_export.test"
-		rName      = acceptance.RandomAccResourceName()
+		rName      = acceptance.RandomAccResourceNameWithDash()
 		dc         = acceptance.InitDataSourceCheck(dataSource)
 	)
 
@@ -40,5 +40,5 @@ func testDataSourceDataSourcePrivateCaExport_basic(name string) string {
 data "huaweicloud_ccm_private_ca_export" "test" {
   ca_id = huaweicloud_ccm_private_ca.test_root.id
 }
-`, tesPrivateCA_base(name))
+`, tesPrivateCA_postpaid_root(name))
 }

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_cas_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_cas_test.go
@@ -168,5 +168,5 @@ locals {
 output "sort_filter_is_useful" {
   value = local.asc_first_id == local.desc_last_id
 }
-`, tesPrivateCA_basic(name))
+`, tesPrivateCA_postpaid_subordinate(name))
 }

--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_ca_test.go
@@ -2,9 +2,11 @@ package ccm
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -45,10 +47,12 @@ func getPrivateCAResourceFunc(conf *config.Config, state *terraform.ResourceStat
 	return getPrivateCARespBody, nil
 }
 
-func TestAccCCMPrivateCA_basic(t *testing.T) {
-	var obj interface{}
-	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_ccm_private_ca.test_subordinate"
+func TestAccCCMPrivateCA_postpaid_root(t *testing.T) {
+	var (
+		obj          interface{}
+		rName        = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_ccm_private_ca.test_root"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -64,32 +68,49 @@ func TestAccCCMPrivateCA_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: tesPrivateCA_basic(rName),
+				Config: tesPrivateCA_postpaid_root(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "type", "SUBORDINATE"),
-					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.country", "CN"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
 					resource.TestCheckResourceAttr(resourceName, "key_algorithm", "RSA2048"),
+					resource.TestCheckResourceAttr(resourceName, "pending_days", "7"),
 					resource.TestCheckResourceAttr(resourceName, "signature_algorithm", "SHA512"),
+					resource.TestCheckResourceAttr(resourceName, "type", "ROOT"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "issuer_name"),
+					resource.TestCheckResourceAttrPair(resourceName, "crl_configuration.0.obs_bucket_name",
+						"huaweicloud_obs_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "crl_configuration.0.valid_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.common_name", fmt.Sprintf("%s-root", rName)),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.country", "CN"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.state", "GD"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.locality", "SZ"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.organization", "huawei"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.organizational_unit", "cloud"),
+					resource.TestCheckResourceAttr(resourceName, "validity.0.type", "DAY"),
+					resource.TestCheckResourceAttr(resourceName, "validity.0.value", "5"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVED"),
+
+					// attributes
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "serial_number"),
-					resource.TestCheckResourceAttrSet(resourceName, "gen_mode"),
-					resource.TestCheckResourceAttrSet(resourceName, "charging_mode"),
-					resource.TestCheckResourceAttrSet(resourceName, "free_quota"),
 					resource.TestCheckResourceAttrSet(resourceName, "expired_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "free_quota"),
+					resource.TestCheckResourceAttrSet(resourceName, "gen_mode"),
+					resource.TestCheckResourceAttrSet(resourceName, "path_length"),
+					resource.TestCheckResourceAttrSet(resourceName, "serial_number"),
 					resource.TestCheckResourceAttrSet(resourceName, "crl_configuration.0.crl_dis_point"),
+					resource.TestCheckResourceAttrSet(resourceName, "crl_configuration.0.crl_name"),
 				),
 			},
 			{
-				Config: testPrivateCA_updateTags(rName),
+				Config: tesPrivateCA_postpaid_rootUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo1", "bar1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "action", "disable"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DISABLED"),
 				),
 			},
 			{
@@ -97,126 +118,273 @@ func TestAccCCMPrivateCA_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"validity", "key_usages", "pending_days",
+					"validity", "key_usages", "pending_days", "action", "auto_renew",
 				},
 			},
 		},
 	})
 }
 
-// lintignore:AT004
-func tesPrivateCA_base(commonName string) string {
+func tesPrivateCA_postpaid_root(name string) string {
 	return fmt.Sprintf(`
-provider "huaweicloud" {
-  endpoints = {
-    ccm = "https://ccm.cn-north-4.myhuaweicloud.com/"
-  }
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s-crl-bucket"
+  acl           = "private"
+  force_destroy = true
 }
 
 resource "huaweicloud_ccm_private_ca" "test_root" {
-  type = "ROOT"
+  type                = "ROOT"
+  key_algorithm       = "RSA2048"
+  signature_algorithm = "SHA512"
+  pending_days        = "7"
+  charging_mode       = "postPaid"
+  auto_renew          = false
+
   distinguished_name {
-    common_name         = "%s-root"
+    common_name         = "%[1]s-root"
     country             = "CN"
     state               = "GD"
     locality            = "SZ"
     organization        = "huawei"
     organizational_unit = "cloud"
   }
-  key_algorithm       = "RSA2048"
-  signature_algorithm = "SHA512"
-  pending_days        = "7"
+
   validity {
     type  = "DAY"
     value = 5
   }
-}`, commonName)
-}
 
-// lintignore:AT004
-func tesPrivateCA_basic(commonName string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_obs_bucket" "test" {
-  bucket        = "%[2]s-crl-bucket"
-  acl           = "private"
-  force_destroy = true
-}
-
-resource "huaweicloud_ccm_private_ca" "test_subordinate" {
-  type = "SUBORDINATE"
-  distinguished_name {
-    common_name         = "%[2]s-subordinate"
-    country             = "CN"
-    state               = "GD"
-    locality            = "SZ"
-    organization        = "huawei"
-    organizational_unit = "cloud"
+  crl_configuration {
+    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
+    valid_days      = "7"
   }
-  key_algorithm       = "RSA2048"
-  issuer_id           = huaweicloud_ccm_private_ca.test_root.id
-  signature_algorithm = "SHA512"
-  pending_days        = "7"
-  validity {
-    type  = "DAY"
-    value = 1
-  }
+
   tags = {
     foo = "bar"
     key = "value"
   }
-  crl_configuration {
-    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
-    valid_days      = "7"
-  }
-}`, tesPrivateCA_base(commonName), commonName)
+}
+`, name)
 }
 
-// lintignore:AT004
-func testPrivateCA_updateTags(commonName string) string {
+func tesPrivateCA_postpaid_rootUpdate(name string) string {
 	return fmt.Sprintf(`
-%s
-
 resource "huaweicloud_obs_bucket" "test" {
-  bucket        = "%[2]s-crl-bucket"
+  bucket        = "%[1]s-crl-bucket"
   acl           = "private"
   force_destroy = true
 }
-  
-resource "huaweicloud_ccm_private_ca" "test_subordinate" {
-  type = "SUBORDINATE"
+
+resource "huaweicloud_ccm_private_ca" "test_root" {
+  type                = "ROOT"
+  key_algorithm       = "RSA2048"
+  signature_algorithm = "SHA512"
+  pending_days        = "7"
+  action              = "disable"
+  charging_mode       = "postPaid"
+  auto_renew          = false
+
   distinguished_name {
-    common_name         = "%[2]s-subordinate"
+    common_name         = "%[1]s-root"
     country             = "CN"
     state               = "GD"
     locality            = "SZ"
     organization        = "huawei"
     organizational_unit = "cloud"
   }
-  key_algorithm       = "RSA2048"
-  issuer_id           = huaweicloud_ccm_private_ca.test_root.id
-  signature_algorithm = "SHA512"
-  pending_days        = "7"
+
   validity {
     type  = "DAY"
-    value = 1
+    value = 5
   }
-  tags = {
-    foo1 = "bar1"
-    key1 = "value1"
-  }
+
   crl_configuration {
     obs_bucket_name = huaweicloud_obs_bucket.test.bucket
     valid_days      = "7"
   }
-}`, tesPrivateCA_base(commonName), commonName)
+
+  tags = {
+    foo_update = "bar_update"
+    key_update = "value_update"
+  }
+}
+`, name)
 }
 
-func TestAccCCMPrivateCA_prePaid(t *testing.T) {
-	var obj interface{}
-	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_ccm_private_ca.test_subordinate"
+func TestAccCCMPrivateCA_postpaid_subordinate(t *testing.T) {
+	var (
+		obj          interface{}
+		rName        = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_ccm_private_ca.test_subordinate"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getPrivateCAResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: tesPrivateCA_postpaid_subordinate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
+					resource.TestCheckResourceAttr(resourceName, "charging_mode", "postPaid"),
+					resource.TestCheckResourceAttr(resourceName, "key_algorithm", "RSA2048"),
+					resource.TestCheckResourceAttr(resourceName, "pending_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "signature_algorithm", "SHA512"),
+					resource.TestCheckResourceAttr(resourceName, "type", "SUBORDINATE"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttrPair(resourceName, "issuer_id", "huaweicloud_ccm_private_ca.test_root", "id"),
+					resource.TestCheckResourceAttr(resourceName, "key_usages.0", "cRLSign"),
+					resource.TestCheckResourceAttr(resourceName, "path_length", "5"),
+					resource.TestCheckResourceAttrPair(resourceName, "crl_configuration.0.obs_bucket_name",
+						"huaweicloud_obs_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "crl_configuration.0.valid_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.common_name", fmt.Sprintf("%s-subordinate", rName)),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.country", "CN"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.state", "GD"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.locality", "SZ"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.organization", "huawei"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.organizational_unit", "cloud"),
+					resource.TestCheckResourceAttr(resourceName, "validity.0.type", "DAY"),
+					resource.TestCheckResourceAttr(resourceName, "validity.0.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVED"),
+
+					// attributes
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "expired_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "issuer_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "free_quota"),
+					resource.TestCheckResourceAttrSet(resourceName, "gen_mode"),
+					resource.TestCheckResourceAttrSet(resourceName, "serial_number"),
+					resource.TestCheckResourceAttrSet(resourceName, "crl_configuration.0.crl_dis_point"),
+					resource.TestCheckResourceAttrSet(resourceName, "crl_configuration.0.crl_name"),
+				),
+			},
+			{
+				Config: tesPrivateCA_postpaid_subordinateUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value_update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"validity", "key_usages", "pending_days", "auto_renew",
+				},
+			},
+		},
+	})
+}
+
+func tesPrivateCA_postpaid_subordinate(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ccm_private_ca" "test_subordinate" {
+  type                  = "SUBORDINATE"
+  issuer_id             = huaweicloud_ccm_private_ca.test_root.id
+  key_algorithm         = "RSA2048"
+  signature_algorithm   = "SHA512"
+  pending_days          = "7"
+  charging_mode         = "postPaid"
+  auto_renew            = false
+  path_length           = 5
+  enterprise_project_id = "%[2]s"
+  key_usages            = ["cRLSign"]
+
+  distinguished_name {
+    common_name         = "%[3]s-subordinate"
+    country             = "CN"
+    state               = "GD"
+    locality            = "SZ"
+    organization        = "huawei"
+    organizational_unit = "cloud"
+  }
+
+  validity {
+    type  = "DAY"
+    value = 1
+  }
+
+  crl_configuration {
+    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
+    valid_days      = "7"
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, tesPrivateCA_postpaid_root(name), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}
+
+func tesPrivateCA_postpaid_subordinateUpdate(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ccm_private_ca" "test_subordinate" {
+  type                  = "SUBORDINATE"
+  issuer_id             = huaweicloud_ccm_private_ca.test_root.id
+  key_algorithm         = "RSA2048"
+  signature_algorithm   = "SHA512"
+  pending_days          = "7"
+  charging_mode         = "postPaid"
+  auto_renew            = false
+  path_length           = 5
+  enterprise_project_id = "%[2]s"
+  key_usages            = ["cRLSign"]
+
+  distinguished_name {
+    common_name         = "%[3]s-subordinate"
+    country             = "CN"
+    state               = "GD"
+    locality            = "SZ"
+    organization        = "huawei"
+    organizational_unit = "cloud"
+  }
+
+  validity {
+    type  = "DAY"
+    value = 1
+  }
+
+  crl_configuration {
+    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
+    valid_days      = "7"
+  }
+
+  tags = {
+    foo_update = "bar_update"
+    key_update = "value_update"
+  }
+}
+`, tesPrivateCA_postpaid_root(name), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, name)
+}
+
+func TestAccCCMPrivateCA_prepaid_root(t *testing.T) {
+	var (
+		obj          interface{}
+		rName        = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_ccm_private_ca.test_root"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -233,132 +401,58 @@ func TestAccCCMPrivateCA_prePaid(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: tesPrivateCA_prePaid(rName),
+				Config: tesPrivateCA_prepaid_root(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "type", "SUBORDINATE"),
-					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.country", "CN"),
-					resource.TestCheckResourceAttr(resourceName, "key_algorithm", "RSA2048"),
-					resource.TestCheckResourceAttr(resourceName, "signature_algorithm", "SHA512"),
+					resource.TestCheckResourceAttr(resourceName, "auto_renew", "false"),
 					resource.TestCheckResourceAttr(resourceName, "charging_mode", "prePaid"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
-					resource.TestCheckResourceAttrSet(resourceName, "issuer_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "serial_number"),
-					resource.TestCheckResourceAttrSet(resourceName, "gen_mode"),
-					resource.TestCheckResourceAttrSet(resourceName, "free_quota"),
-					resource.TestCheckResourceAttrSet(resourceName, "expired_at"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"validity", "key_usages", "pending_days",
-				},
-			},
-		},
-	})
-}
-
-// lintignore:AT004
-func tesPrivateCA_prePaid(commonName string) string {
-	return fmt.Sprintf(`
-provider "huaweicloud" {
-  endpoints = {
-    ccm = "https://ccm.cn-north-4.myhuaweicloud.com/"
-  }
-}
-
-resource "huaweicloud_ccm_private_ca" "test_root" {
-  type = "ROOT"
-  distinguished_name {
-    common_name         = "%s-root"
-    country             = "CN"
-    state               = "GD"
-    locality            = "SZ"
-    organization        = "huawei"
-    organizational_unit = "cloud"
-  }
-  key_algorithm       = "RSA2048"
-  signature_algorithm = "SHA512"
-  pending_days        = "7"
-  validity {
-    type  = "MONTH"
-    value = 2
-  }
-  charging_mode = "prePaid"
-}
-
-resource "huaweicloud_ccm_private_ca" "test_subordinate" {
-  type = "SUBORDINATE"
-  distinguished_name {
-    common_name         = "%s-subordinate"
-    country             = "CN"
-    state               = "GD"
-    locality            = "SZ"
-    organization        = "huawei"
-    organizational_unit = "cloud"
-  }
-  key_algorithm       = "RSA2048"
-  issuer_id           = huaweicloud_ccm_private_ca.test_root.id
-  signature_algorithm = "SHA512"
-  pending_days        = "7"
-  validity {
-    type  = "MONTH"
-    value = 1
-  }
-  charging_mode = "prePaid"
-}`, commonName, commonName)
-}
-
-func TestAccCCMPrivateCA_withoutParentCA(t *testing.T) {
-	var obj interface{}
-	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_ccm_private_ca.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getPrivateCAResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: tesPrivateCA_withoutParentCA(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "type", "ROOT"),
-					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.country", "CN"),
 					resource.TestCheckResourceAttr(resourceName, "key_algorithm", "RSA2048"),
+					resource.TestCheckResourceAttr(resourceName, "pending_days", "7"),
 					resource.TestCheckResourceAttr(resourceName, "signature_algorithm", "SHA512"),
+					resource.TestCheckResourceAttr(resourceName, "type", "ROOT"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
-					resource.TestCheckResourceAttr(resourceName, "action", "disable"),
-					resource.TestCheckResourceAttr(resourceName, "status", "DISABLED"),
-					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrPair(resourceName, "crl_configuration.0.obs_bucket_name",
+						"huaweicloud_obs_bucket.test", "bucket"),
+					resource.TestCheckResourceAttr(resourceName, "crl_configuration.0.valid_days", "7"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.common_name", fmt.Sprintf("%s-root", rName)),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.country", "CN"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.state", "GD"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.locality", "SZ"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.organization", "huawei"),
+					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.organizational_unit", "cloud"),
+					resource.TestCheckResourceAttr(resourceName, "validity.0.type", "MONTH"),
+					resource.TestCheckResourceAttr(resourceName, "validity.0.value", "1"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVED"),
+
+					// attributes
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(resourceName, "serial_number"),
-					resource.TestCheckResourceAttrSet(resourceName, "gen_mode"),
-					resource.TestCheckResourceAttrSet(resourceName, "charging_mode"),
-					resource.TestCheckResourceAttrSet(resourceName, "free_quota"),
 					resource.TestCheckResourceAttrSet(resourceName, "expired_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "free_quota"),
+					resource.TestCheckResourceAttrSet(resourceName, "gen_mode"),
+					resource.TestCheckResourceAttrSet(resourceName, "path_length"),
+					resource.TestCheckResourceAttrSet(resourceName, "serial_number"),
+					resource.TestCheckResourceAttrSet(resourceName, "enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "crl_configuration.0.crl_dis_point"),
+					resource.TestCheckResourceAttrSet(resourceName, "crl_configuration.0.crl_name"),
 				),
 			},
 			{
-				Config: tesPrivateCA_withoutParentCA_update(rName),
+				Config: tesPrivateCA_prepaid_rootUpdate1(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "tags.foo1", "bar1"),
-					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "action", "disable"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DISABLED"),
+				),
+			},
+			{
+				Config: tesPrivateCA_prepaid_rootUpdate2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "action", "enable"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVED"),
 				),
 			},
@@ -367,67 +461,268 @@ func TestAccCCMPrivateCA_withoutParentCA(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"validity", "key_usages", "pending_days", "action",
+					"validity", "key_usages", "pending_days", "action", "auto_renew",
 				},
 			},
 		},
 	})
 }
 
-// lintignore:AT004
-func tesPrivateCA_withoutParentCA(commonName string) string {
+func tesPrivateCA_prepaid_root(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_ccm_private_ca" "test" {
-  type = "ROOT"
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s-crl-bucket"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_ccm_private_ca" "test_root" {
+  type                = "ROOT"
+  key_algorithm       = "RSA2048"
+  signature_algorithm = "SHA512"
+  pending_days        = "7"
+  charging_mode       = "prePaid"
+  auto_renew          = false
+
   distinguished_name {
-    common_name         = "%s-root"
+    common_name         = "%[1]s-root"
     country             = "CN"
     state               = "GD"
     locality            = "SZ"
     organization        = "huawei"
     organizational_unit = "cloud"
   }
-  key_algorithm       = "RSA2048"
-  signature_algorithm = "SHA512"
-  pending_days        = "7"
-  action              = "disable"
+
   validity {
-    type  = "DAY"
-    value = 5
+    type  = "MONTH"
+    value = 1
+  }
+
+  crl_configuration {
+    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
+    valid_days      = "7"
   }
 
   tags = {
     foo = "bar"
     key = "value"
   }
-}`, commonName)
+}
+`, name)
 }
 
-// lintignore:AT004
-func tesPrivateCA_withoutParentCA_update(commonName string) string {
+func tesPrivateCA_prepaid_rootUpdate1(name string) string {
 	return fmt.Sprintf(`
-resource "huaweicloud_ccm_private_ca" "test" {
-  type = "ROOT"
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s-crl-bucket"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_ccm_private_ca" "test_root" {
+  type                = "ROOT"
+  key_algorithm       = "RSA2048"
+  signature_algorithm = "SHA512"
+  pending_days        = "7"
+  action              = "disable"
+  charging_mode       = "prePaid"
+  auto_renew          = false
+
   distinguished_name {
-    common_name         = "%s-root"
+    common_name         = "%[1]s-root"
     country             = "CN"
     state               = "GD"
     locality            = "SZ"
     organization        = "huawei"
     organizational_unit = "cloud"
   }
+
+  validity {
+    type  = "MONTH"
+    value = 1
+  }
+
+  crl_configuration {
+    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
+    valid_days      = "7"
+  }
+
+  tags = {
+    foo_update = "bar_update"
+    key_update = "value_update"
+  }
+}
+`, name)
+}
+
+func tesPrivateCA_prepaid_rootUpdate2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s-crl-bucket"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_ccm_private_ca" "test_root" {
+  type                = "ROOT"
   key_algorithm       = "RSA2048"
   signature_algorithm = "SHA512"
   pending_days        = "7"
   action              = "enable"
+  charging_mode       = "prePaid"
+  auto_renew          = false
+
+  distinguished_name {
+    common_name         = "%[1]s-root"
+    country             = "CN"
+    state               = "GD"
+    locality            = "SZ"
+    organization        = "huawei"
+    organizational_unit = "cloud"
+  }
+
+  validity {
+    type  = "MONTH"
+    value = 1
+  }
+
+  crl_configuration {
+    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
+    valid_days      = "7"
+  }
+}
+`, name)
+}
+
+// TestAccCCMPrivateCA_other using to test some special code
+func TestAccCCMPrivateCA_other(t *testing.T) {
+	var (
+		obj                 interface{}
+		rName               = acceptance.RandomAccResourceNameWithDash()
+		prepaidResourceName = "huaweicloud_ccm_private_ca.test_root"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		prepaidResourceName,
+		&obj,
+		getPrivateCAResourceFunc,
+	)
+
+	// test prepaid special code
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckChargingMode(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      tesPrivateCA_prepaid_other1(rName),
+				ExpectError: regexp.MustCompile("only `YEAR` or `MONTH` is supported when creating a prepaid private CA"),
+			},
+			{
+				Config: tesPrivateCA_prepaid_other2(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				ResourceName:      prepaidResourceName,
+				ExpectError:       regexp.MustCompile("Cannot import non-existent remote object"),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testOtherCaseImportIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"validity", "key_usages", "pending_days", "action", "auto_renew",
+				},
+			},
+		},
+	})
+}
+
+// testOtherCaseImportIdFunc using to import a non-exist resource ID
+func testOtherCaseImportIdFunc() resource.ImportStateIdFunc {
+	return func(_ *terraform.State) (string, error) {
+		randUUID, err := uuid.GenerateUUID()
+		if err != nil {
+			return "", fmt.Errorf("error generating uuid: %s", err)
+		}
+		return randUUID, nil
+	}
+}
+
+func tesPrivateCA_prepaid_other1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_private_ca" "prepaid_root" {
+  type                = "ROOT"
+  key_algorithm       = "RSA2048"
+  signature_algorithm = "SHA512"
+  pending_days        = "7"
+  charging_mode       = "prePaid"
+  auto_renew          = false
+
+  distinguished_name {
+    common_name         = "%[1]s-root"
+    country             = "CN"
+    state               = "GD"
+    locality            = "SZ"
+    organization        = "huawei"
+    organizational_unit = "cloud"
+  }
+
   validity {
     type  = "DAY"
-    value = 5
+    value = 2
   }
 
   tags = {
-    foo1 = "bar1"
-    key1 = "value1"
+    foo = "bar"
+    key = "value"
   }
-}`, commonName)
+}
+`, name)
+}
+
+func tesPrivateCA_prepaid_other2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_obs_bucket" "test" {
+  bucket        = "%[1]s-crl-bucket"
+  acl           = "private"
+  force_destroy = true
+}
+
+resource "huaweicloud_ccm_private_ca" "test_root" {
+  type                = "ROOT"
+  key_algorithm       = "RSA2048"
+  signature_algorithm = "SHA512"
+  pending_days        = "7"
+  charging_mode       = "prePaid"
+  auto_renew          = false
+
+  distinguished_name {
+    common_name         = "%[1]s-root"
+    country             = "CN"
+    state               = "GD"
+    locality            = "SZ"
+    organization        = "huawei"
+    organizational_unit = "cloud"
+  }
+
+  validity {
+    type  = "MONTH"
+    value = 1
+  }
+
+  crl_configuration {
+    obs_bucket_name = huaweicloud_obs_bucket.test.bucket
+    valid_days      = "7"
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, name)
 }

--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go
@@ -45,7 +45,7 @@ func getCertificateResourceFunc(conf *config.Config, state *terraform.ResourceSt
 
 func TestAccCcmPrivateCertificate_basic(t *testing.T) {
 	var obj interface{}
-	rName := acceptance.RandomAccResourceName()
+	rName := acceptance.RandomAccResourceNameWithDash()
 	resourceName := "huaweicloud_ccm_private_certificate.test"
 
 	rc := acceptance.InitResourceCheck(
@@ -136,7 +136,7 @@ resource "huaweicloud_ccm_private_certificate" "test" {
     fooo = "bar"
     keye = "value"
   }
-}`, tesPrivateCA_base(commonName), commonName)
+}`, tesPrivateCA_postpaid_root(commonName), commonName)
 }
 
 // lintignore:AT004
@@ -164,5 +164,5 @@ resource "huaweicloud_ccm_private_certificate" "test" {
     foo = "bar"
     key = "value"
   }
-}`, tesPrivateCA_base(commonName), commonName)
+}`, tesPrivateCA_postpaid_root(commonName), commonName)
 }

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go
@@ -225,55 +225,201 @@ func ResourcePrivateCertificateAuthority() *schema.Resource {
 	}
 }
 
-func resourcePrivateCACreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.Get("type").(string) == "SUBORDINATE" {
-		if _, ok := d.GetOk("issuer_id"); !ok {
-			return diag.Errorf("error: required parameter [%s] for creating subordinate CA is not set", "issuer_id")
+func buildPrepaidPrivateCABodyParams(d *schema.ResourceData, raw map[string]interface{}) map[string]interface{} {
+	periodType := 2
+	if raw["type"].(string) == "YEAR" {
+		periodType = 3
+	}
+
+	autoRenew := 0
+	if val, ok := d.GetOk("auto_renew"); ok && val == "true" {
+		autoRenew = 1
+	}
+
+	var productInfos []map[string]interface{}
+	productInfos = append(productInfos, map[string]interface{}{
+		"cloud_service_type": "hws.service.type.ccm",
+		"resource_type":      "hws.resource.type.pca.duration",
+		"resource_spec_code": "ca.duration",
+	})
+
+	bodyParams := map[string]interface{}{
+		"cloud_service_type": "hws.service.type.ccm",
+		"charging_mode":      0,
+		"period_type":        periodType,
+		"period_num":         raw["value"].(int),
+		"is_auto_renew":      autoRenew,
+		"is_auto_pay":        1,
+		"subscription_num":   1,
+		"product_infos":      productInfos,
+	}
+	return bodyParams
+}
+
+func createPrepaidPrivateCA(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	var (
+		httpUrl  = "v1/private-certificate-authorities/order"
+		rawArray = d.Get("validity").([]interface{})
+		raw      = rawArray[0].(map[string]interface{})
+		rawType  = raw["type"].(string)
+	)
+
+	if rawType != "YEAR" && rawType != "MONTH" {
+		return nil, fmt.Errorf("the validity type value (%s) is invalid, only `YEAR` or `MONTH` is supported when"+
+			" creating a prepaid private CA", rawType)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildPrepaidPrivateCABodyParams(d, raw),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CCM prepaid private CA: %s", err)
+	}
+	return utils.FlattenResponse(createResp)
+}
+
+func waitingForOrderComplete(ctx context.Context, bssClient *golangsdk.ServiceClient, orderID string, timeout time.Duration) error {
+	if err := common.WaitOrderComplete(ctx, bssClient, orderID, timeout); err != nil {
+		return err
+	}
+
+	if _, err := common.WaitOrderResourceComplete(ctx, bssClient, orderID, timeout); err != nil {
+		return fmt.Errorf("error waiting for order resource %s complete: %s", orderID, err)
+	}
+	return nil
+}
+
+func buildPrivateCARequestBodyDistinguishedName(rawParams interface{}) map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok && len(rawArray) > 0 {
+		raw := rawArray[0].(map[string]interface{})
+		return map[string]interface{}{
+			"common_name":         raw["common_name"],
+			"country":             raw["country"],
+			"state":               raw["state"],
+			"locality":            raw["locality"],
+			"organization":        raw["organization"],
+			"organizational_unit": raw["organizational_unit"],
 		}
+	}
+	return nil
+}
+
+func buildPrivateCARequestBodyValidity(rawParams interface{}) map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok && len(rawArray) > 0 {
+		raw := rawArray[0].(map[string]interface{})
+		return map[string]interface{}{
+			"type":       raw["type"],
+			"value":      raw["value"],
+			"start_from": utils.ValueIgnoreEmpty(raw["started_at"]),
+		}
+	}
+	return nil
+}
+
+func buildPrivateCARequestBodyKeyUsages(caType interface{}, rawParams interface{}) []interface{} {
+	rawArray, _ := rawParams.([]interface{})
+	if caType.(string) == "ROOT" || len(rawArray) == 0 {
+		return []interface{}{"digitalSignature", "keyCertSign", "cRLSign"}
+	}
+	return rawArray
+}
+
+func buildPrivateCARequestBodyCrlConfiguration(rawParams interface{}) map[string]interface{} {
+	if rawArray, ok := rawParams.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+		raw := rawArray[0].(map[string]interface{})
+		params := map[string]interface{}{
+			"enabled":         true,
+			"crl_name":        raw["crl_name"],
+			"obs_bucket_name": raw["obs_bucket_name"],
+			"valid_days":      raw["valid_days"],
+		}
+		return params
+	}
+	return nil
+}
+
+func buildCreateOrActivatePrivateCABodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"type":                  d.Get("type"),
+		"distinguished_name":    buildPrivateCARequestBodyDistinguishedName(d.Get("distinguished_name")),
+		"key_algorithm":         d.Get("key_algorithm"),
+		"signature_algorithm":   d.Get("signature_algorithm"),
+		"validity":              buildPrivateCARequestBodyValidity(d.Get("validity")),
+		"issuer_id":             utils.ValueIgnoreEmpty(d.Get("issuer_id")),
+		"path_length":           utils.ValueIgnoreEmpty(d.Get("path_length")),
+		"key_usages":            buildPrivateCARequestBodyKeyUsages(d.Get("type"), d.Get("key_usages")),
+		"crl_configuration":     buildPrivateCARequestBodyCrlConfiguration(d.Get("crl_configuration")),
+		"enterprise_project_id": cfg.GetEnterpriseProjectID(d),
+	}
+	return bodyParams
+}
+
+func activatePrivateCA(client *golangsdk.ServiceClient, d *schema.ResourceData, cfg *config.Config) error {
+	activatePath := client.Endpoint + "v1/private-certificate-authorities/{ca_id}/activate"
+	activatePath = strings.ReplaceAll(activatePath, "{ca_id}", d.Id())
+	activateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+		JSONBody: utils.RemoveNil(buildCreateOrActivatePrivateCABodyParams(d, cfg)),
+	}
+
+	_, err := client.Request("POST", activatePath, &activateOpt)
+	if err != nil {
+		return fmt.Errorf("error activating CCM private CA: %s", err)
+	}
+	return nil
+}
+
+func createPostpaidPrivateCA(client *golangsdk.ServiceClient, d *schema.ResourceData, cfg *config.Config) (interface{}, error) {
+	createPath := client.Endpoint + "v1/private-certificate-authorities"
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateOrActivatePrivateCABodyParams(d, cfg)),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CCM postpaid private CA: %s", err)
+	}
+	return utils.FlattenResponse(createResp)
+}
+
+func resourcePrivateCACreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if _, ok := d.GetOk("issuer_id"); !ok && d.Get("type").(string) == "SUBORDINATE" {
+		return diag.Errorf("the parameter `issuer_id` is required when creating a subordinate private CA")
 	}
 
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
-	var (
-		createPrivateCAHttpUrl = "v1/private-certificate-authorities"
-		createPrivateCAProduct = "ccm"
-	)
-	createPrivateCAClient, err := cfg.NewServiceClient(createPrivateCAProduct, region)
+	client, err := cfg.NewServiceClient("ccm", region)
 	if err != nil {
 		return diag.Errorf("error creating CCM client: %s", err)
 	}
-	createPrivateCAPath := createPrivateCAClient.Endpoint + createPrivateCAHttpUrl
-	createPrivateCAOpt := golangsdk.RequestOpts{
-		KeepResponseBody: true,
-	}
 
-	// if charging mode is pre-paid, need to order private CA first and then activate it.
 	if v, ok := d.GetOk("charging_mode"); ok && v.(string) == "prePaid" {
-		// order private CA
-		orderPrivateCAPath := createPrivateCAPath + "/order"
-		orderPrivateCAOpt := createPrivateCAOpt
-		parms, err := buildOrderPrivateCABodyParams(d)
+		createRespBody, err := createPrepaidPrivateCA(client, d)
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		orderPrivateCAOpt.JSONBody = utils.RemoveNil(parms)
-		orderPrivateCAResp, err := createPrivateCAClient.Request("POST", orderPrivateCAPath, &orderPrivateCAOpt)
-		if err != nil {
-			return diag.Errorf("error orderring CCM private CA: %s", err)
+
+		id, err := jmespath.Search("ca_ids|[0]", createRespBody)
+		if err != nil || id == nil {
+			return diag.Errorf("error creating CCM prepaid private CA: ID is not found in API response")
 		}
-		orderPrivateCARespBody, err := utils.FlattenResponse(orderPrivateCAResp)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-		ids, err := jmespath.Search("ca_ids", orderPrivateCARespBody)
-		if err != nil {
-			return diag.Errorf("error orderring CCM private CA: ID is not found in API response")
-		}
-		id := ids.([]interface{})[0]
 		d.SetId(id.(string))
-		orderID, err := jmespath.Search("order_id", orderPrivateCARespBody)
-		if err != nil {
-			return diag.Errorf("error orderring CCM private CA: order ID is not found in API response")
+
+		orderID, err := jmespath.Search("order_id", createRespBody)
+		if err != nil || orderID == nil {
+			return diag.Errorf("error creating CCM prepaid private CA: order ID is not found in API response")
 		}
 
 		// wait for order success
@@ -281,70 +427,37 @@ func resourcePrivateCACreate(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.Errorf("error creating BSS v2 client: %s", err)
 		}
-		err = common.WaitOrderComplete(ctx, bssClient, orderID.(string), d.Timeout(schema.TimeoutCreate))
-		if err != nil {
+		if err := waitingForOrderComplete(ctx, bssClient, orderID.(string), d.Timeout(schema.TimeoutCreate)); err != nil {
 			return diag.FromErr(err)
-		}
-		_, err = common.WaitOrderResourceComplete(ctx, bssClient, orderID.(string), d.Timeout(schema.TimeoutCreate))
-		if err != nil {
-			return diag.Errorf("error waiting for order resource %s complete: %s", orderID.(string), err)
 		}
 
 		// activate private CA
-		activePrivateCAPath := createPrivateCAPath + "/{ca_id}/activate"
-		activePrivateCAPath = strings.ReplaceAll(activePrivateCAPath, "{ca_id}", d.Id())
-		activePrivateCAOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			OkCodes: []int{
-				204,
-			},
+		if err := activatePrivateCA(client, d, cfg); err != nil {
+			return diag.FromErr(err)
 		}
-		activePrivateCAOpt.JSONBody = utils.RemoveNil(buildCreatePrivateCABodyParams(d, cfg))
-		_, err = createPrivateCAClient.Request("POST", activePrivateCAPath, &activePrivateCAOpt)
+	} else {
+		createPrivateCARespBody, err := createPostpaidPrivateCA(client, d, cfg)
 		if err != nil {
-			return diag.Errorf("error activating CCM private CA: %s", err)
-		}
-
-		createTagsHttpUrl := "v1/private-certificate-authorities/{ca_id}/tags/create"
-		tags := d.Get("tags").(map[string]interface{})
-		if err := createTags(id.(string), createPrivateCAClient, tags, createTagsHttpUrl, "{ca_id}"); err != nil {
 			return diag.FromErr(err)
 		}
 
-		if d.Get("action").(string) == "disable" {
-			if err := disablePrivateCA(createPrivateCAClient, d); err != nil {
-				return diag.FromErr(err)
-			}
+		id, err := jmespath.Search("ca_id", createPrivateCARespBody)
+		if err != nil || id == nil {
+			return diag.Errorf("error creating CCM postpaid private CA: ID is not found in API response")
 		}
-
-		return resourcePrivateCARead(ctx, d, meta)
+		d.SetId(id.(string))
 	}
 
-	// if charging mode is post-paid, then directly create
-	createPrivateCAOpt.JSONBody = utils.RemoveNil(buildCreatePrivateCABodyParams(d, cfg))
-	createPrivateCAResp, err := createPrivateCAClient.Request("POST", createPrivateCAPath, &createPrivateCAOpt)
-	if err != nil {
-		return diag.Errorf("error creating private CA: %s", err)
-	}
-	createPrivateCARespBody, err := utils.FlattenResponse(createPrivateCAResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	id, err := jmespath.Search("ca_id", createPrivateCARespBody)
-	if err != nil {
-		return diag.Errorf("error creating CCM private CA: ID is not found in API response")
-	}
-	d.SetId(id.(string))
-
+	// create tags
 	createTagsHttpUrl := "v1/private-certificate-authorities/{ca_id}/tags/create"
 	tags := d.Get("tags").(map[string]interface{})
-	if err := createTags(id.(string), createPrivateCAClient, tags, createTagsHttpUrl, "{ca_id}"); err != nil {
+	if err := createTags(d.Id(), client, tags, createTagsHttpUrl, "{ca_id}"); err != nil {
 		return diag.FromErr(err)
 	}
 
+	// disable private CA
 	if d.Get("action").(string) == "disable" {
-		if err := disablePrivateCA(createPrivateCAClient, d); err != nil {
+		if err := disablePrivateCA(client, d); err != nil {
 			return diag.FromErr(err)
 		}
 	}
@@ -384,175 +497,69 @@ func disablePrivateCA(client *golangsdk.ServiceClient, d *schema.ResourceData) e
 	return nil
 }
 
-func buildOrderPrivateCABodyParams(d *schema.ResourceData) (map[string]interface{}, error) {
-	rawArray := d.Get("validity").([]interface{})
-	raw := rawArray[0].(map[string]interface{})
-
-	// precheck period type
-	rawTyepe := raw["type"].(string)
-	if rawTyepe == "DAY" || rawTyepe == "HOUR" {
-		return nil, fmt.Errorf("error: required parameter [%s] for creating pre-paid CA is invalid",
-			"validity.period_type")
-	}
-
-	periodType := 2
-	if rawTyepe == "YEAR" {
-		periodType = 3
-	}
-	autoRenew := 0
-	if val, ok := d.GetOk("auto_renew"); ok && val == "true" {
-		autoRenew = 1
-	}
-
-	var prodecutInfos []map[string]interface{}
-	prodecutInfos = append(prodecutInfos, map[string]interface{}{
-		"cloud_service_type": "hws.service.type.ccm",
-		"resource_type":      "hws.resource.type.pca.duration",
-		"resource_spec_code": "ca.duration",
-	})
-	bodyParams := map[string]interface{}{
-		"cloud_service_type": "hws.service.type.ccm",
-		"charging_mode":      0,
-		"period_type":        periodType,
-		"period_num":         raw["value"].(int),
-		"is_auto_renew":      autoRenew,
-		"is_auto_pay":        1,
-		"subscription_num":   1,
-		"product_infos":      prodecutInfos,
-	}
-	return bodyParams, nil
-}
-
-func buildCreatePrivateCABodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
-	bodyParams := map[string]interface{}{
-		"type":                  d.Get("type"),
-		"distinguished_name":    buildPrivateCARequestBodyDistinguishedName(d.Get("distinguished_name")),
-		"key_algorithm":         d.Get("key_algorithm"),
-		"signature_algorithm":   d.Get("signature_algorithm"),
-		"validity":              buildPrivateCARequestBodyValidity(d.Get("validity")),
-		"issuer_id":             utils.ValueIgnoreEmpty(d.Get("issuer_id")),
-		"path_length":           utils.ValueIgnoreEmpty(d.Get("path_length")),
-		"key_usages":            buildPrivateCARequestBodyKeyUsages(d.Get("type"), d.Get("key_usages")),
-		"crl_configuration":     buildPrivateCARequestBodyCrlConfiguration(d.Get("crl_configuration")),
-		"enterprise_project_id": cfg.GetEnterpriseProjectID(d),
-	}
-	return bodyParams
-}
-
-func buildPrivateCARequestBodyDistinguishedName(rawParams interface{}) map[string]interface{} {
-	rawArray, _ := rawParams.([]interface{})
-	raw := rawArray[0].(map[string]interface{})
-	params := map[string]interface{}{
-		"common_name":         raw["common_name"],
-		"country":             raw["country"],
-		"state":               raw["state"],
-		"locality":            raw["locality"],
-		"organization":        raw["organization"],
-		"organizational_unit": raw["organizational_unit"],
-	}
-	return params
-}
-
-func buildPrivateCARequestBodyValidity(rawParams interface{}) map[string]interface{} {
-	rawArray, _ := rawParams.([]interface{})
-	raw := rawArray[0].(map[string]interface{})
-	params := map[string]interface{}{
-		"type":       raw["type"],
-		"value":      raw["value"],
-		"start_from": utils.ValueIgnoreEmpty(raw["started_at"]),
-	}
-	return params
-}
-
-func buildPrivateCARequestBodyKeyUsages(caType interface{}, rawParams interface{}) []interface{} {
-	rawArray, _ := rawParams.([]interface{})
-	if caType.(string) == "ROOT" || len(rawArray) == 0 {
-		return []interface{}{"digitalSignature", "keyCertSign", "cRLSign"}
-	}
-	return rawArray
-}
-
-func buildPrivateCARequestBodyCrlConfiguration(rawParams interface{}) map[string]interface{} {
-	if rawArray, ok := rawParams.([]interface{}); ok {
-		if len(rawArray) == 0 {
-			return nil
-		}
-		raw := rawArray[0].(map[string]interface{})
-		params := map[string]interface{}{
-			"enabled":         true,
-			"crl_name":        raw["crl_name"],
-			"obs_bucket_name": raw["obs_bucket_name"],
-			"valid_days":      raw["valid_days"],
-		}
-		return params
-	}
-	return nil
-}
-
-func resourcePrivateCARead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	var (
-		getPrivateCAHttpUrl = "v1/private-certificate-authorities/{ca_id}"
-		getPrivateCAProduct = "ccm"
-	)
-	getPrivateCAClient, err := cfg.NewServiceClient(getPrivateCAProduct, region)
-	if err != nil {
-		return diag.Errorf("error getting CCM client: %s", err)
-	}
-
-	getPrivateCAPath := getPrivateCAClient.Endpoint + getPrivateCAHttpUrl
+func readPrivateCA(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getPrivateCAPath := client.Endpoint + "v1/private-certificate-authorities/{ca_id}"
 	getPrivateCAPath = strings.ReplaceAll(getPrivateCAPath, "{ca_id}", d.Id())
-
 	getPrivateCAOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 	}
-	getPrivateCAResp, err := getPrivateCAClient.Request("GET", getPrivateCAPath, &getPrivateCAOpt)
+
+	getResp, err := client.Request("GET", getPrivateCAPath, &getPrivateCAOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving private CA")
+		return nil, err
 	}
-	getPrivateCARespBody, err := utils.FlattenResponse(getPrivateCAResp)
+	return utils.FlattenResponse(getResp)
+}
+
+func resourcePrivateCARead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ccm"
+	)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error creating CCM client: %s", err)
 	}
 
-	status := utils.PathSearch("status", getPrivateCARespBody, nil).(string)
+	getRespBody, err := readPrivateCA(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "PCA.10010002"),
+			"error retrieving CCM private CA")
+	}
+
+	status := utils.PathSearch("status", getRespBody, nil).(string)
 	if status == "DELETED" {
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving private CA")
 	}
 
-	chargingMode := "prePaid"
-	if utils.PathSearch("charging_mode", getPrivateCARespBody, float64(0)).(float64) == 1 {
-		chargingMode = "postPaid"
-	}
-
 	getTagsHttpUrl := "v1/private-certificate-authorities/{ca_id}/tags"
-	tags, err := getTags(d.Id(), getPrivateCAClient, getTagsHttpUrl, "{ca_id}")
+	tags, err := getTags(d.Id(), client, getTagsHttpUrl, "{ca_id}")
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("type", utils.PathSearch("type", getPrivateCARespBody, nil)),
-		d.Set("distinguished_name", flattenDistinguishedName(getPrivateCARespBody)),
-		d.Set("key_algorithm", utils.PathSearch("key_algorithm", getPrivateCARespBody, nil)),
-		d.Set("signature_algorithm", utils.PathSearch("signature_algorithm", getPrivateCARespBody, nil)),
-		d.Set("crl_configuration", flattenCrlConfiguration(getPrivateCARespBody)),
-		d.Set("issuer_id", utils.PathSearch("issuer_id", getPrivateCARespBody, nil)),
-		d.Set("issuer_name", utils.PathSearch("issuer_name", getPrivateCARespBody, nil)),
-		d.Set("path_length", utils.PathSearch("path_length", getPrivateCARespBody, nil)),
-		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", getPrivateCARespBody, nil)),
-		d.Set("status", utils.PathSearch("status", getPrivateCARespBody, nil)),
-		d.Set("charging_mode", chargingMode),
-		d.Set("gen_mode", utils.PathSearch("gen_mode", getPrivateCARespBody, nil)),
-		d.Set("serial_number", utils.PathSearch("serial_number", getPrivateCARespBody, nil)),
+		d.Set("type", utils.PathSearch("type", getRespBody, nil)),
+		d.Set("distinguished_name", flattenDistinguishedName(getRespBody)),
+		d.Set("key_algorithm", utils.PathSearch("key_algorithm", getRespBody, nil)),
+		d.Set("signature_algorithm", utils.PathSearch("signature_algorithm", getRespBody, nil)),
+		d.Set("crl_configuration", flattenCrlConfiguration(getRespBody)),
+		d.Set("issuer_id", utils.PathSearch("issuer_id", getRespBody, nil)),
+		d.Set("issuer_name", utils.PathSearch("issuer_name", getRespBody, nil)),
+		d.Set("path_length", utils.PathSearch("path_length", getRespBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", getRespBody, nil)),
+		d.Set("status", utils.PathSearch("status", getRespBody, nil)),
+		d.Set("charging_mode", flattenChargingMode(getRespBody)),
+		d.Set("gen_mode", utils.PathSearch("gen_mode", getRespBody, nil)),
+		d.Set("serial_number", utils.PathSearch("serial_number", getRespBody, nil)),
 		d.Set("created_at", utils.FormatTimeStampRFC3339(
-			int64(utils.PathSearch("create_time", getPrivateCARespBody, float64(0)).(float64))/1000, false)),
+			int64(utils.PathSearch("create_time", getRespBody, float64(0)).(float64))/1000, false)),
 		d.Set("expired_at", utils.FormatTimeStampRFC3339(
-			int64(utils.PathSearch("not_after", getPrivateCARespBody, float64(0)).(float64))/1000, false)),
-		d.Set("free_quota", utils.PathSearch("free_quota", getPrivateCARespBody, nil)),
+			int64(utils.PathSearch("not_after", getRespBody, float64(0)).(float64))/1000, false)),
+		d.Set("free_quota", utils.PathSearch("free_quota", getRespBody, nil)),
 		d.Set("tags", tags),
 	)
 
@@ -563,137 +570,144 @@ func resourcePrivateCARead(_ context.Context, d *schema.ResourceData, meta inter
 	return nil
 }
 
+func flattenChargingMode(getRespBody interface{}) string {
+	if utils.PathSearch("charging_mode", getRespBody, float64(0)).(float64) == 1 {
+		return "postPaid"
+	}
+	return "prePaid"
+}
+
 func flattenDistinguishedName(resp interface{}) []interface{} {
-	curJson := utils.PathSearch("distinguished_name", resp, make([]interface{}, 0))
-	curArray := curJson.(map[string]interface{})
+	curJson := utils.PathSearch("distinguished_name", resp, make(map[string]interface{}))
+	rawMap := curJson.(map[string]interface{})
 	rst := make([]interface{}, 0, 1)
 	rst = append(rst, map[string]interface{}{
-		"common_name":         curArray["common_name"],
-		"country":             curArray["country"],
-		"state":               curArray["state"],
-		"locality":            curArray["locality"],
-		"organization":        curArray["organization"],
-		"organizational_unit": curArray["organizational_unit"],
+		"common_name":         rawMap["common_name"],
+		"country":             rawMap["country"],
+		"state":               rawMap["state"],
+		"locality":            rawMap["locality"],
+		"organization":        rawMap["organization"],
+		"organizational_unit": rawMap["organizational_unit"],
 	})
 	return rst
 }
 
 func flattenCrlConfiguration(resp interface{}) []interface{} {
-	curJson := utils.PathSearch("crl_configuration", resp, make([]interface{}, 0))
-	curArray := curJson.(map[string]interface{})
+	curJson := utils.PathSearch("crl_configuration", resp, make(map[string]interface{}))
+	rawMap := curJson.(map[string]interface{})
 	rst := make([]interface{}, 0, 1)
 	rst = append(rst, map[string]interface{}{
-		"crl_name":        curArray["crl_name"],
-		"obs_bucket_name": curArray["obs_bucket_name"],
-		"valid_days":      curArray["valid_days"],
-		"crl_dis_point":   curArray["crl_dis_point"],
+		"crl_name":        rawMap["crl_name"],
+		"obs_bucket_name": rawMap["obs_bucket_name"],
+		"valid_days":      rawMap["valid_days"],
+		"crl_dis_point":   rawMap["crl_dis_point"],
 	})
 	return rst
 }
 
-func resourcePrivateCADelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	var (
-		privateCAHttpUrl = "v1/private-certificate-authorities/{ca_id}"
-		privateCAProduct = "ccm"
-	)
-	privateCAClient, err := cfg.NewServiceClient(privateCAProduct, region)
-	if err != nil {
-		return diag.Errorf("error deleting CCM client: %s", err)
+func deletePrepaidPrivateCA(ctx context.Context, client *golangsdk.ServiceClient, d *schema.ResourceData, cfg *config.Config) diag.Diagnostics {
+	if err := common.UnsubscribePrePaidResource(d, cfg, []string{d.Id()}); err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "CBC.30000067"),
+			"error unsubscribing CCM private CA")
 	}
-	privateCAPath := privateCAClient.Endpoint + privateCAHttpUrl
-	privateCAPath = strings.ReplaceAll(privateCAPath, "{ca_id}", d.Id())
-	privateCAOpt := golangsdk.RequestOpts{
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"PENDING"},
+		Target:  []string{"COMPLETED"},
+		Refresh: func() (interface{}, string, error) {
+			getRespBody, err := readPrivateCA(client, d)
+			if err != nil {
+				if hasErrorCode(err, "PCA.10010002") {
+					return "deleted", "COMPLETED", nil
+				}
+				return getRespBody, "ERROR", err
+			}
+
+			status := utils.PathSearch("status", getRespBody, "").(string)
+			if status == "" {
+				return getRespBody, "ERROR", fmt.Errorf("attribute `status` is not found in API response")
+			}
+
+			if status == "DELETED" {
+				return "deleted", "COMPLETED", nil
+			}
+			return "continue", "PENDING", nil
+		},
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        15 * time.Second,
+		PollInterval: 10 * time.Second,
+	}
+
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for CCM prepaid private CA (%s) to be deleted: %s", d.Id(), err)
+	}
+	return nil
+}
+
+func deletePostpaidPrivateCA(client *golangsdk.ServiceClient, d *schema.ResourceData) diag.Diagnostics {
+	getRespBody, err := readPrivateCA(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "PCA.10010002"),
+			"error retrieving CCM private CA")
+	}
+	status := utils.PathSearch("status", getRespBody, "").(string)
+	// Only CA in `PENDING` or `DISABLED` status can be deleted.
+	// When the CA is in `ACTIVED` or `EXPIRED` status, it needs to be disabled first and then deleted.
+	if status == "ACTIVED" || status == "EXPIRED" {
+		if err := disablePrivateCA(client, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if status == "DELETED" {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving CCM private CA")
+	}
+
+	deletePath := client.Endpoint + "v1/private-certificate-authorities/{ca_id}"
+	deletePath = strings.ReplaceAll(deletePath, "{ca_id}", d.Id())
+	deletePath += fmt.Sprintf("?pending_days=%v", d.Get("pending_days"))
+	deleteOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		OkCodes: []int{
 			200,
 			204,
 		},
 	}
-
-	// if charging mode is pre-paid, unsubscribe the order.
-	if v, ok := d.GetOk("charging_mode"); ok && v.(string) == "prePaid" {
-		if err := common.UnsubscribePrePaidResource(d, cfg, []string{d.Id()}); err != nil {
-			return diag.Errorf("error unsubscribing CCM private CA: %s", err)
-		}
-
-		stateConf := &resource.StateChangeConf{
-			Pending:      []string{"ACTIVED", "DISABLED", "EXPIRED"},
-			Target:       []string{"DELETED"},
-			Refresh:      privateCAStatusRefreshFunc(d.Id(), region, cfg),
-			Timeout:      d.Timeout(schema.TimeoutDelete),
-			Delay:        15 * time.Second,
-			PollInterval: 10 * time.Second,
-		}
-
-		_, err := stateConf.WaitForStateContext(ctx)
-		if err != nil {
-			return diag.Errorf("Error deleting private CA: %s", err)
-		}
-
-		return nil
-	}
-
-	// get and check CA status, if not expired or disable then disable it.
-	getPrivateCAResp, err := privateCAClient.Request("GET", privateCAPath, &privateCAOpt)
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error getting private CA: %s", err)
-	}
-	getPrivateCARespBody, err := utils.FlattenResponse(getPrivateCAResp)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	status := utils.PathSearch("status", getPrivateCARespBody, nil).(string)
-	if !(status == "EXPIRED" || status == "DISABLED") {
-		disablePrivateCAPath := privateCAPath + "/disable"
-		_, err = privateCAClient.Request("POST", disablePrivateCAPath, &privateCAOpt)
-		if err != nil {
-			return diag.Errorf("error disabling private CA: %s", err)
-		}
-	}
-
-	pendingDays := d.Get("pending_days")
-	privateCAPath += fmt.Sprintf("?pending_days=%v", pendingDays)
-
-	_, err = privateCAClient.Request("DELETE", privateCAPath, &privateCAOpt)
-	if err != nil {
-		return diag.Errorf("error deleting private CA: %s", err)
+		return diag.Errorf("error deleting postpaid private CA: %s", err)
 	}
 	return nil
 }
 
-func privateCAStatusRefreshFunc(id, region string, cfg *config.Config) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		getPrivateCAHttpUrl := "v1/private-certificate-authorities/{ca_id}"
-		getPrivateCAProduct := "ccm"
-		getPrivateCAClient, err := cfg.NewServiceClient(getPrivateCAProduct, region)
-		if err != nil {
-			return nil, "", fmt.Errorf("error creating CCM client: %s", err)
-		}
-
-		getPrivateCAPath := getPrivateCAClient.Endpoint + getPrivateCAHttpUrl
-		getPrivateCAPath = strings.ReplaceAll(getPrivateCAPath, "{ca_id}", id)
-		getPrivateCAOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-		}
-		getPrivateCAResp, err := getPrivateCAClient.Request("GET", getPrivateCAPath, &getPrivateCAOpt)
-		if err != nil && hasErrorCode(err, "PCA.10010002") {
-			return getPrivateCAResp, "DELETED", nil
-		}
-		getPrivateCARespBody, err := utils.FlattenResponse(getPrivateCAResp)
-		if err != nil {
-			return nil, "", err
-		}
-		status := utils.PathSearch("status", getPrivateCARespBody, "")
-		return getPrivateCARespBody, status.(string), nil
+func resourcePrivateCADelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "ccm"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
 	}
+
+	// if charging mode is pre-paid, unsubscribe the order.
+	if v, ok := d.GetOk("charging_mode"); ok && v.(string) == "prePaid" {
+		return deletePrepaidPrivateCA(ctx, client, d, cfg)
+	}
+	return deletePostpaidPrivateCA(client, d)
 }
 
 func resourcePrivateCAUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-	privateCAClient, err := cfg.NewServiceClient("ccm", region)
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("ccm", region)
 	if err != nil {
 		return diag.Errorf("error creating CCM client: %s", err)
 	}
@@ -707,7 +721,7 @@ func resourcePrivateCAUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		// remove old tags
 		if len(oMap) > 0 {
 			deleteTagsHttpUrl := "v1/private-certificate-authorities/{ca_id}/tags/delete"
-			if err = deleteTags(d.Id(), privateCAClient, oMap, deleteTagsHttpUrl, "{ca_id}"); err != nil {
+			if err = deleteTags(d.Id(), client, oMap, deleteTagsHttpUrl, "{ca_id}"); err != nil {
 				return diag.FromErr(err)
 			}
 		}
@@ -715,7 +729,7 @@ func resourcePrivateCAUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		// set new tags
 		if len(nMap) > 0 {
 			createTagsHttpUrl := "v1/private-certificate-authorities/{ca_id}/tags/create"
-			if err := createTags(d.Id(), privateCAClient, nMap, createTagsHttpUrl, "{ca_id}"); err != nil {
+			if err := createTags(d.Id(), client, nMap, createTagsHttpUrl, "{ca_id}"); err != nil {
 				return diag.FromErr(err)
 			}
 		}
@@ -725,9 +739,9 @@ func resourcePrivateCAUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		var actionErr error
 		switch d.Get("action").(string) {
 		case "enable":
-			actionErr = enablePrivateCA(privateCAClient, d)
+			actionErr = enablePrivateCA(client, d)
 		case "disable":
-			actionErr = disablePrivateCA(privateCAClient, d)
+			actionErr = disablePrivateCA(client, d)
 		}
 
 		if actionErr != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- chore private ca resource functions and specifications
- improve test case coverage.
- fix documentation issues.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

![image](https://github.com/user-attachments/assets/b9977e07-a308-43cf-a88c-be7423c83afa)


```
go test -v -coverprofile=coverage_1722926164055_TestAccCCMPrivateCA_.cov -coverpkg=./huaweicloud/services/ccm ./huaweicloud/services/acceptance/ccm -run TestAccCCMPrivateCA_ -timeout 360m -parallel 4
=== RUN   TestAccCCMPrivateCA_postpaid_root
=== PAUSE TestAccCCMPrivateCA_postpaid_root
=== RUN   TestAccCCMPrivateCA_postpaid_subordinate
=== PAUSE TestAccCCMPrivateCA_postpaid_subordinate
=== RUN   TestAccCCMPrivateCA_prepaid_root
=== PAUSE TestAccCCMPrivateCA_prepaid_root
=== RUN   TestAccCCMPrivateCA_other
=== PAUSE TestAccCCMPrivateCA_other
=== CONT  TestAccCCMPrivateCA_postpaid_root
=== CONT  TestAccCCMPrivateCA_prepaid_root
=== CONT  TestAccCCMPrivateCA_postpaid_subordinate
=== CONT  TestAccCCMPrivateCA_other
--- PASS: TestAccCCMPrivateCA_postpaid_root (46.73s)
--- PASS: TestAccCCMPrivateCA_postpaid_subordinate (66.32s)
--- PASS: TestAccCCMPrivateCA_other (101.74s)
--- PASS: TestAccCCMPrivateCA_prepaid_root (138.25s)
PASS
coverage: 24.1% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       138.313s        coverage: 24.1% of statements in ./huaweicloud/services/ccm
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/ccm' TESTARGS='-run TestAccCCMPrivateCA_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCCMPrivateCA_ -timeout 360m -parallel 4
=== RUN   TestAccCCMPrivateCA_postpaid_root
=== PAUSE TestAccCCMPrivateCA_postpaid_root
=== RUN   TestAccCCMPrivateCA_postpaid_subordinate
=== PAUSE TestAccCCMPrivateCA_postpaid_subordinate
=== RUN   TestAccCCMPrivateCA_prepaid_root
=== PAUSE TestAccCCMPrivateCA_prepaid_root
=== RUN   TestAccCCMPrivateCA_other
=== PAUSE TestAccCCMPrivateCA_other
=== CONT  TestAccCCMPrivateCA_postpaid_root
=== CONT  TestAccCCMPrivateCA_prepaid_root
=== CONT  TestAccCCMPrivateCA_other
=== CONT  TestAccCCMPrivateCA_postpaid_subordinate
--- PASS: TestAccCCMPrivateCA_postpaid_root (47.62s)
--- PASS: TestAccCCMPrivateCA_postpaid_subordinate (66.18s)
--- PASS: TestAccCCMPrivateCA_other (81.80s)
--- PASS: TestAccCCMPrivateCA_prepaid_root (118.77s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       118.819s
```

```
make testacc TEST='./huaweicloud/services/acceptance/ccm' TESTARGS='-run TestAccDataSourcePrivateCaExport_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccDataSourcePrivateCaExport_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePrivateCaExport_basic
=== PAUSE TestAccDataSourcePrivateCaExport_basic
=== CONT  TestAccDataSourcePrivateCaExport_basic
--- PASS: TestAccDataSourcePrivateCaExport_basic (26.74s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       26.795s
```

```
make testacc TEST='./huaweicloud/services/acceptance/ccm' TESTARGS='-run TestAccDataSourcePrivateCas_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccDataSourcePrivateCas_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePrivateCas_basic
=== PAUSE TestAccDataSourcePrivateCas_basic
=== CONT  TestAccDataSourcePrivateCas_basic
--- PASS: TestAccDataSourcePrivateCas_basic (60.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       60.821s
```

```
make testacc TEST='./huaweicloud/services/acceptance/ccm' TESTARGS='-run TestAccCcmPrivateCertificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCcmPrivateCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccCcmPrivateCertificate_basic
=== PAUSE TestAccCcmPrivateCertificate_basic
=== CONT  TestAccCcmPrivateCertificate_basic
--- PASS: TestAccCcmPrivateCertificate_basic (46.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       46.110s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
