### PR TITLE
fix(aom/dds/dms/eip): change jemspath search to utils path search and change parse error method to common error convert

### DIFF
--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_prom_instance_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -41,9 +40,9 @@ func getPromInstanceResourceFunc(conf *config.Config, state *terraform.ResourceS
 		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
 	}
 
-	curJson, err := jmespath.Search("prometheus[0]", getPrometheusInstanceRespBody)
-	if err != nil || curJson == nil {
-		return nil, fmt.Errorf("error retrieving AOM prometheus instance: %s", err)
+	curJson := utils.PathSearch("prometheus[0]", getPrometheusInstanceRespBody, nil)
+	if curJson == nil {
+		return nil, fmt.Errorf("unable to find the instance from the API response")
 	}
 
 	return curJson, nil

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_group_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_group_rule.go
@@ -336,7 +336,8 @@ func resourceAlarmGroupRuleDelete(_ context.Context, d *schema.ResourceData, met
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseQueryError400(err, "AOM.08002002"), "error deleting alarm group rule")
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "AOM.08002002"),
+			"error deleting alarm group rule")
 	}
 
 	return nil

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_silence_rule.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_alarm_silence_rule.go
@@ -8,13 +8,11 @@ package aom
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -322,9 +320,8 @@ func resourceAlarmSilenceRuleRead(_ context.Context, d *schema.ResourceData, met
 
 func flattenSilenceRuleSilenceTime(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("mute_config", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing silence_time from response= %#v", resp)
+	curJson := utils.PathSearch("mute_config", resp, nil)
+	if curJson == nil {
 		return rst
 	}
 

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_cmdb_application.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_cmdb_application.go
@@ -7,14 +7,11 @@ package aom
 
 import (
 	"context"
-	"encoding/json"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -113,12 +110,12 @@ func resourceCmdbApplicationCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createApplicationRespBody)
-	if err != nil {
-		return diag.Errorf("error creating CMDB application: ID is not found in API response")
+	id := utils.PathSearch("id", createApplicationRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("unable to find application ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(id)
 	return resourceCmdbApplicationRead(ctx, d, meta)
 }
 
@@ -142,10 +139,8 @@ func resourceCmdbApplicationRead(_ context.Context, d *schema.ResourceData, meta
 
 	getApplicationResp, err := client.Request("GET", getApplicationPath, &getApplicationOpt)
 	if err != nil {
-		if hasErrorCode(err, AppNotExistsCode) {
-			err = golangsdk.ErrDefault404{}
-		}
-		return common.CheckDeletedDiag(d, err, "error retrieving CMDB application")
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", AppNotExistsCode),
+			"error retrieving CMDB application")
 	}
 
 	getApplicationRespBody, err := utils.FlattenResponse(getApplicationResp)
@@ -225,27 +220,10 @@ func resourceCmdbApplicationDelete(_ context.Context, d *schema.ResourceData, me
 	}
 
 	_, err = client.Request("DELETE", deleteApplicationPath, &deleteApplicationOpt)
-	if err != nil && !hasErrorCode(err, AppNotExistsCode) {
-		return diag.Errorf("error deleting CMDB application: %s", err)
+	if err != nil {
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", AppNotExistsCode),
+			"error deleting CMDB application")
 	}
 
 	return nil
-}
-
-func hasErrorCode(err error, expectCode string) bool {
-	if errCode, ok := err.(golangsdk.ErrDefault400); ok {
-		var response interface{}
-		if jsonErr := json.Unmarshal(errCode.Body, &response); jsonErr == nil {
-			errorCode, parseErr := jmespath.Search("error_code", response)
-			if parseErr != nil {
-				log.Printf("[WARN] failed to parse error_code from response body: %s", parseErr)
-			}
-
-			if errorCode == expectCode {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/huaweicloud/services/aom/resource_huaweicloud_aom_message_template.go
+++ b/huaweicloud/services/aom/resource_huaweicloud_aom_message_template.go
@@ -173,7 +173,8 @@ func resourceMessageTemplateRead(_ context.Context, d *schema.ResourceData, meta
 
 	template, err := GetMessageTemplate(client, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseQueryError400(err, "AOM.08025006"), "error retrieving message template")
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "AOM.08025006"),
+			"error retrieving message template")
 	}
 
 	mErr := multierror.Append(nil,
@@ -287,7 +288,8 @@ func resourceMessageTemplateDelete(_ context.Context, d *schema.ResourceData, me
 
 	_, err = client.Request("DELETE", deletePath, &deleteOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, parseQueryError400(err, "AOM.08023006"), "error deleting message template")
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "AOM.08023006"),
+			"error deleting message template")
 	}
 
 	return nil

--- a/huaweicloud/services/dds/data_source_huaweicloud_dds_instances.go
+++ b/huaweicloud/services/dds/data_source_huaweicloud_dds_instances.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
@@ -433,9 +432,8 @@ func flattenInstanceNodes(resp interface{}) []interface{} {
 
 func flattenInstanceDatastore(resp interface{}) interface{} {
 	var rst []map[string]interface{}
-	curJson, err := jmespath.Search("datastore", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing datastore from response= %#v", resp)
+	curJson := utils.PathSearch("datastore", resp, nil)
+	if curJson == nil {
 		return rst
 	}
 
@@ -451,9 +449,8 @@ func flattenInstanceDatastore(resp interface{}) interface{} {
 
 func flattenInstanceBackupStrategy(resp interface{}) interface{} {
 	var rst []map[string]interface{}
-	curJson, err := jmespath.Search("backup_strategy", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing backup_strategy from response= %#v", resp)
+	curJson := utils.PathSearch("backup_strategy", resp, nil)
+	if curJson == nil {
 		return rst
 	}
 

--- a/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template.go
+++ b/huaweicloud/services/dds/resource_huaweicloud_dds_parameter_template.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -168,11 +167,11 @@ func resourceDdsParameterTemplateCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("configuration.id", createParameterTemplateRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DDS parameter template: ID is not found in API response")
+	id := utils.PathSearch("configuration.id", createParameterTemplateRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("unable to find ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	return resourceDdsParameterTemplateRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_user_client_quota.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_kafka_user_client_quota.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -439,13 +438,13 @@ func handleOperationConflictError(err error) (bool, error) {
 			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
 		}
 
-		errorCode, errorCodeErr := jmespath.Search("error_code", apiError)
-		if errorCodeErr != nil {
-			return false, fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
+		errorCode := utils.PathSearch("error_code", apiError, "").(string)
+		if errorCode == "" {
+			return false, fmt.Errorf("unable to find error code from the API response")
 		}
 
 		// DMS.00404022 This instance does not exist.
-		if errorCode.(string) == "DMS.00404022" {
+		if errorCode == "DMS.00404022" {
 			return true, err
 		}
 	}
@@ -455,13 +454,13 @@ func handleOperationConflictError(err error) (bool, error) {
 			return false, fmt.Errorf("unmarshal the response body failed: %s", jsonErr)
 		}
 
-		errorCode, errorCodeErr := jmespath.Search("error_code", apiError)
-		if errorCodeErr != nil {
-			return false, fmt.Errorf("error parse errorCode from response body: %s", errorCodeErr)
+		errorCode := utils.PathSearch("error_code", apiError, "").(string)
+		if errorCode == "" {
+			return false, fmt.Errorf("unable to find error code from the API response")
 		}
 
 		// DMS.00400026 This operation is not allowed due to the instance status.
-		if errorCode.(string) == "DMS.00400026" {
+		if errorCode == "DMS.00400026" {
 			return true, err
 		}
 	}

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_consumer_group.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -124,12 +123,12 @@ func resourceDmsRocketMQConsumerGroupCreate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("name", createRocketmqConsumerGroupRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DmsRocketMQConsumerGroup: ID is not found in API response")
+	name := utils.PathSearch("name", createRocketmqConsumerGroupRespBody, "").(string)
+	if name == "" {
+		return diag.Errorf("unable to find consumer group name from the API response")
 	}
 
-	d.SetId(instanceID + "/" + id.(string))
+	d.SetId(instanceID + "/" + name)
 
 	return resourceDmsRocketMQConsumerGroupRead(ctx, d, meta)
 }
@@ -172,7 +171,7 @@ func resourceDmsRocketMQConsumerGroupUpdate(ctx context.Context, d *schema.Resou
 
 		parts := strings.SplitN(d.Id(), "/", 2)
 		if len(parts) != 2 {
-			return diag.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+			return diag.Errorf("invalid ID format, must be <instance_id>/<name>")
 		}
 		instanceID := parts[0]
 		name := parts[1]
@@ -228,7 +227,7 @@ func resourceDmsRocketMQConsumerGroupRead(_ context.Context, d *schema.ResourceD
 
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return diag.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+		return diag.Errorf("invalid ID format, must be <instance_id>/<name>")
 	}
 	instanceID := parts[0]
 	name := parts[1]
@@ -285,7 +284,7 @@ func resourceDmsRocketMQConsumerGroupDelete(_ context.Context, d *schema.Resourc
 
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return diag.Errorf("invalid id format, must be <instance_id>/<consumerGroup>")
+		return diag.Errorf("invalid ID format, must be <instance_id>/<name>")
 	}
 	instanceID := parts[0]
 	name := parts[1]

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_topic.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_topic.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -176,11 +175,11 @@ func resourceDmsRocketMQTopicCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createRocketmqTopicRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DmsRocketMQTopic: ID is not found in API response")
+	id := utils.PathSearch("id", createRocketmqTopicRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("unable to find topic ID from the API response")
 	}
-	d.SetId(instanceID + "/" + id.(string))
+	d.SetId(instanceID + "/" + id)
 
 	return resourceDmsRocketMQTopicUpdate(ctx, d, meta)
 }

--- a/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
+++ b/huaweicloud/services/dms/resource_huaweicloud_dms_rocketmq_user.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -160,11 +159,11 @@ func resourceDmsRocketMQUserCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("access_key", createRocketmqUserRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DmsRocketMQUser: ID is not found in API response")
+	accessKey := utils.PathSearch("access_key", createRocketmqUserRespBody, "").(string)
+	if accessKey == "" {
+		return diag.Errorf("unable to find access key from the API response")
 	}
-	d.SetId(instanceID + "/" + id.(string))
+	d.SetId(instanceID + "/" + accessKey)
 
 	return resourceDmsRocketMQUserRead(ctx, d, meta)
 }
@@ -209,7 +208,7 @@ func resourceDmsRocketMQUserUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		parts := strings.SplitN(d.Id(), "/", 2)
 		if len(parts) != 2 {
-			return diag.Errorf("invalid id format, must be <instance_id>/<access_key>")
+			return diag.Errorf("invalid ID format, must be <instance_id>/<access_key>")
 		}
 		instanceID := parts[0]
 		user := parts[1]
@@ -281,7 +280,7 @@ func resourceDmsRocketMQUserRead(_ context.Context, d *schema.ResourceData, meta
 
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return diag.Errorf("invalid id format, must be <instance_id>/<access_key>")
+		return diag.Errorf("invalid ID format, must be <instance_id>/<access_key>")
 	}
 	instanceID := parts[0]
 	user := parts[1]
@@ -371,7 +370,7 @@ func resourceDmsRocketMQUserDelete(_ context.Context, d *schema.ResourceData, me
 
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return diag.Errorf("invalid id format, must be <instance_id>/<access_key>")
+		return diag.Errorf("invalid ID format, must be <instance_id>/<access_key>")
 	}
 	instanceID := parts[0]
 	user := parts[1]

--- a/huaweicloud/services/eip/resource_huaweicloud_global_eip_associate.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_eip_associate.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -179,13 +178,13 @@ func resourceGlobalEIPAssociateCreate(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	jobID, err := jmespath.Search("job_id", createGEIPAssociateRespBody)
-	if err != nil {
-		return diag.Errorf("error associating global EIP with instance: %s is not found in API response", "job_id")
+	jobID := utils.PathSearch("job_id", createGEIPAssociateRespBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("unable to find job ID from the API response")
 	}
 
 	// wait for job status become SUCCESS
-	err = waitForJobStatusComplete(ctx, d.Timeout(schema.TimeoutCreate), jobID.(string), cfg.DomainID, client)
+	err = waitForJobStatusComplete(ctx, d.Timeout(schema.TimeoutCreate), jobID, cfg.DomainID, client)
 	if err != nil {
 		return diag.Errorf("error waiting for global EIP associating with instance: %s", err)
 	}
@@ -198,9 +197,9 @@ func resourceGlobalEIPAssociateCreate(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.Errorf("error waiting for global EIP associating with instance: %s", err)
 	}
-	gcbID, err := jmespath.Search("global_eip.global_connection_bandwidth_info.gcb_id", geip)
-	if err != nil {
-		return diag.Errorf("error: %s is not found in API response", "gcb_id")
+	gcbID := utils.PathSearch("global_eip.global_connection_bandwidth_info.gcb_id", geip, "").(string)
+	if gcbID == "" {
+		return diag.Errorf("unable to find global connection bandwidth ID from the API response")
 	}
 
 	// if bandwidth charge_mode is not "bwd", call Update GCB
@@ -211,7 +210,7 @@ func resourceGlobalEIPAssociateCreate(ctx context.Context, d *schema.ResourceDat
 	if v, ok := d.GetOk("gc_bandwidth"); ok && len(v.([]interface{})) > 0 {
 		gcb := d.Get("gc_bandwidth").([]interface{})[0].(map[string]interface{})
 		if gcb["id"].(string) == "" && gcb["charge_mode"].(string) == "95" {
-			err = updateGCB(ccClient, gcbID.(string), cfg.DomainID)
+			err = updateGCB(ccClient, gcbID, cfg.DomainID)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -297,15 +296,15 @@ func jobStatusRefreshFunc(client *golangsdk.ServiceClient, jobID, domainID strin
 		if err != nil {
 			return nil, "ERROR", err
 		}
-		status, err := jmespath.Search("job.status", getJobRespBody)
-		if err != nil {
-			return nil, "ERROR", err
+		status := utils.PathSearch("job.status", getJobRespBody, "").(string)
+		if status == "" {
+			return nil, "ERROR", fmt.Errorf("unable to find job status from the API response")
 		}
 
 		// status are FINISH_ROLLBACK_SUCC, FINISH_SUCC and WAIT_TO_SCHEDULE
-		if status.(string) == "FINISH_ROLLBACK_SUCC" {
+		if status == "FINISH_ROLLBACK_SUCC" {
 			return nil, "FAILURE", fmt.Errorf("job fail: %s", utils.PathSearch("job.error_message", getJobRespBody, nil))
-		} else if status.(string) == "FINISH_SUCC" {
+		} else if status == "FINISH_SUCC" {
 			return getJobRespBody, "SUCCESS", nil
 		}
 		return getJobRespBody, "PENDING", nil
@@ -372,9 +371,9 @@ func resourceGlobalEIPAssociateRead(_ context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	geip, err := jmespath.Search("global_eip", getGEIPRespBody)
-	if err != nil {
-		return diag.Errorf("error getting global EIP: %s is not found in API response", "global_eip")
+	geip := utils.PathSearch("global_eip", getGEIPRespBody, nil)
+	if geip == nil {
+		return diag.Errorf("unable to find global EIP from the API response")
 	}
 
 	// Call GET GCB API to get more info, because charge_mode is not in return.
@@ -382,13 +381,10 @@ func resourceGlobalEIPAssociateRead(_ context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.Errorf("error creating CC client: %s", err)
 	}
-	gcbID, err := jmespath.Search("global_connection_bandwidth_info.gcb_id", geip)
-	if err != nil {
-		return diag.Errorf("error: %s is not found in API response", "gcb_id")
-	}
+	gcbID := utils.PathSearch("global_connection_bandwidth_info.gcb_id", geip, "").(string)
 	var gcbInfo interface{}
-	if gcbID != nil {
-		gcbInfo, err = getGCBInfo(ccClient, cfg.DomainID, gcbID.(string))
+	if gcbID != "" {
+		gcbInfo, err = getGCBInfo(ccClient, cfg.DomainID, gcbID)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -425,9 +421,9 @@ func getGCBInfo(client *golangsdk.ServiceClient, domainID, gcbID string) (interf
 	if err != nil {
 		return nil, fmt.Errorf("error flattening GCB: %s", err)
 	}
-	gcb, err := jmespath.Search("globalconnection_bandwidth", getGCBRespBody)
-	if err != nil {
-		return nil, fmt.Errorf("error getting GCB: %s is not found in API response", "globalconnection_bandwidth")
+	gcb := utils.PathSearch("globalconnection_bandwidth", getGCBRespBody, nil)
+	if gcb == nil {
+		return nil, fmt.Errorf("unable to find global connection bandwidth from the API response")
 	}
 
 	result := make([]interface{}, 0)
@@ -490,12 +486,12 @@ func resourceGlobalEIPAssociateDelete(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	jobID, err := jmespath.Search("job_id", deleteGEIPAssociateRespBody)
-	if err != nil {
-		return diag.Errorf("error disassociating global EIP with instance: %s is not found in API response", "job_id")
+	jobID := utils.PathSearch("job_id", deleteGEIPAssociateRespBody, "").(string)
+	if jobID == "" {
+		return diag.Errorf("unable to find job ID from the API response")
 	}
 
-	err = waitForJobStatusComplete(ctx, d.Timeout(schema.TimeoutDelete), jobID.(string), cfg.DomainID, client)
+	err = waitForJobStatusComplete(ctx, d.Timeout(schema.TimeoutDelete), jobID, cfg.DomainID, client)
 	if err != nil {
 		return diag.Errorf("error waiting for global EIP disassociating with instance: %s", err)
 	}

--- a/huaweicloud/services/eip/resource_huaweicloud_global_internet_bandwidth.go
+++ b/huaweicloud/services/eip/resource_huaweicloud_global_internet_bandwidth.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -135,11 +134,11 @@ func resourceInternetBandwidthCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("internet_bandwidth.id", createInternetBandwidthRespBody)
-	if err != nil {
-		return diag.Errorf("error creating global internet bandwidth: %s is not found in API response", "id")
+	id := utils.PathSearch("internet_bandwidth.id", createInternetBandwidthRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("unable to find internet bandwidth ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(id)
 
 	return resourceInternetBandwidthRead(ctx, d, meta)
 }
@@ -186,9 +185,9 @@ func resourceInternetBandwidthRead(_ context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	bandwidth, err := jmespath.Search("internet_bandwidth", getInternetBandwidthRespBody)
-	if err != nil {
-		return diag.Errorf("error getting global internet bandwidth: %s is not found in API response", "bandwidth")
+	bandwidth := utils.PathSearch("internet_bandwidth", getInternetBandwidthRespBody, nil)
+	if bandwidth == nil {
+		return diag.Errorf("unable to find internet bandwidth from the API response")
 	}
 
 	mErr := multierror.Append(nil,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
change jemspath.Search to utils.PathSearch
change parse error method to common error convert
modify some error infos


## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run TestAccIGW_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccIGW_basic -timeout 360m -parallel 4
=== RUN   TestAccIGW_basic
=== PAUSE TestAccIGW_basic
=== CONT  TestAccIGW_basic
--- PASS: TestAccIGW_basic (102.35s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       102.410s

make testacc TEST='./huaweicloud/services/acceptance/eip' TESTARGS='-run TestAccGEIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/eip -v -run TestAccGEIPAssociate_basic -timeout 360m -parallel 4
=== RUN   TestAccGEIPAssociate_basic
=== PAUSE TestAccGEIPAssociate_basic
=== CONT  TestAccGEIPAssociate_basic
--- PASS: TestAccGEIPAssociate_basic (280.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/eip       280.400s

make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccDmsKafkaUserClientQuota_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccDmsKafkaUserClientQuota_basic -timeout 360m -parallel 4
=== RUN   TestAccDmsKafkaUserClientQuota_basic
=== PAUSE TestAccDmsKafkaUserClientQuota_basic
=== CONT  TestAccDmsKafkaUserClientQuota_basic
--- PASS: TestAccDmsKafkaUserClientQuota_basic (1078.45s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       1078.496s

make testacc TEST='./huaweicloud/services/acceptance/dms' TESTARGS='-run TestAccKafkaInstance_prePaid'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dms -v -run TestAccKafkaInstance_prePaid -timeout 360m -parallel 4
=== RUN   TestAccKafkaInstance_prePaid
=== PAUSE TestAccKafkaInstance_prePaid
=== CONT  TestAccKafkaInstance_prePaid
--- PASS: TestAccKafkaInstance_prePaid (904.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dms       904.135s
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
