### PR TITLE
feat(drs): support new param node type and data source to get available node types

### DIFF
--- a/docs/data-sources/drs_node_types.md
+++ b/docs/data-sources/drs_node_types.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Data Replication Service (DRS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_drs_node_types"
+description: |-
+  Use this data source to query available node types for DRS jobs.
+---
+
+# huaweicloud_drs_node_types
+
+Use this data source to query available node types for DRS jobs.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_drs_node_types" "test" {
+  engine_type = "mysql"
+  type        = "sync"
+  direction   = "up"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `engine_type` - (Required, String) Specifies the DRS job engine type.
+  For details, see [engine types](https://support.huaweicloud.com/intl/en-us/api-drs/drs_api_0159.html)
+
+* `type` - (Required, String) Specifies the job type.
+  The options are as follows:
+  + **migration**: Online Migration.
+  + **sync**: Data Synchronization.
+  + **cloudDataGuard**: Disaster Recovery.
+
+* `direction` - (Required, String) Specifies the direction of data flow.
+  The options are as follows:
+  + **up**: To the cloud. The destination database must be a database in the current cloud.
+  + **down**: Out of the cloud. The source database must be a database in the current cloud.
+  + **non-dbs**: Self-built database.
+
+* `multi_write` - (Optional, Bool) Specifies whether dual-active disaster recovery is used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `node_types` - The available node types list.

--- a/docs/resources/drs_job.md
+++ b/docs/resources/drs_job.md
@@ -129,6 +129,12 @@ variable "database_name" {}
 variable "source_db_vpc_id" {}
 variable "source_db_subnet_id" {}
 
+data "huaweicloud_drs_node_types" "test" {
+  engine_type = "mysql"
+  type        = "sync"
+  direction   = "up"
+}
+
 resource "huaweicloud_rds_instance" "mysql" {
   ...
 }
@@ -138,6 +144,7 @@ resource "huaweicloud_drs_job" "test" {
   type           = "sync"
   engine_type    = "mysql"
   direction      = "up"
+  node_type      = data.huaweicloud_drs_node_types.test.node_types[0]
   net_type       = "vpc"
   migration_type = "FULL_INCR_TRANS"
   description    = "terraform demo"
@@ -342,6 +349,9 @@ The following arguments are supported:
 * `destination_db` - (Required, List, ForceNew) Specifies the destination database configuration.
   The [db_info](#block--db_info) structure of the `destination_db` is documented below.
   Changing this parameter will create a new resource.
+
+* `node_type` - (Optional, String, ForceNew) Specifies the node flavor type. Valid values are **micro**, **small**,
+  **medium**, **high**, **xlarge**, **2xlarge**. Default to **high**.
 
 * `net_type` - (Optional, String, ForceNew) Specifies the network type.
   Changing this parameter will create a new resource. The default value is **eip**. The options are as follows:

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -697,6 +697,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dns_zones":               dns.DataSourceZones(),
 
 			"huaweicloud_drs_availability_zones": drs.DataSourceAvailabilityZones(),
+			"huaweicloud_drs_node_types":         drs.DataSourceNodeTypes(),
 
 			"huaweicloud_eg_custom_event_channels": eg.DataSourceCustomEventChannels(),
 			"huaweicloud_eg_custom_event_sources":  eg.DataSourceCustomEventSources(),

--- a/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_node_types_test.go
+++ b/huaweicloud/services/acceptance/drs/data_source_huaweicloud_drs_node_types_test.go
@@ -1,0 +1,35 @@
+package drs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceNodeTypes_basic(t *testing.T) {
+	dataSourceName := "data.huaweicloud_drs_node_types.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNodeTypes_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "node_types.#"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceNodeTypes_basic string = `data "huaweicloud_drs_node_types" "test" {
+  engine_type = "mysql"
+  type        = "migration"
+  direction   = "up"
+  multi_write = false
+}`

--- a/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_job_test.go
+++ b/huaweicloud/services/acceptance/drs/resource_huaweicloud_drs_job_test.go
@@ -388,6 +388,12 @@ func testAccDrsJob_synchronize_mysql(name, dbName, pwd string, autoRenew bool) s
 
 data "huaweicloud_availability_zones" "test" {}
 
+data "huaweicloud_drs_node_types" "test" {
+  engine_type = "mysql"
+  type        = "sync"
+  direction   = "up"
+}
+
 %[3]s
 
 %[4]s
@@ -399,6 +405,7 @@ resource "huaweicloud_drs_job" "test" {
   type           = "sync"
   engine_type    = "mysql"
   direction      = "up"
+  node_type      = data.huaweicloud_drs_node_types.test.node_types[0]
   net_type       = "vpc"
   migration_type = "FULL_INCR_TRANS"
   description    = "%[6]s"

--- a/huaweicloud/services/drs/data_source_huaweicloud_drs_node_types.go
+++ b/huaweicloud/services/drs/data_source_huaweicloud_drs_node_types.go
@@ -1,0 +1,116 @@
+package drs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DRS GET /v3/{project_id}/node-type
+func DataSourceNodeTypes() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNodeTypesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"engine_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"direction": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"multi_write": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"node_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceNodeTypesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*config.Config)
+	region := conf.GetRegion(d)
+	client, err := conf.DrsV3Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DRS client: %s", err)
+	}
+
+	listNodeTypesHttpUrl := "v3/{project_id}/node-type"
+	listNodeTypesPath := client.Endpoint + listNodeTypesHttpUrl
+	listNodeTypesPath = strings.ReplaceAll(listNodeTypesPath, "{project_id}", client.ProjectID)
+	listNodeTypesPath += buildListNodeTypesQueryParams(d)
+	listNodeTypesOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	listNodeTypesResp, err := client.Request("GET", listNodeTypesPath, &listNodeTypesOpt)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	listNodeTypesRespBody, err := utils.FlattenResponse(listNodeTypesResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("node_types", utils.PathSearch("node_types[?is_sellout == `false`].node_type", listNodeTypesRespBody, make([]interface{}, 0))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildListNodeTypesQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if v, ok := d.GetOk("engine_type"); ok {
+		res = fmt.Sprintf("%s&engine_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		res = fmt.Sprintf("%s&db_use_type=%v", res, v)
+	}
+	if v, ok := d.GetOk("direction"); ok {
+		res = fmt.Sprintf("%s&job_direction=%v", res, v)
+	}
+	if v, ok := d.GetOk("amulti_write"); ok {
+		res = fmt.Sprintf("%s&is_multi_write=%v", res, v)
+	}
+
+	if res != "" {
+		res = "?" + res[1:]
+	}
+	return res
+}

--- a/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
+++ b/huaweicloud/services/drs/resource_huaweicloud_drs_job.go
@@ -54,6 +54,12 @@ func ResourceDrsJob() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,
@@ -61,30 +67,25 @@ func ResourceDrsJob() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-
 			"engine_type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-
 			"direction": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-
 			"source_db": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -92,7 +93,6 @@ func ResourceDrsJob() *schema.Resource {
 				MaxItems: 1,
 				Elem:     dbInfoSchemaResource(),
 			},
-
 			"destination_db": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -100,67 +100,63 @@ func ResourceDrsJob() *schema.Resource {
 				MaxItems: 1,
 				Elem:     dbInfoSchemaResource(),
 			},
-
+			"node_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "high",
+			},
 			"destination_db_readnoly": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 				Default:  true,
 			},
-
 			"net_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Default:  "eip",
 			},
-
 			"migration_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Default:  "FULL_INCR_TRANS",
 			},
-
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"enterprise_project_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"multi_write": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 				Default:  false,
 			},
-
 			"expired_days": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 				Default:  14,
 			},
-
 			"start_time": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"migrate_definer": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 				Default:  true,
 			},
-
 			"limit_speed": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -173,13 +169,11 @@ func ResourceDrsJob() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
-
 						"start_time": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
-
 						"end_time": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -188,7 +182,6 @@ func ResourceDrsJob() *schema.Resource {
 					},
 				},
 			},
-
 			"policy_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -201,13 +194,11 @@ func ResourceDrsJob() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
-
 						"conflict_policy": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
 						},
-
 						"index_trans": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -284,39 +275,32 @@ func ResourceDrsJob() *schema.Resource {
 					},
 				},
 			},
-
 			"tags": common.TagsSchema(),
-
 			"force_destroy": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-
 			"action": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"is_sync_re_edit": {
 				Type:         schema.TypeBool,
 				Optional:     true,
 				RequiredWith: []string{"action"},
 			},
-
 			"pause_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				RequiredWith: []string{"action"},
 			},
-
 			"databases": {
 				Type:          schema.TypeSet,
 				Optional:      true,
 				ConflictsWith: []string{"tables"},
 				Elem:          &schema.Schema{Type: schema.TypeString},
 			},
-
 			"tables": {
 				Type:          schema.TypeSet,
 				Optional:      true,
@@ -336,14 +320,12 @@ func ResourceDrsJob() *schema.Resource {
 					},
 				},
 			},
-
 			"master_az": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				RequiredWith: []string{"slave_az"},
 			},
-
 			"slave_az": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -402,21 +384,18 @@ func ResourceDrsJob() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
-
 						"delay_time": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"rpo_delay": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
-
 						"rto_delay": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -426,71 +405,54 @@ func ResourceDrsJob() *schema.Resource {
 					},
 				},
 			},
-
 			"order_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"master_job_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"slave_job_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"created_at": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"updated_at": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"progress": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"public_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"private_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
 			"security_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(60 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 	}
 }
@@ -503,96 +465,81 @@ func dbInfoSchemaResource() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
 			"ip": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-
 			"port": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"user": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"password": {
 				Type:      schema.TypeString,
 				Optional:  true,
 				ForceNew:  true,
 				Sensitive: true,
 			},
-
 			"instance_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
-
 			"ssl_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 				Default:  false,
 			},
-
 			"ssl_cert_key": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"ssl_cert_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"ssl_cert_check_sum": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"ssl_cert_password": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
 			"kafka_security_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -600,7 +547,6 @@ func dbInfoSchemaResource() *schema.Resource {
 				MaxItems: 1,
 				Elem:     dbInfoKafkaSecurityConfigSchemaResource(),
 			},
-
 			"security_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -1011,6 +957,7 @@ func resourceJobRead(_ context.Context, d *schema.ResourceData, meta interface{}
 		d.Set("net_type", listResp.Jobs[0].NetType),
 		d.Set("public_ip", detail.InstInfo.PublicIp),
 		d.Set("private_ip", detail.InstInfo.Ip),
+		d.Set("node_type", detail.InstInfo.InstType),
 		d.Set("destination_db_readnoly", detail.IsTargetReadonly),
 		d.Set("migration_type", detail.TaskType),
 		d.Set("description", detail.Description),
@@ -1612,7 +1559,7 @@ func buildCreateParamter(d *schema.ResourceData, projectId, enterpriseProjectID 
 		Description:      d.Get("description").(string),
 		MultiWrite:       utils.Bool(d.Get("multi_write").(bool)),
 		ExpiredDays:      fmt.Sprint(d.Get("expired_days").(int)),
-		NodeType:         "high",
+		NodeType:         d.Get("node_type").(string),
 		SourceEndpoint:   *sourceDb,
 		TargetEndpoint:   *targetDb,
 		SubnetId:         subnetId,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
support new param node_type and data source to get available node types

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/drs' TESTARGS='-run TestAccDataSourceNodeTypes_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccDataSourceNodeTypes_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceNodeTypes_basic
=== PAUSE TestAccDataSourceNodeTypes_basic
=== CONT  TestAccDataSourceNodeTypes_basic
--- PASS: TestAccDataSourceNodeTypes_basic (11.30s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       11.340s

make testacc TEST='./huaweicloud/services/acceptance/drs' TESTARGS='-run TestAccResourceDrsJob_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccResourceDrsJob_ -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_basic
=== PAUSE TestAccResourceDrsJob_basic
=== RUN   TestAccResourceDrsJob_sync
=== PAUSE TestAccResourceDrsJob_sync
=== RUN   TestAccResourceDrsJob_dualAZ
=== PAUSE TestAccResourceDrsJob_dualAZ
=== RUN   TestAccResourceDrsJob_mysql_to_kafka
=== PAUSE TestAccResourceDrsJob_mysql_to_kafka
=== CONT  TestAccResourceDrsJob_basic
=== CONT  TestAccResourceDrsJob_dualAZ
=== CONT  TestAccResourceDrsJob_sync
=== CONT  TestAccResourceDrsJob_mysql_to_kafka
--- PASS: TestAccResourceDrsJob_mysql_to_kafka (1281.67s)
--- PASS: TestAccResourceDrsJob_sync (1356.30s)
--- PASS: TestAccResourceDrsJob_basic (1438.76s)
--- PASS: TestAccResourceDrsJob_dualAZ (2519.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       2519.228s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
