### PR TITLE
feat(servicestage/env): add new resource to manage environments

### DIFF
--- a/docs/resources/servicestagev3_environment.md
+++ b/docs/resources/servicestagev3_environment.md
@@ -1,0 +1,81 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_environment"
+description: |-
+  Manages an environment resource within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_environment
+
+Manages an environment resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "vpc_id" {}
+variable "env_name" {}
+variable "enterprise_project_id" {}
+
+resource "huaweicloud_servicestagev3_environment" "test" {
+  vpc_id                = var.vpc_id
+  name                  = var.env_name
+  deploy_mode           = "mixed"
+  description           = "Created by terraform script"
+  enterprise_project_id = var.enterprise_project_id
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the environment is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID to which the environment belongs.  
+  Changing this will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the environment.  
+  The valid length is limited from `2` to `64`, only letters, digits, hyphens (-) and underscores (_) are allowed.
+  The name must start with a letter and end with a letter or a digit.
+
+* `deploy_mode` - (Optional, String, ForceNew) Specifies the deploy mode of the environment.  
+  + **virtualmachine**: Virtual machine.
+  + **container**: Kubernetes.
+  + **mixed**: Both virtual machine and Kubernetes.
+
+  Defaults to **mixed**.
+  Changing this will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of the environment.  
+  The value can contain a maximum of `128` characters.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the environment belongs.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the environment that used to filter resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, in UUID format.
+
+* `creator` - The creator name of the environment.
+
+* `created_at` - The creation time of the environment, in RFC3339 format.
+
+* `updated_at` - The latest update time of the environment, in RFC3339 format.
+
+## Import
+
+Environments can be imported using their `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_servicestagev3_environment.test <id>
+```

--- a/huaweicloud/common/resource_schema.go
+++ b/huaweicloud/common/resource_schema.go
@@ -8,12 +8,16 @@ import (
 )
 
 // TagsSchema returns the schema to use for tags.
-func TagsSchema() *schema.Schema {
-	return &schema.Schema{
+func TagsSchema(description ...string) *schema.Schema {
+	schemaObj := schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
+	if len(description) > 0 {
+		schemaObj.Description = description[0]
+	}
+	return &schemaObj
 }
 
 // TagsForceNewSchema returns the schema to use for tags with ForceNew

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1827,6 +1827,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestage_environment":                 servicestage.ResourceEnvironment(),
 			"huaweicloud_servicestage_repo_token_authorization":    servicestage.ResourceRepoTokenAuth(),
 			"huaweicloud_servicestage_repo_password_authorization": servicestage.ResourceRepoPwdAuth(),
+			// v3 managements
+			"huaweicloud_servicestagev3_environment": servicestage.ResourceV3Environment(),
 
 			"huaweicloud_sfs_turbo":            sfsturbo.ResourceSFSTurbo(),
 			"huaweicloud_sfs_turbo_dir":        sfsturbo.ResourceSfsTurboDir(),

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_environment_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_environment_test.go
@@ -1,0 +1,135 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
+)
+
+func getV3EnvFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("servicestage", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ServiceStage client: %s", err)
+	}
+	return servicestage.QueryV3Environment(client, state.Primary.ID)
+}
+
+func TestAccV3Environment_basic(t *testing.T) {
+	var (
+		env interface{}
+
+		resourceName = "huaweicloud_servicestagev3_environment.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &env, getV3EnvFunc)
+
+		name       = acceptance.RandomAccResourceNameWithDash()
+		updateName = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV3Environment_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform test"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "creator"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccV3Environment_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "baar"),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccV3Environment_basic_step3(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccV3Environment_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_environment" "test" {
+  name                  = "%[2]s"
+  description           = "Created by terraform test"
+  vpc_id                = huaweicloud_vpc.test.id
+  enterprise_project_id = "0"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+`, common.TestVpc(name), name)
+}
+
+func testAccV3Environment_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_environment" "test" {
+  name                  = "%[2]s"
+  vpc_id                = huaweicloud_vpc.test.id
+  enterprise_project_id = "%[3]s"
+
+  tags = {
+    foo = "baar"
+  }
+}
+`, common.TestVpc(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccV3Environment_basic_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_environment" "test" {
+  name                  = "%[2]s"
+  vpc_id                = huaweicloud_vpc.test.id
+  enterprise_project_id = "%[3]s"
+}
+`, common.TestVpc(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment.go
@@ -1,0 +1,289 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v3EnvNotFoundCodes = []string{
+	"SVCSTG.00100401",
+}
+
+// @API ServiceStage POST /v3/{project_id}/cas/environments
+// @API ServiceStage GET /v3/{project_id}/cas/environments/{environment_id}
+// @API ServiceStage PUT /v3/{project_id}/cas/environments/{environment_id}
+// @API ServiceStage DELETE /v3/{project_id}/cas/environments/{environment_id}
+func ResourceV3Environment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV3EnvironmentCreate,
+		ReadContext:   resourceV3EnvironmentRead,
+		UpdateContext: resourceV3EnvironmentUpdate,
+		DeleteContext: resourceV3EnvironmentDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the environment is located.`,
+			},
+			"vpc_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The VPC ID to which the environment belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the environment.`,
+			},
+			"deploy_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The deploy mode of the environment.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the environment.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The the enterprise project ID to which the environment belongs.`,
+			},
+			"tags": common.TagsSchema(
+				`The key/value pairs to associate with the environment that used to filter resource.`,
+			),
+			"creator": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator name of the environment.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the environment, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the environment, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildV3EnvironmentCreateBodyParams(cfg *config.Config, d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"vpc_id":                d.Get("vpc_id"),
+		"name":                  d.Get("name"),
+		"deploy_mode":           utils.ValueIgnoreEmpty(d.Get("deploy_mode")),
+		"description":           utils.ValueIgnoreEmpty(d.Get("description")),
+		"enterprise_project_id": cfg.GetEnterpriseProjectID(d),
+		"labels":                utils.ValueIgnoreEmpty(utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{}))),
+	}
+}
+
+func resourceV3EnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/cas/environments"
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildV3EnvironmentCreateBodyParams(cfg, d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating environment: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	envId, err := jmespath.Search("id", respBody)
+	if err != nil || envId == nil {
+		return diag.Errorf("failed to find the environment ID from the API response: %s", err)
+	}
+	d.SetId(envId.(string))
+
+	return resourceV3EnvironmentRead(ctx, d, meta)
+}
+
+func QueryV3Environment(client *golangsdk.ServiceClient, envId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/cas/environments/{environment_id}"
+
+	queryPath := client.Endpoint + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+	queryPath = strings.ReplaceAll(queryPath, "{environment_id}", envId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceV3EnvironmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		envId  = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	respBody, err := QueryV3Environment(client, envId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", v3EnvNotFoundCodes...),
+			fmt.Sprintf("error getting environment (%s)", envId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("vpc_id", utils.PathSearch("vpc_id", respBody, nil)),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("deploy_mode", utils.PathSearch("deploy_mode", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", respBody, nil)),
+		d.Set("creator", utils.PathSearch("creator", respBody, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("labels", respBody, make([]interface{}, 0)))),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", respBody, float64(0)).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", respBody, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildV3EnvironmentUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": d.Get("description"),
+		"labels":      utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{}), true),
+	}
+}
+
+func resourceV3EnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/cas/environments/{environment_id}"
+		envId   = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	if d.HasChangeExcept("enterprise_project_id") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{environment_id}", envId)
+
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: buildV3EnvironmentUpdateBodyParams(d),
+		}
+
+		_, err = client.Request("PUT", updatePath, &opt)
+		if err != nil {
+			return diag.Errorf("error updating environment (%s): %s", envId, err)
+		}
+	}
+
+	if d.HasChange("enterprise_project_id") {
+		migrateOpts := config.MigrateResourceOpts{
+			ResourceId:   envId,
+			ResourceType: "servicestage-environment",
+			RegionId:     region,
+			ProjectId:    client.ProjectID,
+		}
+		if err := cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceV3EnvironmentRead(ctx, d, meta)
+}
+
+func resourceV3EnvironmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/cas/environments/{environment_id}"
+		envId   = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{environment_id}", envId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		OkCodes: []int{204},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", v3EnvNotFoundCodes...),
+			fmt.Sprintf("error deleting environment (%s)", envId))
+	}
+	return nil
+}

