### PR TITLE
chore(CCM): make field `crl_name` from argument to attribute

### DIFF
--- a/docs/resources/ccm_private_ca.md
+++ b/docs/resources/ccm_private_ca.md
@@ -177,9 +177,6 @@ The `validity` block supports:
 <a name="block-crl_configuration"></a>
 The `crl_configuration` block supports:
 
-* `crl_name` - (Optional, String, ForceNew) Specifies the name of the certificate revocation list.
-  It is [issuer_name] by default. Changing this parameter will create a new resource.
-
 * `obs_bucket_name` - (Required, String, ForceNew) Specifies the OBS bucket name.
   Changing this parameter will create a new resource.
 
@@ -217,6 +214,8 @@ In addition to all arguments above, the following attributes are exported:
 * `free_quota` - The free quota of the private certificate.
 
 * `crl_configuration/crl_dis_point` - The address of the CRL file in the OBS bucket.
+
+* `crl_configuration/crl_name` - The name of the certificate revocation list.
 
 ## Timeouts
 

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go
@@ -157,12 +157,6 @@ func ResourcePrivateCertificateAuthority() *schema.Resource {
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"crl_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
-							ForceNew: true,
-						},
 						"obs_bucket_name": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -176,6 +170,13 @@ func ResourcePrivateCertificateAuthority() *schema.Resource {
 						"crl_dis_point": {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+						"crl_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: "schema: Computed",
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Make field `crl_name` from argument to attribute.
- The work order has been submitted for confirmation. This field `crl_name` does not support configuration, so it is modified as an attribute field in the document.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/ccm' TESTARGS='-run TestAccCCMPrivateCA_postpaid_root'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCCMPrivateCA_postpaid_root -timeout 360m -parallel 4
=== RUN   TestAccCCMPrivateCA_postpaid_root
=== PAUSE TestAccCCMPrivateCA_postpaid_root
=== CONT  TestAccCCMPrivateCA_postpaid_root
--- PASS: TestAccCCMPrivateCA_postpaid_root (37.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       37.253s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
