### PR TITLE
chore(SFS): deprecate sfs capacity type resources and data sources

### DIFF
--- a/docs/data-sources/sfs_file_system.md
+++ b/docs/data-sources/sfs_file_system.md
@@ -1,11 +1,13 @@
 ---
-subcategory: "Scalable File Service (SFS)"
+subcategory: "Deprecated"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_sfs_file_system"
 description: ""
 ---
 
 # huaweicloud_sfs_file_system
+
+!> **WARNING:** It has been deprecated.
 
 Provides information about an Shared File System (SFS) within HuaweiCloud.
 

--- a/docs/resources/sfs_access_rule.md
+++ b/docs/resources/sfs_access_rule.md
@@ -1,11 +1,13 @@
 ---
-subcategory: "Scalable File Service (SFS)"
+subcategory: "Deprecated"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_sfs_access_rule"
 description: ""
 ---
 
 # huaweicloud_sfs_access_rule
+
+!> **WARNING:** It has been deprecated.
 
 Provides an access rule resource of Scalable File Resource (SFS).
 

--- a/docs/resources/sfs_file_system.md
+++ b/docs/resources/sfs_file_system.md
@@ -1,11 +1,13 @@
 ---
-subcategory: "Scalable File Service (SFS)"
+subcategory: "Deprecated"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_sfs_file_system"
 description: ""
 ---
 
 # huaweicloud_sfs_file_system
+
+!> **WARNING:** It has been deprecated.
 
 Provides a Shared File System (SFS) resource within HuaweiCloud.
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -927,10 +927,6 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_sms_source_servers": sms.DataSourceServers(),
 
-			// Deprecated, use `huaweicloud_ccm_certificates` instead
-			"huaweicloud_scm_certificates": ccm.DataSourceCertificates(),
-
-			"huaweicloud_sfs_file_system":       sfs.DataSourceSFSFileSystemV2(),
 			"huaweicloud_sfs_turbos":            sfs.DataSourceTurbos(),
 			"huaweicloud_sfs_turbo_data_tasks":  sfs.DataSourceSfsTurboDataTasks(),
 			"huaweicloud_sfs_turbo_du_tasks":    sfs.DataSourceSfsTurboDuTasks(),
@@ -1028,8 +1024,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kms_key_v1":      dew.DataSourceKmsKey(),
 			"huaweicloud_kms_data_key_v1": dew.DataSourceKmsDataKeyV1(),
 
-			"huaweicloud_rds_flavors_v3":     rds.DataSourceRdsFlavor(),
-			"huaweicloud_sfs_file_system_v2": sfs.DataSourceSFSFileSystemV2(),
+			"huaweicloud_rds_flavors_v3": rds.DataSourceRdsFlavor(),
 
 			"huaweicloud_vpc_v1":                     vpc.DataSourceVpcV1(),
 			"huaweicloud_vpc_ids_v1":                 vpc.DataSourceVpcIdsV1(),
@@ -1078,6 +1073,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpc_flow_logs":              vpc.DataSourceVpcFlowLogs(),
 			"huaweicloud_vpc_sub_network_interfaces": vpc.DataSourceVpcSubNetworkInterfaces(),
 
+			// Deprecated Just discard the resource name, use `huaweicloud_ccm_certificates` instead
+			"huaweicloud_scm_certificates": ccm.DataSourceCertificates(),
+
 			// Deprecated
 			"huaweicloud_antiddos":                      deprecated.DataSourceAntiDdosV1(),
 			"huaweicloud_antiddos_v1":                   deprecated.DataSourceAntiDdosV1(),
@@ -1095,6 +1093,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_dcs_product_v1":                deprecated.DataSourceDcsProductV1(),
 			"huaweicloud_dms_az":                        deprecated.DataSourceDmsAZ(),
 			"huaweicloud_dms_az_v1":                     deprecated.DataSourceDmsAZ(),
