### PR TITLE
feat(GaussDBforMySQL): gaussdb mysql instance support secondes level monitoring

### DIFF
--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -90,6 +90,15 @@ The following arguments are supported:
 -> **Note** The start time and end time of a maintenance window must be on the hour, and the interval between them at
   most four hours.
 
+* `seconds_level_monitoring_enabled` - (Optional, Bool) Specifies whether to enable seconds level monitoring.
+
+* `seconds_level_monitoring_period` - (Optional, Int) Specifies the seconds level collection period.
+  + This parameter is valid only when `seconds_level_monitoring_enabled` is set to **true**.
+  + This parameter can not be specified when `seconds_level_monitoring_enabled` is set to **false**.
+  + Value options:
+      - **1**: The collection period is 1s.
+      - **5** (default value): The collection period is 5s.
+
 * `enterprise_project_id` - (Optional, String) Specifies the enterprise project id. Required if EPS enabled.
 
 * `table_name_case_sensitivity` - (Optional, Bool) Whether the kernel table name is case sensitive. The value can

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
@@ -53,6 +53,8 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 						"testprivatednsname.internal.cn-north-4.gaussdbformysql.myhuaweicloud.com"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "08:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "11:00"),
+					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_period", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
@@ -82,6 +84,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 						"testprivatednsnameupdate.internal.cn-north-4.gaussdbformysql.myhuaweicloud.com"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "14:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "18:00"),
+					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 				),
@@ -279,6 +282,9 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   maintain_begin           = "08:00"
   maintain_end             = "11:00"
 
+  seconds_level_monitoring_enabled = true
+  seconds_level_monitoring_period  = 1
+
   parameters {
     name  = "default_authentication_plugin"
     value = "mysql_native_password"
@@ -320,6 +326,8 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   private_dns_name_prefix  = "testprivatednsnameupdate"
   maintain_begin           = "14:00"
   maintain_end             = "18:00"
+
+  seconds_level_monitoring_enabled = false
 
   parameters {
     name  = "binlog_gtid_simple_recovery"


### PR DESCRIPTION
…monitoring

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  gaussdb mysql instance support secondes level monitoring
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb mysql instance support secondes level monitoring
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBInstance_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== RUN   TestAccGaussDBInstance_prePaid
=== PAUSE TestAccGaussDBInstance_prePaid
=== RUN   TestAccGaussDBInstance_updateWithEpsId
=== PAUSE TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_prePaid
=== CONT  TestAccGaussDBInstance_updateWithEpsId
    acceptance.go:629: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccGaussDBInstance_updateWithEpsId (0.01s)
--- PASS: TestAccGaussDBInstance_prePaid (1576.36s)
--- PASS: TestAccGaussDBInstance_basic (2926.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   2926.656s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
