### PR TITLE
feat(GaussDBforMySQL): gaussdb mysql instance support maintain window

### DIFF
--- a/docs/data-sources/gaussdb_mysql_instances.md
+++ b/docs/data-sources/gaussdb_mysql_instances.md
@@ -82,6 +82,10 @@ The `instances` block supports:
 
 * `private_write_ip` - Indicates the private IP address of the DB instance.
 
+* `maintain_begin` - Indicates the start time for a maintenance window.
+
+* `maintain_end` - Indicates the end time for a maintenance window.
+
 * `nodes` - Indicates the instance nodes information. Structure is documented below.
 
 The `datastore` block supports:

--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -83,6 +83,13 @@ The following arguments are supported:
 * `private_dns_name_prefix` - (Optional, String) Specifies the prefix of the private domain name. The value contains
   **8** to **63** characters. Only uppercase letters, lowercase letters, and digits are allowed.
 
+* `maintain_begin` - (Optional, String) Specifies the start time for a maintenance window, for example, **22:00**.
+
+* `maintain_end` - (Optional, String) Specifies the end time for a maintenance window, for example, **01:00**.
+
+-> **Note** The start time and end time of a maintenance window must be on the hour, and the interval between them at
+  most four hours.
+
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project id. Required if EPS enabled.
 
 * `table_name_case_sensitivity` - (Optional, Bool) Whether the kernel table name is case sensitive. The value can

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
@@ -51,6 +51,8 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "private_dns_name_prefix", "testprivatednsname"),
 					resource.TestCheckResourceAttr(resourceName, "private_dns_name",
 						"testprivatednsname.internal.cn-north-4.gaussdbformysql.myhuaweicloud.com"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "11:00"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
@@ -78,6 +80,8 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "private_dns_name_prefix", "testprivatednsnameupdate"),
 					resource.TestCheckResourceAttr(resourceName, "private_dns_name",
 						"testprivatednsnameupdate.internal.cn-north-4.gaussdbformysql.myhuaweicloud.com"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "14:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "18:00"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 				),
@@ -272,6 +276,8 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   private_write_ip         = "192.168.0.156"
   port                     = "8888"
   private_dns_name_prefix  = "testprivatednsname"
+  maintain_begin           = "08:00"
+  maintain_end             = "11:00"
 
   parameters {
     name  = "default_authentication_plugin"
@@ -312,6 +318,8 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   private_write_ip         = "192.168.0.157"
   port                     = "9999"
   private_dns_name_prefix  = "testprivatednsnameupdate"
+  maintain_begin           = "14:00"
+  maintain_end             = "18:00"
 
   parameters {
     name  = "binlog_gtid_simple_recovery"

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_instances.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_instances.go
@@ -117,6 +117,14 @@ func DataSourceGaussDBMysqlInstances() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"maintain_begin": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"maintain_end": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"datastore": {
 							Type:     schema.TypeList,
 							Computed: true,
@@ -288,6 +296,12 @@ func dataSourceGaussDBMysqlInstancesRead(_ context.Context, d *schema.ResourceDa
 		if len(instance.PrivateDnsNames) > 0 {
 			instanceToSet["private_dns_name_prefix"] = strings.Split(instance.PrivateDnsNames[0], ".")[0]
 			instanceToSet["private_dns_name"] = instance.PrivateDnsNames[0]
+		}
+
+		maintainWindow := strings.Split(instance.MaintenanceWindow, "-")
+		if len(maintainWindow) == 2 {
+			instanceToSet["maintain_begin"] = maintainWindow[0]
+			instanceToSet["maintain_end"] = maintainWindow[1]
 		}
 
 		flavor := ""


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  gaussdb mysql instance support maintain window
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb mysql instance support maintain window
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBInstance_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== RUN   TestAccGaussDBInstance_prePaid
=== PAUSE TestAccGaussDBInstance_prePaid
=== RUN   TestAccGaussDBInstance_updateWithEpsId
=== PAUSE TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_prePaid
=== CONT  TestAccGaussDBInstance_updateWithEpsId
    acceptance.go:629: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccGaussDBInstance_updateWithEpsId (0.00s)
--- PASS: TestAccGaussDBInstance_prePaid (1548.68s)
--- PASS: TestAccGaussDBInstance_basic (2844.21s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   2844.258s

make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussdbMysqlInstancesDataSource_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussdbMysqlInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussdbMysqlInstancesDataSource_basic
=== PAUSE TestAccGaussdbMysqlInstancesDataSource_basic
=== CONT  TestAccGaussdbMysqlInstancesDataSource_basic
--- PASS: TestAccGaussdbMysqlInstancesDataSource_basic (1358.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1359.017s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
