### PR TITLE
feat(dms): support rabbitmq exchange associate

### DIFF
--- a/docs/resources/dms_rabbitmq_exchange_associate.md
+++ b/docs/resources/dms_rabbitmq_exchange_associate.md
@@ -1,0 +1,79 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dms_rabbitmq_exchange_associate"
+description: |-
+  Manages a DMS RabbitMQ exchange association resource within HuaweiCloud.
+---
+
+# huaweicloud_dms_rabbitmq_exchange_associate
+
+Manages a DMS RabbitMQ exchange association resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "vhost" {}
+variable "exchange" {}
+variable "destination" {}
+variable "routing_key" {}
+
+resource "huaweicloud_dms_rabbitmq_exchange_associate" "test" {
+  instance_id      = var.instance_id
+  vhost            = var.vhost
+  exchange         = var.exchange
+  destination_type = "Queue"
+  destination      = var.destination
+  routing_key      = var.routing_key
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the DMS RabbitMQ instance ID.
+  Changing this creates a new resource.
+
+* `vhost` - (Required, String, ForceNew) Specifies the vhost name. Changing this creates a new resource.
+
+* `exchange` - (Required, String, ForceNew) Specifies the exchange name. Changing this creates a new resource.
+
+-> If `vhost` and `exchange` has slashes, please change them into **\_\_F_SLASH\_\_**.
+
+* `destination_type` - (Required, String, ForceNew) Specifies the type of the binding target.
+  The options are **Exchange** and **Queue**. Changing this creates a new resource.
+
+* `destination` - (Required, String, ForceNew) Specifies the name of a target exchange or queue.
+  Changing this creates a new resource.
+
+* `routing_key` - (Optional, String, ForceNew) Specifies the binding key-value. Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `properties_key` - The URL-translated routing key.
+
+## Import
+
+The RabbitMQ exchange association can be imported using the `instance_id`, `vhost`, `exchange`, `destination_type`,
+`destination` and `routing_key` separated by commas.
+
+If `routing_key` is empty e.g.
+
+```bash
+$ terraform import huaweicloud_dms_rabbitmq_exchange.test <instance_id>,<vhost>,<exchange>,<destination_type>,<destination>
+```
+
+If `routing_key` is specified e.g.
+
+```bash
+$ terraform import huaweicloud_dms_rabbitmq_exchange.test <instance_id>,<vhost>,<exchange>,<destination_type>,<destination>,<routing_key>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1412,11 +1412,12 @@ func Provider() *schema.Provider {
 			"huaweicloud_dms_kafka_smart_connect_task_action": dms.ResourceDmsKafkaSmartConnectTaskAction(),
 			"huaweicloud_dms_kafka_user_client_quota":         dms.ResourceDmsKafkaUserClientQuota(),
 
-			"huaweicloud_dms_rabbitmq_instance": dms.ResourceDmsRabbitmqInstance(),
-			"huaweicloud_dms_rabbitmq_plugin":   dms.ResourceDmsRabbitmqPlugin(),
-			"huaweicloud_dms_rabbitmq_vhost":    dms.ResourceDmsRabbitmqVhost(),
-			"huaweicloud_dms_rabbitmq_exchange": dms.ResourceDmsRabbitmqExchange(),
-			"huaweicloud_dms_rabbitmq_queue":    dms.ResourceDmsRabbitmqQueue(),
+			"huaweicloud_dms_rabbitmq_instance":           dms.ResourceDmsRabbitmqInstance(),
+			"huaweicloud_dms_rabbitmq_plugin":             dms.ResourceDmsRabbitmqPlugin(),
+			"huaweicloud_dms_rabbitmq_vhost":              dms.ResourceDmsRabbitmqVhost(),
+			"huaweicloud_dms_rabbitmq_exchange":           dms.ResourceDmsRabbitmqExchange(),
+			"huaweicloud_dms_rabbitmq_queue":              dms.ResourceDmsRabbitmqQueue(),
+			"huaweicloud_dms_rabbitmq_exchange_associate": dms.ResourceDmsRabbitmqExchangeAssociate(),
 
 			"huaweicloud_dms_rocketmq_instance":       dms.ResourceDmsRocketMQInstance(),
 			"huaweicloud_dms_rocketmq_consumer_group": dms.ResourceDmsRocketMQConsumerGroup(),

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_exchange_associate_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_exchange_associate_test.go
@@ -1,0 +1,257 @@
+package dms
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getRabbitmqExchangeAssociateResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("dmsv2", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS client: %s", err)
+	}
+
+	getHttpUrl := "v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges/{exchange}/binding"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", state.Primary.Attributes["instance_id"])
+	getPath = strings.ReplaceAll(getPath, "{vhost}", state.Primary.Attributes["vhost"])
+	getPath = strings.ReplaceAll(getPath, "{exchange}", state.Primary.Attributes["exchange"])
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving the exchange association infos: %s", err)
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flattening the exchanges association infos: %s", err)
+	}
+
+	searchPath := fmt.Sprintf("items[?destination_type=='%s']|[?destination=='%s']",
+		strings.ToLower(state.Primary.Attributes["destination_type"]), state.Primary.Attributes["destination"])
+	associations := utils.PathSearch(searchPath, getRespBody, make([]interface{}, 0)).([]interface{})
+
+	routingKey := state.Primary.Attributes["routing_key"]
+
+	for _, association := range associations {
+		if routingKey == utils.PathSearch("routing_key", association, "").(string) {
+			return association, nil
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func TestAccRabbitmqExchangeAssociate_basic(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_rabbitmq_exchange_associate.test"
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getRabbitmqExchangeAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRabbitmqExchangeAssociate_basic(rName, ""),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "properties_key"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceExchangeAssociateImportStateIDFunc(resourceName),
+			},
+			{
+				Config: testRabbitmqExchangeAssociate_basic(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "properties_key"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceExchangeAssociateImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testRabbitmqExchangeAssociate_basic(rName, routingKey string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "huaweicloud_dms_rabbitmq_exchange_associate" "test" {
+  depends_on = [
+    huaweicloud_dms_rabbitmq_vhost.test,
+    huaweicloud_dms_rabbitmq_exchange.test,
+    huaweicloud_dms_rabbitmq_queue.test
+  ]
+
+  instance_id      = huaweicloud_dms_rabbitmq_instance.test.id
+  vhost            = huaweicloud_dms_rabbitmq_vhost.test.name
+  exchange         = huaweicloud_dms_rabbitmq_exchange.test.name
+  destination_type = "Queue"
+  destination      = huaweicloud_dms_rabbitmq_queue.test.name
+  routing_key      = "%[3]s"
+}
+`, testRabbitmqVhost_basic(rName), testRabbitmqExchangeAssociate_base_queue_and_exchange(rName), routingKey)
+}
+
+func testRabbitmqExchangeAssociate_base_queue_and_exchange(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dms_rabbitmq_exchange" "test" {
+  depends_on = [huaweicloud_dms_rabbitmq_vhost.test]
+
+  instance_id = huaweicloud_dms_rabbitmq_instance.test.id
+  vhost       = huaweicloud_dms_rabbitmq_vhost.test.name
+  name        = "%[1]s"
+  type        = "direct"
+  auto_delete = false
+}
+
+resource "huaweicloud_dms_rabbitmq_queue" "test" {
+  depends_on = [huaweicloud_dms_rabbitmq_vhost.test]
+
+  instance_id = huaweicloud_dms_rabbitmq_instance.test.id
+  vhost       = huaweicloud_dms_rabbitmq_vhost.test.name
+  name        = "%[1]s"
+  auto_delete = false
+}
+`, rName)
+}
+
+func testAccResourceExchangeAssociateImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", resourceName, rs)
+		}
+
+		instanceID := rs.Primary.Attributes["instance_id"]
+		vhost := rs.Primary.Attributes["vhost"]
+		exchange := rs.Primary.Attributes["exchange"]
+		destinationType := rs.Primary.Attributes["destination_type"]
+		destination := rs.Primary.Attributes["destination"]
+		routingKey := rs.Primary.Attributes["routing_key"]
+
+		if instanceID == "" || vhost == "" || exchange == "" || destinationType == "" || destination == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, "+
+				"want '<instance_id>,<vhost>,<exchange>,<destination_type>,<destination>,', but got '%s,%s,%s,%s,%s'",
+				instanceID, vhost, exchange, destinationType, destination)
+		}
+
+		if routingKey == "" {
+			return fmt.Sprintf("%s,%s,%s,%s,%s", instanceID, vhost, exchange, destinationType, destination), nil
+		}
+
+		return fmt.Sprintf("%s,%s,%s,%s,%s,%s", instanceID, vhost, exchange, destinationType, destination, routingKey), nil
+	}
+}
+
+func TestAccRabbitmqExchangeAssociate_special_characters(t *testing.T) {
+	var obj interface{}
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_dms_rabbitmq_exchange_associate.test"
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getRabbitmqExchangeAssociateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testRabbitmqExchangeAssociate_special_characters(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(resourceName, "properties_key"),
+					resource.TestCheckResourceAttr(resourceName, "routing_key", "/test%encode|\\"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccResourceExchangeAssociateImportStateIDFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testRabbitmqExchangeAssociate_special_characters(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+locals {
+  special_characters_name = "/test%%special|characters_-"
+}
+
+resource "huaweicloud_dms_rabbitmq_vhost" "test" {
+  instance_id = huaweicloud_dms_rabbitmq_instance.test.id
+  name        = local.special_characters_name
+}
+
+resource "huaweicloud_dms_rabbitmq_exchange" "test" {
+  depends_on = [huaweicloud_dms_rabbitmq_vhost.test]
+
+  instance_id = huaweicloud_dms_rabbitmq_instance.test.id
+  vhost       = urlencode(replace(huaweicloud_dms_rabbitmq_vhost.test.name, "/", "__F_SLASH__"))
+  name        = local.special_characters_name
+  type        = "direct"
+  auto_delete = false
+}
+
+resource "huaweicloud_dms_rabbitmq_queue" "test" {
+  depends_on = [huaweicloud_dms_rabbitmq_vhost.test]
+
+  instance_id = huaweicloud_dms_rabbitmq_instance.test.id
+  vhost       = urlencode(replace(huaweicloud_dms_rabbitmq_vhost.test.name, "/", "__F_SLASH__"))
+  name        = local.special_characters_name
+  auto_delete = false
+}
+
+resource "huaweicloud_dms_rabbitmq_exchange_associate" "test" {
+  depends_on = [
+    huaweicloud_dms_rabbitmq_vhost.test,
+    huaweicloud_dms_rabbitmq_exchange.test,
+    huaweicloud_dms_rabbitmq_queue.test
+  ]
+
+  instance_id      = huaweicloud_dms_rabbitmq_instance.test.id
+  vhost            = urlencode(replace(huaweicloud_dms_rabbitmq_vhost.test.name, "/", "__F_SLASH__"))
+  exchange         = urlencode(replace(huaweicloud_dms_rabbitmq_exchange.test.name, "/", "__F_SLASH__"))
+  destination_type = "queue"
+  destination      = huaweicloud_dms_rabbitmq_queue.test.name
+  routing_key      = "/test%%encode|\\"
+}
+`, testAccDmsRabbitmqInstance_basic(rName))
+}

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_exchange_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_exchange_test.go
@@ -76,7 +76,7 @@ resource "huaweicloud_dms_rabbitmq_exchange" "test" {
 `, testRabbitmqVhost_basic(rName), rName)
 }
 
-func TestAccRabbitmqExchange_slash(t *testing.T) {
+func TestAccRabbitmqExchange_special_charcters(t *testing.T) {
 	var obj interface{}
 	resourceName := "huaweicloud_dms_rabbitmq_exchange.test"
 	rc := acceptance.InitResourceCheck(
@@ -91,11 +91,11 @@ func TestAccRabbitmqExchange_slash(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testRabbitmqExchange_slash(),
+				Config: testRabbitmqExchange_special_charcters(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", "/test/Exchange"),
-					resource.TestCheckResourceAttr(resourceName, "vhost", "__F_SLASH__test__F_SLASH__Vhost"),
+					resource.TestCheckResourceAttr(resourceName, "name", "/test%Exchange|-_"),
+					resource.TestCheckResourceAttr(resourceName, "vhost", "__F_SLASH__test%25Vhost%7C-_"),
 				),
 			},
 			{
@@ -108,7 +108,7 @@ func TestAccRabbitmqExchange_slash(t *testing.T) {
 	})
 }
 
-func testRabbitmqExchange_slash() string {
+func testRabbitmqExchange_special_charcters() string {
 	return fmt.Sprintf(`
 %s
 
@@ -116,12 +116,12 @@ resource "huaweicloud_dms_rabbitmq_exchange" "test" {
   depends_on = [huaweicloud_dms_rabbitmq_vhost.test]
 
   instance_id = huaweicloud_dms_rabbitmq_instance.test.id
-  vhost       = "__F_SLASH__test__F_SLASH__Vhost"
-  name        = "/test/Exchange"
+  vhost       = urlencode(replace(huaweicloud_dms_rabbitmq_vhost.test.name, "/", "__F_SLASH__"))
+  name        = "/test%%Exchange|-_"
   type        = "direct"
   auto_delete = false
 }
-`, testRabbitmqVhost_slash())
+`, testRabbitmqVhost_special_charcters())
 }
 
 func testAccResourceExchangeOrQueueImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_queue_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_queue_test.go
