### PR TITLE
chore(cph): fix cph server test and lint error

### DIFF
--- a/docs/data-sources/cph_phone_flavors.md
+++ b/docs/data-sources/cph_phone_flavors.md
@@ -2,7 +2,8 @@
 subcategory: "Cloud Phone (CPH)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cph_phone_flavors"
-description: ""
+description: |-
+  Use this data source to get available flavors of CPH phone.
 ---
 
 # huaweicloud_cph_phone_flavors
@@ -13,7 +14,7 @@ Use this data source to get available flavors of CPH phone.
 
 ```hcl
 data "huaweicloud_cph_phone_flavors" "test" {
-  type = 1
+  type = "1"
 }
 ```
 
@@ -26,13 +27,13 @@ The following arguments are supported:
 
 * `status` - (Optional, String) The flavor status. Defaults to **1**.  
   The options are as follows:
-    - **0**: offline.
-    - **1**: normal.
+  + **0**: offline.
+  + **1**: normal.
 
 * `type` - (Optional, String) The cloud phone type.  
   The options are as follows:
-    - **0**: Cloud phone.
-    - **1**: Cloud mobile gaming.
+  + **0**: Cloud phone.
+  + **1**: Cloud mobile gaming.
 
 * `vcpus` - (Optional, Int) The vcpus of the CPH phone.
 
@@ -71,13 +72,13 @@ The `Flavors` block supports:
 
 * `status` - The flavor status.  
   The options are as follows:
-    - **0**: offline.
-    - **1**: normal.
+  + **0**: offline.
+  + **1**: normal.
 
 * `type` - The cloud phone type.  
   The options are as follows:
-    - **0**: Cloud phone.
-    - **1**: Cloud mobile gaming.
+  + **0**: Cloud phone.
+  + **1**: Cloud mobile gaming.
 
 * `image_label` - (Optional, String) The label of image.
   The valid values are **cloud_phone**, **cloud_game**, **qemu_phone**, **cloud_phone_1620**, and **cloud_game_1620**.

--- a/docs/data-sources/cph_phone_images.md
+++ b/docs/data-sources/cph_phone_images.md
@@ -2,7 +2,8 @@
 subcategory: "Cloud Phone (CPH)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cph_phone_images"
-description: ""
+description: |-
+  Use this data source to get available images of CPH phone.
 ---
 
 # huaweicloud_cph_phone_images
@@ -26,8 +27,8 @@ The following arguments are supported:
 
 * `is_public` - (Optional, Int) The image type.  
   The options are as follows:
-    - **1**: Public image.
-    - **2**: Private image.
+  + **1**: Public image.
+  + **2**: Private image.
 
 * `image_label` - (Optional, String) The label of image.  
   The valid values are **cloud_phone**, **cloud_game**, **qemu_phone**, **cloud_phone_1620**, and **cloud_game_1620**.
@@ -54,8 +55,8 @@ The `Images` block supports:
 
 * `is_public` - The image type.  
   The options are as follows:
-    - **1**: Public image.
-    - **2**: Private image.
+  + **1**: Public image.
+  + **2**: Private image.
 
 * `image_label` - The label of the image.  
   The valid values are **cloud_phone**, **cloud_game**, **qemu_phone**, **cloud_phone_1620**, and **cloud_game_1620**.

--- a/docs/data-sources/cph_server_flavors.md
+++ b/docs/data-sources/cph_server_flavors.md
@@ -2,7 +2,8 @@
 subcategory: "Cloud Phone (CPH)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_cph_server_flavors"
-description: ""
+description: |-
+  Use this data source to get available flavors of CPH server.
 ---
 
 # huaweicloud_cph_server_flavors
@@ -13,7 +14,7 @@ Use this data source to get available flavors of CPH server.
 
 ```hcl
 data "huaweicloud_cph_server_flavors" "flavor" {
-  type = 0
+  type = "0"
 }
 ```
 
@@ -26,9 +27,9 @@ The following arguments are supported:
 
 * `type` - (Optional, String) The type of the CPH server flavor.  
   The options are as follows:
-    - **0**: Cloud phone servers are designed for app hosting and multi-platform live streaming.
-    - **1**: Cloud mobile gaming servers, GPU hardware acceleration and graphics interfaces
-      allow you to run mobile games on the cloud.
+  + **0**: Cloud phone servers are designed for app hosting and multi-platform live streaming.
+  + **1**: Cloud mobile gaming servers, GPU hardware acceleration and graphics interfaces
+    allow you to run mobile games on the cloud.
 
 * `vcpus` - (Optional, Int) The vcpus of the CPH server.
 
@@ -54,9 +55,9 @@ The `Flavors` block supports:
 
 * `type` - The type of the CPH server flavor.  
   The options are as follows:
