### PR TITLE
fix(ims): modify the use of deprecated resource in tests cases

### DIFF
--- a/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go
+++ b/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go
@@ -160,7 +160,7 @@ resource "huaweicloud_compute_instance" "test" {
   }
 }
 
-resource "huaweicloud_images_image" "test" {
+resource "huaweicloud_ims_ecs_system_image" "test" {
   name        = "%[2]s"
   instance_id = huaweicloud_compute_instance.test.id
   description = "created by Terraform AccTest"
@@ -179,7 +179,7 @@ func testAccImsImageDataSource_queryName(rName string) string {
 
 data "huaweicloud_images_image" "test" {
   most_recent = true
-  name        = huaweicloud_images_image.test.name
+  name        = huaweicloud_ims_ecs_system_image.test.name
 }
 `, testAccImsImageDataSource_base(rName))
 }

--- a/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go
+++ b/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go
@@ -160,7 +160,7 @@ resource "huaweicloud_compute_instance" "test" {
   }
 }
 
-resource "huaweicloud_images_image" "test" {
+resource "huaweicloud_ims_ecs_system_image" "test" {
   name        = "%[2]s"
   instance_id = huaweicloud_compute_instance.test.id
   description = "created by Terraform AccTest"
@@ -178,7 +178,7 @@ func testAccImsImagesDataSource_queryName(rName string) string {
 %s
 
 data "huaweicloud_images_images" "test" {
-  name = huaweicloud_images_image.test.name
+  name = huaweicloud_ims_ecs_system_image.test.name
 }
 `, testAccImsImagesDataSource_base(rName))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Modify the use of deprecated resource in tests cases

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Modify the use of deprecated resource in tests cases

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### `images_image` test
```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImsImageDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImsImageDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccImsImageDataSource_basic
=== PAUSE TestAccImsImageDataSource_basic
=== RUN   TestAccImsImageDataSource_testQueries
=== PAUSE TestAccImsImageDataSource_testQueries
=== CONT  TestAccImsImageDataSource_basic
=== CONT  TestAccImsImageDataSource_testQueries
--- PASS: TestAccImsImageDataSource_basic (34.55s)
--- PASS: TestAccImsImageDataSource_testQueries (426.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       426.304s

```

### `images_images` test
```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImsImagesDataSource_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImsImagesDataSource_ -timeout 360m -parallel 4
=== RUN   TestAccImsImagesDataSource_basic
=== PAUSE TestAccImsImagesDataSource_basic
=== RUN   TestAccImsImagesDataSource_testQueries
=== PAUSE TestAccImsImagesDataSource_testQueries
=== CONT  TestAccImsImagesDataSource_basic
=== CONT  TestAccImsImagesDataSource_testQueries
--- PASS: TestAccImsImagesDataSource_basic (42.33s)
--- PASS: TestAccImsImagesDataSource_testQueries (449.37s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       449.512s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
