### PR TITLE
feat(cfw): data source supports query_service_set_type field

### DIFF
--- a/docs/data-sources/cfw_service_group_members.md
+++ b/docs/data-sources/cfw_service_group_members.md
@@ -31,6 +31,9 @@ The following arguments are supported:
 
 * `key_word` - (Optional, String) Specifies the key word.
 
+* `group_type` - (Optional, String) Specifies the service group type.
+  The value can be **0** (custom service group), **1** (predefined service group).
+
 * `item_id` - (Optional, String) Specifies the service group member ID.
 
 * `fw_instance_id` - (Optional, String) Specifies the firewall instance ID.

--- a/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_service_group_members_test.go
+++ b/huaweicloud/services/acceptance/cfw/data_source_huaweicloud_cfw_service_group_members_test.go
@@ -40,6 +40,32 @@ func TestAccDataSourceCfwServiceGroupMembers_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceCfwServiceGroupMembers_predefinedGroupMembers(t *testing.T) {
+	dataSource := "data.huaweicloud_cfw_service_group_members.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCfw(t)
+			acceptance.TestAccPreCheckCfwPredefinedServiceGroup(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCfwServiceGroupMembers_predefinedGroupMembers(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.item_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.protocol"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.source_port"),
+					resource.TestCheckResourceAttrSet(dataSource, "records.0.dest_port"),
+				),
+			},
+		},
+	})
+}
+
 func testDataSourceCfwServiceGroupMembers_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -129,6 +155,15 @@ output "is_protocol_filter_useful" {
   ])
 }
 `, testDataSourceCfwServiceGroupMembers_base(name))
+}
+
+func testDataSourceCfwServiceGroupMembers_predefinedGroupMembers() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cfw_service_group_members" "test" {
+  group_id   = "%[1]s"
+  group_type = "1"
+}
+`, acceptance.HW_CFW_PREDEFINED_SERVICE_GROUP1)
 }
 
 func testDataSourceCfwServiceGroupMembers_base(name string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
data source supports query_service_set_type field
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. data source supports query_service_set_type field
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cfw" TESTARGS="-run  TestAccDataSourceCfwServiceGroupMembers_predefinedGroupMembers"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cfw -v -run  TestAccDataSourceCfwServiceGroupMembers_predefinedGroupMembers -timeout 360m -parallel 1
=== RUN   TestAccDataSourceCfwServiceGroupMembers_predefinedGroupMembers
=== PAUSE TestAccDataSourceCfwServiceGroupMembers_predefinedGroupMembers
=== CONT  TestAccDataSourceCfwServiceGroupMembers_predefinedGroupMembers
--- PASS: TestAccDataSourceCfwServiceGroupMembers_predefinedGroupMembers (12.06s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cfw       12.129s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
