### PR TITLE
feat(ims/image_export): support image export resource

### DIFF
--- a/docs/resources/ims_image_export.md
+++ b/docs/resources/ims_image_export.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Image Management Service (IMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ims_image_export"
+description: |-
+  Manages an IMS image export resource within HuaweiCloud.
+---
+
+# huaweicloud_ims_image_export
+
+Manages an IMS image export resource within HuaweiCloud.
+
+-> 1. The whole image, ISO image, private images created by public images of Windows, SUSE, Red Hat, Ubuntu, and
+   Oracle Linux, and private images created by market images are not allowed to be exported.
+   <br/>2. The image size must be less than `1` TB. The images larger than `128` GB only support fast export, the
+   maximum image size supported for export in some regions may be greater than `128` GB, please refer to the actual
+   operation prompts on the console for accuracy.<br/>3. Destroying resource does not change the current action of the
+   image export resource.
+
+## Example Usage
+
+### Ordinary export image
+
+```hcl
+variable "image_id" {}
+variable "bucket_url" {}
+variable "file_format" {}
+
+resource "huaweicloud_ims_image_export" "test" {
+  image_id    = var.image_id
+  bucket_url  = var.bucket_url
+  file_format = var.file_format
+}
+```
+
+### Quickly export image
+
+```hcl
+variable "image_id" {}
+variable "bucket_url" {}
+
+resource "huaweicloud_ims_image_export" "test" {
+  image_id        = var.image_id
+  bucket_url      = var.bucket_url
+  is_quick_export = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `image_id` - (Required, String, ForceNew) Specifies the image ID to export.
+  Changing this parameter will create a new resource.
+
+* `bucket_url` - (Required, String, ForceNew) Specifies the URL of the image file to be exported to the OBS bucket, the
+  format is **OBS bucket name:image file name**, e.g. **test_bucket:test_image_file**. The storage category of the OBS
+  bucket and image file here must be OBS standard storage. Changing this parameter will create a new resource.
+
+* `file_format` - (Optional, String, ForceNew) Specifies the format of the image file to be exported. The valid values
+  are **qcow2**, **vhd**, **zvhd**, or **vmdk**. Changing this parameter will create a new resource.
+
+* `is_quick_export` - (Optional, Bool, ForceNew) Specifies whether to use quick export. The valid value is **true** or
+  **false**. Changing this parameter will create a new resource.
+
+-> 1. When the `is_quick_export` parameter is ignored or set to **false**, the `file_format` parameter is required.
+   <br/>2. When the `is_quick_export` parameter is set to **true**, the `file_format` parameter must be ignored, and
+   the exported image file format is **zvhd2** at this time.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, same as `image_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1583,6 +1583,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ims_obs_data_image":          ims.ResourceObsDataImage(),
 			"huaweicloud_ims_obs_system_image":        ims.ResourceObsSystemImage(),
 			"huaweicloud_ims_obs_iso_image":           ims.ResourceObsIsoImage(),
+			"huaweicloud_ims_image_export":            ims.ResourceImageExport(),
 			"huaweicloud_images_image_copy":           ims.ResourceImsImageCopy(),
 			"huaweicloud_images_image_share":          ims.ResourceImsImageShare(),
 			"huaweicloud_images_image_share_accepter": ims.ResourceImsImageShareAccepter(),

--- a/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_image_export_test.go
+++ b/huaweicloud/services/acceptance/ims/resource_huaweicloud_ims_image_export_test.go
@@ -1,0 +1,83 @@
+package ims
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccImageExport_basic(t *testing.T) {
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
+	// method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This resource will export an image file to the OBS bucket,
+			// so here we need to set a URL in the format **OBS bucket name:image file name**.
+			acceptance.TestAccPreCheckImsImageUrl(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// One-time action resource do not need to be checked and no processing is performed in the Read method.
+				Config: testAccImageExport_basic(),
+			},
+		},
+	})
+}
+
+func TestAccImageExport_with_isQuickExport(t *testing.T) {
+	// Avoid CheckDestroy because this resource is a one-time action resource and there is nothing in the destroy
+	// method.
+	// lintignore:AT001
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This resource will export an image file to the OBS bucket,
+			// so here we need to set a URL in the format **OBS bucket name:image file name**.
+			acceptance.TestAccPreCheckImsImageUrl(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// One-time action resource do not need to be checked and no processing is performed in the Read method.
+				Config: testAccImageExport_with_isQuickExport(),
+			},
+		},
+	})
+}
+
+func testAccImageExport_basic() string {
+	rName := acceptance.RandomAccResourceName()
+	rNameSuffix := acctest.RandString(4)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_image_export" "test" {
+  image_id    = huaweicloud_ims_ecs_system_image.test.id
+  bucket_url  = "%[2]s_%[3]s"
+  file_format = "qcow2"
+}
+`, testAccEcsSystemImage_basic(rName), acceptance.HW_IMS_IMAGE_URL, rNameSuffix)
+}
+
+func testAccImageExport_with_isQuickExport() string {
+	rName := acceptance.RandomAccResourceName()
+	rNameSuffix := acctest.RandString(4)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ims_image_export" "test" {
+  image_id        = huaweicloud_ims_ecs_system_image.test.id
+  bucket_url      = "%[2]s_%[3]s"
+  is_quick_export = true
+}
+`, testAccEcsSystemImage_basic(rName), acceptance.HW_IMS_IMAGE_URL, rNameSuffix)
+}

