### PR TITLE
chore(ims/images_image): update the parameter description and order in the resource document

### DIFF
--- a/docs/resources/images_image.md
+++ b/docs/resources/images_image.md
@@ -2,29 +2,25 @@
 subcategory: "Image Management Service (IMS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_images_image"
-description: ""
+description: |-
+  Manages an IMS image resource within HuaweiCloud.
 ---
 
 # huaweicloud_images_image
 
-Manages an Image resource within HuaweiCloud IMS.
+Manages an IMS image resource within HuaweiCloud.
 
 ## Example Usage
 
-### Creating an image from an existing ECS
+### Creating a system image from an existing ECS instance
 
 ```hcl
-variable "instance_name" {}
-variable "image_name" {}
-
-data "huaweicloud_compute_instance" "test" {
-  name = var.instance_name
-}
+variable "name" {}
+variable "instance_id" {}
 
 resource "huaweicloud_images_image" "test" {
-  name        = var.image_name
-  instance_id = data.huaweicloud_compute_instance.test.id
-  description = "created by Terraform"
+  name        = var.name
+  instance_id = var.instance_id
 
   tags = {
     foo = "bar"
@@ -33,65 +29,55 @@ resource "huaweicloud_images_image" "test" {
 }
 ```
 
-### Creating an image from OBS bucket
+### Creating a system image from OBS bucket
 
 ```hcl
-resource "huaweicloud_images_image" "ims_test_file" {
-  name        = "ims_test_file"
-  image_url   = "ims-image:centos70.qcow2"
-  min_disk    = 40
-  description = "Create an image from the OBS bucket."
+variable "name" {}
+variable "image_url" {}
+variable "min_disk" {}
 
-  tags = {
-    foo = "bar1"
-    key = "value"
-  }
+resource "huaweicloud_images_image" "test" {
+  name      = var.name
+  image_url = var.image_url
+  min_disk  = var.min_disk
 }
 ```
 
-### Creating a whole image from an existing ECS
+### Creating a whole image from an existing ECS instance
 
 ```hcl
-variable "vault_id" {}
+variable "name" {}
 variable "instance_id" {}
+variable "vault_id" {}
 
 resource "huaweicloud_images_image" "test" {
-  name        = "test_whole_image"
+  name        = var.name
   instance_id = var.instance_id
   vault_id    = var.vault_id
-
-  tags = {
-    foo = "bar2"
-    key = "value"
-  }
-}
-```
-
-### Creating a data image from the data disk bound to the ECS instance
-
-```hcl
-variable "image_name" {}
-variable "volume_id" {}
-
-resource "huaweicloud_images_image" "test" {
-  name      = var.image_name
-  volume_id = var.volume_id
 }
 ```
 
 ### Creating a whole image from CBR backup
 
 ```hcl
+variable "name" {}
 variable "backup_id" {}
 
 resource "huaweicloud_images_image" "test" {
-  name      = "test_whole_image"
+  name      = var.name
   backup_id = var.backup_id
+}
+```
 
-  tags = {
-    foo = "bar1"
-    key = "value"
-  }
+### Creating a data image from the data disk bound to the ECS instance
+
+```hcl
+variable "name" {}
+variable "volume_id" {}
+
+resource "huaweicloud_images_image" "test" {
+  name      = var.name
+  volume_id = var.volume_id
 }
 ```
 
@@ -99,52 +85,74 @@ resource "huaweicloud_images_image" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required, String) The name of the image.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `instance_id` - (Optional, String, ForceNew) The ID of the ECS that needs to be converted into an image. This
-  parameter is mandatory when you create a private image or a private whole image from an ECS.
-  If the value of `vault_id` is not empty, then a whole image will be created.
+* `name` - (Required, String) Specifies the name of the image.
 
-* `backup_id` - (Optional, String, ForceNew) The ID of the CBR backup that needs to be converted into an image. This
-  parameter is mandatory when you create a private whole image from a CBR backup.
+* `instance_id` - (Optional, String, ForceNew) Specifies the ID of the ECS that needs to be converted into an image.
+  This parameter is valid and mandatory only when you create a private system image or a private whole image from an
+  ECS instance. Changing this parameter will create a new resource.
+  + If the value of `vault_id` is empty, then a private system image will be created.
+  + If the value of `vault_id` is not empty, then a private whole image will be created.
 
-* `image_url` - (Optional, String, ForceNew) The URL of the external image file in the OBS bucket. This parameter is
-  mandatory when you create a private image from an external file uploaded to an OBS bucket. The format is *OBS bucket
-  name:Image file name*.
+-> Exactly one of `instance_id`, `backup_id`, `volume_id` or `image_url` must be set.
 
