### PR TITLE
feat(ims/ov_versions): support ims os_versions datasource

### DIFF
--- a/docs/data-sources/ims_os_versions.md
+++ b/docs/data-sources/ims_os_versions.md
@@ -1,0 +1,67 @@
+---
+subcategory: "Image Management Service (IMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ims_os_versions"
+description: |-
+  Use this data source to get the list of OS versions supported by IMS image within HuaweiCloud.
+---
+
+# huaweicloud_ims_os_versions
+
+Use this data source to get the list of OS versions supported by IMS image within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_ims_os_versions" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `tag` - (Optional, String) Specifies the label value for the OS versions.
+  Multiple tags separated by commas, e.g. **bms,uefi**.  
+  The valid values are as follows:
+  + **bms**: OS versions that supports BMS image type.
+  + **uefi**: OS versions that supports UEFI boot mode.
+  + **arm**: OS versions based on ARM architecture.
+  + **x86**: OS versions based on x86 architecture.
+
+  If omitted, query all supported OS versions in the current region.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `os_versions` - The OS version details.
+
+  The [os_versions](#os_versions_struct) structure is documented below.
+
+<a name="os_versions_struct"></a>
+The `os_versions` block supports:
+
+* `platform` - The operating system platform.
+
+* `versions` - The operating system details.
+
+  The [versions](#os_versions_versions_struct) structure is documented below.
+
+<a name="os_versions_versions_struct"></a>
+The `versions` block supports:
+
+* `platform` - The operating system platform.
+
+* `os_version_key` - The operating system key value.
+  By default, the value of `os_version` is taken as the `os_version_key` value.
+
+* `os_version` - The complete information of the operating system.
+
+* `os_bit` - The number of bits for the operating system.
+
+* `os_type` - The type of operating system.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -776,8 +776,9 @@ func Provider() *schema.Provider {
 			"huaweicloud_iec_vpc":            iec.DataSourceVpc(),
 			"huaweicloud_iec_vpc_subnets":    iec.DataSourceVpcSubnets(),
 
-			"huaweicloud_images_image":  ims.DataSourceImagesImageV2(),
-			"huaweicloud_images_images": ims.DataSourceImagesImages(),
+			"huaweicloud_images_image":    ims.DataSourceImagesImageV2(),
+			"huaweicloud_images_images":   ims.DataSourceImagesImages(),
+			"huaweicloud_ims_os_versions": ims.DataSourceOsVersions(),
 
 			"huaweicloud_kms_data_key":      dew.DataSourceKmsDataKeyV1(),
 			"huaweicloud_kms_grants":        dew.DataSourceKmsGrants(),

--- a/huaweicloud/services/acceptance/ims/data_source_huaweicloud_ims_os_versions_test.go
+++ b/huaweicloud/services/acceptance/ims/data_source_huaweicloud_ims_os_versions_test.go
@@ -1,0 +1,62 @@
+package ims
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceOsVersions_basic(t *testing.T) {
+	var (
+		dataSource = "data.huaweicloud_ims_os_versions.test"
+		dc         = acceptance.InitDataSourceCheck(dataSource)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceOsVersion_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "os_versions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "os_versions.0.platform"),
+					resource.TestCheckResourceAttrSet(dataSource, "os_versions.0.versions.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "os_versions.0.versions.0.platform"),
+					resource.TestCheckResourceAttrSet(dataSource, "os_versions.0.versions.0.os_version_key"),
+					resource.TestCheckResourceAttrSet(dataSource, "os_versions.0.versions.0.os_version"),
+					resource.TestCheckResourceAttrSet(dataSource, "os_versions.0.versions.0.os_bit"),
+					resource.TestCheckResourceAttrSet(dataSource, "os_versions.0.versions.0.os_type"),
+					resource.TestCheckOutput("is_test1_filter_successful", "true"),
+					resource.TestCheckOutput("is_test2_filter_successful", "true"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceOsVersion_basic = `
+data "huaweicloud_ims_os_versions" "test" {
+}
+
+data "huaweicloud_ims_os_versions" "test1" {
+  tag = "x86"
+}
+
+output "is_test1_filter_successful" {
+  value = length(data.huaweicloud_ims_os_versions.test1.os_versions) < length(data.huaweicloud_ims_os_versions.test.os_versions) 
+}
+
+data "huaweicloud_ims_os_versions" "test2" {
+  tag = "x86,bms"
+}
+
+output "is_test2_filter_successful" {
+  value = length(data.huaweicloud_ims_os_versions.test2.os_versions) < length(data.huaweicloud_ims_os_versions.test1.os_versions) 
+}
+`

--- a/huaweicloud/services/ims/data_source_huaweicloud_ims_os_versions.go
+++ b/huaweicloud/services/ims/data_source_huaweicloud_ims_os_versions.go
@@ -1,0 +1,158 @@
+// Some response parameters in the API documentation display abnormally, causing the PMS platform to be unable to
+// recognize the response parameters. Therefore, this dataSource is written in an automatically generated format.
+package ims
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IMS GET /v1/cloudimages/os_version
+func DataSourceOsVersions() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceOsVersionsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"os_versions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"platform": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"versions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"platform": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"os_version_key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"os_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"os_bit": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"os_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceOsVersionsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.ImageV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v1 client: %s", err)
+	}
+
+	getPath := client.Endpoint + "v1/cloudimages/os_version"
+	if v, ok := d.GetOk("tag"); ok && v.(string) != "" {
+		result := strings.Split(v.(string), ",")
+		for i, tag := range result {
+			if i == 0 {
+				getPath += "?tag=" + tag
+			} else {
+				getPath += "&tag=" + tag
+			}
+		}
+	}
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return diag.Errorf("error retrieving IMS OS versions, %s", err)
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuId)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("os_versions", flattenOsVersions(getRespBody.([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenOsVersions(osVersions []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(osVersions))
+
+	for _, osVersion := range osVersions {
+		result = append(result, map[string]interface{}{
+			"platform": utils.PathSearch("platform", osVersion, nil),
+			"versions": flattenVersions(utils.PathSearch("version_list", osVersion, make([]interface{}, 0)).([]interface{})),
+		})
+	}
+
+	return result
+}
+
+func flattenVersions(versions []interface{}) []interface{} {
+	result := make([]interface{}, 0, len(versions))
+
+	for _, version := range versions {
+		result = append(result, map[string]interface{}{
+			"platform":       utils.PathSearch("platform", version, nil),
+			"os_version_key": utils.PathSearch("os_version_key", version, nil),
+			"os_version":     utils.PathSearch("os_version", version, nil),
+			"os_bit":         utils.PathSearch("os_bit", version, nil),
+			"os_type":        utils.PathSearch("os_type", version, nil),
+		})
+	}
+
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support ims os_versions datasource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

1. Support ims os_versions datasource.
2. Some response parameters in the API documentation display abnormally, causing the PMS platform to be unable to recognize the response parameters. Therefore, this dataSource is written in an automatically generated format.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccDataSourceOsVersions_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccDataSourceOsVersions_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceOsVersions_basic
=== PAUSE TestAccDataSourceOsVersions_basic
=== CONT  TestAccDataSourceOsVersions_basic
--- PASS: TestAccDataSourceOsVersions_basic (8.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       8.754s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
