### PR TITLE
fix(dataarts/dataservice): API can create and update with or without params now

### DIFF
--- a/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_api_test.go
+++ b/huaweicloud/services/acceptance/dataarts/resource_huaweicloud_dataarts_dataservice_api_test.go
@@ -401,6 +401,7 @@ func TestAccDataServiceApi_simple(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
+				// Create an API without request parameters.
 				Config: testAccDataServiceApi_simple_step1(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
@@ -412,7 +413,7 @@ func TestAccDataServiceApi_simple(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "manager", acceptance.HW_DATAARTS_REVIEWER_NAME),
 					resource.TestCheckResourceAttr(rName, "path", fmt.Sprintf("/simple/%s", name)),
 					resource.TestCheckResourceAttr(rName, "protocol", "PROTOCOL_TYPE_HTTPS"),
-					resource.TestCheckResourceAttr(rName, "request_type", "REQUEST_TYPE_GET"),
+					resource.TestCheckResourceAttr(rName, "request_type", "REQUEST_TYPE_POST"),
 					resource.TestCheckResourceAttr(rName, "request_params.#", "0"),
 					resource.TestCheckResourceAttr(rName, "datasource_config.0.backend_params.#", "0"),
 					resource.TestCheckResourceAttr(rName, "datasource_config.0.response_params.#", "1"),
@@ -423,6 +424,40 @@ func TestAccDataServiceApi_simple(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "datasource_config.0.order_params.#", "0"),
 					resource.TestCheckResourceAttrSet(rName, "create_user"),
 					resource.TestCheckResourceAttrSet(rName, "created_at"),
+				),
+			},
+			{
+				// Supports an request parameter and setting the corresponding backend parameter.
+				Config: testAccDataServiceApi_simple_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "request_params.#", "1"),
+					resource.TestCheckResourceAttr(rName, "request_params.0.name", "configuration"),
+					resource.TestCheckResourceAttr(rName, "request_params.0.position", "REQUEST_PARAMETER_POSITION_BODY"),
+					resource.TestCheckResourceAttr(rName, "request_params.0.type", "REQUEST_PARAMETER_TYPE_STRING"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.backend_params.#", "1"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.backend_params.0.name", "configuration"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.backend_params.0.mapping", "configuration"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.backend_params.0.condition", "CONDITION_TYPE_EQ"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.response_params.#", "1"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.order_params.#", "0"),
+					resource.TestCheckResourceAttrSet(rName, "updated_at"),
+				),
+			},
+			{
+				// Remove the request parameter and update the field mapping to the order parameter.
+				Config: testAccDataServiceApi_simple_step3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "request_params.#", "0"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.backend_params.#", "0"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.response_params.#", "1"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.order_params.#", "1"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.order_params.0.name", "order_configuration"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.order_params.0.field", "configuration"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.order_params.0.optional", "true"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.order_params.0.sort", "ASC"),
+					resource.TestCheckResourceAttr(rName, "datasource_config.0.order_params.0.order", "1"),
 				),
 			},
 			{
@@ -440,7 +475,7 @@ func TestAccDataServiceApi_simple(t *testing.T) {
 	})
 }
 
