### PR TITLE
feat(fgs): Delete function supports the CheckDeleted logic

### DIFF
--- a/huaweicloud/common/errors_test.go
+++ b/huaweicloud/common/errors_test.go
@@ -57,6 +57,54 @@ func TestErrorFunc_ConvertExpected400ErrInto404Err(t *testing.T) {
 	}
 }
 
+func TestErrorFunc_ConvertExpected401ErrInto404Err(t *testing.T) {
+	input401Err := golangsdk.ErrDefault401{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte("{\"error_code\": \"TESTERR.0002\", \"error_msg\": \"Resource not found\"}"),
+		},
+	}
+	input403Err := golangsdk.ErrDefault403{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte("{\"error_code\": \"TESTERR.0003\", \"error_msg\": \"Authentication Failed\"}"),
+		},
+	}
+
+	// Step1: Check whether the function can normally identify the expected error code under follow input and convert
+	// the 401 error into a 404 error.
+	parseResult1 := common.ConvertExpected401ErrInto404Err(input401Err, "error_code", "TESTERR.0002")
+	if _, ok := parseResult1.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 401 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult1).String())
+	}
+	// Step2: Check whether the function can normally recognize unexpected 403 error under follow input and
+	// terminate subsequent processing, and directly return error.
+	parseResult2 := common.ConvertExpected401ErrInto404Err(input403Err, "error_code", "TESTERR.0002")
+	if _, ok := parseResult2.(golangsdk.ErrDefault404); ok {
+		t.Fatalf("The expected 403 error was not recognized and was incorrectly converted")
+	}
+	// Step3: Check whether the function can normally recognize unexpected error code key under follow input and
+	// terminate subsequent processing, and directly return error.
+	parseResult3 := common.ConvertExpected401ErrInto404Err(input401Err, "err_code", "TESTERR.0002")
+	if !reflect.DeepEqual(parseResult3, input401Err) {
+		t.Fatalf("Illegal recognition of unexpected error code key and convert the error to other type")
+	}
+	// Step4: Check whether the function can normally identify the expected error code (during a expected code list)
+	// under follow input and convert the 401 error into a 404 error.
+	parseResult4 := common.ConvertExpected401ErrInto404Err(input401Err, "error_code",
+		[]string{"TESTERR.0001", "TESTERR.0002"}...)
+	if _, ok := parseResult4.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 401 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult1).String())
+	}
+	// Step5: Check whether the function can normally recognize unexpected error code under (during a unmatched code
+	// list) follow input and terminate subsequent processing, and directly return error.
+	parseResult5 := common.ConvertExpected401ErrInto404Err(input401Err, "error_code",
+		[]string{"TESTERR.0001", "TESTERR.0003"}...)
+	if !reflect.DeepEqual(parseResult5, input401Err) {
+		t.Fatalf("error converting 401 error to 404 error via a non-exist error code")
+	}
+}
+
 func TestErrorFunc_ConvertExpected403ErrInto404Err(t *testing.T) {
 	input403Err := golangsdk.ErrDefault403{
 		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_async_invoke_configuration.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_async_invoke_configuration.go
@@ -225,7 +225,7 @@ func resourceAsyncInvokeConfigurationDelete(_ context.Context, d *schema.Resourc
 
 	err = function.DeleteAsyncInvokeConfig(client, d.Id())
 	if err != nil {
-		return diag.Errorf("error deleting the configuration of the asynchronous invocation: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting the configuration of the asynchronous invocation")
 	}
 	return nil
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency.go
@@ -166,7 +166,7 @@ func resourceFgsDependencyDelete(_ context.Context, d *schema.ResourceData, meta
 
 	err = dependencies.Delete(fgsClient, d.Id()).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting custom dependency: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting custom dependency")
 	}
 	return nil
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
@@ -189,7 +189,7 @@ func resourceDependencyVersionDelete(_ context.Context, d *schema.ResourceData, 
 	}
 	err = dependencies.DeleteVersion(client, dependId, version)
 	if err != nil {
-		return diag.Errorf("error deleting custom dependency version: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting custom dependency version")
 	}
 	return nil
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function.go
@@ -1229,7 +1229,7 @@ func resourceFgsFunctionDelete(_ context.Context, d *schema.ResourceData, meta i
 
 	err = function.Delete(fgsClient, urn).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting function: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting function")
 	}
 	return nil
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_event.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_event.go
@@ -226,7 +226,7 @@ func resourceFunctionEventDelete(_ context.Context, d *schema.ResourceData, meta
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting FunctionGraph function event: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting FunctionGraph function event")
 	}
 	return nil
 }

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_function_trigger.go
@@ -350,7 +350,9 @@ func resourceFunctionTriggerDelete(ctx context.Context, d *schema.ResourceData, 
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpts)
 	if err != nil {
-		return diag.Errorf("error deleting function trigger: %s", err)
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected401ErrInto404Err(err, "error_code", "FSS.0401"), // Function not found.
+			"error deleting function trigger")
 	}
 
 	err = waitForFunctionTriggerDeleted(ctx, client, d)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
DeleteContext supports the CheckDeleted logic for the FunctionGraph resources.
To handle the special error code, such as 401 errors, we should to support a public method.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new method to convert the 401 error to the 404 error.
2. delete function supports the CheckDeleted logic.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
go test -v -run=TestErrorFunc_ConvertExpected401ErrInto404Err
=== RUN   TestErrorFunc_ConvertExpected401ErrInto404Err
2024/08/12 19:59:00 [INFO] Identified 401 error with code 'TESTERR.0002' and parsed it as 404 error
2024/08/12 19:59:00 [WARN] Unable to recognize expected error type, want 'golangsdk.ErrDefault401', but got 'golangsdk.ErrDefault403'
2024/08/12 19:59:00 [WARN] Unable to find the expected error code key (err_code)
2024/08/12 19:59:00 [INFO] Identified 401 error with code 'TESTERR.0002' and parsed it as 404 error
2024/08/12 19:59:00 [WARN] Unable to recognize expected error code (TESTERR.0002), want [TESTERR.0001 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertExpected401ErrInto404Err (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common        0.014s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During delete/disassociate/unbind operation (Delete Context)**
  (Function)
  Resource not found
  ![cdcd9e23e5f1bf315498cc1c2556fb4](https://github.com/user-attachments/assets/1d3184fe-45ca-42da-bfd4-14e4d178737b)

  (Function event)
  Resource not found  
  ![image](https://github.com/user-attachments/assets/c0e5762b-4af7-4e9e-9c64-27cea6d15d16)

  Related resources (parent resources) not found
  ![image](https://github.com/user-attachments/assets/d9331971-b8c7-4c62-a9d3-df9bee925049)

  (Function trigger)
  Resource not found
  ![image](https://github.com/user-attachments/assets/7b836a07-2d66-488b-9e21-be5fba0fce47)

  Related resources (parent resources) not found
  ![image](https://github.com/user-attachments/assets/164eb48f-09b9-4bcc-83e8-7b5c1643b891)

  (Dependency)
  Resource not found
  ![image](https://github.com/user-attachments/assets/f0622bad-3621-4173-b986-b0c3bf588cff)

  (Dependency Version)
  Resource not found
  ![image](https://github.com/user-attachments/assets/517715c4-127b-444a-99ff-093bd137e94f)

  (Invoke configuration)
  Resource not found
  ![image](https://github.com/user-attachments/assets/8e6905f1-b337-4911-99d5-146f7567dbe3)

  Related resources (parent resources) not found
  ![image](https://github.com/user-attachments/assets/3a84fbb2-d40d-48e4-a9cb-1ff287c6f958)

