### PR TITLE
feat(cce): replace service_network_cidr and support lts_reclaim_polic…

### DIFF
--- a/docs/resources/cce_cluster.md
+++ b/docs/resources/cce_cluster.md
@@ -330,6 +330,13 @@ The following arguments are supported:
 * `delete_all` - (Optional, String) Specified whether to delete all associated storage resources when deleting the CCE
   cluster. valid values are **true**, **try** and **false**. Default is **false**.
 
+* `lts_reclaim_policy` - (Optional, String) Specified whether to delete LTS resources when deleting the CCE cluster.
+  Valid values are:
+  + **Delete_Log_Group**: Delete the log group, ignore it if it fails, and continue with the subsequent process.
+  + **Delete_Master_Log_Stream**: Delete the the log stream, ignore it if it fails, and continue the subsequent process.
+  The default option.
+  + **Retain**: Skip the deletion process.
+
 * `hibernate` - (Optional, Bool) Specifies whether to hibernate the CCE cluster. Defaults to **false**. After a cluster is
   hibernated, resources such as workloads cannot be created or managed in the cluster, and the cluster cannot be
   deleted.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240829015804-ec51829ca93d
+	github.com/chnsz/golangsdk v0.0.0-20240829112004-4c29a61a0558
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240829015804-ec51829ca93d h1:68DdLyJ19Iick6g2kfQpegFdY27YwYuwHFgxSq9mS4w=
-github.com/chnsz/golangsdk v0.0.0-20240829015804-ec51829ca93d/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240829112004-4c29a61a0558 h1:9KOx02tDyYGw5ymNJczMFHHJPe2YVUcoWAwJwWLnTMo=
+github.com/chnsz/golangsdk v0.0.0-20240829112004-4c29a61a0558/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/requests.go
@@ -243,14 +243,15 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 }
 
 type DeleteOpts struct {
-	ErrorStatus string `q:"errorStatus"`
-	DeleteEfs   string `q:"delete_efs"`
-	DeleteENI   string `q:"delete_eni"`
-	DeleteEvs   string `q:"delete_evs"`
-	DeleteNet   string `q:"delete_net"`
-	DeleteObs   string `q:"delete_obs"`
-	DeleteSfs   string `q:"delete_sfs"`
-	DeleteSfs30 string `q:"delete_sfs30"`
+	ErrorStatus      string `q:"errorStatus"`
+	DeleteEfs        string `q:"delete_efs"`
+	DeleteENI        string `q:"delete_eni"`
+	DeleteEvs        string `q:"delete_evs"`
+	DeleteNet        string `q:"delete_net"`
+	DeleteObs        string `q:"delete_obs"`
+	DeleteSfs        string `q:"delete_sfs"`
+	DeleteSfs30      string `q:"delete_sfs30"`
+	LtsReclaimPolicy string `q:"lts_reclaim_policy"`
 }
 
 type DeleteOptsBuilder interface {

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/clusters/results.go
@@ -73,6 +73,8 @@ type Spec struct {
 	Masters []MasterSpec `json:"masters,omitempty"`
 	//Range of kubernetes clusterIp
 	KubernetesSvcIPRange string `json:"kubernetesSvcIpRange,omitempty"`
+	// Service network, use this to replace KubernetesSvcIPRange
+	ServiceNetwork *ServiceNetwork `json:"serviceNetwork,omitempty"`
 	//Custom san list for certificates
 	CustomSan []string `json:"customSan,omitempty"`
 	// Tags of cluster, key value pair format
@@ -87,6 +89,10 @@ type Spec struct {
 	SupportIstio bool `json:"supportIstio,omitempty"`
 	// The category, the value can be CCE and CCE
 	Category string `json:"category,omitempty"`
+}
+
+type ServiceNetwork struct {
+	IPv4Cidr string `json:"IPv4CIDR,omitempty"`
 }
 
 type PackageConfiguration struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240829015804-ec51829ca93d
+# github.com/chnsz/golangsdk v0.0.0-20240829112004-4c29a61a0558
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
…y in cluster

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. `KubernetesSvcIPRange` is deprecated by API, replace it with `ServiceNetwork`
2. support `lts_reclaim_policy` in delete func

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccCluster -timeout 360m -parallel 4
=== RUN   TestAccClusterCertificateDataSource_basic
=== PAUSE TestAccClusterCertificateDataSource_basic
=== RUN   TestAccClusterOpenIDJWKSDataSource_basic
=== PAUSE TestAccClusterOpenIDJWKSDataSource_basic
=== RUN   TestAccClusterLogConfig_basic
=== PAUSE TestAccClusterLogConfig_basic
=== RUN   TestAccCluster_basic
=== PAUSE TestAccCluster_basic
=== RUN   TestAccCluster_prePaid
=== PAUSE TestAccCluster_prePaid
=== RUN   TestAccCluster_withEip
=== PAUSE TestAccCluster_withEip
=== RUN   TestAccCluster_withEpsId
=== PAUSE TestAccCluster_withEpsId
=== RUN   TestAccCluster_turbo
=== PAUSE TestAccCluster_turbo
=== RUN   TestAccCluster_hibernate
=== PAUSE TestAccCluster_hibernate
=== RUN   TestAccCluster_multiContainerNetworkCidrs
=== PAUSE TestAccCluster_multiContainerNetworkCidrs
=== RUN   TestAccCluster_secGroup
=== PAUSE TestAccCluster_secGroup
=== RUN   TestAccCluster_resize
=== PAUSE TestAccCluster_resize
=== RUN   TestAccCluster_resizePeriod
=== PAUSE TestAccCluster_resizePeriod
=== CONT  TestAccClusterCertificateDataSource_basic
=== CONT  TestAccCluster_turbo
=== CONT  TestAccCluster_prePaid
=== CONT  TestAccCluster_withEpsId
=== CONT  TestAccCluster_prePaid
    acceptance.go:850: This environment does not support prepaid tests
--- SKIP: TestAccCluster_prePaid (0.02s)
=== CONT  TestAccCluster_withEip
--- PASS: TestAccClusterCertificateDataSource_basic (522.85s)
=== CONT  TestAccCluster_secGroup
--- PASS: TestAccCluster_withEip (569.28s)
=== CONT  TestAccCluster_resizePeriod
    acceptance.go:850: This environment does not support prepaid tests
--- SKIP: TestAccCluster_resizePeriod (0.01s)
=== CONT  TestAccCluster_resize
--- PASS: TestAccCluster_withEpsId (603.47s)
=== CONT  TestAccCluster_multiContainerNetworkCidrs
--- PASS: TestAccCluster_turbo (626.07s)
=== CONT  TestAccClusterLogConfig_basic
--- PASS: TestAccCluster_multiContainerNetworkCidrs (475.89s)
=== CONT  TestAccCluster_basic
--- PASS: TestAccCluster_secGroup (564.72s)
=== CONT  TestAccClusterOpenIDJWKSDataSource_basic
    acceptance.go:1368: HW_CCE_CLUSTER_ID must be set for this acceptance test
--- SKIP: TestAccClusterOpenIDJWKSDataSource_basic (0.01s)
=== CONT  TestAccCluster_hibernate
--- PASS: TestAccClusterLogConfig_basic (563.12s)
--- PASS: TestAccCluster_resize (757.71s)
--- PASS: TestAccCluster_basic (555.15s)
--- PASS: TestAccCluster_hibernate (810.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1897.929s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
