### PR TITLE
feat(dws): add new resource supports modifying workload configuration

### DIFF
--- a/docs/resources/dws_workload_configuration.md
+++ b/docs/resources/dws_workload_configuration.md
@@ -1,0 +1,58 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_workload_configuration"
+description: |-
+  Manages a workload configuration resource under specified DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_workload_configuration
+
+Manages a workload configuration resource under specified DWS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "dws_cluster_id" {}
+
+resource "huaweicloud_dws_workload_configuration" "test" {
+  cluster_id          = var.dws_cluster_id
+  workload_switch     = "on"
+  max_concurrency_num = "100"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the DWS cluster ID.
+  Changing this creates a new resource.
+
+* `workload_switch` - (Required, String) Specifies the workload management switch.  
+  The valid value are as follows:
+  + **on**
+  + **off**
+
+  -> If this parameter is set to **off**, all resource management functions will be unavailable.
+
+* `max_concurrency_num` - (Optional, String) Specifies the maximum number of concurrent tasks on a single CN.  
+  The valid value ranges from `-1` to `2,147,483,647`, `-1` and `0` means unlimited.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, also `cluster_id`.
+
+## Import
+
+The resource can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_dws_workload_configuration.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1449,6 +1449,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_public_domain_associate": dws.ResourcePublicDomainAssociate(),
 			"huaweicloud_dws_snapshot_policy":         dws.ResourceDwsSnapshotPolicy(),
 			"huaweicloud_dws_snapshot":                dws.ResourceDwsSnapshot(),
+			"huaweicloud_dws_workload_configuration":  dws.ResourceWorkLoadConfiguration(),
 			"huaweicloud_dws_workload_plan_execution": dws.ResourceWorkLoadPlanExecution(),
 			"huaweicloud_dws_workload_plan_stage":     dws.ResourceWorkLoadPlanStage(),
 			"huaweicloud_dws_workload_plan":           dws.ResourceWorkLoadPlan(),

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_configuration_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_workload_configuration_test.go
@@ -1,0 +1,111 @@
+package dws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
+)
+
+func getWorkloadConfigurationFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS Client: %s", err)
+	}
+
+	return dws.GetWorkloadConfiguration(client, state.Primary.ID)
+}
+
+// lintignore:AT001
+func TestAccWorkloadConfiguration_basic(t *testing.T) {
+	var obj interface{}
+	rName := "huaweicloud_dws_workload_configuration.test"
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getWorkloadConfigurationFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testWorkloadConfiguration_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workload_switch", "off"),
+				),
+			},
+			{
+				Config: testWorkloadConfiguration_basic_step2(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workload_switch", "on"),
+					resource.TestCheckResourceAttr(rName, "max_concurrency_num", "0"),
+				),
+			},
+			{
+				Config: testWorkloadConfiguration_basic_step3(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workload_switch", "on"),
+					resource.TestCheckResourceAttr(rName, "max_concurrency_num", "-1"),
+				),
+			},
+			{
+				Config: testWorkloadConfiguration_basic_step4(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workload_switch", "on"),
+					resource.TestCheckResourceAttr(rName, "max_concurrency_num", "100"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testWorkloadConfiguration_basic(concurrencyNum string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_workload_configuration" "test" {
+  cluster_id          = "%s"
+  workload_switch     = "on"
+  max_concurrency_num = "%s"
+}
+`, acceptance.HW_DWS_CLUSTER_ID, concurrencyNum)
+}
+
+func testWorkloadConfiguration_basic_step1() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_workload_configuration" "test" {
+  cluster_id      = "%s"
+  workload_switch = "off"
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}
+
+func testWorkloadConfiguration_basic_step2() string {
+	return testWorkloadConfiguration_basic("0")
+}
+
+func testWorkloadConfiguration_basic_step3() string {
+	return testWorkloadConfiguration_basic("-1")
+}
+
+func testWorkloadConfiguration_basic_step4() string {
+	return testWorkloadConfiguration_basic("100")
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_workload_configuration.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_workload_configuration.go
@@ -1,0 +1,172 @@
+package dws
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS POST /v2/{project_id}/clusters/{cluster_id}/workload
+// @API DWS GET /v2/{project_id}/clusters/{cluster_id}/workload
+func ResourceWorkLoadConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceWorkLoadConfigurationCreate,
+		ReadContext:   resourceWorkLoadConfigurationRead,
+		UpdateContext: resourceWorkLoadConfigurationUpdate,
+		DeleteContext: resourceWorkLoadConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Specifies the DWS cluster ID.",
+			},
+			"workload_switch": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the workload management switch.",
+			},
+			"max_concurrency_num": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the maximum number of concurrent tasks on a single CN.",
+			},
+		},
+	}
+}
+
+func resourceWorkLoadConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	client, err := cfg.NewServiceClient("dws", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = modifyWorkloadConfiguration(client, d, clusterId)
+	if err != nil {
+		return diag.Errorf("error setting workload configuration for DWS cluster(%s): %s", clusterId, err)
+	}
+
+	d.SetId(clusterId)
+	return resourceWorkLoadConfigurationRead(ctx, d, meta)
+}
+
+func buildModifyConfigurationParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"workload_switch":     d.Get("workload_switch"),
+		"max_concurrency_num": d.Get("max_concurrency_num"),
+	}
+
+	return map[string]interface{}{
+		"workload_status": params,
+	}
+}
+
+func modifyWorkloadConfiguration(client *golangsdk.ServiceClient, d *schema.ResourceData, clusterId string) error {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/workload"
+	modifyPath := client.Endpoint + httpUrl
+	modifyPath = strings.ReplaceAll(modifyPath, "{project_id}", client.ProjectID)
+	modifyPath = strings.ReplaceAll(modifyPath, "{cluster_id}", clusterId)
+
+	opts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildModifyConfigurationParams(d)),
+	}
+
+	_, err := client.Request("POST", modifyPath, &opts)
+	return err
+}
+
+func GetWorkloadConfiguration(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/workload"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+func resourceWorkLoadConfigurationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	respBody, err := GetWorkloadConfiguration(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, parseWorkLoadPlanError(err), "DWS workload configuration")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("cluster_id", d.Id()),
+		d.Set("workload_switch", utils.PathSearch("workload_status.workload_switch", respBody, "")),
+		// The type returned by the query interface is int.
+		d.Set("max_concurrency_num", strconv.Itoa(int(utils.PathSearch("workload_status.max_concurrency_num", respBody, float64(0)).(float64)))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceWorkLoadConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dws", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	if err = modifyWorkloadConfiguration(client, d, d.Id()); err != nil {
+		return diag.Errorf("error updating workload configuration: %s", err)
+	}
+
+	return resourceWorkLoadConfigurationRead(ctx, d, meta)
+}
+
+func resourceWorkLoadConfigurationDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only used to modify the workload configuration. Deleting this resource will
+	not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resources to support modifying resource management switch and maximum concurrency.
Add related document and acceptance test.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
The feature corresponding to the resource already exists. Only the ability to modify the feature is provided, so deletion logic is not supported.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccWorkloadConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccWorkloadConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccWorkloadConfiguration_basic
=== PAUSE TestAccWorkloadConfiguration_basic
=== CONT  TestAccWorkloadConfiguration_basic
--- PASS: TestAccWorkloadConfiguration_basic (92.69s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       92.742s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found(Cluster ID does not exist)
  ![image](https://github.com/user-attachments/assets/ba2565bb-6f29-411f-b69a-ea2c1df1d195)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
