### PR TITLE
docs(argument): fix the incorrect description about length

### DIFF
--- a/docs/resources/apig_api.md
+++ b/docs/resources/apig_api.md
@@ -120,7 +120,7 @@ The following arguments are supported:
   The valid values are **Public** and **Private**.
 
 * `name` - (Required, String) Specifies the API name.  
-  The valid length is limited from can contain `3` to `255`, only Chinese and English letters, digits and
+  The valid length is limited from `3` to `255`, only Chinese and English letters, digits and
   following special characters are allowed: `-_./（()）:：、`.
   The name must start with a digit, Chinese or English letter.
 
@@ -208,7 +208,7 @@ The following arguments are supported:
 The `request_params` block supports:
 
 * `name` - (Required, String) Specifies the request parameter name.  
-  The valid length is limited from can contain `1` to `32`, only letters, digits, hyphens (-), underscores (_) and
+  The valid length is limited from `1` to `32`, only letters, digits, hyphens (-), underscores (_) and
   periods (.) are allowed.  
   If Location is specified as **HEADER** and `security_authentication` is specified as **APP**, the parameter name
   cannot be `Authorization` (case-insensitive) and cannot contain underscores.
@@ -362,7 +362,7 @@ The `web` block supports:
 The `mock_policy` block supports:
 
 * `name` - (Required, String) Specifies the backend policy name.  
-  The valid length is limited from can contain `3` to `64`, only letters, digits and underscores (_) are allowed.
+  The valid length is limited from `3` to `64`, only letters, digits and underscores (_) are allowed.
 
 * `conditions` - (Required, List) Specifies an array of one or more policy conditions.  
   Up to five conditions can be set.
@@ -386,7 +386,7 @@ The `mock_policy` block supports:
 The `func_graph_policy` block supports:
 
 * `name` - (Required, String) Specifies the backend policy name.  
-  The valid length is limited from can contain `3` to `64`, only letters, digits and underscores (_) are allowed.
+  The valid length is limited from `3` to `64`, only letters, digits and underscores (_) are allowed.
 
 * `function_urn` - (Required, String) Specifies the URN of the FunctionGraph function.
 
@@ -431,7 +431,7 @@ The `func_graph_policy` block supports:
 The `web_policy` block supports:
 
 * `name` - (Required, String) Specifies the backend policy name.  
-  The valid length is limited from can contain `3` to `64`, only letters, digits and underscores (_) are allowed.
+  The valid length is limited from `3` to `64`, only letters, digits and underscores (_) are allowed.
 
 * `path` - (Required, String) Specifies the backend request address, which can contain a maximum of `512` characters and
   must comply with URI specifications.  

--- a/docs/resources/apig_application.md
+++ b/docs/resources/apig_application.md
@@ -37,7 +37,7 @@ The following arguments are supported:
   Changing this will create a new resource.
 
 * `name` - (Required, String) Specifies the application name.  
-  The valid length is limited from can contain `3` to `64`, only Chinese and English letters, digits and hyphens (-)
+  The valid length is limited from `3` to `64`, only Chinese and English letters, digits and hyphens (-)
   are allowed.  
   The name must start with a Chinese or English letter.
 

--- a/docs/resources/iotda_upgrade_package.md
+++ b/docs/resources/iotda_upgrade_package.md
@@ -112,7 +112,7 @@ The `obs_location` block supports:
 * `object_key` - (Required, String, ForceNew) Specifies the name of the OBS object where the upgrade package is located,
   including the folder path. The maximum size of OBS objects is **1GB**, and only supports files in **.bin**, **.dav**,
   **.tar**, **.gz**, **.zip**, **.gzip**, **.apk**, **.ta.gz**, **.tar.xz**, **.pack**, **.exe**, **.bat** and **.img**
-  formats. The valid length is limited from can contain `1` to `1024`.
+  formats. The valid length is limited from `1` to `1024`.
   Changing this parameter will create a new resource.
 
 ## Attribute Reference

--- a/docs/resources/rfs_stack.md
+++ b/docs/resources/rfs_stack.md
@@ -117,7 +117,7 @@ The following arguments are supported:
   If omitted, the provider-level region will be used. Change this parameter will create a new resource.
 
 * `name` - (Required, String, ForceNew) Specifies the name of the resource stack.  
-  The valid length is limited from can contain `1` to `64`, only letters, digits and hyphens (-) are allowed.
+  The valid length is limited from `1` to `64`, only letters, digits and hyphens (-) are allowed.
   The name must start with a lowercase letter and end with a lowercase letter or digit.
   Change this parameter will create a new resource.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The description about the length of the parameter value is incorrect, should not include the `can contain`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. fix the incorrect description about length.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
