### PR TITLE
feat(ims/ecs_whole_image): support `ecs_whole_image` resource

### DIFF
--- a/docs/resources/ims_ecs_whole_image.md
+++ b/docs/resources/ims_ecs_whole_image.md
@@ -1,0 +1,121 @@
+---
+subcategory: "Image Management Service (IMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ims_ecs_whole_image"
+description: |-
+  Manages an IMS whole image resource created from ECS instance within HuaweiCloud.
+---
+
+# huaweicloud_ims_ecs_whole_image
+
+Manages an IMS whole image resource created from ECS instance within HuaweiCloud.
+
+-> After deleting the image, the CBR backup that has not been deleted will be retained and continue to be charged.
+   If you need to delete it later, you can delete the corresponding CBR backup in the CBR backup console.
+
+## Example Usage
+
+### Creating an IMS whole image from an existing ECS instance
+
+```hcl
+variable "name" {}
+variable "instance_id" {}
+variable "vault_id" {}
+
+resource "huaweicloud_ims_ecs_whole_image" "test" {
+  name        = var.name
+  instance_id = var.instance_id
+  vault_id    = var.vault_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the image.
+  The valid length is limited from `1` to `128` characters.
+  The first and last letters of the name cannot be spaces.
+  The name can contain uppercase letters, lowercase letters, numbers, spaces, chinese, and special characters (-._).
+
+* `instance_id` - (Required, String, ForceNew) Specifies the source ECS instance ID used to create the image.
+  Changing this parameter will create a new resource.
+
+* `vault_id` - (Required, String, ForceNew) Specifies the ID of the vault to which an ECS instance is to be added or has
+  been added. Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of the image.
+
+* `max_ram` - (Optional, Int) Specifies the maximum memory of the image, in MB unit.
+
+* `min_ram` - (Optional, Int) Specifies the minimum memory of the image, in MB unit.
+  The default value is `0`, indicating that the memory is not restricted.
+
+* `is_delete_backup` - (Optional, Bool) Specifies whether to delete the associated CBR backup when deleting image.
+  The value can be **true** or **false**.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the image.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the IMS image belongs.
+  For enterprise users, if omitted, default enterprise project will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the image.
+
+* `status` - The status of the image. The value can be **active**, **queued**, **saving**, **deleted**, or **killed*,
+  only image with a status of **active** can be used.
+
+* `visibility` - Whether the image is visible to other tenants.
+
+* `backup_id` - The ID of CBR backup.
+
+* `disk_format` - The image format. The value can be **zvhd2**, **vhd**, **zvhd**, **raw**, or **qcow2**.
+
+* `data_origin` - The image resource. The format is **server_backup,vault_id**.
+
+* `os_version` - The operating system version of the image.
+
+* `active_at` - The time when the image status changes to active, in RFC3339 format.
+
+* `created_at` - The creation time of the image, in RFC3339 format.
+
+* `updated_at` - The last update time of the image, in RFC3339 format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The IMS ECS whole image resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_ims_ecs_whole_image.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `is_delete_backup`.
+It is generally recommended running `terraform plan` after importing the resource. You can then decide if changes should
+be applied to the resource, or the resource definition should be updated to align with the image. Also, you can ignore
+changes as below.
+
+```
+resource "huaweicloud_ims_ecs_whole_image" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      is_delete_backup,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1522,6 +1522,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iec_vpc_subnet":          iec.ResourceSubnet(),
 
 			"huaweicloud_ims_ecs_system_image":        ims.ResourceEcsSystemImage(),
