### PR TITLE
feat(GaussDBforMySQL): gaussdb mysql instance support auto scaling

### DIFF
--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -149,6 +149,9 @@ The following arguments are supported:
 * `parameters` - (Optional, List) Specifies an array of one or more parameters to be set to the instance after launched.
   The [parameters](#parameters_struct) structure is documented below.
 
+* `auto_scaling` - (Optional, List) Specifies the auto-scaling policies.
+  The [auto_scaling](#auto_scaling_struct) structure is documented below.
+
 * `force_import` - (Optional, Bool) If specified, try to import the instance instead of creating if the name already
   existed.
 
@@ -188,6 +191,55 @@ The `parameters` block supports:
 
 * `value` - (Required, String) Specifies the value of the parameter.
 
+<a name="auto_scaling_struct"></a>
+The `auto_scaling` block supports:
+
+* `status` - (Required, String) Specifies whether auto-scaling is enabled. Value options:
+  + **ON**: enabled.
+  + **OFF**: disabled.
+
+* `scaling_strategy` - (Required, List) Specifies the auto-scaling policy.
+  The [scaling_strategy](#scaling_strategy_struct) structure is documented below.
+
+* `monitor_cycle` - (Optional, Int) Specifies the observation period, in seconds. During the entire observation period,
+  if the average CPU usage is greater than or equal to the preset value, a scale-up is triggered. It is mandatory when
+  `status` is set to **ON**. Value options: **300**, **600**, **900** or **1800**.
+
+* `silence_cycle` - (Optional, Int) Specifies the silent period, in seconds. It indicates the minimum interval between
+  two auto scale-up operations or two scale-down operations. It is mandatory when `status` is set to **ON**. Value
+  options: **300**,  **600**, **1800**, **3600**, **7200**, **10800**, **86400** or **604800**.
+
+* `enlarge_threshold` - (Optional, Int) Specifies the average CPU usage (%). It is mandatory when `status` is set to
+  **ON**. Value options: **50–100**.
+
+* `max_flavor` - (Optional, String) Specifies the maximum specifications. It is mandatory when the instance specifications
+  are automatically scaled up or down.
+
+* `reduce_enabled` - (Optional, Bool) Specifies whether auto-down is enabled. It is mandatory when `status` is set to
+  **ON**. Value options:
+  + **true**: enabled.
+  + **false**: disabled.
+
+* `max_read_only_count` - (Optional, Int) Specifies the maximum number of read replicas. It is mandatory when read
+  replicas are automatically added or deleted.
+
+* `read_only_weight` - (Optional, Int) Specifies the read weights of read replicas. It is mandatory when read replicas
+  are automatically added or deleted.
+
+<a name="scaling_strategy_struct"></a>
+The `scaling_strategy` block supports:
+
+* `flavor_switch` - (Required, String) Specifies whether instance specifications can be automatically scaled up or down.
+  Value options:
+  + **ON**: Yes
+  + **OFF**: No
+
+* `read_only_switch` - (Required, String) Specifies whether read replicas can be automatically added or deleted. To use
+  this function, ensure that there is only one proxy instance.
+  Value options:
+  + **ON**: Yes
+  + **OFF**: No
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -206,8 +258,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `updated_at` - Indicates the Update time in the **yyyy-mm-ddThh:mm:ssZ** format.
 
-* `nodes` - Indicates the instance nodes information. Structure is documented below.
+* `nodes` - Indicates the instance nodes information.
+  The [nodes](#nodes_struct) structure is documented below.
 
+* `auto_scaling` - Indicates the auto-scaling policies.
+  The [auto_scaling](#auto_scaling_struct) structure is documented below.
+
+<a name="nodes_struct"></a>
 The `nodes` block contains:
 
 * `id` - Indicates the node ID.
@@ -221,6 +278,17 @@ The `nodes` block contains:
 * `private_read_ip` - Indicates the private IP address of a node.
 
 * `availability_zone` - Indicates the availability zone where the node resides.
+
+<a name="auto_scaling_struct"></a>
+The `auto_scaling` block supports:
+
+* `id` - Indicates the ID of an auto-scaling policy.
+
+* `min_flavor` - Indicates the minimum specifications.
+
+* `silence_start_at` - Indicates the start time of the silent period.
+
+* `min_read_only_count` - Indicates the minimum number of read replicas.
 
 ## Timeouts
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20240913032404-d6a9e09b69bd
+	github.com/chnsz/golangsdk v0.0.0-20240919093604-1298793bf256
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20240913032404-d6a9e09b69bd h1:7abT4MJooLgwwJzHDugw/OFWwIOqexssojQkbIcxz5c=
-github.com/chnsz/golangsdk v0.0.0-20240913032404-d6a9e09b69bd/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20240919093604-1298793bf256 h1:ZaPyx37vKMr9f3/oFYfdq5MqAqmLUqByQv4ilEkeFXA=
+github.com/chnsz/golangsdk v0.0.0-20240919093604-1298793bf256/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
@@ -60,6 +60,23 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "test_description"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.status", "ON"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.scaling_strategy.0.flavor_switch",
+						"ON"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.scaling_strategy.0.read_only_switch",
+						"OFF"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.monitor_cycle", "600"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.silence_cycle", "1800"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.enlarge_threshold", "70"),
+					resource.TestCheckResourceAttrPair(resourceName, "auto_scaling.0.max_flavor",
+						"data.huaweicloud_gaussdb_mysql_flavors.test", "flavors.2.name"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.reduce_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.max_read_only_count", "20"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.read_only_weight", "10"),
+					resource.TestCheckResourceAttrSet(resourceName, "auto_scaling.0.id"),
+					resource.TestCheckResourceAttrSet(resourceName, "auto_scaling.0.min_flavor"),
+					resource.TestCheckResourceAttrSet(resourceName, "auto_scaling.0.silence_start_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "auto_scaling.0.min_read_only_count"),
 				),
 			},
 			{
@@ -93,6 +110,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.status", "OFF"),
 				),
 			},
 			{
@@ -105,6 +123,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					"password",
 					"ssl_option",
 					"parameters",
+					"auto_scaling.0.scaling_strategy",
 				},
 			},
 		},
@@ -304,6 +323,23 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
     keep_days  = "7"
   }
 