@@ -81,7 +81,7 @@ resource "huaweicloud_dms_rabbitmq_queue" "test" {
 `, testRabbitmqVhost_basic(rName), rName)
 }
 
-func TestAccRabbitmqQueue_slash(t *testing.T) {
+func TestAccRabbitmqQueue_special_charcters(t *testing.T) {
 	var obj interface{}
 	resourceName := "huaweicloud_dms_rabbitmq_queue.test"
 	rc := acceptance.InitResourceCheck(
@@ -96,11 +96,11 @@ func TestAccRabbitmqQueue_slash(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testRabbitmqQueue_slash(),
+				Config: testRabbitmqQueue_special_charcters(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", "/test/Queue"),
-					resource.TestCheckResourceAttr(resourceName, "vhost", "__F_SLASH__test__F_SLASH__Vhost"),
+					resource.TestCheckResourceAttr(resourceName, "name", "/test%Queue|-_"),
+					resource.TestCheckResourceAttr(resourceName, "vhost", "__F_SLASH__test%25Vhost%7C-_"),
 					resource.TestCheckResourceAttrPair(resourceName, "instance_id", "huaweicloud_dms_rabbitmq_instance.test", "id"),
 				),
 			},
@@ -114,7 +114,7 @@ func TestAccRabbitmqQueue_slash(t *testing.T) {
 	})
 }
 
-func testRabbitmqQueue_slash() string {
+func testRabbitmqQueue_special_charcters() string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -122,10 +122,10 @@ resource "huaweicloud_dms_rabbitmq_queue" "test" {
   depends_on = [huaweicloud_dms_rabbitmq_vhost.test]
 
   instance_id = huaweicloud_dms_rabbitmq_instance.test.id
-  vhost       = "__F_SLASH__test__F_SLASH__Vhost"
-  name        = "/test/Queue"
+  vhost       = urlencode(replace(huaweicloud_dms_rabbitmq_vhost.test.name, "/", "__F_SLASH__"))
+  name        = "/test%%Queue|-_"
   auto_delete = false
   durable     = true
 }
-`, testRabbitmqVhost_slash())
+`, testRabbitmqVhost_special_charcters())
 }

--- a/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_vhost_test.go
+++ b/huaweicloud/services/acceptance/dms/resource_huaweicloud_dms_rabbitmq_vhost_test.go
@@ -64,7 +64,7 @@ resource "huaweicloud_dms_rabbitmq_vhost" "test" {
 `, testAccDmsRabbitmqInstance_basic(rName), rName)
 }
 
