### PR TITLE
feat(eg/channel): add new data source to query official channels

### DIFF
--- a/docs/data-sources/eg_event_channels.md
+++ b/docs/data-sources/eg_event_channels.md
@@ -1,0 +1,83 @@
+---
+subcategory: "EventGrid (EG)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_eg_event_channels"
+description: |-
+  Use this data source to filter EG event channels within HuaweiCloud.
+---
+
+# huaweicloud_eg_event_channels
+
+Use this data source to filter EG event channels within HuaweiCloud.
+
+## Example Usage
+
+### Query all kinds of event channels
+
+```hcl
+data "huaweicloud_eg_event_channels" "test" {}
+```
+
+### Query all official event channels
+
+```hcl
+data "huaweicloud_eg_event_channels" "test" {
+  provider_type = "OFFICIAL"
+}
+```
+
+### Query the custom event channel with the specified name
+
+```hcl
+variable "channel_name" {}
+
+data "huaweicloud_eg_event_channels" "test" {
+  provider_type = "CUSTOM"
+  name          = var.channel_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the event channels are located.  
+  If omitted, the provider-level region will be used.
+
+* `provider_type` - (Optional, String) Specifies the type of the event channels to be queried.
+  + **OFFICIAL**
+  + **CUSTOM**
+  + **PARTNER**
+
+* `name` - (Optional, String) Specifies the channel name used to query specified event channel.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the event channels
+  belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `channels` - All event channels that match the filter parameters.  
+  The [channels](#eg_event_channels_attr) structure is documented below.
+
+<a name="eg_event_channels_attr"></a>
+The `channels` block supports:
+
+* `id` - The ID of the event channel.
+
+* `name` - The name of the event channel.
+
+* `description` - The description of the event channel.
+
+* `provider_type` - The type of the event channel.
+
+* `enterprise_project_id` - The ID of the enterprise project to which the event channel belongs.
+
+* `cross_account_ids` - The list of domain IDs (other tenants) for the cross-account policy.
+
+* `created_at` - The creation time of the event channel.
+
+* `updated_at` - The latest update time of the event channel.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -667,6 +667,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_eg_custom_event_channels": eg.DataSourceCustomEventChannels(),
 			"huaweicloud_eg_custom_event_sources":  eg.DataSourceCustomEventSources(),
+			"huaweicloud_eg_event_channels":        eg.DataSourceEventChannels(),
 
 			"huaweicloud_enterprise_project":  eps.DataSourceEnterpriseProject(),
 			"huaweicloud_enterprise_projects": eps.DataSourceEnterpriseProjects(),

--- a/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_channels_test.go
+++ b/huaweicloud/services/acceptance/eg/data_source_huaweicloud_eg_event_channels_test.go
@@ -1,0 +1,161 @@
+package eg
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataEventChannels_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_eg_event_channels.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byProviderType   = "data.huaweicloud_eg_event_channels.filter_by_provider_type"
+		dcByProviderType = acceptance.InitDataSourceCheck(byProviderType)
+
+		byName   = "data.huaweicloud_eg_event_channels.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNotFoundName   = "data.huaweicloud_eg_event_channels.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+
+		byEpsId   = "data.huaweicloud_eg_event_channels.filter_by_eps_id"
+		dcByEpsId = acceptance.InitDataSourceCheck(byEpsId)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataEventChannels_basic_step1(name),
+			},
+			{
+				// Make sure the attribute 'updated_at' has been configured.
+				Config: testAccDataEventChannels_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "channels.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("is_query_result_contains_at_least_two_types", "true"),
+					dcByProviderType.CheckResourceExists(),
+					resource.TestCheckOutput("is_provider_type_filter_useful", "true"),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckResourceAttrPair(byName, "channels.0.id", "huaweicloud_eg_custom_event_channel.test", "id"),
+					resource.TestCheckResourceAttr(byName, "channels.0.name", name),
+					resource.TestCheckResourceAttr(byName, "channels.0.description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(byName, "channels.0.cross_account_ids.#", "2"),
+					resource.TestCheckResourceAttr(byName, "channels.0.enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(byName, "channels.0.provider_type", "CUSTOM"),
+					resource.TestCheckResourceAttrSet(byName, "channels.0.created_at"),
+					resource.TestCheckResourceAttrSet(byName, "channels.0.updated_at"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_name_filter_useful", "true"),
+					dcByEpsId.CheckResourceExists(),
+					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataEventChannels_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name                  = "%[1]s"
+  description           = "Created by terraform script"
+  enterprise_project_id = "%[2]s"
+  cross_account_ids     = ["account1", "account2"]
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccDataEventChannels_basic_step2(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_eg_custom_event_channel" "test" {
+  name                  = "%[1]s"
+  description           = "Updated by terraform script"
+  enterprise_project_id = "%[2]s"
+  cross_account_ids     = ["account1", "account2"]
+}
+
+data "huaweicloud_eg_event_channels" "test" {
+  depends_on = [huaweicloud_eg_custom_event_channel.test]
+}
+
+// At least one of official event channel exist, e.g. official channel names Default.
+output "is_query_result_contains_at_least_two_types" {
+  value = length(distinct(data.huaweicloud_eg_event_channels.test.channels[*].provider_type)) >= 2
+}
+
+# Filter by provider type
+data "huaweicloud_eg_event_channels" "filter_by_provider_type" {
+  depends_on = [huaweicloud_eg_custom_event_channel.test]
+
+  provider_type = "CUSTOM"
+}
+
+locals {
+  provider_type_filter_result = [
+    for v in data.huaweicloud_eg_event_channels.filter_by_provider_type.channels[*].provider_type : v == "CUSTOM"
+  ]
+}
+
+output "is_provider_type_filter_useful" {
+  value = length(local.provider_type_filter_result) > 0 && alltrue(local.provider_type_filter_result)
+}
+
+# Filter by name
+data "huaweicloud_eg_event_channels" "filter_by_name" {
+  depends_on = [huaweicloud_eg_custom_event_channel.test]
+
+  name = "%[1]s"
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_eg_event_channels.filter_by_name.channels[*].name : v == "%[1]s"
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by not found name
+data "huaweicloud_eg_event_channels" "filter_by_not_found_name" {
+  name = "not_found"
+}
+
+output "is_not_found_name_filter_useful" {
+  value = length(data.huaweicloud_eg_event_channels.filter_by_not_found_name.channels) < 1
+}
+
+# Filter by enterprise project ID
+data "huaweicloud_eg_event_channels" "filter_by_eps_id" {
+  depends_on = [huaweicloud_eg_custom_event_channel.test]
+
+  enterprise_project_id = "%[2]s"
+}
+
+locals {
+  eps_id_filter_result = [
+    for v in data.huaweicloud_eg_event_channels.filter_by_name.channels[*].enterprise_project_id : v == "%[2]s"
+  ]
+}
+
+output "is_eps_id_filter_useful" {
+  value = length(local.eps_id_filter_result) > 0 && alltrue(local.eps_id_filter_result)
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
@@ -104,7 +104,7 @@ func DataSourceCustomEventChannels() *schema.Resource {
 	}
 }
 
-func buildEventChannelsQueryParams(d *schema.ResourceData) string {
+func buildEventChannelsQueryParams(d *schema.ResourceData, providerTypeInput ...string) string {
 	res := ""
 	if apiName, ok := d.GetOk("name"); ok {
 		res = fmt.Sprintf("%s&name=%v", res, apiName)
@@ -112,19 +112,26 @@ func buildEventChannelsQueryParams(d *schema.ResourceData) string {
 	if channelId, ok := d.GetOk("channel_id"); ok {
 		res = fmt.Sprintf("%s&channel_id=%v", res, channelId)
 	}
+
+	if len(providerTypeInput) > 0 {
+		res = fmt.Sprintf("%s&provider_type=%v", res, providerTypeInput[0])
+	} else if typeVal, ok := d.GetOk("provider_type"); ok {
+		res = fmt.Sprintf("%s&provider_type=%v", res, typeVal)
+	}
 	return res
 }
 
-func queryEventChannels(client *golangsdk.ServiceClient, d *schema.ResourceData, providerType string) ([]interface{}, error) {
+func queryEventChannels(client *golangsdk.ServiceClient, d *schema.ResourceData, providerTypeInput ...string) ([]interface{}, error) {
 	var (
-		httpUrl = "v1/{project_id}/channels?provider_type={provider_type}&limit=100"
-		offset  = 0
-		result  = make([]interface{}, 0)
+		httpUrl      = "v1/{project_id}/channels?limit=100"
+		offset       = 0
+		result       = make([]interface{}, 0)
+		providerType string
 	)
 	listPath := client.Endpoint + httpUrl
 	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
 	listPath = strings.ReplaceAll(listPath, "{provider_type}", providerType)
-	listPath += buildEventChannelsQueryParams(d)
+	listPath += buildEventChannelsQueryParams(d, providerTypeInput...)
 
 	opt := golangsdk.RequestOpts{
 		KeepResponseBody: true,

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_custom_event_channels.go
@@ -161,6 +161,7 @@ func flattenEventChannels(channels []interface{}) []interface{} {
 		result = append(result, map[string]interface{}{
 			"id":                    utils.PathSearch("id", channel, nil),
 			"name":                  utils.PathSearch("name", channel, nil),
+			"description":           utils.PathSearch("description", channel, nil),
 			"provider_type":         utils.PathSearch("provider_type", channel, nil),
 			"enterprise_project_id": utils.PathSearch("eps_id", channel, nil),
 			"cross_account_ids":     utils.PathSearch("policy.Principal.IAM", channel, make([]interface{}, 0)),

--- a/huaweicloud/services/eg/data_source_huaweicloud_eg_event_channels.go
+++ b/huaweicloud/services/eg/data_source_huaweicloud_eg_event_channels.go
@@ -1,0 +1,127 @@
+package eg
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API EG GET /v1/{project_id}/channels
+func DataSourceEventChannels() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEventChannelsRead,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The region where the event channels are located.`,
+			},
+			"provider_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of the event channels to be queried.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The channel name used to query specified event channel.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the enterprise project to which the event channels belong.`,
+			},
+			"channels": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the event channel.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the event channel.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the event channel.`,
+						},
+						"provider_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the event channel.`,
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the enterprise project to which the event channel belongs.`,
+						},
+						"cross_account_ids": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of domain IDs (other tenants) for the cross-account policy.`,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the event channel.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the event channel.`,
+						},
+					},
+				},
+				Description: `All event channels that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataSourceEventChannelsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("eg", region)
+	if err != nil {
+		return diag.Errorf("error creating EG client: %s", err)
+	}
+
+	channels, err := queryEventChannels(client, d)
+	if err != nil {
+		return diag.Errorf("error querying event channels: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("channels", flattenDataEventChannels(filterDataEventChannels(cfg, d, channels))),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving data source fields of EG event channels: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a new data source to query official channels.
![image](https://github.com/user-attachments/assets/96ea857a-6391-4d4b-8e86-4c98ae98ddcc)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query official channels.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o eg -f TestAccDataOfficialEventChannels_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/eg" -v -coverprofile="./huaweicloud/services/acceptance/eg_coverage.cov" -coverpkg="./huaweicloud/services/eg" -run TestAccDataOfficialEventChannels_basic -timeout 360m -parallel 10
=== RUN   TestAccDataOfficialEventChannels_basic
--- PASS: TestAccDataOfficialEventChannels_basic (35.69s)
PASS
coverage: 8.4% of statements in ./huaweicloud/services/eg
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eg        35.749s coverage: 8.4% of statements in ./huaweicloud/services/eg
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
