### PR TITLE
feat(GaussDBforMySQL): add gaussdb mysql instance upgrade resource

### DIFF
--- a/docs/resources/gaussdb_mysql_instance_upgrade.md
+++ b/docs/resources/gaussdb_mysql_instance_upgrade.md
@@ -1,0 +1,49 @@
+---
+subcategory: "GaussDB(for MySQL)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_mysql_instance_upgrade"
+description: |-
+  Manages a GaussDB MySQL instance upgrade resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_mysql_instance_upgrade
+
+Manages a GaussDB MySQL instance upgrade resource within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "huaweicloud_gaussdb_mysql_instance_upgrade" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the GaussDB MySQL instance. Changing this parameter
+  will create a new resource.
+
+* `delay` - (Optional, Bool, ForceNew) Specifies whether the instance will be upgraded with a delay. Value options:
+  + **true**: The instance will be upgraded during the specified maintenance window.
+  + **false(default)**: The instance will be upgraded immediately.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is `instance_id`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1567,6 +1567,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_instance":                   gaussdb.ResourceGaussDBInstance(),
 			"huaweicloud_gaussdb_mysql_instance_node_config":       gaussdb.ResourceGaussDBMysqlNodeConfig(),
 			"huaweicloud_gaussdb_mysql_instance_restart":           gaussdb.ResourceGaussDBMysqlRestart(),
+			"huaweicloud_gaussdb_mysql_instance_upgrade":           gaussdb.ResourceGaussDBMysqlUpgrade(),
 			"huaweicloud_gaussdb_mysql_proxy":                      gaussdb.ResourceGaussDBProxy(),
 			"huaweicloud_gaussdb_mysql_proxy_restart":              gaussdb.ResourceGaussDBProxyRestart(),
 			"huaweicloud_gaussdb_mysql_database":                   gaussdb.ResourceGaussDBDatabase(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_upgrade_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_upgrade_test.go
@@ -1,0 +1,36 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGaussDBMysqlInstanceUpgrade_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBMysqlInstanceId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBMysqlInstanceUpgrade_basic(),
+			},
+		},
+	})
+}
+
+func testAccGaussDBMysqlInstanceUpgrade_basic() string {
+	return fmt.Sprintf(`
+
+
+resource "huaweicloud_gaussdb_mysql_instance_upgrade" "test" {
+  instance_id = "%[1]s"
+  delay       = true
+}`, acceptance.HW_GAUSSDB_MYSQL_INSTANCE_ID)
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_upgrade.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_upgrade.go
@@ -1,0 +1,116 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforMySQL POST /v3/{project_id}/instances/{instance_id}/db-upgrade
+func ResourceGaussDBMysqlUpgrade() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGaussDBMysqlUpgradeCreate,
+		ReadContext:   resourceGaussDBMysqlUpgradeRead,
+		DeleteContext: resourceGaussDBMysqlUpgradeDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"delay": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGaussDBMysqlUpgradeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/{instance_id}/db-upgrade"
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateGaussDBMysqlUpgradeBodyParams(d))
+
+	createResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB MySQL instance upgrade: %s", err)
+	}
+	createRespBody, err := utils.FlattenResponse(createResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	jobId := utils.PathSearch("job_id", createRespBody, nil)
+	if jobId == nil {
+		return diag.Errorf("error upgrading GaussDB MySQL instance: job_id is not found in API response")
+	}
+	err = checkGaussDBMySQLJobFinish(ctx, client, jobId.(string), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.Errorf("error waiting for updating GaussDB MySQL instance(%s) job to complete: %s", instanceId,
+			err)
+	}
+
+	d.SetId(instanceId)
+
+	return nil
+}
+
+func buildCreateGaussDBMysqlUpgradeBodyParams(d *schema.ResourceData) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"delay": d.Get("delay"),
+	}
+	return bodyParams
+}
+
+func resourceGaussDBMysqlUpgradeRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGaussDBMysqlUpgradeDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GaussDB MySQL instance upgrade resource is not supported. The upgrade resource is only " +
+		"removed from the state, the GaussDB MySQL instance remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb mysql instance upgrade resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb mysql instance upgrade resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
...
=== RUN   TestAccSomethingV0_basic
--- PASS: TestAccSomethingV0_basic (70.75s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud       70.796s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
