### PR TITLE
feat(dws/cluster): the cluster resource supports scale-in nodes

### DIFF
--- a/docs/resources/dws_cluster.md
+++ b/docs/resources/dws_cluster.md
@@ -133,6 +133,10 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the cluster.
 
+* `force_backup` - (Optional, Bool) Specified whether to automatically execute snapshot when shrinking the number of nodes.
+  The default value is **true**.
+  This parameter is required and available only when scaling-in the `number_of_node` parameter value.
+
 <a name="DwsCluster_PublicIp"></a>
 The `PublicIp` block supports:
 
@@ -276,7 +280,7 @@ $ terraform import huaweicloud_dws_cluster.test <id>
 
 Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
 API response, security or some other reason. The missing attributes include: `user_pwd`, `number_of_cn`, `kms_key_id`,
-`volume`, `dss_pool_id`, `logical_cluster_enable`, `lts_enable`.
+`volume`, `dss_pool_id`, `logical_cluster_enable`, `lts_enable`, `force_backup`.
 It is generally recommended running `terraform plan` after importing a cluster.
 You can then decide if changes should be applied to the cluster, or the resource definition
 should be updated to align with the cluster. Also you can ignore changes as below.
@@ -287,7 +291,7 @@ resource "huaweicloud_dws_cluster" "test" {
 
   lifecycle {
     ignore_changes = [
-      user_pwd, number_of_cn, kms_key_id, volume, dss_pool_id, logical_cluster_enable, lts_enable
+      user_pwd, number_of_cn, kms_key_id, volume, dss_pool_id, logical_cluster_enable, lts_enable, `force_backup`,
     ]
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The resource support scaling-in nodes.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccResourceCluster_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccResourceCluster_ -timeout 360m -parallel 4
=== RUN   TestAccResourceCluster_basicV1
=== PAUSE TestAccResourceCluster_basicV1
=== RUN   TestAccResourceCluster_basicV2
=== PAUSE TestAccResourceCluster_basicV2
=== RUN   TestAccResourceCluster_basicV2_mutilAZs
=== PAUSE TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV1
=== CONT  TestAccResourceCluster_basicV2
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
    acceptance.go:2051: HW_DWS_MUTIL_AZS must be set for the acceptance test
--- SKIP: TestAccResourceCluster_basicV2_mutilAZs (0.01s)
--- PASS: TestAccResourceCluster_basicV1 (3195.04s)
--- PASS: TestAccResourceCluster_basicV2 (4001.53s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       4001.581s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
