### PR TITLE
feat(servicestage/env): add new data source to query environmnets

### DIFF
--- a/docs/data-sources/servicestage_environments.md
+++ b/docs/data-sources/servicestage_environments.md
@@ -1,0 +1,63 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestage_environments"
+description: |-
+  Use this data source to query available environments within HuaweiCloud.
+---
+
+# huaweicloud_servicestage_environments
+
+Use this data source to query available environments within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_servicestage_environments" "test" {}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region where the environments are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `environments` - All queried environments.
+  The [environments](#servicestage_environments) structure is documented below.
+
+<a name="servicestage_environments"></a>
+The `environments` block contains:
+
+* `id` - The ID of the environment.
+
+* `name` - The name of the environment.
+
+* `description` - The description of the environment.
+
+* `deploy_mode` - The deploy mode of the environment.
+
+* `vpc_id` - The VPC ID to which the environment belongs.
+
+* `basic_resources` - The basic resources.
+  The [basic_resources](#resources_associated_environment) structure is documented below.
+
+* `optional_resources` - The optional resources.
+  The [optional_resources](#resources_associated_environment) structure is documented below.
+
+* `creator` - The creator name.
+
+* `created_at` - The creation time of the environment, in RFC3339 format.
+
+* `updated_at` - The latest update time of the environment, in RFC3339 format.
+
+<a name="resources_associated_environment"></a>
+The `basic_resources` and `optional_resources` block contains:
+
+* `id` - The resource ID.
+
+* `type` - The resource type.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -936,6 +936,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_data_class_fields":      secmaster.DataSourceSecmasterDataClassFields(),
 
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
+			"huaweicloud_servicestage_environments":       servicestage.DataSourceEnvironments(),
 
 			"huaweicloud_smn_topics":            smn.DataSourceTopics(),
 			"huaweicloud_smn_message_templates": smn.DataSourceSmnMessageTemplates(),

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestage_environments_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestage_environments_test.go
@@ -1,0 +1,107 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataServiceStageEnvironments_basic(t *testing.T) {
+	rName := "data.huaweicloud_servicestage_environments.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataServiceStageEnvironments_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(rName, "environments.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckOutput("all_envs_queried", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataServiceStageEnvironments_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_images_images" "test" {
+  name = "Ubuntu 18.04 server 64bit"
+}
+
+resource "huaweicloud_kps_keypair" "test" {
+  name = "%[1]s"
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  gateway_ip  = "192.168.0.1"
+  vpc_id      = huaweicloud_vpc.test.id
+  ipv6_enable = true
+}
+
+resource "huaweicloud_networking_secgroup" "test" {
+  name                 = "%[1]s"
+  delete_default_rules = true
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[1]s"
+  image_id           = data.huaweicloud_images_images.test.images[0].id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+  key_pair           = huaweicloud_kps_keypair.test.name
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+
+  network {
+    uuid = huaweicloud_vpc_subnet.test.id
+  }
+}
+
+resource "huaweicloud_servicestage_environment" "test" {
+  count = 2
+
+  name   = format("%[1]s_%%d", count.index)
+  vpc_id = huaweicloud_vpc.test.id
+
+  basic_resources {
+    type = "ecs"
+    id   = huaweicloud_compute_instance.test.id
+  }
+}
+
+data "huaweicloud_servicestage_environments" "test" {
+  depends_on = [huaweicloud_servicestage_environment.test]
+}
+
+output "all_envs_queried" {
+  value = length([for v in data.huaweicloud_servicestage_environments.test.environments: v if strcontains(v.name, "%[1]s")]) == 2
+}
+`, name)
+}

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestage_environments.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestage_environments.go
@@ -1,0 +1,214 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v2/{project_id}/cas/environments
+func DataSourceEnvironments() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEnvironmentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The region where the environments are located.`,
+			},
+			"environments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the environment.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the environment.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the environment.`,
+						},
+						"deploy_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The deploy mode of the environment.`,
+						},
+						"vpc_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The VPC ID to which the environment belongs.`,
+						},
+						"basic_resources": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataEnvResourcesSchema(),
+							Description: `The basic resources.`,
+						},
+						"optional_resources": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataEnvResourcesSchema(),
+							Description: `The optional resources.`,
+						},
+						"creator": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator name.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the environment, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the environment, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `All queried environments.`,
+			},
+		},
+	}
+}
+
+func dataEnvResourcesSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource ID.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The resource type.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func queryEnvironments(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/cas/environments?limit=1000"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		environments := utils.PathSearch("environments", respBody, make([]interface{}, 0)).([]interface{})
+		if len(environments) < 1 {
+			break
+		}
+		result = append(result, environments...)
+		offset += len(environments)
+	}
+
+	return result, nil
+}
+
+func flattenDataEnvResources(resources []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(resources))
+
+	for _, resource := range resources {
+		result = append(result, map[string]interface{}{
+			"id":   utils.PathSearch("id", resource, nil),
+			"type": utils.PathSearch("type", resource, nil),
+		})
+	}
+
+	return result
+}
+
+func flattenDataEnvironments(environments []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(environments))
+
+	for _, env := range environments {
+		result = append(result, map[string]interface{}{
+			"id":                 utils.PathSearch("id", env, nil),
+			"name":               utils.PathSearch("name", env, nil),
+			"alias":              utils.PathSearch("alias", env, nil),
+			"description":        utils.PathSearch("description", env, nil),
+			"deploy_mode":        utils.PathSearch("deploy_mode", env, nil),
+			"vpc_id":             utils.PathSearch("vpc_id", env, nil),
+			"basic_resources":    flattenDataEnvResources(utils.PathSearch("base_resources", env, make([]interface{}, 0)).([]interface{})),
+			"optional_resources": flattenDataEnvResources(utils.PathSearch("optional_resources", env, make([]interface{}, 0)).([]interface{})),
+			"creator":            utils.PathSearch("creator", env, nil),
+			"created_at":         utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", env, float64(0)).(float64)/1000), false),
+			"updated_at":         utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", env, float64(0)).(float64)/1000), false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceEnvironmentsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	environments, err := queryEnvironments(client)
+	if err != nil {
+		return diag.Errorf("error querying environments: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("environments", flattenDataEnvironments(environments)),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving data source fields of ServiceStage environments: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source to query available environments of the ServiceStage service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query environmnets.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run=TestAccDataServiceStageEnvironments_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run=TestAccDataServiceStageEnvironments_basic -timeout 360m -parallel 4
=== RUN   TestAccDataServiceStageEnvironments_basic
=== PAUSE TestAccDataServiceStageEnvironments_basic
=== CONT  TestAccDataServiceStageEnvironments_basic
--- PASS: TestAccDataServiceStageEnvironments_basic (233.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      233.883s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