-* `volume_id` - (Optional, String, ForceNew) Specifies the ID of the data disk. This parameter is mandatory when you
-  create a private data image from an ECS, and the data disk must be bound to the ECS instance.
+* `vault_id` - (Optional, String, ForceNew) Specifies the ID of the vault to which an ECS instance is to be added or has
+  been added. This parameter can only be used with `instance_id`. Changing this parameter will create a new resource.
+
+* `backup_id` - (Optional, String, ForceNew) Specifies the ID of the CBR backup that needs to be converted into an
+  image. This parameter is valid and mandatory only when you create a private whole image from a CBR backup.
   Changing this parameter will create a new resource.
 
-* `min_ram` - (Optional, Int) The minimum memory of the image in the unit of MB. The default value is 0,
-  indicating that the memory is not restricted.
+* `volume_id` - (Optional, String, ForceNew) Specifies the ID of the data disk. This parameter is valid and mandatory
+  when you create a private data image from an ECS instance, and the data disk must be bound to the ECS instance.
+  Changing this parameter will create a new resource.
 
-* `max_ram` - (Optional, Int) The maximum memory of the image in the unit of MB.
+* `image_url` - (Optional, String, ForceNew) Specifies the URL of the external image file in the OBS bucket, the format
+  is **OBS bucket name:Image file name**, e.g. **obs_bucket_name:image_test.vhd**. The storage category for OBS bucket
+  and image file must be OBS standard storage. This parameter is valid and mandatory when you create a private system
+  image from an external file uploaded to an OBS bucket, and this parameter can only be used with `min_disk`.
+  Changing this parameter will create a new resource.
 
-* `description` - (Optional, String) A description of the image.
+* `min_disk` - (Optional, Int, ForceNew) Specifies the minimum size of the system disk in the unit of GB. This parameter
+  is valid and mandatory when you create a private system image from an external file uploaded to an OBS bucket.
+  Changing this parameter will create a new resource.
+  + When the operating system is Linux, the value ranges from `10` to `1,024`.
+  + When the operating system is Windows, the value ranges from `20` to `1,024`.
 
