### PR TITLE
chore(CCM): refactor CCM certificate push resource

### DIFF
--- a/docs/resources/ccm_certificate_push.md
+++ b/docs/resources/ccm_certificate_push.md
@@ -2,14 +2,17 @@
 subcategory: "Cloud Certificate Manager (CCM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ccm_certificate_push"
-description: ""
+description: |
+  Manages a CCM resource to push SSL certificate to ELB or WAF service within HuaweiCloud.
 ---
 
 # huaweicloud_ccm_certificate_push
 
-Push a **SSL** ceritificate to **ELB** or **WAF** within HuaweiCloud.
+Manages a CCM resource to push SSL certificate to ELB or WAF service within HuaweiCloud.
 
 ## Example Usage
+
+### Pushing a certificate to ELB service
 
 ```hcl
 variable "certificate_id" {}
@@ -17,14 +20,31 @@ variable "project_name1" {}
 variable "project_name2" {}
 
 resource "huaweicloud_ccm_certificate_push" "test"{
-  region         = "cn-north-4"
   certificate_id = var.certificate_id
   service        = "ELB"
+  
   targets {
     project_name = var.project_name1
   }
+  
   targets {
     project_name = var.project_name2
+  }
+}
+```
+
+### Pushing a certificate to WAF service
+
+```hcl
+variable "certificate_id" {}
+variable "project_name" {}
+
+resource "huaweicloud_ccm_certificate_push" "test"{
+  certificate_id = var.certificate_id
+  service        = "WAF"
+  
+  targets {
+    project_name = var.project_name
   }
 }
 ```
@@ -36,11 +56,13 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the certificate region. Changing this creates a new
   private certificate resource. Now only support cn-north-4 (china) and ap-southeast-1 (international).
 
-* `certificate_id` - (Required, String, ForceNew) Specifies the certificate which will be push.
+* `certificate_id` - (Required, String, ForceNew) Specifies the ID of the SSL certificate to be pushed.
   Changing this parameter will create a new resource.
 
-* `service` - (Required, String, ForceNew) Specifies the service which certificate will be push to.
+* `service` - (Required, String, ForceNew) Specifies the target service for certificate push.
   Changing this creates a new resource. Valid values are **ELB** and **WAF**.
+
+  -> Before pushing the certificate to the WAF service, please confirm that the target region has an available WAF instance.
 
 * `targets` - (Required, List) Specifies the projects which certificate will be push to.
   The [targets](#block-targets) structure is documented below.
@@ -48,8 +70,7 @@ The following arguments are supported:
 <a name="block-targets"></a>
 The `targets` block supports:
 
-* `project_name` - (Required, String) Specifies the project which certificate will be push to.
-  Only the **default** projects with the same region name are supported.
+* `project_name` - (Required, String) Specifies the region where the target service for certificate push is located.
 
 ## Attribute Reference
 
@@ -63,6 +84,6 @@ In addition to all arguments above, the following attributes are exported:
 <a name="block-targets-attr"></a>
 The `targets` block supports:
 
-* `cert_id` - Indicates the pushed certificate new ID.
+* `cert_id` - Indicates the target certificate ID.
 
-* `cert_name` - Indicates the pushed certificate name.
+* `cert_name` - Indicates the target certificate name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1218,7 +1218,7 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_ccm_certificate":                ccm.ResourceCCMCertificate(),
 			"huaweicloud_ccm_certificate_apply":          ccm.ResourceCertificateApply(),
-			"huaweicloud_ccm_certificate_push":           ccm.ResourceCcmCertificatePush(),
+			"huaweicloud_ccm_certificate_push":           ccm.ResourceCertificatePush(),
 			"huaweicloud_ccm_private_ca":                 ccm.ResourcePrivateCertificateAuthority(),
 			"huaweicloud_ccm_private_ca_revoke":          ccm.ResourcePrivateCaRevoke(),
 			"huaweicloud_ccm_private_certificate":        ccm.ResourceCcmPrivateCertificate(),

--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certifiacte_push_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_certifiacte_push_test.go
@@ -2,52 +2,55 @@ package ccm
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/elb/v3/certificates"
-	wafcertificates "github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
+	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-)
-
-const (
-	targetServiceWaf = "WAF"
-	targetServiceElb = "ELB"
+	ccmcertificatepush "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ccm"
 )
 
 func getCertificatePushResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	projectName := state.Primary.Attributes["targets.1.project_name"]
