### PR TITLE
chore(CCM): remove conflicting validation fields in datasource test case

### DIFF
--- a/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_certificate_export_test.go
+++ b/huaweicloud/services/acceptance/ccm/data_source_huaweicloud_ccm_certificate_export_test.go
@@ -27,12 +27,10 @@ func TestAccDataSourceCertificateExport_basic(t *testing.T) {
 				Config: testDataSourceDataSourceCertificateExport_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSource, "enc_private_key"),
 					resource.TestCheckResourceAttrSet(dataSource, "entire_certificate"),
 					resource.TestCheckResourceAttrSet(dataSource, "certificate"),
 					resource.TestCheckResourceAttrSet(dataSource, "certificate_chain"),
 					resource.TestCheckResourceAttrSet(dataSource, "private_key"),
-					resource.TestCheckResourceAttrSet(dataSource, "enc_certificate"),
 				),
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

remove conflicting validation fields in datasource test case

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1726123738308_TestAccDataSourceCertificateExport_basic.cov -coverpkg=./huaweicloud/services/ccm ./huaweicloud/services/acceptance/ccm -run TestAccDataSourceCertificateExport_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCertificateExport_basic
=== PAUSE TestAccDataSourceCertificateExport_basic
=== CONT  TestAccDataSourceCertificateExport_basic
--- PASS: TestAccDataSourceCertificateExport_basic (10.71s)
PASS
coverage: 4.0% of statements in ./huaweicloud/services/ccm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ccm       10.772s coverage: 4.0% of statements in ./huaweicloud/services/ccm
```

![image](https://github.com/user-attachments/assets/1bf0b741-090c-40b9-9a7e-6a44fd8093d2)


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
