### PR TITLE
refactor(eg/channel): deprecate the channel_id filter and refactor the resource codes

### DIFF
--- a/docs/data-sources/eg_custom_event_channels.md
+++ b/docs/data-sources/eg_custom_event_channels.md
@@ -26,8 +26,6 @@ The following arguments are supported:
 * `region` - (Optional, String) Specifies the region where the custom event channels are located.  
   If omitted, the provider-level region will be used.
 
-* `channel_id` - (Optional, String) Specifies the channel ID used to query specified custom event channel.
-
 * `name` - (Optional, String) Specifies the channel name used to query specified custom event channel.
 
 * `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the custom event

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_custom_event_channels_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_custom_event_channels_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
@@ -18,7 +16,7 @@ func TestAccDataCustomEventChannels_basic(t *testing.T) {
 		byName       = "data.huaweicloud_eg_custom_event_channels.filter_by_name"
 		nameNotFound = "data.huaweicloud_eg_custom_event_channels.name_not_found"
 
-		obj            custom.Channel
+		obj            interface{}
 		rc             = acceptance.InitResourceCheck(baseRes, &obj, getCustomEventChannelFunc)
 		dcByName       = acceptance.InitDataSourceCheck(byName)
 		dcNameNotFound = acceptance.InitDataSourceCheck(nameNotFound)
@@ -96,7 +94,7 @@ func TestAccDataCustomEventChannels_filterById(t *testing.T) {
 		byId       = "data.huaweicloud_eg_custom_event_channels.filter_by_id"
 		idNotFound = "data.huaweicloud_eg_custom_event_channels.id_not_found"
 
-		obj          custom.Channel
+		obj          interface{}
 		rc           = acceptance.InitResourceCheck(baseRes, &obj, getCustomEventChannelFunc)
 		dcById       = acceptance.InitDataSourceCheck(byId)
 		dcIdNotFound = acceptance.InitDataSourceCheck(idNotFound)
@@ -162,7 +160,7 @@ func TestAccDataCustomEventChannels_filterByEpsId(t *testing.T) {
 		byChannelId       = "data.huaweicloud_eg_custom_event_channels.filter_by_eps_id"
 		channelIdNotFound = "data.huaweicloud_eg_custom_event_channels.eps_id_not_found"
 
-		obj             custom.Channel
+		obj             interface{}
 		rc              = acceptance.InitResourceCheck(baseRes, &obj, getCustomEventChannelFunc)
 		dcByEpsId       = acceptance.InitDataSourceCheck(byChannelId)
 		dcEpsIdNotFound = acceptance.InitDataSourceCheck(channelIdNotFound)

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
@@ -3,13 +3,14 @@ package eg
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/chnsz/golangsdk/openstack/eg/v1/channel/custom"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -28,13 +29,13 @@ func DataSourceCustomEventChannels() *schema.Resource {
 			"region": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The region where the custom event channels are located.",
+				Description: `The region where the custom event channels are located.`,
 			},
 			"channel_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: utils.SchemaDesc(
-					"The channel ID used to query specified custom event channel.",
+					`The channel ID used to query specified custom event channel.`,
 					utils.SchemaDescInput{
 						Deprecated: true,
 					},
@@ -43,12 +44,12 @@ func DataSourceCustomEventChannels() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The channel name used to query specified custom event channel.",
+				Description: `The channel name used to query specified custom event channel.`,
 			},
 			"enterprise_project_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The ID of the enterprise project to which the custom event channels belong.",
+				Description: `The ID of the enterprise project to which the custom event channels belong.`,
 			},
 			"channels": {
 				Type:     schema.TypeList,
@@ -58,43 +59,43 @@ func DataSourceCustomEventChannels() *schema.Resource {
 						"id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The ID of the custom event channel.",
+							Description: `The ID of the custom event channel.`,
 						},
 						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The name of the custom event channel.",
+							Description: `The name of the custom event channel.`,
 						},
 						"description": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The description of the custom event channel.",
+							Description: `The description of the custom event channel.`,
 						},
 						"provider_type": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The type of the custom event channel.",
+							Description: `The type of the custom event channel.`,
 						},
 						"enterprise_project_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The ID of the enterprise project to which the custom event channel belongs.",
+							Description: `The ID of the enterprise project to which the custom event channel belongs.`,
 						},
 						"cross_account_ids": {
 							Type:        schema.TypeSet,
 							Computed:    true,
-							Description: "The list of domain IDs (other tenants) for the cross-account policy.",
+							Description: `The list of domain IDs (other tenants) for the cross-account policy.`,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
 						"created_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The creation time of the custom event channel.",
+							Description: `The creation time of the custom event channel.`,
 						},
 						"updated_at": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "The latest update time of the custom event channel.",
+							Description: `The latest update time of the custom event channel.`,
 						},
 					},
 				},
@@ -103,35 +104,79 @@ func DataSourceCustomEventChannels() *schema.Resource {
 	}
 }
 
-func filterEventChannels(channels []custom.Channel, epsId string) ([]interface{}, error) {
-	filter := map[string]interface{}{
-		"EnterpriseProjectId": epsId,
+func buildEventChannelsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if apiName, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, apiName)
 	}
-
-	filterResult, err := utils.FilterSliceWithField(channels, filter)
-	if err != nil {
-		return nil, fmt.Errorf("error filting list of event channels: %s", err)
+	if channelId, ok := d.GetOk("channel_id"); ok {
+		res = fmt.Sprintf("%s&channel_id=%v", res, channelId)
 	}
-	return filterResult, nil
+	return res
 }
 
-func flattenEventChannels(channels []interface{}) []map[string]interface{} {
-	if len(channels) < 1 {
-		return nil
+func queryEventChannels(client *golangsdk.ServiceClient, d *schema.ResourceData, providerType string) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/channels?provider_type={provider_type}&limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{provider_type}", providerType)
+	listPath += buildEventChannelsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
 	}
 
-	result := make([]map[string]interface{}, len(channels))
-	for i, val := range channels {
-		channel := val.(custom.Channel)
-		result[i] = map[string]interface{}{
-			"id":                    channel.ID,
-			"name":                  channel.Name,
-			"provider_type":         channel.ProviderType,
-			"enterprise_project_id": channel.EnterpriseProjectId,
-			"cross_account_ids":     channel.Policy.Principal.IAM,
-			"created_at":            channel.CreatedTime,
-			"updated_at":            channel.UpdatedTime,
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
 		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		channels := utils.PathSearch("items", respBody, make([]interface{}, 0)).([]interface{})
+		if len(channels) < 1 {
+			break
+		}
+		result = append(result, channels...)
+		offset += len(channels)
+	}
+
+	return result, nil
+}
+
+func flattenEventChannels(channels []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(channels))
+
+	for _, channel := range channels {
+		result = append(result, map[string]interface{}{
+			"id":                    utils.PathSearch("id", channel, nil),
+			"name":                  utils.PathSearch("name", channel, nil),
+			"provider_type":         utils.PathSearch("provider_type", channel, nil),
+			"enterprise_project_id": utils.PathSearch("eps_id", channel, nil),
+			"cross_account_ids":     utils.PathSearch("policy.Principal.IAM", channel, make([]interface{}, 0)),
+			"created_at":            utils.PathSearch("created_time", channel, nil),
+			"updated_at":            utils.PathSearch("updated_time", channel, nil),
+		})
+	}
+
+	return result
+}
+
+func filterEventChannels(cfg *config.Config, d *schema.ResourceData, channels []interface{}) []interface{} {
+	// Copy slice contents without having to worry about underlying reuse issues.
+	result := channels
+	if epsId := cfg.GetEnterpriseProjectID(d); epsId != "" {
+		result = utils.PathSearch(fmt.Sprintf("[?eps_id=='%s']", epsId), result, make([]interface{}, 0)).([]interface{})
 	}
 	return result
 }
@@ -140,24 +185,15 @@ func dataSourceCustomEventChannelsRead(_ context.Context, d *schema.ResourceData
 	var (
 		cfg    = meta.(*config.Config)
 		region = cfg.GetRegion(d)
-		opts   = custom.ListOpts{
-			ChannelId:    d.Get("channel_id").(string),
-			ProviderType: "CUSTOM",
-			Name:         d.Get("name").(string),
-		}
 	)
 	client, err := cfg.EgV1Client(region)
 	if err != nil {
 		return diag.Errorf("error creating EG v1 client: %s", err)
 	}
 
-	resp, err := custom.List(client, opts)
+	channaels, err := queryEventChannels(client, d, "CUSTOM")
 	if err != nil {
 		return diag.Errorf("error querying custom event channels: %s", err)
-	}
-	filterResult, err := filterEventChannels(resp, cfg.GetEnterpriseProjectID(d))
-	if err != nil {
-		return diag.FromErr(err)
 	}
 
 	uuid, err := uuid.GenerateUUID()
@@ -168,7 +204,7 @@ func dataSourceCustomEventChannelsRead(_ context.Context, d *schema.ResourceData
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("channels", flattenEventChannels(filterResult)),
+		d.Set("channels", flattenEventChannels(filterEventChannels(cfg, d, channaels))),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error saving data source fields of EG custom event channels: %s", err)

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
@@ -82,7 +82,7 @@ func DataSourceCustomEventChannels() *schema.Resource {
 							Description: `The ID of the enterprise project to which the custom event channel belongs.`,
 						},
 						"cross_account_ids": {
-							Type:        schema.TypeSet,
+							Type:        schema.TypeList,
 							Computed:    true,
 							Description: `The list of domain IDs (other tenants) for the cross-account policy.`,
 							Elem:        &schema.Schema{Type: schema.TypeString},

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
@@ -31,9 +31,14 @@ func DataSourceCustomEventChannels() *schema.Resource {
 				Description: "The region where the custom event channels are located.",
 			},
 			"channel_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The channel ID used to query specified custom event channel.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: utils.SchemaDesc(
+					"The channel ID used to query specified custom event channel.",
+					utils.SchemaDescInput{
+						Deprecated: true,
+					},
+				),
 			},
 			"name": {
 				Type:        schema.TypeString,
@@ -98,19 +103,19 @@ func DataSourceCustomEventChannels() *schema.Resource {
 	}
 }
 
-func filterCustomEventChannels(channels []custom.Channel, epsId string) ([]interface{}, error) {
+func filterEventChannels(channels []custom.Channel, epsId string) ([]interface{}, error) {
 	filter := map[string]interface{}{
 		"EnterpriseProjectId": epsId,
 	}
 
 	filterResult, err := utils.FilterSliceWithField(channels, filter)
 	if err != nil {
-		return nil, fmt.Errorf("error filting list of custom event channels: %s", err)
+		return nil, fmt.Errorf("error filting list of event channels: %s", err)
 	}
 	return filterResult, nil
 }
 
-func flattenCustomEventChannels(channels []interface{}) []map[string]interface{} {
+func flattenEventChannels(channels []interface{}) []map[string]interface{} {
 	if len(channels) < 1 {
 		return nil
 	}
@@ -150,7 +155,7 @@ func dataSourceCustomEventChannelsRead(_ context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.Errorf("error querying custom event channels: %s", err)
 	}
-	filterResult, err := filterCustomEventChannels(resp, cfg.GetEnterpriseProjectID(d))
+	filterResult, err := filterEventChannels(resp, cfg.GetEnterpriseProjectID(d))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -163,7 +168,7 @@ func dataSourceCustomEventChannelsRead(_ context.Context, d *schema.ResourceData
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("channels", flattenCustomEventChannels(filterResult)),
+		d.Set("channels", flattenEventChannels(filterResult)),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return diag.Errorf("error saving data source fields of EG custom event channels: %s", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The API document has offline the channel_id parameter, so, we mark it as deprecated and remove it from the markdown file definition.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. deprecate the channel_id filter
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/eg' TESTARGS='-run=TestAccDataCustomEventChannels_filterById'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eg -v -run=TestAccDataCustomEventChannels_filterById -timeout 360m -parallel 4
=== RUN   TestAccDataCustomEventChannels_filterById
=== PAUSE TestAccDataCustomEventChannels_filterById
=== CONT  TestAccDataCustomEventChannels_filterById
--- PASS: TestAccDataCustomEventChannels_filterById (37.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        37.113s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