+			"huaweicloud_sfs_file_system":               deprecated.DataSourceSFSFileSystemV2(),
+			"huaweicloud_sfs_file_system_v2":            deprecated.DataSourceSFSFileSystemV2(),
 			"huaweicloud_vbs_backup_policy":             deprecated.DataSourceVBSBackupPolicyV2(),
 			"huaweicloud_vbs_backup":                    deprecated.DataSourceVBSBackupV2(),
 			"huaweicloud_vbs_backup_policy_v2":          deprecated.DataSourceVBSBackupPolicyV2(),
@@ -1761,8 +1761,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestage_repo_token_authorization":    servicestage.ResourceRepoTokenAuth(),
 			"huaweicloud_servicestage_repo_password_authorization": servicestage.ResourceRepoPwdAuth(),
 
-			"huaweicloud_sfs_access_rule":      sfs.ResourceSFSAccessRuleV2(),
-			"huaweicloud_sfs_file_system":      sfs.ResourceSFSFileSystemV2(),
 			"huaweicloud_sfs_turbo":            sfs.ResourceSFSTurbo(),
 			"huaweicloud_sfs_turbo_dir":        sfs.ResourceSfsTurboDir(),
 			"huaweicloud_sfs_turbo_dir_quota":  sfs.ResourceSfsTurboDirQuota(),
@@ -1953,9 +1951,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_nat_gateway_v2":   nat.ResourcePublicGateway(),
 			"huaweicloud_nat_snat_rule_v2": nat.ResourcePublicSnatRule(),
 
-			"huaweicloud_sfs_access_rule_v2": sfs.ResourceSFSAccessRuleV2(),
-			"huaweicloud_sfs_file_system_v2": sfs.ResourceSFSFileSystemV2(),
-
 			"huaweicloud_iam_agency":    iam.ResourceIAMAgencyV3(),
 			"huaweicloud_iam_agency_v3": iam.ResourceIAMAgencyV3(),
 
@@ -2050,6 +2045,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_cs_peering_connect_v1": deprecated.ResourceCsPeeringConnectV1(),
 
 			"huaweicloud_lts_structuring_configuration": lts.ResourceStructConfig(),
+
+			"huaweicloud_sfs_access_rule":    deprecated.ResourceSFSAccessRuleV2(),
+			"huaweicloud_sfs_file_system":    deprecated.ResourceSFSFileSystemV2(),
+			"huaweicloud_sfs_access_rule_v2": deprecated.ResourceSFSAccessRuleV2(),
+			"huaweicloud_sfs_file_system_v2": deprecated.ResourceSFSFileSystemV2(),
 
 			"huaweicloud_vbs_backup":           deprecated.ResourceVBSBackupV2(),
 			"huaweicloud_vbs_backup_policy":    deprecated.ResourceVBSBackupPolicyV2(),

--- a/huaweicloud/services/acceptance/deprecated/data_source_huaweicloud_sfs_file_system_test.go
+++ b/huaweicloud/services/acceptance/deprecated/data_source_huaweicloud_sfs_file_system_test.go
@@ -1,4 +1,4 @@
-package sfs
+package deprecated
 
 import (
 	"fmt"

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_sfs_access_rule_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_sfs_access_rule_test.go
@@ -1,4 +1,4 @@
-package sfs
+package deprecated
 
 import (
 	"fmt"

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_sfs_file_system_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_sfs_file_system_test.go
@@ -1,4 +1,4 @@
-package sfs
+package deprecated
 
 import (
 	"fmt"

--- a/huaweicloud/services/deprecated/data_source_huaweicloud_sfs_file_system.go
+++ b/huaweicloud/services/deprecated/data_source_huaweicloud_sfs_file_system.go
@@ -1,4 +1,4 @@
-package sfs
+package deprecated
 
 import (
 	"context"

--- a/huaweicloud/services/deprecated/resource_huaweicloud_sfs_access_rule.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_sfs_access_rule.go
@@ -1,4 +1,4 @@
-package sfs
+package deprecated
 
 import (
 	"context"

--- a/huaweicloud/services/deprecated/resource_huaweicloud_sfs_file_system.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_sfs_file_system.go
@@ -1,4 +1,4 @@
-package sfs
+package deprecated
 
 import (
 	"context"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Due to the SFS capacity file systems being offline, deprecate SFS capacity type resources and data sources.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [X] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
