### PR TITLE
feat(NAT): NAT gateway supports creating prepaid type resource

### DIFF
--- a/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
+++ b/huaweicloud/services/acceptance/nat/resource_huaweicloud_nat_gateway_test.go
@@ -119,3 +119,118 @@ resource "huaweicloud_nat_gateway" "test" {
 }
 `, relatedConfig, name)
 }
+
+func TestAccPublicGateway_prepaid(t *testing.T) {
+	var (
+		obj           interface{}
+		rName         = "huaweicloud_nat_gateway.test"
+		name          = acceptance.RandomAccResourceNameWithDash()
+		relatedConfig = common.TestBaseNetwork(name)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPublicGatewayResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckChargingMode(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPublicGateway_prepaid_step_1(name, relatedConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccPublicGateway_prepaid_step_2(name, relatedConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "spec", string(nat.PublicSpecTypeSmall)),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "ngport_ip_address", "192.168.0.101"),
+					resource.TestCheckResourceAttr(rName, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "baaar"),
+					resource.TestCheckResourceAttr(rName, "tags.newkey", "value"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"charging_mode",
+					"period_unit",
+					"period",
+					"auto_renew",
+				},
+			},
+		},
+	})
+}
+
+func testAccPublicGateway_prepaid_step_1(name, relatedConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_gateway" "test" {
+  name                  = "%[2]s"
+  spec                  = "1"
+  description           = "Created by acc test"
+  ngport_ip_address     = "192.168.0.101"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = "0"
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = "1"
+  auto_renew    = "true"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, relatedConfig, name)
+}
+
+func testAccPublicGateway_prepaid_step_2(name, relatedConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_nat_gateway" "test" {
+  name                  = "%[2]s"
+  spec                  = "1"
+  description           = "Created by acc test"
+  ngport_ip_address     = "192.168.0.101"
+  vpc_id                = huaweicloud_vpc.test.id
+  subnet_id             = huaweicloud_vpc_subnet.test.id
+  enterprise_project_id = "0"
+
+  charging_mode = "prePaid"
+  period_unit   = "month"
+  period        = "1"
+  auto_renew    = "false"
+
+  tags = {
+    foo    = "baaar"
+    newkey = "value"
+  }
+}
+`, relatedConfig, name)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

NAT gateway supports creating prepaid type resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
go test -v -coverprofile=coverage_1728874249672_TestAccPublicGateway_.cov -coverpkg=./huaweicloud/services/nat ./huaweicloud/services/acceptance/nat -run TestAccPublicGateway_ -timeout 360m -parallel 4
=== RUN   TestAccPublicGateway_basic
=== PAUSE TestAccPublicGateway_basic
=== RUN   TestAccPublicGateway_prepaid
=== PAUSE TestAccPublicGateway_prepaid
=== CONT  TestAccPublicGateway_basic
=== CONT  TestAccPublicGateway_prepaid
--- PASS: TestAccPublicGateway_basic (125.07s)
--- PASS: TestAccPublicGateway_prepaid (235.72s)
PASS
coverage: 13.9% of statements in ./huaweicloud/services/nat
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       235.777s        coverage: 13.9% of statements in ./huaweicloud/services/nat
```
![image](https://github.com/user-attachments/assets/826c4604-c2f0-4972-b830-ad8f8fe30a68)


* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
