### PR TITLE
feat(cce): support extension_scale_groups in node pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240909034204-207f58c0b9a3
+	github.com/chnsz/golangsdk v0.0.0-20240912015604-d3867c750df2
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240909034204-207f58c0b9a3 h1:iSjt1Y+qGsS9k/uNaJGLZpjEm3ckKRy+AKqCGVmQio4=
-github.com/chnsz/golangsdk v0.0.0-20240909034204-207f58c0b9a3/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240912015604-d3867c750df2 h1:Xru+LnMZPHWj0MvP+fO2rewydjv3ub7tzFSw+99ye1I=
+github.com/chnsz/golangsdk v0.0.0-20240912015604-d3867c750df2/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -942,3 +942,177 @@ resource "huaweicloud_cce_node_pool" "test" {
 }
 `, testAccNodePool_base(rName), rName)
 }
+
+func TestAccNodePool_extensionScaleGroups(t *testing.T) {
+	var (
+		nodePool nodepools.NodePool
+
+		name         = acceptance.RandomAccResourceNameWithDash()
+		updateName   = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_cce_node_pool.test"
+
+		baseConfig = testAccNodePool_base(name)
+
+		rc = acceptance.InitResourceCheck(
+			resourceName,
+			&nodePool,
+			getNodePoolFunc,
+		)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNodePool_extensionScaleGroups_step1(name, baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					// extension_scale_groups not saved, nothing to check, just ensure there is no error
+				),
+			},
+			{
+				Config: testAccNodePool_extensionScaleGroups_step2(updateName, baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					// extension_scale_groups not saved, nothing to check, just ensure there is no error
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccNodePoolImportStateIdFunc(resourceName),
+				ImportStateVerifyIgnore: []string{
+					"initial_node_count", "extend_params", "extension_scale_groups",
+				},
+			},
+		},
+	})
+}
+
+func testAccNodePool_extensionScaleGroups_step1(name, baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cce_node_pool" "test" {
+  cluster_id               = huaweicloud_cce_cluster.test.id
+  name                     = "%[2]s"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
+  initial_node_count       = 0
+  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  key_pair                 = huaweicloud_kps_keypair.test.name
+  scall_enable             = false
+  min_node_count           = 0
+  max_node_count           = 0
+  scale_down_cooldown_time = 0
+  priority                 = 0
+  type                     = "vm"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  extension_scale_groups {
+    metadata {
+      name = "%[2]s-group1"
+    }
+
+    spec {
+      flavor = data.huaweicloud_compute_flavors.test.ids[0]
+      az     = data.huaweicloud_availability_zones.test.names[1]
+      autoscaling {
+        extension_priority = 1
+        enable             = true
+      }
+    }
+  }
+}
+`, baseConfig, name)
+}
+
+func testAccNodePool_extensionScaleGroups_step2(name, baseConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cce_node_pool" "test" {
+  cluster_id               = huaweicloud_cce_cluster.test.id
+  name                     = "%[2]s"
+  os                       = "EulerOS 2.9"
+  flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
+  initial_node_count       = 0
+  availability_zone        = data.huaweicloud_availability_zones.test.names[0]
+  key_pair                 = huaweicloud_kps_keypair.test.name
+  scall_enable             = true
+  min_node_count           = 0
+  max_node_count           = 0
+  scale_down_cooldown_time = 100
+  priority                 = 1
+  type                     = "vm"
+
+  root_volume {
+    size       = 40
+    volumetype = "SSD"
+  }
+  data_volumes {
+    size       = 100
+    volumetype = "SSD"
+  }
+
+  extension_scale_groups {
+    metadata {
+      name = "%[2]s-group1"
+    }
+
+    spec {
+      flavor = data.huaweicloud_compute_flavors.test.ids[0]
+      az     = data.huaweicloud_availability_zones.test.names[1]
+      autoscaling {
+        extension_priority = 1
+        enable             = true
+      }
+    }
+  }
+
+  extension_scale_groups {
+    metadata {
+      name = "%[2]s-group2"
+    }
+
+    spec {
+      flavor = data.huaweicloud_compute_flavors.test.ids[1]
+      az     = data.huaweicloud_availability_zones.test.names[0]
+      autoscaling {
+        extension_priority = 1
+        enable             = true
+      }
+    }
+  }
+
+  extension_scale_groups {
+    metadata {
+      name = "%[2]s-group3"
+    }
+
+    spec {
+      flavor = data.huaweicloud_compute_flavors.test.ids[1]
+      az     = data.huaweicloud_availability_zones.test.names[1]
+
+      autoscaling {
+        extension_priority = 1
+        enable             = true
+      }
+    }
+  }
+}
+`, baseConfig, name)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/requests.go
@@ -129,6 +129,37 @@ type CreateSpec struct {
 	UserTagPolicyOnExistingNodes string `json:"userTagsPolicyOnExistingNodes,omitempty"`
 	// taint policy on existing nodes
 	TaintPolicyOnExistingNodes string `json:"taintPolicyOnExistingNodes,omitempty"`
+	// The list of extension scale groups
+	ExtensionScaleGroups []ExtensionScaleGroups `json:"extensionScaleGroups,omitempty"`
+}
+
+type ExtensionScaleGroups struct {
+	Metadata *ExtensionScaleGroupsMetadata `json:"metadata,omitempty"`
+	Spec     *ExtensionScaleGroupsSpec     `json:"spec,omitempty"`
+}
+
+type ExtensionScaleGroupsMetadata struct {
+	Uid  string `json:"uid,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type ExtensionScaleGroupsSpec struct {
+	Flavor                           string                            `json:"flavor,omitempty"`
+	Az                               string                            `json:"az,omitempty"`
+	CapacityReservationSpecification *CapacityReservationSpecification `json:"capacityReservationSpecification,omitempty"`
+	Autoscaling                      *Autoscaling                      `json:"autoscaling,omitempty"`
+}
+
+type CapacityReservationSpecification struct {
+	ID         string `json:"id,omitempty"`
+	Preference string `json:"preference,omitempty"`
+}
+
+type Autoscaling struct {
+	Enable            bool `json:"enable,omitempty"`
+	ExtensionPriority int  `json:"extensionPriority,omitempty"`
+	MinNodeCount      int  `json:"minNodeCount,omitempty"`
+	MaxNodeCount      int  `json:"maxNodeCount,omitempty"`
 }
 
 type PodSecurityGroupSpec struct {
@@ -255,6 +286,8 @@ type UpdateSpec struct {
 	UserTagPolicyOnExistingNodes string `json:"userTagsPolicyOnExistingNodes,omitempty"`
 	// taint policy on existing nodes
 	TaintPolicyOnExistingNodes string `json:"taintPolicyOnExistingNodes,omitempty"`
+	// The list of extension scale groups
+	ExtensionScaleGroups []ExtensionScaleGroups `json:"extensionScaleGroups,omitempty"`
 }
 
 // ToNodePoolUpdateMap builds an update body based on UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/cce/v3/nodepools/results.go
@@ -67,6 +67,8 @@ type Spec struct {
 	UserTagPolicyOnExistingNodes string `json:"userTagsPolicyOnExistingNodes"`
 	// taint policy on existing nodes
 	TaintPolicyOnExistingNodes string `json:"taintPolicyOnExistingNodes"`
+	// The list of extension scale groups
+	ExtensionScaleGroups []ExtensionScaleGroups `json:"extensionScaleGroups"`
 }
 
 type AutoscalingSpec struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240909034204-207f58c0b9a3
+# github.com/chnsz/golangsdk v0.0.0-20240912015604-d3867c750df2
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodePool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodePool -timeout 360m -parallel 4
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== RUN   TestAccNodePool_tagsLabelsTaints
=== PAUSE TestAccNodePool_tagsLabelsTaints
=== RUN   TestAccNodePool_volume_encryption
=== PAUSE TestAccNodePool_volume_encryption
=== RUN   TestAccNodePool_prePaid
=== PAUSE TestAccNodePool_prePaid
=== RUN   TestAccNodePool_SecurityGroups
=== PAUSE TestAccNodePool_SecurityGroups
=== RUN   TestAccNodePool_serverGroup
=== PAUSE TestAccNodePool_serverGroup
=== RUN   TestAccNodePool_storage
=== PAUSE TestAccNodePool_storage
=== CONT  TestAccNodePool_basic
=== CONT  TestAccNodePool_SecurityGroups
=== CONT  TestAccNodePool_prePaid
=== CONT  TestAccNodePool_volume_encryption
=== CONT  TestAccNodePool_prePaid
    acceptance.go:891: This environment does not support prepaid tests
--- SKIP: TestAccNodePool_prePaid (0.00s)
=== CONT  TestAccNodePool_tagsLabelsTaints
=== CONT  TestAccNodePool_volume_encryption
    acceptance.go:1232: This environment does not support KMS tests
--- SKIP: TestAccNodePool_volume_encryption (0.01s)
=== CONT  TestAccNodePool_storage
--- PASS: TestAccNodePool_storage (819.53s)
=== CONT  TestAccNodePool_serverGroup
--- PASS: TestAccNodePool_SecurityGroups (837.13s)
--- PASS: TestAccNodePool_tagsLabelsTaints (880.33s)
--- PASS: TestAccNodePool_basic (1296.21s)
--- PASS: TestAccNodePool_serverGroup (810.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1630.070s

make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodePool_extensionScaleGroups'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodePool_extensionScaleGroups -timeout 360m -parallel 4
=== RUN   TestAccNodePool_extensionScaleGroups
=== PAUSE TestAccNodePool_extensionScaleGroups
=== CONT  TestAccNodePool_extensionScaleGroups
--- PASS: TestAccNodePool_extensionScaleGroups (825.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       825.795s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