-	certId := state.Primary.Attributes["targets.1.cert_id"]
-	targetService := state.Primary.Attributes["service"]
-	if targetService == targetServiceElb {
-		elbClient, err := conf.ElbV3Client(projectName)
-		if err != nil {
-			return nil, fmt.Errorf("error creating ELB client: %s", err)
-		}
-
-		return certificates.Get(elbClient, certId).Extract()
-	}
-	if targetService == targetServiceWaf {
-		wafClient, err := conf.WafV1Client(projectName)
-		if err != nil {
-			return nil, fmt.Errorf("error creating WAF client: %s", err)
-		}
-
-		return wafcertificates.Get(wafClient, certId).Extract()
+	targetsLength, err := strconv.Atoi(state.Primary.Attributes["targets.#"])
+	if err != nil {
+		return nil, fmt.Errorf("[ERROR] convert the string %q to int failed", state.Primary.Attributes["targets.#"])
 	}
 
-	return nil, fmt.Errorf("find certificate is failed")
+	rst := make([]interface{}, 0, len(state.Primary.Attributes["targets.#"]))
+	for index := 0; index < targetsLength; index++ {
+		project := state.Primary.Attributes[fmt.Sprintf("targets.%d.project_name", index)]
+		certId := state.Primary.Attributes[fmt.Sprintf("targets.%d.cert_id", index)]
+
+		switch state.Primary.Attributes["service"] {
+		case "ELB":
+			if elbRstMap := ccmcertificatepush.FlattenElbCertificateDetail(conf, project, certId); elbRstMap != nil {
+				rst = append(rst, elbRstMap)
+			}
+		case "WAF":
+			if wafRstMap := ccmcertificatepush.FlattenWafCertificateDetail(conf, project, certId); wafRstMap != nil {
+				rst = append(rst, wafRstMap)
+			}
+		}
+	}
+
+	if len(rst) == 0 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return rst, nil
 }
