### PR TITLE
feat(dataarts/dataservice): supports new resource and data source to manage exclusive messages

### DIFF
--- a/docs/data-sources/dataarts_dataservice_messages.md
+++ b/docs/data-sources/dataarts_dataservice_messages.md
@@ -1,0 +1,103 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_messages"
+description: |-
+  Use this data source to get the list of approval messages within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_messages
+
+Use this data source to get the list of approval messages within HuaweiCloud.
+
+-> Only exclusive messages are supported.
+
+## Example Usage
+
+### Query all exclusive approval messages
+
+```hcl
+variable "workspace_id" {}
+
+data "huaweicloud_dataarts_dataservice_messages" "test" {
+  workspace_id = var.workspace_id
+}
+```
+
+### Query all exclusive approval messages for a specified API
+
+```hcl
+variable "workspace_id" {}
+variable "api_name" {}
+
+data "huaweicloud_dataarts_dataservice_messages" "test" {
+  workspace_id = var.workspace_id
+  api_name     = var.api_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the approval messages are located.  
+  If omitted, the provider-level region will be used.
+
+* `workspace_id` - (Required, String) Specifies the workspace ID of the exclusive API to which the approval message
+  belongs.
+
+* `api_name` - (Optional, String) Specifies the name of the API to be approved.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `messages` - All approval messages that match the filter parameters.  
+  The [messages](#dataservice_approve_messages_elem) structure is documented below.
+
+<a name="dataservice_approve_messages_elem"></a>
+The `messages` block supports:
+
+* `id` - The ID of the approval message, in UUID format.
+
+* `api_apply_status` - The apply status for API.
+  + **STATUS_TYPE_PENDING_APPROVAL**: Pending review.
+  + **STATUS_TYPE_REJECTED**: Rejected.
+  + **STATUS_TYPE_PENDING_CHECK**: Pending confirmation.
+  + **STATUS_TYPE_PENDING_EXECUTE**: Pending execution.
+  + **STATUS_TYPE_SYNCHRONOUS_EXECUTE**: Synchronous execution.
+  + **STATUS_TYPE_FORCED_CANCEL**: Forced cancellation.
+  + **STATUS_TYPE_PASSED**: Passed.
+
+* `api_apply_type` - The apply type.
+  + **APPLY_TYPE_PUBLISH**: Release API.
+  + **APPLY_TYPE_AUTHORIZE**: API active authorization.
+  + **APPLY_TYPE_APPLY**: Review API.
+  + **APPLY_TYPE_RENEW**: Apply for renewal of API.
+  + **APPLY_TYPE_STOP**: Apply for suspension of API.
+  + **APPLY_TYPE_RECOVER**: Apply for recovery of API.
+  + **APPLY_TYPE_API_CANCEL_AUTHORIZE**: API cancellation of authorization.
+  + **APPLY_TYPE_APP_CANCEL_AUTHORIZE**: APP cancellation of authorization.
+  + **APPLY_TYPE_OFFLINE**: Apply for offline.
+
+* `api_id` - The ID of the exclusive API to which the approval message belongs.
+
+* `api_name` - The name of the exclusive API to which the approval message belongs.
+
+* `api_using_time` - The expiration time used by the API, in RFC3339 format.
+
+* `app_id` - The application ID of the API that has been bound (or is to be bound).
+
+* `app_name` - The application name of the API that has been bound (or is to be bound).
+
+* `apply_time` - The apply time, in RFC3339 format.
+
+* `approval_time` - The approval time of the approval message, in RFC3339 format.
+
+* `approver_name` - The approver name.
+
+* `comment` - The approval comment.
+
+* `user_name` - The name of applicant.

--- a/docs/resources/dataarts_dataservice_message_approve.md
+++ b/docs/resources/dataarts_dataservice_message_approve.md
@@ -1,0 +1,77 @@
+---
+subcategory: "DataArts Studio"
+layout: "huaweicloud"
+page_title: "HuaweiCLoud: huaweicloud_dataarts_dataservice_message_approve"
+description: |-
+  Use this resource to approve the API message for DataArts Data Service within HuaweiCloud.
+---
+
+# huaweicloud_dataarts_dataservice_message_approve
+
+Use this resource to approve the API message for DataArts Data Service within HuaweiCloud.
+
+-> 1. Only messages of the exclusive (and published) API can be approved.
+   <br>2. This resource is a one-time action resource used only for approval message. Deleting this resource will not
+   clear the corresponding request record, but will only remove the resource information from the tfstate file.
+   <br>3. Before using this resource, please make sure that the current user has the approver permission.
+
+## Example Usage
+
+### Approve the message immediately
+
+```hcl
+variable "workspace_id" {}
+variable "message_id" {}
+
+resource "huaweicloud_dataarts_dataservice_message_approve" "test" {
+  workspace_id = var.workspace_id
+  message_id   = var.message_id
+  action       = 0
+}
+```
+
+### Approve the message on the hour after 1 day
+
+```hcl
+variable "workspace_id" {}
+variable "message_id" {}
+
+resource "huaweicloud_dataarts_dataservice_message_approve" "test" {
+  workspace_id = var.workspace_id
+  message_id   = var.message_id
+  action       = 1
+  time         = formatdate("YYYY-MM-DD'T'hh:mm:ss.000Z", timeadd(timestamp(), "24h"))
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the message (to be approved) is located.  
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `workspace_id` - (Required, String, ForceNew) Specifies the workspace ID of the exclusive API to which the message
+  (to be approved) belongs.
+  Changing this parameter will create a new resource.
+
+* `message_id` - (Required, String, ForceNew) Specifies the ID of the message (to be approved).  
+  Changing this parameter will create a new resource.
+
+* `action` - (Optional, Int, ForceNew) Specifies the approval action performed by the message.  
+  The valid values are as follows:
+  + **0**: Immediate approval.
+  + **1**: Regular approval.
+
+  Defaults to **0**. Changing this parameter will create a new resource.
+
+* `time` - (Optional, String, ForceNew) Specifies the regular approval time.  
+  The format is `YYYY-MM-DDThh:mm:ss.000Z`.  
+  Required if the value of the parameter `action` is **1**.  
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, in UUID format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -589,6 +589,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_dataservice_apps":            dataarts.DataSourceDataServiceApps(),
 			"huaweicloud_dataarts_dataservice_authorized_apps": dataarts.DataSourceDataServiceAuthorizedApps(),
 			"huaweicloud_dataarts_dataservice_instances":       dataarts.DataSourceDataServiceInstances(),
+			"huaweicloud_dataarts_dataservice_messages":        dataarts.DataSourceDataServiceMessages(),
 			// DataArts Quality
 			"huaweicloud_dataarts_quality_tasks": dataarts.DataSourceQualityTasks(),
 			// DataArts Factory

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1665,6 +1665,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dataarts_dataservice_api_publishment": dataarts.ResourceDataServiceApiPublishment(),
 			"huaweicloud_dataarts_dataservice_app":             dataarts.ResourceDataServiceApp(),
 			"huaweicloud_dataarts_dataservice_catalog":         dataarts.ResourceDatatServiceCatalog(),
+			"huaweicloud_dataarts_dataservice_message_approve": dataarts.ResourceDataServiceMessageApprove(),
 
 			"huaweicloud_mpc_transcoding_template":       mpc.ResourceTranscodingTemplate(),
 			"huaweicloud_mpc_transcoding_template_group": mpc.ResourceTranscodingTemplateGroup(),

--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_message_approve_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_message_approve_test.go
@@ -1,0 +1,112 @@
+package dataarts
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataServiceMessageApprove_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_dataarts_dataservice_messages.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDataArtsWorkSpaceID(t)
+			acceptance.TestAccPreCheckDataArtsReviewerName(t)
+			acceptance.TestAccPreCheckDataArtsRelatedDliQueueName(t)
+		},
+
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Authorize the APP to access the API (do not need to approve).
+				Config: testAccDataServiceMessageApprove_basic_step1(name),
+			},
+			{
+				// Cancel the API access permission of the APP, then generate an approve message and inform the reviewer.
+				Config: testAccDataServiceMessageApprove_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_any_message_pending_check", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataServiceMessageApprove_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_auth_action" "publish" {
+  depends_on = [huaweicloud_dataarts_dataservice_api_publishment.test]
+
+  workspace_id = "%[2]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  app_id      = huaweicloud_dataarts_dataservice_app.test[0].id
+  type        = "APPLY_TYPE_AUTHORIZE"
+}
+`, testAccDataServiceApiAuth_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID)
+}
+
+func testAccDataServiceMessageApprove_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api_auth_action" "unpublish" {
+  depends_on = [huaweicloud_dataarts_dataservice_api_publishment.test]
+
+  workspace_id = "%[2]s"
+
+  api_id      = huaweicloud_dataarts_dataservice_api.test.id
+  instance_id = try(data.huaweicloud_dataarts_dataservice_instances.test.instances[0].id, "")
+  app_id      = huaweicloud_dataarts_dataservice_app.test[0].id
+  type        = "APPLY_TYPE_API_CANCEL_AUTHORIZE"
+}
+
+data "huaweicloud_dataarts_dataservice_messages" "test" {
+  depends_on = [huaweicloud_dataarts_dataservice_api_auth_action.unpublish]
+
+  workspace_id = "%[2]s"
+
+  api_name = huaweicloud_dataarts_dataservice_api.test.name
+}
+
+locals {
+  pending_check_message_ids = [
+    for v in data.huaweicloud_dataarts_dataservice_messages.test.messages: v.id if v.api_apply_status == "STATUS_TYPE_PENDING_CHECK"
+  ]
+}
+
+output "is_any_message_pending_check" {
+  value = length(local.pending_check_message_ids) > 0
+}
+
+resource "huaweicloud_dataarts_dataservice_message_approve" "approve_immediately" {
+  workspace_id = "%[2]s"
+
+  message_id = try(local.pending_check_message_ids[0], "")
+  action     = 0
+
+  lifecycle {
+    ignore_changes = [
+      message_id,
+    ]
+  }
+}
+`, testAccDataServiceApiAuth_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID)
+}

