### PR TITLE
fix(ims): deprecated `huaweicloud_images_image` resource

### DIFF
--- a/docs/resources/images_image.md
+++ b/docs/resources/images_image.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Image Management Service (IMS)"
+subcategory: "Deprecated"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_images_image"
 description: |-
@@ -7,6 +7,9 @@ description: |-
 ---
 
 # huaweicloud_images_image
+
+!> **WARNING:** It has been deprecated, please select the corresponding resource replacement based on the image type and
+creation method, please use resources named in `huaweicloud_ims_xxx_xxx_image` format instead.
 
 Manages an IMS image resource within HuaweiCloud.
 

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1566,7 +1566,6 @@ func Provider() *schema.Provider {
 			"huaweicloud_ims_obs_data_image":          ims.ResourceObsDataImage(),
 			"huaweicloud_ims_obs_system_image":        ims.ResourceObsSystemImage(),
 			"huaweicloud_ims_obs_iso_image":           ims.ResourceObsIsoImage(),
-			"huaweicloud_images_image":                ims.ResourceImsImage(),
 			"huaweicloud_images_image_copy":           ims.ResourceImsImageCopy(),
 			"huaweicloud_images_image_share":          ims.ResourceImsImageShare(),
 			"huaweicloud_images_image_share_accepter": ims.ResourceImsImageShareAccepter(),
@@ -2095,6 +2094,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpnaas_site_connection": deprecated.ResourceVpnSiteConnectionV2(),
 
 			"huaweicloud_iotda_batchtask_file": deprecated.ResourceBatchTaskFile(),
+
+			"huaweicloud_images_image": deprecated.ResourceImsImage(),
 		},
 	}
 

--- a/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_test.go
+++ b/huaweicloud/services/acceptance/deprecated/resource_huaweicloud_images_image_test.go
@@ -1,4 +1,4 @@
-package ims
+package deprecated
 
 import (
 	"fmt"
@@ -13,7 +13,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
 )
 
 func getImageResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -22,7 +22,7 @@ func getImageResourceFunc(cfg *config.Config, state *terraform.ResourceState) (i
 		return nil, fmt.Errorf("error creating IMS v2 client: %s", err)
 	}
 
-	img, err := ims.GetCloudImage(imsClient, state.Primary.ID)
+	img, err := deprecated.GetCloudImage(imsClient, state.Primary.ID)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving image: %s", err)
 	}

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_copy_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_copy_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/chnsz/golangsdk"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
@@ -25,11 +27,16 @@ func getImsImageCopyResourceFunc(cfg *config.Config, state *terraform.ResourceSt
 		return nil, fmt.Errorf("error creating IMS client: %s", err)
 	}
 
-	img, err := ims.GetCloudImage(imsClient, state.Primary.ID)
+	imageList, err := ims.GetImageList(imsClient, state.Primary.ID)
 	if err != nil {
-		return nil, fmt.Errorf("image %s not found: %s", state.Primary.ID, err)
+		return nil, fmt.Errorf("error retrieving IMS images: %s", err)
 	}
-	return img, nil
+
+	if len(imageList) < 1 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return imageList[0], nil
 }
 
 func TestAccImsImageCopy_basic(t *testing.T) {
@@ -141,7 +148,7 @@ func testImsImageCopy_basic(baseImageName, copyImageName string) string {
 %s
 
 resource "huaweicloud_images_image_copy" "test" {
-  source_image_id = huaweicloud_images_image.test.id
+  source_image_id = huaweicloud_ims_ecs_system_image.test.id
   name            = "%s"
   min_ram         = 1024
   max_ram         = 4096
@@ -151,7 +158,7 @@ resource "huaweicloud_images_image_copy" "test" {
     key2 = "value2"
   }
 }
-`, testAccImsImage_basic(baseImageName), copyImageName)
+`, testAccEcsSystemImage_basic(baseImageName), copyImageName)
 }
 
 func testImsImageCopy_update(baseImageName, copyImageName string, minRAM, maxRAM int) string {
@@ -159,7 +166,7 @@ func testImsImageCopy_update(baseImageName, copyImageName string, minRAM, maxRAM
 %s
 
 resource "huaweicloud_images_image_copy" "test" {
-  source_image_id = huaweicloud_images_image.test.id
+  source_image_id = huaweicloud_ims_ecs_system_image.test.id
   name            = "%[2]s"
   description     = "it's a test"
   min_ram         = %[3]d
@@ -171,7 +178,7 @@ resource "huaweicloud_images_image_copy" "test" {
     key4 = "value4"
   }
 }
-`, testAccImsImage_basic(baseImageName), copyImageName, minRAM, maxRAM)
+`, testAccEcsSystemImage_basic(baseImageName), copyImageName, minRAM, maxRAM)
 }
 
 func testImsImageCopy_basic_cross_region(baseImageName, copyImageName string) string {
@@ -179,7 +186,7 @@ func testImsImageCopy_basic_cross_region(baseImageName, copyImageName string) st
 %s
 
 resource "huaweicloud_images_image_copy" "test" {
- source_image_id = huaweicloud_images_image.test.id
+ source_image_id = huaweicloud_ims_ecs_system_image.test.id
  name            = "%s"
  description     = "it's a test"
  target_region   = "%s"
@@ -189,7 +196,7 @@ resource "huaweicloud_images_image_copy" "test" {
     key1 = "value1"
     key2 = "value2"
  }
-}`, testAccImsImage_basic(baseImageName), copyImageName, acceptance.HW_DEST_REGION)
+}`, testAccEcsSystemImage_basic(baseImageName), copyImageName, acceptance.HW_DEST_REGION)
 }
 
 func testImsImageCopy_update_cross_region(baseImageName, copyImageName string) string {
@@ -197,7 +204,7 @@ func testImsImageCopy_update_cross_region(baseImageName, copyImageName string) s
 %s
 
 resource "huaweicloud_images_image_copy" "test" {
- source_image_id = huaweicloud_images_image.test.id
+ source_image_id = huaweicloud_ims_ecs_system_image.test.id
  name            = "%s"
  description     = "it's a test"
  target_region   = "%s"
@@ -209,5 +216,5 @@ resource "huaweicloud_images_image_copy" "test" {
     key4 = "value4"
  }
 }
-`, testAccImsImage_basic(baseImageName), copyImageName, acceptance.HW_DEST_REGION)
+`, testAccEcsSystemImage_basic(baseImageName), copyImageName, acceptance.HW_DEST_REGION)
 }

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_share_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_images_image_share_test.go
@@ -90,7 +90,7 @@ func TestAccImsImageShare_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "source_image_id",
-						"huaweicloud_images_image.test", "id"),
+						"huaweicloud_ims_ecs_system_image.test", "id"),
 				),
 			},
 			{
@@ -98,7 +98,7 @@ func TestAccImsImageShare_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttrPair(rName, "source_image_id",
-						"huaweicloud_images_image.test", "id"),
+						"huaweicloud_ims_ecs_system_image.test", "id"),
 				),
 			},
 		},
