### PR TITLE
chore(waf): add checkDeleted logic to delete function

### DIFF
--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_cc_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_cc_protection.go
@@ -345,6 +345,7 @@ func resourceRuleCCProtectionRead(_ context.Context, d *schema.ResourceData, met
 	getResp, err := getClient.Request("GET", getPath, &getOpt)
 
 	if err != nil {
+		// If the cc rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving RuleCCProtection")
 	}
 
@@ -487,7 +488,8 @@ func resourceRuleCCProtectionDelete(_ context.Context, d *schema.ResourceData, m
 	}
 	_, err = deleteRuleCCProtectionClient.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting RuleCCProtection: %s", err)
+		// If the cc rule does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting RuleCCProtection")
 	}
 	return nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_data_masking.go
@@ -128,6 +128,7 @@ func resourceWafRuleDataMaskingRead(_ context.Context, d *schema.ResourceData, m
 	epsID := cfg.GetEnterpriseProjectID(d)
 	n, err := rules.GetWithEpsID(wafClient, policyID, d.Id(), epsID).Extract()
 	if err != nil {
+		// If the data masking rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF data masking rule")
 	}
 
@@ -185,7 +186,8 @@ func resourceWafRuleDataMaskingDelete(_ context.Context, d *schema.ResourceData,
 	policyID := d.Get("policy_id").(string)
 	err = rules.DeleteWithEpsID(wafClient, policyID, d.Id(), cfg.GetEnterpriseProjectID(d)).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting WAF data masking rule: %s", err)
+		// If the data masking rule does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF data masking rule")
 	}
 	return nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_geolocation_access_control.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_geolocation_access_control.go
@@ -165,6 +165,7 @@ func resourceRuleGeolocationRead(_ context.Context, d *schema.ResourceData, meta
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
+		// If the rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF geolocation access control rule")
 	}
 
@@ -264,7 +265,8 @@ func resourceRuleGeolocationDelete(_ context.Context, d *schema.ResourceData, me
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting WAF geolocation access control rule: %s", err)
+		// If the rule does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF geolocation access control rule")
 	}
 
 	return nil

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_global_protection_whitelist.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_global_protection_whitelist.go
@@ -272,6 +272,7 @@ func resourceRuleGlobalProtectionWhitelistRead(_ context.Context, d *schema.Reso
 	getResp, err := getClient.Request("GET", getPath, &getOpt)
 
 	if err != nil {
+		// If the rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving RuleGlobalProtectionWhitelist")
 	}
 
@@ -399,7 +400,8 @@ func resourceRuleGlobalProtectionWhitelistDelete(_ context.Context, d *schema.Re
 	}
 	_, err = deleteClient.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting RuleGlobalProtectionWhitelist: %s", err)
+		// If the rule does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting RuleGlobalProtectionWhitelist")
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add checkDeleted logic to delete function of the correspond rule resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Involved rule resources are as follows:
  cc rule resource, data masking rule resource, geolocation access control rule resource, global protection whitelist rule resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccRuleCCProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleCCProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccRuleCCProtection_basic
=== PAUSE TestAccRuleCCProtection_basic
=== CONT  TestAccRuleCCProtection_basic
--- PASS: TestAccRuleCCProtection_basic (506.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       506.460s
```
```
506.460s
root@ecs-ruwenqiang:/home/huawei/go/src/github.com/huaweicloud/terraform-provider-huaweicloud (dev_rule)$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafRuleDataMasking_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleDataMasking_basic -timeout 360m -parallel 4
=== RUN   TestAccWafRuleDataMasking_basic
=== PAUSE TestAccWafRuleDataMasking_basic
=== CONT  TestAccWafRuleDataMasking_basic
--- PASS: TestAccWafRuleDataMasking_basic (526.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       526.891s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccRuleGeolocation_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleGeolocation_basic -timeout 360m -parallel 4
=== RUN   TestAccRuleGeolocation_basic
=== PAUSE TestAccRuleGeolocation_basic
=== CONT  TestAccRuleGeolocation_basic
--- PASS: TestAccRuleGeolocation_basic (450.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       450.241s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccRuleGlobalProtectionWhitelist_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleGlobalProtectionWhitelist_basic -timeout 360m -parallel 4
=== RUN   TestAccRuleGlobalProtectionWhitelist_basic
=== PAUSE TestAccRuleGlobalProtectionWhitelist_basic
=== CONT  TestAccRuleGlobalProtectionWhitelist_basic
--- PASS: TestAccRuleGlobalProtectionWhitelist_basic (544.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       544.776s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
### cc rule resource
![image](https://github.com/user-attachments/assets/b9ddc363-885e-4d40-a6f9-b71ed687072d)
### data masking rule resource
![image](https://github.com/user-attachments/assets/d6a44226-4521-49ad-a5e3-c3f719c2685a)
### geolocation access control rule resource
![image](https://github.com/user-attachments/assets/54419a96-28ff-4e94-a746-09e75d275af0)
### global protection whitelist rule resource
![image](https://github.com/user-attachments/assets/9edd6e32-3a95-402a-9231-3cb6c2913a9b)
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
### cc rule resource
![image](https://github.com/user-attachments/assets/9b06aba7-c415-493b-8ac2-3e3ea78d2c31)
### data masking rule resource
![image](https://github.com/user-attachments/assets/c4baadec-187c-4b0c-aecf-a9d526748412)
### geolocation access control rule resource
![image](https://github.com/user-attachments/assets/837047cd-6504-4397-b8d5-e9465eb846da)
### global protection whitelist rule resource
![image](https://github.com/user-attachments/assets/c9b56b09-2dc8-4657-99a5-104ab365d4b7)
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
### cc rule resource
![image](https://github.com/user-attachments/assets/6352e3bd-6ed6-46d7-bb41-952f176d7d63)
### data masking rule resource
![image](https://github.com/user-attachments/assets/8ad126be-98c2-4d10-8c8f-4046df509c55)
### geolocation access control rule resource
![image](https://github.com/user-attachments/assets/597ba707-bc6e-4f27-9575-beacf0f63f38)
### global protection whitelist rule resource
![image](https://github.com/user-attachments/assets/f7ef2dd1-3b6b-4f9e-9ed7-7b8b143c165b)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
