### PR TITLE
chore(CCM): improve datasource certificates test case coverage

### DIFF
--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_certificates_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_certificates_test.go
@@ -10,8 +10,22 @@ import (
 )
 
 func TestAccDatasourceCertificates_basic(t *testing.T) {
-	rName := "data.huaweicloud_ccm_certificates.test"
-	dc := acceptance.InitDataSourceCheck(rName)
+	var (
+		datasource = "data.huaweicloud_ccm_certificates.test"
+		dc         = acceptance.InitDataSourceCheck(datasource)
+
+		byStatus   = "data.huaweicloud_ccm_certificates.test"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byEpsID   = "data.huaweicloud_ccm_certificates.test"
+		dcByEpsID = acceptance.InitDataSourceCheck(byEpsID)
+
+		byDeploySupport   = "data.huaweicloud_ccm_certificates.test"
+		dcByDeploySupport = acceptance.InitDataSourceCheck(byDeploySupport)
+
+		notFound   = "data.huaweicloud_ccm_certificates.test"
+		dcNotFound = acceptance.InitDataSourceCheck(notFound)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -24,14 +38,26 @@ func TestAccDatasourceCertificates_basic(t *testing.T) {
 				Config: testAccDatasourceCertificates_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(rName, "certificates.0.id"),
-					resource.TestCheckResourceAttrSet(rName, "certificates.0.name"),
-					resource.TestCheckResourceAttrSet(rName, "certificates.0.domain"),
-					resource.TestCheckResourceAttrSet(rName, "certificates.0.expire_time"),
-					resource.TestCheckResourceAttrSet(rName, "certificates.0.status"),
-					resource.TestCheckResourceAttrSet(rName, "certificates.0.domain_count"),
-					resource.TestCheckResourceAttrSet(rName, "certificates.0.wildcard_count"),
-					resource.TestCheckResourceAttrSet(rName, "certificates.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(datasource, "certificates.0.id"),
+					resource.TestCheckResourceAttrSet(datasource, "certificates.0.name"),
+					resource.TestCheckResourceAttrSet(datasource, "certificates.0.domain"),
+					resource.TestCheckResourceAttrSet(datasource, "certificates.0.expire_time"),
+					resource.TestCheckResourceAttrSet(datasource, "certificates.0.status"),
+					resource.TestCheckResourceAttrSet(datasource, "certificates.0.domain_count"),
+					resource.TestCheckResourceAttrSet(datasource, "certificates.0.wildcard_count"),
+					resource.TestCheckResourceAttrSet(datasource, "certificates.0.enterprise_project_id"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("status_filter_is_useful", "true"),
+
+					dcByEpsID.CheckResourceExists(),
+					resource.TestCheckOutput("epsID_filter_is_useful", "true"),
+
+					dcByDeploySupport.CheckResourceExists(),
+					resource.TestCheckOutput("deploy_support_filter_is_useful", "true"),
+
+					dcNotFound.CheckResourceExists(),
+					resource.TestCheckOutput("not_found_filter_is_empty", "true"),
 				),
 			},
 		},
@@ -42,6 +68,72 @@ func testAccDatasourceCertificates_basic() string {
 	return fmt.Sprintf(`
 data "huaweicloud_ccm_certificates" "test" {
   name = "%s"
+}
+
+# Search results by status.
+locals {
+  status = data.huaweicloud_ccm_certificates.test.certificates[0].status
+}
+
+data "huaweicloud_ccm_certificates" "filter_by_status" {
+  status = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_ccm_certificates.filter_by_status.certificates[*].status : v == local.status
+  ]
+}
+
+output "status_filter_is_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+
+# Search results by enterprise project ID.
+locals {
+  epsID = data.huaweicloud_ccm_certificates.test.certificates[0].enterprise_project_id
+}
+
+data "huaweicloud_ccm_certificates" "filter_by_epsID" {
+  enterprise_project_id = local.epsID
+}
+
+locals {
+  epsID_filter_result = [
+    for v in data.huaweicloud_ccm_certificates.filter_by_epsID.certificates[*].enterprise_project_id : v == local.epsID
+  ]
+}
+
+output "epsID_filter_is_useful" {
+  value = alltrue(local.epsID_filter_result) && length(local.epsID_filter_result) > 0
+}
+
+# Search results by deploy support.
+locals {
+  deploy_support = data.huaweicloud_ccm_certificates.test.certificates[0].deploy_support
+}
+
+data "huaweicloud_ccm_certificates" "filter_by_deploy_support" {
+  deploy_support = local.deploy_support
+}
+
+locals {
+  deploy_support_filter_result = [
+    for v in data.huaweicloud_ccm_certificates.filter_by_deploy_support.certificates[*].deploy_support : v == local.deploy_support
+  ]
+}
+
+output "deploy_support_filter_is_useful" {
+  value = alltrue(local.deploy_support_filter_result) && length(local.deploy_support_filter_result) > 0
+}
+
+# Not found by name.
+data "huaweicloud_ccm_certificates" "not_found" {
+  name = "not_found"
+}
+
+output "not_found_filter_is_empty" {
+  value = length(data.huaweicloud_ccm_certificates.not_found.certificates) == 0
 }
 `, acceptance.HW_CCM_CERTIFICATE_NAME)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

improve datasource certificates test case coverage.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1726123089516_TestAccDatasourceCertificates_basic.cov -coverpkg=./huaweicloud/services/ccm ./huaweicloud/services/acceptance/ccm -run TestAccDatasourceCertificates_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceCertificates_basic
=== PAUSE TestAccDatasourceCertificates_basic
=== CONT  TestAccDatasourceCertificates_basic
--- PASS: TestAccDatasourceCertificates_basic (28.98s)
PASS
coverage: 6.0% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       29.038s coverage: 6.0% of statements in ./huaweicloud/services/ccm
```

![image](https://github.com/user-attachments/assets/0bb8c31c-76e5-4c6f-8905-1a88c96af414)


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
