### PR TITLE
feat(dws): add new datasource to query parameters of the cluster

### DIFF
--- a/docs/data-sources/dws_cluster_parameters.md
+++ b/docs/data-sources/dws_cluster_parameters.md
@@ -1,0 +1,77 @@
+---
+subcategory: "GaussDB(DWS)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_dws_cluster_parameters"
+description: |-
+  Use this data source to get the list of the parameters under specified DWS cluster within HuaweiCloud.
+---
+
+# huaweicloud_dws_cluster_parameters
+
+Use this data source to get the list of the parameters under specified DWS cluster within HuaweiCloud.
+
+## Example Usage
+
+```hcl
+variable "dws_cluster_id" {}
+
+data "huaweicloud_dws_cluster_parameters" "test" {
+  cluster_id = var.dws_cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `cluster_id` - (Required, String) Specifies the DWS cluster ID.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `parameters` - The list of the parameters under specified DWS cluster.
+
+  The [parameters](#cluster_parameters_struct) structure is documented below.
+
+<a name="cluster_parameters_struct"></a>
+The `parameters` block supports:
+
+* `name` - The name of the parameter.
+
+* `values` - The list of the parameter values.
+
+  The [values](#parameters_values_struct) structure is documented below.
+
+* `unit` - The unit of the parameter.
+
+* `type` - The type of the parameter value.
+  + **boolean**
+  + **string**
+  + **integer**
+  + **float**
+  + **list**
+
+* `readonly` - Whether the parameter is read-only.
+
+* `value_range` - The range of the parameter value.
+
+* `restart_required` - Whether the DWS cluster needs to be restarted after modifying the parameter value.
+
+* `description` - The description of the parameter.
+
+<a name="parameters_values_struct"></a>
+The `values` block supports:
+
+* `type` - The type of the parameter.
+  + **cn**
+  + **dn**
+
+* `value` - The value of the parameter.
+
+* `default_value` - The default value of the parameter.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1073,6 +1073,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_dws_cluster_cns":                     dws.DataSourceDwsClusterCns(),
 			"huaweicloud_dws_cluster_logs":                    dws.DataSourceDwsClusterLogs(),
 			"huaweicloud_dws_cluster_nodes":                   dws.DataSourceDwsClusterNodes(),
+			"huaweicloud_dws_cluster_parameters":              dws.DataSourceClusterParameters(),
 			"huaweicloud_dws_cluster_snapshot_statistics":     dws.DataSourceDwsClusterSnapshotStatistics(),
 			"huaweicloud_dws_cluster_topo_rings":              dws.DataSourceDwsClusterTopoRings(),
 			"huaweicloud_dws_clusters":                        dws.DataSourceDwsClusters(),

--- a/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_parameters_test.go
+++ b/huaweicloud/services/acceptance/dws/data_source_huaweicloud_dws_cluster_parameters_test.go
@@ -1,0 +1,64 @@
+package dws
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceClusterParameters_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_dws_cluster_parameters.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testDataSourceClusterParameters_clusterNotFound(),
+				ExpectError: regexp.MustCompile("Cluster does not exist or has been deleted"),
+			},
+			{
+				Config: testDataSourceClusterParameters_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSource, "parameters.#", regexp.MustCompile(`^[1-9]([0-9]*)?$`)),
+					resource.TestCheckResourceAttrSet(dataSource, "parameters.0.name"),
+					resource.TestCheckResourceAttr(dataSource, "parameters.0.values.#", "2"),
+					// The values ​​and default values ​​of some parameters are empty.
+					resource.TestCheckResourceAttrSet(dataSource, "parameters.0.values.0.type"),
+					resource.TestCheckResourceAttrSet(dataSource, "parameters.0.readonly"),
+					resource.TestCheckResourceAttrSet(dataSource, "parameters.0.restart_required"),
+					resource.TestCheckResourceAttrSet(dataSource, "parameters.0.description"),
+					// The `parameters.type`, `parameters.unit`, `parameters.value_range`, `parameters.values.value` and
+					// `parameters.values.default_value` of some parameters are empty.
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceClusterParameters_clusterNotFound() string {
+	randUUID, _ := uuid.GenerateUUID()
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_parameters" "test" {
+  cluster_id = "%s"
+}
+`, randUUID)
+}
+
+func testDataSourceClusterParameters_basic() string {
+	return fmt.Sprintf(`
+data "huaweicloud_dws_cluster_parameters" "test" {
+  cluster_id = "%s"
+}
+`, acceptance.HW_DWS_CLUSTER_ID)
+}

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_parameters.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_cluster_parameters.go
@@ -1,0 +1,162 @@
+package dws
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API DWS GET /v1.0/{project_id}/clusters/{cluster_id}/configurations/{configuration_id}
+func DataSourceClusterParameters() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceClusterParametersRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The DWS cluster ID.`,
+			},
+			"parameters": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the parameters under specified DWS cluster.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The name of the parameter.`,
+						},
+						"values": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The list of the parameter values.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The type of the parameter.`,
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The value of the parameter.`,
+									},
+									"default_value": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The default value of the parameter.`,
+									},
+								},
+							},
+						},
+						"unit": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The unit of the parameter.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the parameter value.`,
+						},
+						"readonly": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the parameter is read-only.`,
+						},
+						"value_range": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The range of the parameter value.`,
+						},
+						"restart_required": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the DWS cluster needs to be restarted after modifying the parameter value.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the parameter.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceClusterParametersRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	client, err := cfg.NewServiceClient("dws", region)
+	if err != nil {
+		return diag.Errorf("error creating DWS client: %s", err)
+	}
+
+	resp, err := GetParameterConfigurations(client, d.Get("cluster_id").(string))
+	if err != nil {
+		return diag.Errorf("error retrieving DWS cluster parameters: %s", err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("parameters",
+			flattenClusterParameters(utils.PathSearch("configurations", resp, make([]interface{}, 0)).([]interface{}))),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenClusterParameters(all []interface{}) []map[string]interface{} {
+	if len(all) < 1 {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(all))
+	for i, v := range all {
+		result[i] = map[string]interface{}{
+			"name":             utils.PathSearch("name", v, nil),
+			"values":           flattenParamterValues(utils.PathSearch("values", v, make([]interface{}, 0)).([]interface{})),
+			"unit":             utils.PathSearch("unit", v, nil),
+			"type":             utils.PathSearch("type", v, nil),
+			"readonly":         utils.PathSearch("readonly", v, false),
+			"value_range":      utils.PathSearch("value_range", v, nil),
+			"restart_required": utils.PathSearch("restart_required", v, false),
+			"description":      utils.PathSearch("description", v, nil),
+		}
+	}
+	return result
+}
+
+func flattenParamterValues(values []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(values))
+	for i, v := range values {
+		result[i] = map[string]interface{}{
+			"type":          utils.PathSearch("type", v, nil),
+			"value":         utils.PathSearch("value", v, nil),
+			"default_value": utils.PathSearch("default_value", v, false),
+		}
+	}
+	return result
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new dataSource to query parameters under specified the cluster.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new data source.
2. add corresponding to document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/dws TESTARGS='-run TestAccDataSourceClusterParameters_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dws -v -run TestAccDataSourceClusterParameters_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceClusterParameters_basic
=== PAUSE TestAccDataSourceClusterParameters_basic
=== CONT  TestAccDataSourceClusterParameters_basic
--- PASS: TestAccDataSourceClusterParameters_basic (17.72s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       17.780s```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
