### PR TITLE
chore(CCM): reconstruct CCM private certificate export data source

### DIFF
--- a/docs/data-sources/ccm_private_certificate_export.md
+++ b/docs/data-sources/ccm_private_certificate_export.md
@@ -2,7 +2,8 @@
 subcategory: "Cloud Certificate Manager (CCM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ccm_private_certificate_export"
-description: ""
+description: |
+  Use this data source export a private Certificate within HuaweiCloud.
 ---
 
 # huaweicloud_ccm_private_certificate_export
@@ -14,7 +15,7 @@ Use this data source export a private Certificate within HuaweiCloud.
 ```hcl
 variable "certificate_id" {}
 
-data "huaweicloud_ccm_private_certificate_export" "test3" {
+data "huaweicloud_ccm_private_certificate_export" "test" {
   region         = "cn-north-4"
   type           = "OTHER"
   certificate_id = var.certificate_id
@@ -25,29 +26,29 @@ data "huaweicloud_ccm_private_certificate_export" "test3" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) Specifies the certificate region. Changing this creates a new
-  private certificate resource. Now only support cn-north-4 (china) and ap-southeast-3 (international).
+* `region` - (Optional, String) Specifies the certificate region in which to query the resource.
+  If omitted, the provider-level region will be used.
 
-* `certificate_id` - (Required, String, ForceNew) Specifies the certificate ID of the private certificate
+* `certificate_id` - (Required, String) Specifies the certificate ID of the private certificate
   you want to export.
 
-* `type` - (Required, String, ForceNew) Specifies the Type of the server on which the certificate is installed.
+* `type` - (Required, String) Specifies the type of the server on which the certificate is installed.
   The options are as follows:
-  + **APACHE**: This parameter is recommended if you want to use the certificate for an Apache server.
-  + **NGINX**: This parameter is recommended if you want to use the certificate for an Nginx server.
-  + **OTHER**: This parameter is recommended if you want to download a certificate in PEM format.
-  + **IIS**: This parameter is recommended if you want to use the certificate for an IIS server.
-  + **TOMCAT**: This parameter is recommended if you want to use the certificate for a TOMCAT server.
+  + **APACHE**: Using for apache server.
+  + **NGINX**: Using for nginx server.
+  + **OTHER**: Using for download certificates in PEM format.
+  + **IIS**: Using for Windows server.
+  + **TOMCAT**: Using for tomcat server.
 
-  -> **NOTE:** When the **type** is "IIS" or "TOMCAT" the export certificate file is different everytime.
+  -> The certificate file exported is different each time when `type` is set to **IIS** or **TOMCAT**.
 
-* `sm_standard` - (Optional, String) Specifies the GB/T GMT0009 standard specifications and
-  GB/T GMT0010 standard. When the certificate algorithm is SM2,
-  it is only valid when it is passed in. If it is not passed in, it defaults to false.
+* `sm_standard` - (Optional, String) Specifies whether to use the national secret **GMT0009** and **GMT0010** standard
+  specification. This field is valid only when the certificate algorithm is **SM2**.
+  The sm2 cert only support **OTHER** type. Valid values are **true** and **false**. Defaults to **false**.
 
-* `password` - (Optional, String) Specifies the password used to encrypt the private key. Support the use of uppercase
-  and lowercase English letters, numbers, special characters (such as.+- _ #), etc. The maximum length is 32 bytes.
-  If not passed in, encryption will not be used for export by default.
+* `password` - (Optional, String) Specifies the password used to encrypt the private key. Only uppercase letters,
+  lowercase letters, digits, and special characters (`,.+-_#`) are allowed. The maximum length is 32 bytes.
+  By default, encryption is not used when exporting.
 
 ## Attribute Reference
 
@@ -63,14 +64,14 @@ In addition to all arguments above, the following attributes are exported:
 
 * `enc_private_key` - Indicates the encryption certificate private key in PEM format.
 
-* `enc_sm2_enveloped_key` - Indicates the National Security GMT0009 Standard Specification for Encrypting Private
-  Keys SM2 Digital Envelope.
-  
-* `signed_and_enveloped_data` - Indicates the National Security GMT0010 Standard Specification for
-  Encrypting Private Keys - Signature Digital Envelope.
+* `enc_sm2_enveloped_key` - Indicates the national secret **GMT0009** standard specification SM2 digital envelope for
+  encrypting private key.
 
-* `keystore_pass` - Indicates the keystore password. If argument "password" passed in, it will be empty.
+* `signed_and_enveloped_data` - Indicates the national secret **GMT0010** standard specification signed digital envelope
+  with encrypted private key.
 
