### PR TITLE
chore(NAT): refactor code using auto-generated styles.

### DIFF
--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/chnsz/golangsdk/openstack/nat/v2/gateways"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
@@ -21,13 +19,12 @@ func getPublicGatewayResourceFunc(cfg *config.Config, state *terraform.ResourceS
 		return nil, fmt.Errorf("error creating NAT v2 client: %s", err)
 	}
 
-	return gateways.Get(client, state.Primary.ID)
+	return nat.ReadPublicGateway(client, state.Primary.ID)
 }
 
 func TestAccPublicGateway_basic(t *testing.T) {
 	var (
-		obj gateways.Gateway
-
+		obj           interface{}
 		rName         = "huaweicloud_nat_gateway.test"
 		name          = acceptance.RandomAccResourceNameWithDash()
 		updateName    = acceptance.RandomAccResourceNameWithDash()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

refactor code using auto-generated styles.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

In order to support the prepaid NAT gateway, the code needs to be refactored using the automatic generation style.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1728627751295_TestAccPublicGateway_basic.cov -coverpkg=./huaweicloud/services/nat ./huaweicloud/services/acceptance/nat -run TestAccPublicGateway_basic -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_basic
--- PASS: TestAccPublicGateway_basic (120.98s)
PASS
coverage: 12.0% of statements in ./huaweicloud/services/nat
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       121.045s        coverage: 12.0% of statements in ./huaweicloud/services/nat
```

![image](https://github.com/user-attachments/assets/7cc85890-fc5c-417f-b60a-129703c7a683)


- Use the code package before refactoring to create resources, and then use the code package after refactoring to execute the terraform plan. Terraform did not prompt any exceptions, proving that this code reconstruction is safe.
![image](https://github.com/user-attachments/assets/0d6ad278-b286-4daf-aa31-8ff222f066f3)



* [ ] Documentation updated.
* [ ] Schema updated.
* [X] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/1e70be68-378a-4ada-b406-b6a7ae7ea34b)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    ![image](https://github.com/user-attachments/assets/b2c04bab-4a97-4ddc-b512-1075996a6e33)