-func TestAccCcmCertificatePush_basic(t *testing.T) {
-	var obj interface{}
-	resourceName := "huaweicloud_ccm_certificate_push.test"
-	project := "cn-north-4"
-	project2 := "cn-east-3"
-	changeProject := "cn-south-1"
+
+func TestAccCcmCertificatePush_elb(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_ccm_certificate_push.test"
+	)
+
 	rc := acceptance.InitResourceCheck(
 		resourceName,
 		&obj,
@@ -63,81 +66,244 @@ func TestAccCcmCertificatePush_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: tesCcmCertificatePush_basic(targetServiceElb, project, project2),
+				Config:      tesCcmCertificatePush_basic_step1(),
+				ExpectError: regexp.MustCompile("all attempts to push the certificate to the services failed in creation"),
+			},
+			{
+				Config:             tesCcmCertificatePush_basic_step2(),
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.project_name", project2),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.project_name", "cn-north-4"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_name"),
+				),
+			},
+			{
+				Config:             tesCcmCertificatePush_basic_step3(),
+				ExpectNonEmptyPlan: true,
+				ExpectError:        regexp.MustCompile("all attempts to push the certificate to the services failed in update operation"),
+			},
+			{
+				Config: tesCcmCertificatePush_basic_step4(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.project_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.project_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_name"),
 				),
 			},
 			{
-				Config: tesCcmCertificatePush_basic(targetServiceElb, project, changeProject),
+				Config:             tesCcmCertificatePush_basic_step5(),
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.project_name", changeProject),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.project_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.1.project_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_name"),
+				),
+			},
+			{
+				Config: tesCcmCertificatePush_basic_step6(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.project_name", "cn-north-4"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_name"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccCcmCertificatePush_waf(t *testing.T) {
-	var obj interface{}
-	resourceName := "huaweicloud_ccm_certificate_push.test"
-	project := "cn-north-4"
-	project2 := "cn-east-3"
-	changeProject := "cn-south-1"
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&obj,
-		getCertificatePushResourceFunc,
-	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCCMPushCertificateID(t)
-			acceptance.TestAccPreCheckCCMPushWAFInstance(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: tesCcmCertificatePush_basic(targetServiceWaf, project, project2),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.project_name", project2),
-					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_name"),
-				),
-			},
-			{
-				Config: tesCcmCertificatePush_basic(targetServiceWaf, project, changeProject),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "targets.1.project_name", changeProject),
-					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_id"),
-					resource.TestCheckResourceAttrSet(resourceName, "targets.1.cert_name"),
-				),
-			},
-		},
-	})
-}
-
-func tesCcmCertificatePush_basic(service string, project string, project2 string) string {
+// tesCcmCertificatePush_basic_step1 using to test the scenario of all certificate push failures in creation operation.
+func tesCcmCertificatePush_basic_step1() string {
 	return fmt.Sprintf(`
 resource "huaweicloud_ccm_certificate_push" "test"{
-  region         = "cn-north-4"
   certificate_id = "%s"
-  service        = "%s"
+  service        = "ELB"
+
+  targets {
+    project_name = "unexpected-error-4"
+  }
+
+  targets {
+    project_name = "unexpected-error-5"
+  }
+}`, acceptance.HW_CERT_BATCH_PUSH_ID)
+}
+
+// tesCcmCertificatePush_basic_step2 using to test the scenario of partial push success.
+// This test step needs to ignore changes to `targets`.
+func tesCcmCertificatePush_basic_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_certificate_push" "test"{
+  certificate_id = "%s"
+  service        = "ELB"
+
+  targets {
+    project_name = "cn-north-4"
+  }
+
+  targets {
+    project_name = "unexpected-error-5"
+  }
+}`, acceptance.HW_CERT_BATCH_PUSH_ID)
+}
+
+// tesCcmCertificatePush_basic_step3 using to test the scenario of all certificate push failures in update operation.
+func tesCcmCertificatePush_basic_step3() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_certificate_push" "test"{
+  certificate_id = "%s"
+  service        = "ELB"
+
+  targets {
+    project_name = "unexpected-error-4"
+  }
+
+  targets {
+    project_name = "unexpected-error-5"
+  }
+}`, acceptance.HW_CERT_BATCH_PUSH_ID)
+}
+
+// tesCcmCertificatePush_basic_step4 using to test that all pushes are successful.
+func tesCcmCertificatePush_basic_step4() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_certificate_push" "test"{
+  certificate_id = "%s"
+  service        = "ELB"
+
+  targets {
+    project_name = "cn-north-4"
+  }
+
+  targets {
+    project_name = "ap-southeast-3"
+  }
+}`, acceptance.HW_CERT_BATCH_PUSH_ID)
+}
+
+// tesCcmCertificatePush_basic_step5 using to test editing part push succeeds and the other fails.
+func tesCcmCertificatePush_basic_step5() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_certificate_push" "test"{
+  certificate_id = "%s"
+  service        = "ELB"
+
+  targets {
+    project_name = "cn-north-4"
+  }
+
+  targets {
+    project_name = "cn-east-3"
+  }
+
+  targets {
+    project_name = "unexpected-error-5"
+  }
+}`, acceptance.HW_CERT_BATCH_PUSH_ID)
+}
+
+// tesCcmCertificatePush_basic_step6 using to test the successful push of a certificate.
+func tesCcmCertificatePush_basic_step6() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_certificate_push" "test"{
+  certificate_id = "%s"
+  service        = "ELB"
+
+  targets {
+    project_name = "cn-north-4"
+  }
+}`, acceptance.HW_CERT_BATCH_PUSH_ID)
+}
+
+// Before executing this test case, please confirm that the WAF instances has been purchased in the target project.
+// Otherwise, the test case may fail to execute.
+func TestAccCcmCertificatePush_waf(t *testing.T) {
+	var (
+		obj          interface{}
+		resourceName = "huaweicloud_ccm_certificate_push.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getCertificatePushResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCCMPushCertificateID(t)
+			// Please ensure that there is an available WAF instance in the custom region.
+			acceptance.TestAccPrecheckCustomRegion(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:             tesCcmCertificatePush_waf_step1(),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.project_name", acceptance.HW_CUSTOM_REGION_NAME),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_name"),
+				),
+			},
+			{
+				Config: tesCcmCertificatePush_waf_step2(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "targets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "targets.0.project_name", acceptance.HW_CUSTOM_REGION_NAME),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "targets.0.cert_name"),
+				),
+			},
+		},
+	})
+}
+
+// tesCcmCertificatePush_waf_step1 using to test the scenario where one push succeeds and the other fails.
+func tesCcmCertificatePush_waf_step1() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_certificate_push" "test"{
+  certificate_id = "%s"
+  service        = "WAF"
+
   targets {
     project_name = "%s"
- }
- targets {
+  }
+
+  targets {
+    project_name = "unexpected-error-4"
+  }
+}`, acceptance.HW_CERT_BATCH_PUSH_ID, acceptance.HW_CUSTOM_REGION_NAME)
+}
+
+// tesCcmCertificatePush_waf_step2 using to test the scenario where one push succeeds.
+func tesCcmCertificatePush_waf_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_ccm_certificate_push" "test"{
+  certificate_id = "%s"
+  service        = "WAF"
+
+  targets {
     project_name = "%s"
- }
-}`, acceptance.HW_CERT_BATCH_PUSH_ID, service, project, project2)
+  }
+}`, acceptance.HW_CERT_BATCH_PUSH_ID, acceptance.HW_CUSTOM_REGION_NAME)
 }

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate_push.go
@@ -19,22 +19,17 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
-const (
-	targetServiceWaf = "WAF"
-	targetServiceElb = "ELB"
-)
-
 // @API CCM POST /v3/scm/certificates/{certificate_id}/batch-push
 // @API WAF GET /v1/{project_id}/waf/certificate/{certificate_id}
 // @API WAF DELETE /v1/{project_id}/waf/certificate/{certificate_id}
 // @API ELB GET /v3/{project_id}/elb/certificates/{certificate_id}
 // @API ELB DELETE /v3/{project_id}/elb/certificates/{certificate_id}
