### PR TITLE
feat(WAF): domain resources support new computed attribute

### DIFF
--- a/docs/data-sources/waf_domains.md
+++ b/docs/data-sources/waf_domains.md
@@ -67,6 +67,8 @@ The `domains` block supports:
   + **0** - The domain name is not connected to WAF.
   + **1** - The domain name is connected to WAF.
 
+* `access_code` - The CNAME prefix. The CNAME suffix is `.vip1.huaweicloudwaf.com`.
+
 * `charging_mode` - The charging mode of the domain.
   Valid values are **prePaid** and **postPaid**.
 

--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -298,6 +298,8 @@ The following attributes are exported:
 * `access_status` - Whether a domain name is connected to WAF. 0: The domain name is not connected to WAF, 1: The domain
   name is connected to WAF.
 
+* `access_code` - The CNAME prefix. The CNAME suffix is `.vip1.huaweicloudwaf.com`.
+
 * `protocol` - The protocol type of the client. The options are HTTP, HTTPS, and HTTP&HTTPS.
 
 ## Import

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_domains_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_domains_test.go
@@ -35,6 +35,7 @@ func TestAccDatasourceWAFDomains_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "domains.0.pci_3ds"),
 					resource.TestCheckResourceAttrSet(rName, "domains.0.pci_dss"),
 					resource.TestCheckResourceAttrSet(rName, "domains.0.access_status"),
+					resource.TestCheckResourceAttrSet(rName, "domains.0.access_code"),
 					resource.TestCheckResourceAttrSet(rName, "domains.0.enterprise_project_id"),
 					resource.TestCheckResourceAttrSet(policyNameTestName, "domains.#"),
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_domain_test.go
@@ -66,6 +66,8 @@ func TestAccWafDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "forward_header_map.key2", "$tenant_id"),
 					resource.TestCheckResourceAttr(resourceName, "website_name", "websiteName"),
 					resource.TestCheckResourceAttr(resourceName, "protect_status", "-1"),
+					resource.TestCheckResourceAttrSet(resourceName, "access_status"),
+					resource.TestCheckResourceAttrSet(resourceName, "access_code"),
 				),
 			},
 			{

--- a/huaweicloud/services/waf/data_source_huaweicloud_waf_domains.go
+++ b/huaweicloud/services/waf/data_source_huaweicloud_waf_domains.go
@@ -92,6 +92,10 @@ func wafDomainSchema() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"access_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"charging_mode": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -192,6 +196,7 @@ func flattenListDomainsBody(resp interface{}) []interface{} {
 			"pci_dss":               utils.StringToBool(utils.PathSearch("flag.pci_dss", v, "")),
 			"ipv6_enable":           utils.StringToBool(utils.PathSearch("flag.ipv6", v, "")),
 			"access_status":         utils.PathSearch("access_status", v, nil),
+			"access_code":           utils.PathSearch("access_code", v, nil),
 			"charging_mode":         utils.PathSearch("paid_type", v, nil),
 			"website_name":          utils.PathSearch("web_tag", v, nil),
 			"proxy_layer":           utils.PathSearch("proxy_layer", v, nil),

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
@@ -188,6 +188,10 @@ func ResourceWafDomain() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"access_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"protocol": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -554,6 +558,7 @@ func resourceWafDomainRead(_ context.Context, d *schema.ResourceData, meta inter
 		d.Set("proxy", dm.Proxy),
 		d.Set("protect_status", dm.ProtectStatus),
 		d.Set("access_status", dm.AccessStatus),
+		d.Set("access_code", dm.AccessCode),
 		d.Set("protocol", dm.Protocol),
 		d.Set("server", flattenDomainServerAttrs(dm)),
 		d.Set("custom_page", flattenDomainCustomPage(dm)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

domain resources support new computed attribute

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- WAF domain resource supports new computed attribute `access_code`.
- WAF domain datasource supports new computed attribute `access_code`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDomainV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_basic
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (169.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       169.285s
```

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDatasourceWAFDomains_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDatasourceWAFDomains_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceWAFDomains_basic
=== PAUSE TestAccDatasourceWAFDomains_basic
=== CONT  TestAccDatasourceWAFDomains_basic
--- PASS: TestAccDatasourceWAFDomains_basic (158.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       158.506s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
