### PR TITLE
feat(ims/images_image): support create data image from OBS bucket

### DIFF
--- a/docs/resources/images_image.md
+++ b/docs/resources/images_image.md
@@ -49,6 +49,21 @@ resource "huaweicloud_images_image" "ims_test_file" {
 }
 ```
 
+### Creating a data image from OBS bucket
+
+```hcl
+variable "image_name" {}
+variable "image_url" {}
+variable "os_type" {}
+
+resource "huaweicloud_images_image" "test" {
+  name      = var.image_name
+  image_url = var.image_url
+  min_disk  = 40
+  os_type   = var.os_type
+}
+```
+
 ### Creating a whole image from an existing ECS
 
 ```hcl
@@ -128,6 +143,11 @@ The following arguments are supported:
 * `min_disk` - (Optional, Int, ForceNew) The minimum size of the system disk in the unit of GB. This parameter is
   mandatory when you create a private image from an external file uploaded to an OBS bucket. The value ranges from 1 GB
   to 1024 GB.
+
+* `os_type` - (Optional, String, ForceNew) Specifies the operating system type of the data image. The value can be
+  **Windows** or **Linux**. This parameter is valid and mandatory only when you create a private data image from an
+  external file uploaded to an OBS bucket. In other cases, it is only used as an attribute.
+  Changing this parameter will create a new resource.
 
 * `os_version` - (Optional, String, ForceNew) The OS version. This parameter is valid when you create a private image
   from an external file uploaded to an OBS bucket.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240807095004-29a2cd9bf396
+	github.com/chnsz/golangsdk v0.0.0-20240809065204-907ba5e4960b
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240807095004-29a2cd9bf396 h1:IzgyadrSmtda+2u/8O38J3mg9iG/7wx47xuMvG7uT9Q=
-github.com/chnsz/golangsdk v0.0.0-20240807095004-29a2cd9bf396/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240809065204-907ba5e4960b h1:COiOQ9OuX8PjniBFHKPZ16Q4fnErzVEyObUmZaAtwi0=
+github.com/chnsz/golangsdk v0.0.0-20240809065204-907ba5e4960b/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -255,6 +255,8 @@ var (
 
 	// The ID of the CBR backup
 	HW_IMS_BACKUP_ID = os.Getenv("HW_IMS_BACKUP_ID")
+	// The image file in the obs bucket
+	HW_IMS_IMAGE_URL = os.Getenv("HW_IMS_IMAGE_URL")
 	// The shared backup ID wants to accept.
 	HW_SHARED_BACKUP_ID = os.Getenv("HW_SHARED_BACKUP_ID")
 
@@ -1414,6 +1416,13 @@ func TestAccPreCheckSwrRepository(t *testing.T) {
 func TestAccPreCheckImsBackupId(t *testing.T) {
 	if HW_IMS_BACKUP_ID == "" {
 		t.Skip("HW_IMS_BACKUP_ID must be set for IMS whole image with CBR backup id")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckImsImageUrl(t *testing.T) {
+	if HW_IMS_IMAGE_URL == "" {
+		t.Skip("HW_IMS_IMAGE_URL must be set for IMS data image with OBS bucket")
 	}
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages/requests.go
@@ -227,6 +227,8 @@ type CreateDataImageByOBSOpts struct {
 	MinDisk int `json:"min_disk" required:"true"`
 	// the master key used for encrypting an image
 	CmkId string `json:"cmk_id,omitempty"`
+	// One or more tag key and value pairs to associate with the image
+	ImageTags []ImageTag `json:"image_tags,omitempty"`
 	// Enterprise project ID
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240807095004-29a2cd9bf396
+# github.com/chnsz/golangsdk v0.0.0-20240809065204-907ba5e4960b
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support create data image from OBS bucket

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

1. Support create data image from OBS bucket.
2. Add a check for the `os_type` attribute in other test cases.
3. Inject the `image_url` parameter using environment variable. Because it is necessary to ensure that there is an image file in the OBS bucket, this operation cannot be completed through automated scripts temporarily.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImsImage_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImsImage_ -timeout 360m -parallel 4
=== RUN   TestAccImsImage_basic
=== PAUSE TestAccImsImage_basic
=== RUN   TestAccImsImage_withEpsId
=== PAUSE TestAccImsImage_withEpsId
=== RUN   TestAccImsImage_wholeImage_withServer
=== PAUSE TestAccImsImage_wholeImage_withServer
=== RUN   TestAccImsImage_wholeImage_withBackup
=== PAUSE TestAccImsImage_wholeImage_withBackup
=== RUN   TestAccImsImage_dataImage_withVolumeId
=== PAUSE TestAccImsImage_dataImage_withVolumeId
=== RUN   TestAccImsImage_dataImage_fromOBS
=== PAUSE TestAccImsImage_dataImage_fromOBS
=== CONT  TestAccImsImage_basic
=== CONT  TestAccImsImage_wholeImage_withBackup
=== CONT  TestAccImsImage_wholeImage_withServer
=== CONT  TestAccImsImage_dataImage_fromOBS
--- PASS: TestAccImsImage_wholeImage_withBackup (63.01s)
=== CONT  TestAccImsImage_withEpsId
--- PASS: TestAccImsImage_dataImage_fromOBS (185.55s)
=== CONT  TestAccImsImage_dataImage_withVolumeId
--- PASS: TestAccImsImage_basic (461.84s)
--- PASS: TestAccImsImage_withEpsId (402.59s)
--- PASS: TestAccImsImage_dataImage_withVolumeId (404.74s)
--- PASS: TestAccImsImage_wholeImage_withServer (722.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       722.701s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
