### PR TITLE
docs(drs): fix ssl password

### DIFF
--- a/docs/resources/drs_job.md
+++ b/docs/resources/drs_job.md
@@ -302,6 +302,12 @@ resource "huaweicloud_drs_job" "test" {
   lifecycle {
     ignore_changes = [
       source_db.0.password, destination_db.0.password,
+      source_db.0.kafka_security_config.0.trust_store_password,
+      destination_db.0.kafka_security_config.0.trust_store_password,
+      source_db.0.kafka_security_config.0.key_store_password,
+      destination_db.0.kafka_security_config.0.key_store_password,
+      source_db.0.kafka_security_config.0.key_password,
+      destination_db.0.kafka_security_config.0.key_password,
     ]
   }
 }
@@ -790,8 +796,12 @@ $ terraform import huaweicloud_drs_job.test <id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `enterprise_project_id`, `force_destroy`,
-`source_db.0.password`, `destination_db.0.password`, `source_db.0.ip`, `destination_db.0.ip`, `action`, `is_sync_re_edit`,
-`pause_mode`, `auto_renew`, `alarm_notify.0.topic_urn`, `policy_config`, `engine_type`, `public_ip_list`, `start_time`.
+`source_db.0.password`, `destination_db.0.password`, `source_db.0.ip`, `destination_db.0.ip`,
+`source_db.0.kafka_security_config.0.trust_store_password`, `destination_db.0.kafka_security_config.0.trust_store_password`,
+`source_db.0.kafka_security_config.0.key_store_password`,`destination_db.0.kafka_security_config.0.key_store_password`,
+`source_db.0.kafka_security_config.0.key_password`, `destination_db.0.kafka_security_config.0.key_password`,
+`action`, `is_sync_re_edit`, `pause_mode`, `auto_renew`, `alarm_notify.0.topic_urn`, `policy_config`, `engine_type`,
+`public_ip_list`, `start_time`.
 It is generally recommended running **terraform plan** after importing a job. You can then
 decide if changes should be applied to the job, or the resource definition should be updated to align with the job. Also
 you can ignore changes as below.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
fix ssl password, 


* [x] Tests added/passed.

```
 make testacc TEST='./huaweicloud/services/acceptance/drs' TESTARGS='-run TestAccResourceDrsJob_mysql_to_kafka'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/drs -v -run TestAccResourceDrsJob_mysql_to_kafka -timeout 360m -parallel 4
=== RUN   TestAccResourceDrsJob_mysql_to_kafka
=== PAUSE TestAccResourceDrsJob_mysql_to_kafka
=== CONT  TestAccResourceDrsJob_mysql_to_kafka
--- PASS: TestAccResourceDrsJob_mysql_to_kafka (1249.20s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/drs       1249.269s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
