### PR TITLE
feat(ces): add data source to get the list of CES one-click alarm rules

### DIFF
--- a/docs/data-sources/ces_one_click_alarm_rules.md
+++ b/docs/data-sources/ces_one_click_alarm_rules.md
@@ -1,0 +1,127 @@
+---
+subcategory: "Cloud Eye (CES)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ces_one_click_alarm_rules"
+description: |-
+  Use this data source to get the list of CES one-click alarm rules.
+---
+
+# huaweicloud_ces_one_click_alarm_rules
+
+Use this data source to get the list of CES one-click alarm rules.
+
+## Example Usage
+
+```hcl
+variable "one_click_alarm_id" {}
+
+data "huaweicloud_ces_one_click_alarm_rules" test {
+  one_click_alarm_id = var.one_click_alarm_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `one_click_alarm_id` - (Required, String) Specifies the one-click monitoring ID for a service.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `alarms` - The alarm rule list.
+
+  The [alarms](#alarms_struct) structure is documented below.
+
+<a name="alarms_struct"></a>
+The `alarms` block supports:
+
+* `alarm_id` - The ID of an alarm rule.
+
+* `name` - The alarm rule name.
+
+* `description` - The supplementary information about an alarm rule.
+
+* `namespace` - The metric namespace.
+
+* `policies` - The alarm policy list.
+
+  The [policies](#alarms_policies_struct) structure is documented below.
+
+* `resources` - The resource list.
+
+  The [resources](#alarms_resources_struct) structure is documented below.
+
+* `type` - The alarm rule type.
+
+* `enabled` - Whether to generate alarms when the alarm triggering conditions are met.
+
+* `notification_enabled` - Whether the alarm notification is enabled.
+
+* `alarm_notifications` - The action to be triggered by an alarm.
+
+  The [alarm_notifications](#notifications_struct) structure is documented below.
+
+* `ok_notifications` - The action to be triggered after an alarm is cleared.
+
+  The [ok_notifications](#notifications_struct) structure is documented below.
+
+* `notification_begin_time` - The time when the alarm notification was enabled.
+
+* `notification_end_time` - The time when the alarm notification was disabled.
+
+<a name="alarms_policies_struct"></a>
+The `policies` block supports:
+
+* `alarm_policy_id` - The alarm policy ID.
+
+* `metric_name` - The metric name.
+
+* `period` - How often to generate an alarm.
+
+* `comparison_operator` - The operator of an alarm threshold.
+
+* `filter` - The roll up method.
+
+* `value` - The threshold.
+
+* `unit` - The metric unit.
+
+* `count` - The number of times that the alarm triggering conditions are met.
+
+* `suppress_duration` - The suppression period.
+
+* `level` - The alarm severity.
+
+* `enabled` - Whether the one-click monitoring is enabled.
+
+<a name="alarms_resources_struct"></a>
+The `resources` block supports:
+
+* `resource_group_id` - The resource group ID.
+
+* `resource_group_name` - The resource group name.
+
+* `dimensions` - The dimension information.
+
+  The [dimensions](#resources_dimensions_struct) structure is documented below.
+
+<a name="resources_dimensions_struct"></a>
+The `dimensions` block supports:
+
+* `name` - The name of the metric dimension.
+
+* `value` - The value of the metric dimension.
+
+<a name="notifications_struct"></a>
+The `alarm_notifications` or `ok_notifications` block supports:
+
+* `type` - The notification type.
+
+* `notification_list` - The list of objects to be notified if the alarm status changes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -538,6 +538,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_ces_event_details":                    ces.DataSourceCesEventDetails(),
 			"huaweicloud_ces_metrics":                          ces.DataSourceCesMetrics(),
 			"huaweicloud_ces_one_click_alarms":                 ces.DataSourceCesOneClickAlarms(),
+			"huaweicloud_ces_one_click_alarm_rules":            ces.DataSourceCesOneClickAlarmRules(),
 			"huaweicloud_ces_resource_groups":                  ces.DataSourceCesGroups(),
 			"huaweicloud_ces_resource_group_service_resources": ces.DataSourceCesGroupServiceResources(),
 

--- a/huaweicloud/services/acceptance/ces/data_source_huaweicloud_ces_one_click_alarm_rules_test.go
+++ b/huaweicloud/services/acceptance/ces/data_source_huaweicloud_ces_one_click_alarm_rules_test.go
@@ -1,0 +1,58 @@
+package ces
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceCesOneClickAlarmRules_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_ces_one_click_alarm_rules.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceCesOneClickAlarmRules_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.alarm_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.name"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.namespace"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.policies.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.policies.0.alarm_policy_id"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.policies.0.metric_name"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.enabled"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.notification_enabled"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.alarm_notifications.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.alarm_notifications.0.notification_list.#"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.notification_begin_time"),
+					resource.TestCheckResourceAttrSet(dataSource, "alarms.0.notification_end_time"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceCesOneClickAlarmRules_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_ces_one_click_alarm_rules" "test" {
+  one_click_alarm_id = huaweicloud_ces_one_click_alarm.test.id
+}
+`, testDataSourceCesOneClickAlarmRules_base(name))
+}
+
+func testDataSourceCesOneClickAlarmRules_base(name string) string {
+	return testOneClickAlarm_basic(name)
+}