+  auto_scaling {
+    status = "ON"
+
+    scaling_strategy {
+      flavor_switch    = "ON"
+      read_only_switch = "OFF"
+    }
+
+    monitor_cycle       = 600
+    silence_cycle       = 1800
+    enlarge_threshold   = 70
+    max_flavor          = data.huaweicloud_gaussdb_mysql_flavors.test.flavors[2].name
+    reduce_enabled      = true
+    max_read_only_count = 20
+    read_only_weight    = 10
+  }
+
   tags = {
     foo = "bar"
     key = "value"
@@ -350,9 +386,22 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
     keep_days  = "10"
   }
 
+  auto_scaling {
+    status = "OFF"
+
+    scaling_strategy {
+      flavor_switch    = "ON"
+      read_only_switch = "OFF"
+    }
+  }
+
   tags = {
     foo_update = "bar"
     key        = "value_update"
+  }
+
+  lifecycle {
+    ignore_changes = [auto_scaling.0.scaling_strategy]
   }
 }
 `, testAccGaussDBInstanceConfig_base(rName), rName)

--- a/huaweicloud/services/gaussdb/common.go
+++ b/huaweicloud/services/gaussdb/common.go
@@ -12,10 +12,11 @@ import (
 var (
 	// Some error codes that need to be retried coming from https://support.huaweicloud.com/api-gaussdbformysql/ErrorCode.html
 	retryErrCodes = map[string]struct{}{
-		"DBS.200019": {},
-		"DBS.201014": {},
-		"DBS.201015": {},
-		"DBS.200047": {},
+		"DBS.200019":   {},
+		"DBS.201014":   {},
+		"DBS.201015":   {},
+		"DBS.200047":   {},
+		"DBS.05000084": {},
 	}
 )
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/aad/v1/rules/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/aad/v1/rules/requests.go
@@ -15,10 +15,10 @@ type RuleOpts struct {
 	// The forward protocol.
 	ForwardProtocol string `json:"forward_protocol" required:"true"`
 	// The forward port.
-	// The valid value is range from `1` to `65,535`.
+	// The valid value is range from 1 to 65535.
 	ForwardPort int `json:"forward_port" required:"true"`
 	// The source port.
-	// The valid value is range from `1` to `65,535`.
+	// The valid value is range from 1 to 65535.
 	SourcePort int `json:"source_port" required:"true"`
 	// The source IP list, separate the IPs with commas.
 	SourceIp string `json:"source_ip" required:"true"`
@@ -57,10 +57,10 @@ type UpdateOpts struct {
 	// The forward protocol.
 	ForwardProtocol string `json:"forward_protocol" required:"true"`
 	// The forward port.
-	// The valid value is range from `1` to `65,535`.
+	// The valid value is range from 1 to 65535.
 	ForwardPort int `json:"forward_port" required:"true"`
 	// The source port.
-	// The valid value is range from `1` to `65,535`.
+	// The valid value is range from 1 to 65535.
 	SourcePort int `json:"source_port" required:"true"`
 	// The source IP list, separate the IPs with commas.
 	SourceIp string `json:"source_ip" required:"true"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels/requests.go
