### PR TITLE
chore(cc): add CheckDeleted to CC resource deletion

### DIFF
--- a/docs/resources/cc_central_network_policy_apply.md
+++ b/docs/resources/cc_central_network_policy_apply.md
@@ -52,8 +52,8 @@ This resource provides the following timeouts configuration options:
 
 ## Import
 
-The central network policy apply can be imported using `id`, separated by a slash, e.g.
+The central network policy apply can be imported using `central_network_id` and `policy_id`, separated by a slash, e.g.
 
 ```bash
-$ terraform import huaweicloud_cc_central_network_policy_apply.test 0ce123456a00f2591fabc00385ff1234
+$ terraform import huaweicloud_cc_central_network_policy_apply.test <central_network_id>/<policy_id>
 ```

--- a/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_central_network_policy_apply_test.go
+++ b/huaweicloud/services/acceptance/cc/resource_huaweicloud_cc_central_network_policy_apply_test.go
@@ -92,6 +92,7 @@ func TestAccCentralNetworkPolicyApply_basic(t *testing.T) {
 				ResourceName:      rName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: testCentralNetworkPolicyApplyImportState(rName),
 			},
 		},
 	})
@@ -108,4 +109,22 @@ resource "huaweicloud_cc_central_network_policy_apply" "test" {
   policy_id          = huaweicloud_cc_central_network_policy.test.id
 }
 `, policyConfig)
+}
+
+func testCentralNetworkPolicyApplyImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("attribute (ID) of resource (%s) not found: %s", name, rs)
+		}
+
+		if rs.Primary.Attributes["policy_id"] == "" {
+			return "", fmt.Errorf("attribute (policy_id) of resource (%s) not found: %s", name, rs)
+		}
+
+		return rs.Primary.ID + "/" + rs.Primary.Attributes["policy_id"], nil
+	}
 }

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_authorization.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_authorization.go
@@ -280,7 +280,7 @@ func resourceAuthorizationDelete(_ context.Context, d *schema.ResourceData, meta
 
 	_, err = deleteAuthorizationClient.Request("DELETE", deleteAuthorizationPath, &deleteAuthorizationOpt)
 	if err != nil {
-		return diag.Errorf("error deleting authorization: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting authorization")
 	}
 
 	return nil

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_bandwidth_package.go
@@ -541,7 +541,7 @@ func resourceBandwidthPackageDelete(_ context.Context, d *schema.ResourceData, m
 
 	_, err = deleteBandwidthPackageClient.Request("DELETE", deleteBandwidthPackagePath, &deleteBandwidthPackageOpt)
 	if err != nil {
-		return diag.Errorf("error deleting bandwidth package: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting bandwidth package")
 	}
 
 	return nil

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network.go
@@ -346,7 +346,7 @@ func resourceCentralNetworkDelete(ctx context.Context, d *schema.ResourceData, m
 
 	_, err = deleteCentralNetworkClient.Request("DELETE", deleteCentralNetworkPath, &deleteCentralNetworkOpt)
 	if err != nil {
-		return diag.Errorf("error deleting central network: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting central network")
 	}
 
 	err = deleteCentralNetworkWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_attachment.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_attachment.go
@@ -409,7 +409,7 @@ func resourceCentralNetworkAttachmentDelete(ctx context.Context, d *schema.Resou
 	_, err = deleteCentralNetworkAttachmentClient.Request("DELETE", deleteCentralNetworkAttachmentPath,
 		&deleteCentralNetworkAttachmentOpt)
 	if err != nil {
-		return diag.Errorf("error deleting central network attachment: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting central network attachment")
 	}
 
 	err = centralNetworkAttachmentDeleteWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_connection_bandwidth_associate.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_connection_bandwidth_associate.go
@@ -253,7 +253,9 @@ func resourceCentralNetworkConnectionBandwidthAssociateDelete(ctx context.Contex
 
 	_, err = client.Request("PUT", path, &opt)
 	if err != nil {
-		return diag.Errorf("error deleting central network connection bandwidth associate: %s", err)
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "GCN.101505"),
+			"error deleting central network connection bandwidth associate")
 	}
 
 	err = centralNetworkConnectionBandwidthAssociateWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_policy.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_policy.go
@@ -488,7 +488,7 @@ func resourceCentralNetworkPolicyDelete(_ context.Context, d *schema.ResourceDat
 	_, err = deleteCentralNetworkPolicyClient.Request("DELETE", deleteCentralNetworkPolicyPath,
 		&deleteCentralNetworkPolicyOpt)
 	if err != nil {
-		return diag.Errorf("error deleting CentralNetworkPolicy: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting CentralNetworkPolicy")
 	}
 
 	return nil

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_policy_apply.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_central_network_policy_apply.go
@@ -34,8 +34,9 @@ func ResourceCentralNetworkPolicyApply() *schema.Resource {
 		ReadContext:   resourceCentralNetworkPolicyApplyRead,
 		DeleteContext: resourceCentralNetworkPolicyApplyDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: resourceCentralNetworkPolicyApplyImportState,
 		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
@@ -221,10 +222,10 @@ func resourceCentralNetworkPolicyApplyRead(_ context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	getCentralNetworkPolicyApplyRespBody = utils.PathSearch("central_network_policies[?is_applied]|[0]",
-		getCentralNetworkPolicyApplyRespBody, nil)
+	jsonPath := fmt.Sprintf("central_network_policies[?id =='%s' && is_applied == `true`]|[0]", d.Get("policy_id").(string))
+	getCentralNetworkPolicyApplyRespBody = utils.PathSearch(jsonPath, getCentralNetworkPolicyApplyRespBody, nil)
 	if getCentralNetworkPolicyApplyRespBody == nil {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "no data found")
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "no policy found")
 	}
 
 	mErr = multierror.Append(
@@ -276,9 +277,15 @@ func resourceCentralNetworkPolicyApplyDelete(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 
+	jsonPath := fmt.Sprintf("central_network_policies[?id =='%s' && is_applied == `true`]|[0]", d.Get("policy_id").(string))
+	appliedID := utils.PathSearch(jsonPath, getCentralNetworkPolicyApplyRespBody, nil)
+	if appliedID == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "no policy found")
+	}
+
 	defaultId := utils.PathSearch("central_network_policies[?version == `1`]|[0].id", getCentralNetworkPolicyApplyRespBody, nil)
 	if defaultId == nil {
-		return diag.Errorf("error applying central network policy to none: %s", err)
+		return diag.Errorf("error applying central network policy to none: no default policy found")
 	}
 
 	// apply default policy
@@ -287,4 +294,16 @@ func resourceCentralNetworkPolicyApplyDelete(ctx context.Context, d *schema.Reso
 		return diag.Errorf("error applying central network policy to none: %s", err)
 	}
 	return nil
+}
+
+func resourceCentralNetworkPolicyApplyImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, must be <central_network_id>/<policy_id>")
+	}
+
+	d.SetId(parts[0])
+	d.Set("policy_id", parts[1])
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_connection.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_connection.go
@@ -392,7 +392,7 @@ func resourceCloudConnectionDelete(_ context.Context, d *schema.ResourceData, me
 	}
 	_, err = deleteCloudConnectionClient.Request("DELETE", deleteCloudConnectionPath, &deleteCloudConnectionOpt)
 	if err != nil {
-		return diag.Errorf("error deleting CloudConnection: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting CloudConnection")
 	}
 
 	return nil

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_global_connection_bandwidth.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_global_connection_bandwidth.go
@@ -398,7 +398,7 @@ func resourceGlobalConnectionBandwidthDelete(_ context.Context, d *schema.Resour
 
 	_, err = client.Request("DELETE", deleteGCBPath, &deleteGCBOpt)
 	if err != nil {
-		return diag.Errorf("error deleting global connection bandwidth: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting global connection bandwidth")
 	}
 
 	return nil

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_inter_region_bandwidth.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_inter_region_bandwidth.go
@@ -300,7 +300,7 @@ func resourceInterRegionBandwidthDelete(_ context.Context, d *schema.ResourceDat
 
 	_, err = deleteInterRegionBandwidthClient.Request("DELETE", deleteInterRegionBandwidthPath, &deleteInterRegionBandwidthOpt)
 	if err != nil {
-		return diag.Errorf("error deleting inter-region bandwidth: %s", err)
+		return common.CheckDeletedDiag(d, err, "error deleting inter-region bandwidth")
 	}
 
 	return nil

--- a/huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go
+++ b/huaweicloud/services/cc/resource_huaweicloud_cc_network_instance.go
@@ -330,7 +330,9 @@ func resourceNetworkInstanceDelete(_ context.Context, d *schema.ResourceData, me
 	}
 	_, err = deleteNetworkInstanceClient.Request("DELETE", deleteNetworkInstancePath, &deleteNetworkInstanceOpt)
 	if err != nil {
-		return diag.Errorf("error deleting NetworkInstance: %s", err)
+		return common.CheckDeletedDiag(d,
+			common.ConvertExpected400ErrInto404Err(err, "error_code", "CC.1002"),
+			"error deleting NetworkInstance")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add CheckDeleted to CC resource deletion
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add CheckDeleted to CC resource deletion
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccAuthorization_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccAuthorization_basic -timeout 360m -parallel 4
=== RUN   TestAccAuthorization_basic
=== PAUSE TestAccAuthorization_basic
=== CONT  TestAccAuthorization_basic
--- PASS: TestAccAuthorization_basic (57.51s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        57.585s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccBandwidthPackage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccBandwidthPackage_basic -timeout 360m -parallel 4
=== RUN   TestAccBandwidthPackage_basic
=== PAUSE TestAccBandwidthPackage_basic
=== CONT  TestAccBandwidthPackage_basic
--- PASS: TestAccBandwidthPackage_basic (47.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        47.258s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetwork_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetwork_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetwork_basic
=== PAUSE TestAccCentralNetwork_basic
=== CONT  TestAccCentralNetwork_basic
--- PASS: TestAccCentralNetwork_basic (66.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        66.788s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetworkAttachment_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetworkAttachment_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetworkAttachment_basic
=== PAUSE TestAccCentralNetworkAttachment_basic
=== CONT  TestAccCentralNetworkAttachment_basic
--- PASS: TestAccCentralNetworkAttachment_basic (252.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        252.852s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetworkConnectionBandwidthAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetworkConnectionBandwidthAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetworkConnectionBandwidthAssociate_basic
=== PAUSE TestAccCentralNetworkConnectionBandwidthAssociate_basic
=== CONT  TestAccCentralNetworkConnectionBandwidthAssociate_basic
--- PASS: TestAccCentralNetworkConnectionBandwidthAssociate_basic (412.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        412.176s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetworkPolicy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetworkPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetworkPolicy_basic
=== PAUSE TestAccCentralNetworkPolicy_basic
=== CONT  TestAccCentralNetworkPolicy_basic
--- PASS: TestAccCentralNetworkPolicy_basic (129.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        129.786s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCentralNetworkPolicyApply_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCentralNetworkPolicyApply_basic -timeout 360m -parallel 4
=== RUN   TestAccCentralNetworkPolicyApply_basic
=== PAUSE TestAccCentralNetworkPolicyApply_basic
=== CONT  TestAccCentralNetworkPolicyApply_basic
--- PASS: TestAccCentralNetworkPolicyApply_basic (145.95s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        146.028s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccCloudConnection_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccCloudConnection_basic -timeout 360m -parallel 4
=== RUN   TestAccCloudConnection_basic
=== PAUSE TestAccCloudConnection_basic
=== CONT  TestAccCloudConnection_basic
--- PASS: TestAccCloudConnection_basic (26.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        26.798s

 make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccGCB_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccGCB_basic -timeout 360m -parallel 4
=== RUN   TestAccGCB_basic
=== PAUSE TestAccGCB_basic
=== CONT  TestAccGCB_basic
--- PASS: TestAccGCB_basic (25.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        25.632s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccGCBAssociate_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccGCBAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccGCBAssociate_basic
=== PAUSE TestAccGCBAssociate_basic
=== CONT  TestAccGCBAssociate_basic
--- PASS: TestAccGCBAssociate_basic (541.05s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        541.107s

 make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccInterRegionBandwidth_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccInterRegionBandwidth_basic -timeout 360m -parallel 4
=== RUN   TestAccInterRegionBandwidth_basic
=== PAUSE TestAccInterRegionBandwidth_basic
=== CONT  TestAccInterRegionBandwidth_basic
--- PASS: TestAccInterRegionBandwidth_basic (60.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        60.696s

make testacc TEST="./huaweicloud/services/acceptance/cc" TESTARGS="-run TestAccNetworkInstance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cc -v -run TestAccNetworkInstance_basic -timeout 360m -parallel 4
=== RUN   TestAccNetworkInstance_basic
=== PAUSE TestAccNetworkInstance_basic
=== CONT  TestAccNetworkInstance_basic
--- PASS: TestAccNetworkInstance_basic (133.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cc        133.225s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  * **a. During query operation (Read Context)**
  
  aa. Resource not found
  1. resource_huaweicloud_cc_authorization
![image](https://github.com/user-attachments/assets/07221553-85be-494a-9178-e2208819db50)

  2. resource_huaweicloud_cc_bandwidth_package
![image](https://github.com/user-attachments/assets/75234c66-5825-4ca5-ab32-7df7408d210f)

  3. resource_huaweicloud_cc_central_network
![image](https://github.com/user-attachments/assets/3ad286f2-c410-4066-b096-1a39f55d6956)

  4. resource_huaweicloud_cc_central_network_policy
![image](https://github.com/user-attachments/assets/8093f40f-6fdd-49eb-9d1a-c7723a703efd)

  5. resource_huaweicloud_cc_central_network_policy_apply
![image](https://github.com/user-attachments/assets/474e99bd-2f08-4cdb-b09c-dabaf286546b)

  6. resource_huaweicloud_cc_central_network_connection_bandwidth_associate
![image](https://github.com/user-attachments/assets/ac9746fd-f4ec-4909-86e9-f8380697aea2)

  7. resource_huaweicloud_cc_central_network_attachment
![image](https://github.com/user-attachments/assets/548a9189-e7b9-4383-b24f-322994212858)

  8. resource_huaweicloud_cc_connection
![image](https://github.com/user-attachments/assets/36ee67fe-4c78-4b7d-875f-37677472ebea)

  9. resource_huaweicloud_cc_network_instance
![image](https://github.com/user-attachments/assets/c8b83ee3-dbf1-4bea-a6b1-07126a52d2b3)

  10. huaweicloud_cc_global_connection_bandwidth
![image](https://github.com/user-attachments/assets/6040022d-f511-4b06-9ebe-782bb2ce7d6e)

  11. resource_huaweicloud_cc_inter_region_bandwidth
![image](https://github.com/user-attachments/assets/999f4305-d7b3-4d21-a95e-69f9668ac4c7)

  12. huaweicloud_cc_global_connection_bandwidth_associate
![image](https://github.com/user-attachments/assets/9c0d53ac-4e86-420f-84a7-3de26220ce78)

  ab. Related resources (parent resources) not found

  1. resource_huaweicloud_cc_central_network_policy_apply
![image](https://github.com/user-attachments/assets/236ab52b-ac73-4dc1-b39d-4216ec9288ea)

  2. huaweicloud_cc_central_network_connection_bandwidth_associate
![image](https://github.com/user-attachments/assets/94ebb7a3-654e-4153-8c2f-0d2e72a1e0de)

  3. huaweicloud_cc_inter_region_bandwidth
![image](https://github.com/user-attachments/assets/cca33853-eb69-4e7e-b1d9-24ee77457b4b)

  * **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
  1. resource_huaweicloud_cc_authorization
![image](https://github.com/user-attachments/assets/b4d36348-1492-4c58-abdc-b6067ff482a6)

  2. resource_huaweicloud_cc_bandwidth_package
![image](https://github.com/user-attachments/assets/aa9f80e9-4f13-4141-a2b7-ee81abbad7fa)

  3. resource_huaweicloud_cc_central_network
![image](https://github.com/user-attachments/assets/385e91f4-693a-4add-9b9c-40ed269078f1)

  4. resource_huaweicloud_cc_central_network_policy
![image](https://github.com/user-attachments/assets/3ffd9585-0a61-4913-9c49-f45f6d9778a6)

  5. resource_huaweicloud_cc_central_network_policy_apply
![image](https://github.com/user-attachments/assets/898bfd8b-0763-476d-85ee-64add060333c)

  6. resource_huaweicloud_cc_central_network_connection_bandwidth_associate
![image](https://github.com/user-attachments/assets/492daeb6-9e4d-4cd2-80ae-26c0c8516a59)

  7. resource_huaweicloud_cc_central_network_attachment
![image](https://github.com/user-attachments/assets/d114e8eb-e7cb-4431-8b25-28d0bd1acb3e)

  8. resource_huaweicloud_cc_connection
![image](https://github.com/user-attachments/assets/8f260a54-d4f5-4c24-878c-1ab7d66877da)

  9. resource_huaweicloud_cc_network_instance
![image](https://github.com/user-attachments/assets/dfd47f05-9428-4547-82bc-48fc3962164b)

  10. huaweicloud_cc_global_connection_bandwidth
![image](https://github.com/user-attachments/assets/3b3e3d7f-6723-4381-b41d-058ef0b872bc)

  11. resource_huaweicloud_cc_inter_region_bandwidth
![image](https://github.com/user-attachments/assets/a35a4cf2-cc1a-4f60-a9dd-8de67e50bc6f)

  12. huaweicloud_cc_global_connection_bandwidth_associate
![image](https://github.com/user-attachments/assets/6569726b-d2b8-4ec8-9eb4-c3cfbdbbf643)

  bb. Related resources (parent resources) not found

  1. resource_huaweicloud_cc_central_network_policy_apply
![image](https://github.com/user-attachments/assets/a4a0c74a-61dc-425c-95be-8e236bac82ca)

  2. resource_huaweicloud_cc_central_network_connection_bandwidth_associate
![image](https://github.com/user-attachments/assets/4431171e-6251-4d0b-944a-7602ccdb17e7)

  3. huaweicloud_cc_inter_region_bandwidth
![image](https://github.com/user-attachments/assets/8100162f-4e27-4a0f-a168-0c35e0de5bd2)