### PR TITLE
feat(lts): supports creation host group of 'label' type

### DIFF
--- a/docs/resources/lts_host_group.md
+++ b/docs/resources/lts_host_group.md
@@ -39,12 +39,23 @@ The following arguments are supported:
 
 * `name` - (Required, String) Specifies the name of the host group.
 
-* `type` - (Required, String, ForceNew) Specifies the type of the host group.
+* `type` - (Required, String, ForceNew) Specifies the type of the host.
   The value can be **linux** and **windows**.
 
   Changing this parameter will create a new resource.
 
 * `host_ids` - (Optional, List) Specifies the ID list of hosts to join the host group.
+
+* `agent_access_type` - (Optional, String) Specifies the type of the host group.
+  The default value is **IP**.  
+  The valid values are as follows:
+  + **IP**
+  + **LABEL**
+
+* `labels` - (Optional, List) Specifies the custom label list of the host group.
+  This parameter is required when `agent_access_type` is set to **LABEL**.
+
+  -> Currently, a maximum of `10` labels can be created.
 
 * `tags` - (Optional, Map) Specifies the key/value to attach to the host group.
 

--- a/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_host_group_test.go
+++ b/huaweicloud/services/acceptance/lts/resource_huaweicloud_lts_host_group_test.go
@@ -89,6 +89,7 @@ func TestAccHostGroup_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "type", "linux"),
+					resource.TestCheckResourceAttr(rName, "agent_access_type", "IP"),
 					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
 					resource.TestCheckOutput("is_host_id_different", "false"),
@@ -190,6 +191,112 @@ resource "huaweicloud_lts_host_group" "test" {
     foo        = "bar_update"
     key_update = "value"
   }
+}
+`, name)
+}
+
+func TestAccHostGroup_withLabelType(t *testing.T) {
+	var (
+		obj        interface{}
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		rName      = "huaweicloud_lts_host_group.test"
+
+		rc = acceptance.InitResourceCheck(
+			rName,
+			&obj,
+			getHostGroupResourceFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHostGroup_withLabelType_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "linux"),
+					resource.TestCheckResourceAttr(rName, "agent_access_type", "LABEL"),
+					resource.TestCheckResourceAttr(rName, "labels.#", "1"),
+					resource.TestCheckResourceAttr(rName, "labels.0", name),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", "terraform"),
+				),
+			},
+			{
+				Config: testAccHostGroup_withLabelType_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "type", "linux"),
+					resource.TestCheckResourceAttr(rName, "agent_access_type", "LABEL"),
+					resource.TestCheckResourceAttr(rName, "labels.#", "2"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.owner", updateName),
+				),
+			},
+			{
+				Config: testAccHostGroup_withLabelType_step3(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "tags.%", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccHostGroup_withLabelType_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_host_group" "test" {
+  name              = "%[1]s"
+  type              = "linux"
+  agent_access_type = "LABEL"
+  labels            = ["%[1]s"]
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+`, name)
+}
+
+func testAccHostGroup_withLabelType_step2(updateName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_host_group" "test" {
+  name              = "%[1]s"
+  type              = "linux"
+  agent_access_type = "LABEL"
+  labels            = ["%[1]s", "terraform"]
+
+  tags = {
+    foo   = "bar"
+    owner = "%[1]s"
+  }
+}
+`, updateName)
+}
+
+func testAccHostGroup_withLabelType_step3(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_lts_host_group" "test" {
+  name              = "%[1]s"
+  type              = "linux"
+  agent_access_type = "LABEL"
+  labels            = ["%[1]s", "terraform"]
 }
 `, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Provide new parameter `agent_access_type` and `labels` for host group resources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/acc-test.sh
>>> Start to test
=== RUN   TestAccHostGroup_basic
=== PAUSE TestAccHostGroup_basic
=== RUN   TestAccHostGroup_withLabelType
=== PAUSE TestAccHostGroup_withLabelType
=== CONT  TestAccHostGroup_basic
=== CONT  TestAccHostGroup_withLabelType
--- PASS: TestAccHostGroup_withLabelType (58.04s)
--- PASS: TestAccHostGroup_basic (73.75s)
PASS
coverage: 6.5% of statements in ../../lts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lts       73.812s```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
