### PR TITLE
refactor(ims): refactor `images_images` and `images_image` dataSources

### DIFF
--- a/docs/data-sources/images_image.md
+++ b/docs/data-sources/images_image.md
@@ -2,16 +2,23 @@
 subcategory: "Image Management Service (IMS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_images_image"
-description: ""
+description: |-
+  Use this data source to get an available IMS image within HuaweiCloud.
 ---
 
 # huaweicloud_images_image
 
-Use this data source to get the ID of an available HuaweiCloud image.
+Use this data source to get an available IMS image within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
+variable "image_id" {}
+
+data "huaweicloud_images_image" "test" {
+  image_id = var.image_id
+}
+
 data "huaweicloud_images_image" "ubuntu" {
   name        = "Ubuntu 18.04 server 64bit"
   visibility  = "public"
@@ -20,7 +27,6 @@ data "huaweicloud_images_image" "ubuntu" {
 
 data "huaweicloud_images_image" "centos-1" {
   architecture = "x86"
-  os_version   = "CentOS 7.4 64bit"
   visibility   = "public"
   most_recent  = true
 }
@@ -35,7 +41,6 @@ data "huaweicloud_images_image" "centos-2" {
 data "huaweicloud_images_image" "bms_image" {
   architecture = "x86"
   image_type   = "Ironic"
-  os_version   = "CentOS 7.4 64bit"
   visibility   = "public"
   most_recent  = true
 }
@@ -43,62 +48,97 @@ data "huaweicloud_images_image" "bms_image" {
 
 ## Argument Reference
 
-* `region` - (Optional, String) The region in which to obtain the images. If omitted, the provider-level region will be
-  used.
+* `region` - (Optional, String) Specifies the region in which to obtain the images.
+  If omitted, the provider-level region will be used.
 
-* `most_recent` - (Optional, Bool) If more than one result is returned, use the latest updated image.
+* `most_recent` - (Optional, Bool) Specifies whether to return the latest updated image if the query returns more than
+  results. The valid value is **true** or **false**. Defaults to **false**.
 
-* `name` - (Optional, String) The name of the image. Cannot be used simultaneously with `name_regex`.
+* `image_id` - (Optional, String) Specifies the ID of the image.
 
-* `name_regex` - (Optional, String) The regular expression of the name of the image.
+* `name` - (Optional, String) Specifies the name of the image. Cannot be used simultaneously with `name_regex`.
+
+* `name_regex` - (Optional, String) Specifies the regular expression of the name of the image.
   Cannot be used simultaneously with `name`.
 
-* `visibility` - (Optional, String) The visibility of the image. Must be one of
-  **public**, **private**, **market** or **shared**.
+* `image_type` - (Optional, String) Specifies the environment where the image is used.
+  The valid values are as follows:
+  + **FusionCompute**: Cloud server image, also known as system disk image.
+  + **DataImage**: Data disk image.
+  + **Ironic**: Bare metal server image.
+  + **IsoImage**: ISO image.
 
-* `architecture` - (Optional, String) Specifies the image architecture type. The value can be **x86** and **arm**.
+* `is_whole_image` - (Optional, Bool) Specifies whether it is a whole image. The valid value is **true** or **false**.
+  Defaults to **false**.
 
-* `os` - (Optional, String) Specifies the image OS type. The value can be **Windows**, **Ubuntu**,
-  **RedHat**, **SUSE**, **CentOS**, **Debian**, **OpenSUSE**, **Oracle Linux**, **Fedora**, **Other**,
-  **CoreOS**, or **EulerOS**.
+* `visibility` - (Optional, String) Specifies the visibility of the image. Must be one of **public**, **private**,
+  **market** or **shared**.
 
-* `os_version` - (Optional, String) Specifies the OS version. For example, *CentOS 7.4 64bit* or *Ubuntu 18.04 server 64bit*.
-  For all its valid values, see [API docs](https://support.huaweicloud.com/intl/en-us/api-ims/ims_03_0910.html).
-
-* `image_type` - (Optional, String) Specifies the environment where the image is used. For a BMS image, the value is **Ironic**.
-
-* `owner` - (Optional, String) The owner (UUID) of the image.
-
-* `tag` - (Optional, String) Search for images with a specific tag in "Key=Value" format.
-
-* `sort_direction` - (Optional, String) Order the results in either `asc` or `desc`.
-
-* `sort_key` - (Optional, String) Sort images based on a certain key. Must be one of
-  "name", "container_format", "disk_format", "status", "id" or "size". Defaults to `name`.
-
-* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the image.
+* `owner` - (Optional, String) Specifies the owner (UUID) of the image.
 
 * `flavor_id` - (Optional, String) Specifies the ECS flavor ID used to filter out available images.
   You can specify only one flavor ID and only ECS flavor ID is valid, BMS flavor is not supported.
+
+* `sort_key` - (Optional, String) Specifies which field to use for sorting. The valid values are **name**,
+  **container_format**, **disk_format**, **status**, **id**, **size**, and **created_at**. Defaults to **name**.
+
+* `sort_direction` - (Optional, String) Specifies whether to sort the query results in ascending or descending order.
+  The valid values are as follows:
+  + **asc**: Ascending order.
+  + **desc**: Descending order.
+
+  Defaults to **asc**.
+
+* `os` - (Optional, String) Specifies the image OS type. The value can be **Windows**, **Ubuntu**, **RedHat**, **SUSE**,
+  **CentOS**, **Debian**, **OpenSUSE**, **Oracle Linux**, **Fedora**, **Other**, **CoreOS**, or **EulerOS**.
+
+* `architecture` - (Optional, String) Specifies the image architecture type. The value can be **x86** or **arm**.
+
+* `tag` - (Optional, String) Specifies the image tag in **Key=Value** format.
+  
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the image.
+  For enterprise users, if omitted, will query the images under all enterprise projects.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - Specifies a resource ID in UUID format.
-* `checksum` - The checksum of the data associated with the image.
+* `id` - The data source ID, same as `image_id`.
+
+* `os_version` - The operating system version of the image.
+
+* `file` - The image file download and upload links.
+
+* `schema` - The image view.
+
+* `status` - The status of the image. The valid value is **active**.
+
+* `description` - The description of the image.
+
+* `protected` - Indicates whether the image is protected, protected images cannot be deleted.
+  The valid value is **true** or **false**.
+
 * `container_format` - The format of the image's container.
-* `disk_format` - The format of the image's disk.
-* `file` - the trailing path after the glance endpoint that represent the location of the image or the path to retrieve
-  it.
-* `metadata` - The metadata associated with the image. Image metadata allow for meaningfully define the image properties
-  and tags.
-* `min_disk_gb` - The minimum amount of disk space required to use the image.
-* `min_ram_mb` - The minimum amount of ram required to use the image.
-* `protected` - Whether or not the image is protected.
-* `schema` - The path to the JSON-schema that represent the image or image.
-* `size_bytes` - The size of the image (in bytes).
-* `status` - The status of the image.
+
+* `min_ram_mb` - The minimum memory required to run an image, in MB unit.
+
+* `max_ram_mb` - The maximum memory supported by the image, in MB unit.
+
+* `min_disk_gb` - The minimum disk space required to run an image, in GB unit.
+  + When the operating system is Linux, the value ranges from `10` to `1,024`.
+  + When the operating system is Windows, the value ranges from `20` to `1,024`.
+
+* `disk_format` - The image format. The value can be **zvhd2**, **vhd**, **zvhd**, **raw**, **qcow2**, or **iso**.
+
+* `data_origin` - The image source. The format is **server_backup,backup_id**,  **instance,instance_id**,
+  **server_backup,vault_id**,  **volume,volume_id**, **file,image_url**, or **image,region,image_id**.
+
 * `backup_id` - The backup ID of the whole image in the CBR vault.
-* `created_at` - The date when the image was created.
-* `updated_at` - The date when the image was last updated.
+
+* `size_bytes` - The size of the image file, in bytes unit.
+
+* `active_at` - The time when the image status changes to active, in RFC3339 format.
+
+* `created_at` - The creation time of the image, in RFC3339 format.
+
+* `updated_at` - The last update time of the image, in RFC3339 format.

--- a/docs/data-sources/images_images.md
+++ b/docs/data-sources/images_images.md
@@ -2,16 +2,23 @@
 subcategory: "Image Management Service (IMS)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_images_images"
-description: ""
+description: |-
+  Use this data source to get available IMS images within HuaweiCloud.
 ---
 
 # huaweicloud_images_images
 
-Use this data source to get available HuaweiCloud IMS images.
+Use this data source to get available IMS images within HuaweiCloud.
 
 ## Example Usage
 
 ```hcl
+variable "image_id" {}
+
+data "huaweicloud_images_image" "test" {
+  image_id = var.image_id
+}
+
 data "huaweicloud_images_images" "ubuntu" {
   name        = "Ubuntu 18.04 server 64bit"
   visibility  = "public"
@@ -19,7 +26,7 @@ data "huaweicloud_images_images" "ubuntu" {
 
 data "huaweicloud_images_images" "centos-1" {
   architecture = "x86"
-  os_version   = "CentOS 7.4 64bit"
+  os           = "CentOS"
   visibility   = "public"
 }
 
@@ -32,48 +39,59 @@ data "huaweicloud_images_images" "centos-2" {
 data "huaweicloud_images_images" "bms_image" {
   architecture = "x86"
   image_type   = "Ironic"
-  os_version   = "CentOS 7.4 64bit"
   visibility   = "public"
 }
 ```
 
 ## Argument Reference
 
-* `region` - (Optional, String) The region in which to obtain the images. If omitted, the provider-level region will be
-  used.
+* `region` - (Optional, String) Specifies the region in which to obtain the images.
+  If omitted, the provider-level region will be used.
 
-* `name` - (Optional, String) The name of the image. Cannot be used simultaneously with `name_regex`.
+* `image_id` - (Optional, String) Specifies the ID of the image.
 
-* `name_regex` - (Optional, String) The regular expression of the name of the image.
+* `name` - (Optional, String) Specifies the name of the image. Cannot be used simultaneously with `name_regex`.
+
+* `name_regex` - (Optional, String) Specifies the regular expression of the name of the image.
   Cannot be used simultaneously with `name`.
 
-* `visibility` - (Optional, String) The visibility of the image. Must be one of
-  **public**, **private**, **market** or **shared**.
+* `image_type` - (Optional, String) Specifies the environment where the image is used.
+  The valid values are as follows:
+  + **FusionCompute**: Cloud server image, also known as system disk image.
+  + **DataImage**: Data disk image.
+  + **Ironic**: Bare metal server image.
+  + **IsoImage**: ISO image.
 
-* `architecture` - (Optional, String) Specifies the image architecture type. The value can be **x86** and **arm**.
+* `is_whole_image` - (Optional, Bool) Specifies whether it is a whole image. The valid value is **true** or **false**.
+  Defaults to **false**.
 
-* `os` - (Optional, String) Specifies the image OS type. The value can be **Windows**, **Ubuntu**,
-  **RedHat**, **SUSE**, **CentOS**, **Debian**, **OpenSUSE**, **Oracle Linux**, **Fedora**, **Other**,
-  **CoreOS**, or **EulerOS**.
+* `visibility` - (Optional, String) Specifies the visibility of the image. Must be one of **public**, **private**,
+  **market** or **shared**.
 
-* `os_version` - (Optional, String) Specifies the OS version. For example, *CentOS 7.4 64bit* or *Ubuntu 18.04 server 64bit*.
-  For all its valid values, see [API docs](https://support.huaweicloud.com/intl/en-us/api-ims/ims_03_0910.html).
-
-* `image_type` - (Optional, String) Specifies the environment where the image is used. For a BMS image, the value is **Ironic**.
-
-* `owner` - (Optional, String) The owner (UUID) of the image.
-
-* `tag` - (Optional, String) Search for images with a specific tag in "Key=Value" format.
-
-* `sort_direction` - (Optional, String) Order the results in either `asc` or `desc`.
-
-* `sort_key` - (Optional, String) Sort images based on a certain key. Must be one of
-  "name", "container_format", "disk_format", "status", "id" or "size". Defaults to `name`.
-
-* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the image.
+* `owner` - (Optional, String) Specifies the owner (UUID) of the image.
 
 * `flavor_id` - (Optional, String) Specifies the ECS flavor ID used to filter out available images.
   You can specify only one flavor ID and only ECS flavor ID is valid, BMS flavor is not supported.
+
+* `sort_key` - (Optional, String) Specifies which field to use for sorting. The valid values are **name**,
+  **container_format**, **disk_format**, **status**, **id**, **size**, and **created_at**. Defaults to **name**.
+
+* `sort_direction` - (Optional, String) Specifies whether to sort the query results in ascending or descending order.
+  The valid values are as follows:
+  + **asc**: Ascending order.
+  + **desc**: Descending order.
+
+  Defaults to **asc**.
+
+* `os` - (Optional, String) Specifies the image OS type. The value can be **Windows**, **Ubuntu**, **RedHat**, **SUSE**,
+  **CentOS**, **Debian**, **OpenSUSE**, **Oracle Linux**, **Fedora**, **Other**, **CoreOS**, or **EulerOS**.
+
+* `architecture` - (Optional, String) Specifies the image architecture type. The value can be **x86** or **arm**.
+
+* `tag` - (Optional, String) Specifies the image tag in **Key=Value** format.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the image.
+  For enterprise users, if omitted, will query the images under all enterprise projects.
 
 ## Attribute Reference
 
@@ -81,44 +99,62 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `images` - Indicates the images information. Structure is documented below.
+* `images` - All images that match the filter parameters.
+  The [images](#ims_images) structure is documented below.
 
-The `images` block contains:
+<a name="ims_images"></a>
+The `images` block supports:
 
 * `id` - The ID of the image
 
 * `name` - The name of the image.
 
+* `image_type` - The environment where the image is used.
+
 * `visibility` - The visibility of the image.
-
-* `checksum` - The checksum of the data associated with the image.
-
-* `container_format` - The format of the image's container.
-
-* `disk_format` - The format of the image's disk.
-
-* `min_disk_gb` - The minimum amount of disk space required to use the image.
-
-* `min_ram_mb` - The minimum amount of ram required to use the image.
 
 * `owner` - The owner (UUID) of the image.
 
-* `protected` - Whether or not the image is protected.
+* `os` - The image OS type.
 
-* `image_type` - The environment where the image is used. For a BMS image, the value is **Ironic**.
-
-* `os` - Specifies the image OS type.
-
-* `os_version` - The OS version.
+* `architecture` - The image architecture type.
 
 * `enterprise_project_id` - The enterprise project ID of the image.
 
-* `status` - The status of the image.
+* `os_version` - The operating system version of the image.
+
+* `file` - The image file download and upload links.
+
+* `schema` - The image view.
+
+* `status` - The status of the image. The valid value is **active**.
+
+* `description` - The description of the image.
+
+* `protected` - Indicates whether the image is protected, protected images cannot be deleted.
+  The valid value is **true** or **false**.
+
+* `container_format` - The format of the image's container.
+
+* `min_ram_mb` - The minimum memory required to run an image, in MB unit.
+
+* `max_ram_mb` - The maximum memory supported by the image, in MB unit.
+
+* `min_disk_gb` - The minimum disk space required to run an image, in GB unit.
+  + When the operating system is Linux, the value ranges from `10` to `1,024`.
+  + When the operating system is Windows, the value ranges from `20` to `1,024`.
+
+* `disk_format` - The image format. The value can be **zvhd2**, **vhd**, **zvhd**, **raw**, **qcow2**, or **iso**.
+
+* `data_origin` - The image source. The format is **server_backup,backup_id**,  **instance,instance_id**,
+  **server_backup,vault_id**,  **volume,volume_id**, **file,image_url**, or **image,region,image_id**.
 
 * `backup_id` - The backup ID of the whole image in the CBR vault.
 
-* `created_at` - The date when the image was created.
+* `size_bytes` - The size of the image file, in bytes unit.
 
-* `updated_at` - The date when the image was last updated.
+* `active_at` - The time when the image status changes to active, in RFC3339 format.
 
-* `size_bytes` - The size of the image (in bytes).
+* `created_at` - The creation time of the image, in RFC3339 format.
+
+* `updated_at` - The last update time of the image, in RFC3339 format.

--- a/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go
+++ b/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_image_test.go
@@ -11,27 +11,45 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func TestAccImsImageDataSource_basic(t *testing.T) {
-	imageName := "CentOS 7.4 64bit"
-	dataSourceName := "data.huaweicloud_images_image.test"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccImageDataSource_basic(t *testing.T) {
+	var (
+		imageName      = "CentOS 7.4 64bit"
+		dataSourceName = "data.huaweicloud_images_image.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImsImageDataSource_publicName(imageName),
+				Config: testAccImageDataSource_public_queryByName(imageName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "name", imageName),
 					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
 					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "image_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "image_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "owner"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "os"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "architecture"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "os_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "file"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "schema"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "container_format"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "min_ram_mb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "max_ram_mb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "min_disk_gb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "disk_format"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "size_bytes"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "updated_at"),
 				),
 			},
 			{
-				Config: testAccImsImageDataSource_osVersion(imageName),
+				Config: testAccImageDataSource_public_queryByNameRegex("^CentOS 7.4"),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
@@ -40,16 +58,7 @@ func TestAccImsImageDataSource_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccImsImageDataSource_nameRegex("^CentOS 7.4"),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
-					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
-					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
-				),
-			},
-			{
-				Config: testAccImsImageDataSource_market(),
+				Config: testAccImageDataSource_market(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
@@ -61,39 +70,69 @@ func TestAccImsImageDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccImsImageDataSource_testQueries(t *testing.T) {
-	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	dataSourceName := "data.huaweicloud_images_image.test"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccImageDataSource_private(t *testing.T) {
+	var (
+		rName       = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+		byImageId   = "data.huaweicloud_images_image.image_id_filter"
+		dcByImageId = acceptance.InitDataSourceCheck(byImageId)
+
+		byName   = "data.huaweicloud_images_image.name_filter"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byFlavorId   = "data.huaweicloud_images_image.flavor_id_filter"
+		dcByFlavorId = acceptance.InitDataSourceCheck(byFlavorId)
+
+		byTag   = "data.huaweicloud_images_image.tag_filter"
+		dcByTag = acceptance.InitDataSourceCheck(byTag)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImsImageDataSource_base(rName),
+				Config: testAccImageDataSource_private_base(rName),
 			},
 			{
-				Config: testAccImsImageDataSource_queryName(rName),
+				Config: testAccImageDataSource_private_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
-					resource.TestCheckResourceAttr(dataSourceName, "protected", "false"),
-					resource.TestCheckResourceAttr(dataSourceName, "visibility", "private"),
-					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
-				),
-			},
-			{
-				Config: testAccImsImageDataSource_queryTag(rName),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
+					dcByImageId.CheckResourceExists(),
+					resource.TestCheckResourceAttr(byImageId, "name", rName),
+					resource.TestCheckResourceAttr(byImageId, "visibility", "private"),
+					resource.TestCheckResourceAttr(byImageId, "status", "active"),
+					resource.TestCheckResourceAttrSet(byImageId, "image_id"),
+					resource.TestCheckResourceAttrSet(byImageId, "image_type"),
+					resource.TestCheckResourceAttrSet(byImageId, "owner"),
+					resource.TestCheckResourceAttrSet(byImageId, "os"),
+					resource.TestCheckResourceAttrSet(byImageId, "architecture"),
+					resource.TestCheckResourceAttrSet(byImageId, "enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(byImageId, "os_version"),
+					resource.TestCheckResourceAttrSet(byImageId, "file"),
+					resource.TestCheckResourceAttrSet(byImageId, "schema"),
+					resource.TestCheckResourceAttrSet(byImageId, "description"),
+					resource.TestCheckResourceAttrSet(byImageId, "container_format"),
+					resource.TestCheckResourceAttrSet(byImageId, "min_ram_mb"),
+					resource.TestCheckResourceAttrSet(byImageId, "max_ram_mb"),
+					resource.TestCheckResourceAttrSet(byImageId, "min_disk_gb"),
+					resource.TestCheckResourceAttrSet(byImageId, "disk_format"),
+					resource.TestCheckResourceAttrSet(byImageId, "data_origin"),
+					resource.TestCheckResourceAttrSet(byImageId, "size_bytes"),
+					resource.TestCheckResourceAttrSet(byImageId, "active_at"),
+					resource.TestCheckResourceAttrSet(byImageId, "created_at"),
+					resource.TestCheckResourceAttrSet(byImageId, "updated_at"),
+					// Check whether filter parameter `name` is effective.
+					dcByName.CheckResourceExists(),
+					// Check whether filter parameter `flavor_id` is effective.
+					dcByFlavorId.CheckResourceExists(),
+					// Check whether filter parameter `tag` is effective.
+					dcByTag.CheckResourceExists(),
 				),
 			},
 		},
 	})
 }
 
-func testAccImsImageDataSource_publicName(imageName string) string {
+func testAccImageDataSource_public_queryByName(imageName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_images_image" "test" {
   name        = "%s"
@@ -103,39 +142,28 @@ data "huaweicloud_images_image" "test" {
 `, imageName)
 }
 
-func testAccImsImageDataSource_nameRegex(regexp string) string {
+func testAccImageDataSource_public_queryByNameRegex(regexp string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_images_image" "test" {
-  architecture = "x86"
   name_regex   = "%s"
   visibility   = "public"
+  architecture = "x86"
   most_recent  = true
 }
 `, regexp)
 }
 
-func testAccImsImageDataSource_osVersion(osVersion string) string {
-	return fmt.Sprintf(`
-data "huaweicloud_images_image" "test" {
-  architecture = "x86"
-  os_version   = "%s"
-  visibility   = "public"
-  most_recent  = true
-}
-`, osVersion)
-}
-
-func testAccImsImageDataSource_market() string {
+func testAccImageDataSource_market() string {
 	return `
 data "huaweicloud_images_image" "test" {
-  os          = "CentOS"
   visibility  = "market"
+  os          = "CentOS"
   most_recent = true
 }
 `
 }
 
-func testAccImsImageDataSource_base(rName string) string {
+func testAccImageDataSource_private_base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -173,25 +201,32 @@ resource "huaweicloud_ims_ecs_system_image" "test" {
 `, common.TestBaseNetwork(rName), rName)
 }
 
-func testAccImsImageDataSource_queryName(rName string) string {
+func testAccImageDataSource_private_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_images_image" "test" {
-  most_recent = true
+# Filter using image ID.
+data "huaweicloud_images_image" "image_id_filter" {
+  image_id = huaweicloud_ims_ecs_system_image.test.id
+}
+
+# Filter using name.
+data "huaweicloud_images_image" "name_filter" {
   name        = huaweicloud_ims_ecs_system_image.test.name
-}
-`, testAccImsImageDataSource_base(rName))
+  most_recent = true
 }
 
-func testAccImsImageDataSource_queryTag(rName string) string {
-	return fmt.Sprintf(`
-%s
+# Filter using flavor_id.
+data "huaweicloud_images_image" "flavor_id_filter" {
+  flavor_id   = huaweicloud_compute_instance.test.flavor_id
+  most_recent = true
+}
 
-data "huaweicloud_images_image" "test" {
+# Filter using tag.
+data "huaweicloud_images_image" "tag_filter" {
   most_recent = true
   visibility  = "private"
   tag         = "foo=bar"
 }
-`, testAccImsImageDataSource_base(rName))
+`, testAccImageDataSource_private_base(rName))
 }

--- a/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go
+++ b/huaweicloud/services/acceptance/ims/data_source_huaweicloud_images_images_test.go
@@ -11,27 +11,45 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
-func TestAccImsImagesDataSource_basic(t *testing.T) {
-	imageName := "CentOS 7.4 64bit"
-	dataSourceName := "data.huaweicloud_images_images.test"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccImagesDataSource_basic(t *testing.T) {
+	var (
+		imageName      = "CentOS 7.4 64bit"
+		dataSourceName = "data.huaweicloud_images_images.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImsImagesDataSource_publicName(imageName),
+				Config: testAccImagesDataSource_public_queryByName(imageName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "images.0.name", imageName),
 					resource.TestCheckResourceAttr(dataSourceName, "images.0.protected", "true"),
 					resource.TestCheckResourceAttr(dataSourceName, "images.0.visibility", "public"),
 					resource.TestCheckResourceAttr(dataSourceName, "images.0.status", "active"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.image_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.owner"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.os"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.architecture"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.os_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.file"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.schema"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.container_format"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.min_ram_mb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.max_ram_mb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.min_disk_gb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.disk_format"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.size_bytes"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.updated_at"),
 				),
 			},
 			{
-				Config: testAccImsImagesDataSource_osVersion(imageName),
+				Config: testAccImagesDataSource_public_queryByNameRegex("^CentOS 7.4"),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "images.0.protected", "true"),
@@ -40,16 +58,7 @@ func TestAccImsImagesDataSource_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccImsImagesDataSource_nameRegex("^CentOS 7.4"),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "images.0.protected", "true"),
-					resource.TestCheckResourceAttr(dataSourceName, "images.0.visibility", "public"),
-					resource.TestCheckResourceAttr(dataSourceName, "images.0.status", "active"),
-				),
-			},
-			{
-				Config: testAccImsImagesDataSource_market(),
+				Config: testAccImagesDataSource_market(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "images.0.protected", "true"),
@@ -61,39 +70,59 @@ func TestAccImsImagesDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccImsImagesDataSource_testQueries(t *testing.T) {
-	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	dataSourceName := "data.huaweicloud_images_images.test"
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+func TestAccImagesDataSource_private_basic(t *testing.T) {
+	var (
+		rName          = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+		dataSourceName = "data.huaweicloud_images_images.image_id_filter"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccImsImagesDataSource_base(rName),
+				Config: testAccImagesDataSource_private_base(rName),
 			},
 			{
-				Config: testAccImsImagesDataSource_queryName(rName),
+				Config: testAccImagesDataSource_private_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(dataSourceName, "images.0.name", rName),
-					resource.TestCheckResourceAttr(dataSourceName, "images.0.protected", "false"),
 					resource.TestCheckResourceAttr(dataSourceName, "images.0.visibility", "private"),
 					resource.TestCheckResourceAttr(dataSourceName, "images.0.status", "active"),
-				),
-			},
-			{
-				Config: testAccImsImagesDataSource_queryTag(rName),
-				Check: resource.ComposeTestCheckFunc(
-					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.image_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.owner"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.os"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.architecture"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.os_version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.file"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.schema"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.container_format"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.min_ram_mb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.max_ram_mb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.min_disk_gb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.disk_format"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.data_origin"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.size_bytes"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.active_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "images.0.updated_at"),
+					resource.TestCheckOutput("is_image_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("is_flavor_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_tag_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccImsImagesDataSource_publicName(imageName string) string {
+func testAccImagesDataSource_public_queryByName(imageName string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_images_images" "test" {
   name       = "%s"
@@ -102,7 +131,7 @@ data "huaweicloud_images_images" "test" {
 `, imageName)
 }
 
-func testAccImsImagesDataSource_nameRegex(regexp string) string {
+func testAccImagesDataSource_public_queryByNameRegex(regexp string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_images_images" "test" {
   architecture = "x86"
@@ -112,17 +141,7 @@ data "huaweicloud_images_images" "test" {
 `, regexp)
 }
 
-func testAccImsImagesDataSource_osVersion(osVersion string) string {
-	return fmt.Sprintf(`
-data "huaweicloud_images_images" "test" {
-  architecture = "x86"
-  os_version   = "%s"
-  visibility   = "public"
-}
-`, osVersion)
-}
-
-func testAccImsImagesDataSource_market() string {
+func testAccImagesDataSource_market() string {
 	return `
 data "huaweicloud_images_images" "test" {
   os         = "CentOS"
@@ -131,7 +150,7 @@ data "huaweicloud_images_images" "test" {
 `
 }
 
-func testAccImsImagesDataSource_base(rName string) string {
+func testAccImagesDataSource_private_base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -173,22 +192,70 @@ resource "huaweicloud_ims_ecs_system_image" "test" {
 `, common.TestBaseNetwork(rName), rName)
 }
 
-func testAccImsImagesDataSource_queryName(rName string) string {
+func testAccImagesDataSource_private_basic(rName string) string {
 	return fmt.Sprintf(`
 %s
 
-data "huaweicloud_images_images" "test" {
+# Filter using image ID.
+locals {
+  image_id = huaweicloud_ims_ecs_system_image.test.id
+}
+
+data "huaweicloud_images_images" "image_id_filter" {
+  image_id = local.image_id
+}
+
+output "is_image_id_filter_useful" {
+  value = length(data.huaweicloud_images_images.image_id_filter.images) > 0 && alltrue(
+    [for v in data.huaweicloud_images_images.image_id_filter.images[*].id : v == local.image_id]
+  )
+}
+
+# Filter using name.
+locals {
   name = huaweicloud_ims_ecs_system_image.test.name
 }
-`, testAccImsImagesDataSource_base(rName))
+
+data "huaweicloud_images_images" "name_filter" {
+  name = local.name
 }
 
-func testAccImsImagesDataSource_queryTag(rName string) string {
-	return fmt.Sprintf(`
-%s
-data "huaweicloud_images_images" "test" {
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_images_images.name_filter.images) > 0 && alltrue(
+    [for v in data.huaweicloud_images_images.name_filter.images[*].name : v == local.name]
+  )
+}
+
+# Filter using flavor_id.
+locals {
+  flavor_id = huaweicloud_compute_instance.test.flavor_id
+}
+
+data "huaweicloud_images_images" "flavor_id_filter" {
+  flavor_id = local.flavor_id
+}
+
+output "is_flavor_id_filter_useful" {
+  value = length(data.huaweicloud_images_images.flavor_id_filter.images) > 0
+}
+
+# Filter using tag.
+data "huaweicloud_images_images" "tag_filter" {
   visibility = "private"
   tag        = "foo=bar"
 }
-`, testAccImsImagesDataSource_base(rName))
+
+output "is_tag_filter_useful" {
+  value = length(data.huaweicloud_images_images.tag_filter.images) > 0
+}
+
+# Filter using non existent name.
+data "huaweicloud_images_images" "not_found" {
+  name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_images_images.not_found.images) == 0
+}
+`, testAccImagesDataSource_private_base(rName))
 }

--- a/huaweicloud/services/ims/data_source_huaweicloud_images_image.go
+++ b/huaweicloud/services/ims/data_source_huaweicloud_images_image.go
@@ -16,6 +16,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 // @API IMS GET /v2/cloudimages
@@ -29,75 +30,42 @@ func DataSourceImagesImageV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
+			"most_recent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"name_regex": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"name"},
 				ValidateFunc:  validation.StringIsValidRegExp,
 			},
-
-			"visibility": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"owner": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"sort_key": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "name",
-			},
-
-			"sort_direction": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "asc",
-			},
-
-			"tag": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"most_recent": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-
-			"architecture": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"os": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"os_version": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"image_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"enterprise_project_id": {
+			"is_whole_image": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"visibility": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"owner": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -105,7 +73,41 @@ func DataSourceImagesImageV2() *schema.Resource {
 			"flavor_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"sort_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "name",
+			},
+			"sort_direction": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "asc",
+			},
+			"os": {
+				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
+			},
+			"architecture": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enterprise_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"os_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "schema: Computed",
 			},
 
 			// Deprecated values
@@ -121,39 +123,6 @@ func DataSourceImagesImageV2() *schema.Resource {
 			},
 
 			// Computed values
-			"container_format": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"disk_format": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"min_disk_gb": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"min_ram_mb": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"protected": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"checksum": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"size_bytes": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"metadata": {
-				Type:     schema.TypeMap,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
 			"file": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -166,7 +135,53 @@ func DataSourceImagesImageV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protected": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"container_format": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"min_ram_mb": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"max_ram_mb": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"min_disk_gb": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"disk_format": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_origin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"backup_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"metadata": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: utils.SchemaDesc("metadata is deprecated", utils.SchemaDescInput{Internal: true}),
+			},
+			"active_at": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -178,47 +193,44 @@ func DataSourceImagesImageV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"checksum": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: utils.SchemaDesc("checksum is deprecated", utils.SchemaDescInput{Internal: true}),
+			},
 		},
 	}
 }
 
 // dataSourceImagesImageV2Read performs the image lookup.
-func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
+func dataSourceImagesImageV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
 
 	imageClient, err := cfg.ImageV2Client(region)
 	if err != nil {
-		return diag.Errorf("error creating IMS client: %s", err)
-	}
-
-	imageType := d.Get("visibility").(string)
-	if imageType == "public" {
-		imageType = "gold"
+		return diag.Errorf("error creating IMS v2 client: %s", err)
 	}
 
 	listOpts := cloudimages.ListOpts{
-		Name:           d.Get("name").(string),
-		Owner:          d.Get("owner").(string),
-		SortKey:        d.Get("sort_key").(string),
-		SortDir:        d.Get("sort_direction").(string),
-		Tag:            d.Get("tag").(string),
-		Platform:       d.Get("os").(string),
-		OsVersion:      d.Get("os_version").(string),
-		Architecture:   d.Get("architecture").(string),
-		VirtualEnvType: d.Get("image_type").(string),
-		FlavorId:       d.Get("flavor_id").(string),
-		Imagetype:      imageType,
-		Status:         "active",
+		ID:                  d.Get("image_id").(string),
+		Name:                d.Get("name").(string),
+		VirtualEnvType:      d.Get("image_type").(string),
+		WholeImage:          d.Get("is_whole_image").(bool),
+		Imagetype:           buildImageTypeParam(d),
+		Owner:               d.Get("owner").(string),
+		FlavorId:            d.Get("flavor_id").(string),
+		SortKey:             d.Get("sort_key").(string),
+		SortDir:             d.Get("sort_direction").(string),
+		Platform:            d.Get("os").(string),
+		Architecture:        d.Get("architecture").(string),
+		Tag:                 d.Get("tag").(string),
+		EnterpriseProjectID: cfg.GetEnterpriseProjectID(d, "all_granted_eps"),
+		// Default query status for **active** images.
+		Status: "active",
 	}
-
-	if epsId := cfg.GetEnterpriseProjectID(d); epsId != "" {
-		listOpts.EnterpriseProjectID = epsId
-	} else {
-		listOpts.EnterpriseProjectID = "all_granted_eps"
-	}
-
-	log.Printf("[DEBUG] List Options: %#v", listOpts)
 
 	allPages, err := cloudimages.List(imageClient, listOpts).AllPages()
 	if err != nil {
@@ -227,7 +239,7 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 
 	allImages, err := cloudimages.ExtractImages(allPages)
 	if err != nil {
-		return diag.Errorf("unable to retrieve images: %s", err)
+		return diag.Errorf("unable to extract images: %s", err)
 	}
 
 	if len(allImages) < 1 {
@@ -235,7 +247,7 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 			"Please change your search criteria and try again.")
 	}
 
-	// filter images by name_regex
+	// Filter images by `name_regex`.
 	var filteredImages []cloudimages.Image
 	if nameRegex, ok := d.GetOk("name_regex"); ok {
 		r, err := regexp.Compile(nameRegex.(string))
@@ -257,6 +269,7 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 			"Please change your search criteria and try again.")
 	}
 
+	// Filter images by `most_recent`.
 	var image cloudimages.Image
 	if len(filteredImages) > 1 {
 		recent := d.Get("most_recent").(bool)
@@ -270,37 +283,38 @@ func dataSourceImagesImageV2Read(ctx context.Context, d *schema.ResourceData, me
 		image = filteredImages[0]
 	}
 
-	log.Printf("[DEBUG] Single Image found: %s", image.ID)
-	return dataSourceImagesImageV2Attributes(ctx, d, &image)
+	return dataSourceImagesImageV2Attributes(region, d, &image)
 }
 
 // dataSourceImagesImageV2Attributes populates the fields of an Image resource.
-func dataSourceImagesImageV2Attributes(_ context.Context, d *schema.ResourceData, image *cloudimages.Image) diag.Diagnostics {
-	log.Printf("[DEBUG] Get IMS image details: %#v", image)
+func dataSourceImagesImageV2Attributes(region string, d *schema.ResourceData, image *cloudimages.Image) diag.Diagnostics {
 	d.SetId(image.ID)
 
-	imageType := image.Imagetype
-	if imageType == "gold" {
-		imageType = "public"
-	}
 	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("image_id", image.ID),
 		d.Set("name", image.Name),
-		d.Set("visibility", imageType),
-		d.Set("container_format", image.ContainerFormat),
-		d.Set("disk_format", image.DiskFormat),
-		d.Set("min_disk_gb", image.MinDisk),
-		d.Set("min_ram_mb", image.MinRam),
-		d.Set("owner", image.Owner),
-		d.Set("protected", image.Protected),
 		d.Set("image_type", image.VirtualEnvType),
+		d.Set("visibility", flattenVisibility(image.Imagetype)),
+		d.Set("owner", image.Owner),
 		d.Set("os", image.Platform),
+		d.Set("architecture", getArchitecture(image.SupportArm)),
+		d.Set("enterprise_project_id", image.EnterpriseProjectID),
 		d.Set("os_version", image.OsVersion),
-		d.Set("checksum", image.Checksum),
 		d.Set("file", image.File),
 		d.Set("schema", image.Schema),
-		d.Set("enterprise_project_id", image.EnterpriseProjectID),
 		d.Set("status", image.Status),
+		d.Set("description", image.Description),
+		d.Set("protected", image.Protected),
+		d.Set("container_format", image.ContainerFormat),
+		d.Set("min_ram_mb", image.MinRam),
+		d.Set("max_ram_mb", getMaxRAM(image.MaxRam)),
+		d.Set("min_disk_gb", image.MinDisk),
+		d.Set("min_ram_mb", image.MinRam),
+		d.Set("disk_format", image.DiskFormat),
+		d.Set("data_origin", image.DataOrigin),
 		d.Set("backup_id", image.BackupID),
+		d.Set("active_at", image.ActiveAt),
 		d.Set("created_at", image.CreatedAt.Format(time.RFC3339)),
 		d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339)),
 	)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Refactor `images_images` and `images_image` dataSources, the modifications include the following:

1. Add `image_id` and `is_whole_image` fliter parameters.
2. Change the parameter `os_version` to a property, because the API documentation does not support this parameter.
3. Deprecated attributes `checksum` and `metadata`, because these attributes have been marked as temporarily unused in the API documentation.
4. Add `description`, `max_ram_mb`, `data_origin`, and `active_at` attributes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
4. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Refactor `images_images` and `images_image` dataSources

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### `images_images` dataSource test
```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImagesDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImagesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccImagesDataSource_basic
=== PAUSE TestAccImagesDataSource_basic
=== CONT  TestAccImagesDataSource_basic
--- PASS: TestAccImagesDataSource_basic (31.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       31.795s


$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImagesDataSource_private"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImagesDataSource_private_basic -timeout 360m -parallel 4
=== RUN   TestAccImagesDataSource_private_basic
=== PAUSE TestAccImagesDataSource_private_basic
=== CONT  TestAccImagesDataSource_private_basic
--- PASS: TestAccImagesDataSource_private_basic (460.09s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       460.163s

```

### `images_image` dataSource test
```
$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImageDataSource_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImageDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccImageDataSource_basic
=== PAUSE TestAccImageDataSource_basic
=== CONT  TestAccImageDataSource_basic
--- PASS: TestAccImageDataSource_basic (27.29s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       27.355s


$ make testacc TEST="./huaweicloud/services/acceptance/ims" TESTARGS="-run TestAccImageDataSource_private"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ims -v -run TestAccImageDataSource_private -timeout 360m -parallel 4
=== RUN   TestAccImageDataSource_private
=== PAUSE TestAccImageDataSource_private
=== CONT  TestAccImageDataSource_private
--- PASS: TestAccImageDataSource_private (407.18s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ims       407.225s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
