### PR TITLE
feat(cse/engine): add new data source to query engines

### DIFF
--- a/docs/data-sources/cse_microservice_engines.md
+++ b/docs/data-sources/cse_microservice_engines.md
@@ -1,0 +1,93 @@
+---
+subcategory: "Cloud Service Engine (CSE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cse_microservice_engines"
+description: |-
+  Use this data source to query available microservice engines within HuaweiCloud.
+---
+
+# huaweicloud_cse_microservice_engines
+
+Use this data source to query available microservice engines within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_cse_microservice_engines" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where dedicated microservice engines are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `engines` - All queried dedicated microservice engines.  
+  The [engines](#cse_microservice_engines) structure is documented below.
+
+<a name="cse_microservice_engines"></a>
+The `engines` block supports:
+
+* `id` - The ID of the dedicated microservice engine.
+
+* `name` - The name of the dedicated microservice engine.
+
+* `flavor` - The flavor name of the dedicated microservice engine.
+
+* `availability_zones` - The list of availability zones.
+
+* `network_id` - The network ID of the subnet to which the dedicated microservice engine belongs.
+
+* `auth_type` - The authentication method for the dedicated microservice engine
+  + **RBAC**
+  + **NONE**
+
+* `version` - The version of the dedicated microservice engine.
+
+* `enterprise_project_id` - The enterprise project ID to which the dedicated microservice engine belongs.
+
+* `description` - The description of the dedicated microservice engine.
+
+* `eip_id` - The EIP ID to which the dedicated microservice engine assocated.
+
+* `extend_params` - The additional parameters for the dedicated microservice engine.
+
+* `service_limit` - The maximum number of the microservice resources.
+
+* `instance_limit` - The maximum number of the microservice instance resources.
+
+* `service_registry_addresses` - The connection addresses of service center.  
+  The [service_registry_addresses](#cse_microservice_engine_addresses) structure is documented below.
+
+* `config_center_addresses` - The addresses of config center.  
+  The [config_center_addresses](#cse_microservice_engine_addresses) structure is documented below.
+
+* `status` - The status of the dedicated microservice engine.
+  + **Creating**
+  + **Available**
+  + **Unavailable**
+  + **Deleting**
+  + **Deleted**
+  + **Upgrading**
+  + **Modifying**
+  + **CreateFailed**
+  + **DeleteFailed**
+  + **UpgradeFailed**
+  + **ModifyFailed**
+  + **Freezed**
+
+* `created_at` - The creation time of the dedicated microservice engine, in RFC3339 format.
+
+<a name="cse_microservice_engine_addresses"></a>
+The `service_registry_addresses` and `config_center_addresses` blocks support:
+
+* `private` - The internal access address.
+
+* `public` - The public access address.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -576,6 +576,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_cph_phone_flavors":  cph.DataSourcePhoneFlavors(),
 			"huaweicloud_cph_phone_images":   cph.DataSourcePhoneImages(),
 
+			"huaweicloud_cse_microservice_engines": cse.DataSourceMicroserviceEngines(),
+
 			"huaweicloud_csms_events":                   dew.DataSourceDewCsmsEvents(),
 			"huaweicloud_csms_secrets":                  dew.DataSourceDewCsmsSecrets(),
 			"huaweicloud_csms_secret_version":           dew.DataSourceDewCsmsSecret(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -344,6 +344,8 @@ var (
 
 	HW_CC_PERMISSION_ID = os.Getenv("HW_CC_PERMISSION_ID")
 
+	HW_CSE_MICROSERVICE_ENGINE_ID = os.Getenv("HW_CSE_MICROSERVICE_ENGINE_ID")
+
 	HW_CSS_LOCAL_DISK_FLAVOR  = os.Getenv("HW_CSS_LOCAL_DISK_FLAVOR")
 	HW_CSS_ELB_AGENCY         = os.Getenv("HW_CSS_ELB_AGENCY")
 	HW_CSS_UPGRADE_AGENCY     = os.Getenv("HW_CSS_UPGRADE_AGENCY")
@@ -1871,6 +1873,13 @@ func TestAccPreCheckCCAuth(t *testing.T) {
 func TestAccPreCheckCCPermission(t *testing.T) {
 	if HW_CC_PERMISSION_ID == "" {
 		t.Skip("HW_CC_PERMISSION_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCSEMicroserviceEngineID(t *testing.T) {
+	if HW_CSE_MICROSERVICE_ENGINE_ID == "" {
+		t.Skip("HW_CSE_MICROSERVICE_ENGINE_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engines_test.go
+++ b/huaweicloud/services/acceptance/cse/data_source_huaweicloud_cse_microservice_engines_test.go
@@ -1,0 +1,50 @@
+package cse
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataMicroserviceEngines_basic(t *testing.T) {
+	var (
+		all = "data.huaweicloud_cse_microservice_engines.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataMicroserviceEngines_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckOutput("filter_engine_by_id", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataMicroserviceEngines_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  id_filter_result = [
+	for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
+  ]
+}
+
+output "filter_engine_by_id" {
+  value = length(local.id_filter_result) > 0
+}
+`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID)
+}

--- a/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engines.go
+++ b/huaweicloud/services/cse/data_source_huaweicloud_cse_microservice_engines.go
@@ -1,0 +1,278 @@
+package cse
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSE GET /v2/{project_id}/enginemgr/engines
+func DataSourceMicroserviceEngines() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceMicroserviceEnginesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where dedicated microservice engines are located.`,
+			},
+			"engines": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the dedicated microservice engine.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the dedicated microservice engine.`,
+						},
+						"flavor": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The flavor name of the dedicated microservice engine.`,
+						},
+						"availability_zones": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of availability zones.`,
+						},
+						"network_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The network ID of the subnet to which the dedicated microservice engine belongs.`,
+						},
+						"auth_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The authentication method for the dedicated microservice engine.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version of the dedicated microservice engine.`,
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The enterprise project ID to which the dedicated microservice engine belongs.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the dedicated microservice engine.`,
+						},
+						"eip_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The EIP ID to which the dedicated microservice engine assocated.`,
+						},
+						"extend_params": {
+							Type:        schema.TypeMap,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The additional parameters for the dedicated microservice engine.`,
+						},
+						"service_limit": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum number of the microservice resources.`,
+						},
+						"instance_limit": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: `The maximum number of the microservice instance resources.`,
+						},
+						"service_registry_addresses": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"private": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The internal access address.`,
+									},
+									"public": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The public access address.`,
+									},
+								},
+							},
+							Description: `The connection addresses of service center.`,
+						},
+						"config_center_addresses": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"private": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The internal access address.`,
+									},
+									"public": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The public access address.`,
+									},
+								},
+							},
+							Description: `The addresses of config center.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the dedicated microservice engine.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the dedicated microservice engine, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: `All queried dedicated microservice engines.`,
+			},
+		},
+	}
+}
+
+func queryMicroserviceEngines(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v2/{project_id}/enginemgr/engines?type=CSE&limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		listPathWithOffset := fmt.Sprintf("%s&offset=%d", listPath, offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, fmt.Errorf("error querying microservice engines: %s", err)
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		engines := utils.PathSearch("data", respBody, make([]interface{}, 0)).([]interface{})
+		// When the number of remaining engines is 1, both offset 0 and 1 will return this engine object.
+		// So it needs to be included in the total determination.
+		if len(engines) < 1 || offset >= int(utils.PathSearch("total", respBody, float64(0)).(float64)) {
+			break
+		}
+		result = append(result, engines...)
+		offset += len(engines)
+	}
+	return result, nil
+}
+
+func flattenMicroserviceEngineServiceRegistryAddresses(engineDetail interface{}) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"private": utils.PathSearch("serviceEndpoint.serviceCenter.masterEntrypoint", engineDetail, nil),
+			"public":  utils.PathSearch("publicServiceEndpoint.serviceCenter.masterEntrypoint", engineDetail, nil),
+		},
+	}
+}
+
+func flattenMicroserviceEngineConfigCenterAddresses(engineDetail interface{}) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
+			"private": utils.PathSearch("serviceEndpoint.kie.masterEntrypoint", engineDetail, nil),
+			"public":  utils.PathSearch("publicServiceEndpoint.kie.masterEntrypoint", engineDetail, nil),
+		},
+	}
+}
+
+func convertStrNumberToIntIgnoreErr(strNum string) int {
+	result, err := strconv.Atoi(strNum)
+	if err != nil {
+		log.Printf("[ERROR] unable to convert object from type string to type int: %s", err)
+		return 0
+	}
+	return result
+}
+
+func flattenAllMicroserviceEngines(engines []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(engines))
+
+	for _, engineDetail := range engines {
+		result = append(result, map[string]interface{}{
+			"id":                         utils.PathSearch("id", engineDetail, nil),
+			"name":                       utils.PathSearch("name", engineDetail, nil),
+			"flavor":                     utils.PathSearch("flavor", engineDetail, nil),
+			"availability_zones":         utils.PathSearch("reference.azList", engineDetail, nil),
+			"network_id":                 utils.PathSearch("reference.networkId", engineDetail, nil),
+			"auth_type":                  utils.PathSearch("authType", engineDetail, nil),
+			"version":                    utils.PathSearch("version", engineDetail, nil),
+			"enterprise_project_id":      utils.PathSearch("enterpriseProjectId", engineDetail, nil),
+			"description":                utils.PathSearch("description", engineDetail, nil),
+			"eip_id":                     utils.PathSearch("reference.publicIpId", engineDetail, nil),
+			"extend_params":              utils.PathSearch("reference.inputs", engineDetail, nil),
+			"service_limit":              convertStrNumberToIntIgnoreErr(utils.PathSearch("reference.serviceLimit", engineDetail, "").(string)),
+			"instance_limit":             convertStrNumberToIntIgnoreErr(utils.PathSearch("reference.instanceLimit", engineDetail, "").(string)),
+			"service_registry_addresses": flattenMicroserviceEngineServiceRegistryAddresses(engineDetail),
+			"config_center_addresses":    flattenMicroserviceEngineConfigCenterAddresses(engineDetail),
+			"status":                     utils.PathSearch("status", engineDetail, nil),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("createTime",
+				engineDetail, float64(0)).(float64))/1000, false),
+		})
+	}
+
+	return result
+}
+
+func dataSourceMicroserviceEnginesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.NewServiceClient("cse", region)
+	if err != nil {
+		return diag.Errorf("error creating CSE client: %s", err)
+	}
+
+	engines, err := queryMicroserviceEngines(client)
+	if err != nil {
+		return diag.Errorf("error querying CSE microservice engines: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("engines", flattenAllMicroserviceEngines(engines)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports new data source that used to query CSE dedicated microservice engines.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query engines
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o cse -f TestAccDataMicroserviceEngines_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccDataMicroserviceEngines_basic -timeout 360m -parallel 10
=== RUN   TestAccDataMicroserviceEngines_basic
=== PAUSE TestAccDataMicroserviceEngines_basic
=== CONT  TestAccDataMicroserviceEngines_basic
--- PASS: TestAccDataMicroserviceEngines_basic (15.31s)
PASS
coverage: 14.2% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       15.351s coverage: 14.2% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
