### PR TITLE
chore(cfw): deprecate the name field in CFW service group member resource

### DIFF
--- a/docs/resources/cfw_service_group_member.md
+++ b/docs/resources/cfw_service_group_member.md
@@ -17,7 +17,7 @@ variable "protocol" {}
 variable "source_port" {}
 variable "dest_port" {}
 
-resource "huaweicloud_cfw_service_group" "test" {
+resource "huaweicloud_cfw_service_group_member" "test" {
   group_id    = var.group_id
   protocol    = var.protocol
   source_port = var.source_port
@@ -46,7 +46,7 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `source_port` - (Required, String, ForceNew) Specifies the source port.source_port
+* `source_port` - (Required, String, ForceNew) Specifies the source port.
 
   Changing this parameter will create a new resource.
 
@@ -54,11 +54,7 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-* `name` - (Optional, String, ForceNew) Specifies the service member name
-
-  Changing this parameter will create a new resource.
-
-* `description` - (Optional, String, ForceNew) Specifies the service member description.
+* `description` - (Optional, String, ForceNew) Specifies the service group member description.
 
   Changing this parameter will create a new resource.
 

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_service_group_member_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_service_group_member_test.go
@@ -26,7 +26,7 @@ func getServiceGroupMemberResourceFunc(cfg *config.Config, state *terraform.Reso
 	)
 	getServiceGroupMemberClient, err := cfg.NewServiceClient(getServiceGroupMemberProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating CFW Client: %s", err)
+		return nil, fmt.Errorf("error creating CFW client: %s", err)
 	}
 
 	getServiceGroupMemberPath := getServiceGroupMemberClient.Endpoint + getServiceGroupMemberHttpUrl
@@ -37,9 +37,6 @@ func getServiceGroupMemberResourceFunc(cfg *config.Config, state *terraform.Reso
 
 	getServiceGroupMemberOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getServiceGroupMemberResp, err := getServiceGroupMemberClient.Request("GET", getServiceGroupMemberPath, &getServiceGroupMemberOpt)
 	if err != nil {

--- a/huaweicloud/services/cfw/resource_huaweicloud_cfw_service_group_member.go
+++ b/huaweicloud/services/cfw/resource_huaweicloud_cfw_service_group_member.go
@@ -57,7 +57,7 @@ func ResourceServiceGroupMember() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: `Specifies the source port.source_port`,
+				Description: `Specifies the source port.`,
 			},
 			"dest_port": {
 				Type:        schema.TypeString,
@@ -65,19 +65,24 @@ func ResourceServiceGroupMember() *schema.Resource {
 				ForceNew:    true,
 				Description: `Specifies the destination port.`,
 			},
-			"name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Computed:    true,
-				ForceNew:    true,
-				Description: `Specifies the service member name`,
-			},
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 				ForceNew:    true,
-				Description: `Specifies the service member description.`,
+				Description: `Specifies the service group member description.`,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Description: utils.SchemaDesc(
+					"Specifies the service group member name.",
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 		},
 	}
@@ -94,7 +99,7 @@ func resourceServiceGroupMemberCreate(ctx context.Context, d *schema.ResourceDat
 	)
 	createServiceGroupMemberClient, err := cfg.NewServiceClient(createServiceGroupMemberProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating CFW Client: %s", err)
+		return diag.Errorf("error creating CFW client: %s", err)
 	}
 
 	createServiceGroupMemberPath := createServiceGroupMemberClient.Endpoint + createServiceGroupMemberHttpUrl
@@ -103,9 +108,6 @@ func resourceServiceGroupMemberCreate(ctx context.Context, d *schema.ResourceDat
 
 	createServiceGroupMemberOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	createServiceGroupMemberOpt.JSONBody = utils.RemoveNil(buildCreateServiceGroupMemberBodyParams(d))
 	createServiceGroupMemberResp, err := createServiceGroupMemberClient.Request("POST", createServiceGroupMemberPath,
@@ -157,7 +159,7 @@ func resourceServiceGroupMemberRead(_ context.Context, d *schema.ResourceData, m
 	)
 	getServiceGroupMemberClient, err := cfg.NewServiceClient(getServiceGroupMemberProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating CFW Client: %s", err)
+		return diag.Errorf("error creating CFW client: %s", err)
 	}
 
 	getServiceGroupMemberPath := getServiceGroupMemberClient.Endpoint + getServiceGroupMemberHttpUrl
@@ -169,9 +171,6 @@ func resourceServiceGroupMemberRead(_ context.Context, d *schema.ResourceData, m
 
 	getServiceGroupMemberOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getServiceGroupMemberResp, err := getServiceGroupMemberClient.Request("GET", getServiceGroupMemberPath,
 		&getServiceGroupMemberOpt)
@@ -240,7 +239,7 @@ func resourceServiceGroupMemberDelete(_ context.Context, d *schema.ResourceData,
 	)
 	deleteServiceGroupMemberClient, err := cfg.NewServiceClient(deleteServiceGroupMemberProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating CFW Client: %s", err)
+		return diag.Errorf("error creating CFW client: %s", err)
 	}
 
 	deleteServiceGroupMemberPath := deleteServiceGroupMemberClient.Endpoint + deleteServiceGroupMemberHttpUrl
@@ -250,9 +249,6 @@ func resourceServiceGroupMemberDelete(_ context.Context, d *schema.ResourceData,
 
 	deleteServiceGroupMemberOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	_, err = deleteServiceGroupMemberClient.Request("DELETE", deleteServiceGroupMemberPath,
 		&deleteServiceGroupMemberOpt)
@@ -264,7 +260,7 @@ func resourceServiceGroupMemberDelete(_ context.Context, d *schema.ResourceData,
 }
 
 func resourceServiceGroupMemberImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
-	parts := strings.SplitN(d.Id(), "/", 2)
+	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid format specified for import id, must be <group_id>/<member_id>")
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
deprecate the name field in CFW service group member resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. Deprecate the name field in CFW service group member resource.
2. Correct errors in the documentation.
3. Remove redundant statements.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run  TestAccServiceGroupMember_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run  TestAccServiceGroupMember_basic -timeout 360m -parallel 1
=== RUN   TestAccServiceGroupMember_basic
=== PAUSE TestAccServiceGroupMember_basic
=== CONT  TestAccServiceGroupMember_basic
--- PASS: TestAccServiceGroupMember_basic (36.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       36.673s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
