### PR TITLE
chore(dws/queue): replacing the list api with the query detail api and adjust acceptance test

### DIFF
--- a/docs/resources/dws_workload_queue.md
+++ b/docs/resources/dws_workload_queue.md
@@ -112,8 +112,8 @@ and **cpu_share** are exclusive, one of them must be set, and the **cpu_limit** 
     no restriction, unit: MB.
   + When the `resource name` is **activestatements**, the value range is from `-1` to `2,147,483,647`, where `-1` and
     `0` indicates no control.
-  + When the `resource name` is **cpu_limit**, the value range is from `0` to `99`, unit: %.
-  + When the `resource name` is **cpu_share**, the value range is from `0` to `99`, unit: %.
+  + When the `resource name` is **cpu_limit**, the value range is from `0` to `99`, `0` means unlimited, unit: %.
+  + When the `resource name` is **cpu_share**, the value range is from `1` to `99`, the default value is `20`, unit: %.
 
 ## Attribute Reference
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -387,8 +387,11 @@ var (
 	HW_IOTDA_ACCESS_ADDRESS      = os.Getenv("HW_IOTDA_ACCESS_ADDRESS")
 	HW_IOTDA_BATCHTASK_FILE_PATH = os.Getenv("HW_IOTDA_BATCHTASK_FILE_PATH")
 
-	HW_DWS_MUTIL_AZS            = os.Getenv("HW_DWS_MUTIL_AZS")
-	HW_DWS_CLUSTER_ID           = os.Getenv("HW_DWS_CLUSTER_ID")
+	HW_DWS_MUTIL_AZS               = os.Getenv("HW_DWS_MUTIL_AZS")
+	HW_DWS_CLUSTER_ID              = os.Getenv("HW_DWS_CLUSTER_ID")
+	HW_DWS_LOGICAL_MODE_CLUSTER_ID = os.Getenv("HW_DWS_LOGICAL_MODE_CLUSTER_ID")
+	HW_DWS_LOGICAL_CLUSTER_NAME    = os.Getenv("HW_DWS_LOGICAL_CLUSTER_NAME")
+
 	HW_DWS_SNAPSHOT_POLICY_NAME = os.Getenv("HW_DWS_SNAPSHOT_POLICY_NAME")
 
 	HW_DCS_ACCOUNT_WHITELIST = os.Getenv("HW_DCS_ACCOUNT_WHITELIST")
@@ -2018,6 +2021,20 @@ func TestAccPreCheckMutilAZ(t *testing.T) {
 func TestAccPreCheckDwsClusterId(t *testing.T) {
 	if HW_DWS_CLUSTER_ID == "" {
 		t.Skip("HW_DWS_CLUSTER_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDwsLogicalModeClusterId(t *testing.T) {
+	if HW_DWS_LOGICAL_MODE_CLUSTER_ID == "" {
+		t.Skip("HW_DWS_LOGICAL_MODE_CLUSTER_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDwsLogicalClusterName(t *testing.T) {
+	if HW_DWS_LOGICAL_CLUSTER_NAME == "" {
+		t.Skip("HW_DWS_LOGICAL_CLUSTER_NAME must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_workload_queues_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_workload_queues_test.go
@@ -9,18 +9,19 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
-func TestAccWorkloadQueuesDataSource_basic(t *testing.T) {
+func TestAccDataSourceWorkloadQueues_basic(t *testing.T) {
 	resourceName := "data.huaweicloud_dws_workload_queues.test"
 	dc := acceptance.InitDataSourceCheck(resourceName)
 	name := acceptance.RandomAccResourceName()
-	// The cluster password requires a minimum length of 12 characters, and the string 'gap' is used to fill in the gap.
-	password := acceptance.RandomPassword() + "gap"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkloadQueuesDataSourceBasic(name, password),
+				Config: testAccDataSourceWorkloadQueues_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(resourceName, "queues.#"),
@@ -33,23 +34,23 @@ func TestAccWorkloadQueuesDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccWorkloadQueuesDataSourceBasic(name, password string) string {
+func testAccDataSourceWorkloadQueues_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_dws_workload_queues" "test" {
-  cluster_id = huaweicloud_dws_cluster.test.id
+  cluster_id = "%[2]s"
 
   depends_on = [huaweicloud_dws_workload_queue.test]
 }
 
 data "huaweicloud_dws_workload_queues" "name_filter" {
-  cluster_id = huaweicloud_dws_cluster.test.id
+  cluster_id = "%[2]s"
   name       = huaweicloud_dws_workload_queue.test.name
 }
 
 data "huaweicloud_dws_workload_queues" "name_not_exist_filter" {
-  cluster_id = huaweicloud_dws_cluster.test.id
+  cluster_id = "%[2]s"
   name       = "name_not_exist"
 
   depends_on = [huaweicloud_dws_workload_queue.test]
@@ -75,5 +76,51 @@ output "name_filter_is_useful" {
 output "name_not_exist_filter_is_useful" {
   value = length(local.name_not_exist_filter) == 0
 }
-`, testAccWorkloadQueue_basic(name, password))
+`, testAccWorkloadQueue_basic(name), acceptance.HW_DWS_CLUSTER_ID)
+}
+
+func TestAccDataSourceWorkloadQueues_logicalCluster(t *testing.T) {
+	resourceName := "data.huaweicloud_dws_workload_queues.filter_by_logical_cluster_name"
+	dc := acceptance.InitDataSourceCheck(resourceName)
+	name := acceptance.RandomAccResourceName()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsLogicalModeClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceWorkloadQueues_logicalCluster(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "queues.#"),
+					resource.TestCheckOutput("is_userful_logical_cluster_name", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceWorkloadQueues_logicalCluster(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_dws_workload_queues" "filter_by_logical_cluster_name" {
+  depends_on = [huaweicloud_dws_workload_queue.test]
+
+  cluster_id           = "%[2]s"
+  logical_cluster_name = "%[3]s"
+}
+
+locals {
+  fliter_result = [for v in data.huaweicloud_dws_workload_queues.filter_by_logical_cluster_name.queues[*].logical_cluster_name : v == "%[3]s"]
+}
+
+output "is_userful_logical_cluster_name" {
+  value = alltrue(local.fliter_result) && length(local.fliter_result) > 0
+}
+`, testAccResourceWorkloadQueue_basic_logicalClusterName(name),
+		acceptance.HW_DWS_LOGICAL_MODE_CLUSTER_ID,
+		acceptance.HW_DWS_LOGICAL_CLUSTER_NAME)
 }

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_workload_queues_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_workload_queues_test.go
@@ -120,7 +120,7 @@ locals {
 output "is_userful_logical_cluster_name" {
   value = alltrue(local.fliter_result) && length(local.fliter_result) > 0
 }
-`, testAccResourceWorkloadQueue_basic_logicalClusterName(name),
+`, testAccResourceWorkloadQueue_logicalClusterName(name),
 		acceptance.HW_DWS_LOGICAL_MODE_CLUSTER_ID,
 		acceptance.HW_DWS_LOGICAL_CLUSTER_NAME)
 }

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_queue_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_queue_test.go
@@ -2,24 +2,19 @@ package dws
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
 )
 
 func getWorkloadQueueResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	var (
 		region  = acceptance.HW_REGION_NAME
-		httpUrl = "v2/{project_id}/clusters/{cluster_id}/workload/queues"
 		product = "dws"
 	)
 
@@ -28,31 +23,9 @@ func getWorkloadQueueResourceFunc(cfg *config.Config, state *terraform.ResourceS
 		return nil, fmt.Errorf("error creating DWS client: %s", err)
 	}
 
-	getPath := client.Endpoint + httpUrl
-	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
-	getPath = strings.ReplaceAll(getPath, "{cluster_id}", state.Primary.Attributes["cluster_id"])
-	getOpt := golangsdk.RequestOpts{
-		MoreHeaders:      map[string]string{"Content-Type": "application/json;charset=UTF-8"},
-		KeepResponseBody: true,
-	}
-
-	getResp, err := client.Request("GET", getPath, &getOpt)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving DWS workload queue: %s", err)
-	}
-
-	getRespBody, err := utils.FlattenResponse(getResp)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving DWS workload queue: %s", err)
-	}
-
-	expression := fmt.Sprintf("workload_queue_name_list[?@=='%s']|[0]", state.Primary.ID)
-	resp := utils.PathSearch(expression, getRespBody, nil)
-	if resp == nil {
-		return nil, golangsdk.ErrDefault404{}
-	}
-
-	return resp, nil
+	clusterId := state.Primary.Attributes["cluster_id"]
+	logicalClusterName := state.Primary.Attributes["logical_cluster_name"]
+	return dws.GetWorkloadQueueByName(client, clusterId, state.Primary.ID, logicalClusterName)
 }
 
 func TestAccResourceWorkloadQueue_basic(t *testing.T) {
@@ -69,17 +42,20 @@ func TestAccResourceWorkloadQueue_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWorkloadQueue_basic(name, "Admin_user@123"),
+				Config: testAccWorkloadQueue_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "4"),
-					resource.TestCheckResourceAttrPair(resourceName, "cluster_id", "huaweicloud_dws_cluster.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
 				),
 			},
 			{
@@ -88,39 +64,17 @@ func TestAccResourceWorkloadQueue_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateIdFunc: testWorkloadQueueImportState(resourceName),
 				ImportStateVerifyIgnore: []string{
-					"configuration", "logical_cluster_name",
+					"configuration",
 				},
 			},
 		},
 	})
 }
 
-func testAccWorkloadQueue_base(name, password string) string {
+func testAccWorkloadQueue_basic(name string) string {
 	return fmt.Sprintf(`
-%[1]s
-
-data "huaweicloud_availability_zones" "test" {}
-
-resource "huaweicloud_dws_cluster" "test" {
-  name              = "%[2]s"
-  node_type         = "dwsk2.xlarge"
-  number_of_node    = 3
-  vpc_id            = huaweicloud_vpc.test.id
-  network_id        = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  user_name         = "admin_user"
-  user_pwd          = "%[3]s"
-}
-`, common.TestBaseNetwork(name), name, password)
-}
-
-func testAccWorkloadQueue_basic(name, password string) string {
-	return fmt.Sprintf(`
-%[1]s
-
 resource "huaweicloud_dws_workload_queue" "test" {
-  cluster_id = huaweicloud_dws_cluster.test.id
+  cluster_id = "%[1]s"
   name       = "%[2]s"
 
   configuration {
@@ -140,7 +94,78 @@ resource "huaweicloud_dws_workload_queue" "test" {
     resource_value = -1
   }
 }
-`, testAccWorkloadQueue_base(name, password), name)
+`, acceptance.HW_DWS_CLUSTER_ID, name)
+}
+
+func TestAccResourceWorkloadQueue_logicalClusterName(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_dws_workload_queue.test"
+		name         = acceptance.RandomAccResourceName()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getWorkloadQueueResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsLogicalModeClusterId(t)
+			acceptance.TestAccPreCheckDwsLogicalClusterName(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceWorkloadQueue_logicalClusterName(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "cluster_id", acceptance.HW_DWS_LOGICAL_MODE_CLUSTER_ID),
+					resource.TestCheckResourceAttr(resourceName, "logical_cluster_name", acceptance.HW_DWS_LOGICAL_CLUSTER_NAME),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testWorkloadQueueImportState(resourceName),
+				ImportStateVerifyIgnore: []string{
+					"configuration",
+				},
+			},
+		},
+	})
+}
+
+func testAccResourceWorkloadQueue_logicalClusterName(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_workload_queue" "test" {
+  cluster_id           = "%[1]s"
+  name                 = "%[2]s"
+  logical_cluster_name = "%[3]s"
+
+  configuration {
+    resource_name  = "cpu_limit"
+    resource_value = 10
+  }
+  configuration {
+    resource_name  = "memory"
+    resource_value = 10
+  }
+  configuration {
+    resource_name  = "tablespace"
+    resource_value = -1
+  }
+  configuration {
+    resource_name  = "activestatements"
+    resource_value = -1
+  }
+}
+`, acceptance.HW_DWS_LOGICAL_MODE_CLUSTER_ID, name, acceptance.HW_DWS_LOGICAL_CLUSTER_NAME)
 }
 
 func testWorkloadQueueImportState(name string) resource.ImportStateIdFunc {
@@ -155,6 +180,10 @@ func testWorkloadQueueImportState(name string) resource.ImportStateIdFunc {
 			return "", fmt.Errorf("the workload queue is not exist or related cluster ID is missing")
 		}
 
+		logicalClusterName := rs.Primary.Attributes["logical_cluster_name"]
+		if logicalClusterName != "" {
+			return fmt.Sprintf("%s/%s/%s", clusterId, id, logicalClusterName), nil
+		}
 		return fmt.Sprintf("%s/%s", clusterId, id), nil
 	}
 }

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_workload_queue.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_workload_queue.go
@@ -18,12 +18,14 @@ import (
 )
 
 // @API DWS PUT /v2/{project_id}/clusters/{cluster_id}/workload/queues
-// @API DWS GET /v2/{project_id}/clusters/{cluster_id}/workload/queues
+// @API DWS GET /v2/{project_id}/clusters/{cluster_id}/workload/queues{queue_name}
 // @API DWS DELETE /v2/{project_id}/clusters/{cluster_id}/workload/queues
 func ResourceWorkLoadQueue() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceWorkLoadQueueCreate,
 		ReadContext:   resourceWorkLoadQueueRead,
+		// The API only supports updating "configuration" parameter, but the update cannot be implemented due to
+		// inconsistencies between the parameters on the API and the resource.
 		DeleteContext: resourceWorkLoadQueueDelete,
 
 		Importer: &schema.ResourceImporter{
@@ -137,47 +139,59 @@ func buildCreateConfigurationBodyParams(d *schema.ResourceData) []map[string]int
 	return params
 }
 
-func resourceWorkLoadQueueRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	var (
-		cfg     = meta.(*config.Config)
-		region  = cfg.GetRegion(d)
-		httpUrl = "v2/{project_id}/clusters/{cluster_id}/workload/queues"
-		product = "dws"
-	)
+// GetWorkloadQueueByName is a method used to obtain resource pool information by resource pool name.
+func GetWorkloadQueueByName(client *golangsdk.ServiceClient, clusterId, queueName, logicalClusterName string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/workload/queues/{queue_name}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+	getPath = strings.ReplaceAll(getPath, "{queue_name}", queueName)
 
-	getClient, err := cfg.NewServiceClient(product, region)
-	if err != nil {
-		return diag.Errorf("error creating DWS client: %s", err)
+	if logicalClusterName != "" {
+		getPath = fmt.Sprintf("%s?logical_cluster_name=%s", getPath, logicalClusterName)
 	}
 
-	getPath := getClient.Endpoint + httpUrl
-	getPath = strings.ReplaceAll(getPath, "{project_id}", getClient.ProjectID)
-	getPath = strings.ReplaceAll(getPath, "{cluster_id}", d.Get("cluster_id").(string))
 	getOpt := golangsdk.RequestOpts{
 		MoreHeaders:      requestOpts.MoreHeaders,
 		KeepResponseBody: true,
 	}
 
-	getResp, err := getClient.Request("GET", getPath, &getOpt)
+	resp, err := client.Request("GET", getPath, &getOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "DWS workload queue")
+		// 1. "DWS.0047": The cluster ID is a standard UUID, the status code is 404.
+		// 2. The API response includes these cases about resource not found:
+		//   a. The queue name does not exist, e.g. { "workload_res_code": 1, "workload_res_str": "", "workload_queue": null }.
+		//   b. Logical cluster name does not exist in logical cluster mode, e.g.
+		//   { "workload_res_code": -1,"workload_res_str": "xxx", "workload_queue": null }.
+		//   c. Unspecifies logical cluster name in logical cluster mode, e.g.
+		//   { "workload_res_code": 1, "workload_res_str": "xxx", "workload_queue": null }.
+		return nil, common.ConvertExpected500ErrInto404Err(err, "workload_res_code")
 	}
+	return utils.FlattenResponse(resp)
+}
 
-	getRespBody, err := utils.FlattenResponse(getResp)
+func resourceWorkLoadQueueRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "dws"
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.FromErr(err)
+		return diag.Errorf("error creating DWS client: %s", err)
 	}
 
-	expression := fmt.Sprintf("workload_queue_name_list[?@=='%s']|[0]", d.Id())
-	resp := utils.PathSearch(expression, getRespBody, nil)
-	if resp == nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "DWS workload queue")
+	getRespBody, err := GetWorkloadQueueByName(client, d.Get("cluster_id").(string), d.Id(), d.Get("logical_cluster_name").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving DWS workload queue")
 	}
 
-	// Due to API restrictions, only the queue name can be found in the API response.
 	mErr := multierror.Append(
 		d.Set("region", region),
-		d.Set("name", d.Id()),
+		d.Set("name", utils.PathSearch("workload_queue.queue_name", getRespBody, nil)),
+		d.Set("logical_cluster_name", utils.PathSearch("workload_queue.logical_cluster_name", getRespBody, nil)),
+		// Since the API return value is inconsistent with the resource, the "configuration" parameter is ignored.
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -220,13 +234,21 @@ func resourceWorkLoadQueueDelete(_ context.Context, d *schema.ResourceData, meta
 }
 
 func resourceWorkloadQueueImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
-	parts := strings.SplitN(d.Id(), "/", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid format specified for import id, must be <cluster_id>/<name>")
+	importedId := d.Id()
+	parts := strings.Split(d.Id(), "/")
+
+	// In logical cluster mode, the "logical_cluster_name" parameter must not be set, otherwise the query interface will report an error.
+	if len(parts) != 2 && len(parts) != 3 {
+		return nil, fmt.Errorf("invalid format specified for import id, must be '<cluster_id>/<name>' or "+
+			"'<cluster_id>/<name>/<logical_cluster_name>', but got '%s'", importedId)
 	}
 
-	d.Set("cluster_id", parts[0])
+	mErr := multierror.Append(nil, d.Set("cluster_id", parts[0]))
 	d.SetId(parts[1])
 
-	return []*schema.ResourceData{d}, nil
+	if len(parts) == 3 {
+		mErr = multierror.Append(mErr, d.Set("logical_cluster_name", parts[2]))
+	}
+
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1.  Replacing the list API with the query detail API.
2. Adjust acceptance test corresponding to workload queue.
3. Modify workload queue resource document.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run WorkloadQueue'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run WorkloadQueue -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWorkloadQueues_basic
=== PAUSE TestAccDataSourceWorkloadQueues_basic
=== RUN   TestAccDataSourceWorkloadQueues_logicalCluster
=== PAUSE TestAccDataSourceWorkloadQueues_logicalCluster
=== RUN   TestAccResourceWorkloadQueue_basic
=== PAUSE TestAccResourceWorkloadQueue_basic
=== RUN   TestAccResourceWorkloadQueue_basic_logicalClusterName
=== PAUSE TestAccResourceWorkloadQueue_basic_logicalClusterName
=== CONT  TestAccDataSourceWorkloadQueues_basic
=== CONT  TestAccResourceWorkloadQueue_basic
=== CONT  TestAccDataSourceWorkloadQueues_logicalCluster
=== CONT  TestAccResourceWorkloadQueue_basic_logicalClusterName
--- PASS: TestAccResourceWorkloadQueue_basic_logicalClusterName (53.39s)
--- PASS: TestAccResourceWorkloadQueue_basic (55.06s)
--- PASS: TestAccDataSourceWorkloadQueues_logicalCluster (98.84s)
--- PASS: TestAccDataSourceWorkloadQueues_basic (123.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       123.754s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   ![image](https://github.com/user-attachments/assets/ca5525be-00f4-4087-b02f-5a71d3dbecb6)

    ab. Related resources (parent resources) not found
     The DWS cluster ID does not exist (standard UUID).
      ![image](https://github.com/user-attachments/assets/c0a8e814-6ad2-4eea-9a1d-eac94f05bf8d)

     Unspecifies logical cluster name in logical cluster mode.
      ![image](https://github.com/user-attachments/assets/aa5f430c-75db-4ca3-9044-e99f6083a790)

     Logical cluster name does not exist in logical cluster mode.  
      ![image](https://github.com/user-attachments/assets/1129c8be-62ad-4c48-bcc0-803d86334849)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
