### PR TITLE
fix(vpcep): remove policy_document field

### DIFF
--- a/docs/resources/vpcep_endpoint.md
+++ b/docs/resources/vpcep_endpoint.md
@@ -174,11 +174,6 @@ The following arguments are supported:
   -> Please refer to [official document](https://support.huaweicloud.com/intl/en-us/usermanual-iam/iam_01_0017.html) for
   the data structure rules of the policy. Just pay attention to the fields `Effect`, `Action` and `Resource`.
 
-* `policy_document` - (Optional, String) Specifies the IAM 5.0 policies. This parameter is only available when
-  `enable_policy` of the VPC endpoint services is set to **true**. Defaults to full access.
-  The VPC endpoint services of Object Storage Service (OBS) and Scalable File Service (SFS) do not support configuring
-  this parameter.
-
 * `tags` - (Optional, Map) The key/value pairs to associate with the VPC endpoint.
 
 ## Attribute Reference

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240904093004-8405480f47e9
+	github.com/chnsz/golangsdk v0.0.0-20240906025604-372d490f10dc
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240904093004-8405480f47e9 h1:TnwaufPiSeAii/Dp8QiWczguUT/1XTwg2FMnDtNMuvk=
-github.com/chnsz/golangsdk v0.0.0-20240904093004-8405480f47e9/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240906025604-372d490f10dc h1:i7vU0KgfWXtnrFc93qe57Jbs10OS3n5rUwmvabIulcI=
+github.com/chnsz/golangsdk v0.0.0-20240906025604-372d490f10dc/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/requests.go
@@ -40,8 +40,6 @@ type CreateOpts struct {
 	Description string `json:"description,omitempty"`
 	// Specifies the endpoint policy information for the gateway type
 	PolicyStatement []PolicyStatement `json:"policy_statement,omitempty"`
-	// Specifies the endpoint policy information
-	PolicyDocument string `json:"policy_document,omitempty"`
 	// Specifies the IP version
 	IPVersion string `json:"ip_version,omitempty"`
 	// Specifies the IPv6 address
@@ -115,8 +113,6 @@ type UpdatePolicyOptsBuilder interface {
 type UpdatePolicyOpts struct {
 	// Specifies the endpoint policy information for the gateway type
 	PolicyStatement []PolicyStatement `json:"policy_statement,omitempty"`
-	// Specifies the endpoint policy information
-	PolicyDocument string `json:"policy_document,omitempty"`
 }
 
 // UpdatePolicyOptsMap assembles a request body based on the contents of a UpdatePolicyOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/results.go
@@ -55,8 +55,6 @@ type Endpoint struct {
 	Description string `json:"description"`
 	// The gateway type endpoint policy information
 	PolicyStatement []PolicyStatementResult `json:"policy_statement"`
-	// the endpoint policy information
-	PolicyDocument string `json:"policy_document"`
 	// The cluster ID associated with the instance
 	EndpointPoolID string `json:"endpoint_pool_id"`
 	// The public border group information of the terminal node corresponding to the pool

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240904093004-8405480f47e9
+# github.com/chnsz/golangsdk v0.0.0-20240906025604-372d490f10dc
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The field type provided in the API document is different from the type returned
by the API, as a result, an error is reported when the resource is imported.
a. before deprecated
![image](https://github.com/user-attachments/assets/76c14c0e-7761-4511-85fa-2c1ae39d06c8)
b. after deprecated
![image](https://github.com/user-attachments/assets/15ea0cd8-13af-4113-a30d-c65d2e1d55fe)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccVPCEndpoint_Basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpoint_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_Basic
=== PAUSE TestAccVPCEndpoint_Basic
=== CONT  TestAccVPCEndpoint_Basic
--- PASS: TestAccVPCEndpoint_Basic (308.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     308.947s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccVPCEndpoint_Public"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpoint_Public -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_Public
=== PAUSE TestAccVPCEndpoint_Public
=== CONT  TestAccVPCEndpoint_Public
--- PASS: TestAccVPCEndpoint_Public (58.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     58.433s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccVPCEndpoint_gatewayEndpoint"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEndpoint_gatewayEndpoint -timeout 360m -parallel 4
=== RUN   TestAccVPCEndpoint_gatewayEndpoint
=== PAUSE TestAccVPCEndpoint_gatewayEndpoint
=== CONT  TestAccVPCEndpoint_gatewayEndpoint
--- PASS: TestAccVPCEndpoint_gatewayEndpoint (263.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     263.287s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
