### PR TITLE
feat(dws): add new resource to modify parameter configurations

### DIFF
--- a/docs/resources/dws_parameter_configurations.md
+++ b/docs/resources/dws_parameter_configurations.md
@@ -1,0 +1,76 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_parameter_configurations"
+description: |-
+  Use this resource to modify the parameter configurations of DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_parameter_configurations
+
+Use this resource to modify the parameter configurations of DWS cluster within HuaweiCloud.
+
+-> 1. Only one `huaweicloud_dws_parameter_configurations` resource can be created for a DWS cluster.
+   <br>2. If the modified parameters require restarting the DWS cluster, the modified values ​​will be displayed in the
+   corresponding tfstate file after the resource is created, and the cluster status will be pending restart, and some
+   operation and maintenance operations will be disabled. The modified values ​​will not take effect until the cluster
+   is restarted, and the cluster will be restored to an available state.
+   <br>3. This resource is only used to modify the DWS cluster parameter configurations. Deleting this resource will
+   not clear the corresponding request record, but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "dws_cluster_id" {}
+variable "parameter_name" {}
+variable "parameter_value" {}
+
+resource "huaweicloud_dws_parameter_configurations" "test" {
+  cluster_id = var.dws_cluster_id
+
+  configurations {
+    name  = var.parameter_name
+    type  = "cn"
+    value = var.parameter_value
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `cluster_id` - (Required, String, ForceNew) Specifies the DWS cluster ID.
+  Changing this creates a new resource.
+
+* `configurations` - (Required, List) Specifies the list of the DWS cluster parameter configurations.
+  The [configurations](#parameter_configurations) structure is documented below.
+
+<a name="parameter_configurations"></a>
+The `configurations` block supports:
+
+* `name` - (Required, String) Specifies the name of the parameter.
+
+* `type` - (Required, String) Specifies the type of the parameter.  
+  The valid values are as follows:
+  + **cn**
+  + **dn**
+
+* `value` - (Required, String) Specifies the value of the parameter.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1498,6 +1498,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_logical_cluster_restart":       dws.ResourceLogicalClusterRestart(),
 			"huaweicloud_dws_logical_cluster":               dws.ResourceLogicalCluster(),
 			"huaweicloud_dws_om_account_action":             dws.ResourceOmAccountAction(),
+			"huaweicloud_dws_parameter_configurations":      dws.ResourceParameterConfigurations(),
 			"huaweicloud_dws_public_domain_associate":       dws.ResourcePublicDomainAssociate(),
 			"huaweicloud_dws_snapshot_copy":                 dws.ResourceSnapshotCopy(),
 			"huaweicloud_dws_snapshot_policy":               dws.ResourceDwsSnapshotPolicy(),

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_parameter_configurations_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_parameter_configurations_test.go
@@ -1,0 +1,104 @@
+package dws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
+)
+
+func getParameterConfigurationsFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := acceptance.HW_REGION_NAME
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DWS client: %s", err)
+	}
+
+	return dws.GetParameterConfigurations(client, state.Primary.ID)
+}
+
+// lintignore:AT001
+func TestAccParameterConfigurations_basic(t *testing.T) {
+	var obj interface{}
+	rName := "huaweicloud_dws_parameter_configurations.test"
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getParameterConfigurationsFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testParameterConfigurations_basic_step1(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "configurations.0.name", "agg_max_mem"),
+					resource.TestCheckResourceAttr(rName, "configurations.0.type", "cn"),
+					resource.TestCheckResourceAttr(rName, "configurations.0.value", "2097151"),
+				),
+			},
+			{
+				Config: testParameterConfigurations_basic_step2(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "configurations.0.name", "ssl_ciphers"),
+					resource.TestCheckResourceAttr(rName, "configurations.0.type", "dn"),
+					resource.TestCheckResourceAttr(rName, "configurations.0.value", "TLS_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256"),
+					resource.TestCheckResourceAttr(rName, "configurations.1.value", "2097152"),
+				),
+			},
+		},
+	})
+}
+
+func testParameterConfigurations_basic_step1() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_parameter_configurations" "test" {
+  cluster_id = "%s"
+
+  configurations {
+    name  = "agg_max_mem"
+    type  = "cn"
+    value = "2097151"
+  }
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}
+
+func testParameterConfigurations_basic_step2() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_parameter_configurations" "test" {
+  cluster_id = "%[1]s"
+
+  configurations {
+    name  = "ssl_ciphers"
+    type  = "dn"
+    value = "TLS_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256"
+  }
+  configurations {
+    name  = "agg_max_mem"
+    type  = "cn"
+    value = "2097152"
+  }
+}
+
+resource "huaweicloud_dws_cluster_restart" "test" {
+  depends_on = [
+    huaweicloud_dws_parameter_configurations.test
+  ]
+
+  cluster_id = "%[1]s"
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dws/common.go
+++ b/huaweicloud/services/dws/common.go
@@ -1,0 +1,53 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func waitClusterTaskStateCompleted(ctx context.Context, client *golangsdk.ServiceClient, timeout time.Duration, clusterId string) error {
+	stateCluster := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshClusterTaskStateFun(client, clusterId),
+		Timeout:      timeout,
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+	_, err := stateCluster.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for DWS cluster task to complete: %s", err)
+	}
+
+	return nil
+}
+
+func refreshClusterTaskStateFun(client *golangsdk.ServiceClient, clusterId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := GetClusterInfoByClusterId(client, clusterId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		taskStatus := utils.PathSearch("cluster.task_status", respBody, "").(string)
+		status := utils.PathSearch("cluster.status", respBody, "").(string)
+		if taskStatus == "" && utils.StrSliceContains([]string{"AVAILABLE", "ACTIVE"}, status) {
+			return respBody, "COMPLETED", nil
+		}
+
+		// ACTIVE_STANDY_SWITCHOVER: The active-standby switchover is beibng performed.
+		if strings.Contains(taskStatus, "ING") || taskStatus == "ACTIVE_STANDY_SWITCHOVER" {
+			return respBody, "PENDING", nil
+		}
+
+		return respBody, taskStatus, nil
+	}
+}

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_parameter_configurations.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_parameter_configurations.go
@@ -1,0 +1,292 @@
+package dws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS PUT /v2/{project_id}/clusters/{cluster_id}/configurations/{configuration_id}
+// @API DWS GET /v1.0/{project_id}/clusters/{cluster_id}/configurations
+// @API DWS GET /v1.0/{project_id}/clusters/{cluster_id}/configurations/{configuration_id}
+// @API DWS GET /v1.0/{project_id}/clusters/{cluster_id}
+func ResourceParameterConfigurations() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceParameterConfigurationsCreate,
+		ReadContext:   resourceParameterConfigurationsRead,
+		UpdateContext: resourceParameterConfigurationsUpdate,
+		DeleteContext: resourceParameterConfigurationsDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The DWS cluster ID.`,
+			},
+			"configurations": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: `The list of the DWS cluster parameter configurations.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the parameter.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The type of the parameter.`,
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The value of the parameter.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceParameterConfigurationsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		clusterId = d.Get("cluster_id").(string)
+	)
+	// For the same DWS cluster, it is not supported to run multiple tasks at the same time.
+	config.MutexKV.Lock(clusterId)
+	defer config.MutexKV.Unlock(clusterId)
+
+	client, err := cfg.NewServiceClient("dws", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = modifyConfigurations(ctx, client, clusterId, d.Get("configurations").([]interface{}), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(clusterId)
+	return resourceParameterConfigurationsRead(ctx, d, meta)
+}
+
+func modifyConfigurations(ctx context.Context, client *golangsdk.ServiceClient, clusterId string, configurations []interface{},
+	timeout time.Duration) error {
+	if err := waitClusterTaskStateCompleted(ctx, client, timeout, clusterId); err != nil {
+		return err
+	}
+
+	group, err := getParameterGroup(client, clusterId)
+	if err != nil {
+		return err
+	}
+
+	httpUrl := "v2/{project_id}/clusters/{cluster_id}/configurations/{configuration_id}"
+	modifyPath := client.Endpoint + httpUrl
+	modifyPath = strings.ReplaceAll(modifyPath, "{project_id}", client.ProjectID)
+	modifyPath = strings.ReplaceAll(modifyPath, "{cluster_id}", clusterId)
+	modifyPath = strings.ReplaceAll(modifyPath, "{configuration_id}", utils.PathSearch("id", group, "").(string))
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"configurations": configurations,
+		},
+	}
+
+	_, err = client.Request("PUT", modifyPath, &createOpt)
+	if err != nil {
+		return fmt.Errorf("error setting the DWS cluster (%s) paramsters: %s", clusterId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      refreshParamesterStateFun(client, clusterId),
+		Timeout:      timeout,
+		Delay:        30 * time.Second,
+		PollInterval: 30 * time.Second,
+	}
+
+	_, err = stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for the parameters modification to completed: %s", err)
+	}
+	return nil
+}
+
+func refreshParamesterStateFun(client *golangsdk.ServiceClient, clusterId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		respBody, err := getParameterGroup(client, clusterId)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		status := utils.PathSearch("status", respBody, "").(string)
+		if utils.StrSliceContains([]string{"In-Sync", "Pending-Reboot"}, status) {
+			return respBody, "COMPLETED", nil
+		}
+
+		if utils.StrSliceContains([]string{"Sync-Failure"}, status) {
+			return respBody, status, nil
+		}
+		// The status value is `Applying`.
+		return respBody, "PENDING", nil
+	}
+}
+
+func resourceParameterConfigurationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	resp, err := GetParameterConfigurations(client, d.Id())
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving parameter configurations")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("configurations",
+			flattenConfigurations(d.Get("configurations").([]interface{}), resp)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenConfigurations(configurations []interface{}, resp interface{}) interface{} {
+	if resp == nil {
+		return nil
+	}
+
+	parameters := make([]map[string]interface{}, len(configurations))
+	for i, v := range configurations {
+		name := utils.PathSearch("name", v, "").(string)
+		parameterType := utils.PathSearch("type", v, "").(string)
+		express := fmt.Sprintf("configurations[?name=='%s']|[0].{values:values}", name)
+		valueRaw := utils.PathSearch(express, resp, nil)
+		typeExpress := fmt.Sprintf("values[?type=='%s']|[0].value", parameterType)
+		// For multi-option parameters that require restarting the cluster, the input parameters are connected by commas (,),
+		// the obtained values ​​are connected by semicolons (;). The backend is used to distinguish before and after parameter adjustment.
+		value := strings.ReplaceAll(utils.PathSearch(typeExpress, valueRaw, "").(string), ";", ",")
+		parameters[i] = map[string]interface{}{
+			"name":  name,
+			"value": value,
+			"type":  parameterType,
+		}
+	}
+
+	return parameters
+}
+
+func GetParameterConfigurations(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
+	group, err := getParameterGroup(client, clusterId)
+	if err != nil {
+		return nil, err
+	}
+
+	getHttpUrl := "v1.0/{project_id}/clusters/{cluster_id}/configurations/{configuration_id}"
+	getPath := client.Endpoint + getHttpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+	getPath = strings.ReplaceAll(getPath, "{configuration_id}", utils.PathSearch("id", group, "").(string))
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+	}
+
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, err
+	}
+	return utils.FlattenResponse(getResp)
+}
+
+func getParameterGroup(client *golangsdk.ServiceClient, clusterId string) (interface{}, error) {
+	httpUrl := "v1.0/{project_id}/clusters/{cluster_id}/configurations"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{cluster_id}", clusterId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      requestOpts.MoreHeaders,
+	}
+
+	resp, err := client.Request("GET", getPath, &createOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.PathSearch("configurations[?type=='hiddenParameterGroup']|[0]", respBody, nil), nil
+}
+
+func resourceParameterConfigurationsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		clusterId = d.Get("cluster_id").(string)
+	)
+
+	config.MutexKV.Lock(clusterId)
+	defer config.MutexKV.Unlock(clusterId)
+
+	client, err := cfg.NewServiceClient("dws", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	err = modifyConfigurations(ctx, client, clusterId, d.Get("configurations").([]interface{}), d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	return resourceParameterConfigurationsRead(ctx, d, meta)
+}
+
+func resourceParameterConfigurationsDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := `This resource is only used to modify the DWS cluster parameter configurations. Deleting this resource will	not clear
+	the corresponding request record, but will only remove the resource information from the tfstate file.`
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new resource to support modifying parameter configurations of the DWS cluster.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add related to document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccParameterConfigurations_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccParameterConfigurations_basic -timeout 360m -parallel 4
=== RUN   TestAccParameterConfigurations_basic
=== PAUSE TestAccParameterConfigurations_basic
=== CONT  TestAccParameterConfigurations_basic
--- PASS: TestAccParameterConfigurations_basic (252.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       252.413s
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    The DWS cluster does not exist.
    ![image](https://github.com/user-attachments/assets/2e3814d7-dc53-4bc0-97b1-4910dca91788)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
