### PR TITLE
fix(waf): fix WAF reference table resource lint error and doucument description

### DIFF
--- a/docs/resources/waf_reference_table.md
+++ b/docs/resources/waf_reference_table.md
@@ -2,7 +2,8 @@
 subcategory: "Web Application Firewall (WAF)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_waf_reference_table"
-description: ""
+description: |-
+  Manages a WAF reference table resource within HuaweiCloud.
 ---
 
 # huaweicloud_waf_reference_table
@@ -15,10 +16,11 @@ used. The reference table resource can be used in Cloud Mode (professional versi
 ## Example Usage
 
 ```hcl
+variable "name" {}
 variable "enterprise_project_id" {}
 
-resource "huaweicloud_waf_reference_table" "ref_table" {
-  name                  = "tf_ref_table_demo"
+resource "huaweicloud_waf_reference_table" "test" {
+  name                  = var.name
   type                  = "url"
   enterprise_project_id = var.enterprise_project_id
 
@@ -33,30 +35,32 @@ resource "huaweicloud_waf_reference_table" "ref_table" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the WAF reference table resource. If omitted,
-  the provider-level region will be used. Changing this setting will push a new reference table.
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF reference table resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String) The name of the reference table. Only letters, digits, and underscores(_) are allowed. The
-  maximum length is 64 characters.
+* `name` - (Required, String) Specifies the name of the reference table. Only letters, digits, hyphens (-),
+  underscores(_) and dots(.) are allowed. The maximum length is `64` characters.
 
-* `type` - (Required, String, ForceNew) The type of the reference table, The options are `url`, `user-agent`, `ip`,
-  `params`, `cookie`, `referer` and `header`. Changing this setting will push a new reference table.
+* `type` - (Required, String, ForceNew) Specifies the type of the reference table.
+  The valid values are **url**, **user-agent**, **ip**, **params**, **cookie**, **referer** and **header**.
+  Changing this parameter will create a new resource.
 
-* `conditions` - (Required, List) The conditions of the reference table. The maximum length is 30. The maximum length of
-  condition is 2048 characters.
+* `conditions` - (Required, List) Specifies the conditions of the reference table.
 
-* `description` - (Optional, String) The description of the reference table. The maximum length is 128 characters.
+* `description` - (Optional, String) Specifies the description of the reference table.
+  The maximum length is `128` characters.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF reference table.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the reference
+  table belongs.
   Changing this parameter will create a new resource.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The id of the reference table.
+* `id` - The resource ID.
 
-* `creation_time` - The server time when reference table was created.
+* `creation_time` - The creation time of the reference table, in UTC format.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_reference_table_test.go
@@ -110,7 +110,7 @@ func testAccCheckWafReferenceTableV1Destroy(s *terraform.State) error {
 	config := acceptance.TestAccProvider.Meta().(*config.Config)
 	wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return fmt.Errorf("error creating WAF client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -141,7 +141,7 @@ func testAccCheckWafReferenceTableV1Exists(n string, valueList *valuelists.WafVa
 		config := acceptance.TestAccProvider.Meta().(*config.Config)
 		wafClient, err := config.WafV1Client(acceptance.HW_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("error creating HuaweiCloud WAF client: %s", err)
+			return fmt.Errorf("error creating WAF client: %s", err)
 		}
 
 		found, err := valuelists.GetWithEpsID(wafClient, rs.Primary.ID, rs.Primary.Attributes["enterprise_project_id"])

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_reference_table.go
@@ -1,10 +1,11 @@
 package waf
 
 import (
-	"regexp"
+	"context"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/logp"
 )
 
@@ -24,10 +24,10 @@ import (
 // @API WAF POST /v1/{project_id}/waf/valuelist
 func ResourceWafReferenceTableV1() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceWafReferenceTableCreate,
-		Read:   resourceWafReferenceTableRead,
-		Update: resourceWafReferenceTableUpdate,
-		Delete: resourceWafReferenceTableDelete,
+		CreateContext: resourceWafReferenceTableCreate,
+		ReadContext:   resourceWafReferenceTableRead,
+		UpdateContext: resourceWafReferenceTableUpdate,
+		DeleteContext: resourceWafReferenceTableDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceWAFImportState,
 		},
@@ -42,9 +42,6 @@ func ResourceWafReferenceTableV1() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile("^([\\w]{1,64})$"),
-					"The name can contains of 1 to 64 characters."+
-						"Only letters, digits and underscores (_) are allowed."),
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -83,11 +80,11 @@ func ResourceWafReferenceTableV1() *schema.Resource {
 }
 
 // resourceWafReferenceTableCreate create a record of reference table.
-func resourceWafReferenceTableCreate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafReferenceTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	opt := valuelists.CreateOpts{
@@ -95,35 +92,37 @@ func resourceWafReferenceTableCreate(d *schema.ResourceData, meta interface{}) e
 		Type:                d.Get("type").(string),
 		Values:              utils.ExpandToStringList(d.Get("conditions").([]interface{})),
 		Description:         d.Get("description").(string),
-		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
+		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 	}
 	logp.Printf("[DEBUG] Create WAF reference table options: %#v", opt)
 
 	r, err := valuelists.Create(client, opt)
 	if err != nil {
-		return fmtp.Errorf("error creating WAF reference table: %s", err)
+		return diag.Errorf("error creating WAF reference table: %s", err)
 	}
 	logp.Printf("[DEBUG] Waf reference table created: %#v", r)
 	d.SetId(r.Id)
 
-	return resourceWafReferenceTableRead(d, meta)
+	return resourceWafReferenceTableRead(ctx, d, meta)
 }
 
 // resourceWafReferenceTableRead read a record of reference table by id.
-func resourceWafReferenceTableRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafReferenceTableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.WafV1Client(region)
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
-	r, err := valuelists.GetWithEpsID(client, d.Id(), config.GetEnterpriseProjectID(d))
+	r, err := valuelists.GetWithEpsID(client, d.Id(), cfg.GetEnterpriseProjectID(d))
 	if err != nil {
-		return common.CheckDeleted(d, err, "Error obtain WAF reference table information")
+		// If the reference table does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF reference table")
 	}
 
 	mErr := multierror.Append(nil,
-		d.Set("region", config.GetRegion(d)),
+		d.Set("region", region),
 		d.Set("name", r.Name),
 		d.Set("type", r.Type),
 		d.Set("conditions", r.Values),
@@ -131,19 +130,15 @@ func resourceWafReferenceTableRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("creation_time", time.Unix(r.CreationTime/1000, 0).Format("2006-01-02 15:04:05")),
 	)
 
-	if mErr.ErrorOrNil() != nil {
-		return fmtp.Errorf("error setting WAF reference table fields: %s", err)
-	}
-
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 // resourceWafReferenceTableUpdate update record of reference table by id.
-func resourceWafReferenceTableUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafReferenceTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
 	desc := d.Get("description").(string)
@@ -153,31 +148,31 @@ func resourceWafReferenceTableUpdate(d *schema.ResourceData, meta interface{}) e
 		Type:                d.Get("type").(string),
 		Values:              utils.ExpandToStringList(d.Get("conditions").([]interface{})),
 		Description:         &desc,
-		EnterpriseProjectId: config.GetEnterpriseProjectID(d),
+		EnterpriseProjectId: cfg.GetEnterpriseProjectID(d),
 	}
 	logp.Printf("[DEBUG] Update WAF reference table options: %#v", opt)
 
 	_, err = valuelists.Update(client, d.Id(), opt)
 	if err != nil {
-		return fmtp.Errorf("error updating WAF reference table: %s", err)
+		return diag.Errorf("error updating WAF reference table: %s", err)
 	}
 
-	return resourceWafReferenceTableRead(d, meta)
+	return resourceWafReferenceTableRead(ctx, d, meta)
 }
 
 // resourceWafReferenceTableDelete delete the reference table record by id.
-func resourceWafReferenceTableDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*config.Config)
-	client, err := config.WafV1Client(config.GetRegion(d))
+func resourceWafReferenceTableDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.WafV1Client(cfg.GetRegion(d))
 	if err != nil {
-		return fmtp.Errorf("error creating HuaweiCloud WAF client: %s", err)
+		return diag.Errorf("error creating WAF client: %s", err)
 	}
 
-	_, err = valuelists.DeleteWithEpsID(client, d.Id(), config.GetEnterpriseProjectID(d))
+	_, err = valuelists.DeleteWithEpsID(client, d.Id(), cfg.GetEnterpriseProjectID(d))
 	if err != nil {
-		return fmtp.Errorf("error deleting WAF reference table: %s", err)
+		// If the reference table does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF reference table")
 	}
 
-	d.SetId("")
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix WAF reference table resource lint error and document description.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafReferenceTableV1.*"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafReferenceTableV1.* -timeout 360m -parallel 4
=== RUN   TestAccWafReferenceTableV1_basic
=== PAUSE TestAccWafReferenceTableV1_basic
=== RUN   TestAccWafReferenceTableV1_withEpsID
=== PAUSE TestAccWafReferenceTableV1_withEpsID
=== CONT  TestAccWafReferenceTableV1_basic
=== CONT  TestAccWafReferenceTableV1_withEpsID
--- PASS: TestAccWafReferenceTableV1_withEpsID (494.27s)
--- PASS: TestAccWafReferenceTableV1_basic (494.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       494.354s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/6b444d5f-098b-4c8c-a29f-0c37f892edc7)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/654e239f-c1f5-41dd-9504-a82335f860cd)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
