### PR TITLE
feat(servicestage/app): add new resource to manage applications

### DIFF
--- a/docs/resources/servicestagev3_application.md
+++ b/docs/resources/servicestagev3_application.md
@@ -1,0 +1,74 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_application"
+description: |-
+  Manages an application resource within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_application
+
+Manages an application resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "app_name" {}
+variable "enterprise_project_id" {}
+
+resource "huaweicloud_servicestagev3_application" "test" {
+  name                  = var.app_name
+  description           = "Created by terraform script"
+  enterprise_project_id = var.enterprise_project_id
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the application is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the application.  
+  The valid length is limited from `2` to `64`, only letters, digits, hyphens (-) and underscores (_) are allowed.
+  The name must start with a letter and end with a letter or a digit.
+
+* `description` - (Optional, String) Specifies the description of the application.  
+  The value can contain a maximum of `128` characters.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the application belongs.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the application that used to filter resource.
+
+<a name="servicestage_v3_app_labels"></a>
+The `labels` block supports:
+
+* `key` - (Required, String) Specifies the label key.
+
+* `value` - (Required, String) Specifies the label value.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID, in UUID format.
+
+* `creator` - The creator name of the application.
+
+* `created_at` - The creation time of the application, in RFC3339 format.
+
+* `updated_at` - The latest update time of the application, in RFC3339 format.
+
+## Import
+
+Applications can be imported using their `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_servicestagev3_application.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1856,6 +1856,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestage_repo_token_authorization":    servicestage.ResourceRepoTokenAuth(),
 			"huaweicloud_servicestage_repo_password_authorization": servicestage.ResourceRepoPwdAuth(),
 			// v3 managements
+			"huaweicloud_servicestagev3_application":           servicestage.ResourceV3Application(),
 			"huaweicloud_servicestagev3_environment":           servicestage.ResourceV3Environment(),
 			"huaweicloud_servicestagev3_environment_associate": servicestage.ResourceV3EnvironmentAssociate(),
 

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_application_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_application_test.go
@@ -1,0 +1,131 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
+)
+
+func getV3AppFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("servicestage", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ServiceStage client: %s", err)
+	}
+	return servicestage.QueryV3Application(client, state.Primary.ID)
+}
+
+func TestAccV3Application_basic(t *testing.T) {
+	var (
+		app interface{}
+
+		resourceName = "huaweicloud_servicestagev3_application.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &app, getV3AppFunc)
+
+		name       = acceptance.RandomAccResourceNameWithDash()
+		updateName = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV3Application_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform test"),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "creator"),
+					resource.TestMatchResourceAttr(resourceName, "created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccV3Application_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "baar"),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				Config: testAccV3Application_basic_step3(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestMatchResourceAttr(resourceName, "updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccV3Application_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_application" "test" {
+  name                  = "%[2]s"
+  description           = "Created by terraform test"
+  enterprise_project_id = "0"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+`, common.TestVpc(name), name)
+}
+
+func testAccV3Application_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_application" "test" {
+  name                  = "%[2]s"
+  enterprise_project_id = "%[3]s"
+
+  tags = {
+    foo = "baar"
+  }
+}
+`, common.TestVpc(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccV3Application_basic_step3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_application" "test" {
+  name                  = "%[2]s"
+  enterprise_project_id = "%[3]s"
+}
+`, common.TestVpc(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_application.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_application.go
@@ -1,0 +1,272 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var v3AppNotFoundCodes = []string{
+	"SVCSTG.00100401",
+}
+
+// @API ServiceStage POST /v3/{project_id}/cas/applications
+// @API ServiceStage GET /v3/{project_id}/cas/applications/{application_id}
+// @API ServiceStage PUT /v3/{project_id}/cas/applications/{application_id}
+// @API ServiceStage DELETE /v3/{project_id}/cas/applications/{application_id}
+func ResourceV3Application() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV3ApplicationCreate,
+		ReadContext:   resourceV3ApplicationRead,
+		UpdateContext: resourceV3ApplicationUpdate,
+		DeleteContext: resourceV3ApplicationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the application is located.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the application.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the application.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The the enterprise project ID to which the application belongs.`,
+			},
+			"tags": common.TagsSchema(
+				`he key/value pairs to associate with the application that used to filter resource.`,
+			),
+			"creator": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creator name of the application.`,
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the application, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the application, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func buildV3ApplicationCreateBodyParams(cfg *config.Config, d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":                  d.Get("name"),
+		"description":           utils.ValueIgnoreEmpty(d.Get("description")),
+		"enterprise_project_id": cfg.GetEnterpriseProjectID(d),
+		"labels":                utils.ValueIgnoreEmpty(utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{}))),
+	}
+}
+
+func resourceV3ApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/cas/applications"
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: utils.RemoveNil(buildV3ApplicationCreateBodyParams(cfg, d)),
+	}
+
+	requestResp, err := client.Request("POST", createPath, &opt)
+	if err != nil {
+		return diag.Errorf("error creating application: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	appId, err := jmespath.Search("id", respBody)
+	if err != nil || appId == nil {
+		return diag.Errorf("failed to find the application ID from the API response: %s", err)
+	}
+	d.SetId(appId.(string))
+
+	return resourceV3ApplicationRead(ctx, d, meta)
+}
+
+func QueryV3Application(client *golangsdk.ServiceClient, appId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/cas/applications/{application_id}"
+
+	queryPath := client.Endpoint + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+	queryPath = strings.ReplaceAll(queryPath, "{application_id}", appId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceV3ApplicationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		appId  = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	respBody, err := QueryV3Application(client, appId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", v3AppNotFoundCodes...),
+			fmt.Sprintf("error getting application (%s)", appId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", utils.PathSearch("name", respBody, nil)),
+		d.Set("description", utils.PathSearch("description", respBody, nil)),
+		d.Set("enterprise_project_id", utils.PathSearch("enterprise_project_id", respBody, nil)),
+		d.Set("creator", utils.PathSearch("creator", respBody, nil)),
+		d.Set("tags", utils.FlattenTagsToMap(utils.PathSearch("labels", respBody, make([]interface{}, 0)))),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", respBody, float64(0)).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", respBody, float64(0)).(float64))/1000, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildV3ApplicationUpdateBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"name":        d.Get("name"),
+		"description": d.Get("description"),
+		"labels":      utils.ExpandResourceTagsMap(d.Get("tags").(map[string]interface{}), true),
+	}
+}
+
+func resourceV3ApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/cas/applications/{application_id}"
+		appId   = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	if d.HasChangeExcept("enterprise_project_id") {
+		updatePath := client.Endpoint + httpUrl
+		updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+		updatePath = strings.ReplaceAll(updatePath, "{application_id}", appId)
+
+		opt := golangsdk.RequestOpts{
+			KeepResponseBody: true,
+			MoreHeaders: map[string]string{
+				"Content-Type": "application/json",
+			},
+			JSONBody: buildV3ApplicationUpdateBodyParams(d),
+		}
+
+		_, err = client.Request("PUT", updatePath, &opt)
+		if err != nil {
+			return diag.Errorf("error updating application (%s): %s", appId, err)
+		}
+	}
+
+	if d.HasChange("enterprise_project_id") {
+		migrateOpts := config.MigrateResourceOpts{
+			ResourceId:   appId,
+			ResourceType: "servicestage-application",
+			RegionId:     region,
+			ProjectId:    client.ProjectID,
+		}
+		if err := cfg.MigrateEnterpriseProject(ctx, d, migrateOpts); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return resourceV3ApplicationRead(ctx, d, meta)
+}
+
+func resourceV3ApplicationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v3/{project_id}/cas/applications/{application_id}"
+		appId   = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	deletePath := client.Endpoint + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{application_id}", appId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		OkCodes: []int{204},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &opt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", v3AppNotFoundCodes...),
+			fmt.Sprintf("error deleting application (%s)", appId))
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource to manage applications and according to the ver.3 APIs.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage applications.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o servicestage -f TestAccV3Application_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3Application_basic -timeout 360m -parallel 10
=== RUN   TestAccV3Application_basic
=== PAUSE TestAccV3Application_basic
=== CONT  TestAccV3Application_basic
--- PASS: TestAccV3Application_basic (107.38s)
PASS
coverage: 9.2% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      107.436s        coverage: 9.2% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/f21bf313-aabb-4222-be39-83cf564ede83)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/42c84ecd-2e43-4b05-a4e3-a5a4505f8af5)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
