### PR TITLE
feat(dws/cluster): supports modifying description and security group

### DIFF
--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -80,7 +80,7 @@ The following arguments are supported:
 * `network_id` - (Required, String, ForceNew) The subnet ID.
   Changing this parameter will create a new resource.
 
-* `security_group_id` - (Required, String, ForceNew) The security group ID.
+* `security_group_id` - (Required, String) Specifies the security group ID of the cluster.
   Changing this parameter will create a new resource.
 
 * `availability_zone` - (Required, String, ForceNew) The availability zone in which to create the cluster instance.
@@ -124,12 +124,14 @@ The following arguments are supported:
 * `keep_last_manual_snapshot` - (Optional, Int) The number of latest manual snapshots that need to be
   retained when deleting the cluster.
 
-* `logical_cluster_enable` - (Optional, Bool) Specified whether to enable logical cluster. The switch needs to be turned
+* `logical_cluster_enable` - (Optional, Bool) Specifies whether to enable logical cluster. The switch needs to be turned
   on before creating a logical cluster.
 
 * `elb_id` - (Optional, String) Specifies the ID of the ELB load balancer.
 
-* `lts_enable` - (Optional, Bool) Specified whether to enable LTS. The default value is **false**.
+* `lts_enable` - (Optional, Bool) Specifies whether to enable LTS. The default value is **false**.
+
+* `description` - (Optional, String) Specifies the description of the cluster.
 
 <a name="DwsCluster_PublicIp"></a>
 The `PublicIp` block supports:

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_cluster_test.go
@@ -63,6 +63,8 @@ func TestAccResourceCluster_basicV1(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip.0.eip_id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "val"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "huaweicloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created v1 cluster by terraform script"),
 				),
 			},
 			{
@@ -77,6 +79,8 @@ func TestAccResourceCluster_basicV1(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "public_ip.0.eip_id", "huaweicloud_vpc_eip.test.0", "id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "val"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar1"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "huaweicloud_networking_secgroup.test2", "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated cluster info"),
 				),
 			},
 			{
@@ -84,6 +88,7 @@ func TestAccResourceCluster_basicV1(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "public_ip.0.public_bind_type", dws.PublicBindTypeNotUse),
 					resource.TestCheckResourceAttr(resourceName, "public_ip.0.eip_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
@@ -140,6 +145,7 @@ resource "huaweicloud_dws_cluster" "test" {
   user_pwd               = "%[4]s"
   logical_cluster_enable = true
   enterprise_project_id  = "%[5]s"
+  description            = "Created v1 cluster by terraform script"
 
   public_ip {
     # Automatically purchase EIP when creating cluster.
@@ -160,6 +166,11 @@ func testAccDwsCluster_basic_step2(rName, password string) string {
 
 %[2]s
 
+resource "huaweicloud_networking_secgroup" "test2" {
+  name                 = "%[3]s_test2"
+  delete_default_rules = true
+}
+
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_dws_cluster" "test" {
@@ -168,12 +179,13 @@ resource "huaweicloud_dws_cluster" "test" {
   number_of_node         = 6
   vpc_id                 = huaweicloud_vpc.test.id
   network_id             = huaweicloud_vpc_subnet.test.id
-  security_group_id      = huaweicloud_networking_secgroup.test.id
+  security_group_id      = huaweicloud_networking_secgroup.test2.id
   availability_zone      = data.huaweicloud_availability_zones.test.names[0]
   user_name              = "test_cluster_admin"
   user_pwd               = "%[4]s"
   logical_cluster_enable = false
   enterprise_project_id  = "%[5]s"
+  description            = "Updated cluster info"
 
   public_ip {
     # Modify the associated EIP.
@@ -196,6 +208,11 @@ func testAccDwsCluster_basic_step3(rName, password string) string {
 
 %[2]s
 
+resource "huaweicloud_networking_secgroup" "test2" {
+  name                 = "%[3]s_test2"
+  delete_default_rules = true
+}
+
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_dws_cluster" "test" {
@@ -204,7 +221,7 @@ resource "huaweicloud_dws_cluster" "test" {
   number_of_node         = 6
   vpc_id                 = huaweicloud_vpc.test.id
   network_id             = huaweicloud_vpc_subnet.test.id
-  security_group_id      = huaweicloud_networking_secgroup.test.id
+  security_group_id      = huaweicloud_networking_secgroup.test2.id
   availability_zone      = data.huaweicloud_availability_zones.test.names[0]
   user_name              = "test_cluster_admin"
   user_pwd               = "%[4]s"
@@ -269,6 +286,8 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "elb.0.name", name+"_elb0"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "huaweicloud_networking_secgroup.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created v2 cluster by terraform script"),
 				),
 			},
 			// Assert all modifiable parameters.
@@ -285,6 +304,8 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "version"),
 					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_MIGRATE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "elb.0.name", name+"_elb1"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_id", "huaweicloud_networking_secgroup.test2", "id"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated cluster info"),
 				),
 			},
 			// Assert that ELB and EIP are unbound and delete all tags.
@@ -297,6 +318,7 @@ func TestAccResourceCluster_basicV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "public_ip.0.eip_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "elb.0.name", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 				),
 			},
 			// Assert whether the restart is successful.
@@ -319,6 +341,11 @@ func testAccDwsCluster_basicV2_base(rName string) string {
 %[1]s
 
 %[2]s
+
+resource "huaweicloud_networking_secgroup" "test2" {
+  name                 = "%[3]s_test2"
+  delete_default_rules = true
+}
 
 data "huaweicloud_availability_zones" "test" {}
 
@@ -367,6 +394,7 @@ resource "huaweicloud_dws_cluster" "testv2" {
   logical_cluster_enable = false
   enterprise_project_id  = "%[4]s"
   elb_id                 = huaweicloud_elb_loadbalancer.test[0].id
+  description            = "Created v2 cluster by terraform script"
 
   public_ip {
     # Binging a EIP for cluster.
@@ -397,7 +425,7 @@ resource "huaweicloud_dws_cluster" "testv2" {
   number_of_node         = 6
   vpc_id                 = huaweicloud_vpc.test.id
   network_id             = huaweicloud_vpc_subnet.test.id
-  security_group_id      = huaweicloud_networking_secgroup.test.id
+  security_group_id      = huaweicloud_networking_secgroup.test2.id
   availability_zone      = data.huaweicloud_availability_zones.test.names[0]
   user_name              = "test_cluster_admin"
   user_pwd               = "%[3]s"
@@ -407,6 +435,7 @@ resource "huaweicloud_dws_cluster" "testv2" {
   logical_cluster_enable = false
   enterprise_project_id  = "%[4]s"
   elb_id                 = huaweicloud_elb_loadbalancer.test[1].id
+  description            = "Updated cluster info"
 
   public_ip {
     # Modify the associated EIP.
@@ -436,7 +465,7 @@ resource "huaweicloud_dws_cluster" "testv2" {
   number_of_node         = 6
   vpc_id                 = huaweicloud_vpc.test.id
   network_id             = huaweicloud_vpc_subnet.test.id
-  security_group_id      = huaweicloud_networking_secgroup.test.id
+  security_group_id      = huaweicloud_networking_secgroup.test2.id
   availability_zone      = data.huaweicloud_availability_zones.test.names[0]
   user_name              = "test_cluster_admin"
   user_pwd               = "%[3]s"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The cluster supports modifying description and security group.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add description parameter for the cluster resource.
2. Provides modification capabilities for security_group_id parameter.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceCluster'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV1
=== PAUSE TestAccResourceCluster_basicV1
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== RUN   TestAccResourceCluster_basicV2_mutilAZs
=== PAUSE TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV1
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV2
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
    acceptance.go:2051: HW_DWS_MUTIL_AZS must be set for the acceptance test
--- SKIP: TestAccResourceCluster_basicV2_mutilAZs (0.00s)
--- PASS: TestAccResourceCluster_basicV1 (2803.11s)
--- PASS: TestAccResourceCluster_basicV2 (3438.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       3438.393s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
