### PR TITLE
chore(cc): replace the jmespath.Search method with the utils.PathSearch method

### DIFF
--- a/huaweicloud/services/cc/resource_huaweicloud_cc_authorization.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_authorization.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -118,11 +117,11 @@ func resourceAuthorizationCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("authorisation.id", createAuthorizationRespBody)
-	if err != nil {
+	id := utils.PathSearch("authorisation.id", createAuthorizationRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating authorization: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	return resourceAuthorizationRead(ctx, d, meta)
 }

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -179,11 +178,11 @@ func resourceBandwidthPackageCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("bandwidth_package.id", createBandwidthPackageRespBody)
-	if err != nil {
+	id := utils.PathSearch("bandwidth_package.id", createBandwidthPackageRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating bandwidth package: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	return resourceBandwidthPackageRead(ctx, d, meta)
 }

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -120,11 +119,11 @@ func resourceCentralNetworkCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("central_network.id", createCentralNetworkRespBody)
-	if err != nil {
+	id := utils.PathSearch("central_network.id", createCentralNetworkRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating central network: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	err = centralNetworkWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -184,9 +183,9 @@ func centralNetworkWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`central_network.state`, createCentralNetworkWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `central_network.state`)
+			statusRaw := utils.PathSearch(`central_network.state`, createCentralNetworkWaitingRespBody, nil)
+			if statusRaw == nil {
+				return nil, "ERROR", fmt.Errorf("error parsing %s from response body", `central_network.state`)
 			}
 
 			status := fmt.Sprintf("%v", statusRaw)
@@ -399,9 +398,9 @@ func deleteCentralNetworkWaitingForStateCompleted(ctx context.Context, d *schema
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`central_network.state`, deleteCentralNetworkWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `central_network.state`)
+			statusRaw := utils.PathSearch(`central_network.state`, deleteCentralNetworkWaitingRespBody, nil)
+			if statusRaw == nil {
+				return nil, "ERROR", fmt.Errorf("error parsing %s from response body", `central_network.state`)
 			}
 
 			status := fmt.Sprintf("%v", statusRaw)

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_attachment.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_attachment.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -156,11 +155,11 @@ func resourceCentralNetworkAttachmentCreate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("central_network_gdgw_attachment.id", createCentralNetworkAttachmentRespBody)
-	if err != nil {
+	id := utils.PathSearch("central_network_gdgw_attachment.id", createCentralNetworkAttachmentRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating central network attachment: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	err = centralNetworkAttachmentWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -227,8 +226,8 @@ func centralNetworkAttachmentWaitingForStateCompleted(ctx context.Context, d *sc
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`central_network_gdgw_attachment.state`, centralNetworkAttachmentWaitingRespBody)
-			if err != nil {
+			statusRaw := utils.PathSearch(`central_network_gdgw_attachment.state`, centralNetworkAttachmentWaitingRespBody, nil)
+			if statusRaw == nil {
 				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `central_network_gdgw_attachment.state`)
 			}
 
@@ -464,8 +463,8 @@ func centralNetworkAttachmentDeleteWaitingForStateCompleted(ctx context.Context,
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`central_network_gdgw_attachment.state`, centralNetworkAttachmentDeleteWaitingRespBody)
-			if err != nil {
+			statusRaw := utils.PathSearch(`central_network_gdgw_attachment.state`, centralNetworkAttachmentDeleteWaitingRespBody, nil)
+			if statusRaw == nil {
 				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `central_network_gdgw_attachment.state`)
 			}
 

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_connection_bandwidth_associate.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_connection_bandwidth_associate.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -142,9 +141,9 @@ func centralNetworkConnectionBandwidthAssociateWaitingForStateCompleted(ctx cont
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status, err := jmespath.Search(`central_network_connections[0].state`, respBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse state from response body")
+			status := utils.PathSearch(`central_network_connections[0].state`, respBody, nil)
+			if status == nil {
+				return nil, "ERROR", fmt.Errorf("error parsing state from response body")
 			}
 
 			if utils.StrSliceContains([]string{"FAILED", "DELETED"}, status.(string)) {

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_policy.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_policy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -221,11 +220,11 @@ func resourceCentralNetworkPolicyCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("central_network_policy.id", createCentralNetworkPolicyRespBody)
-	if err != nil {
+	id := utils.PathSearch("central_network_policy.id", createCentralNetworkPolicyRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating CentralNetworkPolicy: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	return resourceCentralNetworkPolicyRead(ctx, d, meta)
 }

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_policy_apply.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_policy_apply.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -157,9 +156,9 @@ func centralNetworkPolicyApplyWaitingForStateCompleted(ctx context.Context, d *s
 				return nil, "ERROR", err
 			}
 			jsonPath := fmt.Sprintf("central_network_policies[?id =='%s']|[0].is_applied", policyId)
-			statusRaw, err := jmespath.Search(jsonPath, applyPolicyRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `central_network_policies.is_applied`)
+			statusRaw := utils.PathSearch(jsonPath, applyPolicyRespBody, nil)
+			if statusRaw == nil {
+				return nil, "ERROR", fmt.Errorf("error parsing %s from response body", `central_network_policies.is_applied`)
 			}
 
 			status := fmt.Sprintf("%v", statusRaw)

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_connection.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_connection.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -142,11 +141,11 @@ func resourceCloudConnectionCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("cloud_connection.id", createCloudConnectionRespBody)
-	if err != nil {
+	id := utils.PathSearch("cloud_connection.id", createCloudConnectionRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating CloudConnection: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	if rawTags := d.Get("tags").(map[string]interface{}); len(rawTags) > 0 {
 		err = createResourceTags(createCloudConnectionClient, d.Id(), conf.DomainID, rawTags)

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_global_connection_bandwidth.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_global_connection_bandwidth.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -164,12 +163,12 @@ func resourceGlobalConnectionBandwidthCreate(ctx context.Context, d *schema.Reso
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	id, err := jmespath.Search("globalconnection_bandwidth.id", createGCBRespBody)
-	if err != nil {
-		return diag.Errorf("error creating global connection bandwidth: %s is not found in API response", "id")
+	id := utils.PathSearch("globalconnection_bandwidth.id", createGCBRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating global connection bandwidth: ID is not found in API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	if v, ok := d.GetOk("binding_service"); ok && v.(string) != "ALL" {
 		err = updateGCB(client, d, cfg.DomainID)
@@ -223,8 +222,8 @@ func resourceGlobalConnectionBandwidthRead(_ context.Context, d *schema.Resource
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	getGCBRespBody, err = jmespath.Search("globalconnection_bandwidth", getGCBRespBody)
-	if err != nil {
+	getGCBRespBody = utils.PathSearch("globalconnection_bandwidth", getGCBRespBody, nil)
+	if getGCBRespBody == nil {
 		return diag.Errorf("error getting global connection bandwidth: %s is not found in API response",
 			"globalconnection_bandwidth")
 	}

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_inter_region_bandwidth.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_inter_region_bandwidth.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -138,11 +137,11 @@ func resourceInterRegionBandwidthCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("inter_region_bandwidth.id", createInterRegionBandwidthRespBody)
-	if err != nil {
+	id := utils.PathSearch("inter_region_bandwidth.id", createInterRegionBandwidthRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating inter-region bandwidth: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	return resourceInterRegionBandwidthRead(ctx, d, meta)
 }

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -159,11 +158,11 @@ func resourceNetworkInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("network_instance.id", createNetworkInstanceRespBody)
-	if err != nil {
+	id := utils.PathSearch("network_instance.id", createNetworkInstanceRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating NetworkInstance: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	return resourceNetworkInstanceRead(ctx, d, meta)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
replace the jmespath.Search method with the utils.PathSearch method

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. replace the jmespath.Search method with the utils.PathSearch method
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccDataSourceCcAuthorizations_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccDataSourceCcAuthorizations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCcAuthorizations_basic
=== PAUSE TestAccDataSourceCcAuthorizations_basic
=== CONT  TestAccDataSourceCcAuthorizations_basic
--- PASS: TestAccDataSourceCcAuthorizations_basic (91.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        91.315s

 make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccBandwidthPackage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccBandwidthPackage_basic -timeout 360m -parallel 4
=== RUN   TestAccBandwidthPackage_basic
=== PAUSE TestAccBandwidthPackage_basic
=== CONT  TestAccBandwidthPackage_basic
--- PASS: TestAccBandwidthPackage_basic (43.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        43.710s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetwork_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetwork_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetwork_basic
=== PAUSE TestAccCentralNetwork_basic
=== CONT  TestAccCentralNetwork_basic
--- PASS: TestAccCentralNetwork_basic (65.28s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        65.339s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetworkAttachment_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetworkAttachment_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetworkAttachment_basic
=== PAUSE TestAccCentralNetworkAttachment_basic
=== CONT  TestAccCentralNetworkAttachment_basic
--- PASS: TestAccCentralNetworkAttachment_basic (246.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        246.320s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetworkPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetworkPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetworkPolicy_basic
=== PAUSE TestAccCentralNetworkPolicy_basic
=== CONT  TestAccCentralNetworkPolicy_basic
--- PASS: TestAccCentralNetworkPolicy_basic (146.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        147.047s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetworkPolicyApply_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetworkPolicyApply_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetworkPolicyApply_basic
=== PAUSE TestAccCentralNetworkPolicyApply_basic
=== CONT  TestAccCentralNetworkPolicyApply_basic
--- PASS: TestAccCentralNetworkPolicyApply_basic (132.84s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        132.894s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCloudConnection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCloudConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccCloudConnection_basic
=== PAUSE TestAccCloudConnection_basic
=== CONT  TestAccCloudConnection_basic
--- PASS: TestAccCloudConnection_basic (29.55s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        29.607s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccGCB_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccGCB_basic -timeout 360m -parallel 4
=== RUN   TestAccGCB_basic
=== PAUSE TestAccGCB_basic
=== CONT  TestAccGCB_basic
--- PASS: TestAccGCB_basic (25.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        25.904s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccInterRegionBandwidth_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccInterRegionBandwidth_basic -timeout 360m -parallel 4
=== RUN   TestAccInterRegionBandwidth_basic
=== PAUSE TestAccInterRegionBandwidth_basic
=== CONT  TestAccInterRegionBandwidth_basic
--- PASS: TestAccInterRegionBandwidth_basic (55.82s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        55.881s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccNetworkInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccNetworkInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkInstance_basic
=== PAUSE TestAccNetworkInstance_basic
=== CONT  TestAccNetworkInstance_basic
--- PASS: TestAccNetworkInstance_basic (128.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        128.893s

 make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetworkConnectionBandwidthAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetworkConnectionBandwidthAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetworkConnectionBandwidthAssociate_basic
=== PAUSE TestAccCentralNetworkConnectionBandwidthAssociate_basic
=== CONT  TestAccCentralNetworkConnectionBandwidthAssociate_basic
--- PASS: TestAccCentralNetworkConnectionBandwidthAssociate_basic (401.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        401.404s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
