### PR TITLE
feat(cbr/vault): data source supports auto bind and bind rules

### DIFF
--- a/docs/data-sources/cbr_vaults.md
+++ b/docs/data-sources/cbr_vaults.md
@@ -99,6 +99,10 @@ The `vaults` block supports:
 * `resources` - The array of one or more resources to attach to the vault.
   The [object](#cbr_vault_resources) structure is documented below.
 
+* `auto_bind` - Whether automatic association is enabled. Defaults to **false**.
+
+* `bind_rules` - The tags to filter resources for automatic association with **auto_bind**.
+
 <a name="cbr_vault_resources"></a>
 The `resources` block supports:
 

--- a/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
+++ b/huaweicloud/services/acceptance/cbr/data_source_huaweicloud_cbr_vaults_test.go
@@ -68,6 +68,8 @@ func TestAccDataVaults_backupServer(t *testing.T) {
 					resource.TestCheckResourceAttr(byName, "vaults.0.enterprise_project_id", "0"),
 					resource.TestCheckResourceAttr(byName, "vaults.0.tags.foo", "bar"),
 					resource.TestCheckResourceAttr(byName, "vaults.0.tags.key", "value"),
+					resource.TestCheckResourceAttr(byName, "vaults.0.auto_bind", "true"),
+					resource.TestCheckResourceAttr(byName, "vaults.0.bind_rules.foo", "bar"),
 					dcByType.CheckResourceExists(),
 					resource.TestCheckOutput("is_type_filter_useful", "true"),
 					dcByConsistentLevel.CheckResourceExists(),
@@ -114,6 +116,11 @@ resource "huaweicloud_cbr_vault" "test" {
   enterprise_project_id = "0"
   backup_name_prefix    = "test-prefix-"
   is_multi_az           = true
+  auto_bind             = true
+
+  bind_rules = {
+    foo = "bar"
+  }
 
   resources {
     server_id = huaweicloud_compute_instance.test.id

--- a/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
+++ b/huaweicloud/services/cbr/data_source_huaweicloud_cbr_vaults.go
@@ -181,6 +181,17 @@ func DataSourceVaults() *schema.Resource {
 							},
 							Description: "The array of one or more resources to attach to the vault.",
 						},
+						"auto_bind": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Whether automatic association is supported.",
+						},
+						"bind_rules": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "The rules for automatic association.",
+						},
 					},
 				},
 			},
@@ -257,6 +268,8 @@ func flattenAllVaults(client *golangsdk.ServiceClient, vaultList []interface{}) 
 			"auto_expand_enabled":   utils.PathSearch("auto_expand", val, false),
 			"tags":                  utils.FlattenTagsToMap(utils.PathSearch("tags", val, make(map[string]interface{}))),
 			"resources":             flattenVaultResources(objectType, utils.PathSearch("resources", val, make([]interface{}, 0)).([]interface{})),
+			"auto_bind":             utils.PathSearch("auto_bind", val, nil),
+			"bind_rules":            utils.FlattenTagsToMap(utils.PathSearch("bind_rules.tags", val, nil)),
 		}
 
 		// Query the CBR policy which bound to the vault by ID.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For the vaults query data source, there is missing some attributes, such as the 'auto_bind' and the 'bind_rules'.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. data source supports 'auto_bind' and 'bind_rules' attributes.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o cbr -f TestAccDataVaults_backupServer
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cbr" -v -coverprofile="./huaweicloud/services/acceptance/cbr_coverage.cov" -coverpkg="./huaweicloud/services/cbr" -run TestAccDataVaults_backupServer -timeout 360m -parallel 10
=== RUN   TestAccDataVaults_backupServer
=== PAUSE TestAccDataVaults_backupServer
=== CONT  TestAccDataVaults_backupServer
--- PASS: TestAccDataVaults_backupServer (540.37s)
PASS
coverage: 33.4% of statements in ./huaweicloud/services/cbr
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cbr       540.417s        coverage: 33.4% of statements in ./huaweicloud/services/cbr
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