+			"huaweicloud_ims_ecs_whole_image":         ims.ResourceEcsWholeImage(),
 			"huaweicloud_images_image":                ims.ResourceImsImage(),
 			"huaweicloud_images_image_copy":           ims.ResourceImsImageCopy(),
 			"huaweicloud_images_image_share":          ims.ResourceImsImageShare(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -253,6 +253,8 @@ var (
 	// The repository of SWR image tag
 	HW_SWR_REPOSITORY = os.Getenv("HW_SWR_REPOSITORY")
 
+	// The ID of the CBR vault
+	HW_IMS_VAULT_ID = os.Getenv("HW_IMS_VAULT_ID")
 	// The ID of the CBR backup
 	HW_IMS_BACKUP_ID = os.Getenv("HW_IMS_BACKUP_ID")
 	// The shared backup ID wants to accept.
@@ -1408,6 +1410,13 @@ func TestAccPreCheckSwrOrigination(t *testing.T) {
 func TestAccPreCheckSwrRepository(t *testing.T) {
 	if HW_SWR_REPOSITORY == "" {
 		t.Skip("HW_SWR_REPOSITORY must be set for SWR image tags tests")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckImsVaultId(t *testing.T) {
+	if HW_IMS_VAULT_ID == "" {
+		t.Skip("HW_IMS_VAULT_ID must be set for IMS whole image tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_ecs_whole_image_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_ecs_whole_image_test.go
@@ -1,0 +1,241 @@
+package ims
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccEcsWholeImage_basic(t *testing.T) {
+	var (
+		image        cloudimages.Image
+		rName        = acceptance.RandomAccResourceName()
+		rNameUpdate  = rName + "-update"
+		resourceName = "huaweicloud_ims_ecs_whole_image.test"
+		defaultEpsId = "0"
+		migrateEpsId = acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&image,
+		getImsImageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case need setting a non default enterprise project ID.
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEcsWholeImage_basic(rName, defaultEpsId, 2048, 4096),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform description test"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", defaultEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(resourceName, "visibility"),
+					resource.TestCheckResourceAttrSet(resourceName, "backup_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "disk_format"),
+					resource.TestCheckResourceAttrSet(resourceName, "data_origin"),
+					resource.TestCheckResourceAttrSet(resourceName, "os_version"),
+					resource.TestMatchResourceAttr(resourceName, "active_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_compute_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "vault_id", "huaweicloud_cbr_vault.test", "id"),
+				),
+			},
+			{
+				Config: testAccEcsWholeImage_update1(rName, rNameUpdate, migrateEpsId, 1024, 2048),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", migrateEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+				),
+			},
+			{
+				Config: testAccEcsWholeImage_update2(rName, rNameUpdate, defaultEpsId, 0, 0),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", defaultEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEcsWholeImage_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cbr_vault" "test" {
+  name             = "%[2]s"
+  type             = "server"
+  consistent_level = "app_consistent"
+  protection_type  = "backup"
+  size             = 200
+}
+`, testAccEcsSystemImage_base(rName), rName)
+}
+
+func testAccEcsWholeImage_basic(rName, defaultEpsId string, minRAM, maxRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_ecs_whole_image" "test" {
+  name                  = "%[2]s"
+  instance_id           = huaweicloud_compute_instance.test.id
+  vault_id              = huaweicloud_cbr_vault.test.id
+  description           = "terraform description test"
+  enterprise_project_id = "%[3]s"
+  min_ram               = %[4]d
+  max_ram               = %[5]d
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccEcsWholeImage_base(rName), rName, defaultEpsId, minRAM, maxRAM)
+}
+
+func testAccEcsWholeImage_update1(rName, rNameUpdate, migrateEpsId string, minRAM, maxRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_ecs_whole_image" "test" {
+  name                  = "%[2]s"
+  instance_id           = huaweicloud_compute_instance.test.id
+  vault_id              = huaweicloud_cbr_vault.test.id
+  enterprise_project_id = "%[3]s"
+  min_ram               = %[4]d
+  max_ram               = %[5]d
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testAccEcsWholeImage_base(rName), rNameUpdate, migrateEpsId, minRAM, maxRAM)
+}
+
+func testAccEcsWholeImage_update2(rName, rNameUpdate, defaultEpsId string, minRAM, maxRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_ecs_whole_image" "test" {
+  name                  = "%[2]s"
+  instance_id           = huaweicloud_compute_instance.test.id
+  vault_id              = huaweicloud_cbr_vault.test.id
+  enterprise_project_id = "%[3]s"
+  min_ram               = %[4]d
+  max_ram               = %[5]d
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testAccEcsWholeImage_base(rName), rNameUpdate, defaultEpsId, minRAM, maxRAM)
+}
+
+// When using fully automated script testing to set `is_delete_backup` to true, it can cause CBR vault resource to be
+// deleted very slowly, resulting in a timeout error.
+// So here we use environment variables to inject the `is_delete_backup` parameter to complete the testing.
+func TestAccEcsWholeImage_withDeleteBackup(t *testing.T) {
+	var (
+		image        cloudimages.Image
+		rName        = acceptance.RandomAccResourceName()
+		resourceName = "huaweicloud_ims_ecs_whole_image.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&image,
+		getImsImageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case need setting a CBR vault ID.
+			acceptance.TestAccPreCheckImsVaultId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEcsWholeImage_withDeleteBackup_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "is_delete_backup", "true"),
+					resource.TestCheckResourceAttr(resourceName, "vault_id", acceptance.HW_IMS_VAULT_ID),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_compute_instance.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"is_delete_backup",
+				},
+			},
+		},
+	})
+}
+
+func testAccEcsWholeImage_withDeleteBackup_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_ecs_whole_image" "test" {
+  name             = "%[2]s"
+  instance_id      = huaweicloud_compute_instance.test.id
+  vault_id         = "%[3]s"
+  is_delete_backup = true
+}
+`, testAccEcsSystemImage_base(rName), rName, acceptance.HW_IMS_VAULT_ID)
+}

--- a/huaweicloud/services/ims/resource_huaweicloud_ims_ecs_whole_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_ecs_whole_image.go
@@ -1,0 +1,302 @@
+package ims
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/backups"
+	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API IMS POST /v1/cloudimages/wholeimages/action
+// @API IMS GET /v1/{project_id}/jobs/{job_id}
+// @API IMS GET /v2/cloudimages
+// @API IMS GET /v2/{project_id}/images/{image_id}/tags
+// @API CBR GET /v3/{project_id}/backups/{backup_id}
+// @API IMS PATCH /v2/cloudimages/{image_id}
+// @API IMS POST /v2/{project_id}/images/{image_id}/tags/action
+// @API IMS DELETE /v2/images/{image_id}
+func ResourceEcsWholeImage() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEcsWholeImageCreate,
+		ReadContext:   resourceEcsWholeImageRead,
+		UpdateContext: resourceEcsWholeImageUpdate,
+		DeleteContext: resourceWholeImageDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vault_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			// The `description` field can be left blank, so the `Computed` attribute is not used.
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"max_ram": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"min_ram": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"is_delete_backup": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"tags": common.TagsSchema(),
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// Attributes
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"visibility": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"backup_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_format": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"os_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"active_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceEcsWholeImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		createResp *cloudimages.JobResponse
+	)
+
+	client, err := cfg.ImageV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v1 client: %s", err)
+	}
+
+	imageTags := buildCreateImageTagsParam(d)
+	createOpts := &cloudimages.CreateWholeImageOpts{
+		Name:                d.Get("name").(string),
+		InstanceId:          d.Get("instance_id").(string),
+		VaultId:             d.Get("vault_id").(string),
+		Description:         d.Get("description").(string),
+		MaxRam:              d.Get("max_ram").(int),
+		MinRam:              d.Get("min_ram").(int),
+		ImageTags:           imageTags,
+		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
+	}
+
+	createResp, err = cloudimages.CreateWholeImageByServer(client, createOpts).ExtractJobResponse()
+	if err != nil {
+		return diag.Errorf("error creating IMS ECS whole image: %s", err)
+	}
+
+	imageId, err := waitForCreateImageCompleted(client, d, createResp.JobID)
+	if err != nil {
+		return diag.Errorf("error waiting for IMS ECS whole image to complete: %s", err)
+	}
+
+	d.SetId(imageId)
+
+	return resourceEcsWholeImageRead(ctx, d, meta)
+}
+
+func resourceEcsWholeImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		mErr   *multierror.Error
+	)
+
+	client, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v2 client: %s", err)
+	}
+
+	imageList, err := GetImageList(client, d.Id())
+	if err != nil {
+		return diag.Errorf("error retrieving IMS ECS whole images: %s", err)
+	}
+
+	// If the list API return empty, then process `CheckDeleted` logic.
+	if len(imageList) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS ECS whole image")
+	}
+
+	image := imageList[0]
+	imageTags := getImageTags(d, client)
+	result, err := getBackupDetail(cfg, region, image.BackupID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("name", image.Name),
+		d.Set("instance_id", result[0]),
+		d.Set("vault_id", result[1]),
+		d.Set("description", image.Description),
+		d.Set("max_ram", getMaxRAM(image.MaxRam)),
+		d.Set("min_ram", image.MinRam),
+		d.Set("tags", imageTags),
+		d.Set("enterprise_project_id", image.EnterpriseProjectID),
+		d.Set("status", image.Status),
+		d.Set("visibility", image.Visibility),
+		d.Set("backup_id", image.BackupID),
+		d.Set("disk_format", image.DiskFormat),
+		d.Set("data_origin", image.DataOrigin),
+		d.Set("os_version", image.OsVersion),
+		d.Set("active_at", image.ActiveAt),
+		d.Set("created_at", image.CreatedAt.Format(time.RFC3339)),
+		d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getBackupDetail(cfg *config.Config, region, backupId string) ([]string, error) {
+	cbrClient, err := cfg.CbrV3Client(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CBR v3 client: %s", err)
+	}
+
+	backup, err := backups.Get(cbrClient, backupId)
+	if err != nil {
+		return nil, fmt.Errorf("error querying backup detail: %s", err)
+	}
+
+	return []string{backup.ResourceId, backup.VaultId}, nil
+}
+
+func resourceEcsWholeImageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v2 client: %s", err)
+	}
+
+	err = updateImage(ctx, cfg, client, d)
+	if err != nil {
+		return diag.Errorf("error updating IMS ECS whole image: %s", err)
+	}
+
+	return resourceEcsWholeImageRead(ctx, d, meta)
+}
+
+func resourceWholeImageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		imageId = d.Id()
+	)
+
+	client, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v2 client: %s", err)
+	}
+
+	// Before deleting, call the query API first, if the query result is empty, then process `CheckDeleted` logic.
+	imageList, err := GetImageList(client, imageId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(imageList) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS whole image")
+	}
+
+	// For the whole image, need to use `delete_backup` to control whether to delete backup when deleting image.
+	deletePath := client.Endpoint + "v2/images/{image_id}"
+	deletePath = strings.ReplaceAll(deletePath, "{image_id}", imageId)
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"delete_backup": d.Get("is_delete_backup").(bool),
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting IMS whole image: %s", err)
+	}
+
+	// Because the delete API always return `204` status code,
+	// so we need to call the list query API to check if the image has been successfully deleted.
+	err = waitForDeleteImageCompleted(ctx, client, d)
+	if err != nil {
+		return diag.Errorf("error waiting for IMS whole image deleted: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support `ecs_whole_image` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support `ecs_whole_image` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ export HW_ENTERPRISE_PROJECT_ID_TEST=xxxxxxxx
$ export HW_IMS_VAULT_ID=xxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccEcsWholeImage_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccEcsWholeImage_ -timeout 360m -parallel 4
=== RUN   TestAccEcsWholeImage_basic
=== PAUSE TestAccEcsWholeImage_basic
=== RUN   TestAccEcsWholeImage_withDeleteBackup
=== PAUSE TestAccEcsWholeImage_withDeleteBackup
=== CONT  TestAccEcsWholeImage_basic
=== CONT  TestAccEcsWholeImage_withDeleteBackup
--- PASS: TestAccEcsWholeImage_withDeleteBackup (418.07s)
--- PASS: TestAccEcsWholeImage_basic (702.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       702.290s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/73653e04-498b-48bd-b58c-04b245ab5e41)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/e7726956-6276-441e-9d8d-f8c1819795bc)


