### PR TITLE
fix(dws/workload_queue): unable delete logical cluster resource pool

### DIFF
--- a/huaweicloud/services/dws/resource_huaweicloud_dws_workload_queue.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_workload_queue.go
@@ -200,6 +200,10 @@ func resourceWorkLoadQueueDelete(_ context.Context, d *schema.ResourceData, meta
 	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
 	deletePath = strings.ReplaceAll(deletePath, "{cluster_id}", d.Get("cluster_id").(string))
 	deletePath = strings.ReplaceAll(deletePath, "{name}", d.Get("name").(string))
+
+	if logicalClusterName, ok := d.GetOk("logical_cluster_name"); ok {
+		deletePath = fmt.Sprintf("%s&logical_cluster_name=%s", deletePath, logicalClusterName)
+	}
 	// Due to API restrictions, the request body must pass in an empty JSON.
 	deleteOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixed the error when deleting resource pools under logical clusters.

![image](https://github.com/user-attachments/assets/bcbc179e-1c42-4ef4-ae0a-ebf801c03dc9)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
 make testacc TEST='./huaweicloud/services/acceptance/dws' TESTARGS='-run TestAccResourceWorkloadQueue_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceWorkloadQueue_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceWorkloadQueue_basic
=== PAUSE TestAccResourceWorkloadQueue_basic
=== CONT  TestAccResourceWorkloadQueue_basic
--- PASS: TestAccResourceWorkloadQueue_basic (1480.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1480.353s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
