### PR TITLE
feat(GaussDBforMySQL): gaussdb mysql instance support ssl and description

### DIFF
--- a/docs/data-sources/gaussdb_mysql_instances.md
+++ b/docs/data-sources/gaussdb_mysql_instances.md
@@ -86,6 +86,12 @@ The `instances` block supports:
 
 * `maintain_end` - Indicates the end time for a maintenance window.
 
+* `description` - Indicates the description of the instance.
+
+* `created_at` - Indicates the creation time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `updated_at` - Indicates the Update time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
 * `nodes` - Indicates the instance nodes information. Structure is documented below.
 
 The `datastore` block supports:

--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -76,6 +76,14 @@ The following arguments are supported:
 
 * `port` - (Optional, Int) Specifies the database port.
 
+* `ssl_option` - (Optional, String) Specifies whether to enable SSL. Value options:
+  + **true**: SSL is enabled.
+  + **false**: SSL is disabled.
+
+  Defaults to **true**.
+
+* `description` - (Optional, String) Specifies the description of the instance.
+
 * `private_write_ip` - (Optional, String) Specifies the private IP address of the DB instance.
 
 * `configuration_id` - (Optional, String) Specifies the configuration ID.
@@ -192,6 +200,10 @@ In addition to all arguments above, the following attributes are exported:
 
 * `private_dns_name` - Indicates the private domain name.
 
+* `created_at` - Indicates the creation time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `updated_at` - Indicates the Update time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
 * `nodes` - Indicates the instance nodes information. Structure is documented below.
 
 The `nodes` block contains:
@@ -225,8 +237,8 @@ $ terraform import huaweicloud_gaussdb_mysql_instance.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
-API response. The missing attribute is: `table_name_case_sensitivity`, `enterprise_project_id`, `password` and
-`parameters`. It is generally recommended running `terraform plan` after importing a GaussDB MySQL instance. You can
+API response. The missing attribute is: `table_name_case_sensitivity`, `enterprise_project_id`, `password`, `ssl_option`
+and `parameters`. It is generally recommended running `terraform plan` after importing a GaussDB MySQL instance. You can
 then decide if changes should be applied to the GaussDB MySQL instance, or the resource definition should be updated to
 align with the GaussDB MySQL instance. Also you can ignore changes as below.
 
@@ -236,7 +248,7 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
 
   lifecycle {
     ignore_changes = [
-      new_node_weight, proxy_mode, readonly_nodes_weight, parameters,
+      new_node_weight, proxy_mode, readonly_nodes_weight, parameters, ssl_option,
     ]
   }
 }

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
@@ -32,6 +32,8 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGaussDBInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_gaussdb_mysql_flavors.test", "flavors.0.name"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.start_time", "09:00-10:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "7"),
 					resource.TestCheckResourceAttr(resourceName, "read_replicas", "2"),
@@ -42,8 +44,8 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 						"huaweicloud_gaussdb_mysql_parameter_template.test.0", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_name",
 						"huaweicloud_gaussdb_mysql_parameter_template.test.0", "name"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "default_authentication_plugin"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "mysql_native_password"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "auto_increment_increment"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "50"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
 						"huaweicloud_networking_secgroup.test.0", "id"),
 					resource.TestCheckResourceAttr(resourceName, "private_write_ip", "192.168.0.156"),
@@ -55,6 +57,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "11:00"),
 					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_period", "1"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test_description"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
@@ -64,6 +67,8 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGaussDBInstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttrPair(resourceName, "flavor",
+						"data.huaweicloud_gaussdb_mysql_flavors.test", "flavors.1.name"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.start_time", "12:00-13:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "10"),
 					resource.TestCheckResourceAttr(resourceName, "read_replicas", "4"),
@@ -73,8 +78,8 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 						"huaweicloud_gaussdb_mysql_parameter_template.test.1", "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "configuration_name",
 						"huaweicloud_gaussdb_mysql_parameter_template.test.1", "name"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "binlog_gtid_simple_recovery"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "character_set_server"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "utf8"),
 					resource.TestCheckResourceAttrPair(resourceName, "security_group_id",
 						"huaweicloud_networking_secgroup.test.1", "id"),
 					resource.TestCheckResourceAttr(resourceName, "private_write_ip", "192.168.0.157"),