-func ResourceCcmCertificatePush() *schema.Resource {
+func ResourceCertificatePush() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceCcmCertificatePushCreate,
-		ReadContext:   resourceCcmCertificatePushRead,
-		UpdateContext: resourceCcmCertificatePushUpdate,
-		DeleteContext: resourceCcmCertificatePushDelete,
+		CreateContext: resourceCertificatePushCreate,
+		ReadContext:   resourceCertificatePushRead,
+		UpdateContext: resourceCertificatePushUpdate,
+		DeleteContext: resourceCertificatePushDelete,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -77,273 +72,334 @@ func ResourceCcmCertificatePush() *schema.Resource {
 	}
 }
 
-func resourceCcmCertificatePushCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	scmClient, err := conf.ScmV3Client(conf.GetRegion(d))
+func buildTargetProject(projectList []interface{}) []string {
+	projects := make([]string, 0, len(projectList))
+	for _, v := range projectList {
+		projectName := utils.PathSearch("project_name", v, "").(string)
+		if projectName == "" {
+			continue
+		}
 
-	if err != nil {
-		return diag.Errorf("error creating CCM client: %s", err)
+		projects = append(projects, projectName)
 	}
-	certId := d.Get("certificate_id").(string)
-	pushCertificateHttpUrl := "v3/scm/certificates/{certificate_id}/batch-push"
+	return projects
+}
+
+func buildPushCertificateBodyParams(service string, projectList []interface{}) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"target_service":  service,
+		"target_projects": buildTargetProject(projectList),
+	}
+	return bodyParams
+}
+
+func pushCertificateToService(scmClient *golangsdk.ServiceClient, d *schema.ResourceData, projects []interface{}) (interface{}, error) {
+	var (
+		pushCertificateHttpUrl = "v3/scm/certificates/{certificate_id}/batch-push"
+		certId                 = d.Get("certificate_id").(string)
+		service                = d.Get("service").(string)
+	)
+
 	pushCertificatePath := scmClient.Endpoint + pushCertificateHttpUrl
 	pushCertificatePath = strings.ReplaceAll(pushCertificatePath, "{certificate_id}", certId)
-
 	pushCertificateOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         utils.RemoveNil(buildPushCertificateBodyParams(service, projects)),
 	}
-	service := d.Get("service").(string)
-	projects := d.Get("targets").(*schema.Set).List()
-	pushCertificateOpt.JSONBody = utils.RemoveNil(buildPushCertificateBodyParams(service, projects))
+
 	pushCertificateResp, err := scmClient.Request("POST", pushCertificatePath, &pushCertificateOpt)
 	if err != nil {
-		return diag.Errorf("error pushing certificate: %s", err)
+		return nil, fmt.Errorf("error pushing certificate: %s", err)
 	}
-	pushCertificateRespBody, err := utils.FlattenResponse(pushCertificateResp)
+	return utils.FlattenResponse(pushCertificateResp)
+}
+
+// flattenCreateResult using to obtain the target certificate ID from the response of the creation API and record it.
+// The response body example is as follows: `{"results":[{"project_name":"cn-north-4","cert_id":"XXX","message":"success"},
+// {"project_name":"cn-error-4","cert_id":"","message":"Invalid region id."}]}`
+// If `cert_id` is empty, it means that the certificate push failed.
+func flattenCreateResult(resp interface{}, d *schema.ResourceData) ([]interface{}, error) {
+	curJson := utils.PathSearch("results", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	rst := make([]interface{}, 0, len(curArray))
+	var mErr *multierror.Error
+	for _, v := range curArray {
+		projectName := utils.PathSearch("project_name", v, "").(string)
+		certId := utils.PathSearch("cert_id", v, "").(string)
+		if certId == "" {
+			message := utils.PathSearch("message", v, "").(string)
+			mErr = multierror.Append(
+				mErr,
+				fmt.Errorf("error pushing certificate (%s) to project (%s): %s", d.Id(), projectName, message),
+			)
+			continue
+		}
+
+		rst = append(rst, map[string]interface{}{
+			"project_name": projectName,
+			"cert_id":      certId,
+		})
+	}
+
+	return rst, mErr.ErrorOrNil()
+}
+
+func resourceCertificatePushCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		certId = d.Get("certificate_id").(string)
+	)
+
+	scmClient, err := cfg.ScmV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating CCM client: %s", err)
+	}
+
+	pushCertificateRespBody, err := pushCertificateToService(scmClient, d, d.Get("targets").(*schema.Set).List())
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	d.SetId(certId)
-	d.Set("targets", flattenResult(pushCertificateRespBody))
 
