### PR TITLE
feat(dataarts/dataservice): add new data source to query apps

### DIFF
--- a/docs/data-sources/dataarts_dataservice_apps.md
+++ b/docs/data-sources/dataarts_dataservice_apps.md
@@ -1,0 +1,73 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_apps"
+description: |-
+  Use this data source to get the list of Data Service applications within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_apps
+
+Use this data source to get the list of Data Service applications within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "app_name_to_be_queried" {}
+
+data "huaweicloud_dataarts_dataservice_apps" "test" {
+  workspace_id = var.workspace_id
+  name         = var.app_name_to_be_queried
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the applications are located.
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of the workspace to which the applications belong.
+
+* `dlm_type` - (Optional, String) Specifies the type of DLM engine.  
+  The valid values are as follows:
+  + **SHARED**: Shared data service.
+  + **EXCLUSIVE**: The exclusive data service.
+
+  Defaults to **SHARED**.
+
+* `name` - (Optional, String) Specifies the name of the applications to be fuzzy queried.  
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `apps` - All applications that match the filter parameters.  
+  The [apps](#dataservice_apps_elem) structure is documented below.
+
+<a name="dataservice_apps_elem"></a>
+The `apps` block supports:
+
+* `id` - The ID of the application, in UUID format.
+
+* `name` - The name of the application.
+
+* `description` - The description of the application.
+
+* `app_key` - The key of the application.
+
+* `app_secret` - The secret of the application.
+
+* `created_at` - The creation time of the application, in RFC3339 format.
+
+* `updated_at` - The latest update time of the application, in RFC3339 format.
+
+* `create_user` - The name of the application creator.
+
+* `update_user` - The name of the application updater.
+
+* `app_type` - The type of the application.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -581,6 +581,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_table_models":          dataarts.DataSourceArchitectureTableModels(),
 			// DataArts DataService
 			"huaweicloud_dataarts_dataservice_apis":      dataarts.DataSourceDataServiceApis(),
+			"huaweicloud_dataarts_dataservice_apps":      dataarts.DataSourceDataServiceApps(),
 			"huaweicloud_dataarts_dataservice_instances": dataarts.DataSourceDataServiceInstances(),
 			// DataArts Quality
 			"huaweicloud_dataarts_quality_tasks": dataarts.DataSourceQualityTasks(),

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_apps_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_apps_test.go
@@ -1,0 +1,110 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDataServiceApps_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_dataarts_dataservice_apps.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byName   = "data.huaweicloud_dataarts_dataservice_apps.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNotFoundName   = "data.huaweicloud_dataarts_dataservice_apps.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDataServiceApps_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "apps.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_name_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDataServiceApps_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+resource "huaweicloud_dataarts_dataservice_app" "test" {
+  count = 2
+
+  workspace_id = "%[1]s"
+  dlm_type     = "EXCLUSIVE"
+
+  name         = format("%[2]s_%%d", count.index)
+  app_type     = "APP"
+  description  = "Created by terraform script"
+}
+
+data "huaweicloud_dataarts_dataservice_apps" "test" {
+  depends_on = [
+    huaweicloud_dataarts_dataservice_app.test
+  ]
+
+  workspace_id = "%[1]s"
+  dlm_type     = "EXCLUSIVE"
+}
+
+# Filter by name
+data "huaweicloud_dataarts_dataservice_apps" "filter_by_name" {
+  depends_on = [huaweicloud_dataarts_dataservice_app.test]
+
+  workspace_id = "%[1]s"
+  dlm_type     = "EXCLUSIVE"
+
+  name = "%[2]s" # Fuzzy search
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_dataarts_dataservice_apps.filter_by_name.apps[*].name : strcontains(v, "%[2]s")
+  ]
+}
+
+output "is_name_filter_useful" {
+  // At least two applications have the same name prefix.
+  value = length(local.name_filter_result) >= 2 && alltrue(local.name_filter_result)
+}
+
+# Filter by name (not found)
+locals {
+  not_found_name = "not_found"
+}
+
+data "huaweicloud_dataarts_dataservice_apps" "filter_by_not_found_name" {
+  depends_on = [huaweicloud_dataarts_dataservice_app.test]
+
+  workspace_id = "%[1]s"
+  dlm_type     = "EXCLUSIVE"
+
+  name = local.not_found_name # This name is not exist
+}
+
+output "is_not_found_name_filter_useful" {
+  value = length(data.huaweicloud_dataarts_dataservice_apps.filter_by_not_found_name.apps) == 0
+}
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_apps.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_apps.go
@@ -1,0 +1,216 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/service/apps
+func DataSourceDataServiceApps() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDataServiceAppsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the applications are located.`,
+			},
+
+			// Parameters in request header
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the applications belong.`,
+			},
+			"dlm_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of DLM engine.`,
+			},
+
+			// Query argument
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the applications to be fuzzy queried.`,
+			},
+
+			// Attribute
+			"apps": {
+				Type:        schema.TypeList,
+				Elem:        dataserviceAppSchema(),
+				Computed:    true,
+				Description: `All applications that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataserviceAppSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the application, in UUID format.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the application.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the application.`,
+			},
+			"app_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The key of the application.`,
+			},
+			"app_secret": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The secret of the application.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the application, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the application, in RFC3339 format.`,
+			},
+			"create_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the application creator.`,
+			},
+			"update_user": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the application updater.`,
+			},
+			"app_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The type of the application.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildDataServiceAppsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if appName, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, appName)
+	}
+	return res
+}
+
+func queryDataServiceApps(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/service/apps?limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildDataServiceAppsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    d.Get("workspace_id").(string),
+			"dlm-type":     d.Get("dlm_type").(string),
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		apps := utils.PathSearch("apps", respBody, make([]interface{}, 0)).([]interface{})
+		if len(apps) < 1 {
+			break
+		}
+		result = append(result, apps...)
+		offset += len(apps)
+	}
+
+	return result, nil
+}
+
+func flattenDataServiceApps(apps []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(apps))
+
+	for _, app := range apps {
+		result = append(result, map[string]interface{}{
+			"id":          utils.PathSearch("id", app, nil),
+			"name":        utils.PathSearch("name", app, nil),
+			"description": utils.PathSearch("description", app, nil),
+			"app_key":     utils.PathSearch("app_key", app, nil),
+			"app_secret":  utils.PathSearch("app_secret", app, nil),
+			"created_at":  utils.FormatTimeStampRFC3339(int64(utils.PathSearch("register_time", app, float64(0)).(float64))/1000, false),
+			"updated_at":  utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", app, float64(0)).(float64))/1000, false),
+			"create_user": utils.PathSearch("create_user", app, nil),
+			"update_user": utils.PathSearch("update_user", app, nil),
+			"app_type":    utils.PathSearch("app_type", app, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDataServiceAppsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	appList, err := queryDataServiceApps(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("apps", flattenDataServiceApps(appList)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source for DataArts Data Service that used to query application list. Also we can filter it by given parameter.
![image](https://github.com/user-attachments/assets/42cca173-9b31-47f7-9dcd-52310a65f45e)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
add new data source to query applications
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dataarts' TESTARGS='-run=TestAccDataSourceDataServiceApps_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dataarts -v -run=TestAccDataSourceDataServiceApps_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataServiceApps_basic
--- PASS: TestAccDataSourceDataServiceApps_basic (38.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  38.563s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