-func TestAccRabbitmqVhost_slash(t *testing.T) {
+func TestAccRabbitmqVhost_special_charcters(t *testing.T) {
 	var obj interface{}
 	resourceName := "huaweicloud_dms_rabbitmq_vhost.test"
 	rc := acceptance.InitResourceCheck(
@@ -79,10 +79,10 @@ func TestAccRabbitmqVhost_slash(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testRabbitmqVhost_slash(),
+				Config: testRabbitmqVhost_special_charcters(),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", "/test/Vhost"),
+					resource.TestCheckResourceAttr(resourceName, "name", "/test%Vhost|-_"),
 				),
 			},
 			{
@@ -95,14 +95,14 @@ func TestAccRabbitmqVhost_slash(t *testing.T) {
 	})
 }
 
-func testRabbitmqVhost_slash() string {
+func testRabbitmqVhost_special_charcters() string {
 	rNameWithDash := acceptance.RandomAccResourceNameWithDash()
 	return fmt.Sprintf(`
 %s
 
 resource "huaweicloud_dms_rabbitmq_vhost" "test" {
   instance_id = huaweicloud_dms_rabbitmq_instance.test.id
-  name        = "/test/Vhost"
+  name        = "/test%%Vhost|-_"
 }
 `, testAccDmsRabbitmqInstance_basic(rNameWithDash))
 }

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_exchange_associate.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_exchange_associate.go
@@ -1,0 +1,256 @@
+package dms
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+//nolint:revive
+// @API RabbitMQ DELETE /v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges/{exchange}/destination-type/{destination_type}/destination/{destination}/properties-key/{properties_key}/unbinding
+// @API RabbitMQ POST /v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges/{exchange}/binding
+// @API RabbitMQ GET /v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges/{exchange}/binding
+
+func ResourceDmsRabbitmqExchangeAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsRabbitmqExchangeAssociateCreate,
+		ReadContext:   resourceDmsRabbitmqExchangeAssociateRead,
+		DeleteContext: resourceDmsRabbitmqExchangeAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceExchangeAssociateImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vhost": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"exchange": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"destination_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"destination": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"routing_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"properties_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDmsRabbitmqExchangeAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	vhost := d.Get("vhost").(string)
+	exchange := d.Get("exchange").(string)
+	destination := d.Get("destination").(string)
+	destinationType := d.Get("destination_type").(string)
+
+	createHttpUrl := "v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges/{exchange}/binding"
+	createPath := client.Endpoint + createHttpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceID)
+	createPath = strings.ReplaceAll(createPath, "{vhost}", vhost)
+	createPath = strings.ReplaceAll(createPath, "{exchange}", exchange)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildRabbitmqExchangeAssociateRequestBody(d)),
+	}
+
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating exchange: %s", err)
+	}
+
+	id := fmt.Sprintf("%s/%s/%s/%s/%s", instanceID, vhost, exchange, destinationType, destination)
+	if routingKey, ok := d.GetOk("routing_key"); ok {
+		id += fmt.Sprintf("/%s", routingKey.(string))
+	}
+	d.SetId(id)
+
+	return resourceDmsRabbitmqExchangeAssociateRead(ctx, d, cfg)
+}
+
+func buildRabbitmqExchangeAssociateRequestBody(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"destination":      d.Get("destination"),
+		"destination_type": d.Get("destination_type"),
+		// routing_key have to send empty string if it's empty
+		"routing_key": d.Get("routing_key"),
+	}
+	return bodyParams
+}
+
+func resourceDmsRabbitmqExchangeAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	result, err := getRabbitmqExchangeAssociate(client, d)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving the exchange")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("routing_key", utils.PathSearch("routing_key", result, nil)),
+		d.Set("properties_key", url.PathEscape(utils.PathSearch("properties_key", result, "").(string))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func getRabbitmqExchangeAssociate(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	getHttpUrl := "v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges/{exchange}/binding"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{instance_id}", d.Get("instance_id").(string))
+	getPath = strings.ReplaceAll(getPath, "{vhost}", d.Get("vhost").(string))
+	getPath = strings.ReplaceAll(getPath, "{exchange}", d.Get("exchange").(string))
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving the exchange association infos: %s", err)
+	}
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flattening the exchanges association infos: %s", err)
+	}
+
+	// Queue or queue are all available for destination_type when creating,
+	// but the return will always be queue, so search it in lowercase
+	searchPath := fmt.Sprintf("items[?destination_type=='%s']|[?destination=='%s']",
+		strings.ToLower(d.Get("destination_type").(string)), d.Get("destination").(string))
+	associations := utils.PathSearch(searchPath, getRespBody, make([]interface{}, 0)).([]interface{})
+
+	routingKey := d.Get("routing_key").(string)
+
+	// routing_key may contain `\`
+	for _, association := range associations {
+		if routingKey == utils.PathSearch("routing_key", association, "").(string) {
+			return association, nil
+		}
+	}
+
+	return nil, golangsdk.ErrDefault404{}
+}
+
+func resourceDmsRabbitmqExchangeAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dmsv2", region)
+	if err != nil {
+		return diag.Errorf("error creating DMS client: %s", err)
+	}
+
+	destination := d.Get("destination").(string)
+	destination = strings.ReplaceAll(destination, "/", "__F_SLASH__")
+
+	propertiesKey := d.Get("properties_key").(string)
+	propertiesKey = strings.ReplaceAll(propertiesKey, "%2F", "__F_SLASH__")
+	propertiesKey = strings.ReplaceAll(propertiesKey, "%5C", "__B_SLASH__")
+
+	deleteHttpUrl := "v2/rabbitmq/{project_id}/instances/{instance_id}/vhosts/{vhost}/exchanges/{exchange}" +
+		"/destination-type/{destination_type}/destination/{destination}/properties-key/{properties_key}/unbinding"
+	deletePath := client.Endpoint + deleteHttpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deletePath = strings.ReplaceAll(deletePath, "{instance_id}", d.Get("instance_id").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{vhost}", d.Get("vhost").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{exchange}", d.Get("exchange").(string))
+	deletePath = strings.ReplaceAll(deletePath, "{destination_type}", d.Get("destination_type").(string))
+	// destination may have % or |
+	deletePath = strings.ReplaceAll(deletePath, "{destination}", url.PathEscape(destination))
+	// properties_key is already encoded in READ
+	deletePath = strings.ReplaceAll(deletePath, "{properties_key}", propertiesKey)
+
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			204,
+		},
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting exchange")
+	}
+
+	return nil
+}
+
+func resourceExchangeAssociateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), ",")
+	if !(len(parts) == 5 || len(parts) == 6) {
+		return nil, fmt.Errorf("invalid ID format, must be <instance_id>,<vhost>,<exchange>,<destination_type>,<destination> or" +
+			"<instance_id>,<vhost>,<exchange>,<destination_type>,<destination>,<routing_key>")
+	}
+
+	d.Set("instance_id", parts[0])
+	d.Set("vhost", parts[1])
+	d.Set("exchange", parts[2])
+	d.Set("destination_type", parts[3])
+	d.Set("destination", parts[4])
+
+	id := fmt.Sprintf("%s/%s/%s/%s/%s", parts[0], parts[1], parts[2], parts[3], parts[4])
+
+	if len(parts) == 6 {
+		d.Set("routing_key", parts[5])
+		id += fmt.Sprintf("/%s", parts[5])
+	}
+
+	// reset ID to be separated by slashes
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_queue.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rabbitmq_queue.go
@@ -3,6 +3,7 @@ package dms
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -278,11 +279,12 @@ func GetRabbitmqQueue(client *golangsdk.ServiceClient, instanceID, vhost, name s
 	getPath = strings.ReplaceAll(getPath, "{instance_id}", instanceID)
 	getPath = strings.ReplaceAll(getPath, "{vhost}", vhost)
 
+	// queue name may have % or |
 	if strings.Contains(name, "/") {
 		replacedName := strings.ReplaceAll(name, "/", "__F_SLASH__")
-		getPath = strings.ReplaceAll(getPath, "{queue}", replacedName)
+		getPath = strings.ReplaceAll(getPath, "{queue}", url.PathEscape(replacedName))
 	} else {
-		getPath = strings.ReplaceAll(getPath, "{queue}", name)
+		getPath = strings.ReplaceAll(getPath, "{queue}", url.PathEscape(name))
 	}
 
 	getOpt := golangsdk.RequestOpts{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support rabbitmq exchange associate, and fix queue for setting name containing % and |

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run  TestAccRabbitmqExchangeAssociate_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run  TestAccRabbitmqExchangeAssociate_ -timeout 360m -parallel 4
=== RUN   TestAccRabbitmqExchangeAssociate_basic
=== PAUSE TestAccRabbitmqExchangeAssociate_basic
=== RUN   TestAccRabbitmqExchangeAssociate_special_characters
=== PAUSE TestAccRabbitmqExchangeAssociate_special_characters
=== CONT  TestAccRabbitmqExchangeAssociate_basic
=== CONT  TestAccRabbitmqExchangeAssociate_special_characters
--- PASS: TestAccRabbitmqExchangeAssociate_special_characters (788.89s)
--- PASS: TestAccRabbitmqExchangeAssociate_basic (982.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       982.459s

make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccRabbitmqVhost_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccRabbitmqVhost_ -timeout 360m -parallel 4
=== RUN   TestAccRabbitmqVhost_basic
=== PAUSE TestAccRabbitmqVhost_basic
=== RUN   TestAccRabbitmqVhost_special_charcters
=== PAUSE TestAccRabbitmqVhost_special_charcters
=== CONT  TestAccRabbitmqVhost_basic
=== CONT  TestAccRabbitmqVhost_special_charcters
--- PASS: TestAccRabbitmqVhost_special_charcters (766.47s)
--- PASS: TestAccRabbitmqVhost_basic (829.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       829.428s

make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccRabbitmqExchange_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccRabbitmqExchange_ -timeout 360m -parallel 4
=== RUN   TestAccRabbitmqExchange_basic
=== PAUSE TestAccRabbitmqExchange_basic
=== RUN   TestAccRabbitmqExchange_special_charcters
=== PAUSE TestAccRabbitmqExchange_special_charcters
=== CONT  TestAccRabbitmqExchange_basic
=== CONT  TestAccRabbitmqExchange_special_charcters
--- PASS: TestAccRabbitmqExchange_special_charcters (764.08s)
--- PASS: TestAccRabbitmqExchange_basic (888.04s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       888.121s

make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccRabbitmqQueue_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccRabbitmqQueue_ -timeout 360m -parallel 4
=== RUN   TestAccRabbitmqQueue_basic
=== PAUSE TestAccRabbitmqQueue_basic
=== RUN   TestAccRabbitmqQueue_special_charcters
=== PAUSE TestAccRabbitmqQueue_special_charcters
=== CONT  TestAccRabbitmqQueue_basic
=== CONT  TestAccRabbitmqQueue_special_charcters
--- PASS: TestAccRabbitmqQueue_special_charcters (778.89s)
--- PASS: TestAccRabbitmqQueue_basic (902.98s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       903.072s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/f272f5ec-fdc6-4313-bf22-76b9bcfebeca)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<
![image](https://github.com/user-attachments/assets/a99f11ee-4d41-4e25-a2a4-d37f74ce6da2)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