--- a/huaweicloud/utils/tags.go
+++ b/huaweicloud/utils/tags.go
@@ -126,8 +126,13 @@ func ExpandResourceTags(tagmap map[string]interface{}) []tags.ResourceTag {
 }
 
 // ExpandResourceTagsMap returns the tags in format of list of maps for the given map of data.
-func ExpandResourceTagsMap(tagmap map[string]interface{}) []map[string]interface{} {
-	if len(tagmap) < 1 {
+// Parameters:
+// + tagmap: tags input with the map structure format.
+// + keepEmpty: whether to keep the empty list return instead of the nil.
+func ExpandResourceTagsMap(tagmap map[string]interface{}, keepEmpty ...bool) []map[string]interface{} {
+	// Empty list returned only keepEmpty is set and the value is 'true'.
+	if len(tagmap) < 1 && (len(keepEmpty) < 1 || (len(keepEmpty) > 0 && !keepEmpty[0])) {
+		// If not, returns nil and with the type, the value is '[]map[string]interface{}(nil)'.
 		return nil
 	}
 

--- a/huaweicloud/utils/tags_test.go
+++ b/huaweicloud/utils/tags_test.go
@@ -1,0 +1,52 @@
+package utils_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func TestTagsFunc_ExpandResourceTagsMap(t *testing.T) {
+	var (
+		testInput = map[string]interface{}{
+			"foo": "bar",
+		}
+		emptyInput = make(map[string]interface{})
+
+		expected = []map[string]interface{}{
+			{
+				"key":   "foo",
+				"value": "bar",
+			},
+		}
+		nilExpectedWithType = []map[string]interface{}(nil)
+		EmptyExpected       = make([]map[string]interface{}, 0)
+	)
+
+	testOutput := utils.ExpandResourceTagsMap(testInput)
+	if !reflect.DeepEqual(testOutput, expected) {
+		t.Fatalf("[1]The processing result of ExpandResourceTagsMap method is not as expected, want %s, but %s",
+			utils.Green(expected), utils.Yellow(testOutput))
+	}
+
+	testOutput = utils.ExpandResourceTagsMap(emptyInput)
+	if !reflect.DeepEqual(testOutput, nilExpectedWithType) {
+		t.Fatalf("[2]The processing result of ExpandResourceTagsMap method is not as expected, want %s, but %s",
+			utils.Green(nilExpectedWithType), utils.Yellow(testOutput))
+	}
+
+	testOutput = utils.ExpandResourceTagsMap(emptyInput, false)
+	if !reflect.DeepEqual(testOutput, nilExpectedWithType) {
+		t.Fatalf("[3]The processing result of ExpandResourceTagsMap method is not as expected, want %s, but %s",
+			utils.Green(nilExpectedWithType), utils.Yellow(testOutput))
+	}
+
+	testOutput = utils.ExpandResourceTagsMap(emptyInput, true)
+	if !reflect.DeepEqual(testOutput, EmptyExpected) {
+		t.Fatalf("The processing result of ExpandResourceTagsMap method is not as expected, want %s, but %s",
+			utils.Green(EmptyExpected), utils.Yellow(testOutput))
+	}
+
+	t.Logf("All processing results of the ExpandResourceTagsMap method meets expectation")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to manage environments and according to the ver.3 APIs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage environments
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o servicestage -f TestAccV3Environment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3Environment_basic -timeout 360m -parallel 10
=== RUN   TestAccV3Environment_basic
=== PAUSE TestAccV3Environment_basic
=== CONT  TestAccV3Environment_basic
--- PASS: TestAccV3Environment_basic (112.28s)
PASS
coverage: 9.2% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      112.327s        coverage: 9.2% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/3d3ae558-07b7-4b0e-b176-779fd95ccea0)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    ![image](https://github.com/user-attachments/assets/bf45b482-3ed1-493d-88f5-dd67b75c574e)
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/1331ab56-2a26-448c-ba13-69681c3c9ee4)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
