### PR TITLE
fix(aom): fix hash func for alarm rule and remove precheck for some test

### DIFF
--- a/docs/resources/aomv4_alarm_rule.md
+++ b/docs/resources/aomv4_alarm_rule.md
@@ -12,7 +12,40 @@ Manages an AOM cloud alarm rule resource within HuaweiCloud.
 
 ## Example Usage
 
-### Create an event alarm rule with system event
+### Create an event alarm rule with all system event
+
+```hcl
+variable "alarm_rule_name" {}
+variable "action_rule_id" {}
+
+resource "huaweicloud_aomv4_alarm_rule" "test" {
+  name        = var.alarm_rule_name
+  type        = "event"
+  description = "test"
+  enable      = true
+
+  alarm_notifications {
+    notification_type         = "direct"
+    notification_enable       = true
+    bind_notification_rule_id = var.action_rule_id
+  }
+
+  event_alarm_spec {
+    event_source = "CCE"
+    alarm_source = "systemEvent"
+
+    trigger_conditions {
+      trigger_type = "immediately"
+
+      thresholds = {
+        "Critical" = 2
+      }
+    }
+  }
+}
+```
+
+### Create an event alarm rule with specific system event
 
 ```hcl
 variable "alarm_rule_name" {}

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_action_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_action_rule_test.go
@@ -63,7 +63,6 @@ func TestAccAlarmActionRule_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCnEast3(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_silence_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_alarm_silence_rule_test.go
@@ -73,7 +73,6 @@ func TestAccAlarmSilenceRule_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCnEast3(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_event_alarm_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_event_alarm_rule_test.go
@@ -75,7 +75,6 @@ func TestAccEventAlarmRule_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPreCheckCnEast3(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/huaweicloud/services/aom/resource_huaweicloud_aomv4_alarm_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aomv4_alarm_rule.go
@@ -411,6 +411,7 @@ func resourceSchemeV4MetricTriggerConditions() *schema.Schema {
 				"promql_for": {
 					Type:     schema.TypeString,
 					Optional: true,
+					Computed: true,
 				},
 				"aom_monitor_level": {
 					Type:     schema.TypeString,
@@ -470,6 +471,24 @@ func resourceMetricTriggerConditionHash(v interface{}) int {
 	}
 	if m["metric_statistic_method"] != nil {
 		buf.WriteString(fmt.Sprintf("%s-", m["metric_statistic_method"].(string)))
+	}
+	if m["metric_labels"] != nil {
+		buf.WriteString(fmt.Sprintf("%v-", m["metric_labels"]))
+	}
+	if m["query_param"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["query_param"].(string)))
+	}
+	if m["metric_namespace"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["metric_namespace"].(string)))
+	}
+	if m["metric_unit"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["metric_unit"].(string)))
+	}
+	if m["promql_expr"] != nil {
+		buf.WriteString(fmt.Sprintf("%v-", m["promql_expr"]))
+	}
+	if m["aom_monitor_level"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["aom_monitor_level"].(string)))
 	}
 
 	return hashcode.String(buf.String())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix hash func for alarm rule and remove precheck for some test

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccAlarmActionRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccAlarmActionRule_basic -timeout 360m -parallel 4
=== RUN   TestAccAlarmActionRule_basic
=== PAUSE TestAccAlarmActionRule_basic
=== CONT  TestAccAlarmActionRule_basic
--- PASS: TestAccAlarmActionRule_basic (117.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       117.181s

make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccAlarmSilenceRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccAlarmSilenceRule_basic -timeout 360m -parallel 4
=== RUN   TestAccAlarmSilenceRule_basic
=== PAUSE TestAccAlarmSilenceRule_basic
=== CONT  TestAccAlarmSilenceRule_basic
--- PASS: TestAccAlarmSilenceRule_basic (64.12s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       64.194s

make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccEventAlarmRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccEventAlarmRule_basic -timeout 360m -parallel 4
=== RUN   TestAccEventAlarmRule_basic
=== PAUSE TestAccEventAlarmRule_basic
=== CONT  TestAccEventAlarmRule_basic
--- PASS: TestAccEventAlarmRule_basic (107.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       107.159s

make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccAlarmRuleV4_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccAlarmRuleV4_ -timeout 360m -parallel 4
=== RUN   TestAccAlarmRuleV4_basic
=== PAUSE TestAccAlarmRuleV4_basic
=== RUN   TestAccAlarmRuleV4_metric
=== PAUSE TestAccAlarmRuleV4_metric
=== CONT  TestAccAlarmRuleV4_basic
=== CONT  TestAccAlarmRuleV4_metric
--- PASS: TestAccAlarmRuleV4_metric (95.21s)
--- PASS: TestAccAlarmRuleV4_basic (109.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       110.018s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
