### PR TITLE
feat(cce): support updating os in node pool

### DIFF
--- a/docs/resources/cce_node_pool.md
+++ b/docs/resources/cce_node_pool.md
@@ -276,11 +276,10 @@ The following arguments are supported:
 * `availability_zone` - (Optional, String, ForceNew) Specifies the name of the available partition (AZ). Default value
   is random to create nodes in a random AZ in the node pool. Changing this parameter will create a new resource.
 
-* `os` - (Optional, String, ForceNew) Specifies the operating system of the node.
+* `os` - (Optional, String) Specifies the operating system of the node.
   The value can be **EulerOS 2.9** and **CentOS 7.6** e.g. For more details,
   please see [documentation](https://support.huaweicloud.com/intl/en-us/api-cce/node-os.html).
   This parameter is required when the `node_image_id` in `extend_params` is not specified.
-  Changing this parameter will create a new resource.
 
 * `key_pair` - (Optional, String, ForceNew) Specifies the key pair name when logging in to select the key pair mode.
   This parameter and `password` are alternative. Changing this parameter will create a new resource.

--- a/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
+++ b/huaweicloud/services/acceptance/cce/resource_huaweicloud_cce_node_pool_test.go
@@ -49,6 +49,7 @@ func TestAccNodePool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "os", "EulerOS 2.9"),
 					resource.TestCheckResourceAttr(resourceName, "current_node_count", "1"),
 				),
 			},
@@ -57,6 +58,7 @@ func TestAccNodePool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "os", "EulerOS 2.9"),
 					resource.TestCheckResourceAttr(resourceName, "current_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scall_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "min_node_count", "2"),
@@ -70,6 +72,7 @@ func TestAccNodePool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "os", "CentOS 7.6"),
 					resource.TestCheckResourceAttr(resourceName, "root_volume.0.extend_params.test_key", "test_val"),
 					resource.TestCheckResourceAttr(resourceName, "data_volumes.0.extend_params.test_key1", "test_val1"),
 					resource.TestCheckResourceAttr(resourceName, "data_volumes.1.extend_params.test_key2", "test_val2"),
@@ -207,7 +210,7 @@ func testAccNodePool_basic_step3(name, baseConfig string) string {
 resource "huaweicloud_cce_node_pool" "test" {
   cluster_id               = huaweicloud_cce_cluster.test.id
   name                     = "%[2]s"
-  os                       = "EulerOS 2.9"
+  os                       = "CentOS 7.6"
   flavor_id                = data.huaweicloud_compute_flavors.test.ids[0]
   initial_node_count       = 1
   availability_zone        = data.huaweicloud_availability_zones.test.names[0]

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_node_pool.go
@@ -91,7 +91,6 @@ func ResourceNodePool() *schema.Resource {
 			"os": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"key_pair": {
@@ -669,6 +668,7 @@ func buildNodePoolUpdateOpts(d *schema.ResourceData, cfg *config.Config) (*nodep
 				Taints:                    buildResourceNodeTaint(d),
 				InitializedConditions:     utils.ExpandToStringList(d.Get("initialized_conditions").([]interface{})),
 				ServerEnterpriseProjectID: cfg.GetEnterpriseProjectID(d),
+				Os:                        d.Get("os").(string),
 			},
 			LabelPolicyOnExistingNodes:   d.Get("label_policy_on_existing_nodes").(string),
 			UserTagPolicyOnExistingNodes: d.Get("tag_policy_on_existing_nodes").(string),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/cce' TESTARGS='-run TestAccNodePool'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cce -v -run TestAccNodePool -timeout 360m -parallel 4
=== RUN   TestAccNodePool_basic
=== PAUSE TestAccNodePool_basic
=== RUN   TestAccNodePool_tagsLabelsTaints
=== PAUSE TestAccNodePool_tagsLabelsTaints
=== RUN   TestAccNodePool_volume_encryption
=== PAUSE TestAccNodePool_volume_encryption
=== RUN   TestAccNodePool_prePaid
=== PAUSE TestAccNodePool_prePaid
=== RUN   TestAccNodePool_SecurityGroups
=== PAUSE TestAccNodePool_SecurityGroups
=== RUN   TestAccNodePool_serverGroup
=== PAUSE TestAccNodePool_serverGroup
=== RUN   TestAccNodePool_storage
=== PAUSE TestAccNodePool_storage
=== RUN   TestAccNodePool_extensionScaleGroups
=== PAUSE TestAccNodePool_extensionScaleGroups
=== CONT  TestAccNodePool_basic
=== CONT  TestAccNodePool_SecurityGroups
=== CONT  TestAccNodePool_storage
=== CONT  TestAccNodePool_extensionScaleGroups
--- PASS: TestAccNodePool_storage (796.33s)
=== CONT  TestAccNodePool_serverGroup
--- PASS: TestAccNodePool_SecurityGroups (799.80s)
=== CONT  TestAccNodePool_volume_encryption
    acceptance.go:1297: This environment does not support KMS tests
--- SKIP: TestAccNodePool_volume_encryption (0.08s)
=== CONT  TestAccNodePool_prePaid
    acceptance.go:929: This environment does not support prepaid tests
--- SKIP: TestAccNodePool_prePaid (0.15s)
=== CONT  TestAccNodePool_tagsLabelsTaints
--- PASS: TestAccNodePool_extensionScaleGroups (864.20s)
--- PASS: TestAccNodePool_basic (1217.53s)
--- PASS: TestAccNodePool_serverGroup (696.43s)
--- PASS: TestAccNodePool_tagsLabelsTaints (803.58s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cce       1603.660s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