-    - **0**: Cloud phone servers are designed for app hosting and multi-platform live streaming.
-    - **1**: Cloud mobile gaming servers, GPU hardware acceleration and graphics interfaces
-      allow you to run mobile games on the cloud.
+  + **0**: Cloud phone servers are designed for app hosting and multi-platform live streaming.
+  + **1**: Cloud mobile gaming servers, GPU hardware acceleration and graphics interfaces
+    allow you to run mobile games on the cloud.
 
 * `extend_spec` - The extended attribute description.
   The [ExtendSpec](#serverFlavors_FlavorsExtendSpec) structure is documented below.

--- a/huaweicloud/services/acceptance/cph/data_source_huaweicloud_cph_phone_flavors_test.go
+++ b/huaweicloud/services/acceptance/cph/data_source_huaweicloud_cph_phone_flavors_test.go
@@ -22,7 +22,7 @@ func TestAccDatasourcePhoneFlavors_basic(t *testing.T) {
 				Config: testAccDatasourcePhoneFlavors_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					statusFilter.CheckResourceExists(),
-					resource.TestCheckOutput("status_filter_is_useful", "true"),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
 					resource.TestCheckResourceAttrSet(rName, "flavors.0.flavor_id"),
 					resource.TestCheckResourceAttrSet(rName, "flavors.0.server_flavor_id"),
 					resource.TestCheckResourceAttrSet(rName, "flavors.0.vcpus"),
@@ -35,10 +35,10 @@ func TestAccDatasourcePhoneFlavors_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "flavors.0.extend_spec"),
 
 					typeFilter.CheckResourceExists(),
-					resource.TestCheckOutput("type_filter_is_useful", "true"),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
 
 					vcpusFilter.CheckResourceExists(),
-					resource.TestCheckOutput("vcpus_filter_is_useful", "true"),
+					resource.TestCheckOutput("is_vcpus_filter_useful", "true"),
 				),
 			},
 		},