-* `tags` - (Optional, Map) The tags of the image.
-
-* `min_disk` - (Optional, Int, ForceNew) The minimum size of the system disk in the unit of GB. This parameter is
-  mandatory when you create a private image from an external file uploaded to an OBS bucket. The value ranges from 1 GB
-  to 1024 GB.
-
-* `os_version` - (Optional, String, ForceNew) The OS version. This parameter is valid when you create a private image
-  from an external file uploaded to an OBS bucket.
+* `os_version` - (Optional, String, ForceNew) Specifies the OS version.
+  Changing this parameter will create a new resource.
   For its values, see [API docs](https://support.huaweicloud.com/intl/en-us/api-ims/ims_03_0910.html).
 
-* `is_config` - (Optional, Bool, ForceNew) If automatic configuration is required, set the value to true. Otherwise, set
-  the value to false.
+* `is_config` - (Optional, Bool, ForceNew) Specifies whether to automatically configure. If automatic backend
+  configuration is required, set the value to **true**, Otherwise, set it to **false**. The default value is **false**.
+  Changing this parameter will create a new resource.
 
-* `cmk_id` - (Optional, String, ForceNew) The master key used for encrypting an image.
+* `cmk_id` - (Optional, String, ForceNew) Specifies the master key used for encrypting an image.
+  Changing this parameter will create a new resource.
 
-* `type` - (Optional, String, ForceNew) The image type. Must be one of `ECS`, `FusionCompute`, `BMS`, or `Ironic`.
+* `type` - (Optional, String, ForceNew) Specifies the image type. The value can be **ECS**, **FusionCompute**, **BMS**,
+  or **Ironic**. Changing this parameter will create a new resource.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the image. Changing this creates a
-  new image.
+-> The `os_version`, `is_config`, `cmk_id`, and `type` parameters are valid only when you create a private system image
+   from an external file uploaded to an OBS bucket.
 
-* `vault_id` - (Optional, String, ForceNew) The ID of the vault to which an ECS is to be added or has been added.
-  This parameter is mandatory when you create a private whole image from an ECS.
+* `description` - (Optional, String) Specifies the description of the image.
+
+* `max_ram` - (Optional, Int) Specifies the maximum memory of the image in the unit of MB.
+
+* `min_ram` - (Optional, Int) Specifies the minimum memory of the image in the unit of MB. The default value is `0`,
+  indicating that the memory is not restricted.
+
+-> When creating a private data image using `volume_id`, the `min_ram` and `max_ram` parameters do not take effect,
+   please ignore them when creating. You can update them after the image is successfully created.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the image.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the IMS image
+  belongs. For enterprise users, if omitted, default enterprise project will be used.
+  Changing this parameter will create a new resource.
 
 ## Attribute Reference
 
@@ -154,10 +162,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `visibility` - Whether the image is visible to other tenants.
 
-* `data_origin` - The image resource. The pattern can be 'instance,*instance_id*', 'file,*image_url*'
-  or 'server_backup,*backup_id*'.
+* `data_origin` - The image resource. The pattern can be **server_backup,backup_id**, **instance,instance_id**,
+  **file,image_url**, or **volume,volume_id**.
 
-* `disk_format` - The image file format. The value can be `vhd`, `zvhd`, `raw`, `zvhd2`, or `qcow2`.
+* `disk_format` - The image file format. The value can be **vhd**, **zvhd**, **raw**, **zvhd2**, or **qcow2**.
 
 * `image_size` - The size(bytes) of the image file format.
 
@@ -174,16 +182,16 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-Images can be imported using the `id`, e.g.
+Image can be imported using the `id`, e.g.
 
 ```bash
-terraform import huaweicloud_images_image.my_image <id>
+$ terraform import huaweicloud_images_image.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response. The missing attributes include: `vault_id`. It is generally recommended running `terraform plan` after
 importing the image. You can then decide if changes should be applied to the image, or the resource
-definition should be updated to align with the image. Also you can ignore changes as below.
+definition should be updated to align with the image. Also, you can ignore changes as below.
 
 ```
 resource "huaweicloud_images_image" "test" {

--- a/huaweicloud/services/ims/resource_huaweicloud_images_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_images_image.go
@@ -50,11 +50,17 @@ func ResourceImsImage() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			// instance_id is required for creating an image from an ECS
+			// `instance_id` is required for creating a system image or a whole image from an ECS.
 			"instance_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -68,21 +74,14 @@ func ResourceImsImage() *schema.Resource {
 				ForceNew:     true,
 				RequiredWith: []string{"instance_id"},
 			},
-			// backup_id is required for creating an image from backup of ECS
+			// `backup_id` is required for creating a whole image from backup of ECS.
 			"backup_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
-			// image_url and min_disk are required for creating an image from an OBS
-			"image_url": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				RequiredWith: []string{"min_disk"},
-			},
-			// This filed is required when creating a data image from data disk of ECS,
+			// `volume_id` is required when creating a data image from data disk of ECS,
 			// and this data disk must be bound to the ECS instance.
 			"volume_id": {
 				Type:     schema.TypeString,
@@ -90,13 +89,20 @@ func ResourceImsImage() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			// `image_url` and `min_disk` are required for creating a system image from an OBS.
+			"image_url": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"min_disk"},
+			},
 			"min_disk": {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"instance_id"},
 			},
-			// following are valid for creating an image from an OBS
+			// Following fields are valid for creating a system image from an OBS.
 			"os_version": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -118,12 +124,7 @@ func ResourceImsImage() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"enterprise_project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
+			// `description` can be left blank, so the `Computed` attribute is not used.
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -139,7 +140,13 @@ func ResourceImsImage() *schema.Resource {
 				Computed: true,
 			},
 			"tags": common.TagsSchema(),
-			// following are additional attributes
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			// Following fields are additional attributes.
 			"visibility": {
 				Type:     schema.TypeString,
 				Computed: true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Update the parameter description and order in the resource document

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Update the parameter description and order in the resource document

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImsImage_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImsImage_ -timeout 360m -parallel 4
=== RUN   TestAccImsImage_basic
=== PAUSE TestAccImsImage_basic
=== RUN   TestAccImsImage_withEpsId
=== PAUSE TestAccImsImage_withEpsId
=== RUN   TestAccImsImage_wholeImage_withServer
=== PAUSE TestAccImsImage_wholeImage_withServer
=== RUN   TestAccImsImage_wholeImage_withBackup
=== PAUSE TestAccImsImage_wholeImage_withBackup
=== RUN   TestAccImsImage_dataImage_withVolumeId
=== PAUSE TestAccImsImage_dataImage_withVolumeId
=== CONT  TestAccImsImage_basic
=== CONT  TestAccImsImage_wholeImage_withBackup
=== CONT  TestAccImsImage_wholeImage_withServer
=== CONT  TestAccImsImage_withEpsId
--- PASS: TestAccImsImage_wholeImage_withBackup (61.24s)
=== CONT  TestAccImsImage_dataImage_withVolumeId
--- PASS: TestAccImsImage_withEpsId (408.80s)
--- PASS: TestAccImsImage_dataImage_withVolumeId (413.69s)
--- PASS: TestAccImsImage_basic (513.29s)
--- PASS: TestAccImsImage_wholeImage_withServer (766.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       766.194s


```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
