### PR TITLE
feat(dws): supports updating eip_id for the cluster

### DIFF
--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_ext_data_source_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_ext_data_source_test.go
@@ -123,7 +123,7 @@ resource "huaweicloud_dws_ext_data_source" "test" {
   user_pwd       = "%s"
   description    = "This is a demo"
 }
-`, testAccDwsCluster_basic(name, 3, cluster.PublicBindTypeNotUse, pwd, "bar"),
+`, testAccDwsCluster_basic_step1(name, 3, cluster.PublicBindTypeNotUse, pwd),
 		testDwsExtDataSourceMrs(name, pwd), name, pwd)
 }
 

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_logical_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_logical_cluster_test.go
@@ -121,7 +121,7 @@ func TestAccLogicalCluster_basic(t *testing.T) {
 }
 
 func testLogicalCluster_base(name string) string {
-	clusterBasic := testAccDwsCluster_basic(name, 10, dws.PublicBindTypeAuto, "cluster123@!", "bar")
+	clusterBasic := testAccDwsCluster_basic_step1(name, 10, dws.PublicBindTypeAuto, "cluster123@!")
 	return fmt.Sprintf(`
 %s
 

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_snapshot_policy_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_snapshot_policy_test.go
@@ -108,7 +108,7 @@ resource "huaweicloud_dws_snapshot_policy" "test" {
   type       = "full"
   strategy   = "0 8 6 4 * ?"
 }
-`, testAccDwsCluster_basic(name, 3, cluster.PublicBindTypeNotUse, "cluster123@!", "bar"), name)
+`, testAccDwsCluster_basic_step1(name, 3, cluster.PublicBindTypeNotUse, "cluster123@!"), name)
 }
 
 func testDwsSnapshotPolicyImportState(name string) resource.ImportStateIdFunc {

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_snapshot_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_snapshot_test.go
@@ -95,5 +95,5 @@ resource "huaweicloud_dws_snapshot" "test" {
   name       = "%s"
   cluster_id = huaweicloud_dws_cluster.test.id
 }
-`, testAccDwsCluster_basic(name, 3, cluster.PublicBindTypeNotUse, "cluster123@!", "bar"), name)
+`, testAccDwsCluster_basic_step1(name, 3, cluster.PublicBindTypeNotUse, "cluster123@!"), name)
 }

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
@@ -188,7 +188,6 @@ func ResourceDwsCluster() *schema.Resource {
 				Type:        schema.TypeMap,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
-				Computed:    true,
 				Description: `The key/value pairs to associate with the cluster.`,
 			},
 			"keep_last_manual_snapshot": {

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster.go
@@ -53,6 +53,8 @@ const ClusterIdIllegalErrCode = "DWS.0001"
 // @API DWS DELETE /v2/{project_id}/clusters/{cluster_id}/elbs/{elb_id}
 // @API DWS POST /v1/{project_id}/clusters/{cluster_id}/lts-logs/enable
 // @API DWS POST /v1/{project_id}/clusters/{cluster_id}/lts-logs/disable
+// @API DWS POST /v2/{project_id}/clusters/{cluster_id}/eips/{eip_id}
+// @API DWS DELETE /v2/{project_id}/clusters/{cluster_id}/eips/{eip_id}
 func ResourceDwsCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceDwsClusterCreate,
@@ -174,7 +176,6 @@ func ResourceDwsCluster() *schema.Resource {
 				Elem:     clusterPublicIpSchema(),
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"volume": {
 				Type:     schema.TypeList,
@@ -285,8 +286,14 @@ func clusterPublicIpSchema() *schema.Resource {
 			"eip_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
 				Description: `The EIP ID.`,
+				DiffSuppressFunc: func(_, _, newVal string, d *schema.ResourceData) bool {
+					// If "public_bind_type" is set to "auto_assign", the EIP will be automatically bound, the EIP Will be triggered to change.
+					if v, ok := d.GetOk("public_ip.0.public_bind_type"); ok {
+						return v.(string) == PublicBindTypeAuto && newVal == ""
+					}
+					return false
+				},
 			},
 		},
 	}
@@ -1048,6 +1055,12 @@ func resourceDwsClusterUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
+	if d.HasChange("public_ip.0.eip_id") {
+		if err := updateEip(clusterClient, d); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return resourceDwsClusterRead(ctx, d, meta)
 }
 
@@ -1361,6 +1374,42 @@ func unbindElb(ctx context.Context, d *schema.ResourceData, client *golangsdk.Se
 		return fmt.Errorf("error waiting for unbinding ELB from DWS cluster: %s", err)
 	}
 
+	return nil
+}
+
+func updateEip(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		oldEipRaw, newEipRaw = d.GetChange("public_ip.0.eip_id")
+		oldEipId             = oldEipRaw.(string)
+		newEipId             = newEipRaw.(string)
+		clusterId            = d.Id()
+	)
+
+	path := client.Endpoint + "v2/{project_id}/clusters/{cluster_id}/eips/{eip_id}"
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{cluster_id}", clusterId)
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	if oldEipId != "" {
+		unBindEipPath := strings.ReplaceAll(path, "{eip_id}", oldEipId)
+		_, err := client.Request("DELETE", unBindEipPath, &opt)
+		if err != nil {
+			return fmt.Errorf("error unbinding EIP (%s) from DWS instance (%s): %s", oldEipId, clusterId, err)
+		}
+	}
+
+	if newEipId != "" {
+		bindEipPath := strings.ReplaceAll(path, "{eip_id}", newEipId)
+		_, err := client.Request("POST", bindEipPath, &opt)
+		if err != nil {
+			return fmt.Errorf("error binding EIP (%s) to DWS instance (%s): %s", newEipId, clusterId, err)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. The cluster resource supports updating the EIP ID.
2. Adjust the corresponding acceptance tests.
3. Remove the `Computed` of the tags parameter.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/acc-test.sh
>>> Start to test
=== RUN   TestAccResourceCluster_basicV1
=== PAUSE TestAccResourceCluster_basicV1
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== RUN   TestAccResourceCluster_basicV2_mutilAZs
=== PAUSE TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV1
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV2
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
    acceptance.go:1928: HW_DWS_MUTIL_AZS must be set for the acceptance test
--- SKIP: TestAccResourceCluster_basicV2_mutilAZs (0.00s)
--- PASS: TestAccResourceCluster_basicV1 (2577.02s)
--- PASS: TestAccResourceCluster_basicV2 (3195.93s)
PASS
coverage: 18.9% of statements in ../../dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       3196.003s

```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
