### PR TITLE
chore(waf): add checkDeleted logic to the rule resource delete function

### DIFF
--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_information_leakage_prevention.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_information_leakage_prevention.go
@@ -172,6 +172,8 @@ func resourceRuleRead(_ context.Context, d *schema.ResourceData, meta interface{
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
+		// If the information leakage prevention rule does not exist, the response HTTP status code of
+		// the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF information leakage prevention rule")
 	}
 
@@ -253,7 +255,9 @@ func resourceRuleDelete(_ context.Context, d *schema.ResourceData, meta interfac
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting WAF information leakage prevention rule: %s", err)
+		// If the information leakage prevention rule does not exist, the response HTTP status code of
+		// the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF information leakage prevention rule")
 	}
 	return nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_known_attack_source.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_known_attack_source.go
@@ -152,6 +152,7 @@ func resourceRuleKnownAttackRead(_ context.Context, d *schema.ResourceData, meta
 
 	getResp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
+		// If the known attack source rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF known attack source rule")
 	}
 
@@ -232,7 +233,8 @@ func resourceRuleKnownAttackDelete(_ context.Context, d *schema.ResourceData, me
 
 	_, err = client.Request("DELETE", deletePath, &deleteRuleKnownAttackOpt)
 	if err != nil {
-		return diag.Errorf("error deleting WAF known attack source rule: %s", err)
+		// If the known attack source rule does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF known attack source rule")
 	}
 
 	return nil

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_precise_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_precise_protection.go
@@ -355,6 +355,7 @@ func resourceRulePreciseProtectionRead(_ context.Context, d *schema.ResourceData
 	getRuleResp, err := preciseProtectionClient.Request("GET", getRulePath, &getRuleOpt)
 
 	if err != nil {
+		// If the rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving RulePreciseProtection")
 	}
 
@@ -497,7 +498,8 @@ func resourceRulePreciseProtectionDelete(_ context.Context, d *schema.ResourceDa
 	}
 	_, err = preciseProtectionClient.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return diag.Errorf("error deleting RulePreciseProtection: %s", err)
+		// If the rule does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting RulePreciseProtection")
 	}
 	return nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_web_tamper_protection.go
@@ -131,6 +131,7 @@ func resourceWafRuleWebTamperProtectionRead(_ context.Context, d *schema.Resourc
 	epsID := cfg.GetEnterpriseProjectID(d)
 	n, err := rules.GetWithEpsID(wafClient, policyID, d.Id(), epsID).Extract()
 	if err != nil {
+		// If the web tamper protection rule does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF web tamper protection rule")
 	}
 
@@ -156,7 +157,8 @@ func resourceWafRuleWebTamperProtectionDelete(_ context.Context, d *schema.Resou
 	epsID := cfg.GetEnterpriseProjectID(d)
 	err = rules.DeleteWithEpsID(wafClient, policyID, d.Id(), epsID).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting WAF web tamper protection rule: %s", err)
+		// If the web tamper protection rule does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF web tamper protection rule")
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add checkDeleted logic to the rule rsource delete function.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Involved rule resources are as follows:
   information leakage prevention rule resource, known attack rule resource, precise protection rule resource, web tamper protection rule
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccRuleLeakagePrevention_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleLeakagePrevention_basic -timeout 360m -parallel 4
=== RUN   TestAccRuleLeakagePrevention_basic
=== PAUSE TestAccRuleLeakagePrevention_basic
=== CONT  TestAccRuleLeakagePrevention_basic
--- PASS: TestAccRuleLeakagePrevention_basic (562.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       562.439s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccRuleKnownAttack_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRuleKnownAttack_basic -timeout 360m -parallel 4
=== RUN   TestAccRuleKnownAttack_basic
=== PAUSE TestAccRuleKnownAttack_basic
=== CONT  TestAccRuleKnownAttack_basic
--- PASS: TestAccRuleKnownAttack_basic (545.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       545.534s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccRulePreciseProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccRulePreciseProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccRulePreciseProtection_basic
=== PAUSE TestAccRulePreciseProtection_basic
=== CONT  TestAccRulePreciseProtection_basic
--- PASS: TestAccRulePreciseProtection_basic (567.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       567.145s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafRuleWebTamperProtection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafRuleWebTamperProtection_basic -timeout 360m -parallel 4
=== RUN   TestAccWafRuleWebTamperProtection_basic
=== PAUSE TestAccWafRuleWebTamperProtection_basic
=== CONT  TestAccWafRuleWebTamperProtection_basic
--- PASS: TestAccWafRuleWebTamperProtection_basic (534.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       534.934s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
###  information leakage prevention rule resource
![image](https://github.com/user-attachments/assets/fe522547-fb0b-4ce9-874b-1e1f8d8f8056)
### known attack rule resource
![image](https://github.com/user-attachments/assets/3c0b2389-8b87-47be-a00b-19d24d522346)
### precise protection rule resource
![image](https://github.com/user-attachments/assets/b17c8d9c-e4c6-4b41-94d7-69beb28f1b44)
### web tamper protection rule
![image](https://github.com/user-attachments/assets/f4bc88c5-eb92-43dd-9056-1c91342ff780)
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
 ###  information leakage prevention rule resource
![image](https://github.com/user-attachments/assets/e7960681-a3fc-448e-a70f-38665b9fcad7)
### known attack rule resource
![image](https://github.com/user-attachments/assets/00134c9c-0421-4179-9663-cfd80df8032c)
### precise protection rule resource
![image](https://github.com/user-attachments/assets/2bcbee9b-f52f-4faa-9a72-10ac41a06a48)
### web tamper protection rule
![image](https://github.com/user-attachments/assets/09b61fdc-f1c4-49d2-840f-335e2ed2a0c4)
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
###  information leakage prevention rule resource
![image](https://github.com/user-attachments/assets/26a7768a-8645-4a28-b60f-2921dc12f96e)
### known attack rule resource
![image](https://github.com/user-attachments/assets/cd3691f9-f864-4d95-84df-a16066883c43)
### precise protection rule resource
![image](https://github.com/user-attachments/assets/b5c928b0-67f6-4e3b-8323-4542ffcd1f1c)
### web tamper protection rule
![image](https://github.com/user-attachments/assets/d9acd95f-ec65-4de5-999f-2e9fed0604da)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
