### PR TITLE
feat(servicestage): add new data source to query runtimes

### DIFF
--- a/docs/data-sources/servicestagev3_runtimestacks.md
+++ b/docs/data-sources/servicestagev3_runtimestacks.md
@@ -1,0 +1,56 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_runtime_stacks"
+description: |-
+  Use this data source to query the list of runtime stacks within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_runtime_stacks
+
+Use this data source to query the list of runtime stacks within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_servicestagev3_runtime_stacks" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the runtime stacks are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `runtime_stacks` - All runtime stack details.  
+  The [runtime_stacks](#servicestage_v3_runtime_stacks) structure is documented below.
+
+<a name="servicestage_v3_runtime_stacks"></a>
+The `runtime_stacks` block supports:
+
+* `name` - The name of the runtime stack.
+
+* `deploy_mode` - The deploy mode.
+  + **container**
+  + **virtualmachine**
+
+* `version` - The version number.
+
+* `type` - The type of the runtime stack.
+  + **Nodejs**
+  + **Java**
+  + **Tomcat**
+  + **Python**
+  + **Php**
+  + **Docker**
+
+* `status` - The status of the runtime stack.
+  + **Supported**
+  + **Deprecated**

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -950,7 +950,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_secmaster_data_class_fields":         secmaster.DataSourceSecmasterDataClassFields(),
 			"huaweicloud_secmaster_playbook_action_instances": secmaster.DataSourceSecmasterPlaybookActionInstances(),
 
+			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
+			// Querying by Ver.3 APIs
+			"huaweicloud_servicestagev3_runtime_stacks": servicestage.DataSourceV3RuntimeStacks(),
 
 			"huaweicloud_smn_topics":            smn.DataSourceTopics(),
 			"huaweicloud_smn_message_templates": smn.DataSourceSmnMessageTemplates(),

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_runtime_stacks_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_runtime_stacks_test.go
@@ -1,0 +1,38 @@
+package servicestage
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataV3RuntimeStacks_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_servicestagev3_runtime_stacks.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV3RuntimeStacks_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "runtime_stacks.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckResourceAttrSet(dataSourceName, "runtime_stacks.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "runtime_stacks.0.deploy_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "runtime_stacks.0.version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "runtime_stacks.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "runtime_stacks.0.status"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataV3RuntimeStacks_basic = `data "huaweicloud_servicestagev3_runtime_stacks" "test" {}`

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_runtime_stacks.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_runtime_stacks.go
@@ -1,0 +1,139 @@
+package servicestage
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v3/{project_id}/cas/runtimestacks
+func DataSourceV3RuntimeStacks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3RuntimeStacksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the runtime stacks are located.`,
+			},
+			"runtime_stacks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the runtime stack.`,
+						},
+						"deploy_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The deploy mode.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version number.`,
+						},
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The URL of the runtime stack.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the runtime stack.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the runtime stack.`,
+						},
+					},
+				},
+				Description: "All runtime stack details.",
+			},
+		},
+	}
+}
+
+func queryV3RuntimeStacks(client *golangsdk.ServiceClient) (interface{}, error) {
+	httpUrl := "v3/{project_id}/cas/runtimestacks"
+
+	queryPath := client.Endpoint + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenV3RuntimeStacks(runtimeStacks []interface{}) []map[string]interface{} {
+	if len(runtimeStacks) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(runtimeStacks))
+	for _, runtimeStack := range runtimeStacks {
+		result = append(result, map[string]interface{}{
+			"name":        utils.PathSearch("name", runtimeStack, nil),
+			"deploy_mode": utils.PathSearch("deploy_mode", runtimeStack, nil),
+			"version":     utils.PathSearch("version", runtimeStack, nil),
+			"url":         utils.PathSearch("url", runtimeStack, nil),
+			"type":        utils.PathSearch("type", runtimeStack, nil),
+			"status":      utils.PathSearch("status", runtimeStack, nil),
+		})
+	}
+	return result
+}
+
+func dataSourceV3RuntimeStacksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	respBody, err := queryV3RuntimeStacks(client)
+	if err != nil {
+		return diag.Errorf("error getting runtime stacks: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("runtime_stacks", flattenV3RuntimeStacks(utils.PathSearch("runtime_stacks", respBody, make([]interface{}, 0)).([]interface{}))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new data source to query the runtimes for ServiceStage service.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query runtimes
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/servicestage' TESTARGS='-run=TestAccDataRuntimeStacks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/servicestage -v -run=TestAccDataRuntimeStacks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataRuntimeStacks_basic
=== PAUSE TestAccDataRuntimeStacks_basic
=== CONT  TestAccDataRuntimeStacks_basic
--- PASS: TestAccDataRuntimeStacks_basic (10.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      10.765s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
