### PR TITLE
fix(dws): fix some resources cannot trigger the check checkdeleted logic

### DIFF
--- a/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
@@ -337,9 +337,11 @@ func resourceLogicalClusterRead(_ context.Context, d *schema.ResourceData, meta 
 	}
 
 	clusterRespBody, err := readLogicalClusters(client, d)
-	// The list API response status code is `404` when the cluster does not exist.
+	// The list API response status code is `404` when the cluster does not exist (standard UUID format).
+	// "DWS.0001": The cluster ID is a non-standard UUID, the status code is 400.
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving DWS logical cluster")
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", ClusterIdIllegalErrCode),
+			"error retrieving DWS logical cluster")
 	}
 
 	expression := fmt.Sprintf("logical_clusters[?logical_cluster_id=='%s']|[0]", d.Id())

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot_policy.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_snapshot_policy.go
@@ -181,7 +181,11 @@ func resourceDwsSnapshotPolicyRead(_ context.Context, d *schema.ResourceData, me
 	getDwsSnapshotPolicyResp, err := getDwsSnapshotPolicyClient.Request("GET", getDwsSnapshotPolicyPath, &getDwsSnapshotPolicyOpt)
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving DwsSnapshotPolicy")
+		// The cluster ID does not exist.
+		// "DWS.0001": The cluster ID is a non-standard UUID, the status code is 400.
+		// "DWS.0047": The cluster ID is a standard UUID, the status code is 404.
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", ClusterIdIllegalErrCode),
+			"error retrieving DWS snapshot policy")
 	}
 
 	getDwsSnapshotPolicyRespBody, err := utils.FlattenResponse(getDwsSnapshotPolicyResp)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix  the issue that the checkdeleted logic cannot be triggered for cluster/ext_data_source/snapshot_policy/logical_cluster resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV1
=== PAUSE TestAccResourceCluster_basicV1
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== CONT  TestAccResourceCluster_basicV1
=== CONT  TestAccResourceCluster_basicV2
--- PASS: TestAccResourceCluster_basicV1 (2418.03s)
--- PASS: TestAccResourceCluster_basicV2 (2720.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       2720.910s

make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccDwsExtDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDwsExtDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccDwsExtDataSource_basic
=== PAUSE TestAccDwsExtDataSource_basic
=== CONT  TestAccDwsExtDataSource_basic
--- PASS: TestAccDwsExtDataSource_basic (1546.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1547.013s

make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccDwsSnapshotPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDwsSnapshotPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccDwsSnapshotPolicy_basic
=== PAUSE TestAccDwsSnapshotPolicy_basic
=== CONT  TestAccDwsSnapshotPolicy_basic
--- PASS: TestAccDwsSnapshotPolicy_basic (1369.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1369.409s

make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccLogicalCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccLogicalCluster_basic -timeout 360m -parallel 4
=== RUN   TestAccLogicalCluster_basic
=== PAUSE TestAccLogicalCluster_basic
=== CONT  TestAccLogicalCluster_basic
--- PASS: TestAccLogicalCluster_basic (1934.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1935.000s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    `huaweicloud_dws_cluster`
     Resource not found(the cluster was deleted after it was created. Status code is 404)
     ![image](https://github.com/user-attachments/assets/d6de8713-da84-45af-9d2d-19fb0bec6301)

     Resource not found (cluster ID is standard UUID) 
     ![image](https://github.com/user-attachments/assets/db88f0c8-5c16-40e5-ac77-3bd83df3e0ab)

     Resource not found (cluster ID is non-standard UUID) 
     ![image](https://github.com/user-attachments/assets/195d3949-ff2a-409c-9eb2-0765435caa20)

   `huaweicloud_dws_ext_data_source`
     Resource not found
      ![image](https://github.com/user-attachments/assets/000a705d-d59e-44c6-92be-c79efad74c91)

    Related resources (cluster ID is standard UUID) not found
    ![image](https://github.com/user-attachments/assets/8e2a6349-e104-4b8f-a7b4-0edcd06e2f5e)

    Related resources (cluster ID is non-standard UUID) not found
    ![image](https://github.com/user-attachments/assets/8d8deae4-a0e1-4b26-be15-613b874ce4e2)


    `huaweicloud_dws_snapshot_policy`
    Resource not found
    ![image](https://github.com/user-attachments/assets/4abd2a84-e716-4de2-959c-2a43fd204a27)

    Related resources (cluster ID is standard UUID) not found
    ![image](https://github.com/user-attachments/assets/9e084948-9701-42d8-aea1-f08dc187abb3)

    Related resources (cluster ID is non-standard UUID) not found
    ![image](https://github.com/user-attachments/assets/fd766026-0b91-4d5f-8ae5-79a13de8d7d1)

    `huaweicloud_dws_logical_cluster`
     Resource not found
      ![image](https://github.com/user-attachments/assets/0a9b187c-4a8a-461f-9547-cf02d8ec6caa)

     Resource not found (cluster ID is standard UUID) 
      ![image](https://github.com/user-attachments/assets/14127812-c7e6-4f34-97b0-b4194ae0548e)

     Resource not found (cluster ID is non-standard UUID) 
     ![image](https://github.com/user-attachments/assets/fb05119e-6a56-495a-be89-8fb246340246)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
