### PR TITLE
feat(dew): the secret resource support new fields

### DIFF
--- a/docs/resources/csms_secret.md
+++ b/docs/resources/csms_secret.md
@@ -43,6 +43,25 @@ resource "huaweicloud_csms_secret" "test3" {
 }
 ```
 
+### The secret associated event
+
+```hcl
+variable "name" {}
+variable "secret_type" {}
+variable "secret_text" {}
+
+resource "huaweicloud_csms_event" "test" {
+  ...
+}
+
+resource "huaweicloud_csms_secret" "test" {
+  name                = var.name
+  secret_type         = var.secret_type
+  secret_text         = var.secret_text
+  event_subscriptions = [huaweicloud_csms_event.test.name]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -73,6 +92,16 @@ The following arguments are supported:
   to get the KMS key.
 
 * `description` - (Optional, String) The description of a secret.
+
+* `secret_type` - (Optional, String, ForceNew) Specifies the type of the secret.
+  Currently, only supported **COMMON**. The default value is **COMMON**.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the secret belongs.
+  If omitted, the default enterprise project will be used.
+  If the enterprise project function is not enabled, ignore this parameter.
+
+* `event_subscriptions` - (Optional, List) Specifies the event list associated with the secret.
+  Currently, only one event can be associated.
 
 * `tags` - (Optional, Map) The tags of a CSMS secrets, key/value pair format.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240807095004-29a2cd9bf396
+	github.com/chnsz/golangsdk v0.0.0-20240809085804-adb116c0da60
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240807095004-29a2cd9bf396 h1:IzgyadrSmtda+2u/8O38J3mg9iG/7wx47xuMvG7uT9Q=
-github.com/chnsz/golangsdk v0.0.0-20240807095004-29a2cd9bf396/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240809085804-adb116c0da60 h1:+5KluMZRedbCa8gr3Q428HvO9BmOiOkD4iLCizqiipg=
+github.com/chnsz/golangsdk v0.0.0-20240809085804-adb116c0da60/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/csms/v1/secrets/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/csms/v1/secrets/requests.go
@@ -7,11 +7,14 @@ var RequestOpts = golangsdk.RequestOpts{
 }
 
 type CreateSecretOpts struct {
-	Name         string `json:"name" required:"true"`
-	KmsKeyID     string `json:"kms_key_id,omitempty"`
-	Description  string `json:"description,omitempty"`
-	SecretBinary string `json:"secret_binary,omitempty" xor:"SecretString"`
-	SecretString string `json:"secret_string,omitempty" xor:"SecretBinary"`
+	Name                string   `json:"name" required:"true"`
+	KmsKeyID            string   `json:"kms_key_id,omitempty"`
+	Description         string   `json:"description,omitempty"`
+	SecretType          string   `json:"secret_type,omitempty"`
+	EnterpriseProjectID string   `json:"enterprise_project_id,omitempty"`
+	EventSubscriptions  []string `json:"event_subscriptions,omitempty"`
+	SecretBinary        string   `json:"secret_binary,omitempty" xor:"SecretString"`
+	SecretString        string   `json:"secret_string,omitempty" xor:"SecretBinary"`
 }
 
 func Create(c *golangsdk.ServiceClient, opts CreateSecretOpts) (*Secret, error) {
@@ -46,8 +49,9 @@ func Get(c *golangsdk.ServiceClient, secretName string) (*Secret, error) {
 }
 
 type UpdateSecretOpts struct {
-	KmsKeyID    string  `json:"kms_key_id,omitempty"`
-	Description *string `json:"description,omitempty"`
+	KmsKeyID           string   `json:"kms_key_id,omitempty"`
+	Description        *string  `json:"description,omitempty"`
+	EventSubscriptions []string `json:"event_subscriptions"`
 }
 
 func Update(c *golangsdk.ServiceClient, secretName string, opts UpdateSecretOpts) (*Secret, error) {

--- a/vendor/github.com/chnsz/golangsdk/openstack/csms/v1/secrets/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/csms/v1/secrets/results.go
@@ -5,14 +5,17 @@ type SecretRst struct {
 }
 
 type Secret struct {
-	ID                  string `json:"id"`
-	Name                string `json:"name"`
-	State               string `json:"state"`
-	KmsKeyID            string `json:"kms_key_id"`
-	Description         string `json:"description"`
-	CreateTime          int    `json:"create_time"`
-	UpdateTime          int    `json:"update_time"`
-	ScheduledDeleteTime int    `json:"scheduled_delete_time"`
+	ID                  string        `json:"id"`
+	Name                string        `json:"name"`
+	State               string        `json:"state"`
+	KmsKeyID            string        `json:"kms_key_id"`
+	Description         string        `json:"description"`
+	CreateTime          int           `json:"create_time"`
+	UpdateTime          int           `json:"update_time"`
+	ScheduledDeleteTime int           `json:"scheduled_delete_time"`
+	SecretType          string        `json:"secret_type"`
+	EnterpriseProjectID string        `json:"enterprise_project_id"`
+	EventSubscriptions  []interface{} `json:"event_subscriptions"`
 }
 
 type Version struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240807095004-29a2cd9bf396
+# github.com/chnsz/golangsdk v0.0.0-20240809085804-adb116c0da60
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The secret resource support new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.The new field contain "secret_type", "enterprise_project_id", "event_subscriptions"
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccDewCsmsSecret_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDewCsmsSecret_basic -timeout 360m -parallel 4
=== RUN   TestAccDewCsmsSecret_basic
=== PAUSE TestAccDewCsmsSecret_basic
=== CONT  TestAccDewCsmsSecret_basic
--- PASS: TestAccDewCsmsSecret_basic (40.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       40.254s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccDewCsmsSecret_associatedEvent"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccDewCsmsSecret_associatedEvent -timeout 360m -parallel 4
=== RUN   TestAccDewCsmsSecret_associatedEvent
=== PAUSE TestAccDewCsmsSecret_associatedEvent
=== CONT  TestAccDewCsmsSecret_associatedEvent
--- PASS: TestAccDewCsmsSecret_associatedEvent (120.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       120.859s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
