### PR TITLE
feat(GaussDBforMySQL): gaussdb mysql instance support backup encrypt

### DIFF
--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -184,6 +184,15 @@ The `backup_strategy` block supports:
 
 * `sql_filter_enabled` - (Optional, Bool) Specifies whether sql filter is enabled. The default value is `false`.
 
+* `encryption_status` - (Optional, String) Specifies whether to enable or disable encrypted backup. Value options:
+  + **ON**: enabled
+  + **OFF**: disabled
+
+* `encryption_type` - (Optional, String) Specifies the encryption type. Currently, only **kms (case-insensitive)** is
+  supported. It is mandatory when `encryption_status` is set to **ON**.
+
+* `kms_key_id` - (Optional, String) Specifies the KMS ID. It is mandatory when `encryption_status` is set to **ON**.
+
 <a name="parameters_struct"></a>
 The `parameters` block supports:
 
@@ -307,10 +316,10 @@ $ terraform import huaweicloud_gaussdb_mysql_instance.test <id>
 ```
 
 Note that the imported state may not be identical to your resource definition, due to the attribute missing from the
-API response. The missing attribute is: `table_name_case_sensitivity`, `enterprise_project_id`, `password`, `ssl_option`
-and `parameters`. It is generally recommended running `terraform plan` after importing a GaussDB MySQL instance. You can
-then decide if changes should be applied to the GaussDB MySQL instance, or the resource definition should be updated to
-align with the GaussDB MySQL instance. Also you can ignore changes as below.
+API response. The missing attribute is: `table_name_case_sensitivity`, `enterprise_project_id`, `password`, `ssl_option`,
+`encryption_type`, `kms_key_id` and `parameters`. It is generally recommended running `terraform plan` after importing
+a GaussDB MySQL instance. You can then decide if changes should be applied to the GaussDB MySQL instance, or the resource
+definition should be updated to align with the GaussDB MySQL instance. Also you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_gaussdb_mysql_instance" "test" {
@@ -318,7 +327,7 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
 
   lifecycle {
     ignore_changes = [
-      new_node_weight, proxy_mode, readonly_nodes_weight, parameters, ssl_option,
+      new_node_weight, proxy_mode, readonly_nodes_weight, parameters, ssl_option, encryption_type, kms_key_id
     ]
   }
 }

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
@@ -58,6 +58,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_period", "1"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test_description"),
+					resource.TestCheckResourceAttr(resourceName, "encryption_status", "ON"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.status", "ON"),
@@ -108,6 +109,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "18:00"),
 					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "encryption_status", "OFF"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 					resource.TestCheckResourceAttr(resourceName, "auto_scaling.0.status", "OFF"),
@@ -124,6 +126,8 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					"ssl_option",
 					"parameters",
 					"auto_scaling.0.scaling_strategy",
+					"encryption_type",
+					"kms_key_id",
 				},
 			},
 		},
@@ -282,6 +286,11 @@ resource "huaweicloud_gaussdb_mysql_parameter_template" "test" {
     character_set_server     = "gbk"
   }
 }
+
+resource "huaweicloud_kms_key" "test" {
+  key_alias    = "%[2]s"
+  pending_days = "7"
+}
 `, common.TestVpc(rName), rName)
 }
 
@@ -312,6 +321,10 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
 
   seconds_level_monitoring_enabled = true
   seconds_level_monitoring_period  = 1
+
+  encryption_status = "ON"
+  encryption_type   = "kms"
+  kms_key_id        = huaweicloud_kms_key.test.id
 
   parameters {
     name  = "auto_increment_increment"
@@ -375,6 +388,8 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   description              = ""
 
   seconds_level_monitoring_enabled = false
+
+  encryption_status = "OFF"
 
   parameters {
     name  = "character_set_server"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  gaussdb mysql instance support backup encrypt
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb mysql instance support backup encrypt
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBInstance_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== RUN   TestAccGaussDBInstance_prePaid
=== PAUSE TestAccGaussDBInstance_prePaid
=== RUN   TestAccGaussDBInstance_updateWithEpsId
=== PAUSE TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_prePaid
=== CONT  TestAccGaussDBInstance_updateWithEpsId
    acceptance.go:632: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccGaussDBInstance_updateWithEpsId (0.00s)
--- PASS: TestAccGaussDBInstance_prePaid (1433.29s)
--- PASS: TestAccGaussDBInstance_basic (3876.23s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   3876.276s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
