### PR TITLE
feat(dataarts): Add new data source to query authorized APPs

### DIFF
--- a/docs/data-sources/dataarts_dataservice_authorized_apps.md
+++ b/docs/data-sources/dataarts_dataservice_authorized_apps.md
@@ -1,0 +1,82 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_authorized_apps"
+description: |-
+  Use this data source to get the list of authorized APPs under specified API within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_authorized_apps
+
+Use this data source to get the list of authorized APPs under specified API within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "authorized_api_id" {}
+
+data "huaweicloud_dataarts_dataservice_authorized_apps" "test" {
+  workspace_id = var.workspace_id
+  dlm_type     = "EXCLUSIVE"
+  api_id       = var.authorized_api_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the ID of workspace where the APIs are located.
+
+* `dlm_type` - (Optional, String) Specifies the type of DLM engine.  
+  The valid values are as follows:
+  + **SHARED**: Shared data service.
+  + **EXCLUSIVE**: The exclusive data service.
+
+  Defaults to **SHARED**.
+
+* `api_id` - (Required, String) Specifies the ID of the API used to authorize the APPs.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `apps` - All APPs authorized by API.  
+  The [apis](#dataservice_authorized_apps_elem) structure is documented below.
+
+<a name="dataservice_authorized_apps_elem"></a>
+The `apps` block supports:
+
+* `id` - The ID of the application that has authorization.
+
+* `name` - The name of the application that has authorization.
+
+* `instance_id` - The instance ID to which the authorized API belongs.
+
+* `instance_name` - The instance name to which the authorized API belongs.
+
+* `expired_at` - The expiration time, in RFC3339 format.
+
+* `approved_at` - The approve time, in RFC3339 format.
+
+* `relationship_type` - The relationship between the authorized API and the authorized APP list.
+  + **LINK_WAITING_CHECK**: Pending to approval for authorize operation.
+  + **LINKED**: Already authorized.
+  + **OFFLINE_WAITING_CHECK**: Pending to approval for offline operation.
+  + **RENEW_WAITING_CHECK**: Pending to approval for renew operation.
+
+* `static_params` - The configuration of the static parameters.  
+  The [static_params](#dataservice_authorized_app_static_param) structure is documented below.
+
+<a name="dataservice_authorized_app_static_param"></a>
+The `static_params` block supports:
+
+* `name` - The name of the static parameter.
+
+* `value` - The value of the static parameter.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -581,9 +581,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_architecture_model_statistic":       dataarts.DataSourceArchitectureModelStatistic(),
 			"huaweicloud_dataarts_architecture_table_models":          dataarts.DataSourceArchitectureTableModels(),
 			// DataArts DataService
-			"huaweicloud_dataarts_dataservice_apis":      dataarts.DataSourceDataServiceApis(),
-			"huaweicloud_dataarts_dataservice_apps":      dataarts.DataSourceDataServiceApps(),
-			"huaweicloud_dataarts_dataservice_instances": dataarts.DataSourceDataServiceInstances(),
+			"huaweicloud_dataarts_dataservice_apis":            dataarts.DataSourceDataServiceApis(),
+			"huaweicloud_dataarts_dataservice_apps":            dataarts.DataSourceDataServiceApps(),
+			"huaweicloud_dataarts_dataservice_authorized_apps": dataarts.DataSourceDataServiceAuthorizedApps(),
+			"huaweicloud_dataarts_dataservice_instances":       dataarts.DataSourceDataServiceInstances(),
 			// DataArts Quality
 			"huaweicloud_dataarts_quality_tasks": dataarts.DataSourceQualityTasks(),
 			// DataArts Factory

--- a/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_authorized_apps_test.go
+++ b/huaweicloud/services/acceptance/dataarts/data_source_huaweicloud_dataarts_dataservice_authorized_apps_test.go
@@ -1,0 +1,72 @@
+package dataarts
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDataServiceAuthorizedApps_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_dataservice_authorized_apps.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsReviewerName(t)
+			acceptance.TestAccPreCheckDataArtsRelatedDliQueueName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDataServiceAuthorizedApps_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "apps.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+				),
+			},
+			{
+				// Cancel the authorization, prepare to destroy the environment.
+				Config: testAccDataSourceDataServiceAuthorizedApps_basic_step2(name),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDataServiceAuthorizedApps_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_auth" "test" {
+  depends_on = [huaweicloud_dataarts_dataservice_api_publishment.test]
+
+  workspace_id = "%[2]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  app_ids     = slice(huaweicloud_dataarts_dataservice_app.test[*].id, 0, 2)
+}
+
+data "huaweicloud_dataarts_dataservice_authorized_apps" "test" {
+  depends_on = [huaweicloud_dataarts_dataservice_api_auth.test]
+
+  workspace_id = "%[2]s"
+  dlm_type     = "EXCLUSIVE"
+
+  api_id = huaweicloud_dataarts_dataservice_api.test.id
+}
+`, testAccDataServiceApiAuth_base(name), acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testAccDataSourceDataServiceAuthorizedApps_basic_step2(name string) string {
+	return testAccDataServiceApiAuth_basic_step2(name)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_authorized_apps.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_authorized_apps.go
@@ -1,0 +1,227 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/service/authorize/apis/{api_id}
+func DataSourceDataServiceAuthorizedApps() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDataServiceAuthorizedAppsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the API is located.`,
+			},
+
+			// Parameters in request header
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the workspace to which the API belongs.`,
+			},
+			"dlm_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The type of DLM engine.`,
+			},
+
+			// Argument
+			"api_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the API used to authorize the APPs.`,
+			},
+
+			// Attributes
+			"apps": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataServiceAuthorizedAppElemSchema(),
+				Description: `All APPs authorized by API.`,
+			},
+		},
+	}
+}
+
+func dataServiceAuthorizedAppElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the application that has authorization.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the application that has authorization.`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The instance ID to which the authorized API belongs.`,
+			},
+			"instance_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The instance name to which the authorized API belongs.`,
+			},
+			"expired_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The expiration time, in RFC3339 format.`,
+			},
+			"approved_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The approve time, in RFC3339 format.`,
+			},
+			"relationship_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The relationship between the authorized API and the authorized APP list.`,
+			},
+			"static_params": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        dataServiceAuthorizedAppStaticParamElemSchema(),
+				Description: `The configuration of the static parameters.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func dataServiceAuthorizedAppStaticParamElemSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the static parameter.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the static parameter.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func queryDataServiceAuthorizedApps(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/service/authorize/apis/{api_id}?limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{api_id}", d.Get("api_id").(string))
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    d.Get("workspace_id").(string),
+			"dlm-type":     d.Get("dlm_type").(string),
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		apps := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		if len(apps) < 1 {
+			break
+		}
+		result = append(result, apps...)
+		offset += len(apps)
+	}
+
+	return result, nil
+}
+
+func flattenDataServiceAuthorizedApps(apps []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(apps))
+
+	for _, app := range apps {
+		result = append(result, map[string]interface{}{
+			"id":                utils.PathSearch("app_id", app, nil),
+			"name":              utils.PathSearch("app_name", app, nil),
+			"instance_id":       utils.PathSearch("instance_id", app, nil),
+			"instance_name":     utils.PathSearch("instance_name", app, nil),
+			"expired_at":        utils.FormatTimeStampRFC3339(int64(utils.PathSearch("api_using_time", app, float64(0)).(float64))/1000, false),
+			"approved_at":       utils.FormatTimeStampRFC3339(int64(utils.PathSearch("approve_time", app, float64(0)).(float64))/1000, false),
+			"relationship_type": utils.PathSearch("relationship_type", app, nil),
+			"static_params":     flattenDataServiceAppStaticParams(utils.PathSearch("static_params", app, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func flattenDataServiceAppStaticParams(staticParams []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(staticParams))
+
+	for _, staticParam := range staticParams {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("param_name", staticParam, nil),
+			"value": utils.PathSearch("param_value", staticParam, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDataServiceAuthorizedAppsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	authorizedApps, err := queryDataServiceAuthorizedApps(client, d)
+	if err != nil {
+		return diag.Errorf("error getting Data Service API (%s) for DataArts Studio", d.Id())
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("apps", flattenDataServiceAuthorizedApps(authorizedApps)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query authorized APPs.
![image](https://github.com/user-attachments/assets/73d17183-596f-487d-8b6a-a6dbce05bac6)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query authorized apps.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o dataarts -f TestAccDataSourceDataServiceAuthorizedApps_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataSourceDataServiceAuthorizedApps_basic -timeout 360m -parallel 10
=== RUN   TestAccDataSourceDataServiceAuthorizedApps_basic
--- PASS: TestAccDataSourceDataServiceAuthorizedApps_basic (212.79s)
PASS
coverage: 15.0% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  212.866s        coverage: 15.0% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