@@ -15,7 +15,7 @@ type ChannelOpts struct {
 	// Chinese characters must be in UTF-8 or Unicode format.
 	Name string `json:"name" required:"true"`
 	// Host port of the channel.
-	// The valid value ranges from `1` to `65,535`.
+	// The valid value ranges from 1 to 65535.
 	Port int `json:"port" required:"true"`
 	// Distribution algorithm.
 	// The valid values are as following:
@@ -152,7 +152,7 @@ type VpcHealthConfig struct {
 	// + HEAD
 	Method string `json:"method,omitempty"`
 	// Destination port for health checks. By default, the host port of the channel is used.
-	// The valid value ranges from `1` to `65,535`.
+	// The valid value ranges from 1 to 65535.
 	Port int `json:"port,omitempty"`
 	// Response codes for determining a successful HTTP response.
 	// The value can be any integer within 100–599 in one of the following formats:

--- a/vendor/github.com/chnsz/golangsdk/openstack/apigw/deprecated/dedicated/v2/channels/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/apigw/deprecated/dedicated/v2/channels/requests.go
@@ -101,7 +101,7 @@ type VpcHealthConfig struct {
 	// Destination path for health checks. This parameter is required if protocol is set to http.
 	Path string `json:"path,omitempty"`
 	// Destination port for health checks. By default, the host port of the VPC channel is used.
-	// The valid value is range from `1` to `65,535`.
+	// The valid value is range from 1 to 65535.
 	Port int `json:"port,omitempty"`
 }
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/security/rules/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/security/rules/requests.go
@@ -23,11 +23,11 @@ type CreateOpts struct {
 	// If the parameter is left blank, all protocols are supported.
 	Protocol string `json:"protocol,omitempty"`
 	// Specifies the start port number.
-	// The value ranges from `1` to `65,535`.
+	// The value ranges from 1 to 65535.
 	// The value cannot be greater than the port_range_max value. An empty value indicates all ports.
 	PortRangeMin int `json:"port_range_min,omitempty"`
 	// Specifies the end port number.
-	// The value ranges from `1` to `65,535`.
+	// The value ranges from 1 to 65535.
 	// The value cannot be smaller than the port_range_min value. An empty value indicates all ports.
 	PortRangeMax int `json:"port_range_max,omitempty"`
 	// Specifies the remote IP address.

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/security/rules/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/security/rules/results.go
@@ -24,11 +24,11 @@ type SecurityGroupRule struct {
 	// Specifies the IP protocol version. The value can be IPv4 or IPv6.
 	Ethertype string `json:"ethertype"`
 	// Specifies the start port number.
-	// The value ranges from `1` to `65,535`.
+	// The value ranges from 1 to 65535.
 	// The value cannot be greater than the port_range_max value. An empty value indicates all ports.
 	PortRangeMin int `json:"port_range_min"`
 	// Specifies the end port number.
-	// The value ranges from `1` to `65,535`.
+	// The value ranges from 1 to 65535.
 	// The value cannot be smaller than the port_range_min value. An empty value indicates all ports.
 	PortRangeMax int `json:"port_range_max"`
 	// Specifies the remote IP address.

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/autoscaling/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/autoscaling/requests.go
@@ -1,0 +1,58 @@
+package autoscaling
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+var RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+type UpdateBuilder interface {
+	ToUpdateMap() (map[string]interface{}, error)
+}
+
+type UpdateAutoScalingOpts struct {
+	Status           string           `json:"status" required:"true"`
+	ScalingStrategy  *ScalingStrategy `json:"scaling_strategy" required:"true"`
+	MonitorCycle     int              `json:"monitor_cycle,omitempty"`
+	SilenceCycle     int              `json:"silence_cycle,omitempty"`
+	EnlargeThreshold int              `json:"enlarge_threshold,omitempty"`
+	MaxFlavor        string           `json:"max_flavor,omitempty"`
+	ReduceEnabled    bool             `json:"reduce_enabled,omitempty"`
+	MaxReadOnlyCount int              `json:"max_read_only_count,omitempty"`
+	ReadOnlyWeight   int              `json:"read_only_weight,omitempty"`
+}
+
+type ScalingStrategy struct {
+	FlavorSwitch   string `json:"flavor_switch" required:"true"`
+	ReadOnlySwitch string `json:"read_only_switch" required:"true"`
+}
+
+func (opts UpdateAutoScalingOpts) ToUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Update(c *golangsdk.ServiceClient, instanceId string, opts UpdateBuilder) (r UpdateResult) {
+	b, err := opts.ToUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = c.Put(updateURL(c, instanceId), b, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return
+}
+
+func Get(c *golangsdk.ServiceClient, instanceId string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, instanceId), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/autoscaling/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/autoscaling/results.go
@@ -1,0 +1,53 @@
+package autoscaling
+
+import "github.com/chnsz/golangsdk"
+
+type UpdateResponse struct {
+	InstanceId   string       `json:"instance_id"`
+	InstanceName string       `json:"instance_name"`
+	SwitchStatus SwitchStatus `json:"switch_status"`
+}
+
+type SwitchStatus struct {
+	ScalingSwitch  string `json:"scaling_switch"`
+	FlavorSwitch   string `json:"flavor_switch"`
+	ReadOnlySwitch string `json:"read_only_switch"`
+}
+
+type UpdateResult struct {
+	golangsdk.Result
+}
+
+func (r UpdateResult) ExtractUpdateResponse() (*UpdateResponse, error) {
+	var updateResponse UpdateResponse
+	err := r.ExtractInto(&updateResponse)
+	return &updateResponse, err
+}
+
+type AutoScaling struct {
+	Id               string          `json:"id"`
+	InstanceId       string          `json:"instance_id"`
+	InstanceName     string          `json:"instance_name"`
+	Status           string          `json:"status"`
+	ScalingStrategy  ScalingStrategy `json:"scaling_strategy"`
+	MonitorCycle     int             `json:"monitor_cycle"`
+	SilenceCycle     int             `json:"silence_cycle"`
+	EnlargeThreshold int             `json:"enlarge_threshold"`
+	MaxFavor         string          `json:"max_flavor"`
+	ReduceEnabled    bool            `json:"reduce_enabled"`
+	MinFlavor        string          `json:"min_flavor"`
+	SilenceStartAt   string          `json:"silence_start_at"`
+	MaxReadOnlyCount int             `json:"max_read_only_count"`
+	MinReadOnlyCount int             `json:"min_read_only_count"`
+	ReadOnlyWeight   int             `json:"read_only_weight"`
+}
+
+type GetResult struct {
+	golangsdk.Result
+}
+
+func (r GetResult) Extract() (*AutoScaling, error) {
+	var autoScaling AutoScaling
+	err := r.ExtractInto(&autoScaling)
+	return &autoScaling, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/autoscaling/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/autoscaling/urls.go
@@ -1,0 +1,11 @@
+package autoscaling
+
+import "github.com/chnsz/golangsdk"
+
+func updateURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "auto-scaling/policy")
+}
+
+func getURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "auto-scaling/policy")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/backups/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/backups/requests.go
@@ -41,3 +41,36 @@ func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r Up
 	_, r.Err = c.Put(resourceURL(c, id), b, nil, reqOpt)
 	return
 }
+
+type UpdateEncryptionOptsBuilder interface {
+	ToUpdateEncryptionMap() (map[string]interface{}, error)
+}
+
+type UpdateEncryptionOpts struct {
+	EncryptionStatus string `json:"encryption_status" required:"true"`
+	Type             string `json:"type,omitempty"`
+	KmsKeyId         string `json:"kms_key_id,omitempty"`
+}
+
+func (opts UpdateEncryptionOpts) ToUpdateEncryptionMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+func UpdateEncryption(c *golangsdk.ServiceClient, id string, opts UpdateEncryptionOptsBuilder) (r UpdateEncryptionResult) {
+	b, err := opts.ToUpdateEncryptionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(updateEncryptionURL(c, id), b, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return
+}
+
+func GetEncryption(c *golangsdk.ServiceClient, instanceId string) (r GetEncryptionResult) {
+	_, r.Err = c.Get(getEncryptionURL(c, instanceId), &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/backups/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/backups/results.go
@@ -8,3 +8,31 @@ import (
 type UpdateResult struct {
 	golangsdk.ErrResult
 }
+
+type UpdateEncryptionResponse struct {
+	EncryptionStatus string `json:"encryption_status"`
+}
+
+type UpdateEncryptionResult struct {
+	golangsdk.Result
+}
+
+func (r UpdateEncryptionResult) Extract() (*UpdateEncryptionResponse, error) {
+	var updateEncryptionResponse UpdateEncryptionResponse
+	err := r.ExtractInto(&updateEncryptionResponse)
+	return &updateEncryptionResponse, err
+}
+
+type GetEncryptionResponse struct {
+	EncryptionStatus string `json:"encryption_status"`
+}
+
+type GetEncryptionResult struct {
+	golangsdk.Result
+}
+
+func (r GetEncryptionResult) Extract() (*GetEncryptionResponse, error) {
+	var res GetEncryptionResponse
+	err := r.ExtractInto(&res)
+	return &res, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/backups/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/backups/urls.go
@@ -5,3 +5,11 @@ import "github.com/chnsz/golangsdk"
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
 	return c.ServiceURL("instances", id, "backups/policy/update")
 }
+
+func updateEncryptionURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("instances", id, "backups/encryption")
+}
+
+func getEncryptionURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("instances", id, "backups/encryption")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints/results.go
@@ -61,6 +61,8 @@ type Endpoint struct {
 	PublicBorderGroup string `json:"public_border_group"`
 	// The IPv6 address to access the connected endpoint service
 	Ipv6Address string `json:"ipv6_address"`
+	// The IP version of the VPC endpoint.
+	IpVersion string `json:"ip_version"`
 }
 
 type QueryError struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
@@ -39,6 +39,8 @@ type CreateOpts struct {
 	Tags []tags.ResourceTag `json:"tags,omitempty"`
 	// Specifies the description
 	Description string `json:"description,omitempty"`
+	// Specifies the IP version of the VPC endpoint service
+	IpVersion string `json:"ip_version,omitempty"`
 	// Specifies whether the VPC endpoint policy is enabled.
 	EnablePolicy *bool `json:"enable_policy,omitempty"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
@@ -40,6 +40,8 @@ type Service struct {
 	Error []ErrorInfo `json:"error"`
 	// the description of the VPC endpoint service
 	Description string `json:"description"`
+	// the IP version of the VPC endpoint service
+	IpVersion string `json:"ip_version"`
 	// whether the VPC endpoint policy is enabled.
 	EnablePolicy bool `json:"enable_policy"`
 	// the creation time of the VPC endpoint service

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20240913032404-d6a9e09b69bd
+# github.com/chnsz/golangsdk v0.0.0-20240919093604-1298793bf256
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -333,6 +333,7 @@ github.com/chnsz/golangsdk/openstack/swr/v2/domains
 github.com/chnsz/golangsdk/openstack/swr/v2/namespaces
 github.com/chnsz/golangsdk/openstack/swr/v2/repositories
 github.com/chnsz/golangsdk/openstack/taurusdb/v3/auditlog
+github.com/chnsz/golangsdk/openstack/taurusdb/v3/autoscaling
 github.com/chnsz/golangsdk/openstack/taurusdb/v3/backups
 github.com/chnsz/golangsdk/openstack/taurusdb/v3/configurations
 github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  gaussdb mysql instance support auto scaling
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb mysql instance support auto scaling
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBInstance_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== RUN   TestAccGaussDBInstance_prePaid
=== PAUSE TestAccGaussDBInstance_prePaid
=== RUN   TestAccGaussDBInstance_updateWithEpsId
=== PAUSE TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_prePaid
=== CONT  TestAccGaussDBInstance_updateWithEpsId
    acceptance.go:629: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccGaussDBInstance_updateWithEpsId (0.00s)
--- PASS: TestAccGaussDBInstance_prePaid (1424.77s)
--- PASS: TestAccGaussDBInstance_basic (3265.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   3265.572s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
