### PR TITLE
feat(ims/images_image): support create data image from data disk bound to the ECS instance

### DIFF
--- a/docs/resources/images_image.md
+++ b/docs/resources/images_image.md
@@ -67,6 +67,18 @@ resource "huaweicloud_images_image" "test" {
 }
 ```
 
+### Creating a data image from the data disk bound to the ECS instance
+
+```hcl
+variable "image_name" {}
+variable "volume_id" {}
+
+resource "huaweicloud_images_image" "test" {
+  name      = var.image_name
+  volume_id = var.volume_id
+}
+```
+
 ### Creating a whole image from CBR backup
 
 ```hcl
@@ -99,6 +111,10 @@ The following arguments are supported:
 * `image_url` - (Optional, String, ForceNew) The URL of the external image file in the OBS bucket. This parameter is
   mandatory when you create a private image from an external file uploaded to an OBS bucket. The format is *OBS bucket
   name:Image file name*.
+
+* `volume_id` - (Optional, String, ForceNew) Specifies the ID of the data disk. This parameter is mandatory when you
+  create a private data image from an ECS, and the data disk must be bound to the ECS instance.
+  Changing this parameter will create a new resource.
 
 * `min_ram` - (Optional, Int) The minimum memory of the image in the unit of MB. The default value is 0,
   indicating that the memory is not restricted.

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_test.go
@@ -275,6 +275,62 @@ func TestAccImsImage_wholeImage_withBackup(t *testing.T) {
 	})
 }
 
+func TestAccImsImage_dataImage_withVolumeId(t *testing.T) {
+	var (
+		image        cloudimages.Image
+		rName        = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+		rNameUpdate  = rName + "-update"
+		resourceName = "huaweicloud_images_image.image_test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&image,
+		getImageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImsImage_dataImage_withVolumeId_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "description test"),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttrPair(resourceName, "volume_id", "huaweicloud_evs_volume.test", "id"),
+				),
+			},
+			{
+				Config: testAccImsImage_dataImage_withVolumeId_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", "description update"),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
 func testAccImsImage_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
@@ -507,4 +563,77 @@ resource "huaweicloud_images_image" "test" {
   }
 }
 `, rName, acceptance.HW_IMS_BACKUP_ID)
+}
+
+func testAccImsImage_dataImage_withVolumeId_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_name         = "Ubuntu 18.04 server 64bit"
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_evs_volume" "test" {
+  name              = "%[2]s"
+  volume_type       = "GPSSD"
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  server_id         = huaweicloud_compute_instance.test.id
+  size              = 60
+  charging_mode     = "postPaid"
+}
+`, common.TestBaseNetwork(rName), rName)
+}
+
+func testAccImsImage_dataImage_withVolumeId_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_images_image" "image_test" {
+  name        = "%[2]s"
+  volume_id   = huaweicloud_evs_volume.test.id
+  description = "description test"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccImsImage_dataImage_withVolumeId_base(rName), rName)
+}
+
+func testAccImsImage_dataImage_withVolumeId_update(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_images_image" "image_test" {
+  name        = "%[2]s"
+  volume_id   = huaweicloud_evs_volume.test.id
+  description = "description update"
+  min_ram     = 1024
+  max_ram     = 4096
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testAccImsImage_dataImage_withVolumeId_base(rName), rName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support create data image from data disk bound to the ECS instance

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

Support create data image from data disk bound to the ECS instance

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImsImage_dataImage_withVolumeId"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImsImage_dataImage_withVolumeId -timeout 360m -parallel 4
=== RUN   TestAccImsImage_dataImage_withVolumeId
=== PAUSE TestAccImsImage_dataImage_withVolumeId
=== CONT  TestAccImsImage_dataImage_withVolumeId
--- PASS: TestAccImsImage_dataImage_withVolumeId (451.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       451.283s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