--- a/huaweicloud/services/ims/resource_huaweicloud_ims_image_export.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_ims_image_export.go
@@ -1,0 +1,123 @@
+package ims
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IMS POST /v1/cloudimages/{image_id}/file
+// @API IMS GET /v1/{project_id}/jobs/{job_id}
+// ResourceImageExport is a definition of the one-time action resource that used to manage image export.
+func ResourceImageExport() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceImageExportCreate,
+		ReadContext:   resourceImageExportRead,
+		DeleteContext: resourceImageExportDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"bucket_url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"file_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"is_quick_export": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func buildCreateImageExportBodyParam(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"bucket_url":      d.Get("bucket_url"),
+		"file_format":     utils.ValueIgnoreEmpty(d.Get("file_format")),
+		"is_quick_export": utils.ValueIgnoreEmpty(d.Get("is_quick_export")),
+	}
+}
+
+func resourceImageExportCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		imageId = d.Get("image_id").(string)
+	)
+
+	client, err := cfg.ImageV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating IMS v1 client: %s", err)
+	}
+
+	createPath := client.Endpoint + "v1/cloudimages/{image_id}/file"
+	createPath = strings.ReplaceAll(createPath, "{image_id}", imageId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+		JSONBody:         buildCreateImageExportBodyParam(d),
+	}
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error exporting IMS image, %s", err)
+	}
+
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("error exporting IMS image: job_id is not found in API response")
+	}
+
+	err = cloudimages.WaitForJobSuccess(client, int(d.Timeout(schema.TimeoutCreate)/time.Second), jobId)
+	if err != nil {
+		return diag.Errorf("error waiting for IMS image export to complete: %s", err)
+	}
+
+	d.SetId(imageId)
+
+	return resourceImageExportRead(ctx, d, meta)
+}
+
+func resourceImageExportRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Read()' method because the resource is a one-time action resource.
+	return nil
+}
+
+func resourceImageExportDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// No processing is performed in the 'Delete()' method because the resource is a one-time action resource.
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support image export resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

1. Support image export resource.
2. One time operation resource, without checkDeleted logic.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support image export resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ export HW_IMS_IMAGE_URL=xxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImageExport_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImageExport_ -timeout 360m -parallel 4
=== RUN   TestAccImageExport_basic
=== PAUSE TestAccImageExport_basic
=== RUN   TestAccImageExport_with_isQuickExport
=== PAUSE TestAccImageExport_with_isQuickExport
=== CONT  TestAccImageExport_basic
=== CONT  TestAccImageExport_with_isQuickExport
--- PASS: TestAccImageExport_with_isQuickExport (501.90s)
--- PASS: TestAccImageExport_basic (679.92s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       679.974s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
