### PR TITLE
feat(aom): add data source alarm silence rules

### DIFF
--- a/docs/data-sources/aom_alarm_silence_rules.md
+++ b/docs/data-sources/aom_alarm_silence_rules.md
@@ -1,0 +1,78 @@
+---
+subcategory: "Application Operations Management (AOM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aom_alarm_silence_rules"
+description: |-
+  Use this data source to get the list of alarm silence rules.
+---
+
+# huaweicloud_aom_alarm_silence_rules
+
+Use this data source to get the list of alarm silence rules.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_aom_alarm_silence_rules" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - Indicates the alarm silence rules list.
+  The [rules](#attrblock--rules) structure is documented below.
+
+<a name="attrblock--rules"></a>
+The `rules` block supports:
+
+* `name` - Indicates the rule name.
+
+* `silence_conditions` - Indicates the silence conditions of the rule.
+  The [silence_conditions](#attrblock--rules--silence_conditions) structure is documented below.
+
+* `silence_time` - Indicates the silence time of the rule.
+  The [silence_time](#attrblock--rules--silence_time) structure is documented below.
+
+* `time_zone` - Indicates the time zone of the rule.
+
+* `description` - Indicates the description of the rule.
+
+* `created_at` - Indicates the create time of the rule.
+
+* `updated_at` - Indicates the update time of the rule.
+
+<a name="attrblock--rules--silence_conditions"></a>
+The `silence_conditions` block supports:
+
+* `conditions` - Indicates the serial conditions.
+  The [conditions](#attrblock--rules--silence_conditions--conditions) structure is documented below.
+
+<a name="attrblock--rules--silence_conditions--conditions"></a>
+The `conditions` block supports:
+
+* `key` - Indicates the key of the match condition.
+
+* `operate` - Indicates the operate of the match condition.
+
+* `value` - Indicates the value list of the match condition.
+
+<a name="attrblock--rules--silence_time"></a>
+The `silence_time` block supports:
+
+* `type` - Indicates the effective time type of the rule.
+
+* `starts_at` - Indicates the start time of the rule.
+
+* `ends_at` - Indicates the end time of the rule.
+
+* `scope` - Indicates the silence time of the rule.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -421,6 +421,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aom_alarm_rules":                     aom.DataSourceAlarmRules(),
 			"huaweicloud_aom_dashboards":                      aom.DataSourceDashboards(),
 			"huaweicloud_aom_alarm_rules_templates":           aom.DataSourceAlarmRulesTemplates(),
+			"huaweicloud_aom_alarm_silence_rules":             aom.DataSourceAlarmSilenceRules(),
 
 			"huaweicloud_apig_acl_policies":                       apig.DataSourceAclPolicies(),
 			"huaweicloud_apig_api_associated_acl_policies":        apig.DataSourceApiAssociatedAclPolicies(),

--- a/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_alarm_silence_rules_test.go
+++ b/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_alarm_silence_rules_test.go
@@ -1,0 +1,52 @@
+package aom
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAlarmSilenceRules_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_aom_alarm_silence_rules.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAlarmSilenceRules_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.description"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.time_zone"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.silence_time.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.0.silence_conditions.#"),
+					resource.TestMatchResourceAttr(dataSource,
+						"rules.0.created_at", regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(dataSource,
+						"rules.0.updated_at", regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAlarmSilenceRules_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_aom_alarm_silence_rules" "test" {
+  depends_on = [huaweicloud_aom_alarm_silence_rule.test]
+}
+`, testAlarmSilenceRule_basic(name))
+}

--- a/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_silence_rules.go
+++ b/huaweicloud/services/aom/data_source_huaweicloud_aom_alarm_silence_rules.go
@@ -1,0 +1,186 @@
+package aom
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AOM GET /v2/{project_id}/alert/mute-rules
+func DataSourceAlarmSilenceRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlarmSilenceRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"time_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"silence_time": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"starts_at": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"ends_at": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"scope": {
+										Type:     schema.TypeList,
+										Elem:     &schema.Schema{Type: schema.TypeInt},
+										Computed: true,
+									},
+								},
+							},
+						},
+						"silence_conditions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"conditions": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"operate": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeList,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlarmSilenceRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aom", region)
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	results, err := listAlarmSilenceRules(client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID")
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rules", flattenAlarmSilenceRules(results.([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func listAlarmSilenceRules(client *golangsdk.ServiceClient) (interface{}, error) {
+	listHttpUrl := "v2/{project_id}/alert/mute-rules"
+	listPath := client.Endpoint + listHttpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving alarm silence rules: %s", err)
+	}
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flattening alarm silence rules: %s", err)
+	}
+
+	return listRespBody, nil
+}
+
+func flattenAlarmSilenceRules(rules []interface{}) []interface{} {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		result = append(result, map[string]interface{}{
+			"name":               utils.PathSearch("name", rule, nil),
+			"description":        utils.PathSearch("desc", rule, nil),
+			"time_zone":          utils.PathSearch("timezone", rule, nil),
+			"silence_time":       flattenSilenceRuleSilenceTime(rule),
+			"silence_conditions": flattenSilenceRuleSilenceConditions(rule),
+			"created_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("create_time", rule, float64(0)).(float64))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(
+				int64(utils.PathSearch("update_time", rule, float64(0)).(float64))/1000, false),
+		})
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source alarm silence rules

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccDataSourceAlarmSilenceRules_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccDataSourceAlarmSilenceRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAlarmSilenceRules_basic
=== PAUSE TestAccDataSourceAlarmSilenceRules_basic
=== CONT  TestAccDataSourceAlarmSilenceRules_basic
--- PASS: TestAccDataSourceAlarmSilenceRules_basic (38.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       39.039s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
