### PR TITLE
feat(LB): lb loadbalancer support modify enterprise project id

### DIFF
--- a/docs/resources/lb_loadbalancer.md
+++ b/docs/resources/lb_loadbalancer.md
@@ -59,8 +59,7 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the loadbalancer.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the loadbalancer. Changing this
-  creates a new loadbalancer.
+* `enterprise_project_id` - (Optional, String) The enterprise project id of the loadbalancer.
 
 * `protection_status` - (Optional, String) Specifies whether modification protection is enabled. Value options:
   + **nonProtection**: No protection.

--- a/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go
+++ b/huaweicloud/services/acceptance/lb/resource_huaweicloud_lb_loadbalancer_test.go
@@ -198,6 +198,14 @@ func TestAccLBV2LoadBalancer_withEpsId(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+				),
+			},
+			{
+				Config: testAccLBV2LoadBalancerConfig_withEpsId_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
 						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
@@ -456,6 +464,23 @@ resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
 }
 
 func testAccLBV2LoadBalancerConfig_withEpsId(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_lb_loadbalancer" "loadbalancer_1" {
+  name                  = "%s"
+  vip_subnet_id         = huaweicloud_vpc_subnet.test.ipv4_subnet_id
+  enterprise_project_id = "0"
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+}
+`, common.TestVpc(rName), rName)
+}
+
+func testAccLBV2LoadBalancerConfig_withEpsId_update(rName string) string {
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  lb loadbalancer support modify enterprise project id
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  lb loadbalancer support modify enterprise project id
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/lb/ TESTARGS='-run TestAccLBV2LoadBalancer_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/lb/ -v -run TestAccLBV2LoadBalancer_ -timeout 360m -parallel 4
=== RUN   TestAccLBV2LoadBalancer_basic
=== PAUSE TestAccLBV2LoadBalancer_basic
=== RUN   TestAccLBV2LoadBalancer_prepaid
=== PAUSE TestAccLBV2LoadBalancer_prepaid
=== RUN   TestAccLBV2LoadBalancer_secGroup
=== PAUSE TestAccLBV2LoadBalancer_secGroup
=== RUN   TestAccLBV2LoadBalancer_withEpsId
=== PAUSE TestAccLBV2LoadBalancer_withEpsId
=== RUN   TestAccLBV2LoadBalancer_changeToPrePaid
=== PAUSE TestAccLBV2LoadBalancer_changeToPrePaid
=== CONT  TestAccLBV2LoadBalancer_basic
=== CONT  TestAccLBV2LoadBalancer_withEpsId
=== CONT  TestAccLBV2LoadBalancer_secGroup
=== CONT  TestAccLBV2LoadBalancer_changeToPrePaid
--- PASS: TestAccLBV2LoadBalancer_withEpsId (84.92s)
=== CONT  TestAccLBV2LoadBalancer_prepaid
--- PASS: TestAccLBV2LoadBalancer_basic (143.21s)
--- PASS: TestAccLBV2LoadBalancer_secGroup (165.55s)
--- PASS: TestAccLBV2LoadBalancer_changeToPrePaid (188.69s)
--- PASS: TestAccLBV2LoadBalancer_prepaid (131.48s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/lb        216.445s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
