### PR TITLE
feat(cse/kv): add new resource to manage engine configuration

### DIFF
--- a/docs/resources/cse_microservice_engine_configuration.md
+++ b/docs/resources/cse_microservice_engine_configuration.md
@@ -1,0 +1,161 @@
+---
+subcategory: "Cloud Service Engine (CSE)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cse_microservice_engine_configuration"
+description: |-
+  Manages a key/value pair under a dedicated microservice engine (2.0+) resource within HuaweiCloud.
+---
+
+# huaweicloud_cse_microservice_engine_configuration
+
+Manages a key/value pair under a dedicated microservice engine (2.0+) resource within HuaweiCloud.
+
+-> Before creating a configuration, make sure the engine has enabled the rules shown in the appendix
+   [table](#default_engine_access_rules).
+
+## Example Usage
+
+```hcl
+variable "microservice_engine_id" {} // Enable the EIP access
+variable "microservice_engine_admin_password" {}
+
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  fileter_engines = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == var.microservice_engine_id]
+}
+
+resource "huaweicloud_cse_microservice_engine_configuration" "test" {
+  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
+  connect_address = local.fileter_engines[0].config_center_addresses[0].public
+  admin_user      = "root"
+  admin_pass      = var.microservice_engine_admin_password
+
+  key        = "demo"
+  value_type = "json"
+  value      = jsonencode({
+    "foo": "bar"
+  })
+  status     = "enabled"
+
+  tags = {
+    owner = "terraform"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `auth_address` - (Required, String, ForceNew) Specifies the address that used to request the access token.  
+  Changing this will create a new resource.
+
+* `connect_address` - (Required, String, ForceNew) Specifies the address that used to access engine and manages
+  configuration.  
+  Changing this will create a new resource.
+
+* `admin_user` - (Optional, String, ForceNew) Specifies the account name for **RBAC** login.
+  Changing this will create a new resource.
+
+* `admin_pass` - (Optional, String, ForceNew) Specifies the account password for **RBAC** login.
+  The password format must meet the following conditions:
+  + Must be `8` to `32` characters long.
+  + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
+    (-~!@#%^*_=+?$&()|<>{}[]).
+  + Cannot be the account name or account name spelled backwards.
+  + The password can only start with a letter.
+
+  Changing this will create a new resource.
+
+  -> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
+
+* `key` - (Required, String, ForceNew) Specifies the configuration key (item name).  
+  The valid length is limited from `1` to `2,048` characters, only letters, digits, hyphens (-), underscores (_),
+  colons (:) and periods (.) are allowed.  
+  Changing this will create a new resource.
+
+* `value_type` - (Required, String, ForceNew) Specifies the type of the configuration value.
+  The valid values are as follows:
+  + **ini**
+  + **json**
+  + **text**
+  + **yaml**
+  + **properties**
+  + **xml**
+
+  Changing this will create a new resource.
+
+* `value` - (Required, String) Specifies the configuration value.
+
+* `status` - (Optional, String) Specifies the configuration status.  
+  The valid values are as follows:
+  + **enabled**
+  + **disabled**
+
+* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the configuration that used to
+  filter resource.  
+  Changing this will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `created_at` - The The creation time of the configuration, in RFC3339 format.
+
+* `updated_at` - The latest update time of the configuration, in RFC3339 format.
+
+* `create_revision` - The create version of the configuration.
+
+* `update_revision` - The update version of the configuration.
+
+## Import
+
+If the related engine is disable the `RBAC`, configurations (key/value pairs) can be imported using their
+`auth_address`, `connect_address` and `key`, e.g.
+
+```bash
+$ terraform import huaweicloud_cse_microservice_engine_configuration.test <auth_address>/<connect_address>/<key>
+```
+
+If the related engine is enable the `RBAC`, inputs `admin_user` and `admin_pass` are necessary, e.g.
+
+```bash
+$ terraform import huaweicloud_cse_microservice_engine_configuration.test <auth_address>/<connect_address>/<key>/<admin_user>/<admin_pass>
+```
+
+Note that the imported state may not be identical to your resource definition, due to security reason.
+The missing attribute is `admin_pass`. It is generally recommended running `terraform plan` after importing an instance.
+You can then decide if changes should be applied to the resource, or the definition should be updated to align with the
+resource. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_cse_microservice_engine_configuration" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      admin_pass,
+    ]
+  }
+}
+```
+
+## Appendix
+
+<a name="default_engine_access_rules"></a>
+Security group rules required to access the engine:
+(Remote is not the minimum range and can be adjusted according to business needs)
+
+| Direction | Priority | Action | Protocol | Ports         | Ethertype | Remote                |
+| --------- | -------- | ------ | -------- | ------------- | --------- | --------------------- |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | All      | All           | Ipv6      | cse-engine-default-sg |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv4      | 0.0.0.0/0             |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv4      | 0.0.0.0/0             |
+| Ingress   | 1        | Allow  | All      | All           | Ipv4      | cse-engine-default-sg |
+| Egress    | 100      | Allow  | All      | All           | Ipv6      | ::/0                  |
+| Egress    | 100      | Allow  | All      | All           | Ipv4      | 0.0.0.0/0             |

--- a/huaweicloud/common/resource_schema.go
+++ b/huaweicloud/common/resource_schema.go
@@ -20,14 +20,18 @@ func TagsSchema(description ...string) *schema.Schema {
 	return &schemaObj
 }
 
-// TagsForceNewSchema returns the schema to use for tags with ForceNew
-func TagsForceNewSchema() *schema.Schema {
-	return &schema.Schema{
+// TagsForceNewSchema returns the schema to use for tags with ForceNew behavior.
+func TagsForceNewSchema(description ...string) *schema.Schema {
+	schemaObj := schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
 		ForceNew: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
+	if len(description) > 0 {
+		schemaObj.Description = description[0]
+	}
+	return &schemaObj
 }
 
 // TagsComputedSchema returns the schema to use for tags as an attribute

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1345,9 +1345,10 @@ func Provider() *schema.Provider {
 
 			"huaweicloud_cph_server": cph.ResourceCphServer(),
 
-			"huaweicloud_cse_microservice":          cse.ResourceMicroservice(),
-			"huaweicloud_cse_microservice_engine":   cse.ResourceMicroserviceEngine(),
-			"huaweicloud_cse_microservice_instance": cse.ResourceMicroserviceInstance(),
+			"huaweicloud_cse_microservice":                      cse.ResourceMicroservice(),
+			"huaweicloud_cse_microservice_engine":               cse.ResourceMicroserviceEngine(),
+			"huaweicloud_cse_microservice_engine_configuration": cse.ResourceMicroserviceEngineConfiguration(),
+			"huaweicloud_cse_microservice_instance":             cse.ResourceMicroserviceInstance(),
 
 			"huaweicloud_csms_event":                dew.ResourceCsmsEvent(),
 			"huaweicloud_csms_secret":               dew.ResourceSecret(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -344,7 +344,8 @@ var (
 
 	HW_CC_PERMISSION_ID = os.Getenv("HW_CC_PERMISSION_ID")
 
-	HW_CSE_MICROSERVICE_ENGINE_ID = os.Getenv("HW_CSE_MICROSERVICE_ENGINE_ID")
+	HW_CSE_MICROSERVICE_ENGINE_ID             = os.Getenv("HW_CSE_MICROSERVICE_ENGINE_ID")
+	HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD = os.Getenv("HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD")
 
 	HW_CSS_LOCAL_DISK_FLAVOR  = os.Getenv("HW_CSS_LOCAL_DISK_FLAVOR")
 	HW_CSS_ELB_AGENCY         = os.Getenv("HW_CSS_ELB_AGENCY")
@@ -1880,6 +1881,13 @@ func TestAccPreCheckCCPermission(t *testing.T) {
 func TestAccPreCheckCSEMicroserviceEngineID(t *testing.T) {
 	if HW_CSE_MICROSERVICE_ENGINE_ID == "" {
 		t.Skip("HW_CSE_MICROSERVICE_ENGINE_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckCSEMicroserviceEngineAdminPassword(t *testing.T) {
+	if HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD == "" {
+		t.Skip("HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_configuration_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_configuration_test.go
@@ -1,0 +1,167 @@
+package cse
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
+)
+
+func getMicroserviceEngineConfigurationFunc(_ *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	token, err := cse.GetAuthorizationToken(state.Primary.Attributes["auth_address"],
+		state.Primary.Attributes["admin_user"], state.Primary.Attributes["admin_pass"])
+	if err != nil {
+		return nil, err
+	}
+
+	client := common.NewCustomClient(true, state.Primary.Attributes["connect_address"], "v1", "default")
+	return cse.QueryMicroserviceEngineConfiguration(client, token, state.Primary.ID)
+}
+
+func TestAccMicroserviceEngineConfiguration_basic(t *testing.T) {
+	var (
+		configuration interface{}
+
+		randName     = acceptance.RandomAccResourceNameWithDash()
+		resourceName = "huaweicloud_cse_microservice_engine_configuration.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &configuration, getMicroserviceEngineConfigurationFunc)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineID(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineAdminPassword(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMicroserviceEngineConfiguration_basic_step1(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "key", randName),
+					resource.TestCheckResourceAttr(resourceName, "value_type", "json"),
+					resource.TestCheckResourceAttr(resourceName, "value", "{\"foo\":\"bar\"}"),
+					resource.TestCheckResourceAttr(resourceName, "status", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "tags.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+				),
+			},
+			{
+				Config: testAccMicroserviceEngineConfiguration_basic_step2(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "value", "{\"foo\":\"baar\"}"),
+					resource.TestCheckResourceAttr(resourceName, "status", "disabled"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccMicroserviceEngineConfigurationImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccMicroserviceEngineConfigurationImportStateIdFunc(resName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", resName)
+		}
+
+		authAddr := rs.Primary.Attributes["auth_address"]
+		connAddr := rs.Primary.Attributes["connect_address"]
+		keyName := rs.Primary.Attributes["key"]
+		username := rs.Primary.Attributes["admin_user"]
+		password := rs.Primary.Attributes["admin_pass"]
+		if authAddr != "" && connAddr != "" {
+			if username != "" && password != "" {
+				return fmt.Sprintf("%s/%s/%s/%s/%s", authAddr, connAddr, keyName, username, password), nil
+			}
+			return fmt.Sprintf("%s/%s/%s", authAddr, connAddr, keyName), nil
+		}
+		return "", fmt.Errorf("missing some attributes: %s/%s/%s", authAddr, connAddr, keyName)
+	}
+}
+
+func testAccMicroserviceEngineConfiguration_basic_step1(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  id_filter_result = [
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
+  ]
+}
+
+resource "huaweicloud_cse_microservice_engine_configuration" "test" {
+  auth_address    = local.id_filter_result[0].service_registry_addresses.0.public
+  connect_address = local.id_filter_result[0].config_center_addresses.0.public
+  admin_user      = "root"
+  admin_pass      = "%[2]s"
+
+  key        = "%[3]s"
+  value_type = "json"
+  value      = jsonencode({
+    "foo": "bar"
+  })
+  status = "enabled"
+
+  tags = {
+    owner = "terraform"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      admin_pass,
+    ]
+  }
+}
+`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID, acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD, name)
+}
+
+func testAccMicroserviceEngineConfiguration_basic_step2(name string) string {
+	return fmt.Sprintf(`
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  id_filter_result = [
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
+  ]
+}
+
+resource "huaweicloud_cse_microservice_engine_configuration" "test" {
+  auth_address    = local.id_filter_result[0].service_registry_addresses.0.public
+  connect_address = local.id_filter_result[0].config_center_addresses.0.public
+  admin_user      = "root"
+  admin_pass      = "%[2]s"
+
+  key        = "%[3]s"
+  value_type = "json"
+  value      = jsonencode({
+    "foo": "baar"
+  })
+  status = "disabled"
+
+  tags = {
+    owner = "terraform"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      admin_pass,
+    ]
+  }
+}
+`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID, acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD, name)
+}

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
@@ -1,0 +1,375 @@
+package cse
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API CSE POST /v1/{project_id}/kie/kv
+// @API CSE GET /v1/{project_id}/kie/kv/{kv_id}
+// @API CSE PUT /v1/{project_id}/kie/kv/{kv_id}
+// @API CSE DELETE /v1/{project_id}/kie/kv/{kv_id}
+// @API CSE GET /v1/{project_id}/kie/kv
+func ResourceMicroserviceEngineConfiguration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceMicroserviceEngineConfigurationCreate,
+		ReadContext:   resourceMicroserviceEngineConfigurationRead,
+		UpdateContext: resourceMicroserviceEngineConfigurationUpdate,
+		DeleteContext: resourceMicroserviceEngineConfigurationDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceMicroserviceEngineConfigurationImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			// Authentication and request parameters.
+			"auth_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The address that used to request the access token.`,
+			},
+			"connect_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The address that used to send requests and manage configuration.`,
+			},
+			"admin_user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The user name that used to pass the RBAC control.",
+			},
+			"admin_pass": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ForceNew:     true,
+				RequiredWith: []string{"admin_user"},
+				Description:  "The user password that used to pass the RBAC control.",
+			},
+			// Resource parameters.
+			"key": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The configuration key (item name).",
+			},
+			"value_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The type of the configuration value.`,
+			},
+			"value": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The configuration value.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The configuration status.`,
+			},
+			"tags": common.TagsForceNewSchema(
+				`The key/value pairs to associate with the configuration that used to filter resource.`,
+			),
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The creation time of the configuration, in RFC3339 format.`,
+			},
+			"updated_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The latest update time of the configuration, in RFC3339 format.`,
+			},
+			"create_revision": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The create version of the configuration.`,
+			},
+			"update_revision": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: `The update version of the configuration.`,
+			},
+		},
+	}
+}
+
+func buildMicroserviceEngineConfigurationCreateOpts(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"key":        d.Get("key").(string),
+		"value_type": d.Get("value_type").(string),
+		"value":      d.Get("value").(string),
+		"status":     d.Get("status").(string),
+		"labels":     d.Get("tags").(map[string]interface{}),
+	}
+}
+
+func resourceMicroserviceEngineConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		client     = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
+		httpUrl    = "kie/kv"
+		createPath = client.ResourceBase + httpUrl
+	)
+
+	// The connection address is no longer used to obtain an authentication token.
+	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
+		d.Get("admin_pass").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	createOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildMicroserviceEngineConfigurationCreateOpts(d),
+	}
+	if token != "" {
+		createOpts.MoreHeaders = map[string]string{
+			"Authorization": token,
+		}
+	}
+
+	requestResp, err := client.Request("POST", createPath, &createOpts)
+	if err != nil {
+		return diag.Errorf("error creating configuration: %s", err)
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	configId, err := jmespath.Search("id", respBody)
+	if err != nil || configId == nil {
+		return diag.Errorf("failed to find the configuration ID from the API response: %s", err)
+	}
+	d.SetId(configId.(string))
+
+	return resourceMicroserviceEngineConfigurationRead(ctx, d, meta)
+}
+
+func QueryMicroserviceEngineConfiguration(client *golangsdk.ServiceClient, token, configId string) (interface{}, error) {
+	httpUrl := "kie/kv/{kv_id}"
+
+	queryPath := client.ResourceBase + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{kv_id}", configId)
+
+	queryOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+	if token != "" {
+		queryOpts.MoreHeaders = map[string]string{
+			"Authorization": token,
+		}
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &queryOpts)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(requestResp)
+}
+
+func resourceMicroserviceEngineConfigurationRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	var (
+		client   = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
+		configId = d.Id()
+	)
+	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
+		d.Get("admin_pass").(string))
+	if err != nil {
+		// When the engine does not exist, obtaining a token will cause a request connection exception.
+		// To ensure that the resource is available on RFS platform, this situation is specially handled as a 404 error.
+		log.Printf("[ERROR] %s", err)
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	respBody, err := QueryMicroserviceEngineConfiguration(client, token, configId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error querying configuration (%s)", configId))
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("key", utils.PathSearch("key", respBody, nil)),
+		d.Set("value_type", utils.PathSearch("value_type", respBody, nil)),
+		d.Set("value", utils.PathSearch("value", respBody, nil)),
+		d.Set("status", utils.PathSearch("status", respBody, nil)),
+		d.Set("tags", utils.PathSearch("labels", respBody, nil)),
+		d.Set("created_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time", respBody, float64(0)).(float64))/1000, false)),
+		d.Set("updated_at", utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time", respBody, float64(0)).(float64))/1000, false)),
+		d.Set("create_revision", utils.PathSearch("create_revision", respBody, nil)),
+		d.Set("update_revision", utils.PathSearch("update_revision", respBody, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildMicroserviceEngineConfigurationUpdateOpts(d *schema.ResourceData) map[string]interface{} {
+	return map[string]interface{}{
+		"value":  d.Get("value").(string),
+		"status": d.Get("status").(string),
+	}
+}
+
+func resourceMicroserviceEngineConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		client   = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
+		httpUrl  = "kie/kv/{kv_id}"
+		configId = d.Id()
+	)
+
+	updatePath := client.ResourceBase + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{kv_id}", configId)
+
+	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
+		d.Get("admin_pass").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	updateOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         buildMicroserviceEngineConfigurationUpdateOpts(d),
+	}
+	if token != "" {
+		updateOpts.MoreHeaders = map[string]string{
+			"Authorization": token,
+		}
+	}
+
+	_, err = client.Request("PUT", updatePath, &updateOpts)
+	if err != nil {
+		return diag.Errorf("error updating configuration (%s): %s", configId, err)
+	}
+	return resourceMicroserviceEngineConfigurationRead(ctx, d, meta)
+}
+
+func resourceMicroserviceEngineConfigurationDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	var (
+		client   = common.NewCustomClient(true, d.Get("connect_address").(string), "v1", "default")
+		httpUrl  = "kie/kv/{kv_id}"
+		configId = d.Id()
+	)
+
+	deletePath := client.ResourceBase + httpUrl
+	deletePath = strings.ReplaceAll(deletePath, "{kv_id}", configId)
+
+	token, err := GetAuthorizationToken(d.Get("auth_address").(string), d.Get("admin_user").(string),
+		d.Get("admin_pass").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	deleteOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	if token != "" {
+		deleteOpts.MoreHeaders = map[string]string{
+			"Authorization": token,
+		}
+	}
+
+	_, err = client.Request("DELETE", deletePath, &deleteOpts)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, fmt.Sprintf("error deleting configuration (%s)", configId))
+	}
+	return nil
+}
+
+func queryMicroserviceEngineConfigurationByKey(connectAddress, token, keyName string) (interface{}, error) {
+	var (
+		client  = common.NewCustomClient(true, connectAddress, "v1", "default")
+		httpUrl = "kie/kv"
+	)
+	queryPath := client.ResourceBase + httpUrl
+
+	queryOpts := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	if token != "" {
+		queryOpts.MoreHeaders = map[string]string{
+			"Authorization": token,
+		}
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &queryOpts)
+	if err != nil {
+		return nil, err
+	}
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, err
+	}
+	return utils.PathSearch(fmt.Sprintf("data[?key=='%s']|[0]", keyName), respBody, nil), nil
+}
+
+func resourceMicroserviceEngineConfigurationImportState(_ context.Context, d *schema.ResourceData,
+	_ interface{}) ([]*schema.ResourceData, error) {
+	var (
+		token, authAddr, connectAddr, keyName, adminUser, adminPwd string
+		err                                                        error
+		mErr                                                       *multierror.Error
+
+		addressRegex = `https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}`
+		re           = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)?/?(%[1]s)/(.*)$`, addressRegex))
+		formatErr    = fmt.Errorf("the imported microservice ID specifies an invalid format, must be " +
+			"<auth_address>/<connect_address>/<key> or <auth_address>/<connect_address>/<key>/<admin_user>/<admin_pass>")
+	)
+	if !re.MatchString(d.Id()) {
+		return nil, fmt.Errorf("the imported microservice ID specifies an invalid format, must start with the " +
+			"connection address of the service registry center for the dedicated CSE engine")
+	}
+
+	resp := re.FindAllStringSubmatch(d.Id(), -1)
+	if len(resp) >= 1 && len(resp[0]) == 4 {
+		authAddr = resp[0][1]
+		connectAddr = resp[0][2]
+		mErr = multierror.Append(mErr, d.Set("auth_address", resp[0][1]))
+		mErr = multierror.Append(mErr, d.Set("connect_address", resp[0][2]))
+
+		parts := strings.Split(resp[0][3], "/")
+		switch len(parts) {
+		case 1:
+			keyName = parts[0]
+		case 3:
+			keyName = parts[0]
+			adminUser = parts[1]
+			adminPwd = parts[2]
+			token, err = GetAuthorizationToken(authAddr, adminUser, adminPwd)
+			if err != nil {
+				return nil, err
+			}
+			mErr = multierror.Append(mErr,
+				d.Set("admin_user", adminUser),
+				d.Set("admin_pass", adminPwd),
+			)
+		default:
+			return nil, formatErr
+		}
+		engineDetail, err := queryMicroserviceEngineConfigurationByKey(connectAddr, token, keyName)
+		if err != nil {
+			return nil, err
+		}
+		d.SetId(utils.PathSearch("id", engineDetail, "").(string))
+		return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+	}
+
+	return nil, formatErr
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new resource to manage the configuration (key/value pairs) under a specify microservice engin.

Notes: Engine not exist will cause the request token timeout (connection error).
![image](https://github.com/user-attachments/assets/ce375884-5cec-476c-8b8a-9069757a653a)
We need to handle it.
![image](https://github.com/user-attachments/assets/c4a4e175-0e9b-4b4e-b89e-27e727a7fb86)

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to manage engine configuration.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o cse -f TestAccMicroserviceEngineConfiguration_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceEngineConfiguration_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceEngineConfiguration_basic
=== PAUSE TestAccMicroserviceEngineConfiguration_basic
=== CONT  TestAccMicroserviceEngineConfiguration_basic
--- PASS: TestAccMicroserviceEngineConfiguration_basic (38.38s)
PASS
coverage: 34.4% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       38.423s coverage: 34.4% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/18f039a2-550c-4e83-993d-2909e0c45ee0)

    ab. Related resources (parent resources) not found
    ![image](https://github.com/user-attachments/assets/a0c18ffc-f044-46dd-9362-5f5bb6080ffc)
 
 - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/0df1fcce-6aaf-4b5c-b665-f02661776830)

    If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    Throw error.
