### PR TITLE
chore(waf): add checkDeleted logic to the WAF resource

### DIFF
--- a/huaweicloud/services/waf/resource_huaweicloud_waf_address_group.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_address_group.go
@@ -210,6 +210,7 @@ func resourceAddressGroupRead(_ context.Context, d *schema.ResourceData, meta in
 	getWAFAddressGroupResp, err := getWAFAddressGroupClient.Request("GET", getWAFAddressGroupPath,
 		&getWAFAddressGroupOpt)
 	if err != nil {
+		// If the address group does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving address group")
 	}
 
@@ -333,7 +334,8 @@ func resourceAddressGroupDelete(_ context.Context, d *schema.ResourceData, meta 
 	}
 	_, err = deleteWAFAddressGroupClient.Request("DELETE", deleteWAFAddressGroupPath, &deleteWAFAddressGroupOpt)
 	if err != nil {
-		return diag.Errorf("error deleting address group: %s", err)
+		// If the address group does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting address group")
 	}
 
 	return nil

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_certificate.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_certificate.go
@@ -108,6 +108,7 @@ func resourceWafCertificateV1Read(_ context.Context, d *schema.ResourceData, met
 	epsID := cfg.GetEnterpriseProjectID(d)
 	n, err := certificates.GetWithEpsID(client, d.Id(), epsID).Extract()
 	if err != nil {
+		// If the certificate does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF certificate")
 	}
 
@@ -157,7 +158,8 @@ func resourceWafCertificateV1Delete(_ context.Context, d *schema.ResourceData, m
 	epsID := cfg.GetEnterpriseProjectID(d)
 	err = certificates.DeleteWithEpsID(client, d.Id(), epsID).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting WAF certificate: %s", err)
+		// If the certificate does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF certificate")
 	}
 	return nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
@@ -791,6 +791,7 @@ func resourceWafDedicatedDomainRead(_ context.Context, d *schema.ResourceData, m
 	epsID := cfg.GetEnterpriseProjectID(d)
 	dm, err := domains.GetWithEpsID(dedicatedClient, d.Id(), epsID)
 	if err != nil {
+		// If the dedicated domain does not exist, the response HTTP status code of the details API is 404.
 		return common.CheckDeletedDiag(d, err, "error retrieving WAF dedicated domain")
 	}
 
@@ -866,7 +867,8 @@ func resourceWafDedicatedDomainDelete(_ context.Context, d *schema.ResourceData,
 	epsID := cfg.GetEnterpriseProjectID(d)
 	_, err = domains.DeleteWithEpsID(dedicatedClient, keepPolicy, d.Id(), epsID)
 	if err != nil {
-		return diag.Errorf("error deleting WAF dedicated domain: %s", err)
+		// If the dedicated domain does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF dedicated domain")
 	}
 	return nil
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_instance.go
@@ -250,7 +250,8 @@ func resourceDedicatedInstanceRead(_ context.Context, d *schema.ResourceData, me
 	epsId := common.GetEnterpriseProjectID(d, config)
 	r, err := instances.GetWithEpsId(client, d.Id(), epsId)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error obtain WAF dedicated instance information.")
+		// If the dedicated instance does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF dedicated instance")
 	}
 	logp.Printf("[DEBUG] Get a WAF dedicated instance :%#v", r)
 
@@ -361,7 +362,8 @@ func resourceDedicatedInstanceDelete(ctx context.Context, d *schema.ResourceData
 	epsId := common.GetEnterpriseProjectID(d, config)
 	_, err = instances.DeleteWithEpsId(client, d.Id(), epsId)
 	if err != nil {
-		return fmtp.DiagErrorf("error deleting WAF dedicated : %w", err)
+		// If the dedicated instance does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF dedicated instance")
 	}
 
 	logp.Printf("[DEBUG] Waiting for WAF dedicated instance to be deleted(ID:%s).", d.Id())

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_domain.go
@@ -545,7 +545,8 @@ func resourceWafDomainRead(_ context.Context, d *schema.ResourceData, meta inter
 
 	dm, err := domains.GetWithEpsID(wafClient, d.Id(), cfg.GetEnterpriseProjectID(d)).Extract()
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Error obtain WAF domain information")
+		// If the domain does not exist, the response HTTP status code of the details API is 404.
+		return common.CheckDeletedDiag(d, err, "error retrieving WAF domain")
 	}
 
 	// charging_mode not returned by API
@@ -628,7 +629,8 @@ func resourceWafDomainDelete(_ context.Context, d *schema.ResourceData, meta int
 	}
 	err = domains.Delete(wafClient, d.Id(), delOpts).ExtractErr()
 	if err != nil {
-		return diag.Errorf("error deleting WAF domain: %s", err)
+		// If the domain does not exist, the response HTTP status code of the deletion API is 404.
+		return common.CheckDeletedDiag(d, err, "error deleting WAF domain")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add checkDeleted logic to the WAF resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.Involved WAF resources are as follows:
   address group resource, certificate resource, dedicated instance resource, dedicated domain resource, cloud instance resource, domain resource.

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccAddressGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccAddressGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccAddressGroup_basic
=== PAUSE TestAccAddressGroup_basic
=== CONT  TestAccAddressGroup_basic
--- PASS: TestAccAddressGroup_basic (501.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       501.667s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafCertificateV1_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafCertificateV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafCertificateV1_basic
=== PAUSE TestAccWafCertificateV1_basic
=== CONT  TestAccWafCertificateV1_basic
--- PASS: TestAccWafCertificateV1_basic (512.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       512.725s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafDedicatedInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicatedInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDedicatedInstance_basic
=== PAUSE TestAccWafDedicatedInstance_basic
=== CONT  TestAccWafDedicatedInstance_basic
--- PASS: TestAccWafDedicatedInstance_basic (424.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       424.152s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafDedicateDomainV1_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicateDomainV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDedicateDomainV1_basic
=== PAUSE TestAccWafDedicateDomainV1_basic
=== CONT  TestAccWafDedicateDomainV1_basic
--- PASS: TestAccWafDedicateDomainV1_basic (761.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       761.795s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccWafDomainV1_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDomainV1_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDomainV1_basic
=== PAUSE TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_basic
--- PASS: TestAccWafDomainV1_basic (219.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       219.300s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/waf" TESTARGS="-run TestAccCloudInstance_prepaid_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccCloudInstance_prepaid_basic -timeout 360m -parallel 4
=== RUN   TestAccCloudInstance_prepaid_basic
=== PAUSE TestAccCloudInstance_prepaid_basic
=== CONT  TestAccCloudInstance_prepaid_basic
--- PASS: TestAccCloudInstance_prepaid_basic (113.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       113.166s
```



* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
### WAF address group resource
![image](https://github.com/user-attachments/assets/36bce610-457d-428f-aa26-04373ac427cd)
### WAF certificate resource
![image](https://github.com/user-attachments/assets/eb0b529d-6c62-4fdc-bbe7-69026729d770)
### WAF dedicated instance resource
![image](https://github.com/user-attachments/assets/84cee77b-7f9c-4a40-98ef-125820f0eeb8)
### WAF dedicated domain resource
![image](https://github.com/user-attachments/assets/500da90b-bc2e-497c-ab3b-6ed681e61e61)
### WAF cloud instance resource
![image](https://github.com/user-attachments/assets/be1bc4ee-ba0f-4796-96fe-d276040eb190)
### WAF domain resource
![image](https://github.com/user-attachments/assets/88dff05d-6dfe-4f6f-951a-7faeadd28d09)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
### WAF address group resource
![image](https://github.com/user-attachments/assets/dffb1de2-566a-4755-bd3d-74b86d8181d1)
### WAF certificate resource
![image](https://github.com/user-attachments/assets/c7211417-b2ad-4415-b306-27f6550e7493)
### WAF dedicated instance resource
![image](https://github.com/user-attachments/assets/6a51b539-fa4b-490f-9691-3d96a97cc273)
### WAF dedicated domain resource
![image](https://github.com/user-attachments/assets/934854a2-306c-491c-a820-6a4ace68c5c1)
### WAF cloud instance resource
![image](https://github.com/user-attachments/assets/184ccc52-7044-4fb6-891c-20a36b4e4cbb)
### WAF domain resource
![image](https://github.com/user-attachments/assets/8f049097-72ec-49c0-81a8-adc2c41909fd)
    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
