### PR TITLE
feat(GaussDBforMySQL): add gaussdb mysql instance restart resource

### DIFF
--- a/docs/resources/gaussdb_mysql_instance_restart.md
+++ b/docs/resources/gaussdb_mysql_instance_restart.md
@@ -1,0 +1,69 @@
+---
+subcategory: "GaussDB(for MySQL)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_mysql_instance_restart"
+description: |-
+  Manages a GaussDB MySQL instance restart resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_mysql_instance_restart
+
+Manages a GaussDB MySQL instance restart resource within HuaweiCloud.
+
+## Example Usage
+
+### Restart GaussDB MySQL instance
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_gaussdb_mysql_instance_restart" "test" {
+  instance_id = var.instance_id
+}
+```
+
+### Restart GaussDB MySQL instance node
+
+```hcl
+variable "instance_id" {}
+variable "node_id" {}
+
+resource "huaweicloud_gaussdb_mysql_instance_restart" "test" {
+  instance_id = var.instance_id
+  node_id     = var.node_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the GaussDB MySQL instance. Changing this parameter
+  will create a new resource.
+
+* `node_id` - (Optional, String, ForceNew) Specifies the node ID of the GaussDB MySQL instance. Changing this parameter
+  will create a new resource.
+
+  -> **NOTE:** If `node_id` is not specified, then the GaussDB MySQL instance will be rebooted.
+    <br/> If `node_id` is specified, then the node of the GaussDB MySQL instance will be rebooted.
+
+* `delay` - (Optional, Bool, ForceNew) Specifies whether the instance/node will be rebooted with a delay. Value options:
+  + **true**: The instance/node will be rebooted during the specified maintenance window.
+  + **false(default)**: The instance/node will be rebooted immediately.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. If an instance is rebooted, the value is `instance_id`. If a node is rebooted, the value is `node_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1458,6 +1458,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_cassandra_instance": gaussdb.ResourceGeminiDBInstanceV3(),
 
 			"huaweicloud_gaussdb_mysql_instance":           gaussdb.ResourceGaussDBInstance(),
+			"huaweicloud_gaussdb_mysql_instance_restart":   gaussdb.ResourceGaussDBMysqlRestart(),
 			"huaweicloud_gaussdb_mysql_proxy":              gaussdb.ResourceGaussDBProxy(),
 			"huaweicloud_gaussdb_mysql_proxy_restart":      gaussdb.ResourceGaussDBProxyRestart(),
 			"huaweicloud_gaussdb_mysql_database":           gaussdb.ResourceGaussDBDatabase(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_restart_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_restart_test.go
@@ -1,0 +1,141 @@
+package gaussdb
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getResourceInstance(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}"
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", state.Primary.Attributes["instance_id"])
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(getResp)
+}
+
+func TestAccGaussDBMysqlInstanceRestart_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_gaussdb_mysql_instance_restart.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getResourceInstance,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBMysqlInstanceRestart_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBMysqlInstanceRestart_node(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_gaussdb_mysql_instance_restart.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getResourceInstance,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBMysqlInstanceRestart_node(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccGaussDBMysqlInstanceRestart_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_mysql_flavors" "test" {
+  engine                 = "gaussdb-mysql"
+  version                = "8.0"
+  availability_zone_mode = "multi"
+}
+
+resource "huaweicloud_gaussdb_mysql_instance" "test" {
+  name                     = "%[2]s"
+  password                 = "Test@12345678"
+  flavor                   = data.huaweicloud_gaussdb_mysql_flavors.test.flavors[0].name
+  vpc_id                   = huaweicloud_vpc.test.id
+  subnet_id                = huaweicloud_vpc_subnet.test.id
+  security_group_id        = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id    = "0"
+  master_availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  availability_zone_mode   = "multi"
+  read_replicas            = 2
+}
+`, common.TestBaseNetwork(rName), rName)
+}
+
+func testAccGaussDBMysqlInstanceRestart_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_gaussdb_mysql_instance_restart" "test" {
+  instance_id = huaweicloud_gaussdb_mysql_instance.test.id
+}`, testAccGaussDBMysqlInstanceRestart_base(rName))
+}
+
+func testAccGaussDBMysqlInstanceRestart_node(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_gaussdb_mysql_instance_restart" "test" {
+  instance_id = huaweicloud_gaussdb_mysql_instance.test.id
+  node_id     = huaweicloud_gaussdb_mysql_instance.test.nodes[0].id
+}`, testAccGaussDBMysqlInstanceRestart_base(rName))
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_restart.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_restart.go
@@ -1,0 +1,214 @@
+package gaussdb
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforMySQL POST /v3/{project_id}/instances/{instance_id}/restart
+// @API GaussDBforMySQL POST /v3/{project_id}/instances/{instance_id}/nodes/{node_id}/restart
+// @API GaussDBforMySQL GET /v3/{project_id}/jobs
+func ResourceGaussDBMysqlRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGaussDBMysqlRestartCreate,
+		ReadContext:   resourceGaussDBMysqlRestartRead,
+		DeleteContext: resourceGaussDBMysqlRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"node_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"delay": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGaussDBMysqlRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	nodeId := d.Get("node_id").(string)
+	if len(nodeId) > 0 {
+		err = restartNode(ctx, d, client)
+	} else {
+		err = restartInstance(ctx, d, client)
+	}
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func restartInstance(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/restart"
+	)
+
+	instanceId := d.Get("instance_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateGaussDBMySQLRestartBodyParams(d))
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("POST", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     GaussDBInstanceStateRefreshFunc(client, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("error restarting GaussDB MySQL instance(%s): %s", instanceId, err)
+	}
+	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return err
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, nil)
+	if jobId == nil {
+		return fmt.Errorf("error restarting GaussDB MySQL instance(%s), job_id is not found in the response", instanceId)
+	}
+
+	d.SetId(instanceId)
+
+	err = checkGaussDBMySQLJobFinish(ctx, client, jobId.(string), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return fmt.Errorf("error waiting for restarting instance(%s) job to complete: %s", instanceId, err)
+	}
+
+	return nil
+}
+
+func restartNode(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/nodes/{node_id}/restart"
+	)
+
+	instanceId := d.Get("instance_id").(string)
+	nodeId := d.Get("node_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+	createPath = strings.ReplaceAll(createPath, "{node_id}", nodeId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateGaussDBMySQLRestartBodyParams(d))
+
+	retryFunc := func() (interface{}, bool, error) {
+		res, err := client.Request("POST", createPath, &createOpt)
+		retry, err := handleMultiOperationsError(err)
+		return res, retry, err
+	}
+	r, err := common.RetryContextWithWaitForState(&common.RetryContextWithWaitForStateParam{
+		Ctx:          ctx,
+		RetryFunc:    retryFunc,
+		WaitFunc:     GaussDBInstanceStateRefreshFunc(client, instanceId),
+		WaitTarget:   []string{"ACTIVE"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		DelayTimeout: 10 * time.Second,
+		PollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("error restarting GaussDB MySQL instance(%s) node(%s): %s", instanceId, nodeId, err)
+	}
+	createRespBody, err := utils.FlattenResponse(r.(*http.Response))
+	if err != nil {
+		return err
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, nil)
+	if jobId == nil {
+		return fmt.Errorf("error restarting GaussDB MySQL instance(%s) node(%s), job_id is not found in the "+
+			"response", instanceId, nodeId)
+	}
+
+	d.SetId(nodeId)
+
+	err = checkGaussDBMySQLJobFinish(ctx, client, jobId.(string), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return fmt.Errorf("error waiting for restarting instance(%s) node(%s) job to complete: %s", instanceId,
+			nodeId, err)
+	}
+
+	return nil
+}
+
+func buildCreateGaussDBMySQLRestartBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"delay": d.Get("delay"),
+	}
+	return bodyParams
+}
+
+func resourceGaussDBMysqlRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGaussDBMysqlRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting restart resource is not supported. The restart resource is only removed from the state," +
+		" the GaussDB MySQL instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb mysql instance restart resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb mysql instance restart resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBMysqlInstanceRestart_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBMysqlInstanceRestart_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBMysqlInstanceRestart_basic
=== PAUSE TestAccGaussDBMysqlInstanceRestart_basic
=== RUN   TestAccGaussDBMysqlInstanceRestart_node
=== PAUSE TestAccGaussDBMysqlInstanceRestart_node
=== CONT  TestAccGaussDBMysqlInstanceRestart_basic
=== CONT  TestAccGaussDBMysqlInstanceRestart_node
--- PASS: TestAccGaussDBMysqlInstanceRestart_node (1449.91s)
--- PASS: TestAccGaussDBMysqlInstanceRestart_basic (1524.52s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1524.570s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
