### PR TITLE
feat(ces): add resource one-click alarm

### DIFF
--- a/docs/resources/ces_one_click_alarm.md
+++ b/docs/resources/ces_one_click_alarm.md
@@ -1,0 +1,135 @@
+---
+subcategory: "Cloud Eye (CES)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ces_one_click_alarm"
+description: |-
+  Manages a CES one-click alarm resource within HuaweiCloud.
+---
+
+# huaweicloud_ces_one_click_alarm
+
+Manages a CES one-click alarm resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "notification_object" {}
+
+resource "huaweicloud_ces_one_click_alarm" test {
+  one_click_alarm_id = "OBSSystemOneClickAlarm"
+
+  dimension_names {
+    metric = ["bucket_name"]
+    event  = true
+  }
+
+  alarm_notifications {
+    type = "notification"
+
+    notification_list = [
+      var.notification_object
+    ]
+  }
+
+  ok_notifications {
+    type = "notification"
+
+    notification_list = [
+      var.notification_object
+    ]
+  }
+
+  notification_enabled    = true
+  notification_begin_time = "00:00"
+  notification_end_time   = "23:59"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `one_click_alarm_id` - (Required, String, NonUpdatable) Specifies the default one-click monitoring ID.
+  The value can be queried from the CES one-click alarms data source.
+
+* `dimension_names` - (Required, List, NonUpdatable) Specifies dimensions in metric and event alarm rules that have
+  one-click monitoring enabled.
+
+  The [dimension_names](#DimensionNames) structure is documented below.
+
+* `notification_enabled` - (Required, Bool) Specifies whether to enable the alarm notification.
+
+* `alarm_notifications` - (Optional, List) Specifies the action to be triggered by an alarm.
+  + If the value of `notification_enabled` is **false**, this parameter should not be set.
+  + If the value of `notification_enabled` is **true**, this parameter is required.
+
+  The [alarm_notifications](#Notifications) structure is documented below.
+
+* `ok_notifications` - (Optional, List) Specifies the action to be triggered after an alarm is cleared.
+  + If the value of `notification_enabled` is **false**, this parameter should not be set.
+
+  The [ok_notifications](#Notifications) structure is documented below.
+
+* `notification_begin_time` - (Optional, String) Specifies the time when the alarm notification was enabled.
+
+* `notification_end_time` - (Optional, String) Specifies the time when the alarm notification was disabled.
+
+<a name="DimensionNames"></a>
+The `dimension_names` block supports:
+
+* `event` - (Optional, Bool, NonUpdatable) Specifies whether to enable the event alarm rules.
+
+* `metric` - (Optional, List, NonUpdatable) Specifies dimensions in metric alarm rules that have one-click monitoring enabled.
+
+<a name="Notifications"></a>
+The `alarm_notifications` block or `ok_notifications` block supports:
+
+* `type` - (Required, String) Specifies the notification type.
+  The value can be **notification** or **contact**.
+
+* `notification_list` - (Required, List) Specifies the list of objects to be notified if the alarm status changes.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `description` - The supplementary information about one-click monitoring.
+
+* `enabled` - Whether the one-click monitoring is enabled.
+
+* `namespace` - The metric namespace.
+
+## Import
+
+The one-click alarm can be imported using `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_ces_one_click_alarm.test <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `one_click_alarm_id`, `dimension_names`, `notification_enabled`, `alarm_notifications`,
+`ok_notifications`, `notification_begin_time`, `notification_end_time`.
+It is generally recommended running `terraform plan` after importing the one-click alarm.
+You can then decide if changes should be applied to the one-click alarm, or the resource definition should be updated to
+align with the one-click alarm. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_ces_one_click_alarm" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      one_click_alarm_id, dimension_names, notification_enabled, alarm_notifications,
+      ok_notifications, notification_begin_time, notification_end_time
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1292,6 +1292,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ces_dashboard":        ces.ResourceDashboard(),
 			"huaweicloud_ces_dashboard_widget": ces.ResourceDashboardWidget(),
 			"huaweicloud_ces_event_report":     ces.ResourceCesEventReport(),
+			"huaweicloud_ces_one_click_alarm":  ces.ResourceOneClickAlarm(),
 			"huaweicloud_ces_resource_group":   ces.ResourceResourceGroup(),
 
 			"huaweicloud_cfw_acl_rule":             cfw.ResourceAclRule(),

--- a/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_one_click_alarm_test.go
+++ b/huaweicloud/services/acceptance/ces/resource_huaweicloud_ces_one_click_alarm_test.go
@@ -1,0 +1,134 @@
+package ces
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ces"
+)
+
+func getOneClickAlarmFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+
+	var getOneClickAlarmProduct = "ces"
+	client, err := cfg.NewServiceClient(getOneClickAlarmProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating CES client: %s", err)
+	}
+
+	return ces.GetOneClickAlarm(client, state.Primary.ID)
+}
+
+func TestAccOneClickAlarm_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "huaweicloud_ces_one_click_alarm.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getOneClickAlarmFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testOneClickAlarm_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "one_click_alarm_id", "OBSSystemOneClickAlarm"),
+					resource.TestCheckResourceAttr(rName, "dimension_names.0.metric.0", "bucket_name"),
+					resource.TestCheckResourceAttr(rName, "dimension_names.0.event", "true"),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "true"),
+					resource.TestCheckResourceAttrSet(rName, "namespace"),
+					resource.TestCheckResourceAttrSet(rName, "description"),
+					resource.TestCheckResourceAttrSet(rName, "enabled"),
+				),
+			},
+			{
+				Config: testOneClickAlarm_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "one_click_alarm_id", "OBSSystemOneClickAlarm"),
+					resource.TestCheckResourceAttr(rName, "notification_enabled", "false"),
+					resource.TestCheckResourceAttrSet(rName, "namespace"),
+					resource.TestCheckResourceAttrSet(rName, "description"),
+					resource.TestCheckResourceAttrSet(rName, "enabled"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"one_click_alarm_id", "dimension_names", "notification_enabled",
+					"alarm_notifications", "ok_notifications", "notification_begin_time", "notification_end_time",
+				},
+			},
+		},
+	})
+}
+
+func testOneClickAlarm_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ces_one_click_alarm" test {
+  one_click_alarm_id = "OBSSystemOneClickAlarm"
+
+  dimension_names {
+    metric = ["bucket_name"]
+    event  = true
+  }
+
+  notification_enabled = true
+
+  alarm_notifications {
+    type = "contact"
+
+    notification_list = [
+      huaweicloud_smn_topic.test.topic_urn
+    ]
+  }
+  
+  ok_notifications {
+    type = "contact"
+
+    notification_list = [
+      huaweicloud_smn_topic.test.topic_urn
+    ]
+  }
+  
+  notification_begin_time = "00:00"
+  notification_end_time   = "23:59"
+}
+`, testCESAlarmRule_topicBase(name))
+}
+
+func testOneClickAlarm_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_ces_one_click_alarm" test {
+  one_click_alarm_id = "OBSSystemOneClickAlarm"
+  
+  dimension_names {
+    metric = ["bucket_name"]
+    event  = true
+  }
+  
+  notification_enabled    = false
+  notification_begin_time = "00:00"
+  notification_end_time   = "23:59"
+}
+`, testCESAlarmRule_topicBase(name))
+}

--- a/huaweicloud/services/ces/resource_huaweicloud_ces_one_click_alarm.go
+++ b/huaweicloud/services/ces/resource_huaweicloud_ces_one_click_alarm.go
@@ -1,0 +1,360 @@
+package ces
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var oneClickAlarmNonUpdatableParams = []string{"one_click_alarm_id", "dimension_names", "dimension_names.*.metric", "dimension_names.*.event"}
+
+// @API CES POST /v2/{project_id}/one-click-alarms
+// @API CES GET /v2/{project_id}/one-click-alarms
+// @API CES PUT /v2/{project_id}/one-click-alarms/{one_click_alarm_id}/notifications
+// @API CES POST /v2/{project_id}/one-click-alarms/batch-delete
+func ResourceOneClickAlarm() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceOneClickAlarmCreate,
+		UpdateContext: resourceOneClickAlarmUpdate,
+		ReadContext:   resourceOneClickAlarmRead,
+		DeleteContext: resourceOneClickAlarmDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(oneClickAlarmNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"one_click_alarm_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the default one-click monitoring ID.`,
+			},
+			"dimension_names": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Elem:        dimensionNamesSchema(),
+				Description: `Specifies dimensions in metric and event alarm rules that have one-click monitoring enabled.`,
+			},
+			"notification_enabled": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: `Specifies whether to enable the alarm notification.`,
+			},
+			"alarm_notifications": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        SMNActionSchema(),
+				Description: `Specifies the action to be triggered by an alarm.`,
+			},
+			"ok_notifications": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        SMNActionSchema(),
+				Description: `Specifies the action to be triggered after an alarm is cleared.`,
+			},
+			"notification_begin_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the time when the alarm notification was enabled.`,
+			},
+			"notification_end_time": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the time when the alarm notification was disabled.`,
+			},
+			"namespace": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The metric namespace.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The supplementary information about one-click monitoring.`,
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: `Whether to enable one-click monitoring.`,
+			},
+		},
+	}
+}
+
+func dimensionNamesSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"metric": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				AtLeastOneOf: []string{"dimension_names.0.metric", "dimension_names.0.event"},
+				Description:  `Specifies dimensions in metric alarm rules that have one-click monitoring enabled.`,
+			},
+			"event": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Specifies whether to enable the event alarm rules.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func SMNActionSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the notification type.`,
+			},
+			"notification_list": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the list of objects to be notified if the alarm status changes.`,
+			},
+		},
+	}
+	return &sc
+}
+
+func resourceOneClickAlarmCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		createOneClickAlarmHttpUrl = "v2/{project_id}/one-click-alarms"
+		createOneClickAlarmProduct = "ces"
+	)
+	client, err := cfg.NewServiceClient(createOneClickAlarmProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CES client: %s", err)
+	}
+
+	createOneClickAlarmPath := client.Endpoint + createOneClickAlarmHttpUrl
+	createOneClickAlarmPath = strings.ReplaceAll(createOneClickAlarmPath, "{project_id}", client.ProjectID)
+
+	createOneClickAlarmOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOneClickAlarmOpt.JSONBody = utils.RemoveNil(buildCreateOneClickAlarmBodyParams(d))
+	createOneClickAlarmResp, err := client.Request("POST", createOneClickAlarmPath, &createOneClickAlarmOpt)
+	if err != nil {
+		return diag.Errorf("error creating CES one-click alarm: %s", err)
+	}
+
+	createOneClickAlarmRespBody, err := utils.FlattenResponse(createOneClickAlarmResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("one_click_alarm_id", createOneClickAlarmRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("error creating CES one-click alarm: ID is not found in API response")
+	}
+	d.SetId(id)
+
+	return resourceOneClickAlarmRead(ctx, d, meta)
+}
+
+func buildCreateOneClickAlarmBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"one_click_alarm_id":      d.Get("one_click_alarm_id"),
+		"dimension_names":         buildDimensionNamesBodyParams(d.Get("dimension_names")),
+		"notification_enabled":    d.Get("notification_enabled"),
+		"alarm_notifications":     buildSMNActionBodyParams(d.Get("alarm_notifications")),
+		"ok_notifications":        buildSMNActionBodyParams(d.Get("ok_notifications")),
+		"notification_begin_time": utils.ValueIgnoreEmpty(d.Get("notification_begin_time")),
+		"notification_end_time":   utils.ValueIgnoreEmpty(d.Get("notification_end_time")),
+	}
+}
+
+func buildDimensionNamesBodyParams(rawParam interface{}) map[string]interface{} {
+	if rawArray, ok := rawParam.([]interface{}); ok {
+		if len(rawArray) == 0 {
+			return nil
+		}
+		raw := rawArray[0].(map[string]interface{})
+		param := map[string]interface{}{
+			"metric": utils.ValueIgnoreEmpty(raw["metric"]),
+		}
+		hasEvent := raw["event"].(bool)
+		if hasEvent {
+			param["event"] = []string{""}
+		}
+		return param
+	}
+	return nil
+}
+
+func buildSMNActionBodyParams(rawParam interface{}) []map[string]interface{} {
+	if rawArray, ok := rawParam.([]interface{}); ok && len(rawArray) > 0 {
+		rst := make([]map[string]interface{}, len(rawArray))
+		for i, v := range rawArray {
+			raw := v.(map[string]interface{})
+			rst[i] = map[string]interface{}{
+				"type":              utils.ValueIgnoreEmpty(raw["type"]),
+				"notification_list": utils.ValueIgnoreEmpty(raw["notification_list"]),
+			}
+		}
+		return rst
+	}
+	return nil
+}
+
+func resourceOneClickAlarmRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	getOneClickAlarmProduct := "ces"
+	client, err := cfg.NewServiceClient(getOneClickAlarmProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CES client: %s", err)
+	}
+
+	alarm, err := GetOneClickAlarm(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "no CES one-click alarm found")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("namespace", utils.PathSearch("namespace", alarm, nil)),
+		d.Set("description", utils.PathSearch("description", alarm, nil)),
+		d.Set("enabled", utils.PathSearch("enabled", alarm, false)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func GetOneClickAlarm(client *golangsdk.ServiceClient, id string) (interface{}, error) {
+	getOneClickAlarmHttpUrl := "v2/{project_id}/one-click-alarms"
+	getOneClickAlarmPath := client.Endpoint + getOneClickAlarmHttpUrl
+	getOneClickAlarmPath = strings.ReplaceAll(getOneClickAlarmPath, "{project_id}", client.ProjectID)
+
+	getOneClickAlarmOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getOneClickAlarmResp, err := client.Request("GET", getOneClickAlarmPath, &getOneClickAlarmOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieve CES one-click alarm: %s", err)
+	}
+
+	getOneClickAlarmRespBody, err := utils.FlattenResponse(getOneClickAlarmResp)
+	if err != nil {
+		return nil, err
+	}
+
+	findAlarmStr := fmt.Sprintf("one_click_alarms[?one_click_alarm_id=='%s']|[0]", id)
+	alarm := utils.PathSearch(findAlarmStr, getOneClickAlarmRespBody, nil)
+	if alarm == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+
+	return alarm, nil
+}
+
+func resourceOneClickAlarmUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	alarmId := d.Id()
+	var (
+		updateOneClickAlarmHttpUrl = "v2/{project_id}/one-click-alarms/{one_click_alarm_id}/notifications"
+		updateOneClickAlarmProduct = "ces"
+	)
+	updateOneClickAlarmClient, err := cfg.NewServiceClient(updateOneClickAlarmProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CES client: %s", err)
+	}
+
+	updateOneClickAlarmPath := updateOneClickAlarmClient.Endpoint + updateOneClickAlarmHttpUrl
+	updateOneClickAlarmPath = strings.ReplaceAll(updateOneClickAlarmPath, "{project_id}", updateOneClickAlarmClient.ProjectID)
+	updateOneClickAlarmPath = strings.ReplaceAll(updateOneClickAlarmPath, "{one_click_alarm_id}", alarmId)
+
+	updateOneClickAlarmOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes:          []int{204},
+	}
+	updateOneClickAlarmOpt.JSONBody = utils.RemoveNil(buildUpdateOneClickAlarmBodyParams(d))
+	_, err = updateOneClickAlarmClient.Request("PUT", updateOneClickAlarmPath, &updateOneClickAlarmOpt)
+	if err != nil {
+		return diag.Errorf("error updating CES one-click alarm: %s", err)
+	}
+
+	return resourceOneClickAlarmRead(ctx, d, meta)
+}
+
+func buildUpdateOneClickAlarmBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"notification_enabled":    d.Get("notification_enabled"),
+		"alarm_notifications":     buildSMNActionBodyParams(d.Get("alarm_notifications")),
+		"ok_notifications":        buildSMNActionBodyParams(d.Get("ok_notifications")),
+		"notification_begin_time": utils.ValueIgnoreEmpty(d.Get("notification_begin_time")),
+		"notification_end_time":   utils.ValueIgnoreEmpty(d.Get("notification_end_time")),
+	}
+}
+
+func resourceOneClickAlarmDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		deleteOneClickAlarmHttpUrl = "v2/{project_id}/one-click-alarms/batch-delete"
+		deleteOneClickAlarmProduct = "ces"
+	)
+	deleteOneClickAlarmClient, err := cfg.NewServiceClient(deleteOneClickAlarmProduct, region)
+	if err != nil {
+		return diag.Errorf("error creating CES client: %s", err)
+	}
+
+	deleteOneClickAlarmPath := deleteOneClickAlarmClient.Endpoint + deleteOneClickAlarmHttpUrl
+	deleteOneClickAlarmPath = strings.ReplaceAll(deleteOneClickAlarmPath, "{project_id}", deleteOneClickAlarmClient.ProjectID)
+
+	deleteOneClickAlarmOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	deleteOneClickAlarmOpt.JSONBody = buildDeleteOneClickAlarmBodyParams(d)
+	_, err = deleteOneClickAlarmClient.Request("POST", deleteOneClickAlarmPath, &deleteOneClickAlarmOpt)
+	if err != nil {
+		return diag.Errorf("error deleting CES one-click alarm: %s", err)
+	}
+
+	// Successful deletion API call does not guarantee that the resource is successfully deleted.
+	// Call the details API to confirm that the resource has been successfully deleted.
+	_, err = GetOneClickAlarm(deleteOneClickAlarmClient, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving CES one-click alarm")
+	}
+
+	return diag.Errorf("error deleting CES one-click alarm")
+}
+
+func buildDeleteOneClickAlarmBodyParams(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"one_click_alarm_ids": []string{d.Id()},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 add resource one-click alarm
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  add resource one-click alarm
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/ces" TESTARGS="-run TestAccOneClickAlarm_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run TestAccOneClickAlarm_basic -timeout 360m -parallel 4
=== RUN   TestAccOneClickAlarm_basic
=== PAUSE TestAccOneClickAlarm_basic
=== CONT  TestAccOneClickAlarm_basic
--- PASS: TestAccOneClickAlarm_basic (44.56s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       44.608s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/eb669b28-5c0b-4ae4-8786-ba03f65985d4)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
  ![image](https://github.com/user-attachments/assets/1d66acdc-9b7f-4c38-96fc-e7ab95941a26)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
