### PR TITLE
feat(anti-ddos): support new resource to manage default protection policy

### DIFF
--- a/docs/resources/antiddos_default_protection_policy.md
+++ b/docs/resources/antiddos_default_protection_policy.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Anti-DDoS"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_antiddos_default_protection_policy"
+description: |-
+  Manages Cloud Native Anti-DDos default protection policy resource within HuaweiCloud.
+---
+
+# huaweicloud_antiddos_default_protection_policy
+
+Manages Cloud Native Anti-DDos default protection policy resource within HuaweiCloud.
+
+-> Destroying the resource actually sets the field `traffic_threshold` to 120 Mbps.
+
+## Example Usage
+
+```hcl
+resource "huaweicloud_antiddos_default_protection_policy" "test" {
+  traffic_threshold = 150
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this will create new resource.
+
+* `traffic_threshold` - (Required, Int) Specifies the traffic cleaning threshold in Mbps.
+  The value can be `10`, `30`, `50`, `70`, `100`, `120`, `150`, `200`, `250`, `300`, `1,000` Mbps.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Import
+
+Cloud Native Anti-DDos default protection policy resource can be imported using `id`. e.g.
+
+```bash
+$ terraform import huaweicloud_antiddos_default_protection_policy.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1140,7 +1140,8 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"huaweicloud_aad_forward_rule": aad.ResourceForwardRule(),
 
-			"huaweicloud_antiddos_basic": antiddos.ResourceCloudNativeAntiDdos(),
+			"huaweicloud_antiddos_basic":                     antiddos.ResourceCloudNativeAntiDdos(),
+			"huaweicloud_antiddos_default_protection_policy": antiddos.ResourceDefaultProtectionPolicy(),
 
 			"huaweicloud_access_analyzer":              accessanalyzer.ResourceAccessAnalyzer(),
 			"huaweicloud_access_analyzer_archive_rule": accessanalyzer.ResourceArchiveRule(),

