### PR TITLE
feat(servicestage/app): add new data source to query applications

### DIFF
--- a/docs/data-sources/servicestage_applications.md
+++ b/docs/data-sources/servicestage_applications.md
@@ -1,0 +1,71 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestage_applications"
+description: |-
+  Use this data source to query available applications within HuaweiCloud.
+---
+
+# huaweicloud_servicestage_applications
+
+Use this data source to query available applications within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_servicestage_applications" "test" {}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region where the applications are located.  
+  If omitted, the provider-level region will be used.
+
+* `ignore_environments` - (Optional, Bool) Specifies whether to ignore environments query.  
+  Defaults to **false**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `applications` - All queried applications.
+  The [applications](#servicestage_applications) structure is documented below.
+
+<a name="servicestage_applications"></a>
+The `applications` block contains:
+
+* `id` - The ID of the application.
+
+* `name` - The name of the application.
+
+* `description` - The description of the application.
+
+* `enterprise_project_id` - The enterpeise project ID to which the application belongs.
+
+* `creator` - The creator name.
+
+* `created_at` - The creation time of the application, in RFC3339 format.
+
+* `updated_at` - The latest update time of the application, in RFC3339 format.
+
+* `component_count` - The number of the components associated with the application.
+
+* `environments` - The environment configuration associated with the application.
+  The [environments](#environment_configurations_associated_app) structure is documented below.
+
+<a name="environment_configurations_associated_app"></a>
+The `environments` block contains:
+
+* `id` - The environment ID.
+
+* `variables` - The variables of the environment.
+  The [variables](#environment_variables_associated_app) structure is documented below.
+
+<a name="environment_variables_associated_app"></a>
+The `variables` block contains:
+
+* `name` - The variable name.
+
+* `value` - The variable value.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -974,6 +974,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_playbook_monitors":         secmaster.DataSourceSecmasterPlaybookMonitors(),
 
 			// Querying by Ver.2 APIs
+			"huaweicloud_servicestage_applications":       servicestage.DataSourceApplications(),
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
 			// Querying by Ver.3 APIs
 			"huaweicloud_servicestagev3_runtime_stacks": servicestage.DataSourceV3RuntimeStacks(),

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestage_applications_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestage_applications_test.go
@@ -1,0 +1,112 @@
+package servicestage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataApplications_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_servicestage_applications.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataApplications_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("is_target_application_queried", "true"),
+					resource.TestCheckOutput("is_target_application_name_right", "true"),
+					resource.TestCheckOutput("is_target_application_description_right", "true"),
+					resource.TestCheckOutput("is_target_application_eps_id_right", "true"),
+					resource.TestCheckOutput("is_target_application_creator_set", "true"),
+					resource.TestCheckOutput("is_target_application_created_at_set", "true"),
+					resource.TestCheckOutput("is_target_application_updated_at_set", "true"),
+					resource.TestCheckOutput("is_target_application_environments_set", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataApplications_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestage_application" "test" {
+  name        = "%[2]s"
+  description = "Created by terraform test"
+
+  enterprise_project_id = "%[3]s"
+
+  environment {
+    id = huaweicloud_servicestage_environment.test.id
+
+    variable {
+      name  = "name_1"
+      value = "value_1"
+    }
+    variable {
+      name  = "name_2"
+      value = "abcdefghijklmnopqrstuvwxyz"
+    }
+    variable {
+      name  = "name_3"
+      value = "1234567890"
+    }
+  }
+}
+
+data "huaweicloud_servicestage_applications" "test" {
+  depends_on = [huaweicloud_servicestage_application.test]
+}
+
+locals {
+  app_query_result = [
+    for v in data.huaweicloud_servicestage_applications.test.applications : v if v.id == huaweicloud_servicestage_application.test.id
+  ]
+}
+
+output "is_target_application_queried" {
+  value = length(local.app_query_result) == 1
+}
+
+output "is_target_application_name_right" {
+  value = try(local.app_query_result[0].name == huaweicloud_servicestage_application.test.name, false)
+}
+
+output "is_target_application_description_right" {
+  value = try(local.app_query_result[0].description == huaweicloud_servicestage_application.test.description, false)
+}
+
+output "is_target_application_eps_id_right" {
+  value = try(local.app_query_result[0].enterprise_project_id == huaweicloud_servicestage_application.test.enterprise_project_id, false)
+}
+
+output "is_target_application_creator_set" {
+  value = try(local.app_query_result[0].creator != "", false)
+}
+
+output "is_target_application_created_at_set" {
+  value = try(local.app_query_result[0].created_at != "", false)
+}
+
+output "is_target_application_updated_at_set" {
+  value = try(local.app_query_result[0].updated_at != "", false)
+}
+
+output "is_target_application_environments_set" {
+  value = try(length(local.app_query_result[0].environments[0].variables) == 3, false)
+}
+`, testAccApplication_base(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestage_applications.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestage_applications.go
@@ -1,0 +1,273 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v2/{project_id}/cas/applications
+// @API ServiceStage GET /v2/{project_id}/cas/applications/{application_id}/configuration
+func DataSourceApplications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceApplicationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The region where the applications are located.`,
+			},
+			"ignore_environments": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to ignore environments query. `,
+			},
+			"applications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the application.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the application.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the application.`,
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The enterpeise project ID to which the application belongs.`,
+						},
+						"creator": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator name.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the application, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the application, in RFC3339 format.`,
+						},
+						"component_count": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The number of the components associated with the application.`,
+						},
+						"environments": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        dataAppEnvVariablesSchema(),
+							Description: `The environment configuration associated with the application.`,
+						},
+					},
+				},
+				Description: `All queried applications.`,
+			},
+		},
+	}
+}
+
+func dataAppEnvVariablesSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The environment ID.`,
+			},
+			"variables": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The variable name.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The variable value.`,
+						},
+					},
+				},
+				Description: `The variables of the environment.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func queryApplications(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/cas/applications?limit=1000"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		applications := utils.PathSearch("applications", respBody, make([]interface{}, 0)).([]interface{})
+		if len(applications) < 1 {
+			break
+		}
+		result = append(result, applications...)
+		offset += len(applications)
+	}
+
+	return result, nil
+}
+
+func queryAppConfigurations(client *golangsdk.ServiceClient, appId string) ([]interface{}, error) {
+	httpUrl := "v2/{project_id}/cas/applications/{application_id}/configuration"
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath = strings.ReplaceAll(listPath, "{application_id}", appId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", listPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	configurations := utils.PathSearch("configuration", respBody, make([]interface{}, 0)).([]interface{})
+	return configurations, nil
+}
+
+func flattenAppConfigurationVariables(variables []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(variables))
+
+	for _, variable := range variables {
+		result = append(result, map[string]interface{}{
+			"name":  utils.PathSearch("name", variable, nil),
+			"value": utils.PathSearch("value", variable, nil),
+		})
+	}
+	return result
+}
+
+func flattenAppConfigurations(configurations []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(configurations))
+
+	for _, configuration := range configurations {
+		result = append(result, map[string]interface{}{
+			"id": utils.PathSearch("environment_id", configuration, nil),
+			"variables": flattenAppConfigurationVariables(utils.PathSearch("configuration.env",
+				configuration, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+	return result
+}
+
+func flattenDataApplications(client *golangsdk.ServiceClient, applications []interface{}, ignoreVars bool) []interface{} {
+	result := make([]interface{}, 0, len(applications))
+
+	for _, app := range applications {
+		appId := utils.PathSearch("id", app, "").(string)
+		appElem := map[string]interface{}{
+			"id":                    appId,
+			"name":                  utils.PathSearch("name", app, nil),
+			"description":           utils.PathSearch("description", app, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", app, nil),
+			"creator":               utils.PathSearch("creator", app, nil),
+			"created_at":            utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", app, float64(0)).(float64)/1000), false),
+			"updated_at":            utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", app, float64(0)).(float64)/1000), false),
+			"component_count":       utils.PathSearch("component_count", app, nil),
+		}
+		if !ignoreVars {
+			configurations, err := queryAppConfigurations(client, appId)
+			if err != nil {
+				log.Printf("[ERROR] unable to find the application (%s) configuration: %s", appId, err)
+			} else {
+				appElem["environments"] = flattenAppConfigurations(configurations)
+			}
+		}
+		result = append(result, appElem)
+	}
+
+	return result
+}
+
+func dataSourceApplicationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	applications, err := queryApplications(client)
+	if err != nil {
+		return diag.Errorf("error querying applications: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("applications", flattenDataApplications(client, applications, d.Get("ignore_variables").(bool))),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error saving data source fields of ServiceStage environments: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source that used to query available applications.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query applications.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o ecs -f TestAccComputeInstance_prePaid
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ecs" -v -coverprofile="./huaweicloud/services/acceptance/ecs_coverage.cov" -coverpkg="./huaweicloud/services/ecs" -run TestAccComputeInstance_prePaid -timeout 360m -parallel 10
=== RUN   TestAccComputeInstance_prePaid
=== PAUSE TestAccComputeInstance_prePaid
=== CONT  TestAccComputeInstance_prePaid
--- PASS: TestAccComputeInstance_prePaid (268.80s)
PASS
coverage: 23.9% of statements in ./huaweicloud/services/ecs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       268.855s        coverage: 23.9% of statements in ./huaweicloud/services/ecs
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
