### PR TITLE
chore(dws/ext_data_source): fix update obs type agency not effective

### DIFF
--- a/docs/resources/dws_ext_data_source.md
+++ b/docs/resources/dws_ext_data_source.md
@@ -61,18 +61,20 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
 
 * `name` - (Required, String, ForceNew) The name of the external data source.  
-  The name can contain 1 to 64 characters. Only letters, digits, and underscores (_) are allowed.
+  The name can contain `3` to `64` characters. Only letters, digits, and underscores (_) are allowed, and must start with
+  a lowercase letter.
 
   Changing this parameter will create a new resource.
 
 * `type` - (Required, String, ForceNew) The type of the external data source.  
   The valid values are **OBS**, and **MRS**.
   Changing this parameter will create a new resource.
+  + If `type` is set to **MRS**, the `type` parameter of the `huaweicloud_mapreduce_cluster` resource must be **ANALYSIS**.
+  + If `type` is set to **OBS**, the DWS cluster version must be `8.2.0` or later.
 
-  -> The OBS data source is supported only in version 8.2.0 or later of cluster.
-
-* `user_name` - (Required, String) The user name of the external data source.  
-  It is OBS agency-name when **type** is **MRS**.
+* `user_name` - (Required, String) Specifies the user name of the external data source.  
+  It is OBS agency name when `type` is **OBS**.
+  This parameter can be modified only when `type` is **OBS**.
 
   Changing this parameter will create a new resource.
 
@@ -134,7 +136,7 @@ with the resource. Also you can ignore changes as below.
 
 ```hcl
 resource "huaweicloud_dws_ext_data_source" "test" {
-    ...
+  ...
 
   lifecycle {
     ignore_changes = [

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -416,6 +416,8 @@ var (
 	// The list of the user names under specified DWS cluster. Using commas (,) to separate multiple names.
 	HW_DWS_ASSOCIATE_USER_NAMES  = os.Getenv("HW_DWS_ASSOCIATE_USER_NAMES")
 	HW_DWS_AUTOMATED_SNAPSHOT_ID = os.Getenv("HW_DWS_AUTOMATED_SNAPSHOT_ID")
+	// The OBS agency name list of the DWS data source. Using commas (,) to separate multiple names.
+	HW_DWS_OBS_AGENCY_NAMES = os.Getenv("HW_DWS_OBS_AGENCY_NAMES")
 
 	HW_DCS_ACCOUNT_WHITELIST = os.Getenv("HW_DCS_ACCOUNT_WHITELIST")
 
@@ -2157,6 +2159,15 @@ func TestAccPreCheckDwsClusterUserNames(t *testing.T) {
 func TestAccPreCheckDwsAutomatedSnapshot(t *testing.T) {
 	if HW_DWS_AUTOMATED_SNAPSHOT_ID == "" {
 		t.Skip("HW_DWS_AUTOMATED_SNAPSHOT_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckDwsExtDataSourceAgencyNames(t *testing.T) {
+	// Control OBS type data source acceptance test, one for creating resource and the other for updating resource.
+	agencyNames := strings.Split(HW_DWS_OBS_AGENCY_NAMES, ",")
+	if len(agencyNames) < 2 {
+		t.Skip("The length of HW_DWS_OBS_AGENCY_NAMES must be 2 for the OBS data source acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_ext_data_source_test.go
+++ b/huaweicloud/services/acceptance/dws/resource_huaweicloud_dws_ext_data_source_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/dws/v1/cluster"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
@@ -76,7 +75,10 @@ func TestAccDwsExtDataSource_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
@@ -84,8 +86,8 @@ func TestAccDwsExtDataSource_basic(t *testing.T) {
 				Config: testDwsExtDataSource_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(rName, "cluster_id", "huaweicloud_dws_cluster.test", "id"),
-					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttrPair(rName, "name", "huaweicloud_mapreduce_cluster.test", "name"),
 					resource.TestCheckResourceAttr(rName, "type", "MRS"),
 					resource.TestCheckResourceAttr(rName, "user_name", "admin"),
 					resource.TestCheckResourceAttrPair(rName, "data_source_id", "huaweicloud_mapreduce_cluster.test", "id"),
@@ -110,35 +112,40 @@ func TestAccDwsExtDataSource_basic(t *testing.T) {
 func testDwsExtDataSource_basic(name string) string {
 	pwd := acceptance.RandomPassword()
 	return fmt.Sprintf(`
