### PR TITLE
chore(CCM): refactor CCM private certificate resource

### DIFF
--- a/docs/resources/ccm_private_certificate.md
+++ b/docs/resources/ccm_private_certificate.md
@@ -2,7 +2,8 @@
 subcategory: "Cloud Certificate Manager (CCM)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_ccm_private_certificate"
-description: ""
+description: |
+  Manages a CCM private certificate resource within HuaweiCloud.
 ---
 
 # huaweicloud_ccm_private_certificate
@@ -13,17 +14,17 @@ Manages a CCM private certificate resource within HuaweiCloud.
 
 ```hcl
 variable "common_name" {}
-
 variable "issuer_id" {}
 
 resource "huaweicloud_ccm_private_certificate" "test" {
-  region = "cn-north-4"
-  distinguished_name {
-    common_name = var.common_name
-  }
   issuer_id           = var.issuer_id
   key_algorithm       = "RSA2048"
   signature_algorithm = "SHA256"
+  
+  distinguished_name {
+    common_name = var.common_name
+  }
+  
   validity {
     type  = "DAY"
     value = 1
@@ -42,15 +43,15 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
   The [distinguished_name](#block-distinguished_name) structure is documented below.
 
-* `issuer_id` - (Required, String, ForceNew) Specifies the certificate depends on the parent CA. Changing this creates
+* `issuer_id` - (Required, String, ForceNew) Specifies the ID of the parent CA. Changing this creates
   a new private certificate resource.
 
-* `key_algorithm` - (Required, String, ForceNew) Specifies the certificate key algorithm and key size for the private
-  certificate. Valid values are **RSA2048**, **RSA4096**, **EC256**, or **EC384**.
+* `key_algorithm` - (Required, String, ForceNew) Specifies the key algorithm. Valid values are **RSA2048**, **RSA4096**,
+  **EC256**, and **EC384**.
   Changing this creates a new private certificate resource.
 
 * `signature_algorithm` - (Required, String, ForceNew) Specifies the private certificate signature hash algorithm.
-  Valid values are **SHA256**, **SHA384**, or **SHA512**. Changing this creates a new private certificate resource.
+  Valid values are **SHA256**, **SHA384**, and **SHA512**. Changing this creates a new private certificate resource.
 
 * `validity` - (Required, List, ForceNew) Specifies the validity of private certificate.
   Changing this parameter will create a new resource.
@@ -60,34 +61,49 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
   The [subject_alternative_names](#block-subject_alternative_names) structure is documented below.
 
-* `key_usage` - (Optional, List, ForceNew) Specifies the Key usage. For details, see 4.2.1.3 in RFC 5280. Valid values
-  are **digitalSignature**, **nonRepudiation**, **keyEncipherment**, **dataEncipherment**, **keyAgreement**,
-   **keyCertSign**, **cRLSign**, **encipherOnly** and **decipherOnly**.
+* `key_usage` - (Optional, List, ForceNew) Specifies the key usage. Changing this parameter will create a new resource.
+  Refer to [4.2.1.3](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3)
+  Valid values are as follows:
+  + **digitalSignature**: The key is used as a digital signature.
+  + **nonRepudiation**: The key can be used for non-repudiation.
+  + **keyEncipherment**: The key can be used for key encryption.
+  + **dataEncipherment**: The key can be used for data encryption.
+  + **keyAgreement**: The key can be used for key negotiation.
+  + **keyCertSign**: The key can issue a certificate.
+  + **cRLSign**: The key can issue a certificate revocation list (CRL).
+  + **encipherOnly**: The key is used only for encryption.
+  + **decipherOnly**: The key is used only for decryption.
+
+* `server_auth` - (Optional, Bool, ForceNew) Specifies whether to enable server authentication. Defaults to **false**.
   Changing this parameter will create a new resource.
 
-* `server_auth` - (Optional, Bool, ForceNew) Specifies the enhanced key usage for the server certificate.
-  The default value is false. Changing this parameter will create a new resource.
+  -> Enable this enhanced key usage for the server certificate.
 
-* `client_auth` - (Optional, Bool, ForceNew) Specifies the enhanced key usage for the client certificate.
-  The default value is false. Changing this parameter will create a new resource.
-
-* `code_signing` - (Optional, Bool, ForceNew) Specifies the signing of downloadable executable code client
-  authentication. The default value is false. Changing this parameter will create a new resource.
-
-* `email_protection` - (Optional, Bool, ForceNew) Specifies the Email protection. The default value is false.
+* `client_auth` - (Optional, Bool, ForceNew) Specifies whether to enable client authentication. Defaults to **false**.
   Changing this parameter will create a new resource.
 
-* `time_stamping` - (Optional, Bool, ForceNew) Specifies the binding the hash of an object to a time.
-  The default value is false. Changing this parameter will create a new resource.
+  -> Enable this enhanced key usage for the client certificate.
 
-* `object_identifier` - (Optional, String, ForceNew) Specifies the object identifier. The value of this parameter
-  must be a dot-decimal notation string that complies with the ASN1 specifications, Maximum: 64.
-  for example, 1.3.6.1.4.1.2011.4.99. Changing this parameter will create a new resource.
+* `code_signing` - (Optional, Bool, ForceNew) Specifies whether to enable signing of downloadable executable code client
+  authentication. Defaults to **false**. Changing this parameter will create a new resource.
+
+* `email_protection` - (Optional, Bool, ForceNew) Specifies whether to enable email protection. Defaults to **false**.
+  Changing this parameter will create a new resource.
+
+* `time_stamping` - (Optional, Bool, ForceNew) Specifies whether to bind the hash of an object to a time.
+  Defaults to **false**. Changing this parameter will create a new resource.
+
+* `object_identifier` - (Optional, String, ForceNew) Specifies the object identifier. Changing this parameter will create
+  a new resource.
+  
+  -> The value of this parameter must be a dot-decimal notation string that complies with the ASN1 specifications,
+  for example, **1.3.6.1.4.1.2011.4.99**.
 
 * `object_identifier_value` - (Optional, String, ForceNew) Specifies the custom attribute content,
-  work with object_identifier. Changing this parameter will create a new resource.
+  work with `object_identifier`. Changing this parameter will create a new resource.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of private certificate.
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the certificate belongs.
+  For enterprise users, if omitted, resources under all authorized enterprise projects of the tenant will be queried.
   Changing this parameter will create a new resource.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs associating with the private certificate.
@@ -99,37 +115,43 @@ The `distinguished_name` block supports:
   is limited between `1` to `64`, Only Chinese and English letters, digits, hyphens (-), underscores (_),
   dots (.), comma (,), space ( ) and asterisks (*) are allowed. Changing this parameter will create a new resource.
 
-* `country` - (Optional, String, ForceNew) Specifies the country of private certificate. The valid length is
-  limited in `2`, Only English letters are allowed. Changing this parameter will create a new resource.
+* `country` - (Optional, String, ForceNew) Specifies the country code of private certificate. The valid length is
+  limited in `2`. Only English letters are allowed. The value corresponding to the parent CA is inherited by default.
+  Changing this parameter will create a new resource.
 
-* `state` - (Optional, String, ForceNew) Specifies the state of private certificate. The valid length is
-  limited between `1` to `128`, Only Chinese and English letters, digits, hyphens (-), underscores (_),
+* `state` - (Optional, String, ForceNew) Specifies the state or city name of private certificate. The valid length is
+  limited between `1` to `128`. Only Chinese and English letters, digits, hyphens (-), underscores (_),
   dots (.), comma (,) and space ( ) are allowed. Changing this parameter will create a new resource.
 
 * `locality` - (Optional, String, ForceNew) Specifies the locality of private certificate. The valid length
   is limited between `1` to `128`, Only Chinese and English letters, digits, hyphens (-), underscores (_),
-  dots (.), comma (,) and space ( ) are allowed. Changing this parameter will create a new resource.
+  dots (.), comma (,) and space ( ) are allowed. The value corresponding to the parent CA is inherited by default.
+  Changing this parameter will create a new resource.
 
 * `organization` - (Optional, String, ForceNew) Specifies the organization of private certificate. The valid length
-  is limited between `1` to `64`, Only Chinese and English letters, digits, hyphens (-), underscores (_), dots (.),
-  comma (,) and space ( ) are allowed. Changing this parameter will create a new resource.
+  is limited between `1` to `64`. Only Chinese and English letters, digits, hyphens (-), underscores (_), dots (.),
+  comma (,) and space ( ) are allowed. The value corresponding to the parent CA is inherited by default.
+  Changing this parameter will create a new resource.
 
-* `organizational_unit` - (Optional, String, ForceNew) Specifies the organizational_unit of private certificate.
-  The valid length is limited between `1` to `64`, Only Chinese and English letters, digits, hyphens (-),
-  underscores (_), dots (.), comma (,) and space ( ) are allowed. Changing this parameter will create a new resource.
+* `organizational_unit` - (Optional, String, ForceNew) Specifies the organizational unit of private certificate.
+  The valid length is limited between `1` to `64`. Only Chinese and English letters, digits, hyphens (-),
+  underscores (_), dots (.), comma (,) and space ( ) are allowed. The value corresponding to the parent CA is inherited
+  by default. Changing this parameter will create a new resource.
 
 <a name="block-validity"></a>
 The `validity` block supports:
 
-* `type` - (Required, String, ForceNew) Specifies the type of validity value. Changing this parameter will create a new
+* `type` - (Required, String, ForceNew) Specifies the validity period type. Changing this parameter will create a new
   resource. Options are: **YEAR**, **MONTH**(31 days), **DAY**, **HOUR**.
 
-* `value` - (Required, Int, ForceNew) Specifies the value of validity. Root CA certificate is no longer than 30 years
-  and subordinate CA is no longer than 20 years. Changing this parameter will create a new resource.
+* `value` - (Required, Int, ForceNew) Specifies the value of validity period. The value of this parameter varies
+  depending on the value of `type`. Changing this parameter will create a new resource.
+  + Root CA certificates: no longer than `30` years.
+  + Subordinate CA or private certificates: no longer than `20` years
 
 * `start_at` - (Optional, String, ForceNew) Specifies the private certificate validity start from.
-  The value is a timestamp in milliseconds. For example, 1645146939688 indicates 2022-02-18 09:15:39.
-  it cannot be earlier than the result of the value of current_time minus 5 minutes.
+  The value is a timestamp in milliseconds. For example, `1645146939688` indicates `2022-02-18 09:15:39`.
+  The value of `start_at` cannot be earlier than the result of the value of current time minus `5` minutes.
   Changing this creates a new private certificate resource.
 
 <a name="block-subject_alternative_names"></a>
@@ -139,11 +161,11 @@ The `subject_alternative_names` block supports:
   only **DNS**, **IP**, **EMAIL**, and **URI** are allowed. Changing this parameter will create a new resource.
 
 * `value` - (Required, String, ForceNew) Specifies the value of the corresponding alternative name type.
-  Changing this parameter will create a new resource.  
-  When `type` is **DNS**, the value length range: 0 to 253 characters.  
-  When `type` is **IP**, the value length range: 0 to 39 characters.Support ipv4 and ipv6.  
-  When `type` is **EMAIL**, the value length range: 0 to 256 characters.  
-  When `type` is **URI**, the value length range: 0 to 253 characters.
+  Changing this parameter will create a new resource.
+  + When `type` is **DNS**, the value length ranges from `0` to `253` characters.  
+  + When `type` is **IP**, the value length ranges from `0` to `39` characters. Support IPv4 and IPv6.  
+  + When `type` is **EMAIL**, the value length ranges from `0` to `256` characters.  
+  + When `type` is **URI**, the value length ranges from `0` to `253` characters.
 
 ## Attribute Reference
 
@@ -151,35 +173,36 @@ In addition to all arguments above, the following attributes are exported:
 
 * `issuer_name` - Indicates the parent CA name.
 
-* `status` - Indicates the private certificate status.
+* `status` - Indicates the private certificate status. Valid values are: **ISSUED**, **EXPIRED** and **REVOKED**.
 
 * `start_at` - Indicates the private certificate valid start time.
 
 * `expired_at` - Indicates the private certificate valid expired time.
 
-* `gen_mode` - Indicates the private certificate create mode,by system or user.
+* `gen_mode` - Indicates the private certificate create mode,by system or user. Valid values are as follows:
+  + **GENERATE**: The certificate is generated through the PCA system.
+  + **IMPORT**: The certificate is imported externally.
+  + **CSR**: The CSR is imported externally and issued by the internal CA. The private key is not managed in PCA.
 
-* `created_at` - Indicates he private certificate create time.
+* `created_at` - Indicates the time when the certificate was created.
 
 ## Import
 
-private certificate an be imported using the `id`, e.g.
+The CCM private certificate can be imported using the `id`, e.g.
 
-```
-$ terraform import huaweicloud_ccm_private_certificate.test b90ee7be-4ecf-42f4-9393-e15e2008df3f
+```bash
+$ terraform import huaweicloud_ccm_private_certificate.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
   API response, security or some other reason. The missing attributes include: `validity`,`key_usage`,`server_auth`,
 `client_auth`,`code_signing`,`email_protection`,`time_stamping`,`object_identifier`,`object_identifier_value`,
 `subject_alternative_names`.
-
 It is generally recommended running `terraform plan` after importing a private certificate. You can then decide if
-  changes should be applied to the private certificate, or the resource definition should be updated to align with the
-  private certificate.
-Also, you can ignore changes as below.
+changes should be applied to the private certificate, or the resource definition should be updated to align with the
+private certificate. Also, you can ignore changes as below.
 
-```
+```hcl
 resource "huaweicloud_ccm_private_certificate" "test" {
   ...
 
@@ -194,7 +217,7 @@ resource "huaweicloud_ccm_private_certificate" "test" {
         time_stamping,
         object_identifier,
         object_identifier_value,
-        subject_alternative_names
+        subject_alternative_names,
     ]
   }
 }

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1223,7 +1223,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ccm_certificate_push":           ccm.ResourceCertificatePush(),
 			"huaweicloud_ccm_private_ca":                 ccm.ResourcePrivateCertificateAuthority(),
 			"huaweicloud_ccm_private_ca_revoke":          ccm.ResourcePrivateCaRevoke(),
-			"huaweicloud_ccm_private_certificate":        ccm.ResourceCcmPrivateCertificate(),
+			"huaweicloud_ccm_private_certificate":        ccm.ResourcePrivateCertificate(),
 			"huaweicloud_ccm_private_certificate_revoke": ccm.ResourcePrivateCertificateRevoke(),
 			"huaweicloud_ccm_certificate_import":         ccm.ResourceCertificateImport(),
 

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificate_export_test.go
@@ -101,7 +101,7 @@ data "huaweicloud_ccm_private_certificate_export" "tomcat" {
   type           = "TOMCAT"
   password       = "encryption_password"
 }
-`, tesCmdbCertificate_basic(commonName))
+`, testPrivateCertificate_basic(commonName))
 }
 
 func TestAccPrivateCertificateExport_sm2cert(t *testing.T) {

--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificates_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_private_certificates_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourcePrivateCertificates_basic(t *testing.T) {
 	var (
 		dataSource = "data.huaweicloud_ccm_private_certificates.test"
-		rName      = acceptance.RandomAccResourceName()
+		rName      = acceptance.RandomAccResourceNameWithDash()
 		dc         = acceptance.InitDataSourceCheck(dataSource)
 
 		byName   = "data.huaweicloud_ccm_private_certificates.filter_by_name"
@@ -118,5 +118,5 @@ data "huaweicloud_ccm_private_certificates" "filter_by_sort" {
 output "sort_filter_is_useful" {
   value = length(data.huaweicloud_ccm_private_certificates.filter_by_sort.certificates) > 0
 }
-`, tesCmdbCertificate_basic(name))
+`, testPrivateCertificate_basic(name))
 }

--- a/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go
+++ b/huaweicloud/services/acceptance/ccm/resource_huaweicloud_ccm_private_certificate_test.go
@@ -43,10 +43,12 @@ func getCertificateResourceFunc(conf *config.Config, state *terraform.ResourceSt
 	return getCertificateRespBody, nil
 }
 
-func TestAccCcmPrivateCertificate_basic(t *testing.T) {
-	var obj interface{}
-	rName := acceptance.RandomAccResourceNameWithDash()
-	resourceName := "huaweicloud_ccm_private_certificate.test"
+func TestAccPrivateCertificate_basic(t *testing.T) {
+	var (
+		obj          interface{}
+		rName        = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_ccm_private_certificate.test"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -62,7 +64,7 @@ func TestAccCcmPrivateCertificate_basic(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: tesCmdbCertificate_basic(rName),
+				Config: testPrivateCertificate_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "distinguished_name.0.common_name", rName),
@@ -82,7 +84,7 @@ func TestAccCcmPrivateCertificate_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: tesCmdbCertificate_tagsUpdate(rName),
+				Config: testPrivateCertificate_tagsUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
@@ -112,7 +114,7 @@ func TestAccCcmPrivateCertificate_basic(t *testing.T) {
 }
 
 // lintignore:AT004
-func tesCmdbCertificate_basic(commonName string) string {
+func testPrivateCertificate_basic(commonName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -121,6 +123,7 @@ resource "huaweicloud_ccm_private_certificate" "test" {
   key_algorithm       = "RSA2048"
   signature_algorithm = "SHA256"
   key_usage           = ["nonRepudiation", "keyEncipherment"]
+
   distinguished_name {
     common_name         = "%s"
     country             = "CN"
@@ -129,10 +132,17 @@ resource "huaweicloud_ccm_private_certificate" "test" {
     organization        = "huawei"
     organizational_unit = "cloud"
   }
+
   validity {
     type  = "DAY"
     value = "1"
   }
+
+  subject_alternative_names {
+    type  = "IP"
+    value = "156.127.116.38"
+  }
+
   tags = {
     fooo = "bar"
     keye = "value"
@@ -141,7 +151,7 @@ resource "huaweicloud_ccm_private_certificate" "test" {
 }
 
 // lintignore:AT004
-func tesCmdbCertificate_tagsUpdate(commonName string) string {
+func testPrivateCertificate_tagsUpdate(commonName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -150,6 +160,7 @@ resource "huaweicloud_ccm_private_certificate" "test" {
   key_algorithm       = "RSA2048"
   signature_algorithm = "SHA256"
   key_usage           = ["nonRepudiation", "keyEncipherment"]
+
   distinguished_name {
     common_name         = "%s"
     country             = "CN"
@@ -158,10 +169,17 @@ resource "huaweicloud_ccm_private_certificate" "test" {
     organization        = "huawei"
     organizational_unit = "cloud"
   }
+
   validity {
     type  = "DAY"
     value = "1"
   }
+
+  subject_alternative_names {
+    type  = "IP"
+    value = "156.127.116.38"
+  }
+
   tags = {
     foo = "bar"
     key = "value"

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_ca.go
@@ -2,6 +2,7 @@ package ccm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -625,7 +626,9 @@ func deletePrepaidPrivateCA(ctx context.Context, client *golangsdk.ServiceClient
 		Refresh: func() (interface{}, string, error) {
 			getRespBody, err := readPrivateCA(client, d)
 			if err != nil {
-				if hasErrorCode(err, "PCA.10010002") {
+				convertErr := common.ConvertExpected400ErrInto404Err(err, "error_code", "PCA.10010002")
+				var err404 golangsdk.ErrDefault404
+				if errors.As(convertErr, &err404) {
 					return "deleted", "COMPLETED", nil
 				}
 				return getRespBody, "ERROR", err

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go
@@ -2,8 +2,6 @@ package ccm
 
 import (
 	"context"
-	"encoding/json"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -24,12 +22,12 @@ import (
 // @API CCM GET /v1/private-certificates/{certificate_id}
 // @API CCM GET /v1/private-certificates/{certificate_id}/tags
 // @API CCM DELETE /v1/private-certificates/{certificate_id}
-func ResourceCcmPrivateCertificate() *schema.Resource {
+func ResourcePrivateCertificate() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceCcmPrivateCertificateCreate,
-		ReadContext:   resourceCcmPrivateCertificateRead,
-		UpdateContext: resourceCcmPrivateCertificateUpdate,
-		DeleteContext: resourceCcmPrivateCertificateDelete,
+		CreateContext: resourcePrivateCertificateCreate,
+		ReadContext:   resourcePrivateCertificateRead,
+		UpdateContext: resourcePrivateCertificateUpdate,
+		DeleteContext: resourcePrivateCertificateDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -239,18 +237,19 @@ func subjectAlternativeNameSchema() *schema.Resource {
 	return &sc
 }
 
-func resourceCcmPrivateCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	product := "ccm"
+func resourcePrivateCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                      = meta.(*config.Config)
+		product                  = "ccm"
+		createCertificateHttpUrl = "v1/private-certificates"
+	)
 
 	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating CCM client: %s", err)
 	}
 
-	createCertificateHttpUrl := "v1/private-certificates"
 	createCertificatePath := client.Endpoint + createCertificateHttpUrl
-
 	createCertificateOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
@@ -266,7 +265,7 @@ func resourceCcmPrivateCertificateCreate(ctx context.Context, d *schema.Resource
 	}
 
 	id, err := jmespath.Search("certificate_id", createCertificateRespBody)
-	if err != nil {
+	if err != nil || id == nil {
 		return diag.Errorf("error creating CCM private certificate: certificate_id is not found in API response")
 	}
 
@@ -279,7 +278,7 @@ func resourceCcmPrivateCertificateCreate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	return resourceCcmPrivateCertificateRead(ctx, d, meta)
+	return resourcePrivateCertificateRead(ctx, d, meta)
 }
 
 func buildCreateCertificateBodyParams(d *schema.ResourceData, cfg *config.Config) map[string]interface{} {
@@ -293,13 +292,17 @@ func buildCreateCertificateBodyParams(d *schema.ResourceData, cfg *config.Config
 		"key_usages":                d.Get("key_usage"),
 		"extended_key_usage":        buildExtendedKeyUsage(d),
 		"customized_extension":      buildCustomizedExtension(d),
-		"subject_alternative_names": buidSubjectAlternativeName(d),
+		"subject_alternative_names": buildSubjectAlternativeName(d),
 	}
 	return bodyParams
 }
 
 func buildCertDistinguishedName(rawParams interface{}) map[string]interface{} {
-	rawArray, _ := rawParams.([]interface{})
+	rawArray, ok := rawParams.([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
 	raw := rawArray[0].(map[string]interface{})
 	params := map[string]interface{}{
 		"common_name":         raw["common_name"],
@@ -313,7 +316,11 @@ func buildCertDistinguishedName(rawParams interface{}) map[string]interface{} {
 }
 
 func buildValidity(rawParams interface{}) map[string]interface{} {
-	rawArray, _ := rawParams.([]interface{})
+	rawArray, ok := rawParams.([]interface{})
+	if !ok || len(rawArray) == 0 {
+		return nil
+	}
+
 	raw := rawArray[0].(map[string]interface{})
 	params := map[string]interface{}{
 		"type":       raw["type"],
@@ -339,7 +346,7 @@ func buildCustomizedExtension(d *schema.ResourceData) map[string]interface{} {
 	}
 	return bodyParams
 }
-func buidSubjectAlternativeName(d *schema.ResourceData) []interface{} {
+func buildSubjectAlternativeName(d *schema.ResourceData) []interface{} {
 	curJson := utils.PathSearch("subject_alternative_names", d, make([]interface{}, 0))
 	curArray := curJson.([]interface{})
 	rst := make([]interface{}, 0, len(curArray))
@@ -352,23 +359,23 @@ func buidSubjectAlternativeName(d *schema.ResourceData) []interface{} {
 	return rst
 }
 
-func resourceCcmPrivateCertificateUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	product := "ccm"
-	region := cfg.GetRegion(d)
+func resourcePrivateCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		product = "ccm"
+		region  = cfg.GetRegion(d)
+	)
 
 	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating CCM client: %s", err)
 	}
 
-	// update tags
 	if d.HasChange("tags") {
 		oRaw, nRaw := d.GetChange("tags")
 		oMap := oRaw.(map[string]interface{})
 		nMap := nRaw.(map[string]interface{})
 
-		// remove old tags
 		if len(oMap) > 0 {
 			deleteTagsHttpUrl := "v1/private-certificates/{certificate_id}/tags/delete"
 			if err = deleteTags(d.Id(), client, oMap, deleteTagsHttpUrl, "{certificate_id}"); err != nil {
@@ -376,7 +383,6 @@ func resourceCcmPrivateCertificateUpdate(_ context.Context, d *schema.ResourceDa
 			}
 		}
 
-		// set new tags
 		if len(nMap) > 0 {
 			createTagsHttpUrl := "v1/private-certificates/{certificate_id}/tags/create"
 			if err := createTags(d.Id(), client, nMap, createTagsHttpUrl, "{certificate_id}"); err != nil {
@@ -384,19 +390,22 @@ func resourceCcmPrivateCertificateUpdate(_ context.Context, d *schema.ResourceDa
 			}
 		}
 	}
-	return nil
+	return resourcePrivateCertificateRead(ctx, d, meta)
 }
 
-func resourceCcmPrivateCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	product := "ccm"
-	region := cfg.GetRegion(d)
+func resourcePrivateCertificateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                   = meta.(*config.Config)
+		product               = "ccm"
+		region                = cfg.GetRegion(d)
+		getCertificateHttpUrl = "v1/private-certificates/{certificate_id}"
+	)
 
 	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating CCM client: %s", err)
 	}
-	getCertificateHttpUrl := "v1/private-certificates/{certificate_id}"
+
 	getCertificatePath := client.Endpoint + getCertificateHttpUrl
 	getCertificatePath = strings.ReplaceAll(getCertificatePath, "{certificate_id}", d.Id())
 	getCertificateOpt := golangsdk.RequestOpts{
@@ -404,12 +413,10 @@ func resourceCcmPrivateCertificateRead(_ context.Context, d *schema.ResourceData
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 	getCertificateResp, err := client.Request("GET", getCertificatePath, &getCertificateOpt)
-
 	if err != nil {
-		if hasErrorCode(err, "PCA.10010002") {
-			err = golangsdk.ErrDefault404{}
-		}
-		return common.CheckDeletedDiag(d, err, "error retrieving CCM private certificate")
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "PCA.10010002"),
+			"error retrieving CCM private certificate")
 	}
 
 	getCertificateRespBody, err := utils.FlattenResponse(getCertificateResp)
@@ -433,7 +440,6 @@ func resourceCcmPrivateCertificateRead(_ context.Context, d *schema.ResourceData
 		d.Set("key_algorithm", utils.PathSearch("key_algorithm", getCertificateRespBody, nil)),
 		d.Set("signature_algorithm", utils.PathSearch("signature_algorithm", getCertificateRespBody, nil)),
 		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", getCertificateRespBody, nil)),
-
 		d.Set("issuer_name", utils.PathSearch("issuer_name", getCertificateRespBody, nil)),
 		d.Set("status", utils.PathSearch("status", getCertificateRespBody, nil)),
 		d.Set("gen_mode", utils.PathSearch("gen_mode", getCertificateRespBody, nil)),
@@ -450,15 +456,18 @@ func resourceCcmPrivateCertificateRead(_ context.Context, d *schema.ResourceData
 	return nil
 }
 
-func resourceCcmPrivateCertificateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	product := "ccm"
+func resourcePrivateCertificateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg                   = meta.(*config.Config)
+		product               = "ccm"
+		delCertificateHttpUrl = "v1/private-certificates/{certificate_id}"
+	)
 
 	client, err := cfg.NewServiceClient(product, cfg.GetRegion(d))
 	if err != nil {
 		return diag.Errorf("error creating CCM client: %s", err)
 	}
-	delCertificateHttpUrl := "v1/private-certificates/{certificate_id}"
+
 	delCertificatePath := client.Endpoint + delCertificateHttpUrl
 	delCertificatePath = strings.ReplaceAll(delCertificatePath, "{certificate_id}", d.Id())
 	delCertificateOpt := golangsdk.RequestOpts{
@@ -466,25 +475,10 @@ func resourceCcmPrivateCertificateDelete(_ context.Context, d *schema.ResourceDa
 		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
 	}
 	_, err = client.Request("DELETE", delCertificatePath, &delCertificateOpt)
-	if err != nil && !hasErrorCode(err, "PCA.10010002") {
-		return diag.Errorf("error deleting CCM private certificate: %s", err)
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "PCA.10010002"),
+			"error deleting CCM private certificate")
 	}
 	return nil
-}
-func hasErrorCode(err error, expectCode string) bool {
-	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
-		var response interface{}
-		if jsonErr := json.Unmarshal(errCode.Body, &response); jsonErr == nil {
-			errorCode, parseErr := jmespath.Search("error_code", response)
-			if parseErr != nil {
-				log.Printf("[WARN] failed to parse error_code from response body: %s", parseErr)
-			}
-
-			if errorCode == expectCode {
-				return true
-			}
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor CCM private certificate resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/ccm' TESTARGS='-run TestAccPrivateCertificateExport_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccPrivateCertificateExport_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateCertificateExport_basic
=== PAUSE TestAccPrivateCertificateExport_basic
=== CONT  TestAccPrivateCertificateExport_basic
--- PASS: TestAccPrivateCertificateExport_basic (45.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       45.769s
```
```
make testacc TEST='./huaweicloud/services/acceptance/ccm' TESTARGS='-run TestAccDataSourcePrivateCertificates_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccDataSourcePrivateCertificates_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePrivateCertificates_basic
=== PAUSE TestAccDataSourcePrivateCertificates_basic
=== CONT  TestAccDataSourcePrivateCertificates_basic
--- PASS: TestAccDataSourcePrivateCertificates_basic (48.42s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       48.485s
```
```
make testacc TEST='./huaweicloud/services/acceptance/ccm' TESTARGS='-run TestAccPrivateCertificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccPrivateCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateCertificate_basic
=== PAUSE TestAccPrivateCertificate_basic
=== CONT  TestAccPrivateCertificate_basic
--- PASS: TestAccPrivateCertificate_basic (50.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       50.835s

go test -v -coverprofile=coverage_1724665730873_TestAccPrivateCertificate_basic.cov -coverpkg=./huaweicloud/services/ccm ./huaweicloud/services/acceptance/ccm -run TestAccPrivateCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccPrivateCertificate_basic
=== PAUSE TestAccPrivateCertificate_basic
=== CONT  TestAccPrivateCertificate_basic
--- PASS: TestAccPrivateCertificate_basic (47.57s)
PASS
coverage: 22.2% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       47.636s coverage: 22.2% of statements in ./huaweicloud/services/ccm
```
```
make testacc TEST='./huaweicloud/services/acceptance/ccm' TESTARGS='-run TestAccCCMPrivateCA_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ccm -v -run TestAccCCMPrivateCA_ -timeout 360m -parallel 4
=== RUN   TestAccCCMPrivateCA_postpaid_root
=== PAUSE TestAccCCMPrivateCA_postpaid_root
=== RUN   TestAccCCMPrivateCA_postpaid_subordinate
=== PAUSE TestAccCCMPrivateCA_postpaid_subordinate
=== RUN   TestAccCCMPrivateCA_prepaid_root
=== PAUSE TestAccCCMPrivateCA_prepaid_root
=== RUN   TestAccCCMPrivateCA_other
=== PAUSE TestAccCCMPrivateCA_other
=== CONT  TestAccCCMPrivateCA_postpaid_root
=== CONT  TestAccCCMPrivateCA_prepaid_root
=== CONT  TestAccCCMPrivateCA_other
=== CONT  TestAccCCMPrivateCA_postpaid_subordinate
--- PASS: TestAccCCMPrivateCA_postpaid_root (46.94s)
--- PASS: TestAccCCMPrivateCA_postpaid_subordinate (70.00s)
--- PASS: TestAccCCMPrivateCA_other (101.30s)
--- PASS: TestAccCCMPrivateCA_prepaid_root (129.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       129.537s
```

![image](https://github.com/user-attachments/assets/93f242be-ff22-4383-836e-60cd07fc96f6)
![image](https://github.com/user-attachments/assets/29af93d4-057f-4f13-bf21-24902a725015)


* [X] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
   
![image](https://github.com/user-attachments/assets/799fefe2-2328-4fc5-b092-7166e505fbb8)

  
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    
![image](https://github.com/user-attachments/assets/4540a769-e1d7-43bc-8a12-f8d58ee8655d)

