### PR TITLE
fix(apig/group): remove the default value of the 'domain_access_enabled'

### DIFF
--- a/docs/resources/apig_group.md
+++ b/docs/resources/apig_group.md
@@ -64,7 +64,7 @@ The following arguments are supported:
      Each API group can be associated with up to `5` domain names.
 
 * `domain_access_enabled` - (Optional, Bool) Specifies whether to use the debugging domain name to access the APIs
-  within the group. The default value is `true`.
+  within the group. The default value is `false`.
 
 * `force_destroy` - (Optional, Bool) Specifies whether to delete all sub-resources (for API) when deleting this group.  
   Defaults to **false**.

--- a/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_test.go
+++ b/huaweicloud/services/acceptance/apig/resource_huaweicloud_apig_group_test.go
@@ -353,6 +353,12 @@ func TestAccGroup_withDomainAccess(t *testing.T) {
 					resource.TestCheckResourceAttr(rNameWithDomainAccess, "domain_access_enabled", "true"),
 				),
 			},
+			{
+				ResourceName:      rNameWithDomainAccess,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccGroupImportStateFunc(rNameWithDomainAccess),
+			},
 		},
 	})
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_group.go
@@ -137,7 +137,7 @@ func ResourceApigGroupV2() *schema.Resource {
 			"domain_access_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     true,
+				Computed:    true,
 				Description: "Specifies whether to use the debugging domain name to access the APIs within the group.",
 			},
 			"force_destroy": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Remove the default value of the **domain_access_enabled parameter** and add `Computed` for it.

The reasons for the change are as follows:
 + Some regions do not support the **domain_access_enabled**  feature, and the value obtained by the query interface is **false**, so changes will occur when executing `terraform plan`.
+ For regions that support the **domain_access_enabled** parameter, if it is not specified, the value obtained by the query interface is **true**, so to ensure compatibility, add `Computed` to it.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/apig TESTARGS='-run TestAccGroup_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/apig -v -run TestAccGroup_ -timeout 360m -parallel 4
=== RUN   TestAccGroup_basic
=== PAUSE TestAccGroup_basic
=== RUN   TestAccGroup_withVariables
=== PAUSE TestAccGroup_withVariables
=== RUN   TestAccGroup_withUrlDomain
=== PAUSE TestAccGroup_withUrlDomain
=== RUN   TestAccGroup_withDomainAccess
=== PAUSE TestAccGroup_withDomainAccess
=== CONT  TestAccGroup_basic
=== CONT  TestAccGroup_withUrlDomain
=== CONT  TestAccGroup_withDomainAccess
=== CONT  TestAccGroup_withVariables
--- PASS: TestAccGroup_withDomainAccess (145.35s)
--- PASS: TestAccGroup_withUrlDomain (154.23s)
--- PASS: TestAccGroup_basic (154.34s)
--- PASS: TestAccGroup_withVariables (162.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/apig      162.749s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
