### PR TITLE
fix(workspace/user): supplement 400 error for checkdeleted and schema supports description parameter

### DIFF
--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strconv"
 	"time"
@@ -165,7 +166,8 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	resp, err := users.Get(client, d.Id())
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "Workspace user")
+		// WKS.00170312: The tanant(Workspace service) not exist.
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "WKS.00170312"), "Workspace user")
 	}
 
 	mErr := multierror.Append(nil,
@@ -232,9 +234,12 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("error creating Workspace v2 client: %s", err)
 	}
 
-	err = users.Delete(client, d.Id())
+	userId := d.Id()
+	err = users.Delete(client, userId)
 	if err != nil {
-		return diag.Errorf("error deleting Workspace user (%s): %s", d.Id(), err)
+		// WKS.00170312: The user has been deleted.
+		return common.CheckDeletedDiag(d, common.ConvertExpected400ErrInto404Err(err, "error_code", "WKS.00170312"),
+			fmt.Sprintf("error deleting Workspace user (%s)", d.Id()))
 	}
 
 	return nil

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_user.go
@@ -53,6 +53,10 @@ func ResourceUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"account_expires": {
 				Type:     schema.TypeString,
 				Optional: true,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Add 'description' paramster to schema.
2. Add the CheckDeleted logical for this resource.


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/workspace TESTARGS='-run TestAccUser_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/workspace -v -run TestAccUser_basic -timeout 360m -parallel 4
=== RUN   TestAccUser_basic
--- PASS: TestAccUser_basic (167.71s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 167.780s
```

* [ ] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
The user does not exist.
![image](https://github.com/user-attachments/assets/f03c7091-cdd4-49f2-b3c3-9ec1d7e26d76)

    ab. Related resources (parent resources) not found
    The Workspace service does not exist.
![image](https://github.com/user-attachments/assets/f5c41c9c-7006-41de-a028-bbd2e1a3a217)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/44abe68e-fba1-4f94-922f-39f751e294b3)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
