### PR TITLE
chore(vpn): replace the jmespath.Search method with the utils.PathSearch method

### DIFF
--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -391,11 +390,11 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("vpn_connection.id", createConnectionRespBody)
-	if err != nil {
+	id := utils.PathSearch("vpn_connection.id", createConnectionRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating VPN connection: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	err = createConnectionWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -558,9 +557,9 @@ func createConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`vpn_connection.status`, createConnectionWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `vpn_connection.status`)
+			statusRaw := utils.PathSearch(`vpn_connection.status`, createConnectionWaitingRespBody, nil)
+			if statusRaw == nil {
+				return nil, "ERROR", fmt.Errorf("error parsing %s from response body", `vpn_connection.status`)
 			}
 
 			status := fmt.Sprintf("%v", statusRaw)
@@ -649,8 +648,8 @@ func resourceConnectionRead(_ context.Context, d *schema.ResourceData, meta inte
 
 func flattenGetConnectionResponseBodyCreateRequestIkePolicy(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("vpn_connection.ikepolicy", resp)
-	if err != nil {
+	curJson := utils.PathSearch("vpn_connection.ikepolicy", resp, nil)
+	if curJson == nil {
 		log.Printf("[ERROR] error parsing vpn_connection.ikepolicy from response= %#v", resp)
 		return rst
 	}
@@ -677,8 +676,8 @@ func flattenGetConnectionResponseBodyCreateRequestIkePolicy(resp interface{}) []
 
 func flattenGetConnectionResponseBodyDPD(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("vpn_connection.ikepolicy.dpd", resp)
-	if err != nil {
+	curJson := utils.PathSearch("vpn_connection.ikepolicy.dpd", resp, nil)
+	if curJson == nil {
 		log.Printf("[ERROR] error parsing vpn_connection.ikepolicy.dpd from response= %#v", resp)
 		return rst
 	}
@@ -695,8 +694,8 @@ func flattenGetConnectionResponseBodyDPD(resp interface{}) []interface{} {
 
 func flattenGetConnectionResponseBodyCreateRequestIpsecPolicy(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("vpn_connection.ipsecpolicy", resp)
-	if err != nil {
+	curJson := utils.PathSearch("vpn_connection.ipsecpolicy", resp, nil)
+	if curJson == nil {
 		log.Printf("[ERROR] error parsing vpn_connection.ipsecpolicy from response= %#v", resp)
 		return rst
 	}
@@ -895,9 +894,9 @@ func updateConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`vpn_connection.status`, updateConnectionWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `vpn_connection.status`)
+			statusRaw := utils.PathSearch(`vpn_connection.status`, updateConnectionWaitingRespBody, nil)
+			if statusRaw == nil {
+				return nil, "ERROR", fmt.Errorf("error parsing %s from response body", `vpn_connection.status`)
 			}
 
 			status := fmt.Sprintf("%v", statusRaw)
@@ -995,9 +994,9 @@ func deleteConnectionWaitingForStateCompleted(ctx context.Context, d *schema.Res
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`vpn_connection.status`, deleteConnectionWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `vpn_connection.status`)
+			statusRaw := utils.PathSearch(`vpn_connection.status`, deleteConnectionWaitingRespBody, nil)
+			if statusRaw == nil {
+				return nil, "ERROR", fmt.Errorf("error parsing %s from response body", `vpn_connection.status`)
 			}
 
 			status := fmt.Sprintf("%v", statusRaw)

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection_health_check.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_connection_health_check.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -76,7 +75,7 @@ func resourceConnectionHealthCheckCreate(ctx context.Context, d *schema.Resource
 	)
 	createConnectionHealthCheckClient, err := cfg.NewServiceClient(createConnectionHealthCheckProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating VPN Client: %s", err)
+		return diag.Errorf("error creating VPN client: %s", err)
 	}
 
 	createConnectionHealthCheckPath := createConnectionHealthCheckClient.Endpoint + createConnectionHealthCheckHttpUrl
@@ -90,7 +89,7 @@ func resourceConnectionHealthCheckCreate(ctx context.Context, d *schema.Resource
 	createConnectionHealthCheckResp, err := createConnectionHealthCheckClient.Request("POST",
 		createConnectionHealthCheckPath, &createConnectionHealthCheckOpt)
 	if err != nil {
-		return diag.Errorf("error creating ConnectionHealthCheck: %s", err)
+		return diag.Errorf("error creating VPN connection health check: %s", err)
 	}
 
 	createConnectionHealthCheckRespBody, err := utils.FlattenResponse(createConnectionHealthCheckResp)
@@ -98,11 +97,11 @@ func resourceConnectionHealthCheckCreate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("connection_monitor.id", createConnectionHealthCheckRespBody)
-	if err != nil {
-		return diag.Errorf("error creating ConnectionHealthCheck: ID is not found in API response")
+	id := utils.PathSearch("connection_monitor.id", createConnectionHealthCheckRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating VPN connection health check: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	return resourceConnectionHealthCheckRead(ctx, d, meta)
 }
@@ -129,7 +128,7 @@ func resourceConnectionHealthCheckRead(_ context.Context, d *schema.ResourceData
 	)
 	getConnectionHealthCheckClient, err := cfg.NewServiceClient(getConnectionHealthCheckProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating VPN Client: %s", err)
+		return diag.Errorf("error creating VPN client: %s", err)
 	}
 
 	getConnectionHealthCheckPath := getConnectionHealthCheckClient.Endpoint + getConnectionHealthCheckHttpUrl
@@ -144,7 +143,7 @@ func resourceConnectionHealthCheckRead(_ context.Context, d *schema.ResourceData
 		getConnectionHealthCheckPath, &getConnectionHealthCheckOpt)
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving ConnectionHealthCheck")
+		return common.CheckDeletedDiag(d, err, "error retrieving VPN connection health check")
 	}
 
 	getConnectionHealthCheckRespBody, err := utils.FlattenResponse(getConnectionHealthCheckResp)
@@ -175,7 +174,7 @@ func resourceConnectionHealthCheckDelete(_ context.Context, d *schema.ResourceDa
 	)
 	deleteConnectionHealthCheckClient, err := cfg.NewServiceClient(deleteConnectionHealthCheckProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating VPN Client: %s", err)
+		return diag.Errorf("error creating VPN client: %s", err)
 	}
 
 	deleteConnectionHealthCheckPath := deleteConnectionHealthCheckClient.Endpoint + deleteConnectionHealthCheckHttpUrl
@@ -191,7 +190,7 @@ func resourceConnectionHealthCheckDelete(_ context.Context, d *schema.ResourceDa
 	if err != nil {
 		return common.CheckDeletedDiag(d,
 			common.ConvertExpected400ErrInto404Err(err, "error_code", "VPN.0001"),
-			"error deleting ConnectionHealthCheck",
+			"error deleting VPN connection health check",
 		)
 	}
 

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_customer_gateway.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_customer_gateway.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -188,11 +187,11 @@ func resourceCustomerGatewayCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("customer_gateway.id", createCustomerGatewayRespBody)
-	if err != nil {
+	id := utils.PathSearch("customer_gateway.id", createCustomerGatewayRespBody, "").(string)
+	if id == "" {
 		return diag.Errorf("error creating VPN customer gateway: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	return resourceCustomerGatewayRead(ctx, d, meta)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
replace the jmespath.Search method with the utils.PathSearch method
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. replace the jmespath.Search method with the utils.PathSearch method
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```


make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccConnection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccConnection_basic
=== PAUSE TestAccConnection_basic
=== CONT  TestAccConnection_basic
--- PASS: TestAccConnection_basic (504.16s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       504.225s

 make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccConnectionHealthCheck_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccConnectionHealthCheck_basic -timeout 360m -parallel 4
=== RUN   TestAccConnectionHealthCheck_basic
=== PAUSE TestAccConnectionHealthCheck_basic
=== CONT  TestAccConnectionHealthCheck_basic
--- PASS: TestAccConnectionHealthCheck_basic (418.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       418.501s


make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccCustomerGateway_basic"  ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccCustomerGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccCustomerGateway_basic_withDeprecatedFields
=== PAUSE TestAccCustomerGateway_basic_withDeprecatedFields
=== RUN   TestAccCustomerGateway_basic
=== PAUSE TestAccCustomerGateway_basic
=== CONT  TestAccCustomerGateway_basic_withDeprecatedFields
=== CONT  TestAccCustomerGateway_basic
--- PASS: TestAccCustomerGateway_basic (31.81s)
--- PASS: TestAccCustomerGateway_basic_withDeprecatedFields (32.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       32.498s

make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccGateway_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccGateway_basic
=== PAUSE TestAccGateway_basic
=== CONT  TestAccGateway_basic
--- PASS: TestAccGateway_basic (478.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       479.052s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
