### PR TITLE
feat(ims): support `obs_system_image` resource

### DIFF
--- a/docs/resources/ims_obs_system_image.md
+++ b/docs/resources/ims_obs_system_image.md
@@ -1,0 +1,147 @@
+---
+subcategory: "Image Management Service (IMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ims_obs_system_image"
+description: |-
+  Manages an IMS system image resource created from external image file in the OBS bucket within HuaweiCloud.
+---
+
+# huaweicloud_ims_obs_system_image
+
+Manages an IMS system image resource created from external image file in the OBS bucket within HuaweiCloud.
+
+## Example Usage
+
+### Creating an IMS system image from an external image file in the OBS bucket
+
+```hcl
+variable "name" {}
+variable "image_url" {}
+variable "min_disk" {}
+
+resource "huaweicloud_ims_obs_system_image" "test" {
+  name      = var.name
+  image_url = var.image_url
+  min_disk  = var.min_disk
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the image.
+  The valid length is limited from `1` to `128` characters.
+  The first and last letters of the name cannot be spaces.
+  The name can contain uppercase letters, lowercase letters, numbers, spaces, chinese, and special characters (-._).
+
+* `image_url` - (Required, String, ForceNew) Specifies the URL of the external image file in the OBS bucket, the format
+  is **OBS bucket name:image file name**. Changing this parameter will create a new resource.
+
+* `min_disk` - (Required, Int, ForceNew) Specifies the minimum size of the system disk, in GB unit.
+  Changing this parameter will create a new resource.
+  + When the operating system is Linux, the value ranges from `10` to `1,024`.
+  + When the operating system is Windows, the value ranges from `20` to `1,024`.
+
+* `description` - (Optional, String) Specifies the description of the image.
+
+* `type` - (Optional, String, ForceNew) Specifies the image type. The value can be **ECS**, **FusionCompute**, **BMS**,
+  or **Ironic**. Defaults to **ECS**. Changing this parameter will create a new resource.
+  + Set to **ECS** or **FusionCompute** represent the creation of ECS server image.
+  + Set to **BMS** or **Ironic** represent the creation of BMS server image.
+
+* `is_config` - (Optional, Bool, ForceNew) Specifies whether to automatically configure. The value can be **true** or
+  **false**. Defaults to **false**. Changing this parameter will create a new resource.
+  About the content of automatic backend configuration, please refer to
+  [API docs](https://support.huaweicloud.com/intl/en-us/ims_faq/ims_faq_0020.html).
+
+* `cmk_id` - (Optional, String, ForceNew) Specifies the custom key for creating encrypted image.
+  Changing this parameter will create a new resource.
+
+* `is_quick_import` - (Optional, Bool, ForceNew) Specifies whether to use the image file quick import method to create
+  an image. The value can be **true** or **false**. Changing this parameter will create a new resource.
+  For constraints and limitations on fast import of image files,
+  please refer to [API docs](https://support.huaweicloud.com/intl/en-us/api-ims/ims_03_0605.html).
+
+-> 1. When the `is_quick_import` set to **true**, IMS will not parse the specified external image file, so the
+  `os_type`, `os_version`, and `architecture` parameters is based on the specified value.
+  <br/>2. When ignoring the `is_quick_import` or set to **false** , IMS will parse the external image file and confirm
+  the `os_type`, `os_version`, and `architecture` of the image, if parsing fails, the specified value shall prevail.
+
+* `os_type` - (Optional, String, ForceNew) Specifies the operating system type of the image. The value can be
+  **Windows** or **Linux**. Changing this parameter will create a new resource.
+
+* `os_version` - (Optional, String, ForceNew) Specifies the operating system version of the image. This field is
+  required when `is_quick_import` set to **true**. Changing this parameter will create a new resource.
+  For its values, see [API docs](https://support.huaweicloud.com/intl/en-us/api-ims/ims_03_0910.html).
+
+* `architecture` - (Optional, String, ForceNew) Specifies the schema type of the image. The value can be **x86** or
+  **arm**. Defaults to **x86**. Changing this parameter will create a new resource.
+
+* `max_ram` - (Optional, Int) Specifies the maximum memory of the image, in MB unit.
+
+* `min_ram` - (Optional, Int) Specifies the minimum memory of the image, in MB unit.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the image.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the IMS image belongs.
+  For enterprise users, if omitted, default enterprise project will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the image.
+
+* `status` - The status of the image. The value can be **active**, **queued**, **saving**, **deleted**, or **killed*,
+  only image with a status of **active** can be used.
+
+* `visibility` - Whether the image is visible to other tenants.
+
+* `image_size` - The size of the image file, in bytes unit.
+
+* `disk_format` - The image format. The value can be **zvhd2**, **vhd**, **zvhd**, **raw**, or **qcow2**.
+
+* `data_origin` - The image source. The format is **file,image_url**.
+
+* `active_at` - The time when the image status changes to active, in RFC3339 format.
+
+* `created_at` - The creation time of the image, in RFC3339 format.
+
+* `updated_at` - The last update time of the image, in RFC3339 format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The IMS OBS system image resource can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_ims_obs_system_image.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason. The missing attributes include: `type`, `is_config`, `is_quick_import`.
+It is generally recommended running `terraform plan` after importing the resource. You can then decide if changes should
+be applied to the resource, or the resource definition should be updated to align with the image. Also, you can ignore
+changes as below.
+
+```
+resource "huaweicloud_ims_obs_system_image" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      type, is_config, is_quick_import,
+    ]
+  }
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240828073004-17284ca38239
+	github.com/chnsz/golangsdk v0.0.0-20240829015804-ec51829ca93d
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240828073004-17284ca38239 h1:aDgnqqofGZmmPhVaa3Hlq6HAoHS8c/9NkrtZ3KFE7No=
-github.com/chnsz/golangsdk v0.0.0-20240828073004-17284ca38239/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240829015804-ec51829ca93d h1:68DdLyJ19Iick6g2kfQpegFdY27YwYuwHFgxSq9mS4w=
+github.com/chnsz/golangsdk v0.0.0-20240829015804-ec51829ca93d/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1547,6 +1547,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ims_ecs_whole_image":         ims.ResourceEcsWholeImage(),
 			"huaweicloud_ims_cbr_whole_image":         ims.ResourceCbrWholeImage(),
 			"huaweicloud_ims_evs_data_image":          ims.ResourceEvsDataImage(),
