### PR TITLE
chore(css/thesaurus): fix resource error due to API response change and add checkDeleted logic

### DIFF
--- a/docs/resources/css_thesaurus.md
+++ b/docs/resources/css_thesaurus.md
@@ -9,17 +9,21 @@ description: ""
 
 Manages CSS thesaurus resource within HuaweiCloud
 
--> Only one thesaurus resource can be created for the specified cluster
+-> Only one thesaurus resource can be created for the specified cluster.
 
 ## Example Usage
 
 ### Create a thesaurus
 
 ```hcl
+variable "cluster_id" {}
+variable "bucket_name" {}
+variable "bucket_obj_key" {}
+
 resource "huaweicloud_css_thesaurus" "test" {
-  cluster_id  = {{ css_cluster_id }}
-  bucket_name = {{ bucket_name }}
-  main_object = {{ bucket_obj_key }}
+  cluster_id  = var.cluster_id
+  bucket_name = var.bucket_name
+  main_object = var.bucket_obj_key
 }
 ```
 
@@ -42,7 +46,8 @@ The following arguments are supported:
 
 * `synonym_object` - (Optional, String) Specifies the path of the synonyms thesaurus file object.
 
--> Specifies at least one of `main_object`,`stop_object`,`synonym_object`
+-> Specifies at least one of `main_object`, `stop_object`, `synonym_object`.
+**nil** or **Default** indicates no change, **""** or **Unused** indicates that this value is cleared.
 
 ## Attribute Reference
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
1. Adapt to resource issues caused by corresponding changes in the API
2. add checkDeleted logic

**Special notes for your reviewer**:

**Release note**:

```
fix resource error due to API response change and add checkDeleted logic
```

## PR Checklist

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/css" TESTARGS="-run TestAccCssThesaurus_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/css -v -run TestAccCssThesaurus_basic -timeout 360m -parallel 4
=== RUN   TestAccCssThesaurus_basic
=== PAUSE TestAccCssThesaurus_basic
=== CONT  TestAccCssThesaurus_basic

--- PASS: TestAccCssThesaurus_basic (1006.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1007.027s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
![image](https://github.com/user-attachments/assets/09c0aff1-98fd-4354-9c1d-9614fb94aa76)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
![image](https://github.com/user-attachments/assets/5c8e6d0a-b974-4e31-9dde-002c5b5d415a)

