### PR TITLE
chore(VPCEP): endpoint resource support new fields and fix some error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240809085804-adb116c0da60
+	github.com/chnsz/golangsdk v0.0.0-20240815022804-baa9f87c2b9d
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240809085804-adb116c0da60 h1:+5KluMZRedbCa8gr3Q428HvO9BmOiOkD4iLCizqiipg=
-github.com/chnsz/golangsdk v0.0.0-20240809085804-adb116c0da60/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240815022804-baa9f87c2b9d h1:jHekx6s6NGGJ0v3Sano/3+w7DUphcXKgMtuPg8VM894=
+github.com/chnsz/golangsdk v0.0.0-20240815022804-baa9f87c2b9d/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages/requests.go
@@ -227,6 +227,8 @@ type CreateDataImageByOBSOpts struct {
 	MinDisk int `json:"min_disk" required:"true"`
 	// the master key used for encrypting an image
 	CmkId string `json:"cmk_id,omitempty"`
+	// One or more tag key and value pairs to associate with the image
+	ImageTags []ImageTag `json:"image_tags,omitempty"`
 	// Enterprise project ID
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/requests.go
@@ -22,22 +22,37 @@ type CreateOpts struct {
 	// Specifies the network ID of the subnet created in the VPC specified by vpc_id
 	// The parameter is mandatory to create an interface VPC endpoint
 	SubnetID string `json:"subnet_id,omitempty"`
-	// Specifies the IP address for accessing the associated VPC endpoint service
-	PortIP string `json:"port_ip,omitempty"`
 	// Specifies whether to create a private domain name
 	EnableDNS *bool `json:"enable_dns,omitempty"`
-	// Specifies whether to enable access control
-	EnableWhitelist *bool `json:"enable_whitelist,omitempty"`
-	// Specifies the whitelist for controlling access to the VPC endpoint
-	Whitelist []string `json:"whitelist,omitempty"`
+	// Specifies the resource tags in key/value format
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
 	// Specifies the IDs of route tables
 	// The parameter is mandatory to create a gateway type VPC endpoint
 	// If the parameter is not set, will be associated with the default route table
 	RouteTables []string `json:"routetables,omitempty"`
-	// Specifies the resource tags in key/value format
-	Tags []tags.ResourceTag `json:"tags,omitempty"`
+	// Specifies the IP address for accessing the associated VPC endpoint service
+	PortIP string `json:"port_ip,omitempty"`
+	// Specifies the whitelist for controlling access to the VPC endpoint
+	Whitelist []string `json:"whitelist,omitempty"`
+	// Specifies whether to enable access control
+	EnableWhitelist *bool `json:"enable_whitelist,omitempty"`
 	// Specifies the description of the VPC endpoint service
 	Description string `json:"description,omitempty"`
+	// Specifies the endpoint policy information for the gateway type
+	PolicyStatement []PolicyStatement `json:"policy_statement,omitempty"`
+	// Specifies the endpoint policy information
+	PolicyDocument string `json:"policy_document,omitempty"`
+	// Specifies the IP version
+	IPVersion string `json:"ip_version,omitempty"`
+	// Specifies the IPv6 address
+	IPv6Address string `json:"ipv6_address,omitempty"`
+}
+
+// PolicyStatement represents the Statement of the gateway
+type PolicyStatement struct {
+	Effect   string   `json:"Effect" required:"true"`
+	Action   []string `json:"Action" required:"true"`
+	Resource []string `json:"Resource" required:"true"`
 }
 
 // ToEndpointCreateMap assembles a request body based on the contents of a CreateOpts.
@@ -88,6 +103,36 @@ func Update(c *golangsdk.ServiceClient, opts UpdateOptsBuilder, endpointID strin
 	}
 
 	_, r.Err = c.Put(resourceURL(c, endpointID), b, &r.Body, nil)
+	return
+}
+
+// UpdatePolicyOptsBuilder using to update endpoint policy
+type UpdatePolicyOptsBuilder interface {
+	UpdatePolicyOptsMap() (map[string]interface{}, error)
+}
+
+// UpdatePolicyOpts using to pass to UpdatePolicy()
+type UpdatePolicyOpts struct {
+	// Specifies the endpoint policy information for the gateway type
+	PolicyStatement []PolicyStatement `json:"policy_statement,omitempty"`
+	// Specifies the endpoint policy information
+	PolicyDocument string `json:"policy_document,omitempty"`
+}
+
+// UpdatePolicyOptsMap assembles a request body based on the contents of a UpdatePolicyOpts.
+func (opts UpdatePolicyOpts) UpdatePolicyOptsMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// UpdatePolicy accepts a UpdatePolicyOpts struct and uses the values to update endpoint policy
+func UpdatePolicy(c *golangsdk.ServiceClient, opts UpdatePolicyOptsBuilder, endpointID string) (r UpdateResult) {
+	b, err := opts.UpdatePolicyOptsMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Put(updatePolicyURL(c, endpointID), b, &r.Body, nil)
 	return
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/results.go
@@ -9,6 +9,8 @@ import (
 type Endpoint struct {
 	// the ID of the VPC endpoint
 	ID string `json:"id"`
+	// the type of the VPC endpoint service that is associated with the VPC endpoint
+	ServiceType string `json:"service_type"`
 	// the connection status of the VPC endpoint
 	Status string `json:"status"`
 	// the account status: frozen or active
@@ -17,40 +19,63 @@ type Endpoint struct {
 	EnableStatus string `json:"enable_status"`
 	// the specification name of VPC endpoint
 	SpecificationName string `json:"specification_name"`
-	// the type of the VPC endpoint service that is associated with the VPC endpoint
-	ServiceType string `json:"service_type"`
 	// the name of the VPC endpoint service
 	ServiceName string `json:"endpoint_service_name"`
-	// the ID of the VPC endpoint service
-	ServiceID string `json:"endpoint_service_id"`
-	// the ID of the VPC where the VPC endpoint is to be created
-	VpcID string `json:"vpc_id"`
-	// the network ID of the subnet in the VPC specified by vpc_id
-	SubnetID string `json:"subnet_id"`
-	// the IP address for accessing the associated VPC endpoint service
-	IPAddr string `json:"ip"`
 	// the packet ID of the VPC endpoint
 	MarkerID int `json:"marker_id"`
+	// the ID of the VPC endpoint service
+	ServiceID string `json:"endpoint_service_id"`
 	// whether to create a private domain name
 	EnableDNS bool `json:"enable_dns"`
 	// the domain name for accessing the associated VPC endpoint service
 	DNSNames []string `json:"dns_names"`
-	// whether to enable access control
-	EnableWhitelist bool `json:"enable_whitelist"`
-	// the whitelist for controlling access to the VPC endpoint
-	Whitelist []string `json:"whitelist"`
-	// the IDs of route tables
-	RouteTables []string `json:"routetables"`
-	// the resource tags
-	Tags []tags.ResourceTag `json:"tags"`
-	// the project ID
-	ProjectID string `json:"project_id"`
-	// the description of the VPC endpoint
-	Description string `json:"description"`
+	// the IP address for accessing the associated VPC endpoint service
+	IPAddr string `json:"ip"`
+	// the ID of the VPC where the VPC endpoint is to be created
+	VpcID string `json:"vpc_id"`
+	// the network ID of the subnet in the VPC specified by vpc_id
+	SubnetID string `json:"subnet_id"`
 	// the creation time of the VPC endpoint
 	Created string `json:"created_at"`
 	// the update time of the VPC endpoint
 	Updated string `json:"updated_at"`
+	// the project ID
+	ProjectID string `json:"project_id"`
+	// the resource tags
+	Tags []tags.ResourceTag `json:"tags"`
+	// Exception information returned by query resources
+	Error QueryError `json:"error"`
+	// the whitelist for controlling access to the VPC endpoint
+	Whitelist []string `json:"whitelist"`
+	// whether to enable access control
+	EnableWhitelist bool `json:"enable_whitelist"`
+	// the IDs of route tables
+	RouteTables []string `json:"routetables"`
+	// the description of the VPC endpoint
+	Description string `json:"description"`
+	// The gateway type endpoint policy information
+	PolicyStatement []PolicyStatementResult `json:"policy_statement"`
+	// the endpoint policy information
+	PolicyDocument string `json:"policy_document"`
+	// The cluster ID associated with the instance
+	EndpointPoolID string `json:"endpoint_pool_id"`
+	// The public border group information of the terminal node corresponding to the pool
+	PublicBorderGroup string `json:"public_border_group"`
+	// The IPv6 address to access the connected endpoint service
+	Ipv6Address string `json:"ipv6_address"`
+}
+
+type QueryError struct {
+	// The error code
+	ErrorCode string `json:"error_code"`
+	// The error message
+	ErrorMessage string `json:"error_message"`
+}
+
+type PolicyStatementResult struct {
+	Effect   string   `json:"Effect"`
+	Action   []string `json:"Action"`
+	Resource []string `json:"Resource"`
 }
 
 type commonResult struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/urls.go
@@ -13,3 +13,7 @@ func rootURL(c *golangsdk.ServiceClient) string {
 func resourceURL(c *golangsdk.ServiceClient, endpointID string) string {
 	return c.ServiceURL(rootPath, endpointID)
 }
+
+func updatePolicyURL(c *golangsdk.ServiceClient, endpointID string) string {
+	return c.ServiceURL(rootPath, endpointID, "policy")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240809085804-adb116c0da60
+# github.com/chnsz/golangsdk v0.0.0-20240815022804-baa9f87c2b9d
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- endpoint resource support new fields and fix some documentation error
  - support new fields `policy_statement` and `policy_document`.
  - Improve the document to be compatible with the new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Field `policy_document` was not tested due to insufficient testing conditions.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEndpoint_Basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpoint_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_Basic
=== PAUSE TestAccVPCEndpoint_Basic
=== CONT  TestAccVPCEndpoint_Basic
--- PASS: TestAccVPCEndpoint_Basic (249.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     249.373s
```

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEndpoint_Public'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpoint_Public -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_Public
=== PAUSE TestAccVPCEndpoint_Public
=== CONT  TestAccVPCEndpoint_Public
--- PASS: TestAccVPCEndpoint_Public (43.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     43.682s
```

```
make testacc TEST='./huaweicloud/services/acceptance/vpcep' TESTARGS='-run TestAccVPCEndpoint_gatewayEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpoint_gatewayEndpoint -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_gatewayEndpoint
=== PAUSE TestAccVPCEndpoint_gatewayEndpoint
=== CONT  TestAccVPCEndpoint_gatewayEndpoint
--- PASS: TestAccVPCEndpoint_gatewayEndpoint (234.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     234.434s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
