### PR TITLE
feat(servicestage): add new data source to query applications via ver.3 API

### DIFF
--- a/docs/data-sources/servicestagev3_applications.md
+++ b/docs/data-sources/servicestagev3_applications.md
@@ -1,0 +1,52 @@
+---
+subcategory: "ServiceStage"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_servicestagev3_applications"
+description: |-
+  Use this data source to query the list of applications within HuaweiCloud.
+---
+
+# huaweicloud_servicestagev3_applications
+
+Use this data source to query the list of applications within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+data "huaweicloud_servicestagev3_applications" "test" {}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region where the applications are located.  
+  If omitted, the provider-level region will be used.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID, in UUID format.
+
+* `applications` - All application details.  
+  The [applications](#servicestage_v3_applications) structure is documented below.
+
+<a name="servicestage_v3_applications"></a>
+The `applications` block supports:
+
+* `id` - The application ID.
+
+* `name` - The application name.
+
+* `description` - The description of the application.
+
+* `enterprise_project_id` - The ID of the enterprise project to which the application belongs.
+
+* `tags` - The key/value pairs to associate with the application.
+
+* `creator` - The creator name of the application.
+
+* `created_at` - The creation time of the application, in RFC3339 format.
+
+* `updated_at` - The latest update time of the application, in RFC3339 format.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -980,6 +980,7 @@ func Provider() *schema.Provider {
 			// Querying by Ver.2 APIs
 			"huaweicloud_servicestage_component_runtimes": servicestage.DataSourceComponentRuntimes(),
 			// Querying by Ver.3 APIs
+			"huaweicloud_servicestagev3_applications":   servicestage.DataSourceV3Applications(),
 			"huaweicloud_servicestagev3_environments":   servicestage.DataSourceV3Environments(),
 			"huaweicloud_servicestagev3_runtime_stacks": servicestage.DataSourceV3RuntimeStacks(),
 

--- a/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_applications_test.go
+++ b/huaweicloud/services/acceptance/servicestage/data_source_huaweicloud_servicestagev3_applications_test.go
@@ -1,0 +1,113 @@
+package servicestage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataV3Applications_basic(t *testing.T) {
+	var (
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+
+		all = "data.huaweicloud_servicestagev3_applications.test"
+		dc  = acceptance.InitDataSourceCheck(all)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckEpsID(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataV3Applications_basic_step1(name),
+			},
+			{
+				// Update the application name and make sure the attribute 'updated_at' not empty.
+				Config: testAccDataV3Applications_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(all, "applications.#", regexp.MustCompile(`[1-9]\d*`)),
+					resource.TestCheckOutput("is_application_id_set", "true"),
+					resource.TestCheckOutput("is_application_name_set", "true"),
+					resource.TestCheckOutput("is_application_description_set", "true"),
+					resource.TestCheckOutput("is_application_eps_id_set", "true"),
+					resource.TestCheckOutput("is_application_creator_set", "true"),
+					resource.TestCheckOutput("is_application_created_at_set", "true"),
+					resource.TestCheckOutput("is_application_updated_at_set", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataV3Applications_basic_step1(name string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_servicestagev3_application" "test" {
+  name                  = "%[1]s"
+  description           = "Created by terraform test"
+  enterprise_project_id = "%[2]s"
+
+  tags = {
+    foo   = "bar"
+    owner = "terraform"
+  }
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+}
+
+func testAccDataV3Applications_basic_step2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_servicestagev3_applications" "test" {
+  depends_on = [
+    huaweicloud_servicestagev3_application.test
+  ]
+}
+
+locals {
+  application_id            = huaweicloud_servicestagev3_application.test.id
+  application_filter_result = try([
+    for v in data.huaweicloud_servicestagev3_applications.test.applications : v if v.id == local.application_id
+  ][0], null)
+}
+
+output "is_application_id_set" {
+  value = local.application_filter_result != null
+}
+
+output "is_application_name_set" {
+  value = try(local.application_filter_result.name == huaweicloud_servicestagev3_application.test.name, false)
+}
+
+output "is_application_description_set" {
+  value = try(local.application_filter_result.description == huaweicloud_servicestagev3_application.test.description, false)
+}
+
+output "is_application_eps_id_set" {
+  value = try(local.application_filter_result.enterprise_project_id == huaweicloud_servicestagev3_application.test.enterprise_project_id, false)
+}
+
+output "is_application_creator_set" {
+  value = try(local.application_filter_result.creator != "", false)
+}
+
+output "is_application_created_at_set" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.application_filter_result.created_at)) > 0, false)
+}
+
+output "is_application_updated_at_set" {
+  value = try(length(regexall("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:Z|[+-]\\d{2}:\\d{2})$",
+    local.application_filter_result.updated_at)) > 0, false)
+}
+`, testAccDataV3Applications_basic_step1(name))
+}

--- a/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_applications.go
+++ b/huaweicloud/services/servicestage/data_source_huaweicloud_servicestagev3_applications.go
@@ -1,0 +1,171 @@
+package servicestage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API ServiceStage GET /v3/{project_id}/cas/applications
+func DataSourceV3Applications() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceV3ApplicationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The region where the applications are located.`,
+			},
+			"applications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The application ID.`,
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The application name.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the application.`,
+						},
+						"enterprise_project_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the enterprise project to which the application belongs.`,
+						},
+						"tags": common.TagsComputedSchema(
+							`The key/value pairs to associate with the application.`,
+						),
+						"creator": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creator name of the application.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The creation time of the application, in RFC3339 format.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The latest update time of the application, in RFC3339 format.`,
+						},
+					},
+				},
+				Description: "All application details.",
+			},
+		},
+	}
+}
+
+func queryV3Applications(client *golangsdk.ServiceClient) ([]interface{}, error) {
+	var (
+		httpUrl = "v3/{project_id}/cas/applications?limit=100"
+		offset  = 0
+		result  = make([]interface{}, 0)
+	)
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+
+	opt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+		},
+	}
+
+	for {
+		listPathWithOffset := listPath + fmt.Sprintf("&offset=%d", offset)
+		requestResp, err := client.Request("GET", listPathWithOffset, &opt)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := utils.FlattenResponse(requestResp)
+		if err != nil {
+			return nil, err
+		}
+		apps := utils.PathSearch("applications", respBody, make([]interface{}, 0)).([]interface{})
+		if len(apps) < 1 {
+			break
+		}
+		result = append(result, apps...)
+		offset += len(apps)
+	}
+
+	return result, nil
+}
+
+func flattenV3Applications(applications []interface{}) []map[string]interface{} {
+	if len(applications) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(applications))
+	for _, application := range applications {
+		result = append(result, map[string]interface{}{
+			"id":                    utils.PathSearch("id", application, nil),
+			"name":                  utils.PathSearch("name", application, nil),
+			"description":           utils.PathSearch("description", application, nil),
+			"enterprise_project_id": utils.PathSearch("enterprise_project_id", application, nil),
+			"creator":               utils.PathSearch("creator", application, nil),
+			"created_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("create_time",
+				application, float64(0)).(float64))/1000, false),
+			"updated_at": utils.FormatTimeStampRFC3339(int64(utils.PathSearch("update_time",
+				application, float64(0)).(float64))/1000, false),
+			"tags": utils.FlattenTagsToMap(utils.PathSearch("labels", application, nil)),
+		})
+	}
+
+	return result
+}
+
+func dataSourceV3ApplicationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+	client, err := cfg.NewServiceClient("servicestage", region)
+	if err != nil {
+		return diag.Errorf("error creating ServiceStage client: %s", err)
+	}
+
+	appList, err := queryV3Applications(client)
+	if err != nil {
+		return diag.Errorf("error getting applications: %s", err)
+	}
+
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuid)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("applications", flattenV3Applications(appList)),
+	)
+	return diag.FromErr(mErr.ErrorOrNil())
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports a new data source that used to query application using ver.3 API.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source to query applications.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o servicestage -f TestAccDataV3Applications_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/servicestage" -v -coverprofile="./huaweicloud/services/acceptance/servicestage_coverage.cov" -coverpkg="./huaweicloud/services/servicestage" -run TestAccDataV3Applications_basic -timeout 360m -parallel 10
=== RUN   TestAccDataV3Applications_basic
=== PAUSE TestAccDataV3Applications_basic
=== CONT  TestAccDataV3Applications_basic
--- PASS: TestAccDataV3Applications_basic (36.67s)
PASS
coverage: 10.1% of statements in ./huaweicloud/services/servicestage
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/servicestage      36.715s coverage: 10.1% of statements in ./huaweicloud/services/servicestage
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
