### PR TITLE
feat(GaussDBforMySQL): gaussdb mysql instance support more params update

### DIFF
--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -65,14 +65,18 @@ The following arguments are supported:
 * `subnet_id` - (Required, String, ForceNew) Specifies the network ID of a subnet. Changing this parameter will create a
   new resource.
 
-* `security_group_id` - (Optional, String, ForceNew) Specifies the security group ID. Required if the selected subnet
-  doesn't enable network ACL. Changing this parameter will create a new resource.
-
 * `dedicated_resource_id` - (Optional, String, ForceNew) Specifies the dedicated resource ID. Changing this parameter
   will create a new resource.
 
 * `dedicated_resource_name` - (Optional, String, ForceNew) Specifies the dedicated resource name. Changing this parameter
   will create a new resource.
+
+* `security_group_id` - (Optional, String) Specifies the security group ID. Required if the selected subnet doesn't
+  enable network ACL.
+
+* `port` - (Optional, Int) Specifies the database port.
+
+* `private_write_ip` - (Optional, String) Specifies the private IP address of the DB instance.
 
 * `configuration_id` - (Optional, String) Specifies the configuration ID.
 
@@ -161,10 +165,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Indicates the DB instance ID.
 * `status` - Indicates the DB instance status.
-* `port` - Indicates the database port.
 * `mode` - Indicates the instance mode.
 * `db_user_name` - Indicates the default username.
-* `private_write_ip` - Indicates the private IP address of the DB instance.
 * `nodes` - Indicates the instance nodes information. Structure is documented below.
 
 The `nodes` block contains:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240816033604-f02953116ff3
+	github.com/chnsz/golangsdk v0.0.0-20240820113004-632436968292
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240816033604-f02953116ff3 h1:4K7U8x6TOckvkaLe0ExZBblIWmCErHszVXJ3fjn162A=
-github.com/chnsz/golangsdk v0.0.0-20240816033604-f02953116ff3/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240820113004-632436968292 h1:+FHRUxypeRH7EXc8t8FsFVBt4Y++Z1g7U+miFMpQjkc=
+github.com/chnsz/golangsdk v0.0.0-20240820113004-632436968292/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/requests.go
@@ -107,7 +107,7 @@ func CreateReplica(client *golangsdk.ServiceClient, instanceId string, opts Crea
 		return
 	}
 
-	_, r.Err = client.Post(enlargeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "nodes/enlarge"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{201, 202},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -241,7 +241,7 @@ func UpdateName(client *golangsdk.ServiceClient, instanceId string, opts UpdateN
 		return
 	}
 
-	_, r.Err = client.Put(nameURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Put(updateURL(client, instanceId, "name"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -272,7 +272,7 @@ func UpdatePass(client *golangsdk.ServiceClient, instanceId string, opts UpdateP
 		return
 	}
 
-	_, r.Err = client.Post(passwordURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "password"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -304,7 +304,7 @@ func ExtendVolume(client *golangsdk.ServiceClient, instanceId string, opts Exten
 		return
 	}
 
-	_, r.Err = client.Post(volumeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "volume/extend"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{201},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -340,7 +340,7 @@ func Resize(client *golangsdk.ServiceClient, instanceId string, opts ResizeBuild
 		return
 	}
 
-	_, r.Err = client.Post(actionURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "action"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -372,7 +372,7 @@ func EnableProxy(client *golangsdk.ServiceClient, instanceId string, opts ProxyB
 		return
 	}
 
-	_, r.Err = client.Post(proxyURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "proxy"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{201},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -403,7 +403,7 @@ func EnlargeProxy(client *golangsdk.ServiceClient, instanceId string, opts Enlar
 		return
 	}
 
-	_, r.Err = client.Post(proxyEnlargeURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "proxy/enlarge"), b, &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{201},
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
@@ -465,7 +465,97 @@ func Restart(client *golangsdk.ServiceClient, instanceId string, opts RestartBui
 		return
 	}
 
-	_, r.Err = client.Post(restartURL(client, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+	_, r.Err = client.Post(updateURL(client, instanceId, "restart"), b, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	return
+}
+
+type UpdatePrivateIpOpts struct {
+	InternalIp string `json:"internal_ip" required:"true"`
+}
+
+type UpdatePrivateIpBuilder interface {
+	ToPrivateIpUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdatePrivateIpOpts) ToPrivateIpUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func UpdatePrivateIp(client *golangsdk.ServiceClient, instanceId string, opts UpdatePrivateIpBuilder) (r JobResult) {
+	b, err := opts.ToPrivateIpUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(updateURL(client, instanceId, "internal-ip"), b, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	return
+}
+
+type UpdatePortOpts struct {
+	Port int `json:"port" required:"true"`
+}
+
+type UpdatePortBuilder interface {
+	ToPortUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdatePortOpts) ToPortUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func UpdatePort(client *golangsdk.ServiceClient, instanceId string, opts UpdatePortBuilder) (r JobResult) {
+	b, err := opts.ToPortUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(updateURL(client, instanceId, "port"), b, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	return
+}
+
+type UpdateSecurityGroupOpts struct {
+	SecurityGroupId string `json:"security_group_id" required:"true"`
+}
+
+type UpdateSecurityGroupBuilder interface {
+	ToSecurityGroupUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateSecurityGroupOpts) ToSecurityGroupUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func UpdateSecurityGroup(client *golangsdk.ServiceClient, instanceId string, opts UpdateSecurityGroupBuilder) (r JobResult) {
+	b, err := opts.ToSecurityGroupUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(updateURL(client, instanceId, "security-group"), b, &r.Body, &golangsdk.RequestOpts{
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/urls.go
@@ -18,40 +18,16 @@ func listURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("instances")
 }
 
-func enlargeURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "nodes/enlarge")
+func updateURL(c *golangsdk.ServiceClient, instanceID string, update string) string {
+	return c.ServiceURL("instances", instanceID, update)
 }
 
 func deleteReplicaURL(c *golangsdk.ServiceClient, instanceID, nodeID string) string {
 	return c.ServiceURL("instances", instanceID, "nodes", nodeID)
 }
 
-func nameURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "name")
-}
-
-func passwordURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "password")
-}
-
-func volumeURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "volume/extend")
-}
-
 func proxyURL(c *golangsdk.ServiceClient, instanceID string) string {
 	return c.ServiceURL("instances", instanceID, "proxy")
-}
-
-func proxyEnlargeURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "proxy/enlarge")
-}
-
-func actionURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "action")
-}
-
-func restartURL(c *golangsdk.ServiceClient, instanceID string) string {
-	return c.ServiceURL("instances", instanceID, "restart")
 }
 
 func jobURL(sc *golangsdk.ServiceClient) string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240816033604-f02953116ff3
+# github.com/chnsz/golangsdk v0.0.0-20240820113004-632436968292
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  gaussdb mysql instance support update security_group_id, private_write_ip and port
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb mysql instance support update security_group_id, private_write_ip and port
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBInstance_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== RUN   TestAccGaussDBInstance_prePaid
=== PAUSE TestAccGaussDBInstance_prePaid
=== RUN   TestAccGaussDBInstance_updateWithEpsId
=== PAUSE TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_prePaid
=== CONT  TestAccGaussDBInstance_updateWithEpsId
    acceptance.go:612: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccGaussDBInstance_updateWithEpsId (0.01s)
--- PASS: TestAccGaussDBInstance_prePaid (1554.79s)
--- PASS: TestAccGaussDBInstance_basic (2767.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   2767.323s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