--- a/huaweicloud/services/ces/data_source_huaweicloud_ces_one_click_alarm_rules.go
+++ b/huaweicloud/services/ces/data_source_huaweicloud_ces_one_click_alarm_rules.go
@@ -1,0 +1,352 @@
+package ces
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/tidwall/gjson"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/httphelper"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/schemas"
+)
+
+func DataSourceCesOneClickAlarmRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceCesOneClickAlarmRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"one_click_alarm_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the one-click monitoring ID for a service.`,
+			},
+			"alarms": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The alarm rule list.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alarm_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of an alarm rule.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The alarm rule name.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The supplementary information about an alarm rule.`,
+						},
+						"namespace": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The metric namespace.`,
+						},
+						"policies": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The alarm policy list.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"alarm_policy_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The alarm policy ID.`,
+									},
+									"metric_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The metric name.`,
+									},
+									"period": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `How often to generate an alarm.`,
+									},
+									"comparison_operator": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The operator of an alarm threshold.`,
+									},
+									"filter": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The roll up method.`,
+									},
+									"value": {
+										Type:        schema.TypeFloat,
+										Computed:    true,
+										Description: `The threshold.`,
+									},
+									"unit": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The metric unit.`,
+									},
+									"count": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The number of times that the alarm triggering conditions are met.`,
+									},
+									"suppress_duration": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The suppression period.`,
+									},
+									"level": {
+										Type:        schema.TypeInt,
+										Computed:    true,
+										Description: `The alarm severity.`,
+									},
+									"enabled": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: `Whether the one-click monitoring is enabled.`,
+									},
+								},
+							},
+						},
+						"resources": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The resource list.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"resource_group_id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The resource group ID.`,
+									},
+									"resource_group_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The resource group name.`,
+									},
+									"dimensions": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: `The dimension information.`,
+										Elem:        alarmResourcesDimensionsElem(),
+									},
+								},
+							},
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The alarm rule type.`,
+						},
+						"enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether to generate alarms when the alarm triggering conditions are met.`,
+						},
+						"notification_enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the alarm notification is enabled.`,
+						},
+						"alarm_notifications": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        actionSchema(),
+							Description: `The action to be triggered by an alarm.`,
+						},
+						"ok_notifications": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        actionSchema(),
+							Description: `The action to be triggered after an alarm is cleared.`,
+						},
+						"notification_begin_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the alarm notification was enabled.`,
+						},
+						"notification_end_time": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the alarm notification was disabled.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// alarmResourcesDimensionsElem
+// The Elem of "alarm.resources.dimensions"
+func alarmResourcesDimensionsElem() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The name of the metric dimension.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The value of the metric dimension.`,
+			},
+		},
+	}
+}
+
+func actionSchema() *schema.Resource {
+	sc := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The notification type.`,
+			},
+			"notification_list": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of objects to be notified if the alarm status changes.`,
+			},
+		},
+	}
+	return &sc
+}
+
+type OneClickAlarmRulesDSWrapper struct {
+	*schemas.ResourceDataWrapper
+	Config *config.Config
+}
+
+func newOneClickAlarmRulesDSWrapper(d *schema.ResourceData, meta interface{}) *OneClickAlarmRulesDSWrapper {
+	return &OneClickAlarmRulesDSWrapper{
+		ResourceDataWrapper: schemas.NewSchemaWrapper(d),
+		Config:              meta.(*config.Config),
+	}
+}
+
+func dataSourceCesOneClickAlarmRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	wrapper := newOneClickAlarmRulesDSWrapper(d, meta)
+	lisOneCliAlaRulRst, err := wrapper.ListOneClickAlarmRules()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(id)
+
+	err = wrapper.listOneClickAlarmRulesToSchema(lisOneCliAlaRulRst)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// @API CES GET /v2/{project_id}/one-click-alarms/{one_click_alarm_id}/alarms
+func (w *OneClickAlarmRulesDSWrapper) ListOneClickAlarmRules() (*gjson.Result, error) {
+	client, err := w.NewClient(w.Config, "ces")
+	if err != nil {
+		return nil, err
+	}
+
+	uri := "/v2/{project_id}/one-click-alarms/{one_click_alarm_id}/alarms"
+	uri = strings.ReplaceAll(uri, "{one_click_alarm_id}", w.Get("one_click_alarm_id").(string))
+	return httphelper.New(client).
+		Method("GET").
+		URI(uri).
+		Request().
+		Result()
+}
+
+func (w *OneClickAlarmRulesDSWrapper) listOneClickAlarmRulesToSchema(body *gjson.Result) error {
+	d := w.ResourceData
+	mErr := multierror.Append(nil,
+		d.Set("region", w.Config.GetRegion(w.ResourceData)),
+		d.Set("alarms", schemas.SliceToList(body.Get("alarms"),
+			func(alarms gjson.Result) any {
+				return map[string]any{
+					"alarm_id":                alarms.Get("alarm_id").Value(),
+					"name":                    alarms.Get("name").Value(),
+					"namespace":               alarms.Get("namespace").Value(),
+					"type":                    alarms.Get("type").Value(),
+					"notification_enabled":    alarms.Get("notification_enabled").Value(),
+					"notification_begin_time": alarms.Get("notification_begin_time").Value(),
+					"notification_end_time":   alarms.Get("notification_end_time").Value(),
+					"description":             alarms.Get("description").Value(),
+					"policies": schemas.SliceToList(alarms.Get("policies"),
+						func(policies gjson.Result) any {
+							return map[string]any{
+								"alarm_policy_id":     policies.Get("alarm_policy_id").Value(),
+								"metric_name":         policies.Get("metric_name").Value(),
+								"period":              policies.Get("period").Value(),
+								"comparison_operator": policies.Get("comparison_operator").Value(),
+								"filter":              policies.Get("filter").Value(),
+								"value":               policies.Get("value").Value(),
+								"unit":                policies.Get("unit").Value(),
+								"count":               policies.Get("count").Value(),
+								"suppress_duration":   policies.Get("suppress_duration").Value(),
+								"level":               policies.Get("level").Value(),
+								"enabled":             policies.Get("enabled").Value(),
+							}
+						},
+					),
+					"resources": schemas.SliceToList(alarms.Get("resources"),
+						func(resources gjson.Result) any {
+							return map[string]any{
+								"resource_group_id":   resources.Get("resource_group_id").Value(),
+								"resource_group_name": resources.Get("resource_group_name").Value(),
+								"dimensions":          w.setAlaResDim(resources),
+							}
+						},
+					),
+					"enabled": alarms.Get("enabled").Value(),
+					"alarm_notifications": schemas.SliceToList(alarms.Get("alarm_notifications"),
+						func(alarmNotifications gjson.Result) any {
+							return map[string]any{
+								"type":              alarmNotifications.Get("type").Value(),
+								"notification_list": schemas.SliceToStrList(alarmNotifications.Get("notification_list")),
+							}
+						},
+					),
+					"ok_notifications": schemas.SliceToList(alarms.Get("ok_notifications"),
+						func(okNotifications gjson.Result) any {
+							return map[string]any{
+								"type":              okNotifications.Get("type").Value(),
+								"notification_list": schemas.SliceToStrList(okNotifications.Get("notification_list")),
+							}
+						},
+					),
+				}
+			},
+		)),
+	)
+	return mErr.ErrorOrNil()
+}
+
+func (*OneClickAlarmRulesDSWrapper) setAlaResDim(resources gjson.Result) any {
+	return schemas.SliceToList(resources.Get("dimensions"), func(dimensions gjson.Result) any {
+		return map[string]any{
+			"name":  dimensions.Get("name").Value(),
+			"value": dimensions.Get("value").Value(),
+		}
+	})
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 add data source to get the list of CES one-click alarm rules
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.  add data source to get the list of CES one-click alarm rules
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/ces" TESTARGS="-run TestAccDataSourceCesOneClickAlarmRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ces -v -run TestAccDataSourceCesOneClickAlarmRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceCesOneClickAlarmRules_basic
=== PAUSE TestAccDataSourceCesOneClickAlarmRules_basic
=== CONT  TestAccDataSourceCesOneClickAlarmRules_basic
--- PASS: TestAccDataSourceCesOneClickAlarmRules_basic (41.25s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ces       41.382s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
