### PR TITLE
fix(KMS): fix KMS grant resource force new error

### DIFF
--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_grant_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_grant_test.go
@@ -84,7 +84,7 @@ func TestAccKmsGrant_basic(t *testing.T) {
 				Config: testKmsGrant_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(rName, "operations.#", "2"),
+					resource.TestCheckResourceAttr(rName, "operations.#", "8"),
 					resource.TestCheckResourceAttrPair(rName, "key_id", "huaweicloud_kms_key.test", "id"),
 					resource.TestCheckResourceAttrPair(rName, "grantee_principal", "huaweicloud_identity_user.test", "id"),
 					resource.TestCheckResourceAttrSet(rName, "creator"),
@@ -119,8 +119,18 @@ resource "huaweicloud_identity_user" "test" {
 resource "huaweicloud_kms_grant" "test" {
   key_id             = huaweicloud_kms_key.test.id
   grantee_principal  = huaweicloud_identity_user.test.id
-  operations         = ["create-datakey", "encrypt-datakey"]
   retiring_principal = huaweicloud_identity_user.test.id
+
+  operations = [
+    "create-datakey",
+    "create-datakey-without-plaintext",
+    "describe-key",
+    "encrypt-data",
+    "decrypt-data",
+    "decrypt-datakey",
+    "retire-grant",
+    "encrypt-datakey"
+  ]
 }
 `, name, name)
 }

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_grant.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_grant.go
@@ -56,7 +56,7 @@ func ResourceKmsGrant() *schema.Resource {
 				Description: `The ID of the authorized user or account.`,
 			},
 			"operations": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Required: true,
 				ForceNew: true,
@@ -150,7 +150,7 @@ func buildCreateGrantBodyParams(d *schema.ResourceData, _ *config.Config) map[st
 		"key_id":                 utils.ValueIgnoreEmpty(d.Get("key_id")),
 		"grantee_principal_type": utils.ValueIgnoreEmpty(d.Get("type")),
 		"grantee_principal":      utils.ValueIgnoreEmpty(d.Get("grantee_principal")),
-		"operations":             utils.ValueIgnoreEmpty(d.Get("operations")),
+		"operations":             utils.ValueIgnoreEmpty(d.Get("operations").(*schema.Set).List()),
 		"retiring_principal":     utils.ValueIgnoreEmpty(d.Get("retiring_principal")),
 	}
 	return bodyParams


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix KMS grant resource force new error.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Before correcting this problem, executing the test case would result in the following error:
```
make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run TestAccKmsGrant_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKmsGrant_basic -timeout 360m -parallel 4
=== RUN   TestAccKmsGrant_basic
=== PAUSE TestAccKmsGrant_basic
=== CONT  TestAccKmsGrant_basic
    resource_huaweicloud_kms_grant_test.go:75: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement

        Terraform will perform the following actions:

          # huaweicloud_kms_grant.test must be replaced
        -/+ resource "huaweicloud_kms_grant" "test" {
              ~ creator            = "8f0becad85d248b19973b25680fc07bd" -> (known after apply)
              ~ id                 = "616536db2936371afc772c67a0e40f6ada23a50d89b7044b243a9d6dc012a5b5" -> (known after apply)
              + name               = (known after apply)
              ~ operations         = [ # forces replacement
                    # (1 unchanged element hidden)
                    "create-datakey-without-plaintext",
                  - "encrypt-datakey",
                  - "decrypt-datakey",
                    "describe-key",
                  - "retire-grant",
                    "encrypt-data",
                    "decrypt-data",
                  + "decrypt-datakey",
                  + "retire-grant",
                  + "encrypt-datakey",
                ]
              ~ region             = "cn-north-4" -> (known after apply)
                # (4 unchanged attributes hidden)
            }

        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccKmsGrant_basic (29.96s)
FAIL
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       30.010s
FAIL
make: *** [GNUmakefile:21: testacc] Error 1
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dew' TESTARGS='-run TestAccKmsGrant_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKmsGrant_basic -timeout 360m -parallel 4
=== RUN   TestAccKmsGrant_basic
=== PAUSE TestAccKmsGrant_basic
=== CONT  TestAccKmsGrant_basic
--- PASS: TestAccKmsGrant_basic (37.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       37.189s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