-func testAccDataServiceApi_simple_step1(name string) string {
+func testAccDataServiceApi_simple_base(name string) string {
 	return fmt.Sprintf(`
 // Under root path.
 resource "huaweicloud_dataarts_dataservice_catalog" "test" {
@@ -464,27 +499,33 @@ resource "huaweicloud_dli_table" "test" {
     description = "The configuration for automatic creation, in JSON format"
   }
 }
+`, acceptance.HW_DATAARTS_WORKSPACE_ID, name)
+}
+
+func testAccDataServiceApi_simple_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
 
 resource "huaweicloud_dataarts_dataservice_api" "test" {
-  workspace_id = "%[1]s"
+  workspace_id = "%[2]s"
   dlm_type     = "EXCLUSIVE"
 
   type         = "API_SPECIFIC_TYPE_CONFIGURATION"
   catalog_id   = huaweicloud_dataarts_dataservice_catalog.test.id
-  name         = "%[2]s"
+  name         = "%[3]s"
   auth_type    = "APP"
-  manager      = "%[3]s"
-  path         = "/simple/%[2]s"
+  manager      = "%[4]s"
+  path         = "/simple/%[3]s"
   protocol     = "PROTOCOL_TYPE_HTTPS"
-  request_type = "REQUEST_TYPE_GET"
+  request_type = "REQUEST_TYPE_POST"
   visibility   = "PROJECT"
 
   datasource_config {
     type          = "DLI"
-    connection_id = "%[4]s"
+    connection_id = "%[5]s"
     database      = huaweicloud_dli_database.test.name
     datatable     = huaweicloud_dli_table.test.name
-    queue         = "%[5]s"
+    queue         = "%[6]s"
 
     response_params {
       name  = "configuration"
@@ -493,7 +534,106 @@ resource "huaweicloud_dataarts_dataservice_api" "test" {
     }
   }
 }
-`, acceptance.HW_DATAARTS_WORKSPACE_ID,
+`, testAccDataServiceApi_simple_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID,
+		name,
+		acceptance.HW_DATAARTS_REVIEWER_NAME,
+		acceptance.HW_DATAARTS_CONNECTION_ID,
+		acceptance.HW_DATAARTS_DLI_QUEUE_NAME)
+}
+
+func testAccDataServiceApi_simple_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api" "test" {
+  workspace_id = "%[2]s"
+  dlm_type     = "EXCLUSIVE"
+
+  type         = "API_SPECIFIC_TYPE_CONFIGURATION"
+  catalog_id   = huaweicloud_dataarts_dataservice_catalog.test.id
+  name         = "%[3]s"
+  auth_type    = "APP"
+  manager      = "%[4]s"
+  path         = "/simple/%[3]s"
+  protocol     = "PROTOCOL_TYPE_HTTPS"
+  request_type = "REQUEST_TYPE_POST"
+  visibility   = "PROJECT"
+
+  request_params {
+    name     = "configuration"
+    position = "REQUEST_PARAMETER_POSITION_BODY"
+    type     = "REQUEST_PARAMETER_TYPE_STRING"
+  }
+
+  datasource_config {
+    type          = "DLI"
+    connection_id = "%[5]s"
+    database      = huaweicloud_dli_database.test.name
+    datatable     = huaweicloud_dli_table.test.name
+    queue         = "%[6]s"
+
+    backend_params {
+      name      = "configuration"
+      mapping   = "configuration"
+      condition = "CONDITION_TYPE_EQ"
+    }
+    response_params {
+      name  = "configuration"
+      type  = "REQUEST_PARAMETER_TYPE_STRING"
+      field = "configuration"
+    }
+  }
+}
+`, testAccDataServiceApi_simple_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID,
+		name,
+		acceptance.HW_DATAARTS_REVIEWER_NAME,
+		acceptance.HW_DATAARTS_CONNECTION_ID,
+		acceptance.HW_DATAARTS_DLI_QUEUE_NAME)
+}
+
+func testAccDataServiceApi_simple_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dataarts_dataservice_api" "test" {
+  workspace_id = "%[2]s"
+  dlm_type     = "EXCLUSIVE"
+
+  type         = "API_SPECIFIC_TYPE_CONFIGURATION"
+  catalog_id   = huaweicloud_dataarts_dataservice_catalog.test.id
+  name         = "%[3]s"
+  auth_type    = "APP"
+  manager      = "%[4]s"
+  path         = "/simple/%[3]s"
+  protocol     = "PROTOCOL_TYPE_HTTPS"
+  request_type = "REQUEST_TYPE_GET"
+  visibility   = "PROJECT"
+
+  datasource_config {
+    type          = "DLI"
+    connection_id = "%[5]s"
+    database      = huaweicloud_dli_database.test.name
+    datatable     = huaweicloud_dli_table.test.name
+    queue         = "%[6]s"
+
+    response_params {
+      name  = "configuration"
+      type  = "REQUEST_PARAMETER_TYPE_STRING"
+      field = "configuration"
+    }
+    order_params {
+      name     = "order_configuration"
+      field    = "configuration"
+      optional = true
+      sort     = "ASC"
+      order    = 1
+    }
+  }
+}
+`, testAccDataServiceApi_simple_base(name),
+		acceptance.HW_DATAARTS_WORKSPACE_ID,
 		name,
 		acceptance.HW_DATAARTS_REVIEWER_NAME,
 		acceptance.HW_DATAARTS_CONNECTION_ID,

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api.go
@@ -562,28 +562,26 @@ func apiHostsSchema() *schema.Resource {
 
 func buildModifyDataServiceApiBodyParams(client *golangsdk.ServiceClient, d *schema.ResourceData, workspaceId string) map[string]interface{} {
 	bodyParams := map[string]interface{}{
+		// Required
 		"catalog_id":        d.Get("catalog_id"),
 		"name":              d.Get("name"),
-		"description":       d.Get("description"),
 		"api_type":          d.Get("type"),
 		"auth_type":         d.Get("auth_type"),
-		"manager":           d.Get("manager"),
-		"path":              d.Get("path"),
 		"protocol":          d.Get("protocol"),
+		"path":              d.Get("path"),
 		"request_type":      d.Get("request_type"),
-		"visibility":        d.Get("visibility"),
-		"request_paras":     buildApiRequestParamsBodyParams(d.Get("request_params").(*schema.Set)),
+		"manager":           d.Get("manager"),
 		"datasource_config": buildApiDataSourceConfigBodyParams(client, workspaceId, d.Get("datasource_config").([]interface{})),
-		"backend_config":    utils.RemoveNil(buildApiBackendConfigBodyParams(d.Get("backend_config").([]interface{}))),
+		// Optional
+		"description":    d.Get("description"),
+		"visibility":     d.Get("visibility"),
+		"request_paras":  buildApiRequestParamsBodyParams(d.Get("request_params").(*schema.Set)),
+		"backend_config": utils.RemoveNil(buildApiBackendConfigBodyParams(d.Get("backend_config").([]interface{}))),
 	}
 	return bodyParams
 }
 
 func buildApiRequestParamsBodyParams(params *schema.Set) []interface{} {
-	if params.Len() < 1 {
-		return nil
-	}
-
 	result := make([]interface{}, 0, params.Len())
 	for _, val := range params.List() {
 		result = append(result, map[string]interface{}{
@@ -832,7 +830,7 @@ func resourceDataServiceApiCreate(ctx context.Context, d *schema.ResourceData, m
 			"workspace":    workspaceId,
 			"Dlm-Type":     dlmType,
 		},
-		JSONBody: utils.RemoveNil(buildModifyDataServiceApiBodyParams(client, d, workspaceId)),
+		JSONBody: buildModifyDataServiceApiBodyParams(client, d, workspaceId),
 	}
 
 	requestResp, err := client.Request("POST", createPath, &opt)

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api.go
@@ -130,7 +130,6 @@ func ResourceDataServiceApi() *schema.Resource {
 			"request_params": {
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Computed:    true,
 				Elem:        apiRequestParamsElemSchema(),
 				Description: `The parameters of the API request.`,
 			},
@@ -330,7 +329,6 @@ func apiDataSourceConfigResponseParamsElemSchema() *schema.Resource {
 			"example_value": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
 				Description: `The example value of the response parameter.`,
 			},
 		},
@@ -761,11 +759,11 @@ func buildApiBackendConfigBodyParams(params []interface{}) map[string]interface{
 
 	// The default integer triggers the structure change.
 	return map[string]interface{}{
-		"type":     utils.StringIgnoreEmpty(utils.PathSearch("type", params[0], "").(string)),
-		"protocol": utils.StringIgnoreEmpty(utils.PathSearch("protocol", params[0], "").(string)),
-		"host":     utils.StringIgnoreEmpty(utils.PathSearch("host", params[0], "").(string)),
-		"path":     utils.StringIgnoreEmpty(utils.PathSearch("path", params[0], "").(string)),
-		"timeout":  utils.IntIgnoreEmpty(utils.PathSearch("timeout", params[0], 0).(int)),
+		"type":     utils.ValueIgnoreEmpty(utils.PathSearch("type", params[0], "").(string)),
+		"protocol": utils.ValueIgnoreEmpty(utils.PathSearch("protocol", params[0], "").(string)),
+		"host":     utils.ValueIgnoreEmpty(utils.PathSearch("host", params[0], "").(string)),
+		"path":     utils.ValueIgnoreEmpty(utils.PathSearch("path", params[0], "").(string)),
+		"timeout":  utils.ValueIgnoreEmpty(utils.PathSearch("timeout", params[0], 0).(int)),
 		"backend_paras": buildApiBackendConfigBackendParamsBodyParams(utils.PathSearch("backend_params",
 			params[0], schema.NewSet(schema.HashString, nil)).(*schema.Set)),
 		"constant_paras": buildApiBackendConfigConstantParamsBodyParams(utils.PathSearch("backend_params",
@@ -1166,7 +1164,7 @@ func resourceDataServiceApiUpdate(ctx context.Context, d *schema.ResourceData, m
 			"workspace":    workspaceId,
 			"Dlm-Type":     dlmType,
 		},
-		JSONBody: utils.RemoveNil(buildModifyDataServiceApiBodyParams(client, d, workspaceId)),
+		JSONBody: buildModifyDataServiceApiBodyParams(client, d, workspaceId),
 	}
 
 	_, err = client.Request("PUT", createPath, &opt)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Before fixing, the API cannot left the list of request parameters empty, because of the request value of the OpenAPI must be an empty value, not `null`.
Also supports this function in the update method.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. we can create or update the API with or without parameter configuration.
2. supports a new test case to test this function.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o dataarts -f TestAccDataServiceApi_
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccDataServiceApi_ -timeout 360m -parallel 10
=== RUN   TestAccDataServiceApi_basic
=== PAUSE TestAccDataServiceApi_basic
=== RUN   TestAccDataServiceApi_simple
=== PAUSE TestAccDataServiceApi_simple
=== CONT  TestAccDataServiceApi_basic
=== CONT  TestAccDataServiceApi_simple
--- PASS: TestAccDataServiceApi_basic (94.68s)
--- PASS: TestAccDataServiceApi_simple (119.67s)
PASS
coverage: 9.3% of statements in ./huaweicloud/services/dataarts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  119.739s        coverage: 9.3% of statements in ./huaweicloud/services/dataarts
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