--- a/huaweicloud/services/acceptance/antiddos/resource_huaweicloud_antiddos_default_protection_policy_test.go
+++ b/huaweicloud/services/acceptance/antiddos/resource_huaweicloud_antiddos_default_protection_policy_test.go
@@ -1,0 +1,95 @@
+package antiddos
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/antiddos"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getDefaultProtectionPolicyFunc(cfg *config.Config, _ *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("anti-ddos", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Anti-DDoS v1 client: %s", err)
+	}
+
+	// Default protection strategies always have value.
+	policyResp, err := antiddos.ReadDefaultProtectionPolicy(client)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Anti-DDoS default protection policy: %s", err)
+	}
+
+	trafficPosID := utils.PathSearch("traffic_pos_id", policyResp, nil)
+	if trafficPosID == nil {
+		return nil, fmt.Errorf("error retrieving Anti-DDoS default protection policy: traffic_pos_id is not found in" +
+			" read API response")
+	}
+
+	// The actual operation of deleting the resource is to set `traffic_pos_id` to `99`.
+	if trafficPosID.(float64) == 99 {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return policyResp, nil
+}
+
+func TestAccDefaultProtectionPolicy_basic(t *testing.T) {
+	var (
+		obj   interface{}
+		rName = "huaweicloud_antiddos_default_protection_policy.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDefaultProtectionPolicyFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDefaultProtectionPolicy_basic,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "traffic_threshold", "100"),
+				),
+			},
+			{
+				Config: testDefaultProtectionPolicy_update,
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "traffic_threshold", "200"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+const testDefaultProtectionPolicy_basic = `
+resource "huaweicloud_antiddos_default_protection_policy" "test" {
+  traffic_threshold = 100
+}
+`
+
+const testDefaultProtectionPolicy_update = `
+resource "huaweicloud_antiddos_default_protection_policy" "test" {
+  traffic_threshold = 200
+}
+`

--- a/huaweicloud/services/antiddos/resource_huaweicloud_antiddos_default_protection_policy.go
+++ b/huaweicloud/services/antiddos/resource_huaweicloud_antiddos_default_protection_policy.go
@@ -1,0 +1,202 @@
+package antiddos
+
+import (
+	"context"
+	"math"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ANTI-DDOS POST /v1/{project_id}/antiddos/default-config
+// @API ANTI-DDOS DELETE /v1/{project_id}/antiddos/default-config
+// @API ANTI-DDOS GET /v1/{project_id}/antiddos/default-config
+func ResourceDefaultProtectionPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDefaultProtectionPolicyCreate,
+		ReadContext:   resourceDefaultProtectionPolicyRead,
+		UpdateContext: resourceDefaultProtectionPolicyUpdate,
+		DeleteContext: resourceDefaultProtectionPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region in which to create the resource. If omitted, the provider-level region will be used.`,
+			},
+			"traffic_threshold": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: `The traffic cleaning threshold in Mbps.`,
+			},
+		},
+	}
+}
+
+// ReadDefaultProtectionPolicy Test case will use this method, so the first letter is capitalized.
+func ReadDefaultProtectionPolicy(client *golangsdk.ServiceClient) (interface{}, error) {
+	getPath := client.Endpoint + "v1/{project_id}/antiddos/default-config"
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getResp)
+}
+
+// configDefaultProtectionPolicy Only the field traffic_pos_id is meaningful, other fields are meaningless.
+func configDefaultProtectionPolicy(client *golangsdk.ServiceClient, d *schema.ResourceData, policyResp interface{}) error {
+	createPath := client.Endpoint + "v1/{project_id}/antiddos/default-config"
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+
+	cleaningAccessPosID := utils.PathSearch("cleaning_access_pos_id", policyResp, float64(1)).(float64)
+	createOpt.JSONBody = map[string]interface{}{
+		"enable_L7":           utils.PathSearch("enable_L7", policyResp, nil),
+		"traffic_pos_id":      getTrafficThresholdID(d.Get("traffic_threshold").(int)),
+		"http_request_pos_id": utils.PathSearch("http_request_pos_id", policyResp, nil),
+		// Make sure the `cleaning_access_pos_id` not larger than `8`.
+		// Field `cleaning_access_pos_id` has no practical meaning in the request.
+		// This will avoid error in partners cloud.
+		"cleaning_access_pos_id": int(math.Min(cleaningAccessPosID, 8)),
+		"app_type_id":            utils.PathSearch("app_type_id", policyResp, nil),
+	}
+
+	_, err := client.Request("POST", createPath, &createOpt)
+	return err
+}
+
+func resourceDefaultProtectionPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "anti-ddos"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS v1 client: %s", err)
+	}
+
+	policyResp, err := ReadDefaultProtectionPolicy(client)
+	if err != nil {
+		return diag.Errorf("error retrieving Anti-DDoS default protection policy in creation operation: %s", err)
+	}
+
+	if err := configDefaultProtectionPolicy(client, d, policyResp); err != nil {
+		return diag.Errorf("error configuring Anti-DDoS default protection policy in creation operation: %s", err)
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	return resourceDefaultProtectionPolicyRead(ctx, d, meta)
+}
+
+// The default protection policy always has a value and does not require checkDeleted logic.
+func resourceDefaultProtectionPolicyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "anti-ddos"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS v1 client: %s", err)
+	}
+
+	policyResp, err := ReadDefaultProtectionPolicy(client)
+	if err != nil {
+		return diag.Errorf("error retrieving Anti-DDoS default protection policy: %s", err)
+	}
+
+	trafficPosID := utils.PathSearch("traffic_pos_id", policyResp, nil)
+	if trafficPosID == nil {
+		return diag.Errorf("error retrieving Anti-DDoS default protection policy: traffic_pos_id is not found in" +
+			" read API response")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("traffic_threshold", getTrafficThresholdBandwidth(int(trafficPosID.(float64)))),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceDefaultProtectionPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "anti-ddos"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS v1 client: %s", err)
+	}
+
+	policyResp, err := ReadDefaultProtectionPolicy(client)
+	if err != nil {
+		return diag.Errorf("error retrieving Anti-DDoS default protection policy in update operation: %s", err)
+	}
+
+	if err := configDefaultProtectionPolicy(client, d, policyResp); err != nil {
+		return diag.Errorf("error configuring Anti-DDoS default protection policy in update operation: %s", err)
+	}
+
+	return resourceDefaultProtectionPolicyRead(ctx, d, meta)
+}
+
+// The actual effect of deleting the default protection policy is to set the Traffic Cleaning Threshold to 120.
+func resourceDefaultProtectionPolicyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		product = "anti-ddos"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating Anti-DDoS v1 client: %s", err)
+	}
+
+	deletePath := client.Endpoint + "v1/{project_id}/antiddos/default-config"
+	deletePath = strings.ReplaceAll(deletePath, "{project_id}", client.ProjectID)
+	deleteOpt := golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json;charset=utf8",
+		},
+		KeepResponseBody: true,
+	}
+	_, err = client.Request("DELETE", deletePath, &deleteOpt)
+	if err != nil {
+		return diag.Errorf("error deleting Anti-DDoS default protection policy: %s", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

support new resource to manage default protection policy.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- Destroying the resource actually sets the field `traffic_pos_id` to 120 Mbps.
- Default protection strategies always have value.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/antiddos' TESTARGS='-run TestAccDefaultProtectionPolicy_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/antiddos -v -run TestAccDefaultProtectionPolicy_basic -timeout 360m -parallel 4
=== RUN   TestAccDefaultProtectionPolicy_basic
=== PAUSE TestAccDefaultProtectionPolicy_basic
=== CONT  TestAccDefaultProtectionPolicy_basic
--- PASS: TestAccDefaultProtectionPolicy_basic (23.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/antiddos  23.580s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