-%s
-
-%s
+%[1]s
 
 resource "huaweicloud_dws_ext_data_source" "test" {
-  cluster_id     = huaweicloud_dws_cluster.test.id
-  name           = "%s"
+  cluster_id     = "%[2]s"
+  name           = huaweicloud_mapreduce_cluster.test.name
   type           = "MRS"
   data_source_id = huaweicloud_mapreduce_cluster.test.id
   user_name      = "admin"
-  user_pwd       = "%s"
+  user_pwd       = "%[3]s"
   description    = "This is a demo"
 }
-`, testAccDwsCluster_basic_step1(name, 3, cluster.PublicBindTypeNotUse, pwd),
-		testDwsExtDataSourceMrs(name, pwd), name, pwd)
+`, testDwsExtDataSourceMrs(name, pwd), acceptance.HW_DWS_CLUSTER_ID, pwd)
 }
 
 func testDwsExtDataSourceMrs(rName, pwd string) string {
 	return fmt.Sprintf(`
+data "huaweicloud_availability_zones" "test" {}
+
+# For MRS data source, the DWS cluster and MRS cluster must be in the same VPC.
+data "huaweicloud_dws_clusters" "test" {}
+
+locals {
+  dws_cluster_info = [for v in data.huaweicloud_dws_clusters.test.clusters : v if v.id == "%[1]s"]
+}
 
 resource "huaweicloud_mapreduce_cluster" "test" {
   availability_zone  = data.huaweicloud_availability_zones.test.names[0]
-  name               = "%s"
+  name               = "%[2]s"
   type               = "ANALYSIS"
   version            = "MRS 1.9.2"
-  manager_admin_pass = "%s"
-  node_admin_pass    = "%s"
-  subnet_id          = huaweicloud_vpc_subnet.test.id
-  vpc_id             = huaweicloud_vpc.test.id
+  manager_admin_pass = "%[3]s"
+  node_admin_pass    = "%[3]s"
+  subnet_id          = try(local.dws_cluster_info[0].subnet_id, "")
+  vpc_id             = try(local.dws_cluster_info[0].vpc_id, "")
   component_list     = ["Hadoop", "Hive", "Tez"]
 
   master_nodes {
@@ -168,7 +175,80 @@ resource "huaweicloud_mapreduce_cluster" "test" {
     data_volume_size  = 600
     data_volume_count = 1
   }
-}`, rName, pwd, pwd)
+}`, acceptance.HW_DWS_CLUSTER_ID, rName, pwd)
+}
+
+func getAgencyNames() (agencyName, updateAgencyName string) {
+	agencyNames := strings.Split(acceptance.HW_DWS_OBS_AGENCY_NAMES, ",")
+	if len(agencyNames) < 2 {
+		return "", ""
+	}
+	return agencyNames[0], agencyNames[1]
+}
+
+func TestAccDwsExtDataSource_obs(t *testing.T) {
+	var (
+		obj                          interface{}
+		name                         = acceptance.RandomAccResourceName()
+		rName                        = "huaweicloud_dws_ext_data_source.test"
+		agencyName, updateAgencyName = getAgencyNames()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDwsExtDataSourceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckDwsClusterId(t)
+			acceptance.TestAccPreCheckDwsExtDataSourceAgencyNames(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDwsExtDataSource_obs(name, agencyName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "cluster_id", acceptance.HW_DWS_CLUSTER_ID),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "type", "OBS"),
+					resource.TestCheckResourceAttr(rName, "user_name", agencyName),
+					resource.TestCheckResourceAttr(rName, "connect_info", "gaussdb"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by terraform script"),
+				),
+			},
+			{
+				Config: testDwsExtDataSource_obs(name, updateAgencyName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "user_name", updateAgencyName),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testDwsExtDataSourceImportState(rName),
+			},
+		},
+	})
+}
+
+func testDwsExtDataSource_obs(name, agencyName string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_dws_ext_data_source" "test" {
+  cluster_id   = "%[1]s"
+  name         = "%[2]s"
+  type         = "OBS"
+  user_name    = "%[3]s"
+  connect_info = "gaussdb"
+  description  = "Created by terraform script"
+}
+`, acceptance.HW_DWS_CLUSTER_ID, name, agencyName)
 }
 
 func testDwsExtDataSourceImportState(name string) resource.ImportStateIdFunc {

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_ext_data_source.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_ext_data_source.go
@@ -141,7 +141,7 @@ func resourceDwsExtDataSourceCreate(ctx context.Context, d *schema.ResourceData,
 	)
 	createDwsExtDataSourceClient, err := cfg.NewServiceClient(createDwsExtDataSourceProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating DWS Client: %s", err)
+		return diag.Errorf("error creating DWS client: %s", err)
 	}
 
 	createDwsExtDataSourcePath := createDwsExtDataSourceClient.Endpoint + createDwsExtDataSourceHttpUrl
@@ -241,7 +241,7 @@ func GetExtDataSource(cfg *config.Config, region string, d *schema.ResourceData,
 	)
 	getDwsExtDataSourceClient, err := cfg.NewServiceClient(getDwsExtDataSourceProduct, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating DWS Client: %s", err)
+		return nil, fmt.Errorf("error creating DWS client: %s", err)
 	}
 
 	getDwsExtDataSourcePath := getDwsExtDataSourceClient.Endpoint + getDwsExtDataSourceHttpUrl
@@ -288,7 +288,7 @@ func resourceDwsExtDataSourceUpdate(ctx context.Context, d *schema.ResourceData,
 		)
 		updateDwsExtDataSourceClient, err := cfg.NewServiceClient(updateDwsExtDataSourceProduct, region)
 		if err != nil {
-			return diag.Errorf("error creating DWS Client: %s", err)
+			return diag.Errorf("error creating DWS client: %s", err)
 		}
 
 		updateDwsExtDataSourcePath := updateDwsExtDataSourceClient.Endpoint + updateDwsExtDataSourceHttpUrl
@@ -326,11 +326,15 @@ func resourceDwsExtDataSourceUpdate(ctx context.Context, d *schema.ResourceData,
 }
 
 func buildUpdateDwsExtDataSourceBodyParams(d *schema.ResourceData) map[string]interface{} {
+	params := map[string]interface{}{
+		"reboot": utils.ValueIgnoreEmpty(d.Get("reboot")),
+	}
+	if d.Get("type").(string) == "OBS" {
+		params["agency"] = utils.ValueIgnoreEmpty(d.Get("user_name"))
+	}
+
 	bodyParams := map[string]interface{}{
-		"reconfigure": map[string]interface{}{
-			"reboot":    utils.ValueIgnoreEmpty(d.Get("reboot")),
-			"user_name": utils.ValueIgnoreEmpty(d.Get("user_name")),
-		},
+		"reconfigure": params,
 	}
 	return bodyParams
 }
@@ -346,7 +350,7 @@ func resourceDwsExtDataSourceDelete(ctx context.Context, d *schema.ResourceData,
 	)
 	deleteDwsExtDataSourceClient, err := cfg.NewServiceClient(deleteDwsExtDataSourceProduct, region)
 	if err != nil {
-		return diag.Errorf("error creating DWS Client: %s", err)
+		return diag.Errorf("error creating DWS client: %s", err)
 	}
 
 	deleteDwsExtDataSourcePath := deleteDwsExtDataSourceClient.Endpoint + deleteDwsExtDataSourceHttpUrl
@@ -431,7 +435,7 @@ func extDataSourceWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 			)
 			extDataSourceWaitingClient, err := cfg.NewServiceClient(extDataSourceWaitingProduct, region)
 			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating DWS Client: %s", err)
+				return nil, "ERROR", fmt.Errorf("error creating DWS client: %s", err)
 			}
 
 			extDataSourceWaitingPath := extDataSourceWaitingClient.Endpoint + extDataSourceWaitingHttpUrl


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix the issue that updating the agency of OBS data source does not take effect.

Due to parameter error, the interface returns **200** when modifying the agency , but the modification does not take effect.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix the issue that updating the agency of OBS data source does not take effect.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 ./scripts/acc-test.sh
>>> Start to test
=== RUN   TestAccDwsExtDataSource_basic
=== PAUSE TestAccDwsExtDataSource_basic
=== RUN   TestAccDwsExtDataSource_obs
=== PAUSE TestAccDwsExtDataSource_obs
=== CONT  TestAccDwsExtDataSource_basic
=== CONT  TestAccDwsExtDataSource_obs
--- PASS: TestAccDwsExtDataSource_obs (124.82s)
--- PASS: TestAccDwsExtDataSource_basic (1079.12s)
PASS
coverage: 7.7% of statements in ../../dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1079.179s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