@@ -85,6 +90,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "14:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "18:00"),
 					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 				),
@@ -97,6 +103,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					"table_name_case_sensitivity",
 					"enterprise_project_id",
 					"password",
+					"ssl_option",
 					"parameters",
 				},
 			},
@@ -252,8 +259,8 @@ resource "huaweicloud_gaussdb_mysql_parameter_template" "test" {
   datastore_version = "8.0"
 
   parameter_values = {
-    default_authentication_plugin = "sha256_password"
-    binlog_gtid_simple_recovery   = "OFF"
+    auto_increment_increment = "100"
+    character_set_server     = "gbk"
   }
 }
 `, common.TestVpc(rName), rName)
@@ -281,13 +288,15 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   private_dns_name_prefix  = "testprivatednsname"
   maintain_begin           = "08:00"
   maintain_end             = "11:00"
+  ssl_option               = "false"
+  description              = "test_description"
 
   seconds_level_monitoring_enabled = true
   seconds_level_monitoring_period  = 1
 
   parameters {
-    name  = "default_authentication_plugin"
-    value = "mysql_native_password"
+    name  = "auto_increment_increment"
+    value = "50"
   }
 
   backup_strategy {
@@ -326,12 +335,14 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   private_dns_name_prefix  = "testprivatednsnameupdate"
   maintain_begin           = "14:00"
   maintain_end             = "18:00"
+  ssl_option               = "true"
+  description              = ""
 
   seconds_level_monitoring_enabled = false
 
   parameters {
-    name  = "binlog_gtid_simple_recovery"
-    value = "ON"
+    name  = "character_set_server"
+    value = "utf8"
   }
 
   backup_strategy {

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_instances.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_instances.go
@@ -125,6 +125,10 @@ func DataSourceGaussDBMysqlInstances() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"datastore": {
 							Type:     schema.TypeList,
 							Computed: true,
@@ -196,6 +200,14 @@ func DataSourceGaussDBMysqlInstances() *schema.Resource {
 									},
 								},
 							},
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 					},
 				},
@@ -289,6 +301,9 @@ func dataSourceGaussDBMysqlInstancesRead(_ context.Context, d *schema.ResourceDa
 		instanceToSet["configuration_id"] = instance.ConfigurationId
 		instanceToSet["availability_zone_mode"] = instance.AZMode
 		instanceToSet["master_availability_zone"] = instance.MasterAZ
+		instanceToSet["description"] = instance.Alias
+		instanceToSet["created_at"] = instance.Created
+		instanceToSet["updated_at"] = instance.Updated
 
 		if len(instance.PrivateIps) > 0 {
 			instanceToSet["private_write_ip"] = instance.PrivateIps[0]


### PR DESCRIPTION
…tion

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
   gaussdb mysql instance support ssl and description
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb mysql instance support ssl and description
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
 make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBInstance_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== RUN   TestAccGaussDBInstance_prePaid
=== PAUSE TestAccGaussDBInstance_prePaid
=== RUN   TestAccGaussDBInstance_updateWithEpsId
=== PAUSE TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_prePaid
=== CONT  TestAccGaussDBInstance_updateWithEpsId
    acceptance.go:629: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccGaussDBInstance_updateWithEpsId (0.00s)
--- PASS: TestAccGaussDBInstance_prePaid (1446.54s)
--- PASS: TestAccGaussDBInstance_basic (3285.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   3285.882s

make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussdbMysqlInstancesDataSource_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussdbMysqlInstancesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussdbMysqlInstancesDataSource_basic
=== PAUSE TestAccGaussdbMysqlInstancesDataSource_basic
=== CONT  TestAccGaussdbMysqlInstancesDataSource_basic
--- PASS: TestAccGaussdbMysqlInstancesDataSource_basic (1485.86s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1485.911s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