--- a/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_messages.go
+++ b/huaweicloud/services/dataarts/data_source_huaweicloud_dataarts_dataservice_messages.go
@@ -1,0 +1,231 @@
+package dataarts
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio GET /v1/{project_id}/service/messages
+func DataSourceDataServiceMessages() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDataServiceMessagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the approval messages are located.`,
+			},
+
+			// Parameter in request header
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The workspace ID of the exclusive API to which the approval message belongs.`,
+			},
+
+			// Query argument
+			"api_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the API to be approved.`,
+			},
+
+			// Attribute
+			"messages": {
+				Type:        schema.TypeList,
+				Elem:        dataserviceMessageSchema(),
+				Computed:    true,
+				Description: `All approval messages that match the filter parameters.`,
+			},
+		},
+	}
+}
+
+func dataserviceMessageSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the approval message, in UUID format.`,
+			},
+			"api_apply_status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The apply status for API.`,
+			},
+			"api_apply_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The apply type.`,
+			},
+			"api_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The ID of the exclusive API to which the approval message belongs.`,
+			},
+			"api_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the exclusive API to which the approval message belongs.`,
+			},
+			"api_using_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The expiration time used by the API, in RFC3339 format.`,
+			},
+			"app_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The application ID of the API that has been bound (or is to be bound).`,
+			},
+			"app_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The application name of the API that has been bound (or is to be bound).`,
+			},
+			"apply_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The apply time, in RFC3339 format.`,
+			},
+			"approval_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The approval time of the approval message, in RFC3339 format.`,
+			},
+			"approver_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The approver name.`,
+			},
+			"comment": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The approval comment.`,
+			},
+			"user_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of applicant.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func buildDataServiceMessagesQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if appName, ok := d.GetOk("api_name"); ok {
+		res = fmt.Sprintf("%s&api_name=%v", res, appName)
+	}
+	return res
+}
+
+func queryDataServiceMessages(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v1/{project_id}/service/messages?limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildDataServiceMessagesQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    d.Get("workspace_id").(string),
+			"dlm-type":     "EXCLUSIVE",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		messages := utils.PathSearch("records", respBody, make([]interface{}, 0)).([]interface{})
+		result = append(result, messages...)
+		offset += len(messages)
+		// If the offset is greater than or equal to the total number, the first page of content will be queried instead
+		// of returning an empty page (record list).
+		if total := utils.PathSearch("total", respBody, float64(0)).(float64); offset >= int(total) {
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func flattenDataServiceMessages(messages []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(messages))
+
+	for _, message := range messages {
+		result = append(result, map[string]interface{}{
+			"id":               utils.PathSearch("id", message, nil),
+			"api_apply_status": utils.PathSearch("api_apply_status", message, nil),
+			"api_apply_type":   utils.PathSearch("api_apply_type", message, nil),
+			"api_id":           utils.PathSearch("api_id", message, nil),
+			"api_name":         utils.PathSearch("api_name", message, nil),
+			"api_using_time":   utils.FormatTimeStampRFC3339(int64(utils.PathSearch("api_using_time", message, float64(0)).(float64))/1000, false),
+			"app_id":           utils.PathSearch("app_id", message, nil),
+			"app_name":         utils.PathSearch("app_name", message, nil),
+			"apply_time":       utils.FormatTimeStampRFC3339(int64(utils.PathSearch("api_using_time", message, float64(0)).(float64))/1000, false),
+			"approval_time":    utils.FormatTimeStampRFC3339(int64(utils.PathSearch("api_using_time", message, float64(0)).(float64))/1000, false),
+			"approver_name":    utils.PathSearch("approver_name", message, nil),
+			"comment":          utils.PathSearch("comment", message, nil),
+			"user_name":        utils.PathSearch("user_name", message, nil),
+		})
+	}
+
+	return result
+}
+
+func dataSourceDataServiceMessagesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	messages, err := queryDataServiceMessages(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("messages", flattenDataServiceMessages(messages)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_message_approve.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_message_approve.go
@@ -1,0 +1,138 @@
+package dataarts
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DataArtsStudio POST /v1/{project_id}/service/messages
+func ResourceDataServiceMessageApprove() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDataServiceMessageApproveCreate,
+		ReadContext:   resourceDataServiceMessageApproveRead,
+		DeleteContext: resourceDataServiceMessageApproveDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the message (to be approved) is located.`,
+			},
+
+			// Parameter in request header
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The workspace ID of the exclusive API to which the message (to be approved) belongs.`,
+			},
+
+			// Arguments
+			"message_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The ID of the message (to be approved).`,
+			},
+			"action": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The approve action performed by the message.`,
+			},
+			"time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The execution time of the message action.`,
+			},
+		},
+	}
+}
+
+func buildMessageApproveBodyParams(d *schema.ResourceData) map[string]interface{} {
+	action := d.Get("action").(int)
+	result := map[string]interface{}{
+		"message_id": utils.ValueIgnoreEmpty(d.Get("message_id")),
+		"action":     action,
+	}
+
+	if action == 1 {
+		result["time"] = d.Get("time")
+	}
+	return result
+}
+
+func doMessageApprove(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	var (
+		httpUrl     = "v1/{project_id}/service/messages"
+		workspaceId = d.Get("workspace_id").(string)
+	)
+	debugPath := client.Endpoint + httpUrl
+	debugPath = strings.ReplaceAll(debugPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"workspace":    workspaceId,
+			"Dlm-Type":     "EXCLUSIVE",
+		},
+		JSONBody: buildMessageApproveBodyParams(d),
+		OkCodes:  []int{204},
+	}
+
+	_, err := client.Request("POST", debugPath, &opt)
+	return err
+}
+
+func resourceDataServiceMessageApproveCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("dataarts", region)
+	if err != nil {
+		return diag.Errorf("error creating DataArts Studio client: %s", err)
+	}
+
+	err = doMessageApprove(client, d)
+	if err != nil {
+		return diag.Errorf("error approving message: %s", err)
+	}
+
+	resourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(resourceId)
+
+	return resourceDataServiceMessageApproveRead(ctx, d, meta)
+}
+
+func resourceDataServiceMessageApproveRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// This resource is a one-time action resource used only for approval messages.
+	return nil
+}
+
+func resourceDataServiceMessageApproveDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is a one-time action resource used only for approval messages. Deleting this resource
+will not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source to query all approval messages (also supports a filter to query all approval messages for a specified API). And supports a new resource to manage approve requests.

![捕获](https://github.com/user-attachments/assets/58cef3b2-2e79-4a9e-9bc8-7a4d3c1e27cc)

![捕获](https://github.com/user-attachments/assets/f4653039-f210-481c-ab67-c7b4c14c7c73)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports a new data source to query all approval messages (also supports a filter to query all approval messages for a specified API).
2. supports a new resource to manage approve requests.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o dataarts -f TestAccDataServiceMessageApprove_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataServiceMessageApprove_basic -timeout 360m -parallel 10
=== RUN   TestAccDataServiceMessageApprove_basic
=== PAUSE TestAccDataServiceMessageApprove_basic
=== CONT  TestAccDataServiceMessageApprove_basic
--- PASS: TestAccDataServiceMessageApprove_basic (234.60s)
PASS
coverage: 14.7% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  234.680s        coverage: 14.7% of statements in ./huaweicloud/services/dataarts
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
