### PR TITLE
feat(servicestage/env): add new resource to bind resources to env

### DIFF
--- a/docs/resources/servicestagev3_environment_associate.md
+++ b/docs/resources/servicestagev3_environment_associate.md
@@ -1,0 +1,65 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_environment_associate"
+description: |-
+  Use this resource to bind resources to the environment within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_environment_associate
+
+Use this resource to bind resources to the environment within HuaweiCloud.
+
+-> An environment can only have one resource.
+
+~> Do not use this resource at the same time as resource `huaweicloud_servicestage_environment`.
+
+## Example Usage
+
+```hcl
+variable "environment_id" {}
+variable "eip_id" {}
+
+resource "huaweicloud_servicestagev3_environment_associate" "test" {
+  environment_id = var.environment_id
+
+  resources {
+    id   = var.eip_id
+    type = "eip"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the environment and resources are located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `environment_id` - (Required, String, ForceNew) Specifies the environment ID associated with the resources.  
+  Changing this will create a new resource.
+
+* `resources` - (Required, List) Specifies the information about the associated resources.
+  The [resources](#servicestage_v3_env_associated_resources) structure is documented below.
+
+<a name="servicestage_v3_env_associated_resources"></a>
+The `resources` block supports:
+
+* `id` - (Required, String) Specifies the ID of the resource to be associated.
+
+* `type` - (Required, String) Specifies the type of the resource to be associated.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID (also the environment ID), in UUID format.
+
+## Import
+
+Associate resources can be imported using the `id` (`environment_id`), e.g.
+
+```bash
+$ terraform import huaweicloud_servicestagev3_environment_associate.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1851,7 +1851,8 @@ func Provider() *schema.Provider {
 			"huaweicloud_servicestage_repo_token_authorization":    servicestage.ResourceRepoTokenAuth(),
 			"huaweicloud_servicestage_repo_password_authorization": servicestage.ResourceRepoPwdAuth(),
 			// v3 managements
-			"huaweicloud_servicestagev3_environment": servicestage.ResourceV3Environment(),
+			"huaweicloud_servicestagev3_environment":           servicestage.ResourceV3Environment(),
+			"huaweicloud_servicestagev3_environment_associate": servicestage.ResourceV3EnvironmentAssociate(),
 
 			"huaweicloud_sfs_turbo":            sfsturbo.ResourceSFSTurbo(),
 			"huaweicloud_sfs_turbo_dir":        sfsturbo.ResourceSfsTurboDir(),

--- a/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_environment_associate_test.go
+++ b/huaweicloud/services/acceptance/servicestage/resource_huaweicloud_servicestagev3_environment_associate_test.go
@@ -1,0 +1,124 @@
+package servicestage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/servicestage"
+)
+
+func getV3EnvAssociatedResourcesFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.NewServiceClient("servicestage", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ServiceStage client: %s", err)
+	}
+	return servicestage.QueryV3Environment(client, state.Primary.ID)
+}
+
+func TestAccV3EnvironmentAssociate_basic(t *testing.T) {
+	var (
+		obj interface{}
+
+		resourceName = "huaweicloud_servicestagev3_environment_associate.test"
+		rc           = acceptance.InitResourceCheck(resourceName, &obj, getV3EnvAssociatedResourcesFunc)
+
+		name = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+			// Make sure at least one of node exist.
+			acceptance.TestAccPreCheckCceClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccV3EnvironmentAssociate_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.0.id", "huaweicloud_vpc_eip.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.type", "eip"),
+				),
+			},
+			{
+				Config: testAccV3EnvironmentAssociate_basic_step2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.id", acceptance.HW_CCE_CLUSTER_ID),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.type", "cce"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccV3EnvironmentAssociate_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[2]s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "huaweicloud_servicestagev3_environment" "test" {
+  name                  = "%[2]s"
+  vpc_id                = huaweicloud_vpc.test.id
+  enterprise_project_id = "0"
+}
+`, common.TestVpc(name), name)
+}
+
+func testAccV3EnvironmentAssociate_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_environment_associate" "test" {
+  environment_id = huaweicloud_servicestagev3_environment.test.id
+
+  resources {
+    id   = huaweicloud_vpc_eip.test.id
+    type = "eip"
+  }
+}
+`, testAccV3EnvironmentAssociate_base(name))
+}
+
+func testAccV3EnvironmentAssociate_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_environment_associate" "test" {
+  environment_id = huaweicloud_servicestagev3_environment.test.id
+
+  resources {
+    id   = "%[2]s"
+    type = "cce"
+  }
+}
+`, testAccV3EnvironmentAssociate_base(name), acceptance.HW_CCE_CLUSTER_ID)
+}

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment_associate.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment_associate.go
@@ -1,0 +1,228 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage PUT /v3/{project_id}/cas/environments/{environment_id}/resources
+// @API ServiceStage GET /v3/{project_id}/cas/environments/{environment_id}/resources
+func ResourceV3EnvironmentAssociate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceV3EnvironmentAssociateCreate,
+		ReadContext:   resourceV3EnvironmentAssociateRead,
+		UpdateContext: resourceV3EnvironmentAssociateUpdate,
+		DeleteContext: resourceV3EnvironmentAssociateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceV3EnvironmentAssociateImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: `The region where the environment and resources are located.`,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The environment ID associated with the resources.`,
+			},
+			"resources": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The ID of the resource to be associated.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The type of the resource to be associated.`,
+						},
+					},
+				},
+				Description: "The information about the associated resources.",
+			},
+		},
+	}
+}
+
+func buildV3EnvironmentAssociatedResources(resources *schema.Set) []interface{} {
+	result := make([]interface{}, 0, resources.Len())
+	for _, v := range resources.List() {
+		result = append(result, map[string]interface{}{
+			"id":   utils.PathSearch("id", v, nil),
+			"type": utils.PathSearch("type", v, nil),
+		})
+	}
+	return result
+}
+
+func modifyAssociatedResourcesUnderEnvironment(client *golangsdk.ServiceClient, envId string, resources *schema.Set) error {
+	httpUrl := "v3/{project_id}/cas/environments/{environment_id}/resources"
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{environment_id}", envId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+		JSONBody: map[string]interface{}{
+			"resources": buildV3EnvironmentAssociatedResources(resources),
+		},
+	}
+
+	_, err := client.Request("PUT", createPath, &opt)
+	return err
+}
+
+func resourceV3EnvironmentAssociateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		envId     = d.Get("environment_id").(string)
+		resources = d.Get("resources").(*schema.Set)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	err = modifyAssociatedResourcesUnderEnvironment(client, envId, resources)
+	if err != nil {
+		return diag.Errorf("error associating resources to the environment (%s): %s", envId, err)
+	}
+	d.SetId(envId)
+
+	return resourceV3EnvironmentAssociateRead(ctx, d, meta)
+}
+
+func QueryV3EnvironmentAssociatedResources(client *golangsdk.ServiceClient, envId string) (interface{}, error) {
+	httpUrl := "v3/{project_id}/cas/environments/{environment_id}/resources"
+
+	queryPath := client.Endpoint + httpUrl
+	queryPath = strings.ReplaceAll(queryPath, "{project_id}", client.ProjectID)
+	queryPath = strings.ReplaceAll(queryPath, "{environment_id}", envId)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	requestResp, err := client.Request("GET", queryPath, &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(requestResp)
+}
+
+func flattenV3EnvironmentAssociatedResources(resources []interface{}) []map[string]interface{} {
+	if len(resources) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(resources))
+	for _, resource := range resources {
+		result = append(result, map[string]interface{}{
+			"id":   utils.PathSearch("id", resource, nil),
+			"type": utils.PathSearch("type", resource, nil),
+		})
+	}
+	return result
+}
+
+func resourceV3EnvironmentAssociateRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		envId  = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	respBody, err := QueryV3EnvironmentAssociatedResources(client, envId)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", v3EnvNotFoundCodes...),
+			fmt.Sprintf("error getting environment (%s)", envId))
+	}
+	associatedResources := utils.PathSearch("resources", respBody, make([]interface{}, 0)).([]interface{})
+	if len(associatedResources) < 1 {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "associated resources not found")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("resources", flattenV3EnvironmentAssociatedResources(associatedResources)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceV3EnvironmentAssociateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		envId     = d.Id()
+		resources = d.Get("resources").(*schema.Set)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	err = modifyAssociatedResourcesUnderEnvironment(client, envId, resources)
+	if err != nil {
+		return diag.Errorf("error modifying associated resources under the environment (%s): %s", envId, err)
+	}
+
+	return resourceV3EnvironmentAssociateRead(ctx, d, meta)
+}
+
+func resourceV3EnvironmentAssociateDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+		envId  = d.Id()
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	err = modifyAssociatedResourcesUnderEnvironment(client, envId, schema.NewSet(schema.HashString, nil))
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected401ErrInto404Err(err, "error_code", v3EnvNotFoundCodes...),
+			fmt.Sprintf("error dissociating the resources from the environment (%s)", envId))
+	}
+	return nil
+}
+
+func resourceV3EnvironmentAssociateImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, d.Set("environment_id", d.Id())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new resource for resources binding.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource to bind resources to environment.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o servicestage -f TestAccV3EnvironmentAssociate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccV3EnvironmentAssociate_basic -timeout 360m -parallel 10
=== RUN   TestAccV3EnvironmentAssociate_basic
=== PAUSE TestAccV3EnvironmentAssociate_basic
=== CONT  TestAccV3EnvironmentAssociate_basic
--- PASS: TestAccV3EnvironmentAssociate_basic (98.90s)
PASS
coverage: 12.2% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      98.947s coverage: 12.2% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
