### PR TITLE
feat(dataarts/dataservice): new resources support for auth management

### DIFF
--- a/docs/resources/dataarts_dataservice_api_auth.md
+++ b/docs/resources/dataarts_dataservice_api_auth.md
@@ -1,0 +1,62 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_api_auth"
+description: |-
+  Use this resource to authorize APP(s) to access API for DataArts Data Service within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_api_auth
+
+Use this resource to authorize APP(s) to access API for DataArts Data Service within HuaweiCloud.
+
+-> 1. Only exclusive API can used to authorize APPs.
+   <br>2. This resource is only a one-time action resource for doing API authorization. Deleting this resource will not
+   clear the corresponding request record, but will only remove the resource information from the tfstate file.
+   <br>3. APP authentication APIs can only be authorized to APP-type applications.
+   <br>4. Before using this resource, please make sure that the current user has the approver permission.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "auth_api_id" {} # The auth type is 'APP'
+variable "exclusive_cluster_id" {}
+variable "auth_expiration_time" {}
+variable "authorized_app_ids" {
+  type = list(string)
+}
+
+resource "huaweicloud_dataarts_dataservice_api_auth" "test" {
+  workspace_id = var.workspace_id
+  api_id       = var.auth_api_id
+  instance_id  = var.exclusive_cluster_id
+  expired_at   = var.auth_expiration_time
+  app_ids      = var.authorized_app_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the API and APPs are located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID to which the API and APPs belong.  
+  Changing this parameter will create a new resource.
+
+* `api_id` - (Required, String, ForceNew) Specifies the API ID that used to authorize the authentication.  
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the exclusive cluster ID.  
+  Changing this parameter will create a new resource.
+
+* `app_ids` - (Required, List, ForceNew) Specifies the list of authorized application IDs.  
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/docs/resources/dataarts_dataservice_api_auth_action.md
+++ b/docs/resources/dataarts_dataservice_api_auth_action.md
@@ -1,0 +1,70 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_api_auth_action"
+description: |-
+  Use this resource to authorize an API for DataArts Data Service within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_api_auth_action
+
+Use this resource to operate (authorized) APP for DataArts Data Service within HuaweiCloud.
+
+-> 1. Only exclusive (and published) API can used to authorize APPs.
+   <br>2. This resource is only a one-time action resource for doing authorize operation. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+   <br>3. Before using this resource, please make sure that the current user has the approver permission.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "operate_api_id" {}
+variable "exclusive_cluster_id" {}
+variable "operate_app_id" {}
+
+resource "huaweicloud_dataarts_dataservice_api_auth_action" "test" {
+  workspace_id = var.workspace_id
+  api_id       = var.operate_api_id
+  instance_id  = var.exclusive_cluster_id
+  app_id       = var.operate_app_id
+  type         = "APPLY_TYPE_APP_CANCEL_AUTHORIZE"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the published API and APP to be operated are
+  located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID to which the published API and APP to be
+  operated belong.
+  Changing this parameter will create a new resource.
+
+* `api_id` - (Required, String, ForceNew) Specifies the ID of the published API that to be operated.  
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the exclusive cluster ID to which the published API belongs.  
+  Changing this parameter will create a new resource.
+
+* `app_id` - (Required, String, ForceNew) Specifies the ID of the APP to be operated.  
+  Changing this parameter will create a new resource.
+
+* `type` - (Required, String, ForceNew) Specifies the operation type of the authorization.  
+  The valid values are as follows:
+  + **APPLY_TYPE_APPLY**: Apply for APP access to API.
+  + **APPLY_TYPE_AUTHORIZE**: Apply for APP access to API (fast approval).
+  + **APPLY_TYPE_API_CANCEL_AUTHORIZE**: Cancel the API authorization.
+  + **APPLY_TYPE_APP_CANCEL_AUTHORIZE**: Cancel the APP authorization (fast approval).
+  + **APPLY_TYPE_RENEW**: Renew API.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1621,6 +1621,8 @@ func Provider() *schema.Provider {
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_api":             dataarts.ResourceDataServiceApi(),
 			"huaweicloud_dataarts_dataservice_api_action":      dataarts.ResourceDataServiceApiAction(),
+			"huaweicloud_dataarts_dataservice_api_auth":        dataarts.ResourceDataServiceApiAuth(),
+			"huaweicloud_dataarts_dataservice_api_auth_action": dataarts.ResourceDataServiceApiAuthAction(),
 			"huaweicloud_dataarts_dataservice_api_debug":       dataarts.ResourceDataServiceApiDebug(),
 			"huaweicloud_dataarts_dataservice_api_publish":     dataarts.ResourceDataServiceApiPublish(),
 			"huaweicloud_dataarts_dataservice_api_publishment": dataarts.ResourceDataServiceApiPublishment(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_api_auth_action_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_api_auth_action_test.go
@@ -1,0 +1,75 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataServiceApiAuthAction_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsReviewerName(t)
+			acceptance.TestAccPreCheckDataArtsRelatedDliQueueName(t)
+		},
+
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Just test whether the authorize request was executed successful.
+				Config: testAccDataServiceApiAuthAction_basic_step1(name),
+			},
+			{
+				// Just test whether the authorize status was cancelled successful.
+				Config: testAccDataServiceApiAuthAction_basic_step2(name),
+			},
+		},
+	})
+}
+
+// Authorize some APPs to access the API.
+func testAccDataServiceApiAuthAction_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_auth_action" "test" {
+  depends_on = [huaweicloud_dataarts_dataservice_api_publishment.test]
+  count      = 2
+
+  workspace_id = "%[2]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  app_id      = element(huaweicloud_dataarts_dataservice_app.test[*].id, count.index)
+  type        = "APPLY_TYPE_AUTHORIZE"
+}
+`, testAccDataServiceApiAuth_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+// Cancel the API access permissions for all APPs.
+func testAccDataServiceApiAuthAction_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_auth_action" "test" {
+  depends_on = [huaweicloud_dataarts_dataservice_api_publishment.test]
+  count      = 2
+
+  workspace_id = "%[2]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  app_id      = element(huaweicloud_dataarts_dataservice_app.test[*].id, count.index)
+  type        = "APPLY_TYPE_APP_CANCEL_AUTHORIZE"
+}
+`, testAccDataServiceApiAuth_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_api_auth_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_api_auth_test.go
@@ -1,0 +1,186 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataServiceApiAuth_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsReviewerName(t)
+			acceptance.TestAccPreCheckDataArtsRelatedDliQueueName(t)
+		},
+
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Just test whether the authorize request was executed successful.
+				Config: testAccDataServiceApiAuth_basic_step1(name),
+			},
+			{
+				// Just test whether the authorize status was cancelled successful.
+				Config: testAccDataServiceApiAuth_basic_step2(name),
+			},
+		},
+	})
+}
+
+// Debug and publish the API.
+func testAccDataServiceApiAuth_base(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_dataarts_dataservice_instances" "test" {
+  workspace_id = "%[1]s"
+}
+
+resource "huaweicloud_dataarts_dataservice_catalog" "test" {
+  workspace_id = "%[1]s"
+  name         = "%[2]s"
+  dlm_type     = "EXCLUSIVE"
+}
+
+resource "huaweicloud_dli_database" "test" {
+  name = "%[2]s"
+}
+
+resource "huaweicloud_dli_table" "test" {
+  database_name = huaweicloud_dli_database.test.name
+  name          = "%[2]s"
+  data_location = "DLI"
+
+  columns {
+    name = "test_request_field"
+    type = "string"
+  }
+  columns {
+    name = "test_response_field"
+    type = "string"
+  }
+}
+
+resource "huaweicloud_dataarts_dataservice_api" "test" {
+  depends_on = [huaweicloud_dli_table.test]
+
+  workspace_id = "%[1]s"
+
+  dlm_type     = "EXCLUSIVE"
+  type         = "API_SPECIFIC_TYPE_CONFIGURATION"
+  catalog_id   = huaweicloud_dataarts_dataservice_catalog.test.id
+  name         = "%[2]s"
+  auth_type    = "APP"
+  manager      = "%[3]s"
+  path         = "/%[2]s/test"
+  protocol     = "PROTOCOL_TYPE_HTTPS"
+  request_type = "REQUEST_TYPE_POST"
+  visibility   = "WORKSPACE"
+
+  request_params {
+    name      = "test_request_field"
+    position  = "REQUEST_PARAMETER_POSITION_BODY"
+    type      = "REQUEST_PARAMETER_TYPE_STRING"
+    necessary = true
+  }
+
+  datasource_config {
+    type          = "DLI"
+    connection_id = "%[4]s"
+    queue         = "%[5]s"
+    database      = huaweicloud_dli_database.test.name
+    datatable     = huaweicloud_dli_table.test.name
+
+    backend_params {
+      name     = "test_request_field"
+      mapping  = "test_request_field"
+      condition = "CONDITION_TYPE_EQ"
+    }
+    response_params {
+      name  = "test_response_field"
+      type  = "REQUEST_PARAMETER_TYPE_STRING"
+      field = "test_response_field"
+    }
+  }
+}
+
+resource "huaweicloud_dataarts_dataservice_api_debug" "test" {
+  workspace_id = "%[1]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+
+  params = jsonencode({
+    "page_num": "1",
+    "page_size": "100",
+    "test_request_field": "{\"foo\": \"bar\"}"
+  })
+
+  max_retries = 6
+}
+
+resource "huaweicloud_dataarts_dataservice_api_publishment" "test" {
+  depends_on = [huaweicloud_dataarts_dataservice_api_debug.test]
+
+  workspace_id = "%[1]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+}
+
+resource "huaweicloud_dataarts_dataservice_app" "test" {
+  depends_on = [huaweicloud_dataarts_dataservice_api_publishment.test]
+  count      = 2
+
+  workspace_id = "%[1]s"
+  dlm_type     = "EXCLUSIVE"
+
+  name     = format("%[2]s_%%d", count.index)
+  app_type = "APP"
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID,
+		name,
+		acceptance.HW_DATAARTS_REVIEWER_NAME,
+		acceptance.HW_DATAARTS_CONNECTION_ID,
+		acceptance.HW_DATAARTS_DLI_QUEUE_NAME)
+}
+
+// Authorize some APPs to access the API.
+func testAccDataServiceApiAuth_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_auth" "test" {
+  workspace_id = "%[2]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  app_ids     = slice(huaweicloud_dataarts_dataservice_app.test[*].id, 0, 2)
+}
+`, testAccDataServiceApiAuth_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+// Cancel the API access permissions for all APPs.
+func testAccDataServiceApiAuth_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_auth_action" "test" {
+  count = 2
+
+  workspace_id = "%[2]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  app_id      = element(huaweicloud_dataarts_dataservice_app.test[*].id, count.index)
+  type        = "APPLY_TYPE_APP_CANCEL_AUTHORIZE"
+}
+`, testAccDataServiceApiAuth_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_auth.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_auth.go
@@ -1,0 +1,153 @@
+package dataarts
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio POST /v1/{project_id}/service/apis/{api_id}/instances/{instance_id}/authorize
+func ResourceDataServiceApiAuth() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDataServiceApiAuthCreate,
+		ReadContext:   resourceDataServiceApiAuthRead,
+		DeleteContext: resourceDataServiceApiAuthDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The region where the API and APP(s) are located.`,
+			},
+
+			// Parameter in request header
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The workspace ID to which the API and APP(s) belong.`,
+			},
+
+			// Arguments
+			"api_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the published API.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The exclusive cluster ID to which the published API belongs.`,
+			},
+			"app_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of application IDs that used to authorize API.`,
+			},
+			"expired_at": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The expiration time of the APP authorize operation.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildApiAuthBodyParams(d *schema.ResourceData) map[string]interface{} {
+	result := map[string]interface{}{
+		"app_ids": d.Get("app_ids"),
+	}
+	if expirationTime, ok := d.GetOk("expired_at"); ok {
+		result["time"] = expirationTime.(string)
+	} else {
+		result["time"] = utils.CalculateNextWholeHourAfterFewTime(utils.GetCurrentTime(true), 48*time.Hour)
+	}
+	return result
+}
+
+func authorizeApi(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl     = "v1/{project_id}/service/apis/{api_id}/instances/{instance_id}/authorize"
+		workspaceId = d.Get("workspace_id").(string)
+		apiId       = d.Get("api_id").(string)
+		instanceId  = d.Get("instance_id").(string)
+	)
+	debugPath := client.Endpoint + httpUrl
+	debugPath = strings.ReplaceAll(debugPath, "{project_id}", client.ProjectID)
+	debugPath = strings.ReplaceAll(debugPath, "{api_id}", apiId)
+	debugPath = strings.ReplaceAll(debugPath, "{instance_id}", instanceId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    workspaceId,
+			"Dlm-Type":     "EXCLUSIVE",
+		},
+		JSONBody: buildApiAuthBodyParams(d),
+		OkCodes:  []int{204},
+	}
+
+	_, err := client.Request("POST", debugPath, &opt)
+	return err
+}
+
+func resourceDataServiceApiAuthCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	err = authorizeApi(client, d)
+	if err != nil {
+		return diag.Errorf("failed to authorize APP(s) to access API (%s): %s", d.Get("api_id").(string), err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(resourceId)
+
+	return resourceDataServiceApiAuthRead(ctx, d, meta)
+}
+
+func resourceDataServiceApiAuthRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// This resource is only a one-time action resource for authorizing the API.
+	return nil
+}
+
+func resourceDataServiceApiAuthDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for authorizing the API. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_auth_action.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api_auth_action.go
@@ -1,0 +1,154 @@
+package dataarts
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio POST /v1/{project_id}/service/apis/authorize/action
+func ResourceDataServiceApiAuthAction() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDataServiceApiAuthActionCreate,
+		ReadContext:   resourceDataServiceApiAuthActionRead,
+		DeleteContext: resourceDataServiceApiAuthActionDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The region where the published API and APP to be operated are located.`,
+			},
+
+			// Parameter in request header
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The workspace ID to which the published API and APP to be operated belong.`,
+			},
+
+			// Arguments
+			"api_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the published API that to be operated.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The exclusive cluster ID to which the published API belongs.`,
+			},
+			"app_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the APP to be operated.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The operation type of the authorization.`,
+			},
+			"expired_at": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The expiration time of the authorize operation.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					},
+				),
+			},
+		},
+	}
+}
+
+func buildApiAuthActionBodyParams(d *schema.ResourceData) map[string]interface{} {
+	result := map[string]interface{}{
+		"api_id":      d.Get("api_id"),
+		"instance_id": d.Get("instance_id"),
+		"app_id":      d.Get("app_id"),
+		"apply_type":  d.Get("type"),
+	}
+	if expirationTime, ok := d.GetOk("expired_at"); ok {
+		result["time"] = expirationTime.(string)
+	} else {
+		result["time"] = utils.CalculateNextWholeHourAfterFewTime(utils.GetCurrentTime(true), 48*time.Hour)
+	}
+	return result
+}
+
+func doApiAuthAction(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	httpUrl := "v1/{project_id}/service/apis/authorize/action"
+	debugPath := client.Endpoint + httpUrl
+	debugPath = strings.ReplaceAll(debugPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    d.Get("workspace_id").(string),
+			"Dlm-Type":     "EXCLUSIVE",
+		},
+		JSONBody: buildApiAuthActionBodyParams(d),
+		OkCodes:  []int{204},
+	}
+
+	_, err := client.Request("POST", debugPath, &opt)
+	return err
+}
+
+func resourceDataServiceApiAuthActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	err = doApiAuthAction(client, d)
+	if err != nil {
+		return diag.Errorf("failed to operate API (%s): %s", d.Get("api_id").(string), err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(resourceId)
+
+	return resourceDataServiceApiAuthActionRead(ctx, d, meta)
+}
+
+func resourceDataServiceApiAuthActionRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// This resource is only a one-time action resource for operating the (authorized) APP.
+	return nil
+}
+
+func resourceDataServiceApiAuthActionDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for operating the API. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports two resources to authorize APP(s)  to access API and cancel the authorize permission.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resources support for authorize management.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dataarts' TESTARGS='-run=TestAccDataServiceApiAuth_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run=TestAccDataServiceApiAuth_basic -timeout 360m -parallel 4
=== RUN   TestAccDataServiceApiAuth_basic
=== PAUSE TestAccDataServiceApiAuth_basic
=== CONT  TestAccDataServiceApiAuth_basic
--- PASS: TestAccDataServiceApiAuth_basic (158.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  158.572s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
