### PR TITLE
fix(apig/workspace): using log.Printf instead of errors

### DIFF
--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance.go
@@ -501,7 +501,8 @@ func resourceInstanceRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("create_time", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", respBody, float64(0)).(float64))/1000, false)),
 	)
 	if resp, err := getCustomIngressPorts(client, instanceId); err != nil {
-		mErr = multierror.Append(mErr, err)
+		// This feature is not available in some region, so use log.Printf to record the error.
+		log.Printf("[ERROR] unable to find the custom ingerss ports: %s", err)
 	} else {
 		mErr = multierror.Append(mErr, d.Set("custom_ingress_ports", flattenCustomIngressPorts(resp)))
 	}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_desktop.go
@@ -480,7 +480,8 @@ func resourceDesktopRead(_ context.Context, d *schema.ResourceData, meta interfa
 
 	nicVal, err := getDesktopNetwork(client, desktopId)
 	if err != nil {
-		mErr = multierror.Append(mErr, err)
+		// This feature is not available in some region, so use log.Printf to record the error.
+		log.Printf("[ERROR] %s", err)
 	} else {
 		mErr = multierror.Append(mErr, d.Set("nic", nicVal))
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Because some APIs are not released in certain regions, forcibly calling the interface will block normal business logic. Use log.Printf to record log errors.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccInstance_basic
=== PAUSE TestAccInstance_basic
=== CONT  TestAccInstance_basic
--- PASS: TestAccInstance_basic (1135.71s)
PASS
ok      [github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig](http://github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig)      1135.771s


make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccDesktop_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccDesktop_basic -timeout 360m -parallel 4
=== RUN   TestAccDesktop_basic
--- PASS: TestAccDesktop_basic (1142.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 1142.592s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
