### PR TITLE
feat(dws): add new resource for restarting cluster

### DIFF
--- a/docs/resources/dws_cluster_restart.md
+++ b/docs/resources/dws_cluster_restart.md
@@ -1,0 +1,47 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_restart"
+description: |-
+  Use this resource to restart DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_restart
+
+Use this resource to restart DWS cluster within HuaweiCloud.
+
+-> This resource is only a one-time action resource for restarting the DWS cluster. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "dws_cluster_id" {}
+
+resource "huaweicloud_dws_cluster_restart" "test2" {
+  cluster_id = var.dws_cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the ID of the DWS cluster to be restarted.
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1444,6 +1444,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_drs_job": drs.ResourceDrsJob(),
 
 			"huaweicloud_dws_alarm_subscription":            dws.ResourceDwsAlarmSubs(),
+			"huaweicloud_dws_cluster_restart":               dws.ResourceClusterRestart(),
 			"huaweicloud_dws_cluster":                       dws.ResourceDwsCluster(),
 			"huaweicloud_dws_disaster_recovery_task":        dws.ResourceDwsDisasterRecoveryTask(),
 			"huaweicloud_dws_event_subscription":            dws.ResourceDwsEventSubs(),

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
@@ -89,6 +89,10 @@ func TestAccResourceCluster_basicV1(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
 			},
+			// Assert whether the restart is successful.
+			{
+				Config: testAccDwsCluster_basic_step4(name, updatePassword),
+			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
@@ -217,6 +221,16 @@ resource "huaweicloud_dws_cluster" "test" {
 		acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
 }
 
+func testAccDwsCluster_basic_step4(name, password string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dws_cluster_restart" "test" {
+  cluster_id = huaweicloud_dws_cluster.test.id
+}
+`, testAccDwsCluster_basic_step3(name, password))
+}
+
 func TestAccResourceCluster_basicV2(t *testing.T) {
 	var obj interface{}
 
@@ -284,6 +298,10 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "elb.0.name", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
 				),
+			},
+			// Assert whether the restart is successful.
+			{
+				Config: testAccDwsCluster_basicV2_step4(name, updatePassword),
 			},
 			{
 				ResourceName:      resourceName,
@@ -439,6 +457,16 @@ resource "huaweicloud_dws_cluster" "testv2" {
   }
 }
 `, testAccDwsCluster_basicV2_base(rName), rName, password, acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST)
+}
+
+func testAccDwsCluster_basicV2_step4(name, password string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_dws_cluster_restart" "test" {
+  cluster_id = huaweicloud_dws_cluster.testv2.id
+}
+`, testAccDwsCluster_basicV2_step3(name, password))
 }
 
 // Test the scenarios with multiple AZs and volumes is local disk.

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_restart.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_cluster_restart.go
@@ -1,0 +1,133 @@
+package dws
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DDM POST /v1.0/{project_id}/clusters/{cluster_id}/restart
+// @API DWS GET /v1.0/{project_id}/clusters/{cluster_id}
+func ResourceClusterRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceClusterRestartCreate,
+		ReadContext:   resourceClusterRestartRead,
+		DeleteContext: resourceClusterRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Specifies the ID of the DWS cluster to be restarted.",
+			},
+		},
+	}
+}
+
+func resourceClusterRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	clusterId := d.Get("cluster_id").(string)
+	// For the same DWS cluster, it is not supported to run multiple tasks at the same time.
+	config.MutexKV.Lock(clusterId)
+	defer config.MutexKV.Unlock(clusterId)
+
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("dws", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	httpUrl := "v1.0/{project_id}/clusters/{cluster_id}/restart"
+	path := client.Endpoint + httpUrl
+	path = strings.ReplaceAll(path, "{project_id}", client.ProjectID)
+	path = strings.ReplaceAll(path, "{cluster_id}", clusterId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+		// The "restart" parameter is a restart flag, which has no practical meaning, but is required.
+		JSONBody: map[string]interface{}{
+			"restart": map[string]interface{}{},
+		},
+	}
+
+	_, err = client.Request("POST", path, &opt)
+	if err != nil {
+		return diag.Errorf("error restarting DWS cluster (%s): %s", clusterId, err)
+	}
+
+	// After the interface is sent successfully, the task ID will not be returned, so the query cluster details interface is called
+	// to determine whether the restart is successful.
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshClusterStateFun(client, clusterId),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return diag.Errorf("error waiting for the status of DWS cluster (%s) to become available: %s", clusterId, err)
+	}
+
+	d.SetId(clusterId)
+
+	return nil
+}
+
+func refreshClusterStateFun(client *golangsdk.ServiceClient, clusterId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetClusterInfoByClusterId(client, clusterId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		taskStatus := utils.PathSearch("cluster.task_status", respBody, "").(string)
+		status := utils.PathSearch("cluster.status", respBody, "").(string)
+		// After the restart task is completed, "task_status" will become `null` and the cluster status is available.
+		if taskStatus == "" && utils.StrSliceContains([]string{"AVAILABLE", "ACTIVE"}, status) {
+			return respBody, "COMPLETED", nil
+		}
+
+		if utils.StrSliceContains([]string{"REBOOT_FAILURE"}, taskStatus) {
+			return respBody, taskStatus, nil
+		}
+
+		return respBody, "PENDING", nil
+	}
+}
+
+func resourceClusterRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceClusterRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only a one-time action resource for restarting the DWS cluster. Deleting this resource will
+not clear the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to support restarting a DWS cluster.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
this resource is a one-time action resource.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceCluster_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_ -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV1
=== PAUSE TestAccResourceCluster_basicV1
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== RUN   TestAccResourceCluster_basicV2_mutilAZs
=== PAUSE TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV1
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV2
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
    acceptance.go:2025: HW_DWS_MUTIL_AZS must be set for the acceptance test
--- SKIP: TestAccResourceCluster_basicV2_mutilAZs (0.01s)
--- PASS: TestAccResourceCluster_basicV1 (2754.82s)
--- PASS: TestAccResourceCluster_basicV2 (3581.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       3581.318s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
