### PR TITLE
feat(aom): add data source service discovery rules

### DIFF
--- a/docs/data-sources/aom_service_discovery_rules.md
+++ b/docs/data-sources/aom_service_discovery_rules.md
@@ -1,0 +1,103 @@
+---
+subcategory: "Application Operations Management (AOM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_aom_service_discovery_rules"
+description: |-
+  Use this data source to get the list of AOM service discovery rules.
+---
+
+# huaweicloud_aom_service_discovery_rules
+
+Use this data source to get the list of AOM service discovery rules.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_aom_service_discovery_rules" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `rule_id` - (Optional, String) Specifies the service discovery rule ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `rules` - Indicates the service discovery rules list.
+  The [rules](#attrblock--rules) structure is documented below.
+
+<a name="attrblock--rules"></a>
+The `rules` block supports:
+
+* `id` - Indicates the rule ID.
+
+* `name` - Indicates the rule name.
+
+* `detect_log_enabled` - Indicates whether the log collection is enabled.
+
+* `discovery_rule_enabled` - Indicates whether the rule is enabled.
+
+* `discovery_rules` - Indicates the discovery rule.
+  The [discovery_rules](#attrblock--rules--discovery_rules) structure is documented below.
+
+* `is_default_rule` - Indicates whether the rule is the default one.
+
+* `log_file_suffix` - Indicates the log file suffix.
+
+* `log_path_rules` - Indicates the log path configuration rule.
+  The [log_path_rules](#attrblock--rules--log_path_rules) structure is documented below.
+
+* `name_rules` - Indicates the naming rules for discovered services and applications.
+  The [name_rules](#attrblock--rules--name_rules) structure is documented below.
+
+* `priority` - Indicates the rule priority.
+
+* `service_type` - Indicates the service type.
+
+* `created_at` - Indicates the create time of the rule.
+
+* `description` - Indicates the description of the rule.
+
+<a name="attrblock--rules--discovery_rules"></a>
+The `discovery_rules` block supports:
+
+* `check_content` - Indicates the matched value.
+
+* `check_mode` - Indicates the match condition.
+
+* `check_type` - Indicates the match type.
+
+<a name="attrblock--rules--log_path_rules"></a>
+The `log_path_rules` block supports:
+
+* `args` - Indicates the command.
+
+* `name_type` - Indicates the value type.
+
+* `value` - Indicates the log path.
+
+<a name="attrblock--rules--name_rules"></a>
+The `name_rules` block supports:
+
+* `application_name_rule` - Indicates the application name rule.
+  The [basic_name_rule](#attrblock--rules--basic_name_rule) structure is documented below.
+
+* `service_name_rule` - Indicates the service name rule.
+  The [basic_name_rule](#attrblock--rules--basic_name_rule) structure is documented below.
+
+<a name="attrblock--rules--basic_name_rule"></a>
+The `basic_name_rule` block supports:
+
+* `args` - Indicates the input value.
+
+* `name_type` - Indicates the value type.
+
+* `value` - Indicates the application name.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -424,6 +424,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_aom_dashboards":                      aom.DataSourceDashboards(),
 			"huaweicloud_aom_alarm_rules_templates":           aom.DataSourceAlarmRulesTemplates(),
 			"huaweicloud_aom_alarm_silence_rules":             aom.DataSourceAlarmSilenceRules(),
+			"huaweicloud_aom_service_discovery_rules":         aom.DataSourceServiceDiscoveryRules(),
 
 			"huaweicloud_apig_acl_policies":                       apig.DataSourceAclPolicies(),
 			"huaweicloud_apig_api_associated_acl_policies":        apig.DataSourceApiAssociatedAclPolicies(),

--- a/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_service_discovery_rules_test.go
+++ b/huaweicloud/services/acceptance/aom/data_source_huaweicloud_aom_service_discovery_rules_test.go
@@ -1,0 +1,51 @@
+package aom
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceServiceDiscoveryRules_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_aom_service_discovery_rules.test"
+	rName := acceptance.RandomAccResourceNameWithDash()
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceServiceDiscoveryRules_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "rules.#"),
+
+					resource.TestCheckOutput("rule_id_filter_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceServiceDiscoveryRules_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_aom_service_discovery_rules" "test" {}
+
+data "huaweicloud_aom_service_discovery_rules" "id_filter" {
+  rule_id = huaweicloud_aom_service_discovery_rule.test.rule_id
+}
+
+output "rule_id_filter_validation" {
+  value = alltrue([for v in data.huaweicloud_aom_service_discovery_rules.id_filter.rules[*].id : 
+    v == huaweicloud_aom_service_discovery_rule.test.rule_id])
+}
+`, testAOMServiceDiscoveryRule_basic(name))
+}

--- a/huaweicloud/services/aom/data_source_huaweicloud_aom_service_discovery_rules.go
+++ b/huaweicloud/services/aom/data_source_huaweicloud_aom_service_discovery_rules.go
@@ -1,0 +1,281 @@
+package aom
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API AOM GET /v1/{project_id}/inv/servicediscoveryrules
+func DataSourceServiceDiscoveryRules() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceServiceDiscoveryRulesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"rule_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"discovery_rules": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"check_content": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"check_mode": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"check_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"name_rules": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"service_name_rule":     &dataSourceSchemaBasicNameRule,
+									"application_name_rule": &dataSourceSchemaBasicNameRule,
+								},
+							},
+						},
+						"log_file_suffix": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"discovery_rule_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_default_rule": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"detect_log_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"priority": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"log_path_rules": &dataSourceSchemaBasicNameRule,
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+var dataSourceSchemaBasicNameRule = schema.Schema{
+	Type:     schema.TypeList,
+	Computed: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"args": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"value": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	},
+}
+
+func dataSourceServiceDiscoveryRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("aom", region)
+	if err != nil {
+		return diag.Errorf("error creating AOM client: %s", err)
+	}
+
+	results, err := listServiceDiscoveryRules(client, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("error generating UUID")
+	}
+	d.SetId(id)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("rules", flattenServiceDiscoveryRules(results.([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildListServiceDiscoveryRulesQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("rule_id"); ok {
+		res = fmt.Sprintf("?&id=%v", v)
+	}
+
+	return res
+}
+
+func listServiceDiscoveryRules(client *golangsdk.ServiceClient, d *schema.ResourceData) (interface{}, error) {
+	listHttpUrl := "v1/{project_id}/inv/servicediscoveryrules"
+	listPath := client.Endpoint + listHttpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildListServiceDiscoveryRulesQueryParams(d)
+	listOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	listResp, err := client.Request("GET", listPath, &listOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving service discovery rules: %s", err)
+	}
+	listRespBody, err := utils.FlattenResponse(listResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flattening service discovery rules: %s", err)
+	}
+
+	return utils.PathSearch("appRules", listRespBody, make([]interface{}, 0)), nil
+}
+
+func flattenServiceDiscoveryRules(rules []interface{}) []interface{} {
+	if len(rules) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(rules))
+	for _, rule := range rules {
+		isDefaultRule, _ := strconv.ParseBool(utils.PathSearch("spec.isDefaultRule", rule, "false").(string))
+		detectLogEnabled, _ := strconv.ParseBool(utils.PathSearch("spec.detectLog", rule, "false").(string))
+		createdAt, _ := strconv.ParseInt(utils.PathSearch("createTime", rule, "").(string), 10, 64)
+
+		result = append(result, map[string]interface{}{
+			"id":           utils.PathSearch("id", rule, nil),
+			"name":         utils.PathSearch("name", rule, nil),
+			"service_type": utils.PathSearch("spec.appType", rule, nil),
+			"discovery_rules": flattenDateSourceDiscoveryRules(
+				utils.PathSearch("spec.discoveryRule", rule, make([]interface{}, 0)).([]interface{})),
+			"name_rules":             flattenNameRules((utils.PathSearch("spec.nameRule", rule, nil))),
+			"log_file_suffix":        utils.PathSearch("spec.logFileFix", rule, nil),
+			"discovery_rule_enabled": utils.PathSearch("enable", rule, nil),
+			"is_default_rule":        isDefaultRule,
+			"detect_log_enabled":     detectLogEnabled,
+			"priority":               utils.PathSearch("spec.priority", rule, nil),
+			"log_path_rules": flattenBasicNameRules(
+				utils.PathSearch("spec.logPathRule", rule, make([]interface{}, 0)).([]interface{})),
+			"description": utils.PathSearch("desc", rule, nil),
+			"created_at":  utils.FormatTimeStampRFC3339(createdAt/1000, false),
+		})
+	}
+	return result
+}
+
+func flattenDateSourceDiscoveryRules(paramsList []interface{}) []map[string]interface{} {
+	if len(paramsList) == 0 {
+		return nil
+	}
+	rst := make([]map[string]interface{}, 0, len(paramsList))
+	for _, params := range paramsList {
+		m := map[string]interface{}{
+			"check_content": utils.PathSearch("checkContent", params, nil),
+			"check_mode":    utils.PathSearch("checkMode", params, nil),
+			"check_type":    utils.PathSearch("checkType", params, nil),
+		}
+		rst = append(rst, m)
+	}
+
+	return rst
+}
+
+func flattenNameRules(paramsList interface{}) []interface{} {
+	if paramsList == nil {
+		return nil
+	}
+	rst := map[string]interface{}{
+		"service_name_rule": flattenBasicNameRules(
+			utils.PathSearch("appNameRule", paramsList, make([]interface{}, 0)).([]interface{})),
+		"application_name_rule": flattenBasicNameRules(
+			utils.PathSearch("applicationNameRule", paramsList, make([]interface{}, 0)).([]interface{})),
+	}
+
+	return []interface{}{rst}
+}
+
+func flattenBasicNameRules(paramsList []interface{}) []map[string]interface{} {
+	if len(paramsList) == 0 {
+		return nil
+	}
+	rst := make([]map[string]interface{}, 0, len(paramsList))
+	for _, params := range paramsList {
+		m := map[string]interface{}{
+			"name_type": utils.PathSearch("nameType", params, nil),
+			"args":      utils.PathSearch("args", params, nil),
+			"value":     utils.PathSearch("value", params, nil),
+		}
+		rst = append(rst, m)
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
add data source service discovery rules

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccDataSourceServiceDiscoveryRules_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccDataSourceServiceDiscoveryRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceServiceDiscoveryRules_basic
=== PAUSE TestAccDataSourceServiceDiscoveryRules_basic
=== CONT  TestAccDataSourceServiceDiscoveryRules_basic
--- PASS: TestAccDataSourceServiceDiscoveryRules_basic (55.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       55.869s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
