### PR TITLE
fix(fgs/dependency): Ignore the field setting for link parameter

### DIFF
--- a/docs/resources/fgs_dependency_version.md
+++ b/docs/resources/fgs_dependency_version.md
@@ -102,3 +102,21 @@ Or using related dependency package `name` and the `version` number, separated b
 ```bash
 $ terraform import huaweicloud_fgs_dependency_version.test <name>/<version>
 ```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `link`.
+It is generally recommended running `terraform plan` after importing a dependency package.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the dependency package. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_fgs_dependency_version" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      link,
+    ]
+  }
+}
+```

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_dependency_version_test.go
@@ -62,6 +62,9 @@ func TestAccDependencyVersion_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"link",
+				},
 			},
 			// Test the ID format: <depend_name>/<version>
 			{
@@ -69,6 +72,9 @@ func TestAccDependencyVersion_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccDependencyVersionImportStateFunc_withDependName(resourceName),
+				ImportStateVerifyIgnore: []string{
+					"link",
+				},
 			},
 			// Test the ID format: <depend_name>/<version_id>
 			{
@@ -76,6 +82,9 @@ func TestAccDependencyVersion_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccDependencyVersionImportStateFunc_withVersionId(resourceName),
+				ImportStateVerifyIgnore: []string{
+					"link",
+				},
 			},
 		},
 	})

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_dependency_version.go
@@ -157,11 +157,14 @@ func resourceDependencyVersionRead(_ context.Context, d *schema.ResourceData, me
 		return common.CheckDeletedDiag(d, err, "FunctionGraph dependency version")
 	}
 
+	// FunctionGraph will store the compressed package content pointed to by the link into the new storage bucket that
+	// provided by FunctionGraph and return a new link value.
+	// If the ReadContext is set this value according to the query result, ForceNew behavior will be triggered the next
+	// time it is applied.
 	mErr := multierror.Append(
 		d.Set("runtime", resp.Runtime),
 		d.Set("name", resp.Name),
 		d.Set("description", resp.Description),
-		d.Set("link", resp.Link),
 		d.Set("etag", resp.Etag),
 		d.Set("size", resp.Size),
 		d.Set("owner", resp.Owner),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Ignore the field setting for the link parameter because of the value is not input link (actually is new link that FunctionGraph provided).
![274c61e77c9c335f916cb680bf47ab4](https://github.com/user-attachments/assets/1c8bd7f5-9971-4b90-9444-8d79fb4313b6)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. ignore the field setting for link parameter.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/fgs' TESTARGS='-run=TestAccDependencyVersion_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/fgs -v -run=TestAccDependencyVersion_basic -timeout 360m -parallel 4
=== RUN   TestAccDependencyVersion_basic
=== PAUSE TestAccDependencyVersion_basic
=== CONT  TestAccDependencyVersion_basic
--- PASS: TestAccDependencyVersion_basic (21.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       21.208s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
