### PR TITLE
feat(aom): add data source alarm rules templates

### DIFF
--- a/docs/data-sources/aom_alarm_rules_templates.md
+++ b/docs/data-sources/aom_alarm_rules_templates.md
@@ -1,0 +1,289 @@
+---
+subcategory: "Application Operations Management (AOM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aom_alarm_rules_templates"
+description: |-
+  Use this data source to get the list of AOM alarm rules templates.
+---
+
+# huaweicloud_aom_alarm_rules_templates
+
+Use this data source to get the list of AOM alarm rules templates.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_aom_alarm_rules_templates" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the templates belong.
+
+* `template_id` - (Optional, String) Specifies the template ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `templates` - Indicates the templates.
+  The [templates](#attrblock--templates) structure is documented below.
+
+<a name="attrblock--templates"></a>
+The `templates` block supports:
+
+* `id` - Indicates the template ID.
+
+* `name` - Indicates the template name.
+
+* `type` - Indicates the template type.
+
+* `alarm_template_spec_list` - Indicates the alarm template spec list.
+  The [alarm_template_spec_list](#attrblock--templates--alarm_template_spec_list) structure is documented below.
+
+* `templating` - Indicates the variable list.
+  The [templating](#attrblock--templates--templating) structure is documented below.
+
+* `description` - Indicates the template description.
+
+* `enterprise_project_id` - Indicates the enterprise project ID to which the template belongs.
+
+* `created_at` - Indicates the template create time.
+
+* `updated_at` - Indicates the template update time.
+
+<a name="attrblock--templates--alarm_template_spec_list"></a>
+The `alarm_template_spec_list` block supports:
+
+* `alarm_notification` - Indicates the alarm notification.
+  The [alarm_notification](#attrblock--templates--alarm_template_spec_list--alarm_notification) structure is documented
+  below.
+
+* `alarm_template_spec_items` - Indicates the alarm template spec items.
+  The [alarm_template_spec_items](#attrblock--templates--alarm_template_spec_list--alarm_template_spec_items) structure
+  is documented below.
+
+* `related_cloud_service` - Indicates the related cloud service.
+
+* `related_cce_clusters` - Indicates the related CCE clusters.
+
+* `related_prometheus_instances` - Indicates the related prometheus instances.
+
+<a name="attrblock--templates--alarm_template_spec_list--alarm_notification"></a>
+The `alarm_notification` block supports:
+
+* `bind_notification_rule_id` - Indicates the alarm action rule ID.
+
+* `notification_enable` - Indicates whether the alarm action rule enabled.
+
+* `notification_type` - Indicates the notification type.
+  Value can be as follows:
+  + **direct**: direct alarm reporting
+  + **alarm_policy**: alarm reporting after noise reduction
+
+* `notify_frequency` - Indicates the notification frequency.
+
+* `notify_resolved` - Indicates whether the notification enabled when an alarm is cleared.
+
+* `notify_triggered` - Indicates whether the notification enabled when an alarm is triggered.
+
+* `route_group_enable` - Indicates whether the grouping rule enabled.
+
+* `route_group_rule` - Indicates the grouping rule name.
+
+<a name="attrblock--templates--alarm_template_spec_list--alarm_template_spec_items"></a>
+The `alarm_template_spec_items` block supports:
+
+* `alarm_rule_description` - Indicates the alarm rule description.
+
+* `alarm_rule_name` - Indicates the alarm rule name.
+
+* `alarm_rule_type` - Indicates the alarm rule type.
+
+* `event_alarm_spec` - Indicates the event alarm spec.
+  The [event_alarm_spec](#attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--event_alarm_spec)
+  structure is documented below.
+
+* `metric_alarm_spec` - Indicates the metric alarm spec.
+  The [metric_alarm_spec](#attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec)
+  structure is documented below.
+
+<a name="attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--event_alarm_spec"></a>
+The `metric_alarm_spec` block supports:
+
+* `alarm_source` - Indicates the alarm source.
+
+* `alarm_subtype` - Indicates the alarm subtype.
+
+* `event_source` - Indicates the event source.
+
+* `monitor_object_templates` - Indicates the monitor object templates.
+
+* `monitor_objects` - Indicates the monitor objects.
+  Value can be as follows:
+  + **event_type**: notification type
+  + **event_severity**: alarm severity
+  + **event_name**: event name
+  + **namespace**: namespace
+  + **clusterId**: cluster ID
+  + **customField**: user-defined field
+
+* `trigger_conditions` - Indicates the trigger conditions.
+  The [trigger_conditions](#attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--trigger_conditions)
+  structure is documented below.
+
+<a name="attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--trigger_conditions"></a>
+The `trigger_conditions` block supports:
+
+* `aggregation_window` - Indicates the statistical period, in seconds.
+
+* `event_name` - Indicates the event name.
+
+* `frequency` - Indicates the event alarm notification frequency.
+
+* `operator` - Indicates the operator.
+
+* `thresholds` - Key-value pair. The key indicates the alarm severity while the value indicates the alarm threshold.
+
+* `trigger_type` - Indicates the trigger mode.
+  Value can be as follows:
+  + **immediately:** An alarm is triggered immediately if the alarm condition is met.
+  + **accumulative**: An alarm is triggered if the alarm condition is met for a specified number of times.
+
+<a name="attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec"></a>
+The `metric_alarm_spec` block supports:
+
+* `alarm_source` - Indicates the alarm source.
+
+* `alarm_subtype` - Indicates the alarm subtype.
+
+* `monitor_type` - Indicates the monitor_type.
+
+* `alarm_tags` - Indicates the alarm tags.
+  The [alarm_tags](#attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--alarm_tags)
+  structure is documented below.
+
+* `no_data_conditions` - Indicates the no data conditions.
+  The [no_data_conditions](#attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--no_data_conditions)
+  structure is documented below.
+
+* `recovery_conditions` - Indicates the recovery conditions.
+  The [recovery_conditions](#attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--recovery_conditions)
+  structure is documented below.
+
+* `trigger_conditions` - Indicates the trigger conditions.
+  The [trigger_conditions](#attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--trigger_conditions)
+  structure is documented below.
+
+<a name="attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--alarm_tags"></a>
+The `alarm_tags` block supports:
+
+* `auto_tags` - Indicates the automatic tag.
+
+* `custom_annotations` - Indicates the alarm annotation.
+
+* `custom_tags` - Indicates the custom tag.
+
+<a name="attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--no_data_conditions"></a>
+The `no_data_conditions` block supports:
+
+* `no_data_alert_state` - Indicates the status of the threshold rule when the data is insufficient.
+  Value can be as follows:
+  + **no_data**: A notification indicating insufficient data is sent.
+  + **alerting**: An alarm is triggered.
+  + **ok**: No exception occurs.
+  + **pre_state**: Retain the previous state.
+
+* `no_data_timeframe` - Indicates the number of periods without data.
+
+* `notify_no_data` - Indicates whether to send a notification when data is insufficient.
+
+<a name="attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--recovery_conditions"></a>
+The `recovery_conditions` block supports:
+
+* `recovery_timeframe` - Indicates the number of consecutive periods for which the trigger condition is not met to clear
+  an alarm.
+
+<a name="attrblock--templates--alarm_template_spec_list--alarm_template_spec_items--metric_alarm_spec--trigger_conditions"></a>
+The `trigger_conditions` block supports:
+
+* `aggregate_type` - Indicates the aggregation mode.
+  Value can be **by**, **avg**, **max**, **min** and **sum**.
+
+* `aggregation_type` - Indicates the statistical mode.
+  Value can be **average**, **minimum**, **maximum**, **sum** and **sampleCount**.
+
+* `aggregation_window` - Indicates the statistical period.
+
+* `aom_monitor_level` - Indicates the monitoring layer.
+
+* `expression` - Indicates the expression of a combined operation.
+
+* `metric_labels` - Indicates the metric dimension.
+
+* `metric_name` - Indicates the metric name.
+
+* `metric_namespace` - Indicates the metric namespace.
+
+* `metric_query_mode` - Indicates the metric query mode.
+  Value can be as follows:
+  + **AOM**: native AOM
+  + **PROM**: AOM Prometheus
+  + **NATIVE_PROM**: native Prometheus
+
+* `metric_statistic_method` - Indicates the metric statistics method to be used.
+  Value can be as follows:
+  + **single**: single metric
+  + **mix**: multi-metric combined operations
+
+* `metric_unit` - Indicates the metric unit.
+
+* `mix_promql` - Indicates the promQL of a combined operation.
+
+* `operator` - Indicates the operator.
+
+* `promql` - Indicates the prometheus statement.
+
+* `promql_expr` - Indicates the prometheus statement template.
+
+* `promql_for` - Indicates the native Prometheus monitoring duration.
+
+* `query_match` - Indicates the query filter criteria.
+
+* `thresholds` - Key-value pair. The key indicates the alarm severity while the value indicates the alarm threshold.
+
+* `trigger_interval` - Indicates the check interval.
+
+* `trigger_times` - Indicates the number of consecutive periods.
+
+* `trigger_type` - Indicates the trigger type.
+  Value can be as follows:
+  + **FIXED_RATE**: fixed interval
+  + **HOURLY**: every hour
+  + **DAILY**: every day
+  + **WEEKLY**: every week
+  + **CRON**: Cron expression
+
+<a name="attrblock--templates--templating"></a>
+The `templating` block supports:
+
+* `list` - Indicates the variable list.
+  The [list](#attrblock--templates--templating--list) structure is documented below.
+
+<a name="attrblock--templates--templating--list"></a>
+The `list` block supports:
+
+* `description` - Indicates the variable description.
+
+* `name` - Indicates the variable name.
+
+* `query` - Indicates the variable value.
+
+* `type` - Indicates the variable type.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -420,6 +420,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aom_dashboards_folders":              aom.DataSourceDashboardsFolders(),
 			"huaweicloud_aom_alarm_rules":                     aom.DataSourceAlarmRules(),
 			"huaweicloud_aom_dashboards":                      aom.DataSourceDashboards(),
+			"huaweicloud_aom_alarm_rules_templates":           aom.DataSourceAlarmRulesTemplates(),
 
 			"huaweicloud_apig_acl_policies":                       apig.DataSourceAclPolicies(),
 			"huaweicloud_apig_api_associated_acl_policies":        apig.DataSourceApiAssociatedAclPolicies(),

--- a/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_alarm_rules_templates_test.go
+++ b/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_alarm_rules_templates_test.go
@@ -1,0 +1,56 @@
+package aom
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAlarmRulesTemplates_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_aom_alarm_rules_templates.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAlarmRulesTemplates_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "templates.#"),
+
+					resource.TestCheckOutput("id_filter_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAlarmRulesTemplates_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_aom_alarm_rules_templates" "test" {
+  depends_on = [huaweicloud_aom_alarm_rules_template.test]
+}
+
+data "huaweicloud_aom_alarm_rules_templates" "id_filter" {
+  template_id = huaweicloud_aom_alarm_rules_template.test.id
+}
+
+locals {
+  test_id_filter_results = data.huaweicloud_aom_alarm_rules_templates.id_filter
+}
+
+output "id_filter_validation" {
+  value = alltrue([for v in local.test_id_filter_results.templates[*].id : v == huaweicloud_aom_alarm_rules_template.test.id])
+}
+`, testAlarmRulesTemplate_basic(name))
+}

--- a/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_rules.go
+++ b/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_rules.go
@@ -20,7 +20,7 @@ import (
 // @API AOM GET /v4/{project_id}/alarm-rules
 func DataSourceAlarmRules() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceAlarmPolicesRead,
+		ReadContext: dataSourceAlarmRulesRead,
 
 		Schema: map[string]*schema.Schema{
 			"region": {
@@ -415,7 +415,7 @@ func dataSourceSchemeAlarmNotifications() *schema.Schema {
 	}
 }
 
-func dataSourceAlarmPolicesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAlarmRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
 	client, err := cfg.NewServiceClient("aom", region)

--- a/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_rules_templates.go
+++ b/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_rules_templates.go
@@ -1,0 +1,481 @@
+package aom
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AOM GET /v4/{project_id}/alarm-rules-template
+func DataSourceAlarmRulesTemplates() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlarmRulesTemplatesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"templates": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alarm_template_spec_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"related_cloud_service": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"related_cce_clusters": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"related_prometheus_instances": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"alarm_notification": dataSourceSchemeAlarmNotifications(),
+									"alarm_template_spec_items": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"alarm_rule_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"alarm_rule_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"alarm_rule_description": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"event_alarm_spec":  dataSourceSchemeEventAlarmTemplateSpec(),
+												"metric_alarm_spec": dataSourceSchemeMetricAlarmTemplateSpec(),
+											},
+										},
+									},
+								},
+							},
+						},
+						"templating": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"query": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"description": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enterprise_project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSchemeEventAlarmTemplateSpec() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"alarm_subtype": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"alarm_source": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"event_source": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"trigger_conditions": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"trigger_type": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"event_name": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"thresholds": {
+								Type:     schema.TypeMap,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeInt},
+							},
+							"aggregation_window": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"operator": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"frequency": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"monitor_objects": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeMap,
+						Elem: &schema.Schema{Type: schema.TypeString},
+					},
+				},
+				"monitor_object_templates": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSchemeMetricAlarmTemplateSpec() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"alarm_subtype": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"alarm_source": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"monitor_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"recovery_conditions": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"recovery_timeframe": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"trigger_conditions": dataSourceSchemeTemplateMetricTriggerConditions(),
+				"no_data_conditions": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"no_data_timeframe": {
+								Type:     schema.TypeInt,
+								Computed: true,
+							},
+							"no_data_alert_state": {
+								Type:     schema.TypeString,
+								Computed: true,
+							},
+							"notify_no_data": {
+								Type:     schema.TypeBool,
+								Computed: true,
+							},
+						},
+					},
+				},
+				"alarm_tags": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"auto_tags": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"custom_tags": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+							"custom_annotations": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceSchemeTemplateMetricTriggerConditions() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"metric_query_mode": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"metric_name": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"promql": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aggregation_window": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"query_match": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aggregate_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"metric_labels": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"aggregation_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"operator": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"thresholds": {
+					Type:     schema.TypeMap,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"trigger_times": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"trigger_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"trigger_interval": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"expression": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"mix_promql": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"metric_statistic_method": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"metric_namespace": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"metric_unit": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"promql_expr": {
+					Type:     schema.TypeList,
+					Computed: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+				"promql_for": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"aom_monitor_level": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlarmRulesTemplatesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aom", region)
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	templates, err := getAlarmRulesTemplates(cfg, client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID")
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("templates", templates),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getAlarmRulesTemplates(cfg *config.Config, client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	listHttpUrl := "v4/{project_id}/alarm-rules-template"
+	listPath := client.Endpoint + listHttpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildListAlarmRulesTemplatesQueryParams(d)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      buildHeadersForDataSource(cfg, d),
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving alarm rules templates: %s", err)
+	}
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flattening alarm rules templates: %s", err)
+	}
+
+	templates := listRespBody.([]interface{})
+	results := make([]map[string]interface{}, 0, len(templates))
+	for _, template := range templates {
+		results = append(results, flattenAlarmRulesTemplates(template))
+	}
+
+	return results, nil
+}
+
+func flattenAlarmRulesTemplates(template interface{}) map[string]interface{} {
+	rst := map[string]interface{}{
+		"name":                  utils.PathSearch("alarm_rule_template_name", template, nil),
+		"id":                    utils.PathSearch("alarm_rule_template_id", template, nil),
+		"type":                  utils.PathSearch("alarm_rule_template_type", template, nil),
+		"description":           utils.PathSearch("alarm_rule_template_description", template, nil),
+		"enterprise_project_id": utils.PathSearch("enterprise_project_id", template, nil),
+		"alarm_template_spec_list": flattenTemplateSpecList(
+			utils.PathSearch("alarm_template_spec_list", template, make([]interface{}, 0)).([]interface{})),
+		"templating": flattenTemplating(utils.PathSearch("templating", template, nil)),
+		"created_at": utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("create_time", template, float64(0)).(float64))/1000, true),
+		"updated_at": utils.FormatTimeStampRFC3339(
+			int64(utils.PathSearch("modify_time", template, float64(0)).(float64))/1000, true),
+	}
+	return rst
+}
+
+func buildListAlarmRulesTemplatesQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("template_id"); ok {
+		res = fmt.Sprintf("%s?id=%v", res, v)
+	}
+
+	return res
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add data source alarm rules templates.


## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 go test .\huaweicloud\services\acceptance\aom -v -run TestAccDataSourceAlarmRulesTemplates_basic
=== RUN   TestAccDataSourceAlarmRulesTemplates_basic
=== PAUSE TestAccDataSourceAlarmRulesTemplates_basic
=== CONT  TestAccDataSourceAlarmRulesTemplates_basic
--- PASS: TestAccDataSourceAlarmRulesTemplates_basic (22.65s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       22.755s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
