### PR TITLE
feat(secmaster): add resource playbook enabling

### DIFF
--- a/docs/resources/secmaster_playbook_enable.md
+++ b/docs/resources/secmaster_playbook_enable.md
@@ -1,0 +1,49 @@
+---
+subcategory: "SecMaster"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_secmaster_playbook_enable"
+description: |-
+  Use this resource to enable a SecMaster playbook within HuaweiCloud.
+---
+
+# huaweicloud_secmaster_playbook_enable
+
+Use this resource to enable a SecMaster playbook within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "workspace_id" {}
+variable "playbook_id" {}
+variable "playbook_name" {}
+variable "active_version_id" {}
+
+resource "huaweicloud_secmaster_playbook_enable" "test" {
+  workspace_id      = var.workspace_id
+  playbook_id       = var.playbook_id
+  playbook_name     = var.playbook_name
+  active_version_id = var.active_version_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `workspace_id` - (Required, String, NonUpdatable) Specifies the ID of the workspace to which the playbook version belongs.
+
+* `playbook_id` - (Required, String, NonUpdatable) Specifies the playbook ID.
+
+* `playbook_name` - (Required, String, NonUpdatable) Specifies the playbook name.
+
+* `active_version_id` - (Required, String, NonUpdatable) Specifies the actived playbook version ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1791,6 +1791,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_alert_rule":              secmaster.ResourceAlertRule(),
 			"huaweicloud_secmaster_data_object_relations":   secmaster.ResourceDataObjectRelations(),
 			"huaweicloud_secmaster_playbook":                secmaster.ResourcePlaybook(),
+			"huaweicloud_secmaster_playbook_enable":         secmaster.ResourcePlaybookEnable(),
 			"huaweicloud_secmaster_playbook_version":        secmaster.ResourcePlaybookVersion(),
 			"huaweicloud_secmaster_playbook_version_action": secmaster.ResourcePlaybookVersionAction(),
 			"huaweicloud_secmaster_playbook_rule":           secmaster.ResourcePlaybookRule(),

--- a/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_playbook_enable_test.go
+++ b/huaweicloud/services/acceptance/secmaster/resource_huaweicloud_secmaster_playbook_enable_test.go
@@ -1,0 +1,101 @@
+package secmaster
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/secmaster"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getPlaybookEnableResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	workspaceID := state.Primary.Attributes["workspace_id"]
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	playbook, err := secmaster.GetPlaybook(client, workspaceID, state.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	enabled := utils.PathSearch("enabled", playbook, false).(bool)
+	if !enabled {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return playbook, err
+}
+
+func TestAccPlaybookEnable_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_secmaster_playbook_enable.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPlaybookEnableResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckSecMasterWorkspaceID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testPlaybookEnable_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "workspace_id", acceptance.HW_SECMASTER_WORKSPACE_ID),
+					resource.TestCheckResourceAttrPair(rName, "playbook_id", "huaweicloud_secmaster_playbook.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "playbook_name", "huaweicloud_secmaster_playbook.test", "name"),
+					resource.TestCheckResourceAttrPair(rName, "active_version_id", "huaweicloud_secmaster_playbook_approval.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testPlaybookEnable_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_secmaster_playbook_version_action" "submit_version" {
+  workspace_id = "%[2]s"
+  version_id   = huaweicloud_secmaster_playbook_version.test.id
+  status       = "APPROVING"
+
+  depends_on = [huaweicloud_secmaster_playbook_action.test]
+}
+
+resource "huaweicloud_secmaster_playbook_approval" "test" {
+  workspace_id = "%[2]s"
+  version_id   = huaweicloud_secmaster_playbook_version.test.id
+  result       = "PASS"
+  content      = "ok"
+
+  depends_on = [huaweicloud_secmaster_playbook_version_action.submit_version]
+}
+
+resource "huaweicloud_secmaster_playbook_enable" "test" {
+  workspace_id      = "%[2]s"
+  playbook_id       = huaweicloud_secmaster_playbook.test.id
+  playbook_name     = huaweicloud_secmaster_playbook.test.name
+  active_version_id = huaweicloud_secmaster_playbook_approval.test.id
+}
+`, testPlaybookVersion_basic(name), acceptance.HW_SECMASTER_WORKSPACE_ID)
+}

--- a/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_playbook_enable.go
+++ b/huaweicloud/services/secmaster/resource_huaweicloud_secmaster_playbook_enable.go
@@ -1,0 +1,159 @@
+package secmaster
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var nonUpdatableParamsPlaybookEnable = []string{"workspace_id", "playbook_name", "playbook_id", "active_version_id"}
+
+// @API SecMaster GET /v1/{project_id}/workspaces/{workspace_id}/soc/playbooks/{playbook_id}/versions
+// @API SecMaster PUT /v1/{project_id}/workspaces/{workspace_id}/soc/playbooks/versions/{id}
+func ResourcePlaybookEnable() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePlaybookEnableCreate,
+		UpdateContext: resourcePlaybookEnableRead,
+		ReadContext:   resourcePlaybookEnableUpdate,
+		DeleteContext: resourcePlaybookEnableDelete,
+
+		CustomizeDiff: config.FlexibleForceNew(nonUpdatableParamsPlaybookEnable),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the ID of the workspace to which the playbook version belongs.`,
+			},
+			"playbook_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the playbook ID.`,
+			},
+			"playbook_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the playbook name.`,
+			},
+			"active_version_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the actived playbook version ID.`,
+			},
+		},
+	}
+}
+
+func resourcePlaybookEnableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	bodyParams := map[string]interface{}{
+		"name":              d.Get("playbook_name"),
+		"enabled":           true,
+		"active_version_id": d.Get("active_version_id"),
+	}
+
+	playbookId := d.Get("playbook_id").(string)
+	// updatePlaybookVersion: Update the configuration of SecMaster playbook
+	err = updatePlaybook(client, d.Get("workspace_id").(string), playbookId, bodyParams)
+	if err != nil {
+		return diag.Errorf("error enabling SecMaster playbook: %s", err)
+	}
+
+	d.SetId(playbookId)
+
+	return resourcePlaybookEnableRead(ctx, d, meta)
+}
+
+func resourcePlaybookEnableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	playbook, err := GetPlaybook(client, d.Get("workspace_id").(string), d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected403ErrInto404Err(err, "code", "SecMaster.20010001"), "error retrieving SecMaster playbook")
+	}
+	enabled := utils.PathSearch("enabled", playbook, false).(bool)
+	if !enabled {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("playbook_id", utils.PathSearch("id", playbook, nil)),
+		d.Set("playbook_name", utils.PathSearch("name", playbook, nil)),
+		d.Set("active_version_id", utils.PathSearch("version_id", playbook, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourcePlaybookEnableUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourcePlaybookEnableDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("secmaster", region)
+	if err != nil {
+		return diag.Errorf("error creating SecMaster client: %s", err)
+	}
+
+	bodyParams := map[string]interface{}{
+		"name":    d.Get("playbook_name"),
+		"enabled": false,
+	}
+
+	// updatePlaybookVersion: Update the configuration of SecMaster playbook
+	err = updatePlaybook(client, d.Get("workspace_id").(string), d.Get("playbook_id").(string), bodyParams)
+	if err != nil {
+		return diag.Errorf("error disabling SecMaster playbook: %s", err)
+	}
+
+	return nil
+}
+
+func updatePlaybook(client *golangsdk.ServiceClient, workspaceId, id string, bodyParam interface{}) error {
+	updatePlaybookHttpUrl := "v1/{project_id}/workspaces/{workspace_id}/soc/playbooks/{id}"
+	updatePlaybookPath := client.Endpoint + updatePlaybookHttpUrl
+	updatePlaybookPath = strings.ReplaceAll(updatePlaybookPath, "{project_id}", client.ProjectID)
+	updatePlaybookPath = strings.ReplaceAll(updatePlaybookPath, "{workspace_id}", workspaceId)
+	updatePlaybookPath = strings.ReplaceAll(updatePlaybookPath, "{id}", id)
+
+	updatePlaybookOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         bodyParam,
+	}
+
+	_, err := client.Request("PUT", updatePlaybookPath, &updatePlaybookOpt)
+
+	return err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
add resource playbook enabling

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
add resource playbook enabling
```

## PR Checklist

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/secmaster' TESTARGS='-run TestAccPlaybookEnabling_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/secmaster -v -run TestAccPlaybookEnabling_basic -timeout 360m -parallel 4
=== RUN   TestAccPlaybookEnabling_basic
=== PAUSE TestAccPlaybookEnabling_basic
=== CONT  TestAccPlaybookEnabling_basic
--- PASS: TestAccPlaybookEnabling_basic (82.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/secmaster 82.898s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
