### PR TITLE
chore(waf): add checkDeleted logic

### DIFF
--- a/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_policy.go
@@ -300,6 +300,7 @@ func resourceWafPolicyV1Read(_ context.Context, d *schema.ResourceData, meta int
 
 	n, err := policies.GetWithEpsID(wafClient, d.Id(), cfg.GetEnterpriseProjectID(d)).Extract()
 	if err != nil {
+		// If the policy does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF policy")
 	}
 
@@ -387,7 +388,8 @@ func resourceWafPolicyV1Delete(_ context.Context, d *schema.ResourceData, meta i
 
 	err = policies.DeleteWithEpsID(wafClient, d.Id(), cfg.GetEnterpriseProjectID(d)).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting WAF policy: %s", err)
+		// If the policy does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF policy")
 	}
 	return nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_anti_crawler.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_anti_crawler.go
@@ -256,6 +256,7 @@ func resourceAntiCrawlerRuleRead(_ context.Context, d *schema.ResourceData, meta
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
+		// If the anti crawler rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF anti crawler rule")
 	}
 
@@ -355,7 +356,8 @@ func resourceAntiCrawlerRuleDelete(_ context.Context, d *schema.ResourceData, me
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting WAF anti crawler rule: %s", err)
+		// If the anti crawler rule does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF anti crawler rule")
 	}
 	return nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_blacklist.go
@@ -148,6 +148,7 @@ func resourceWafRuleBlackListRead(_ context.Context, d *schema.ResourceData, met
 	policyID := d.Get("policy_id").(string)
 	n, err := rules.GetWithEpsId(wafClient, policyID, d.Id(), cfg.GetEnterpriseProjectID(d)).Extract()
 	if err != nil {
+		// If the blacklist and whitelist rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF blacklist and whitelist rule")
 	}
 
@@ -227,7 +228,8 @@ func resourceWafRuleBlackListDelete(_ context.Context, d *schema.ResourceData, m
 	policyID := d.Get("policy_id").(string)
 	err = rules.DeleteWithEpsId(wafClient, policyID, d.Id(), cfg.GetEnterpriseProjectID(d)).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting WAF blacklist and whitelist rule: %s", err)
+		// If the blacklist and whitelist rule does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF blacklist and whitelist rule")
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add checkDeleted logic to the resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Involved resources are as follows:
  WAF policy resource, WAF anti crawler rule resource, WAF blacklist and whitelist rule resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafPolicyV1_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafPolicyV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafPolicyV1_basic
=== PAUSE TestAccWafPolicyV1_basic
=== CONT  TestAccWafPolicyV1_basic
--- PASS: TestAccWafPolicyV1_basic (527.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       527.999s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccRuleAntiCrawler_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleAntiCrawler_basic -timeout 360m -parallel 4
=== RUN   TestAccRuleAntiCrawler_basic
=== PAUSE TestAccRuleAntiCrawler_basic
=== CONT  TestAccRuleAntiCrawler_basic
--- PASS: TestAccRuleAntiCrawler_basic (517.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       517.625s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafRuleBlackList_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleBlackList_basic -timeout 360m -parallel 4
=== RUN   TestAccWafRuleBlackList_basic
=== PAUSE TestAccWafRuleBlackList_basic
=== CONT  TestAccWafRuleBlackList_basic
--- PASS: TestAccWafRuleBlackList_basic (524.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       524.264s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
### WAF policy resource
![image](https://github.com/user-attachments/assets/e279e7d6-17e3-4bc0-9461-4b8f5a1d443c)
### WAF anti crawler rule resource
![image](https://github.com/user-attachments/assets/6eda55d6-b8fd-4e06-89bd-595a9ff45bc8)
###  WAF blacklist and whitelist rule resource
![image](https://github.com/user-attachments/assets/e6592e4b-976a-41a7-954b-3ceb65dae60e)
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
### WAF anti crawler rule resource
![image](https://github.com/user-attachments/assets/221b1050-8783-4ffa-91a0-ace9244147dc)
###  WAF blacklist and whitelist rule resource
![image](https://github.com/user-attachments/assets/f2c14c6f-51b5-4967-8416-62c686c8868d)
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
### WAF policy resource
![image](https://github.com/user-attachments/assets/11d9f457-f8e1-405e-acf6-c278d23c3ca9)
### WAF anti crawler rule resource
![image](https://github.com/user-attachments/assets/61ca7e37-4ba1-4da6-93ed-cda388ff4ce1)
###  WAF blacklist and whitelist rule resource
![image](https://github.com/user-attachments/assets/540cecd6-1455-4888-8c77-b73b337f4860)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
