### PR TITLE
feat(servicestage): add new data source to query environments via ver.3 API

### DIFF
--- a/docs/data-sources/servicestagev3_environments.md
+++ b/docs/data-sources/servicestagev3_environments.md
@@ -1,0 +1,67 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_environments"
+description: |-
+  Use this data source to query the list of environments within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_environments
+
+Use this data source to query the list of environments within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_servicestagev3_environments" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the environments are located.  
+  If omitted, the provider-level region will be used.
+
+* `environment_id` - (Optional, String) Specifies the ID of the environment to be queried.
+
+* `name` - (Optional, String) Specifies the name of the environment to be queried.
+
+* `enterprise_project_id` - (Optional, String) Specifies the ID of the enterprise project to which the environments belong.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `environments` - All environments that match the filter parameters.  
+  The [environments](#servicestage_v3_environments) structure is documented below.
+
+<a name="servicestage_v3_environments"></a>
+The `environments` block supports:
+
+* `id` - The environment ID.
+
+* `name` - The environment name.
+
+* `description` - The description of the environment.
+
+* `enterprise_project_id` - The ID of the enterprise project to which the environment belongs.
+
+* `deploy_mode` - The deploy mode of the environment.
+  + **container**
+  + **virtualmachine**
+  + **mixed**
+
+* `vpc_id` - The ID of the VPC to which the environment belongs.
+
+* `version` - The version number of the environment.
+
+* `tags` - The key/value pairs to associate with the environment.
+
+* `creator` - The creator name of the environment.
+
+* `created_at` - The creation time of the environment, in RFC3339 format.
+
+* `updated_at` - The latest update time of the environment, in RFC3339 format.

--- a/huaweicloud/common/resource_schema.go
+++ b/huaweicloud/common/resource_schema.go
@@ -34,13 +34,17 @@ func TagsForceNewSchema(description ...string) *schema.Schema {
 	return &schemaObj
 }
 
-// TagsComputedSchema returns the schema to use for tags as an attribute
-func TagsComputedSchema() *schema.Schema {
-	return &schema.Schema{
+// TagsComputedSchema returns the schema to use for tags as an attribute.
+func TagsComputedSchema(description ...string) *schema.Schema {
+	schemaObj := schema.Schema{
 		Type:     schema.TypeMap,
 		Computed: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
+	if len(description) > 0 {
+		schemaObj.Description = description[0]
+	}
+	return &schemaObj
 }
 
 func SchemaChargingMode(conflicts []string) *schema.Schema {

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -976,6 +976,7 @@ func Provider() *schema.Provider {
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
 			// Querying by Ver.3 APIs
+			"huaweicloud_servicestagev3_environments":   servicestage.DataSourceV3Environments(),
 			"huaweicloud_servicestagev3_runtime_stacks": servicestage.DataSourceV3RuntimeStacks(),
 
 			"huaweicloud_smn_topics":            smn.DataSourceTopics(),

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_environments_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_environments_test.go
@@ -1,0 +1,184 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccDataV3Environments_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_servicestagev3_environments.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+
+		byId   = "data.huaweicloud_servicestagev3_environments.filter_by_id"
+		dcById = acceptance.InitDataSourceCheck(byId)
+
+		byName   = "data.huaweicloud_servicestagev3_environments.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byNotFoundName   = "data.huaweicloud_servicestagev3_environments.filter_by_not_found_name"
+		dcByNotFoundName = acceptance.InitDataSourceCheck(byNotFoundName)
+
+		byEpsId   = "data.huaweicloud_servicestagev3_environments.filter_by_eps_id"
+		dcByEpsId = acceptance.InitDataSourceCheck(byEpsId)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV3Environments_basic_step1(name),
+			},
+			{
+				// Update the environment name and make sure the attribute 'updated_at' not empty.
+				Config: testAccDataV3Environments_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "environments.#", regexp.MustCompile(`[1-9]\d*`)),
+					dcById.CheckResourceExists(),
+					resource.TestCheckOutput("is_id_filter_useful", "true"),
+					resource.TestCheckResourceAttr(byId, "environments.#", "1"),
+					resource.TestCheckResourceAttrSet(byId, "environments.0.id"),
+					resource.TestCheckResourceAttr(byId, "environments.0.name", updateName),
+					resource.TestCheckResourceAttr(byId, "environments.0.description", "Created by terraform test"),
+					resource.TestCheckResourceAttrPair(byId, "environments.0.vpc_id", "huaweicloud_vpc.test", "id"),
+					resource.TestCheckResourceAttr(byId, "environments.0.enterprise_project_id",
+						acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+					resource.TestCheckResourceAttr(byId, "environments.0.tags.%", "2"),
+					resource.TestCheckResourceAttr(byId, "environments.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(byId, "environments.0.tags.owner", "terraform"),
+					resource.TestMatchResourceAttr(byId, "environments.0.created_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					resource.TestMatchResourceAttr(byId, "environments.0.updated_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`)),
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					dcByNotFoundName.CheckResourceExists(),
+					resource.TestCheckOutput("is_not_found_name_filter_useful", "true"),
+					dcByEpsId.CheckResourceExists(),
+					resource.TestCheckOutput("is_eps_id_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataV3Environments_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_servicestagev3_environment" "test" {
+  name                  = "%[2]s"
+  description           = "Created by terraform test"
+  vpc_id                = huaweicloud_vpc.test.id
+  enterprise_project_id = "%[3]s"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+`, common.TestVpc(name), name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccDataV3Environments_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_servicestagev3_environments" "test" {
+  depends_on = [
+    huaweicloud_servicestagev3_environment.test
+  ]
+}
+
+# Filter by ID
+locals {
+  environment_id = huaweicloud_servicestagev3_environment.test.id
+}
+
+data "huaweicloud_servicestagev3_environments" "filter_by_id" {
+  depends_on = [
+    huaweicloud_servicestagev3_environment.test
+  ]
+
+  environment_id = local.environment_id
+}
+
+locals {
+  id_filter_result = [
+    for v in data.huaweicloud_servicestagev3_environments.filter_by_id.environments[*].id : v == local.environment_id
+  ]
+}
+
+output "is_id_filter_useful" {
+  value = length(local.id_filter_result) > 0 && alltrue(local.id_filter_result)
+}
+
+# Filter by name
+locals {
+  environment_name = huaweicloud_servicestagev3_environment.test.name
+}
+
+data "huaweicloud_servicestagev3_environments" "filter_by_name" {
+  depends_on = [
+    huaweicloud_servicestagev3_environment.test
+  ]
+
+  name = local.environment_name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_servicestagev3_environments.filter_by_name.environments[*].name : v == local.environment_name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = length(local.name_filter_result) > 0 && alltrue(local.name_filter_result)
+}
+
+# Filter by name (not found)
+data "huaweicloud_servicestagev3_environments" "filter_by_not_found_name" {
+  depends_on = [
+    huaweicloud_servicestagev3_environment.test
+  ]
+
+  name = "name_not_found"
+}
+
+output "is_not_found_name_filter_useful" {
+  value = length(data.huaweicloud_servicestagev3_environments.filter_by_not_found_name.environments) == 0
+}
+
+data "huaweicloud_servicestagev3_environments" "filter_by_eps_id" {
+  depends_on = [
+    huaweicloud_servicestagev3_environment.test
+  ]
+
+  enterprise_project_id = "%[2]s"
+}
+
+locals {
+  eps_id_filter_result = [
+    for v in data.huaweicloud_servicestagev3_environments.filter_by_eps_id.environments[*].enterprise_project_id : v == "%[2]s"
+  ]
+}
+
+output "is_eps_id_filter_useful" {
+  value = length(local.eps_id_filter_result) > 0 && alltrue(local.eps_id_filter_result)
+}
+`, testAccDataV3Environments_basic_step1(name), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_environments.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_environments.go
@@ -1,0 +1,217 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v3/{project_id}/cas/environments
+func DataSourceV3Environments() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3EnvironmentsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the environments are located.`,
+			},
+			"environment_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the environment to be queried.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The name of the environment to be queried.`,
+			},
+			"enterprise_project_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The ID of the enterprise project to which the environments belong.`,
+			},
+			"environments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The environment ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The environment name.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the environment.`,
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the enterprise project to which the environment belongs.`,
+						},
+						"deploy_mode": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The deploy mode of the environment.`,
+						},
+						"vpc_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the VPC to which the environment belongs.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version number of the environment.`,
+						},
+						"tags": common.TagsComputedSchema(
+							`The key/value pairs to associate with the environment.`,
+						),
+						"creator": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator name of the environment.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the environment, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the environment, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: "All runtime stack details.",
+			},
+		},
+	}
+}
+
+func buildV3EnvironmentsQueryParams(d *schema.ResourceData) string {
+	res := ""
+	if envName, ok := d.GetOk("name"); ok {
+		res = fmt.Sprintf("%s&name=%v", res, envName)
+	}
+	if envId, ok := d.GetOk("environment_id"); ok {
+		res = fmt.Sprintf("%s&environment_id=%v", res, envId)
+	}
+	if epsId, ok := d.GetOk("enterprise_project_id"); ok {
+		res = fmt.Sprintf("%s&enterprise_project_id=%v", res, epsId)
+	}
+	return res
+}
+
+func queryV3Environments(client *golangsdk.ServiceClient, d *schema.ResourceData) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/cas/environments?limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildV3EnvironmentsQueryParams(d)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		envs := utils.PathSearch("environments", respBody, make([]interface{}, 0)).([]interface{})
+		if len(envs) < 1 {
+			break
+		}
+		result = append(result, envs...)
+		offset += len(envs)
+	}
+
+	return result, nil
+}
+
+func flattenV3Environments(environments []interface{}) []map[string]interface{} {
+	if len(environments) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(environments))
+	for _, environment := range environments {
+		result = append(result, map[string]interface{}{
+			"id":                    utils.PathSearch("id", environment, nil),
+			"name":                  utils.PathSearch("name", environment, nil),
+			"description":           utils.PathSearch("description", environment, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", environment, nil),
+			"deploy_mode":           utils.PathSearch("deploy_mode", environment, nil),
+			"vpc_id":                utils.PathSearch("vpc_id", environment, nil),
+			"creator":               utils.PathSearch("creator", environment, nil),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+				environment, float64(0)).(float64))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+				environment, float64(0)).(float64))/1000, false),
+			"tags": utils.FlattenTagsToMap(utils.PathSearch("labels", environment, nil)),
+		})
+	}
+	return result
+}
+
+func dataSourceV3EnvironmentsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	envList, err := queryV3Environments(client, d)
+	if err != nil {
+		return diag.Errorf("error getting environments: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("environments", flattenV3Environments(envList)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source that used to query environments.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query environments
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o servicestage -f TestAccDataV3Environments_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccDataV3Environments_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV3Environments_basic
=== PAUSE TestAccDataV3Environments_basic
=== CONT  TestAccDataV3Environments_basic
--- PASS: TestAccDataV3Environments_basic (82.12s)
PASS
coverage: 11.0% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      82.178s coverage: 11.0% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
