### PR TITLE
feat(utils): add new function to remove the empty element from an array

### DIFF
--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -556,3 +556,31 @@ func IsUUID(uuid string) bool {
 	match, _ := regexp.MatchString(pattern, uuid)
 	return match
 }
+
+// The method can used to remove empty elements from an array
+func RemoveEmptyStrings(s []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(s))
+	for _, elem := range s {
+		if isNonEmpty(elem) {
+			result = append(result, elem)
+		}
+	}
+	return result
+}
+
+// The method can used to check element is empty or not
+func isNonEmpty(v interface{}) bool {
+	switch v := v.(type) {
+	case string:
+		return v != ""
+	case int, float64, bool:
+		// For numerical and Boolean types, non-zero means non empty
+		return true
+	case nil:
+		// Explicitly checking nil
+		return false
+	default:
+		// For other types, if it is not nil, it is non empty
+		return v != nil
+	}
+}

--- a/huaweicloud/utils/utils_test.go
+++ b/huaweicloud/utils/utils_test.go
@@ -116,3 +116,16 @@ func TestAccFunction_IsUUID(t *testing.T) {
 		t.Logf("The processing result of IsUUID method meets expectation: %s", Green(expected[i]))
 	}
 }
+
+func TestAccFunction_RemoveEmptyStrings(t *testing.T) {
+	var (
+		arr      = []interface{}{"test", "1024", " ", "", 4096, 6.4, 0, nil, true, false}
+		expected = []interface{}{"test", "1024", " ", 4096, 6.4, 0, true, false}
+	)
+
+	result := RemoveEmptyStrings(arr)
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("The processing result of RemoveEmptyStrings method is not as expected, want %s, but %s", Green(expected), Yellow(result))
+	}
+	t.Logf("The processing result of RemoveEmptyStrings method meets expectation: %s", Green(expected))
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add new function to remove the empty element from an array.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/utils" TESTARGS="-run TestAccFunction_RemoveEmptyStrings"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/utils -v -run TestAccFunction_RemoveEmptyStrings -timeout 360m -parallel 4
=== RUN   TestAccFunction_RemoveEmptyStrings
    utils_test.go:130: The processing result of RemoveEmptyStrings method meets expectation: []interface {}{"test", "1024", " ", 4096, 6.4, 0, true, false}
--- PASS: TestAccFunction_RemoveEmptyStrings (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils 0.011s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
