### PR TITLE
feat(EIP): eip support modify enterprise project id

### DIFF
--- a/docs/resources/vpc_eip.md
+++ b/docs/resources/vpc_eip.md
@@ -69,8 +69,7 @@ The following arguments are supported:
   The name can contain `1` to `64` characters, including English letters, Chinese characters, digits, underscores (_),
   hyphens (-), and periods (.).
 
-* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the EIP belongs.  
-  Changing this will create a new resource.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID to which the EIP belongs.
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the EIP.
 

--- a/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
+++ b/huaweicloud/services/acceptance/eip/resource_huaweicloud_vpc_eip_test.go
@@ -147,7 +147,15 @@ func TestAccVpcEip_WithEpsId(t *testing.T) {
 				Config: testAccVpcEip_epsId(randName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+				),
+			},
+			{
+				Config: testAccVpcEip_epsId_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				),
 			},
 		},
@@ -398,6 +406,25 @@ resource "huaweicloud_vpc_eip" "test" {
 }
 
 func testAccVpcEip_epsId(rName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_vpc_eip" "test" {
+  enterprise_project_id = "0"
+
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    name        = "%[1]s"
+    size        = 5
+    charge_mode = "traffic"
+  }
+}
+`, rName)
+}
+
+func testAccVpcEip_epsId_update(rName string) string {
 	return fmt.Sprintf(`
 resource "huaweicloud_vpc_eip" "test" {
   enterprise_project_id = "%[1]s"

--- a/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
+++ b/huaweicloud/services/lb/resource_huaweicloud_lb_loadbalancer.go
@@ -31,6 +31,7 @@ import (
 // @API ELB POST /v3/{project_id}/elb/loadbalancers/change-charge-mode
 // @API VPC PUT /v2.0/ports/{port_id}
 // @API VPC GET /v2.0/ports/{port_id}
+// @API EPS POST /v1.0/enterprise-projects/{enterprise_project_id}/resources-migrat
 // @API BSS GET /v2/orders/customer-orders/details/{order_id}
 // @API BSS POST /v2/orders/suscriptions/resources/query
 // @API BSS POST /v2/orders/subscriptions/resources/unsubscribe


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  eip support modify enterprise project id
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  eip support modify enterprise project id
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/eip/ TESTARGS='-run TestAccVpcEip_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip/ -v -run TestAccVpcEip_ -timeout 360m -parallel 4
=== RUN   TestAccVpcEip_basic
=== PAUSE TestAccVpcEip_basic
=== RUN   TestAccVpcEip_share
=== PAUSE TestAccVpcEip_share
=== RUN   TestAccVpcEip_WithEpsId
=== PAUSE TestAccVpcEip_WithEpsId
=== RUN   TestAccVpcEip_prePaid
=== PAUSE TestAccVpcEip_prePaid
=== RUN   TestAccVpcEip_ChangeToPeriod
=== PAUSE TestAccVpcEip_ChangeToPeriod
=== RUN   TestAccVpcEip_deprecated
=== PAUSE TestAccVpcEip_deprecated
=== CONT  TestAccVpcEip_basic
=== CONT  TestAccVpcEip_prePaid
=== CONT  TestAccVpcEip_WithEpsId
=== CONT  TestAccVpcEip_share
--- PASS: TestAccVpcEip_basic (42.90s)
=== CONT  TestAccVpcEip_deprecated
--- PASS: TestAccVpcEip_share (45.40s)
=== CONT  TestAccVpcEip_ChangeToPeriod
--- PASS: TestAccVpcEip_WithEpsId (52.18s)
--- PASS: TestAccVpcEip_prePaid (148.55s)
--- PASS: TestAccVpcEip_ChangeToPeriod (110.66s)
--- PASS: TestAccVpcEip_deprecated (114.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       157.873s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
