### PR TITLE
feat(dew): the keypair resource support user_id, kms_key_id parameter

### DIFF
--- a/docs/resources/kps_keypair.md
+++ b/docs/resources/kps_keypair.md
@@ -87,13 +87,20 @@ The following arguments are supported:
   The default value is `user`.
   Changing this parameter will create a new resource.
 
+* `user_id` - (Optional, String) Specifies the user ID to which the keypair belongs.
+
+  -> If the `scope` set to **user**, this parameter value must be the ID of the user who creates the resource.
+
 * `encryption_type` - (Optional, String) Specifies encryption mode if manages the private key by HuaweiCloud.
   The options are as follows:
   - **default**: The default encryption mode. Applicable to sites where KMS is not deployed.
   - **kms**: KMS encryption mode.
 
+* `kms_key_id` - (Optional, String) Specifies the KMS key ID to encrypt private keys.
+
 * `kms_key_name` - (Optional, String) Specifies the KMS key name to encrypt private keys.
-  It's mandatory when the `encryption_type` is `kms`.
+
+-> When the `encryption_type` set to **kms**, exactly one of `kms_key_id` or `kms_key_name` must be set.
 
 * `description` - (Optional, String) Specifies the description of key pair.
 
@@ -137,7 +144,7 @@ $ terraform import huaweicloud_kps_keypair.my-keypair test-keypair
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
-API response, security or some other reason. The missing attributes include: `encryption_type`,
+API response, security or some other reason. The missing attributes include: `encryption_type`, `kms_key_id`,
 `kms_key_name` and `private_key`. It is generally recommended running `terraform plan` after importing a key pair.
 You can then decide if changes should be applied to the key pair, or the resource definition
 should be updated to align with the key pair. Also you can ignore changes as below.
@@ -148,7 +155,7 @@ resource "huaweicloud_kps_keypair" "test" {
 
   lifecycle {
     ignore_changes = [
-      encryption_type, kms_key_name, private_key
+      encryption_type, kms_key_id, kms_key_name, private_key
     ]
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The keypair resource support user_id, kms_key_id parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccKpsKeypair_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKpsKeypair_basic -timeout 360m -parallel 4
=== RUN   TestAccKpsKeypair_basic
--- PASS: TestAccKpsKeypair_basic (34.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       34.297s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccKpsKeypair_domain"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKpsKeypair_domain -timeout 360m -parallel 4
=== RUN   TestAccKpsKeypair_domain
--- PASS: TestAccKpsKeypair_domain (41.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       41.259s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccKpsKeypair_publicKey"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKpsKeypair_publicKey -timeout 360m -parallel 4
=== RUN   TestAccKpsKeypair_publicKey
--- PASS: TestAccKpsKeypair_publicKey (33.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       33.338s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/dew" TESTARGS="-run TestAccKpsKeypair_privateKey"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dew -v -run TestAccKpsKeypair_privateKey -timeout 360m -parallel 4
=== RUN   TestAccKpsKeypair_privateKey
--- PASS: TestAccKpsKeypair_privateKey (75.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       75.661s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