@@ -50,21 +50,24 @@ func testAccDatasourcePhoneFlavors_basic() string {
 data "huaweicloud_cph_phone_flavors" "status_filter" {
   status = "1"
 }
-output "status_filter_is_useful" {
+
+output "is_status_filter_useful" {
   value = !contains([for v in data.huaweicloud_cph_phone_flavors.status_filter.flavors[*].status : v == "1"], "false")
 }
 
 data "huaweicloud_cph_phone_flavors" "type_filter" {
   type = "0"
 }
-output "type_filter_is_useful" {
+
+output "is_type_filter_useful" {
   value = !contains([for v in data.huaweicloud_cph_phone_flavors.type_filter.flavors[*].type : v == "0"], "false")
 }
 
 data "huaweicloud_cph_phone_flavors" "vcpus_filter" {
   vcpus = 4
 }
-output "vcpus_filter_is_useful" {
+
+output "is_vcpus_filter_useful" {
   value = !contains([for v in data.huaweicloud_cph_phone_flavors.vcpus_filter.flavors[*].vcpus : v == 4], "false")
 }
 `

--- a/huaweicloud/services/acceptance/cph/data_source_huaweicloud_cph_phone_images_test.go
+++ b/huaweicloud/services/acceptance/cph/data_source_huaweicloud_cph_phone_images_test.go
@@ -27,9 +27,9 @@ func TestAccDatasourcePhoneImages_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "images.0.is_public"),
 					resource.TestCheckResourceAttrSet(rName, "images.0.image_label"),
 
-					resource.TestCheckOutput("is_public_filter_is_useful", "true"),
+					resource.TestCheckOutput("is_public_filter_useful", "true"),
 
-					resource.TestCheckOutput("image_label_filter_is_useful", "true"),
+					resource.TestCheckOutput("is_image_label_filter_useful", "true"),
 				),
 			},
 		},
@@ -44,14 +44,16 @@ data "huaweicloud_cph_phone_images" "test" {
 data "huaweicloud_cph_phone_images" "is_public_filter" {
   is_public = 1
 }
-output "is_public_filter_is_useful" {
+
+output "is_public_filter_useful" {
   value = alltrue([for v in data.huaweicloud_cph_phone_images.is_public_filter.images[*].is_public : v == 1])
 }
 
 data "huaweicloud_cph_phone_images" "image_label_filter" {
   image_label = "cloud_phone"
 }
-output "image_label_filter_is_useful" {
+
+output "is_image_label_filter_useful" {
   value = alltrue([for v in data.huaweicloud_cph_phone_images.image_label_filter.images[*].image_label : v == "cloud_phone"])
 }
 `

--- a/huaweicloud/services/acceptance/cph/data_source_huaweicloud_cph_server_flavors_test.go
+++ b/huaweicloud/services/acceptance/cph/data_source_huaweicloud_cph_server_flavors_test.go
@@ -34,7 +34,7 @@ func TestAccDatasourceServerFlavors_basic(t *testing.T) {
 func testAccDatasourceServerFlavors_basic() string {
 	return `
 data "huaweicloud_cph_server_flavors" "test" {
-  type  = 0
+  type  = "0"
   vcpus = 64
 }
 `

--- a/huaweicloud/services/cph/data_source_huaweicloud_cph_phone_flavors.go
+++ b/huaweicloud/services/cph/data_source_huaweicloud_cph_phone_flavors.go
@@ -156,7 +156,7 @@ func resourcePhoneFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 	)
 	listFlavorsClient, err := cfg.NewServiceClient(listFlavorsProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating CPH Client: %s", err)
+		return diag.Errorf("error creating CPH client: %s", err)
 	}
 
 	listFlavorsPath := listFlavorsClient.Endpoint + listFlavorsHttpUrl
@@ -167,14 +167,11 @@ func resourcePhoneFlavorsRead(_ context.Context, d *schema.ResourceData, meta in
 
 	listFlavorsOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	listFlavorsResp, err := listFlavorsClient.Request("GET", listFlavorsPath, &listFlavorsOpt)
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving PhoneFlavors")
+		return common.CheckDeletedDiag(d, err, "error retrieving phone flavors")
 	}
 
 	listFlavorsRespBody, err := utils.FlattenResponse(listFlavorsResp)

--- a/huaweicloud/services/cph/data_source_huaweicloud_cph_phone_images.go
+++ b/huaweicloud/services/cph/data_source_huaweicloud_cph_phone_images.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -105,7 +104,7 @@ func resourcePhoneImagesRead(_ context.Context, d *schema.ResourceData, meta int
 	)
 	listImagesClient, err := cfg.NewServiceClient(listImagesProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating CPH Client: %s", err)
+		return diag.Errorf("error creating CPH client: %s", err)
 	}
 
 	listImagesPath := listImagesClient.Endpoint + listImagesHttpUrl
@@ -113,14 +112,10 @@ func resourcePhoneImagesRead(_ context.Context, d *schema.ResourceData, meta int
 
 	listImagesOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	listImagesResp, err := listImagesClient.Request("GET", listImagesPath, &listImagesOpt)
-
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving PhoneImages")
+		return diag.Errorf("error retrieving CPH phone images: %s", err)
 	}
 
 	listImagesRespBody, err := utils.FlattenResponse(listImagesResp)

--- a/huaweicloud/services/cph/data_source_huaweicloud_cph_server_flavors.go
+++ b/huaweicloud/services/cph/data_source_huaweicloud_cph_server_flavors.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/chnsz/golangsdk"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -153,7 +152,7 @@ func resourceServerFlavorsRead(_ context.Context, d *schema.ResourceData, meta i
 	)
 	listFlavorsClient, err := cfg.NewServiceClient(listFlavorsProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating CPH Client: %s", err)
+		return diag.Errorf("error creating CPH client: %s", err)
 	}
 
 	listFlavorsPath := listFlavorsClient.Endpoint + listFlavorsHttpUrl
@@ -164,14 +163,10 @@ func resourceServerFlavorsRead(_ context.Context, d *schema.ResourceData, meta i
 
 	listFlavorsOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	listFlavorsResp, err := listFlavorsClient.Request("GET", listFlavorsPath, &listFlavorsOpt)
-
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving ServerFlavors")
+		return diag.Errorf("error retrieving CPH server flavors: %s", err)
 	}
 
 	listFlavorsRespBody, err := utils.FlattenResponse(listFlavorsResp)

--- a/huaweicloud/services/cph/resource_huaweicloud_cph_server.go
+++ b/huaweicloud/services/cph/resource_huaweicloud_cph_server.go
@@ -516,7 +516,7 @@ func resourceCphServerRead(_ context.Context, d *schema.ResourceData, meta inter
 	)
 	getCphServerClient, err := cfg.NewServiceClient(getCphServerProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating CPH Client: %s", err)
+		return diag.Errorf("error creating CPH client: %s", err)
 	}
 
 	getCphServerPath := getCphServerClient.Endpoint + getCphServerHttpUrl
@@ -525,14 +525,11 @@ func resourceCphServerRead(_ context.Context, d *schema.ResourceData, meta inter
 
 	getCphServerOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 	getCphServerResp, err := getCphServerClient.Request("GET", getCphServerPath, &getCphServerOpt)
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving CPH Server")
+		return common.CheckDeletedDiag(d, err, "error retrieving CPH server")
 	}
 
 	getCphServerRespBody, err := utils.FlattenResponse(getCphServerResp)
@@ -542,7 +539,7 @@ func resourceCphServerRead(_ context.Context, d *schema.ResourceData, meta inter
 	statusRaw := utils.PathSearch("status", getCphServerRespBody, nil)
 
 	if fmt.Sprint(statusRaw) == "6" {
-		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving CPH Server")
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "error retrieving CPH server")
 	}
 
 	mErr = multierror.Append(
@@ -591,10 +588,10 @@ func flattenGetCphServerResponseBodyBandWidth(resp interface{}) []interface{} {
 
 	rst = []interface{}{
 		map[string]interface{}{
-			"share_type":  fmt.Sprint(utils.PathSearch("band_width_share_type", curJson, nil)),
+			"share_type":  fmt.Sprintf("%v", utils.PathSearch("band_width_share_type", curJson, nil)),
 			"id":          utils.PathSearch("band_width_id", curJson, nil),
 			"size":        utils.PathSearch("band_width_size", curJson, nil),
-			"charge_mode": fmt.Sprint(utils.PathSearch("band_width_charge_mode", curJson, nil)),
+			"charge_mode": fmt.Sprintf("%v", utils.PathSearch("band_width_charge_mode", curJson, nil)),
 		},
 	}
 	return rst
@@ -616,7 +613,7 @@ func resourceCphServerUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		)
 		updateCphServerNameClient, err := cfg.NewServiceClient(updateCphServerNameProduct, region)
 		if err != nil {
-			return diag.Errorf("error creating CPH Client: %s", err)
+			return diag.Errorf("error creating CPH client: %s", err)
 		}
 
 		updateCphServerNamePath := updateCphServerNameClient.Endpoint + updateCphServerNameHttpUrl
@@ -625,14 +622,11 @@ func resourceCphServerUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 		updateCphServerNameOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
 		}
 		updateCphServerNameOpt.JSONBody = utils.RemoveNil(buildUpdateCphServerNameBodyParams(d, cfg))
 		_, err = updateCphServerNameClient.Request("PUT", updateCphServerNamePath, &updateCphServerNameOpt)
 		if err != nil {
-			return diag.Errorf("error updating CPH Server: %s", err)
+			return diag.Errorf("error updating CPH server: %s", err)
 		}
 	}
 	return resourceCphServerRead(ctx, d, meta)
@@ -671,7 +665,7 @@ func deleteCphServerWaitingForStateCompleted(ctx context.Context, d *schema.Reso
 			)
 			getCphServerClient, err := cfg.NewServiceClient(getCphServerProduct, region)
 			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating CPH Client: %s", err)
+				return nil, "ERROR", fmt.Errorf("error creating CPH client: %s", err)
 			}
 
 			getCphServerPath := getCphServerClient.Endpoint + getCphServerHttpUrl
@@ -680,9 +674,6 @@ func deleteCphServerWaitingForStateCompleted(ctx context.Context, d *schema.Reso
 
 			getCphServerOpt := golangsdk.RequestOpts{
 				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
 			}
 			getCphServerResp, err := getCphServerClient.Request("GET", getCphServerPath, &getCphServerOpt)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx
fix cph server test and lint error

**Special notes for your reviewer**:

**Release note**:

```
fix cph server test and lint error
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cph' TESTARGS='-run TestAccDatasourcePhoneFlavors_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cph -v -run TestAccDatasourcePhoneFlavors_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePhoneFlavors_basic
=== PAUSE TestAccDatasourcePhoneFlavors_basic
=== CONT  TestAccDatasourcePhoneFlavors_basic
--- PASS: TestAccDatasourcePhoneFlavors_basic (27.33s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       27.415s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cph' TESTARGS='-run TestAccDatasourcePhoneImages_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cph -v -run TestAccDatasourcePhoneImages_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourcePhoneImages_basic
=== PAUSE TestAccDatasourcePhoneImages_basic
=== CONT  TestAccDatasourcePhoneImages_basic
--- PASS: TestAccDatasourcePhoneImages_basic (27.27s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       27.357s
```

```
make testacc TEST='./huaweicloud/services/acceptance/cph' TESTARGS='-run TestAccDatasourceServerFlavors_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cph -v -run TestAccDatasourceServerFlavors_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceServerFlavors_basic
=== PAUSE TestAccDatasourceServerFlavors_basic
=== CONT  TestAccDatasourceServerFlavors_basic
--- PASS: TestAccDatasourceServerFlavors_basic (16.11s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       16.161s
```

```
 make testacc TEST='./huaweicloud/services/acceptance/cph' TESTARGS='-run TestAccCphServer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cph -v -run TestAccCphServer_basic -timeout 360m -parallel 4
=== RUN   TestAccCphServer_basic
=== PAUSE TestAccCphServer_basic
=== CONT  TestAccCphServer_basic
--- PASS: TestAccCphServer_basic (2035.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       2035.293s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
