### PR TITLE
fix(dms): fix import func for rabbitmq vhost exchange queue

### DIFF
--- a/docs/data-sources/dms_rabbitmq_exchanges.md
+++ b/docs/data-sources/dms_rabbitmq_exchanges.md
@@ -33,6 +33,8 @@ The following arguments are supported:
 
 * `vhost` - (Required, String) Specifies the vhost name.
 
+  -> If `vhost` has slashes, please change them into **\_\_F_SLASH\_\_**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/data-sources/dms_rabbitmq_queues.md
+++ b/docs/data-sources/dms_rabbitmq_queues.md
@@ -33,6 +33,8 @@ The following arguments are supported:
 
 * `vhost` - (Required, String) Specifies the vhost name.
 
+  -> If `vhost` has slashes, please change them into **\_\_F_SLASH\_\_**.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/dms_rabbitmq_exchange.md
+++ b/docs/resources/dms_rabbitmq_exchange.md
@@ -39,6 +39,8 @@ The following arguments are supported:
   Changing this creates a new resource.
 
 * `vhost` - (Required, String, ForceNew) Specifies the vhost name. Changing this creates a new resource.
+  
+  -> If `vhost` has slashes, please change them into **\_\_F_SLASH\_\_**.
 
 * `name` - (Required, String, ForceNew) Specifies the exchange name. Changing this creates a new resource.
 
@@ -61,8 +63,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The RabbitMQ exchange can be imported using the `instance_id`, `vhost` and `name` separated by slashes, e.g.
+The RabbitMQ exchange can be imported using the `instance_id`, `vhost` and `name` separated by slashes or commas, but if
+`name` contains slashes, the import ID can only be separated by commas e.g.
 
 ```bash
 $ terraform import huaweicloud_dms_rabbitmq_exchange.test <instance_id>/<vhost>/<name>
+```
+
+```bash
+$ terraform import huaweicloud_dms_rabbitmq_exchange.test <instance_id>,<vhost>,<name>
 ```

--- a/docs/resources/dms_rabbitmq_queue.md
+++ b/docs/resources/dms_rabbitmq_queue.md
@@ -46,6 +46,8 @@ The following arguments are supported:
 * `vhost` - (Required, String, ForceNew) Specifies the vhost name.
   Changing this creates a new resource.
 
+  -> If `vhost` has slashes, please change them into **\_\_F_SLASH\_\_**.
+
 * `name` - (Required, String, ForceNew) Specifies the queue name.
   Changing this creates a new resource.
 
@@ -129,8 +131,13 @@ The `queue_bindings` block supports:
 
 ## Import
 
-The queue can be imported using `instance_id`, `vhost` and `name` separated by slashes, e.g.
+The RabbitMQ queue can be imported using the `instance_id`, `vhost` and `name` separated by slashes or commas, but if
+`name` contains slashes, the import ID can only be separated by commas e.g.
 
 ```bash
 $ terraform import huaweicloud_dms_rabbitmq_queue.test <instance_id>/<vhost>/<name>
+```
+
+```bash
+$ terraform import huaweicloud_dms_rabbitmq_queue.test <instance_id>,<vhost>,<name>
 ```

--- a/docs/resources/dms_rabbitmq_vhost.md
+++ b/docs/resources/dms_rabbitmq_vhost.md
@@ -44,8 +44,13 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The RabbitMQ vhost can be imported using the `instance_id` and `name` separated by a slash, e.g.
+The RabbitMQ vhost can be imported using the `instance_id` and `name` separated by a slash or a comma, but if `name`
+contains slashes, the import ID can only be separated by a comma, e.g.
 
 ```bash
 $ terraform import huaweicloud_dms_rabbitmq_vhost.test <instance_id>/<name>
+```
+
+```bash
+$ terraform import huaweicloud_dms_rabbitmq_vhost.test <instance_id>,<name>
 ```

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_exchange.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_exchange.go
@@ -26,7 +26,7 @@ func ResourceDmsRabbitmqExchange() *schema.Resource {
 		DeleteContext: resourceDmsRabbitmqExchangeDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceExchangeOrQueueImportState,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -128,13 +128,9 @@ func resourceDmsRabbitmqExchangeRead(_ context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error creating DMS client: %s", err)
 	}
 
-	parts := strings.Split(d.Id(), "/")
-	if len(parts) != 3 {
-		return diag.Errorf("invalid ID format, must be <instance_id>/<vhost>/<name>")
-	}
-	instanceID := parts[0]
-	vhost := parts[1]
-	name := parts[2]
+	instanceID := d.Get("instance_id").(string)
+	vhost := d.Get("vhost").(string)
+	name := d.Get("name").(string)
 
 	exchange, err := GetRabbitmqExchange(client, instanceID, vhost, name)
 	if err != nil {
@@ -143,9 +139,6 @@ func resourceDmsRabbitmqExchangeRead(_ context.Context, d *schema.ResourceData, 
 
 	mErr := multierror.Append(nil,
 		d.Set("region", region),
-		d.Set("instance_id", instanceID),
-		d.Set("vhost", vhost),
-		d.Set("name", name),
 		d.Set("type", utils.PathSearch("type", exchange, nil)),
 		d.Set("auto_delete", utils.PathSearch("auto_delete", exchange, nil)),
 		d.Set("durable", utils.PathSearch("durable", exchange, nil)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
fix import func for rabbitmq vhost exchange queue

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/acc-test.sh 

run acceptance tests of huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_exchange_test.go:
=== RUN   TestAccRabbitmqExchange_basic
=== PAUSE TestAccRabbitmqExchange_basic
=== RUN   TestAccRabbitmqExchange_slash
=== PAUSE TestAccRabbitmqExchange_slash
=== CONT  TestAccRabbitmqExchange_basic
=== CONT  TestAccRabbitmqExchange_slash
--- PASS: TestAccRabbitmqExchange_slash (805.41s)
--- PASS: TestAccRabbitmqExchange_basic (901.69s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/dms
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       901.756s        coverage: 9.8% of statements in ./huaweicloud/services/dms

run acceptance tests of huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_queue_test.go:
=== RUN   TestAccRabbitmqQueue_basic
=== PAUSE TestAccRabbitmqQueue_basic
=== RUN   TestAccRabbitmqQueue_slash
=== PAUSE TestAccRabbitmqQueue_slash
=== CONT  TestAccRabbitmqQueue_basic
=== CONT  TestAccRabbitmqQueue_slash
--- PASS: TestAccRabbitmqQueue_slash (775.06s)
--- PASS: TestAccRabbitmqQueue_basic (886.23s)
PASS
coverage: 9.8% of statements in ./huaweicloud/services/dms
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       886.304s        coverage: 9.8% of statements in ./huaweicloud/services/dms

run acceptance tests of huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_vhost_test.go:
=== RUN   TestAccRabbitmqVhost_basic
=== PAUSE TestAccRabbitmqVhost_basic
=== RUN   TestAccRabbitmqVhost_slash
=== PAUSE TestAccRabbitmqVhost_slash
=== CONT  TestAccRabbitmqVhost_basic
=== CONT  TestAccRabbitmqVhost_slash
--- PASS: TestAccRabbitmqVhost_basic (796.39s)
--- PASS: TestAccRabbitmqVhost_slash (890.33s)
PASS
coverage: 8.3% of statements in ./huaweicloud/services/dms
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       890.410s        coverage: 8.3% of statements in ./huaweicloud/services/dms

### coverage of files in huaweicloud/services:

- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_exchange.go (85.7%)
- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_queue.go (78.0%)
- github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_vhost.go (84.6%)

### [summary] 0 failed in 3 resource acceptance tests
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
