### PR TITLE
feat(CDN): CDN domain resource support new field

### DIFF
--- a/docs/resources/cdn_domain.md
+++ b/docs/resources/cdn_domain.md
@@ -160,6 +160,14 @@ resource "huaweicloud_cdn_domain" "domain_1" {
       target_url = "/new/$1/$2.html"
     }
 
+    user_agent_filter {
+      type          = "black"
+      include_empty = "false"
+      ua_list = [
+        "t1*",
+      ]
+    }
+    
     remote_auth {
       enabled = true
 
@@ -825,6 +833,12 @@ The `user_agent_filter` block support:
   + **off**: The User-Agent blacklist/whitelist is disabled.
   + **black**: The User-Agent blacklist.
   + **white**: The User-Agent whitelist.
+
+* `include_empty` - (Optional, String) Specifies whether empty user agents are included.
+  A User-Agent blacklist including empty user agents indicates that requests without a user agent are rejected.
+  A User-Agent whitelist including empty user agents indicates that requests without a user agent are accepted.
+  Possible values: **true** (included) and **false** (excluded).
+  The default value is **false** for a blacklist and **true** for a whitelist.
 
 * `ua_list` - (Optional, List) Specifies the User-Agent blacklist or whitelist. This parameter is required when `type`
   is set to **black** or **white**. Up to `10` rules can be configured. A rule contains up to `100` characters.

--- a/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
+++ b/huaweicloud/services/acceptance/cdn/resource_huaweicloud_cdn_domain_test.go
@@ -559,6 +559,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.access_area_filter.#", "2"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.type", "white"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.include_empty", "true"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.ua_list.#", "3"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.remote_auth.0.enabled", "true"),
@@ -671,6 +672,7 @@ func TestAccCdnDomain_configs(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "configs.0.origin_request_url_rewrite.0.target_url", "/new/$1/$2.html"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.type", "black"),
+					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.include_empty", "false"),
 					resource.TestCheckResourceAttr(resourceName, "configs.0.user_agent_filter.0.ua_list.0", "t1*"),
 
 					resource.TestCheckResourceAttr(resourceName, "configs.0.error_code_redirect_rules.#", "1"),
@@ -1128,7 +1130,8 @@ resource "huaweicloud_cdn_domain" "test" {
     }
 
     user_agent_filter {
-      type    = "black"
+      type          = "black"
+      include_empty = "false"
       ua_list = [
         "t1*",
       ]

--- a/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
+++ b/huaweicloud/services/cdn/resource_huaweicloud_cdn_domain.go
@@ -660,6 +660,12 @@ var userAgentFilter = schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			// This field has a default value, so Computed is added.
+			"include_empty": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"ua_list": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -1761,7 +1767,8 @@ func flattenUserAgentFilterAttributes(configResp interface{}) []map[string]inter
 
 	rawMap := curJson.(map[string]interface{})
 	userAgentFilterAttrs := map[string]interface{}{
-		"type": rawMap["type"],
+		"type":          rawMap["type"],
+		"include_empty": fmt.Sprintf("%v", rawMap["include_empty"]),
 	}
 
 	if uaList, ok := rawMap["ua_list"].([]interface{}); ok {
@@ -2340,6 +2347,17 @@ func buildCdnDomainOriginRequestUrlRewriteOpts(rawOriginRequestUrlRewrite []inte
 	return rst
 }
 
+// This method is used to handle three scenarios: passing true, passing false and not passing.
+func buildCdnDomainUserAgentFilterIncludeEmptyOpts(includeEmpty string) interface{} {
+	switch includeEmpty {
+	case "true":
+		return true
+	case "false":
+		return false
+	}
+	return nil
+}
+
 func buildCdnDomainUserAgentFilterOpts(rawUserAgentFilter []interface{}) map[string]interface{} {
 	if len(rawUserAgentFilter) != 1 {
 		return nil
@@ -2347,8 +2365,9 @@ func buildCdnDomainUserAgentFilterOpts(rawUserAgentFilter []interface{}) map[str
 
 	userAgentFilter := rawUserAgentFilter[0].(map[string]interface{})
 	return map[string]interface{}{
-		"type":    userAgentFilter["type"],
-		"ua_list": utils.ExpandToStringList(userAgentFilter["ua_list"].(*schema.Set).List()),
+		"type":          userAgentFilter["type"],
+		"ua_list":       utils.ExpandToStringList(userAgentFilter["ua_list"].(*schema.Set).List()),
+		"include_empty": buildCdnDomainUserAgentFilterIncludeEmptyOpts(userAgentFilter["include_empty"].(string)),
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CDN domain resource support new field `include_empty`.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1727583664856_TestAccCdnDomain_.cov -coverpkg=./huaweicloud/services/cdn ./huaweicloud/services/acceptance/cdn -run TestAccCdnDomain_ -timeout 360m -parallel 5
=== RUN   TestAccCdnDomain_basic
=== PAUSE TestAccCdnDomain_basic
=== RUN   TestAccCdnDomain_configHttpSettings
=== PAUSE TestAccCdnDomain_configHttpSettings
=== RUN   TestAccCdnDomain_configs
=== PAUSE TestAccCdnDomain_configs
=== RUN   TestAccCdnDomain_configTypeWholeSite
=== PAUSE TestAccCdnDomain_configTypeWholeSite
=== RUN   TestAccCdnDomain_epsID_migrate
=== PAUSE TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_basic
=== CONT  TestAccCdnDomain_configTypeWholeSite
=== CONT  TestAccCdnDomain_configs
=== CONT  TestAccCdnDomain_epsID_migrate
=== CONT  TestAccCdnDomain_configHttpSettings
--- PASS: TestAccCdnDomain_epsID_migrate (606.29s)
--- PASS: TestAccCdnDomain_configTypeWholeSite (885.81s)
--- PASS: TestAccCdnDomain_basic (1025.12s)
--- PASS: TestAccCdnDomain_configHttpSettings (1330.01s)
--- PASS: TestAccCdnDomain_configs (1480.70s)
PASS
coverage: 54.9% of statements in ./huaweicloud/services/cdn
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cdn       1480.760s       coverage: 54.9% of statements in ./huaweicloud/services/cdn
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