-* `server_pfx` - Indicates the certificate file for IIS server. Encoding by base64.
+* `keystore_pass` - Indicates the keystore password. This field is empty when argument `password` is specified.
 
-* `server_jks` - Indicates the certificate file for TOMCAT server. Encoding by base64.
+* `server_pfx` - Indicates the certificate file for **IIS** server. Encoding by base64.
+
+* `server_jks` - Indicates the certificate file for **TOMCAT** server. Encoding by base64.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -507,7 +507,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ccm_private_cas":                ccm.DataSourcePrivateCas(),
 			"huaweicloud_ccm_private_ca_export":          ccm.DataSourcePrivateCaExport(),
 			"huaweicloud_ccm_private_certificates":       ccm.DataSourcePrivateCertificates(),
-			"huaweicloud_ccm_private_certificate_export": ccm.DataSourceCcmPrivateCertificateExport(),
+			"huaweicloud_ccm_private_certificate_export": ccm.DataSourcePrivateCertificateExport(),
 
 			"huaweicloud_cdn_domain_statistics":   cdn.DataSourceStatistics(),
 			"huaweicloud_cdn_domains":             cdn.DataSourceCdnDomains(),

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go
@@ -9,126 +9,167 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccCcmPrivateCertificateExport_basic(t *testing.T) {
-	rName := acceptance.RandomAccResourceName()
-	dataSourceName := "data.huaweicloud_ccm_private_certificate_export.basiccert"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccPrivateCertificateExport_basic(t *testing.T) {
+	var (
+		rName      = acceptance.RandomAccResourceNameWithDash()
+		apacheName = "data.huaweicloud_ccm_private_certificate_export.apache"
+		apacheDc   = acceptance.InitDataSourceCheck(apacheName)
+
+		nginxName = "data.huaweicloud_ccm_private_certificate_export.nginx"
+		nginxDc   = acceptance.InitDataSourceCheck(nginxName)
+
+		otherName = "data.huaweicloud_ccm_private_certificate_export.other"
+		otherDc   = acceptance.InitDataSourceCheck(otherName)
+
+		iisName = "data.huaweicloud_ccm_private_certificate_export.iis"
+		iisDc   = acceptance.InitDataSourceCheck(iisName)
+
+		tomcatName = "data.huaweicloud_ccm_private_certificate_export.tomcat"
+		tomcatDc   = acceptance.InitDataSourceCheck(tomcatName)
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCcmPrivateCertificateExport_basic(rName),
+				Config: testAccPrivateCertificateExport_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceName, "private_key"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "certificate"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "certificate_chain"),
+					apacheDc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(apacheName, "type", "APACHE"),
+					resource.TestCheckResourceAttrSet(apacheName, "certificate"),
+					resource.TestCheckResourceAttrSet(apacheName, "certificate_chain"),
+					resource.TestCheckResourceAttrSet(apacheName, "password"),
+					resource.TestCheckResourceAttrSet(apacheName, "private_key"),
+
+					nginxDc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(nginxName, "type", "NGINX"),
+					resource.TestCheckResourceAttrSet(nginxName, "certificate"),
+					resource.TestCheckResourceAttrSet(nginxName, "certificate_chain"),
+					resource.TestCheckResourceAttrSet(nginxName, "private_key"),
+
+					otherDc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(otherName, "type", "OTHER"),
+					resource.TestCheckResourceAttrSet(otherName, "certificate"),
+					resource.TestCheckResourceAttrSet(otherName, "certificate_chain"),
+					resource.TestCheckResourceAttrSet(otherName, "password"),
+					resource.TestCheckResourceAttrSet(otherName, "private_key"),
+
+					iisDc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(iisName, "type", "IIS"),
+					resource.TestCheckResourceAttrSet(iisName, "keystore_pass"),
+					resource.TestCheckResourceAttrSet(iisName, "server_pfx"),
+
+					tomcatDc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(tomcatName, "type", "TOMCAT"),
+					resource.TestCheckResourceAttrSet(tomcatName, "password"),
+					resource.TestCheckResourceAttrSet(tomcatName, "server_jks"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCcmPrivateCertificateExport_SM2(t *testing.T) {
-	rName := acceptance.RandomAccResourceName()
-	dataSourceSM2Name := "data.huaweicloud_ccm_private_certificate_export.sm2cert"
-	dc := acceptance.InitDataSourceCheck(dataSourceSM2Name)
+func testAccPrivateCertificateExport_basic(commonName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_ccm_private_certificate_export" "apache" {
+  certificate_id = huaweicloud_ccm_private_certificate.test.id
+  type           = "APACHE"
+  password       = "encryption_password"
+}
+
+data "huaweicloud_ccm_private_certificate_export" "nginx" {
+  certificate_id = huaweicloud_ccm_private_certificate.test.id
+  type           = "NGINX"
+}
+
+data "huaweicloud_ccm_private_certificate_export" "other" {
+  certificate_id = huaweicloud_ccm_private_certificate.test.id
+  type           = "OTHER"
+  password       = "encryption_password"
+}
+
+data "huaweicloud_ccm_private_certificate_export" "iis" {
+  certificate_id = huaweicloud_ccm_private_certificate.test.id
+  type           = "IIS"
+}
+
+data "huaweicloud_ccm_private_certificate_export" "tomcat" {
+  certificate_id = huaweicloud_ccm_private_certificate.test.id
+  type           = "TOMCAT"
+  password       = "encryption_password"
+}
+`, tesCmdbCertificate_basic(commonName))
+}
+
+func TestAccPrivateCertificateExport_sm2cert(t *testing.T) {
+	var (
+		rName     = acceptance.RandomAccResourceNameWithDash()
+		otherName = "data.huaweicloud_ccm_private_certificate_export.other"
+		otherDc   = acceptance.InitDataSourceCheck(otherName)
+
+		sm2certName = "data.huaweicloud_ccm_private_certificate_export.sm2cert"
+		sm2certDc   = acceptance.InitDataSourceCheck(sm2certName)
+	)
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCcmPrivateCertificateSM2Export_basic(rName),
+				Config: testAccPrivateCertificateExport_sm2cert(rName),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "private_key"),
-					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "certificate"),
-					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "certificate_chain"),
-					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "enc_certificate"),
-					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "enc_sm2_enveloped_key"),
-					resource.TestCheckResourceAttrSet(dataSourceSM2Name, "signed_and_enveloped_data"),
-				),
-			},
-		},
-	})
-}
-func TestAccCcmPrivateCertificateExport_compressed(t *testing.T) {
-	rName := acceptance.RandomAccResourceName()
-	tomcatDataSourceName := "data.huaweicloud_ccm_private_certificate_export.tomcatcert"
-	iisDataSourceName := "data.huaweicloud_ccm_private_certificate_export.iiscert"
-	dcTomcat := acceptance.InitDataSourceCheck(tomcatDataSourceName)
-	dcIIS := acceptance.InitDataSourceCheck(iisDataSourceName)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCcmPrivateCertificateExport_TOMCAT(rName),
-				Check: resource.ComposeTestCheckFunc(
-					dcTomcat.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(tomcatDataSourceName, "keystore_pass"),
-					resource.TestCheckResourceAttrSet(tomcatDataSourceName, "server_jks"),
-				),
-			},
-			{
-				Config: testAccCcmPrivateCertificateExport_IIS(rName),
-				Check: resource.ComposeTestCheckFunc(
-					dcIIS.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(iisDataSourceName, "keystore_pass"),
-					resource.TestCheckResourceAttrSet(iisDataSourceName, "server_pfx"),
+					otherDc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(otherName, "type", "OTHER"),
+					resource.TestCheckResourceAttrSet(otherName, "certificate"),
+					resource.TestCheckResourceAttrSet(otherName, "certificate_chain"),
+					resource.TestCheckResourceAttrSet(otherName, "certificate_id"),
+					resource.TestCheckResourceAttrSet(otherName, "enc_certificate"),
+					resource.TestCheckResourceAttrSet(otherName, "enc_private_key"),
+					resource.TestCheckResourceAttrSet(otherName, "password"),
+					resource.TestCheckResourceAttrSet(otherName, "private_key"),
+
+					sm2certDc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(sm2certName, "type", "OTHER"),
+					resource.TestCheckResourceAttrSet(sm2certName, "certificate"),
+					resource.TestCheckResourceAttrSet(sm2certName, "certificate_chain"),
+					resource.TestCheckResourceAttrSet(sm2certName, "enc_certificate"),
+					resource.TestCheckResourceAttrSet(sm2certName, "enc_sm2_enveloped_key"),
+					resource.TestCheckResourceAttrSet(sm2certName, "private_key"),
+					resource.TestCheckResourceAttrSet(sm2certName, "signed_and_enveloped_data"),
+					resource.TestCheckResourceAttrSet(sm2certName, "sm_standard"),
 				),
 			},
 		},
 	})
 }
 
-// lintignore:AT004
-func testAccCcmPrivateCertificateExport_basic(commonName string) string {
+func testAccPrivateCertificateExport_sm2cert(commonName string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_ccm_private_certificate_export" "basiccert" {
-    type           = "other"
-    certificate_id = huaweicloud_ccm_private_certificate.test.id
-}`, tesCmdbCertificate_basic(commonName))
+data "huaweicloud_ccm_private_certificate_export" "other" {
+  certificate_id = huaweicloud_ccm_private_certificate.test.id
+  type           = "OTHER"
+  password       = "encryption_password"
 }
 
-// lintignore:AT004
-func testAccCcmPrivateCertificateExport_TOMCAT(commonName string) string {
+data "huaweicloud_ccm_private_certificate_export" "sm2cert" {
+  certificate_id = huaweicloud_ccm_private_certificate.test.id
+  type           = "OTHER"
+  sm_standard    = "true"
+}
+`, testAccPrivateCertificateExport_sm2Base(commonName))
+}
+
+func testAccPrivateCertificateExport_sm2Base(commonName string) string {
 	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_ccm_private_certificate_export" "tomcatcert" {
-    type           = "TOMCAT"
-    certificate_id = huaweicloud_ccm_private_certificate.test.id
-}`, tesCmdbCertificate_basic(commonName))
-}
-
-// lintignore:AT004
-func testAccCcmPrivateCertificateExport_IIS(commonName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_ccm_private_certificate_export" "iiscert" {
-    type           = "IIS"
-    certificate_id = huaweicloud_ccm_private_certificate.test.id
-}`, tesCmdbCertificate_basic(commonName))
-}
-
-// lintignore:AT004
-func testAccCcmPrivateCertificateSM2Export_basic(commonName string) string {
-	return fmt.Sprintf(`
-provider "huaweicloud" {
-  endpoints = {
-    ccm = "https://ccm.cn-north-4.myhuaweicloud.com/"
-  }
-}
-
-resource "huaweicloud_ccm_private_ca" "test_root" {
+resource "huaweicloud_ccm_private_ca" "test" {
   type   = "ROOT"
   distinguished_name {
-    common_name         = "%s-root"
+    common_name         = "%[1]s-root"
     country             = "CN"
     state               = "GD"
     locality            = "SZ"
@@ -144,11 +185,11 @@ resource "huaweicloud_ccm_private_ca" "test_root" {
   }
 }
 
-resource "huaweicloud_ccm_private_certificate" "test2" {
+resource "huaweicloud_ccm_private_certificate" "test" {
   distinguished_name {
-    common_name = "%s"
+    common_name = "%[1]s"
   }
-  issuer_id           = huaweicloud_ccm_private_ca.test_root.id
+  issuer_id           = huaweicloud_ccm_private_ca.test.id
   key_algorithm       = "SM2"
   signature_algorithm = "SM3"
   validity {
@@ -156,10 +197,5 @@ resource "huaweicloud_ccm_private_certificate" "test2" {
     value = "1"
   }
 }
-	  
-data "huaweicloud_ccm_private_certificate_export" "sm2cert" {
-  type           = "other"
-  certificate_id = huaweicloud_ccm_private_certificate.test2.id
-  sm_standard    = "true"
-}`, commonName, commonName)
+`, commonName)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- reconstruct CCM private certificate export data source.
  - reconstruct data source code.
  - fix and improve documentation.
  - optimize test cases to enhance test coverage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1724226447589_TestAccPrivateCertificateExport_.cov -coverpkg=./huaweicloud/services/ccm ./huaweicloud/services/acceptance/ccm -run TestAccPrivateCertificateExport_ -timeout 360m -parallel 4
=== RUN   TestAccPrivateCertificateExport_basic
=== PAUSE TestAccPrivateCertificateExport_basic
=== RUN   TestAccPrivateCertificateExport_sm2cert
=== PAUSE TestAccPrivateCertificateExport_sm2cert
=== CONT  TestAccPrivateCertificateExport_basic
=== CONT  TestAccPrivateCertificateExport_sm2cert
--- PASS: TestAccPrivateCertificateExport_sm2cert (31.69s)
--- PASS: TestAccPrivateCertificateExport_basic (49.48s)
PASS
coverage: 25.6% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       49.543s coverage: 25.6% of statements in ./huaweicloud/services/ccm
```

![image](https://github.com/user-attachments/assets/f851ccdc-24c7-4cc5-ba69-c0bfa093d2d0)


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
