### PR TITLE
feat(ims): support `cbr_whole_image` resource

### DIFF
--- a/docs/resources/ims_cbr_whole_image.md
+++ b/docs/resources/ims_cbr_whole_image.md
@@ -1,0 +1,113 @@
+---
+subcategory: "Image Management Service (IMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ims_cbr_whole_image"
+description: |-
+  Manages an IMS whole image resource created from CBR backup within HuaweiCloud.
+---
+
+# huaweicloud_ims_cbr_whole_image
+
+Manages an IMS whole image resource created from CBR backup within HuaweiCloud.
+
+-> After deleting the image, the CBR backup that has not been deleted will be retained and continue to be charged.
+   If you need to delete it later, you can delete the corresponding CBR backup in the CBR backup console.
+
+## Example Usage
+
+### Creating an IMS whole image from CBR backup
+
+```hcl
+variable "name" {}
+variable "backup_id" {}
+
+resource "huaweicloud_ims_cbr_whole_image" "test" {
+  name      = var.name
+  backup_id = var.backup_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the image.
+  The valid length is limited from `1` to `128` characters.
+  The first and last letters of the name cannot be spaces.
+  The name can contain uppercase letters, lowercase letters, numbers, spaces, chinese, and special characters (-._).
+
+* `backup_id` - (Required, String, ForceNew) Specifies the CBR instance backup ID used to create the image.
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of the image.
+
+* `max_ram` - (Optional, Int) Specifies the maximum memory of the image, in MB unit.
+
+* `min_ram` - (Optional, Int) Specifies the minimum memory of the image, in MB unit.
+  The default value is `0`, indicating that the memory is not restricted.
+
+* `is_delete_backup` - (Optional, Bool) Specifies whether to delete the associated CBR backup when deleting image.
+  The value can be **true** or **false**.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the image.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the IMS image belongs.
+  For enterprise users, if omitted, default enterprise project will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the image.
+
+* `status` - The status of the image. The value can be **active**, **queued**, **saving**, **deleted**, or **killed*,
+  only image with a status of **active** can be used.
+
+* `visibility` - Whether the image is visible to other tenants.
+
+* `os_version` - The operating system version of the image.
+
+* `disk_format` - The image format. The value can be **zvhd2**, **vhd**, **zvhd**, **raw**, or **qcow2**.
+
+* `data_origin` - The image source. The format is **server_backup,backup_id**.
+
+* `active_at` - The time when the image status changes to active, in RFC3339 format.
+
+* `created_at` - The creation time of the image, in RFC3339 format.
+
+* `updated_at` - The last update time of the image, in RFC3339 format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The IMS CBR whole image resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_ims_cbr_whole_image.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `is_delete_backup`.
+It is generally recommended running `terraform plan` after importing the resource. You can then decide if changes should
+be applied to the resource, or the resource definition should be updated to align with the image. Also, you can ignore
+changes as below.
+
+```
+resource "huaweicloud_ims_cbr_whole_image" "test" {
+    ...
+  lifecycle {
+    ignore_changes = [
+      is_delete_backup,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1531,6 +1531,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_ims_ecs_system_image":        ims.ResourceEcsSystemImage(),
 			"huaweicloud_ims_ecs_whole_image":         ims.ResourceEcsWholeImage(),
+			"huaweicloud_ims_cbr_whole_image":         ims.ResourceCbrWholeImage(),
 			"huaweicloud_images_image":                ims.ResourceImsImage(),
 			"huaweicloud_images_image_copy":           ims.ResourceImsImageCopy(),
 			"huaweicloud_images_image_share":          ims.ResourceImsImageShare(),

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_cbr_whole_image_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_cbr_whole_image_test.go
@@ -1,0 +1,193 @@
+package ims
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCbrWholeImage_basic(t *testing.T) {
+	var (
+		image        cloudimages.Image
+		rName        = acceptance.RandomAccResourceName()
+		rNameUpdate  = rName + "-update"
+		resourceName = "huaweicloud_ims_cbr_whole_image.test"
+		defaultEpsId = "0"
+		migrateEpsId = acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&image,
+		getImsImageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case need setting a non default enterprise project ID.
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCbrWholeImage_basic(rName, 2048, 4096),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform description test"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", defaultEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(resourceName, "visibility"),
+					resource.TestCheckResourceAttrSet(resourceName, "os_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "disk_format"),
+					resource.TestCheckResourceAttrSet(resourceName, "data_origin"),
+					resource.TestMatchResourceAttr(resourceName, "active_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "backup_id", "huaweicloud_cbr_checkpoint.test", "backups.0.id"),
+				),
+			},
+			{
+				Config: testAccCbrWholeImage_update1(rName, rNameUpdate, migrateEpsId, 1024, 2048),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", migrateEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+				),
+			},
+			{
+				Config: testAccCbrWholeImage_update2(rName, rNameUpdate, defaultEpsId, 0, 0),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", defaultEpsId),
+					resource.TestCheckResourceAttr(resourceName, "is_delete_backup", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"is_delete_backup",
+				},
+			},
+		},
+	})
+}
+
+func testAccCbrWholeImage_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cbr_vault" "test" {
+  name             = "%[2]s"
+  type             = "server"
+  consistent_level = "app_consistent"
+  protection_type  = "backup"
+  size             = 200
+
+  resources {
+    server_id = huaweicloud_compute_instance.test.id
+  }
+}
+
+resource "huaweicloud_cbr_checkpoint" "test" {
+  vault_id = huaweicloud_cbr_vault.test.id
+  name     = "%[2]s"
+
+  backups {
+    type        = "OS::Nova::Server"
+    resource_id = huaweicloud_compute_instance.test.id
+  }
+}
+`, testAccEcsSystemImage_base(rName), rName)
+}
+
+func testAccCbrWholeImage_basic(rName string, minRAM, maxRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_cbr_whole_image" "test" {
+  name        = "%[2]s"
+  backup_id   = try(tolist(huaweicloud_cbr_checkpoint.test.backups)[0].id, "")
+  description = "terraform description test"
+  min_ram     = %[3]d
+  max_ram     = %[4]d
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccCbrWholeImage_base(rName), rName, minRAM, maxRAM)
+}
+
+func testAccCbrWholeImage_update1(rName, rNameUpdate, migrateEpsId string, minRAM, maxRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_cbr_whole_image" "test" {
+  name                  = "%[2]s"
+  backup_id             = try(tolist(huaweicloud_cbr_checkpoint.test.backups)[0].id, "")
+  enterprise_project_id = "%[3]s"
+  min_ram               = %[4]d
+  max_ram               = %[5]d
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testAccCbrWholeImage_base(rName), rNameUpdate, migrateEpsId, minRAM, maxRAM)
+}
+
+func testAccCbrWholeImage_update2(rName, rNameUpdate, defaultEpsId string, minRAM, maxRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_cbr_whole_image" "test" {
+  name                  = "%[2]s"
+  backup_id             = try(tolist(huaweicloud_cbr_checkpoint.test.backups)[0].id, "")
+  enterprise_project_id = "%[3]s"
+  min_ram               = %[4]d
+  max_ram               = %[5]d
+  is_delete_backup      = true
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testAccCbrWholeImage_base(rName), rNameUpdate, defaultEpsId, minRAM, maxRAM)
+}

--- a/huaweicloud/services/ims/resource_huaweicloud_ims_cbr_whole_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_cbr_whole_image.go
@@ -1,0 +1,221 @@
+package ims
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API IMS POST /v1/cloudimages/wholeimages/action
+// @API IMS GET /v1/{project_id}/jobs/{job_id}
+// @API IMS GET /v2/cloudimages
+// @API IMS GET /v2/{project_id}/images/{image_id}/tags
+// @API IMS PATCH /v2/cloudimages/{image_id}
+// @API IMS POST /v2/{project_id}/images/{image_id}/tags/action
+// @API IMS DELETE /v2/images/{image_id}
+func ResourceCbrWholeImage() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceCbrWholeImageCreate,
+		ReadContext:   resourceCbrWholeImageRead,
+		UpdateContext: resourceCbrWholeImageUpdate,
+		DeleteContext: resourceWholeImageDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"backup_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			// The `description` field can be left blank, so the `Computed` attribute is not used.
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"max_ram": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"min_ram": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"is_delete_backup": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"tags": common.TagsSchema(),
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// Attributes
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"visibility": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"os_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_format": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"active_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCbrWholeImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.ImageV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v1 client: %s", err)
+	}
+
+	imageTags := buildCreateImageTagsParam(d)
+	createOpts := &cloudimages.CreateWholeImageOpts{
+		Name:                d.Get("name").(string),
+		BackupId:            d.Get("backup_id").(string),
+		Description:         d.Get("description").(string),
+		MaxRam:              d.Get("max_ram").(int),
+		MinRam:              d.Get("min_ram").(int),
+		ImageTags:           imageTags,
+		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
+		WholeImageType:      "CBR",
+	}
+
+	createResp, err := cloudimages.CreateWholeImageByServer(client, createOpts).ExtractJobResponse()
+	if err != nil {
+		return diag.Errorf("error creating IMS CBR whole image: %s", err)
+	}
+
+	imageId, err := waitForCreateImageCompleted(client, d, createResp.JobID)
+	if err != nil {
+		return diag.Errorf("error waiting for IMS CBR whole image to complete: %s", err)
+	}
+
+	d.SetId(imageId)
+
+	return resourceCbrWholeImageRead(ctx, d, meta)
+}
+
+func resourceCbrWholeImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		mErr   *multierror.Error
+	)
+
+	client, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v2 client: %s", err)
+	}
+
+	imageList, err := GetImageList(client, d.Id())
+	if err != nil {
+		return diag.Errorf("error retrieving IMS CBR whole images: %s", err)
+	}
+
+	// If the list API return empty, then process `CheckDeleted` logic.
+	if len(imageList) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS CBR whole image")
+	}
+
+	image := imageList[0]
+	imageTags := getImageTags(d, client)
+
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("name", image.Name),
+		d.Set("backup_id", image.BackupID),
+		d.Set("description", image.Description),
+		d.Set("max_ram", getMaxRAM(image.MaxRam)),
+		d.Set("min_ram", image.MinRam),
+		d.Set("tags", imageTags),
+		d.Set("enterprise_project_id", image.EnterpriseProjectID),
+		d.Set("status", image.Status),
+		d.Set("visibility", image.Visibility),
+		d.Set("os_version", image.OsVersion),
+		d.Set("disk_format", image.DiskFormat),
+		d.Set("data_origin", image.DataOrigin),
+		d.Set("active_at", image.ActiveAt),
+		d.Set("created_at", image.CreatedAt.Format(time.RFC3339)),
+		d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceCbrWholeImageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v2 client: %s", err)
+	}
+
+	err = updateImage(ctx, cfg, client, d)
+	if err != nil {
+		return diag.Errorf("error updating IMS CBR whole image: %s", err)
+	}
+
+	return resourceCbrWholeImageRead(ctx, d, meta)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support `cbr_whole_image` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support `cbr_whole_image` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccCbrWholeImage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccCbrWholeImage_basic -timeout 360m -parallel 4
=== RUN   TestAccCbrWholeImage_basic
=== PAUSE TestAccCbrWholeImage_basic
=== CONT  TestAccCbrWholeImage_basic
--- PASS: TestAccCbrWholeImage_basic (776.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       776.722s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/9a8a2893-3adc-434b-b631-8d75d56da610)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/3e04ab30-d5a5-45e9-a3ef-de24cedcc063)


