### PR TITLE
feat(cce): support hostname_config in node and node pool

### DIFF
--- a/docs/data-sources/cce_node.md
+++ b/docs/data-sources/cce_node.md
@@ -70,6 +70,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `enterprise_project_id` - The enterprise project ID of the node.
 
+* `hostname_config` - The hostname config of the kubernetes node.
+  The [object](#hostname_config) structure is documented below.
+
 The `root_volume` and `data_volumes` blocks support:
 
 * `size` - Disk size in GB.
@@ -77,3 +80,8 @@ The `root_volume` and `data_volumes` blocks support:
 * `volumetype` - Disk type.
 
 * `extend_params` - Disk expansion parameters.
+
+<a name="hostname_config"></a>
+The `hostname_config` block supports:
+
+* `type` - The hostname type of the kubernetes node.

--- a/docs/data-sources/cce_node_pool.md
+++ b/docs/data-sources/cce_node_pool.md
@@ -82,6 +82,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `enterprise_project_id` - The enterprise project ID of the node pool.
 
+* `hostname_config` - The hostname config of the kubernetes node.
+  The [object](#hostname_config) structure is documented below.
+
 The `root_volume` and `data_volumes` blocks support:
 
 * `size` - Disk size in GB.
@@ -89,3 +92,8 @@ The `root_volume` and `data_volumes` blocks support:
 * `volumetype` - Disk type.
 
 * `extend_params` - Disk expansion parameters.
+
+<a name="hostname_config"></a>
+The `hostname_config` block supports:
+
+* `type` - The hostname type of the kubernetes node.

--- a/docs/data-sources/cce_nodes.md
+++ b/docs/data-sources/cce_nodes.md
@@ -87,6 +87,9 @@ The `nodes` block supports:
 
 * `enterprise_project_id` - The enterprise project ID of the node.
 
+* `hostname_config` - The hostname config of the kubernetes node.
+  The [object](#hostname_config) structure is documented below.
+
 The `root_volume` and `data_volumes` blocks support:
 
 * `size` - Disk size in GB.
@@ -94,3 +97,8 @@ The `root_volume` and `data_volumes` blocks support:
 * `volumetype` - Disk type.
 
 * `extend_params` - Disk expansion parameters.
+
+<a name="hostname_config"></a>
+The `hostname_config` block supports:
+
+* `type` - The hostname type of the kubernetes node.

--- a/docs/resources/cce_node.md
+++ b/docs/resources/cce_node.md
@@ -401,6 +401,11 @@ The following arguments are supported:
   + `effect` - (Required, String, ForceNew) Available options are NoSchedule, PreferNoSchedule, and NoExecute.
     Changing this parameter will create a new resource.
 
+* `hostname_config` - (Optional, List, ForceNew) Specifies the hostname config of the kubernetes node,
+  which is supported by clusters of v1.23.6-r0 to v1.25 or clusters of v1.25.2-r0 or later versions.
+  The [object](#hostname_config) structure is documented below.
+  Changing this parameter will create a new resource.
+
 <a name="extension_nics"></a>
 The `extension_nics` block supports:
 
@@ -484,6 +489,23 @@ The `groups` block supports:
     This parameter takes effect only in **user** configuration. Changing this parameter will create a new resource.
   + `runtime_lv_type` - (Optional, String, ForceNew) Specifies the LVM write mode, values can be **linear** and **striped**.
     This parameter takes effect only in **runtime** configuration. Changing this parameter will create a new resource.
+
+<a name="hostname_config"></a>
+The `hostname_config` block supports:
+
+* `type` - (Required, String, ForceNew) Specifies the hostname type of the kubernetes node.
+  The value can be:
+  + **privateIp**: The Kubernetes node is named after its IP address.
+  + **cceNodeName**: The Kubernetes node is named after the CCE node.
+  
+  If `hostname_config` not specified, the default value is **privateIp**.
+  Changing this parameter will create a new resource.
+
+  ~>For a node which is configured using cceNodeName, the name is the same as the Kubernetes node name and the ECS name.
+    The node name cannot be changed. If the ECS name is changed on the ECS console, the node name will retain unchanged
+    after ECS synchronization. To avoid a conflict between Kubernetes nodes, the system automatically adds a suffix to
+    each node name. The suffix is in the format of A hyphen (-) Five random characters. The value of the random
+    characters is a lowercase letter or a digit ranging from 0 to 9.
 
 ## Attribute Reference
 

--- a/docs/resources/cce_node_attach.md
+++ b/docs/resources/cce_node_attach.md
@@ -193,6 +193,14 @@ In addition to all arguments above, the following attributes are exported:
   + `kms_key_id` - The ID of a KMS key. This is used to encrypt the volume.
   + `dss_pool_id` - The DSS pool ID. This field is used only for dedicated storage.
 
+* `hostname_config` - The hostname config of the kubernetes node.
+  The [object](#hostname_config) structure is documented below.
+
+<a name="hostname_config"></a>
+The `hostname_config` block supports:
+
+* `type` - The hostname type of the kubernetes node.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:

--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -283,6 +283,11 @@ The following arguments are supported:
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the node pool.
   If updated, the new value will apply only to new nodes.
 
+* `hostname_config` - (Optional, List, ForceNew) Specifies the hostname config of the kubernetes node,
+  which is supported by clusters of v1.23.6-r0 to v1.25 or clusters of v1.25.2-r0 or later versions.
+  The [object](#hostname_config) structure is documented below.
+  Changing this parameter will create a new resource.
+
 The `root_volume` block supports:
 
 * `size` - (Required, Int, ForceNew) Specifies the disk size in GB. Changing this parameter will create a new resource.
@@ -414,6 +419,23 @@ The `groups` block supports:
     This parameter takes effect only in **user** configuration. Changing this parameter will create a new resource.
   + `runtime_lv_type` - (Optional, String, ForceNew) Specifies the LVM write mode, values can be **linear** and **striped**.
     This parameter takes effect only in **runtime** configuration. Changing this parameter will create a new resource.
+
+<a name="hostname_config"></a>
+The `hostname_config` block supports:
+
+* `type` - (Required, String, ForceNew) Specifies the hostname type of the kubernetes node.
+  The value can be:
+  + **privateIp**: The Kubernetes node is named after its IP address.
+  + **cceNodeName**: The Kubernetes node is named after the CCE node.
+  
+  If `hostname_config` not specified, the default value is **privateIp**.
+  Changing this parameter will create a new resource.
+
+  ~>For a node which is configured using cceNodeName, the name is the same as the Kubernetes node name and the ECS name.
+    The node name cannot be changed. If the ECS name is changed on the ECS console, the node name will retain unchanged
+    after ECS synchronization. To avoid a conflict between Kubernetes nodes, the system automatically adds a suffix to
+    each node name. The suffix is in the format of A hyphen (-) Five random characters. The value of the random
+    characters is a lowercase letter or a digit ranging from 0 to 9.
 
 ## Attribute Reference
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240829112004-4c29a61a0558
+	github.com/chnsz/golangsdk v0.0.0-20240902121404-55237825bd80
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240829112004-4c29a61a0558 h1:9KOx02tDyYGw5ymNJczMFHHJPe2YVUcoWAwJwWLnTMo=
-github.com/chnsz/golangsdk v0.0.0-20240829112004-4c29a61a0558/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240902121404-55237825bd80 h1:o7IDs+SQ35gAVw+YceDXnn6xpOP3InRQRd0t7s6cTY8=
+github.com/chnsz/golangsdk v0.0.0-20240902121404-55237825bd80/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_test.go
@@ -535,6 +535,10 @@ resource "huaweicloud_vpc_eip" "test" {
     share_type  = "PER"
     charge_mode = "traffic"
   }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "huaweicloud_cce_node" "test" {

--- a/huaweicloud/services/cce/common.go
+++ b/huaweicloud/services/cce/common.go
@@ -156,8 +156,8 @@ func buildResourceNodeExtendParams(extendParamsRaw []interface{}) map[string]int
 			"nicMultiqueue":         utils.ValueIgnoreEmpty(extendParams["node_multi_queue"]),
 			"nicThreshold":          utils.ValueIgnoreEmpty(extendParams["nic_threshold"]),
 			"agency_name":           utils.ValueIgnoreEmpty(extendParams["agency_name"]),
-			"kube-reserved-mem":     utils.ValueIgnoreEmpty(extendParams["kube_reserved_mem"]),
-			"system-reserved-mem":   utils.ValueIgnoreEmpty(extendParams["system_reserved_mem"]),
+			"kubeReservedMem":       utils.ValueIgnoreEmpty(extendParams["kube_reserved_mem"]),
+			"systemReservedMem":     utils.ValueIgnoreEmpty(extendParams["system_reserved_mem"]),
 			"marketType":            utils.ValueIgnoreEmpty(extendParams["market_type"]),
 			"spotPrice":             utils.ValueIgnoreEmpty(extendParams["spot_price"]),
 		}

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_node.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_node.go
@@ -131,6 +131,18 @@ func DataSourceNode() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"hostname_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -200,6 +212,7 @@ func dataSourceNodeRead(_ context.Context, d *schema.ResourceData, meta interfac
 		d.Set("private_ip", node.Status.PrivateIP),
 		d.Set("status", node.Status.Phase),
 		d.Set("region", config.GetRegion(d)),
+		d.Set("hostname_config", flattenResourceNodeHostnameConfig(node.Spec.HostnameConfig)),
 		d.Set("enterprise_project_id", node.Spec.ServerEnterpriseProjectID),
 	)
 

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_node_pool_v3.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_node_pool_v3.go
@@ -155,6 +155,18 @@ func DataSourceCCENodePoolV3() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"hostname_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -213,6 +225,7 @@ func dataSourceCceNodePoolsV3Read(_ context.Context, d *schema.ResourceData, met
 		d.Set("priority", NodePool.Spec.Autoscaling.Priority),
 		d.Set("subnet_id", NodePool.Spec.NodeTemplate.NodeNicSpec.PrimaryNic.SubnetId),
 		d.Set("status", NodePool.Status.Phase),
+		d.Set("hostname_config", flattenResourceNodeHostnameConfig(NodePool.Spec.NodeTemplate.HostnameConfig)),
 		d.Set("enterprise_project_id", NodePool.Spec.NodeTemplate.ServerEnterpriseProjectID),
 	)
 

--- a/huaweicloud/services/cce/data_source_huaweicloud_cce_nodes.go
+++ b/huaweicloud/services/cce/data_source_huaweicloud_cce_nodes.go
@@ -165,6 +165,18 @@ func DataSourceNodes() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"hostname_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 						"enterprise_project_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -215,6 +227,7 @@ func dataSourceNodesRead(_ context.Context, d *schema.ResourceData, meta interfa
 			"public_ip":             v.Status.PublicIP,
 			"private_ip":            v.Status.PrivateIP,
 			"status":                v.Status.Phase,
+			"hostname_config":       flattenResourceNodeHostnameConfig(v.Spec.HostnameConfig),
 			"enterprise_project_id": v.Spec.ServerEnterpriseProjectID,
 		}
 

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node.go
@@ -301,6 +301,22 @@ func ResourceNode() *schema.Resource {
 				Optional:    true,
 				Description: "schema: Internal",
 			},
+			"hostname_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -484,6 +500,18 @@ func buildResourceNodeLoginSpec(d *schema.ResourceData) (nodes.LoginSpec, error)
 	return loginSpec, nil
 }
 
+func buildResourceNodeHostnameConfig(d *schema.ResourceData) *nodes.HostnameConfig {
+	if v, ok := d.GetOk("hostname_config"); ok {
+		res := nodes.HostnameConfig{
+			Type: utils.PathSearch("[0].type", v, "").(string),
+		}
+
+		return &res
+	}
+
+	return nil
+}
+
 func resourceNodeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	cfg := meta.(*config.Config)
 	region := cfg.GetRegion(d)
@@ -541,6 +569,7 @@ func resourceNodeCreate(ctx context.Context, d *schema.ResourceData, meta interf
 			UserTags:                  buildResourceNodeTags(d),
 			DedicatedHostID:           d.Get("dedicated_host_id").(string),
 			InitializedConditions:     utils.ExpandToStringList(d.Get("initialized_conditions").([]interface{})),
+			HostnameConfig:            buildResourceNodeHostnameConfig(d),
 			ServerEnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
 		},
 	}
@@ -645,6 +674,7 @@ func resourceNodeRead(_ context.Context, d *schema.ResourceData, meta interface{
 		d.Set("root_volume", flattenResourceNodeRootVolume(d, s.Spec.RootVolume)),
 		d.Set("data_volumes", flattenResourceNodeDataVolume(d, s.Spec.DataVolumes)),
 		d.Set("initialized_conditions", s.Spec.InitializedConditions),
+		d.Set("hostname_config", flattenResourceNodeHostnameConfig(s.Spec.HostnameConfig)),
 		d.Set("enterprise_project_id", s.Spec.ServerEnterpriseProjectID),
 	)
 
@@ -680,6 +710,20 @@ func resourceNodeRead(_ context.Context, d *schema.ResourceData, meta interface{
 		return diag.Errorf("error setting CCE Node fields: %s", err)
 	}
 	return nil
+}
+
+func flattenResourceNodeHostnameConfig(hostNameConfig *nodes.HostnameConfig) []map[string]interface{} {
+	if hostNameConfig == nil {
+		return nil
+	}
+
+	res := []map[string]interface{}{
+		{
+			"type": hostNameConfig.Type,
+		},
+	}
+
+	return res
 }
 
 func resourceNodeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_attach.go
@@ -286,6 +286,18 @@ func ResourceNodeAttach() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"hostname_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -211,6 +211,22 @@ func ResourceNodePool() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"hostname_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -312,6 +328,7 @@ func buildNodePoolCreateOpts(d *schema.ResourceData, cfg *config.Config) (*nodep
 				Taints:                    buildResourceNodeTaint(d),
 				UserTags:                  utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
 				InitializedConditions:     utils.ExpandToStringList(d.Get("initialized_conditions").([]interface{})),
+				HostnameConfig:            buildResourceNodeHostnameConfig(d),
 				ServerEnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
 			},
 			Autoscaling: nodepools.AutoscalingSpec{
@@ -444,6 +461,7 @@ func resourceNodePoolRead(_ context.Context, d *schema.ResourceData, meta interf
 		d.Set("label_policy_on_existing_nodes", s.Spec.LabelPolicyOnExistingNodes),
 		d.Set("tag_policy_on_existing_nodes", s.Spec.UserTagPolicyOnExistingNodes),
 		d.Set("taint_policy_on_existing_nodes", s.Spec.TaintPolicyOnExistingNodes),
+		d.Set("hostname_config", flattenResourceNodeHostnameConfig(s.Spec.NodeTemplate.HostnameConfig)),
 		d.Set("enterprise_project_id", s.Spec.NodeTemplate.ServerEnterpriseProjectID),
 	)
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodes/results.go
@@ -84,6 +84,8 @@ type Spec struct {
 	Partition string `json:"partition,omitempty"`
 	// The initialized conditions
 	InitializedConditions []string `json:"initializedConditions,omitempty"`
+	// The hostname config of k8s node
+	HostnameConfig *HostnameConfig `json:"hostnameConfig,omitempty"`
 	// The enterprise project ID
 	ServerEnterpriseProjectID string `json:"serverEnterpriseProjectID,omitempty"`
 }
@@ -286,6 +288,10 @@ type LVMConfigSpec struct {
 type RuntimeConfigSpec struct {
 	// LVM write mode, values can be linear and striped
 	LvType string `json:"lvType" required:"true"`
+}
+
+type HostnameConfig struct {
+	Type string `json:"type" required:"true"`
 }
 
 // Describes the Job Structure

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240829112004-4c29a61a0558
+# github.com/chnsz/golangsdk v0.0.0-20240902121404-55237825bd80
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. support hostname_config in node and node pool
2. `kube-reserved-mem` and `system-reserved-mem` and deprecated by api, 
    replace them with `kubeReservedMem` and `systemReservedMem`

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNode'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNode -timeout 360m -parallel 4
=== RUN   TestAccNodeDataSource_basic
=== PAUSE TestAccNodeDataSource_basic
=== RUN   TestAccNodesDataSource_basic
=== PAUSE TestAccNodesDataSource_basic
=== RUN   TestAccNodeAttach_basic
=== PAUSE TestAccNodeAttach_basic
=== RUN   TestAccNodeAttach_prePaid
=== PAUSE TestAccNodeAttach_prePaid
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== RUN   TestAccNodePool_tagsLabelsTaints
=== PAUSE TestAccNodePool_tagsLabelsTaints
=== RUN   TestAccNodePool_volume_encryption
=== PAUSE TestAccNodePool_volume_encryption
=== RUN   TestAccNodePool_prePaid
=== PAUSE TestAccNodePool_prePaid
=== RUN   TestAccNodePool_SecurityGroups
=== PAUSE TestAccNodePool_SecurityGroups
=== RUN   TestAccNodePool_serverGroup
=== PAUSE TestAccNodePool_serverGroup
=== RUN   TestAccNodePool_storage
=== PAUSE TestAccNodePool_storage
=== RUN   TestAccNode_basic
=== PAUSE TestAccNode_basic
=== RUN   TestAccNode_eip
=== PAUSE TestAccNode_eip
=== RUN   TestAccNode_volume_encryption
=== PAUSE TestAccNode_volume_encryption
=== RUN   TestAccNode_prePaid
=== PAUSE TestAccNode_prePaid
=== RUN   TestAccNode_password
=== PAUSE TestAccNode_password
=== RUN   TestAccNode_storage
=== PAUSE TestAccNode_storage
=== CONT  TestAccNodeDataSource_basic
=== CONT  TestAccNode_eip
=== CONT  TestAccNodePool_volume_encryption
=== CONT  TestAccNode_password
=== CONT  TestAccNodePool_volume_encryption
    acceptance.go:1185: This environment does not support KMS tests
--- SKIP: TestAccNodePool_volume_encryption (0.01s)
=== CONT  TestAccNodeAttach_prePaid
    acceptance.go:858: This environment does not support prepaid tests
--- SKIP: TestAccNodeAttach_prePaid (0.01s)
=== CONT  TestAccNodePool_tagsLabelsTaints
--- PASS: TestAccNodeDataSource_basic (792.70s)
=== CONT  TestAccNodePool_basic
--- PASS: TestAccNodePool_tagsLabelsTaints (856.23s)
=== CONT  TestAccNode_storage
--- PASS: TestAccNode_password (913.38s)
=== CONT  TestAccNode_prePaid
    acceptance.go:858: This environment does not support prepaid tests
--- SKIP: TestAccNode_prePaid (0.02s)
=== CONT  TestAccNodePool_SecurityGroups
--- PASS: TestAccNode_eip (1245.90s)
=== CONT  TestAccNodePool_prePaid
    acceptance.go:858: This environment does not support prepaid tests
--- SKIP: TestAccNodePool_prePaid (0.01s)
=== CONT  TestAccNode_volume_encryption
    acceptance.go:1185: This environment does not support KMS tests
--- SKIP: TestAccNode_volume_encryption (0.01s)
=== CONT  TestAccNodeAttach_basic
--- PASS: TestAccNode_storage (815.11s)
=== CONT  TestAccNode_basic
--- PASS: TestAccNodePool_SecurityGroups (823.01s)
=== CONT  TestAccNodesDataSource_basic
--- PASS: TestAccNodePool_basic (1332.88s)
=== CONT  TestAccNodePool_storage
--- PASS: TestAccNodeAttach_basic (1176.70s)
=== CONT  TestAccNodePool_serverGroup
--- PASS: TestAccNode_basic (855.79s)
--- PASS: TestAccNodesDataSource_basic (794.81s)
--- PASS: TestAccNodePool_storage (833.53s)
--- PASS: TestAccNodePool_serverGroup (783.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       3206.391s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