@@ -110,10 +110,10 @@ func testImsImageShare_basic(imageName string) string {
 %[1]s
 
 resource "huaweicloud_images_image_share" "test" {
- source_image_id    = huaweicloud_images_image.test.id
+ source_image_id    = huaweicloud_ims_ecs_system_image.test.id
  target_project_ids = ["%[2]s"]
 }
-`, testAccImsImage_basic(imageName), acceptance.HW_DEST_PROJECT_ID)
+`, testAccEcsSystemImage_basic(imageName), acceptance.HW_DEST_PROJECT_ID)
 }
 
 func testImsImageShare_update(imageName string) string {
@@ -121,8 +121,8 @@ func testImsImageShare_update(imageName string) string {
 %s
 
 resource "huaweicloud_images_image_share" "test" {
- source_image_id    = huaweicloud_images_image.test.id
+ source_image_id    = huaweicloud_ims_ecs_system_image.test.id
  target_project_ids = ["%[2]s"]
 }
-`, testAccImsImage_basic(imageName), acceptance.HW_DEST_PROJECT_ID_TEST)
+`, testAccEcsSystemImage_basic(imageName), acceptance.HW_DEST_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/deprecated/resource_huaweicloud_images_image.go
+++ b/huaweicloud/services/deprecated/resource_huaweicloud_images_image.go
@@ -1,4 +1,4 @@
-package ims
+package deprecated
 
 import (
 	"context"
@@ -43,6 +43,8 @@ func ResourceImsImage() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceImsImageImport,
 		},
+
+		DeprecationMessage: "images image has been deprecated.",
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Deprecated `huaweicloud_images_image` resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Deprecated `huaweicloud_images_image` resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### `images_image` test

```
$ export HW_IMS_BACKUP_ID=xxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/deprecated" TESTARGS="-run TestAccImsImage_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/deprecated -v -run TestAccImsImage_ -timeout 360m -parallel 4
=== RUN   TestAccImsImage_basic
=== PAUSE TestAccImsImage_basic
=== RUN   TestAccImsImage_withEpsId
=== PAUSE TestAccImsImage_withEpsId
=== RUN   TestAccImsImage_wholeImage_withServer
=== PAUSE TestAccImsImage_wholeImage_withServer
=== RUN   TestAccImsImage_wholeImage_withBackup
=== PAUSE TestAccImsImage_wholeImage_withBackup
=== RUN   TestAccImsImage_dataImage_withVolumeId
=== PAUSE TestAccImsImage_dataImage_withVolumeId
=== CONT  TestAccImsImage_basic
=== CONT  TestAccImsImage_wholeImage_withBackup
=== CONT  TestAccImsImage_wholeImage_withServer
=== CONT  TestAccImsImage_dataImage_withVolumeId
--- PASS: TestAccImsImage_wholeImage_withBackup (61.18s)
=== CONT  TestAccImsImage_withEpsId
--- PASS: TestAccImsImage_dataImage_withVolumeId (448.85s)
--- PASS: TestAccImsImage_withEpsId (394.20s)
--- PASS: TestAccImsImage_basic (460.29s)
--- PASS: TestAccImsImage_wholeImage_withServer (719.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/deprecated        719.411s

```

### `image_share` test

```
$ export HW_DEST_REGION=xxxxxxxxx
$ export HW_DEST_PROJECT_ID=xxxxxxxxxxx
$ export HW_DEST_PROJECT_ID_TEST=xxxxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImsImageShare_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImsImageShare_ -timeout 360m -parallel 4
=== RUN   TestAccImsImageShare_basic
=== PAUSE TestAccImsImageShare_basic
=== CONT  TestAccImsImageShare_basic
--- PASS: TestAccImsImageShare_basic (1372.63s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       1372.698s

```

### `image_copy` test

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImsImageCopy_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImsImageCopy_ -timeout 360m -parallel 4
=== RUN   TestAccImsImageCopy_basic
=== PAUSE TestAccImsImageCopy_basic
=== RUN   TestAccImsImageCopy_basic_cross_region
=== PAUSE TestAccImsImageCopy_basic_cross_region
=== CONT  TestAccImsImageCopy_basic
=== CONT  TestAccImsImageCopy_basic_cross_region
--- PASS: TestAccImsImageCopy_basic_cross_region (575.58s)
--- PASS: TestAccImsImageCopy_basic (602.76s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       602.811s

```
* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