+			"huaweicloud_ims_obs_system_image":        ims.ResourceObsSystemImage(),
 			"huaweicloud_images_image":                ims.ResourceImsImage(),
 			"huaweicloud_images_image_copy":           ims.ResourceImsImageCopy(),
 			"huaweicloud_images_image_share":          ims.ResourceImsImageShare(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -258,6 +258,8 @@ var (
 	HW_IMS_VAULT_ID = os.Getenv("HW_IMS_VAULT_ID")
 	// The ID of the CBR backup
 	HW_IMS_BACKUP_ID = os.Getenv("HW_IMS_BACKUP_ID")
+	// The image file url in the OBS bucket
+	HW_IMS_IMAGE_URL = os.Getenv("HW_IMS_IMAGE_URL")
 	// The shared backup ID wants to accept.
 	HW_SHARED_BACKUP_ID = os.Getenv("HW_SHARED_BACKUP_ID")
 
@@ -1434,6 +1436,13 @@ func TestAccPreCheckImsVaultId(t *testing.T) {
 func TestAccPreCheckImsBackupId(t *testing.T) {
 	if HW_IMS_BACKUP_ID == "" {
 		t.Skip("HW_IMS_BACKUP_ID must be set for IMS whole image with CBR backup id")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckImsImageUrl(t *testing.T) {
+	if HW_IMS_IMAGE_URL == "" {
+		t.Skip("HW_IMS_IMAGE_URL must be set for IMS acceptance tests")
 	}
 }
 

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_obs_system_image_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_obs_system_image_test.go
@@ -1,0 +1,382 @@
+package ims
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+// This test case tests the creation of an ECS system image through an external image file in the OBS bucket.
+func TestAccObsSystemImage_basic(t *testing.T) {
+	var (
+		image        cloudimages.Image
+		rName        = acceptance.RandomAccResourceName()
+		rNameUpdate  = rName + "-update"
+		resourceName = "huaweicloud_ims_obs_system_image.test"
+		defaultEpsId = "0"
+		migrateEpsId = acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&image,
+		getImsImageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case need setting a non default enterprise project ID.
+			acceptance.TestAccPreCheckEpsID(t)
+			// This test requires ensuring that there is an image file in the OBS bucket.
+			acceptance.TestAccPreCheckImsImageUrl(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsSystemImage_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "image_url", acceptance.HW_IMS_IMAGE_URL),
+					resource.TestCheckResourceAttr(resourceName, "min_disk", "60"),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform description test"),
+					resource.TestCheckResourceAttr(resourceName, "os_type", "Windows"),
+					resource.TestCheckResourceAttr(resourceName, "os_version", "Windows Server 2019 Standard 64bit"),
+					resource.TestCheckResourceAttr(resourceName, "type", "ECS"),
+					resource.TestCheckResourceAttr(resourceName, "is_config", "true"),
+					resource.TestCheckResourceAttr(resourceName, "is_quick_import", "true"),
+					resource.TestCheckResourceAttr(resourceName, "architecture", "arm"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", defaultEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(resourceName, "visibility"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_size"),
+					resource.TestCheckResourceAttrSet(resourceName, "disk_format"),
+					resource.TestCheckResourceAttrSet(resourceName, "data_origin"),
+					resource.TestMatchResourceAttr(resourceName, "active_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "cmk_id", "huaweicloud_kms_key.test", "id"),
+				),
+			},
+			{
+				Config: testAccObsSystemImage_update1(rName, rNameUpdate, migrateEpsId, 2048, 1024),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", migrateEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+				),
+			},
+			{
+				Config: testAccObsSystemImage_update2(rName, rNameUpdate, defaultEpsId, 0, 0),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", defaultEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"type", "is_config", "is_quick_import",
+				},
+			},
+		},
+	})
+}
+
+func testAccObsSystemImage_base(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_kms_key" "test" {
+  key_alias    = "%[1]s"
+  pending_days = "7"
+  region       = "%[2]s"
+}
+`, rName, acceptance.HW_REGION_NAME)
+}
+
+func testAccObsSystemImage_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_obs_system_image" "test" {
+  name            = "%[2]s"
+  image_url       = "%[3]s"
+  min_disk        = 60
+  description     = "terraform description test"
+  os_type         = "Windows"
+  os_version      = "Windows Server 2019 Standard 64bit"
+  type            = "ECS"
+  is_config       = true
+  cmk_id          = huaweicloud_kms_key.test.id
+  is_quick_import = true
+  architecture    = "arm"
+  max_ram         = 4096
+  min_ram         = 2048
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccObsSystemImage_base(rName), rName, acceptance.HW_IMS_IMAGE_URL)
+}
+
+func testAccObsSystemImage_update1(rName, rNameUpdate, migrateEpsId string, maxRAM, minRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_obs_system_image" "test" {
+  name                  = "%[2]s"
+  image_url             = "%[3]s"
+  min_disk              = 60
+  os_type               = "Windows"
+  os_version            = "Windows Server 2019 Standard 64bit"
+  type                  = "ECS"
+  is_config             = true
+  cmk_id                = huaweicloud_kms_key.test.id
+  is_quick_import       = true
+  architecture          = "arm"
+  max_ram               = %[5]d
+  min_ram               = %[6]d
+  enterprise_project_id = "%[4]s"
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testAccObsSystemImage_base(rName), rNameUpdate, acceptance.HW_IMS_IMAGE_URL, migrateEpsId, maxRAM, minRAM)
+}
+
+func testAccObsSystemImage_update2(rName, rNameUpdate, defaultEpsId string, maxRAM, minRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_obs_system_image" "test" {
+  name                  = "%[2]s"
+  image_url             = "%[3]s"
+  min_disk              = 60
+  os_type               = "Windows"
+  os_version            = "Windows Server 2019 Standard 64bit"
+  type                  = "ECS"
+  is_config             = true
+  cmk_id                = huaweicloud_kms_key.test.id
+  is_quick_import       = true
+  architecture          = "arm"
+  max_ram               = %[5]d
+  min_ram               = %[6]d
+  enterprise_project_id = "%[4]s"
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testAccObsSystemImage_base(rName), rNameUpdate, acceptance.HW_IMS_IMAGE_URL, defaultEpsId, maxRAM, minRAM)
+}
+
+// This test case tests the creation of an BMS system image through an external image file in the OBS bucket.
+func TestAccObsSystemImage_withBMSType(t *testing.T) {
+	var (
+		image        cloudimages.Image
+		rName        = acceptance.RandomAccResourceName()
+		rNameUpdate  = rName + "-update"
+		resourceName = "huaweicloud_ims_obs_system_image.test"
+		defaultEpsId = "0"
+		migrateEpsId = acceptance.HW_ENTERPRISE_PROJECT_ID_TEST
+	)
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&image,
+		getImsImageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This test case need setting a non default enterprise project ID.
+			acceptance.TestAccPreCheckEpsID(t)
+			// This test requires ensuring that there is an image file in the OBS bucket.
+			acceptance.TestAccPreCheckImsImageUrl(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsSystemImage_withBMSType_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "image_url", acceptance.HW_IMS_IMAGE_URL),
+					resource.TestCheckResourceAttr(resourceName, "min_disk", "60"),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform description test"),
+					resource.TestCheckResourceAttr(resourceName, "type", "BMS"),
+					resource.TestCheckResourceAttr(resourceName, "is_config", "true"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", defaultEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(resourceName, "os_type"),
+					resource.TestCheckResourceAttrSet(resourceName, "os_version"),
+					resource.TestCheckResourceAttrSet(resourceName, "architecture"),
+					resource.TestCheckResourceAttrSet(resourceName, "visibility"),
+					resource.TestCheckResourceAttrSet(resourceName, "image_size"),
+					resource.TestCheckResourceAttrSet(resourceName, "disk_format"),
+					resource.TestCheckResourceAttrSet(resourceName, "data_origin"),
+					resource.TestMatchResourceAttr(resourceName, "active_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestCheckResourceAttrPair(resourceName, "cmk_id", "huaweicloud_kms_key.test", "id"),
+				),
+			},
+			{
+				Config: testAccObsSystemImage_withBMSType_update1(rName, rNameUpdate, migrateEpsId, 2048, 1024),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", migrateEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+				),
+			},
+			{
+				Config: testAccObsSystemImage_withBMSType_update2(rName, rNameUpdate, defaultEpsId, 0, 0),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", defaultEpsId),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"type", "is_config",
+				},
+			},
+		},
+	})
+}
+
+func testAccObsSystemImage_withBMSType_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_obs_system_image" "test" {
+  name        = "%[2]s"
+  image_url   = "%[3]s"
+  min_disk    = 60
+  description = "terraform description test"
+  type        = "BMS"
+  is_config   = true
+  cmk_id      = huaweicloud_kms_key.test.id
+  max_ram     = 4096
+  min_ram     = 2048
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccObsSystemImage_base(rName), rName, acceptance.HW_IMS_IMAGE_URL)
+}
+
+func testAccObsSystemImage_withBMSType_update1(rName, rNameUpdate, migrateEpsId string, maxRAM, minRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_obs_system_image" "test" {
+  name                  = "%[2]s"
+  image_url             = "%[3]s"
+  min_disk              = 60
+  type                  = "BMS"
+  is_config             = true
+  cmk_id                = huaweicloud_kms_key.test.id
+  max_ram               = %[5]d
+  min_ram               = %[6]d
+  enterprise_project_id = "%[4]s"
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testAccObsSystemImage_base(rName), rNameUpdate, acceptance.HW_IMS_IMAGE_URL, migrateEpsId, maxRAM, minRAM)
+}
+
+func testAccObsSystemImage_withBMSType_update2(rName, rNameUpdate, defaultEpsId string, maxRAM, minRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_obs_system_image" "test" {
+  name                  = "%[2]s"
+  image_url             = "%[3]s"
+  min_disk              = 60
+  type                  = "BMS"
+  is_config             = true
+  cmk_id                = huaweicloud_kms_key.test.id
+  max_ram               = %[5]d
+  min_ram               = %[6]d
+  enterprise_project_id = "%[4]s"
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testAccObsSystemImage_base(rName), rNameUpdate, acceptance.HW_IMS_IMAGE_URL, defaultEpsId, maxRAM, minRAM)
+}

--- a/huaweicloud/services/ims/resource_huaweicloud_ims_obs_system_image.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_obs_system_image.go
@@ -1,0 +1,280 @@
+package ims
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API IMS POST /v2/cloudimages/action
+// @API IMS GET /v1/{project_id}/jobs/{job_id}
+// @API IMS GET /v2/cloudimages
+// @API IMS GET /v2/{project_id}/images/{image_id}/tags
+// @API IMS PATCH /v2/cloudimages/{image_id}
+// @API IMS POST /v2/{project_id}/images/{image_id}/tags/action
+// @API IMS DELETE /v2/images/{image_id}
+func ResourceObsSystemImage() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceObsSystemImageCreate,
+		ReadContext:   resourceObsSystemImageRead,
+		UpdateContext: resourceObsSystemImageUpdate,
+		DeleteContext: resourceImageDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"image_url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"min_disk": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			// The `description` field can be left blank, so the `Computed` attribute is not used.
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"is_config": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"cmk_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"is_quick_import": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"os_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"architecture": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"max_ram": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"min_ram": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": common.TagsSchema(),
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			// Attributes
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"visibility": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_size": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disk_format": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"active_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceObsSystemImageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg        = meta.(*config.Config)
+		region     = cfg.GetRegion(d)
+		createResp *cloudimages.JobResponse
+	)
+
+	client, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v2 client: %s", err)
+	}
+
+	imageTags := buildCreateImageTagsParam(d)
+	createOpts := &cloudimages.CreateByOBSOpts{
+		Name:                d.Get("name").(string),
+		Description:         d.Get("description").(string),
+		OsType:              d.Get("os_type").(string),
+		OsVersion:           d.Get("os_version").(string),
+		ImageUrl:            d.Get("image_url").(string),
+		MinDisk:             d.Get("min_disk").(int),
+		IsConfig:            d.Get("is_config").(bool),
+		CmkId:               d.Get("cmk_id").(string),
+		ImageTags:           imageTags,
+		Type:                d.Get("type").(string),
+		MaxRam:              d.Get("max_ram").(int),
+		MinRam:              d.Get("min_ram").(int),
+		IsQuickImport:       d.Get("is_quick_import").(bool),
+		Architecture:        d.Get("architecture").(string),
+		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
+	}
+	createResp, err = cloudimages.CreateImageByOBS(client, createOpts).ExtractJobResponse()
+	if err != nil {
+		return diag.Errorf("error creating IMS OBS system image: %s", err)
+	}
+
+	imageId, err := waitForCreateImageCompleted(client, d, createResp.JobID)
+	if err != nil {
+		return diag.Errorf("error waiting for IMS OBS system image to complete: %s", err)
+	}
+
+	d.SetId(imageId)
+
+	return resourceObsSystemImageRead(ctx, d, meta)
+}
+
+func resourceObsSystemImageRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		mErr   *multierror.Error
+	)
+
+	client, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v2 client: %s", err)
+	}
+
+	imageList, err := GetImageList(client, d.Id())
+	if err != nil {
+		return diag.Errorf("error retrieving IMS OBS system images: %s", err)
+	}
+
+	// If the list API return empty, then process `CheckDeleted` logic.
+	if len(imageList) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "IMS OBS system image")
+	}
+
+	image := imageList[0]
+	imageTags := getImageTags(d, client)
+	mErr = multierror.Append(
+		d.Set("region", region),
+		d.Set("name", image.Name),
+		d.Set("image_url", getSpecificValueFormDataOrigin(image.DataOrigin, "file")),
+		d.Set("min_disk", image.MinDisk),
+		d.Set("description", image.Description),
+		d.Set("os_type", image.OsType),
+		d.Set("os_version", image.OsVersion),
+		d.Set("cmk_id", image.SystemCmkid),
+		d.Set("max_ram", getMaxRAM(image.MaxRam)),
+		d.Set("min_ram", image.MinRam),
+		d.Set("architecture", getArchitecture(image.SupportArm)),
+		d.Set("tags", imageTags),
+		d.Set("enterprise_project_id", image.EnterpriseProjectID),
+		d.Set("status", image.Status),
+		d.Set("visibility", image.Visibility),
+		d.Set("image_size", image.ImageSize),
+		d.Set("disk_format", image.DiskFormat),
+		d.Set("data_origin", image.DataOrigin),
+		d.Set("active_at", image.ActiveAt),
+		d.Set("created_at", image.CreatedAt.Format(time.RFC3339)),
+		d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getArchitecture(supportArm string) string {
+	if supportArm == "true" {
+		return "arm"
+	}
+
+	return "x86"
+}
+
+func resourceObsSystemImageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v2 client: %s", err)
+	}
+
+	err = updateImage(ctx, cfg, client, d)
+	if err != nil {
+		return diag.Errorf("error updating IMS OBS system image: %s", err)
+	}
+
+	return resourceObsSystemImageRead(ctx, d, meta)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages/requests.go
@@ -157,6 +157,8 @@ type CreateByOBSOpts struct {
 	Name string `json:"name" required:"true"`
 	// Description of image
 	Description string `json:"description,omitempty"`
+	// The OS type of the image
+	OsType string `json:"os_type,omitempty"`
 	// the OS version
 	OsVersion string `json:"os_version,omitempty"`
 	// the URL of the external image file in the OBS bucket
@@ -177,6 +179,10 @@ type CreateByOBSOpts struct {
 	MaxRam int `json:"max_ram,omitempty"`
 	// the minimum memory of the image in the unit of MB
 	MinRam int `json:"min_ram,omitempty"`
+	// Whether to use the image file quick import method to create an image
+	IsQuickImport bool `json:"is_quick_import,omitempty"`
+	// The schema type of the image
+	Architecture string `json:"architecture,omitempty"`
 	// Enterprise project ID
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240828073004-17284ca38239
+# github.com/chnsz/golangsdk v0.0.0-20240829015804-ec51829ca93d
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support `obs_system_image` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support `obs_system_image` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ export HW_ENTERPRISE_PROJECT_ID_TEST=xxxxxxx
$ export HW_IMS_IMAGE_URL=xxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccObsSystemImage_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccObsSystemImage_ -timeout 360m -parallel 4
=== RUN   TestAccObsSystemImage_basic
=== PAUSE TestAccObsSystemImage_basic
=== RUN   TestAccObsSystemImage_withBMSType
=== PAUSE TestAccObsSystemImage_withBMSType
=== CONT  TestAccObsSystemImage_basic
=== CONT  TestAccObsSystemImage_withBMSType
--- PASS: TestAccObsSystemImage_withBMSType (232.66s)
--- PASS: TestAccObsSystemImage_basic (232.91s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       232.974s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/68f2b4b3-5f77-45ea-9c82-a42653ee23d1)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/69c6273b-da38-4cca-8283-ad9747a635f5)