-	return resourceCcmCertificatePushRead(ctx, d, meta)
-}
-
-func buildPushCertificateBodyParams(service string, projectlist []interface{}) map[string]interface{} {
-	bodyParams := map[string]interface{}{
-		"target_service":  service,
-		"target_projects": buildTargetProject(projectlist),
+	rstTargets, err := flattenCreateResult(pushCertificateRespBody, d)
+	if len(rstTargets) == 0 {
+		return diag.Errorf("all attempts to push the certificate to the services failed in creation: %s.\n "+
+			"Please check whether the push service and projects are accurate.", err)
 	}
-	return bodyParams
-}
 
-func buildTargetProject(projectlist []interface{}) []string {
-	var projects []string
-	for _, v := range projectlist {
-		projects = append(projects, utils.PathSearch("project_name", v, "").(string))
+	if err != nil {
+		log.Printf("[WARM] some error occurred when pushing certificate to services in creation: %s", err)
 	}
-	return projects
-}
 
-func flattenResult(resp interface{}) []interface{} {
-	curJson := utils.PathSearch("results", resp, make([]interface{}, 0))
-	curArray := curJson.([]interface{})
-	rst := make([]interface{}, 0, len(curArray))
-	for _, v := range curArray {
-		rst = append(rst, map[string]interface{}{
-			"project_name": utils.PathSearch("project_name", v, ""),
-			"cert_id":      utils.PathSearch("cert_id", v, ""),
-		})
+	if err := d.Set("targets", rstTargets); err != nil {
+		return diag.Errorf("error setting `targets` attributes in creation operation: %s", err)
 	}
-	return rst
+
+	return resourceCertificatePushRead(ctx, d, meta)
 }
 
-func flattenUpdateResult(d *schema.ResourceData, resp interface{}) []interface{} {
-	targets := d.Get("targets").(*schema.Set).List()
-	rst := make([]interface{}, 0, len(targets))
-	for _, v := range targets {
-		certId := utils.PathSearch("cert_id", v, "").(string)
-		projectName := utils.PathSearch("project_name", v, "").(string)
+func FlattenElbCertificateDetail(cfg *config.Config, projectName string, certId string) map[string]interface{} {
+	elbClient, err := cfg.ElbV3Client(projectName)
+	if err != nil {
+		log.Printf("[WARN] error creating ELB client: %s", err)
+		return nil
+	}
+
+	cert, err := certificates.Get(elbClient, certId).Extract()
+	if err != nil {
+		log.Printf("[WARN] error retrieving ELB certificate (%s): %s", certId, err)
+		return nil
+	}
+
+	if cert == nil {
+		log.Printf("[WARN] error retrieving ELB certificate (%s): The certificate in API response is empty", certId)
+		return nil
+	}
+	return map[string]interface{}{
+		"project_name": projectName,
+		"cert_id":      certId,
+		"cert_name":    cert.Name,
+	}
+}
+
+func FlattenWafCertificateDetail(cfg *config.Config, projectName string, certId string) map[string]interface{} {
+	wafClient, err := cfg.WafV1Client(projectName)
+	if err != nil {
+		log.Printf("[WARN] error creating WAF client: %s", err)
+		return nil
+	}
+
+	cert, err := wafcertificates.Get(wafClient, certId).Extract()
+	if err != nil {
+		log.Printf("[WARN] error retrieving WAF certificate (%s): %s", certId, err)
+		return nil
+	}
+
+	if cert == nil {
+		log.Printf("[WARN] error retrieving WAF certificate (%s): The certificate in API response is empty", certId)
+		return nil
+	}
+	return map[string]interface{}{
+		"project_name": projectName,
+		"cert_id":      certId,
+		"cert_name":    cert.Name,
+	}
+}
+
+func resourceCertificatePushRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		projectList   = d.Get("targets").(*schema.Set).List()
+		targetService = d.Get("service").(string)
+		rst           = make([]interface{}, 0, len(projectList))
+		cfg           = meta.(*config.Config)
+	)
+
+	for _, val := range projectList {
+		projectName := utils.PathSearch("project_name", val, "").(string)
+		certId := utils.PathSearch("cert_id", val, "").(string)
 		if certId == "" {
-			certId = getCertIdFromResult(projectName, resp)
+			continue
 		}
-		rst = append(rst, map[string]interface{}{
-			"project_name": projectName,
-			"cert_id":      certId,
-			"cert_name":    utils.PathSearch("cert_name", v, ""),
-		})
-	}
 
-	return rst
-}
-
-func getCertIdFromResult(projectName string, resp interface{}) string {
-	certId := ""
-	curJson := utils.PathSearch("results", resp, make([]interface{}, 0))
-	curArray := curJson.([]interface{})
-	for _, v := range curArray {
-		resName := utils.PathSearch("project_name", v, "").(string)
-		if projectName == resName {
-			certId = utils.PathSearch("cert_id", v, "").(string)
-			break
-		}
-	}
-	return certId
-}
-func resourceCcmCertificatePushRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	projectList := d.Get("targets").(*schema.Set).List()
-	targetService := d.Get("service").(string)
-	rst := make([]interface{}, 0, len(projectList))
-	cfg := meta.(*config.Config)
-	// search elb certificate detail and set to targets
-	if targetService == targetServiceElb {
-		for _, val := range projectList {
-			projectName := utils.PathSearch("project_name", val, "").(string)
-			certId := utils.PathSearch("cert_id", val, "").(string)
-			elbClient, err := cfg.ElbV3Client(projectName)
-			if err != nil {
-				return diag.Errorf("error creating ELB client: %s", err)
+		switch targetService {
+		case "ELB":
+			if elbRstMap := FlattenElbCertificateDetail(cfg, projectName, certId); elbRstMap != nil {
+				rst = append(rst, elbRstMap)
 			}
-
-			cert, err := certificates.Get(elbClient, certId).Extract()
-			if err != nil {
-				log.Printf("[WARN] error retrieving ELB certificate: %s", certId)
-			}
-			if cert != nil {
-				rst = append(rst, map[string]interface{}{
-					"project_name": projectName,
-					"cert_id":      certId,
-					"cert_name":    cert.Name,
-				})
+		case "WAF":
+			if wafRstMap := FlattenWafCertificateDetail(cfg, projectName, certId); wafRstMap != nil {
+				rst = append(rst, wafRstMap)
 			}
 		}
 	}
 
-	// search waf certificate detail and set to targets
-	if targetService == targetServiceWaf {
-		for _, val := range projectList {
-			projectName := utils.PathSearch("project_name", val, "").(string)
-			certId := utils.PathSearch("cert_id", val, "").(string)
-			wafClient, err := cfg.WafV1Client(projectName)
-			if err != nil {
-				return diag.Errorf("error creating WAF client: %s", err)
-			}
-
-			cert, err := wafcertificates.Get(wafClient, certId).Extract()
-			if err != nil {
-				log.Printf("[DEBUG] error retrieving WAF certificate: %s", certId)
-			}
-			if cert != nil && cert.Id != "" {
-				rst = append(rst, map[string]interface{}{
-					"project_name": projectName,
-					"cert_id":      certId,
-					"cert_name":    cert.Name,
-				})
-			}
-		}
-	}
 	if len(rst) == 0 {
 		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving certificate")
 	}
 	mErr := multierror.Append(nil,
 		d.Set("targets", rst),
 	)
-	if err := mErr.ErrorOrNil(); err != nil {
-		return diag.Errorf("error setting targets fields: %s", err)
-	}
-	return nil
+	return diag.FromErr(mErr.ErrorOrNil())
 }
-func resourceCcmCertificatePushUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+func removePushedCertificate(cfg *config.Config, oRaws []interface{}, d *schema.ResourceData) error {
+	var mErr *multierror.Error
+	for _, val := range oRaws {
+		projectName := utils.PathSearch("project_name", val, "").(string)
+		certId := utils.PathSearch("cert_id", val, "").(string)
+		if certId == "" {
+			continue
+		}
+
+		switch d.Get("service").(string) {
+		case "ELB":
+			elbClient, err := cfg.ElbV3Client(projectName)
+			if err != nil {
+				log.Printf("[WARN] error creating ELB client: %s", err)
+				continue
+			}
+
+			err = certificates.Delete(elbClient, certId).ExtractErr()
+			if err != nil && !utils.IsResourceNotFound(err) {
+				mErr = multierror.Append(mErr, fmt.Errorf("error deleting ELB certificate (%s): %s", certId, err))
+			}
+		case "WAF":
+			client, err := cfg.WafV1Client(projectName)
+			if err != nil {
+				log.Printf("[WARN] error creating WAF client: %s", err)
+				continue
+			}
+			epsID := cfg.GetEnterpriseProjectID(d)
+			err = wafcertificates.DeleteWithEpsID(client, certId, epsID).ExtractErr()
+			if err != nil && !utils.IsResourceNotFound(err) {
+				mErr = multierror.Append(mErr, fmt.Errorf("error deleting WAF certificate (%s): %s", certId, err))
+			}
+		}
+	}
+
+	return mErr.ErrorOrNil()
+}
+
+// flattenUpdateResult using to handle response values in the update API.
+// The response body example is as follows: `{"results":[{"project_name":"cn-north-4","cert_id":"XXX","message":"success"},
+// {"project_name":"cn-error-4","cert_id":"","message":"Invalid region id."}]}`
+// 1. Try to get the object from the API response through `project_name`.
+// 2. If it cannot be obtained, directly set the value in `local state`.
+// 3. If the object can be obtained from the API response, try to obtain whether the `cert_id` has a value.
+// 4. If the `cert_id` in the API response has a value, get and set values from response.
+// 5. Otherwise, it will be considered that the push failed, the failed push operation is saved in the error message.
+func flattenUpdateResult(d *schema.ResourceData, resp interface{}) ([]interface{}, error) {
+	targets := d.Get("targets").(*schema.Set).List()
+	rst := make([]interface{}, 0, len(targets))
+	var mErr *multierror.Error
+	for _, v := range targets {
+		projectName := utils.PathSearch("project_name", v, "").(string)
+		if projectName == "" {
+			continue
+		}
+
+		publishResult := utils.PathSearch(fmt.Sprintf("results[?project_name=='%s']|[0]", projectName), resp, nil)
+		if publishResult == nil {
+			rst = append(rst, v)
+			continue
+		}
+
+		certId := utils.PathSearch("cert_id", publishResult, "").(string)
+		if certId != "" {
+			rst = append(rst, map[string]interface{}{
+				"project_name": projectName,
+				"cert_id":      certId,
+			})
+			continue
+		}
+
+		message := utils.PathSearch("message", publishResult, "").(string)
+		mErr = multierror.Append(
+			mErr,
+			fmt.Errorf("error pushing certificate (%s) to project (%s): %s", d.Id(), projectName, message),
+		)
+	}
+
+	return rst, mErr.ErrorOrNil()
+}
+
+func resourceCertificatePushUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
 	if d.HasChange("targets") {
-		err := rePushOrDelete(d, meta)
-		if err != nil {
-			return diag.FromErr(err)
+		oRaw, nRaw := d.GetChange("targets")
+		addSet := nRaw.(*schema.Set).Difference(oRaw.(*schema.Set))
+		rmSet := oRaw.(*schema.Set).Difference(nRaw.(*schema.Set))
+		if rmSet.Len() > 0 {
+			err := removePushedCertificate(cfg, rmSet.List(), d)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		if addSet.Len() > 0 {
+			scmClient, err := cfg.ScmV3Client(region)
+			if err != nil {
+				return diag.Errorf("error creating CCM client: %s", err)
+			}
+			pushCertificateRespBody, err := pushCertificateToService(scmClient, d, addSet.List())
+			if err != nil {
+				return diag.FromErr(err)
+			}
+
+			rstTargets, err := flattenUpdateResult(d, pushCertificateRespBody)
+			if len(rstTargets) == 0 {
+				return diag.Errorf("all attempts to push the certificate to the services failed in update"+
+					" operation: %s.\n Please check whether the push service and projects are accurate.", err)
+			}
+
+			if err != nil {
+				log.Printf("[WARM] some error occurred when pushing certificate to services in update operation: %s", err)
+			}
+
+			if err := d.Set("targets", rstTargets); err != nil {
+				return diag.Errorf("error setting `targets` attributes in update operation: %s", err)
+			}
 		}
 	}
 
-	return resourceCcmCertificatePushRead(ctx, d, meta)
+	return resourceCertificatePushRead(ctx, d, meta)
 }
 
-func rePushOrDelete(d *schema.ResourceData, meta interface{}) error {
-	oRaw, nRaw := d.GetChange("targets")
-	addSet := nRaw.(*schema.Set).Difference(oRaw.(*schema.Set))
-	rmSet := oRaw.(*schema.Set).Difference(nRaw.(*schema.Set))
-	if rmSet.Len() > 0 {
-		// remve the pushed certificate
-		targetService := d.Get("service").(string)
-		_, err := rmPushedCert(targetService, rmSet.List(), meta, d)
-		if err != nil {
-			return err
-		}
-	}
-	if addSet.Len() > 0 {
-		// push to new project
-		conf := meta.(*config.Config)
-		scmClient, err := conf.ScmV3Client(conf.GetRegion(d))
+func resourceCertificatePushDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg   = meta.(*config.Config)
+		oRaws = d.Get("targets").(*schema.Set).List()
+	)
 
-		if err != nil {
-			return err
-		}
-
-		pushCertificateHttpUrl := "v3/scm/certificates/{certificate_id}/batch-push"
-		pushCertificatePath := scmClient.Endpoint + pushCertificateHttpUrl
-		pushCertificatePath = strings.ReplaceAll(pushCertificatePath, "{certificate_id}", d.Get("certificate_id").(string))
-
-		pushCertificateOpt := golangsdk.RequestOpts{
-			KeepResponseBody: true,
-			MoreHeaders:      map[string]string{"Content-Type": "application/json"},
-		}
-		pushCertificateOpt.JSONBody = utils.RemoveNil(buildPushCertificateBodyParams(d.Get("service").(string), addSet.List()))
-		pushCertificateResp, err := scmClient.Request("POST", pushCertificatePath, &pushCertificateOpt)
-		if err != nil {
-			return fmt.Errorf("error pushing certificate: %s", err)
-		}
-		pushCertificateRespBody, err := utils.FlattenResponse(pushCertificateResp)
-		if err != nil {
-			return err
-		}
-		// save push result
-		d.Set("targets", flattenUpdateResult(d, pushCertificateRespBody))
-	}
-	return nil
-}
-
-func resourceCcmCertificatePushDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	targetService := d.Get("service").(string)
-	oRaws := d.Get("targets").(*schema.Set).List()
 	if len(oRaws) == 0 {
 		return nil
 	}
-	_, err := rmPushedCert(targetService, oRaws, meta, d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	return nil
-}
-
-func rmPushedCert(targetService string, oRaws []interface{}, meta interface{}, d *schema.ResourceData) (bool, error) {
-	cfg := meta.(*config.Config)
-	if targetService == targetServiceElb {
-		for _, val := range oRaws {
-			strVal := utils.PathSearch("project_name", val, "").(string)
-			certId := utils.PathSearch("cert_id", val, "").(string)
-			if certId != "" {
-				elbClient, err := cfg.ElbV3Client(strVal)
-				if err != nil {
-					return true, fmt.Errorf("error creating ELB client: %s", err)
-				}
-				err = certificates.Delete(elbClient, certId).ExtractErr()
-				if err != nil {
-					if utils.IsResourceNotFound(err) {
-						return true, nil
-					}
-					return true, fmt.Errorf("error deleting certificate %s: %s", certId, err)
-				}
-			}
-		}
-	}
-
-	if targetService == targetServiceWaf {
-		for _, val := range oRaws {
-			strVal := utils.PathSearch("project_name", val, "").(string)
-			certId := utils.PathSearch("cert_id", val, "").(string)
-			if certId != "" {
-				client, err := cfg.WafV1Client(strVal)
-				if err != nil {
-					return true, fmt.Errorf("error creating WAF client: %s", err)
-				}
-				epsID := cfg.GetEnterpriseProjectID(d)
-				err = wafcertificates.DeleteWithEpsID(client, certId, epsID).ExtractErr()
-				if err != nil {
-					if utils.IsResourceNotFound(err) {
-						return true, nil
-					}
-					return true, fmt.Errorf("error deleting WAF certificate: %s", err)
-				}
-			}
-		}
-	}
-	return false, nil
+	return diag.FromErr(removePushedCertificate(cfg, oRaws, d))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor CCM certificate push resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1724407894813_TestAccCcmCertificatePush_.cov -coverpkg=./huaweicloud/services/ccm ./huaweicloud/services/acceptance/ccm -run TestAccCcmCertificatePush_ -timeout 360m -parallel 4
=== RUN   TestAccCcmCertificatePush_elb
=== PAUSE TestAccCcmCertificatePush_elb
=== RUN   TestAccCcmCertificatePush_waf
=== PAUSE TestAccCcmCertificatePush_waf
=== CONT  TestAccCcmCertificatePush_elb
=== CONT  TestAccCcmCertificatePush_waf
--- PASS: TestAccCcmCertificatePush_waf (26.51s)
--- PASS: TestAccCcmCertificatePush_elb (59.30s)
PASS
coverage: 14.8% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       59.362s coverage: 14.8% of statements in ./huaweicloud/services/ccm
root@ecs-luxiaohang:/mnt/d/Project/Golang/terraform-provider-huaweicloud# go tool cover -html=coverage_1724407894813_TestAccCcmCertificatePush_.cov -o coverage_1724407894813_TestAccCcmCertificatePush_.cov.html
```
![image](https://github.com/user-attachments/assets/953772da-612d-4965-a61d-28a4c34f7725)

* [X] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   ![image](https://github.com/user-attachments/assets/bca4e10e-5089-4d3d-8095-a7ff9fe17198)
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
