### PR TITLE
chore(jmespath): replace all jmespath.Search() functions with the utils.PathSearch() function

### DIFF
--- a/huaweicloud/common/errors.go
+++ b/huaweicloud/common/errors.go
@@ -3,10 +3,9 @@ package common
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"reflect"
-
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -37,21 +36,26 @@ func ConvertExpected400ErrInto404Err(err error, errCodeKey string, specErrCodes 
 		return err
 	}
 
-	errCode, searchErr := jmespath.Search(errCodeKey, apiError)
-	if searchErr != nil || errCode == nil {
-		log.Printf("[WARN] Unable to find the expected error code key (%s)", errCodeKey)
-		return err
+	errCode := utils.PathSearch(errCodeKey, apiError, nil)
+	if errCode == nil {
+		// 4xx means the client parsing was failed.
+		return golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
+					errCodeKey, apiError)),
+			},
+		}
 	}
 
 	if len(specErrCodes) < 1 {
 		log.Printf("[INFO] Identified 400 error parsed it as 404 error (without the error code control)")
 		return golangsdk.ErrDefault404{}
 	}
-	if errCodeStr, ok := errCode.(string); ok && utils.StrSliceContains(specErrCodes, errCodeStr) {
-		log.Printf("[INFO] Identified 400 error with code '%s' and parsed it as 404 error", errCode)
+	if utils.StrSliceContains(specErrCodes, fmt.Sprint(errCode)) {
+		log.Printf("[INFO] Identified 400 error with code '%v' and parsed it as 404 error", errCode)
 		return golangsdk.ErrDefault404{}
 	}
-	log.Printf("[WARN] Unable to recognize expected error code (%s), want %v", errCode, specErrCodes)
+	log.Printf("[WARN] Unable to recognize expected error code (%v), want %v", errCode, specErrCodes)
 	return err
 }
 
@@ -79,21 +83,26 @@ func ConvertExpected401ErrInto404Err(err error, errCodeKey string, specErrCodes 
 		return err
 	}
 
-	errCode, searchErr := jmespath.Search(errCodeKey, apiError)
-	if searchErr != nil || errCode == nil {
-		log.Printf("[WARN] Unable to find the expected error code key (%s)", errCodeKey)
-		return err
+	errCode := utils.PathSearch(errCodeKey, apiError, nil)
+	if errCode == nil {
+		// 4xx means the client parsing was failed.
+		return golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
+					errCodeKey, apiError)),
+			},
+		}
 	}
 
 	if len(specErrCodes) < 1 {
 		log.Printf("[INFO] Identified 401 error parsed it as 404 error (without the error code control)")
 		return golangsdk.ErrDefault404{}
 	}
-	if errCodeStr, ok := errCode.(string); ok && utils.StrSliceContains(specErrCodes, errCodeStr) {
-		log.Printf("[INFO] Identified 401 error with code '%s' and parsed it as 404 error", errCode)
+	if utils.StrSliceContains(specErrCodes, fmt.Sprint(errCode)) {
+		log.Printf("[INFO] Identified 401 error with code '%v' and parsed it as 404 error", errCode)
 		return golangsdk.ErrDefault404{}
 	}
-	log.Printf("[WARN] Unable to recognize expected error code (%s), want %v", errCode, specErrCodes)
+	log.Printf("[WARN] Unable to recognize expected error code (%v), want %v", errCode, specErrCodes)
 	return err
 }
 
@@ -121,21 +130,26 @@ func ConvertExpected403ErrInto404Err(err error, errCodeKey string, specErrCodes 
 		return err
 	}
 
-	errCode, searchErr := jmespath.Search(errCodeKey, apiError)
-	if searchErr != nil || errCode == nil {
-		log.Printf("[WARN] Unable to find the expected error code key (%s)", errCodeKey)
-		return err
+	errCode := utils.PathSearch(errCodeKey, apiError, nil)
+	if errCode == nil {
+		// 4xx means the client parsing was failed.
+		return golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
+					errCodeKey, apiError)),
+			},
+		}
 	}
 
 	if len(specErrCodes) < 1 {
 		log.Printf("[INFO] Identified 403 error parsed it as 404 error (without the error code control)")
 		return golangsdk.ErrDefault404{}
 	}
-	if errCodeStr, ok := errCode.(string); ok && utils.StrSliceContains(specErrCodes, errCodeStr) {
-		log.Printf("[INFO] Identified 403 error with code '%s' and parsed it as 404 error", errCode)
+	if utils.StrSliceContains(specErrCodes, fmt.Sprint(errCode)) {
+		log.Printf("[INFO] Identified 403 error with code '%v' and parsed it as 404 error", errCode)
 		return golangsdk.ErrDefault404{}
 	}
-	log.Printf("[WARN] Unable to recognize expected error code (%s), want %v", errCode, specErrCodes)
+	log.Printf("[WARN] Unable to recognize expected error code (%v), want %v", errCode, specErrCodes)
 	return err
 }
 
@@ -163,20 +177,25 @@ func ConvertExpected500ErrInto404Err(err error, errCodeKey string, specErrCodes 
 		return err
 	}
 
-	errCode, searchErr := jmespath.Search(errCodeKey, apiError)
-	if searchErr != nil || errCode == nil {
-		log.Printf("[WARN] Unable to find the expected error code key (%s)", errCodeKey)
-		return err
+	errCode := utils.PathSearch(errCodeKey, apiError, nil)
+	if errCode == nil {
+		// 4xx means the client parsing was failed.
+		return golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given error code key (%s), the error is: %#v",
+					errCodeKey, apiError)),
+			},
+		}
 	}
 
 	if len(specErrCodes) < 1 {
 		log.Printf("[INFO] Identified 500 error parsed it as 404 error (without the error code control)")
 		return golangsdk.ErrDefault404{}
 	}
-	if errCodeStr, ok := errCode.(string); ok && utils.StrSliceContains(specErrCodes, errCodeStr) {
-		log.Printf("[INFO] Identified 500 error with code '%s' and parsed it as 404 error", errCode)
+	if utils.StrSliceContains(specErrCodes, fmt.Sprint(errCode)) {
+		log.Printf("[INFO] Identified 500 error with code '%v' and parsed it as 404 error", errCode)
 		return golangsdk.ErrDefault404{}
 	}
-	log.Printf("[WARN] Unable to recognize expected error code (%s), want %v", errCode, specErrCodes)
+	log.Printf("[WARN] Unable to recognize expected error code (%v), want %v", errCode, specErrCodes)
 	return err
 }

--- a/huaweicloud/helper/httphelper/link_page.go
+++ b/huaweicloud/helper/httphelper/link_page.go
@@ -3,9 +3,9 @@ package httphelper
 import (
 	"log"
 
-	"github.com/jmespath/go-jmespath"
-
 	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 type LinkPager struct {
@@ -38,12 +38,7 @@ func (p LinkPager) NextPageURL() (string, error) {
 		return "", err
 	}
 
-	val, err := jmespath.Search(p.LinkExp, rst.Value())
-	log.Printf("[DEBUG] [LinkPager] [%v] NextPageURL: %v, LinkExp: %s, error: %v", p.uuid, val, p.LinkExp, err)
-	if err != nil {
-		return "", err
-	}
-
-	link, _ := val.(string)
+	link := utils.PathSearch(p.LinkExp, rst.Value(), "").(string)
+	log.Printf("[DEBUG] [LinkPager] [%v] NextPageURL: %v, LinkExp: %s, error: %v", p.uuid, link, p.LinkExp, err)
 	return link, nil
 }

--- a/huaweicloud/helper/httphelper/marker_page.go
+++ b/huaweicloud/helper/httphelper/marker_page.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/jmespath/go-jmespath"
-
 	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 type MarkerPager struct {
@@ -39,12 +39,8 @@ func (p MarkerPager) LastMarker() (string, error) {
 		return "", err
 	}
 
-	m, err := jmespath.Search(p.NextExp, rst.Value())
-	log.Printf("[DEBUG] [MarkerPager] [%v] last marker: %s, nextPath: %s, error: %s", p.uuid, m, p.NextExp, err)
-	next, _ := m.(string)
-	if next == "" || err != nil {
-		return "", nil
-	}
+	next := utils.PathSearch(p.NextExp, rst.Value(), "").(string)
+	log.Printf("[DEBUG] [MarkerPager] [%v] last marker: %s, nextPath: %s, error: %s", p.uuid, next, p.NextExp, err)
 
 	if !strings.Contains(next, "?") {
 		return next, nil

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_black_white_list_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_black_white_list_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -50,21 +49,12 @@ func getBlackWhiteListResourceFunc(cfg *config.Config, state *terraform.Resource
 		return nil, err
 	}
 
-	lists, err := jmespath.Search("data.records", getBlackWhiteListRespBody)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing data.records from response= %#v", getBlackWhiteListRespBody)
-	}
-
-	val, ok := lists.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("data.records is not a list, data.records= %#v", lists)
-	}
-
-	if len(val) != 1 {
+	list := utils.PathSearch("data.records", getBlackWhiteListRespBody, make([]interface{}, 0)).([]interface{})
+	if len(list) != 1 {
 		return nil, golangsdk.ErrDefault404{}
 	}
 
-	return val[0], nil
+	return list[0], nil
 }
 
 func TestAccBlackWhiteList_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_service_group_member_test.go
+++ b/huaweicloud/services/acceptance/cfw/resource_huaweicloud_cfw_service_group_member_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -48,12 +47,8 @@ func getServiceGroupMemberResourceFunc(cfg *config.Config, state *terraform.Reso
 		return nil, err
 	}
 
-	members, err := jmespath.Search("data.records", getServiceGroupMemberRespBody)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing data.records from response= %#v", getServiceGroupMemberRespBody)
-	}
-
-	return cfw.FilterServiceGroupMembers(members.([]interface{}), state.Primary.ID)
+	members := utils.PathSearch("data.records", getServiceGroupMemberRespBody, make([]interface{}, 0)).([]interface{})
+	return cfw.FilterServiceGroupMembers(members, state.Primary.ID)
 }
 
 func TestAccServiceGroupMember_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_manual_log_backup_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_manual_log_backup_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -44,10 +43,7 @@ func getManualLogBackupResourceFunc(cfg *config.Config, state *terraform.Resourc
 		if err != nil {
 			return getLogBackupJobRespBody, err
 		}
-		logBackupJob, err := jmespath.Search(expression, getLogBackupJobRespBody)
-		if err != nil {
-			return nil, err
-		}
+		logBackupJob := utils.PathSearch(expression, getLogBackupJobRespBody, nil)
 		if logBackupJob != nil {
 			return logBackupJob, nil
 		}

--- a/huaweicloud/services/acceptance/css/resource_huaweicloud_css_scan_task_test.go
+++ b/huaweicloud/services/acceptance/css/resource_huaweicloud_css_scan_task_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -49,10 +48,7 @@ func getScanTaskFunc(conf *config.Config, state *terraform.ResourceState) (inter
 		}
 		scanTasks := utils.PathSearch("aiops_list", getScanTaskRespBody, make([]interface{}, 0)).([]interface{})
 		findAiopsList := fmt.Sprintf("aiops_list | [?name=='%s'] | [0]", state.Primary.Attributes["name"])
-		scanTask, err := jmespath.Search(findAiopsList, getScanTaskRespBody)
-		if err != nil {
-			return nil, err
-		}
+		scanTask := utils.PathSearch(findAiopsList, getScanTaskRespBody, nil)
 		if scanTask != nil {
 			return scanTask, nil
 		}

--- a/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_grant_test.go
+++ b/huaweicloud/services/acceptance/dew/resource_huaweicloud_kms_grant_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -52,8 +51,8 @@ func getKmsGrantResourceFunc(cfg *config.Config, state *terraform.ResourceState)
 	}
 
 	searchPath := fmt.Sprintf("grants[?grant_id=='%s']|[0]", state.Primary.ID)
-	r, err := jmespath.Search(searchPath, grantResponseBody)
-	if err != nil || r == nil {
+	r := utils.PathSearch(searchPath, grantResponseBody, nil)
+	if r == nil {
 		return nil, fmt.Errorf("error retrieving KMS grant: %s", err)
 	}
 

--- a/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_asset_obs_test.go
+++ b/huaweicloud/services/acceptance/dsc/resource_huaweicloud_dsc_asset_obs_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dsc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -48,7 +47,7 @@ func getAssetObsResourceFunc(cfg *config.Config, state *terraform.ResourceState)
 		return nil, fmt.Errorf("error retrieving AssetObs: %s", err)
 	}
 
-	assetObs := dsc.FilterAssetObs(getAssetObsRespBody, state.Primary.ID, "id")
+	assetObs := utils.PathSearch(fmt.Sprintf("buckets[?id=='%s']|[0]", state.Primary.ID), getAssetObsRespBody, nil)
 	if assetObs == nil {
 		return nil, fmt.Errorf("error retrieving AssetObs: %s", err)
 	}

--- a/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_interface_attach_test.go
+++ b/huaweicloud/services/acceptance/ecs/resource_huaweicloud_compute_interface_attach_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -40,8 +39,8 @@ func getPrivateCAResourceFunc(conf *config.Config, state *terraform.ResourceStat
 	}
 
 	jsonPaths := fmt.Sprintf("interfaceAttachments[?port_id=='%s']|[0]", state.Primary.ID)
-	nic, err := jmespath.Search(jsonPaths, listNicsRespBody)
-	if err != nil {
+	nic := utils.PathSearch(jsonPaths, listNicsRespBody, nil)
+	if nic == nil {
 		return nil, golangsdk.ErrDefault404{}
 	}
 

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_application_quota.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_application_quota.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -124,11 +123,11 @@ func resourceApplicationQuotaCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	quotaId, err := jmespath.Search("app_quota_id", createQuotaBody)
-	if err != nil {
-		return diag.Errorf("error creating APIG application quota: app_quota_id is not found in API response")
+	quotaId := utils.PathSearch("app_quota_id", createQuotaBody, "").(string)
+	if quotaId == "" {
+		return diag.Errorf("unable to find the APIG application quota ID from the API response")
 	}
-	d.SetId(quotaId.(string))
+	d.SetId(quotaId)
 
 	return resourceApplicationQuotaRead(ctx, d, meta)
 }

--- a/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
+++ b/huaweicloud/services/apig/resource_huaweicloud_apig_instance_feature.go
@@ -122,12 +122,12 @@ func resourceInstanceFeatureCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	featureName, err := jmespath.Search("name", creatRespBody)
-	if err != nil {
-		return diag.Errorf("error creating feature (%s) configuration under specified instance (%s): %s", name, instanceId, err)
+	featureName := utils.PathSearch("name", creatRespBody, "").(string)
+	if featureName == "" {
+		return diag.Errorf("unable to find the feature name from the API response")
 	}
 
-	d.SetId(featureName.(string))
+	d.SetId(featureName)
 	return resourceInstanceFeatureRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/as/resource_huaweicloud_as_bandwidth_policy.go
+++ b/huaweicloud/services/as/resource_huaweicloud_as_bandwidth_policy.go
@@ -7,13 +7,11 @@ package as
 
 import (
 	"context"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -203,11 +201,11 @@ func resourceASBandWidthPolicyCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("scaling_policy_id", createBandwidthPolicyRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating AS bandwidth policy: ID is not found in API response")
+	policyId := utils.PathSearch("scaling_policy_id", createBandwidthPolicyRespBody, "").(string)
+	if policyId == "" {
+		return diag.Errorf("unable to find the AS bandwidth policy ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(policyId)
 
 	return resourceASBandWidthPolicyRead(ctx, d, meta)
 }
@@ -313,9 +311,8 @@ func resourceASBandWidthPolicyRead(_ context.Context, d *schema.ResourceData, me
 
 func flattenGetBandwidthPolicyResponseBodyScalingPolicyAction(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("scaling_policy.scaling_policy_action", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing scaling_policy_action from response= %#v", resp)
+	curJson := utils.PathSearch("scaling_policy.scaling_policy_action", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -331,9 +328,8 @@ func flattenGetBandwidthPolicyResponseBodyScalingPolicyAction(resp interface{}) 
 
 func flattenGetBandwidthPolicyResponseBodyScheduledPolicy(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("scaling_policy.scheduled_policy", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing scheduled_policy from response= %#v", resp)
+	curJson := utils.PathSearch("scaling_policy.scheduled_policy", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/cae/resource_huaweicloud_cae_component.go
+++ b/huaweicloud/services/cae/resource_huaweicloud_cae_component.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -298,12 +297,12 @@ func resourceComponentCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("metadata.id", createRespBody)
-	if err != nil {
-		return diag.Errorf("error creating CAE component: ID is not found in API response")
+	componentId := utils.PathSearch("metadata.id", createRespBody, "").(string)
+	if componentId == "" {
+		return diag.Errorf("unable to find the CAE component ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(componentId)
 	return resourceComponentRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_upgrade.go
+++ b/huaweicloud/services/cce/resource_huaweicloud_cce_cluster_upgrade.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -388,12 +387,7 @@ func clusterUpgradeWaitingForStateCompleted(ctx context.Context, d *schema.Resou
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`status.phase`, clusterUpgradeWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `status.phase`)
-			}
-
-			status := fmt.Sprintf("%v", statusRaw)
+			status := utils.PathSearch(`status.phase`, clusterUpgradeWaitingRespBody, "").(string)
 
 			targetStatus := []string{
 				"Success",

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_certificate.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -279,11 +278,11 @@ func resourceCCMCertificateCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("cert|[0].cert_id", createRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating CCM certificate: ID is not found in API response")
+	certId := utils.PathSearch("cert|[0].cert_id", createRespBody, "").(string)
+	if certId == "" {
+		return diag.Errorf("unable to find the CCM certificate ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(certId)
 
 	if err := waitingForCCMCertificatePaid(ctx, client, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return diag.Errorf("error waiting for CCM certificate (%s) creation to PAID: %s", d.Id(), err)

--- a/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go
+++ b/huaweicloud/services/ccm/resource_huaweicloud_ccm_private_certificate.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -264,17 +263,17 @@ func resourcePrivateCertificateCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("certificate_id", createCertificateRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating CCM private certificate: certificate_id is not found in API response")
+	certId := utils.PathSearch("certificate_id", createCertificateRespBody, "").(string)
+	if certId == "" {
+		return diag.Errorf("unable to find the CCM private certificate ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(certId)
 
 	// deal tags
 	createTagsHttpUrl := "v1/private-certificates/{certificate_id}/tags/create"
 	tags := d.Get("tags").(map[string]interface{})
-	if err := createTags(id.(string), client, tags, createTagsHttpUrl, "{certificate_id}"); err != nil {
+	if err := createTags(certId, client, tags, createTagsHttpUrl, "{certificate_id}"); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy.go
+++ b/huaweicloud/services/cnad/resource_huaweicloud_cnad_advanced_policy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -134,11 +133,11 @@ func resourceCNADAdvancedPolicyCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createPolicyRespBody)
-	if err != nil {
-		return diag.Errorf("error creating CNAD advanced policy: ID is not found in API response")
+	policyId := utils.PathSearch("id", createPolicyRespBody, "").(string)
+	if policyId == "" {
+		return diag.Errorf("unable to find the CNAD advanced policy ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(policyId)
 
 	_, ok1 := d.GetOk("threshold")
 	_, ok2 := d.GetOk("udp")

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script.go
@@ -177,12 +177,12 @@ func resourceScriptCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("data", createScriptRespBody)
-	if err != nil {
-		return diag.Errorf("error creating COC script: ID is not found in API response")
+	scriptId := utils.PathSearch("data", createScriptRespBody, "").(string)
+	if scriptId == "" {
+		return diag.Errorf("unable to find the COC script ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(scriptId)
 	return resourceScriptRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
+++ b/huaweicloud/services/coc/resource_huaweicloud_coc_script_execute.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -202,12 +201,11 @@ func resourceScriptExecuteCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("data", createExecuteRespBody)
-	if err != nil {
-		return diag.Errorf("error executing COC script: ID is not found in API response")
+	ticketID := utils.PathSearch("data", createExecuteRespBody, "").(string)
+	if ticketID == "" {
+		return diag.Errorf("unable to find the executing COC script ID from the API response")
 	}
 
-	ticketID := id.(string)
 	d.SetId(ticketID)
 
 	// waiting the execution status of COC script

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_application.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_application.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -284,11 +283,11 @@ func resourceDeployApplicationCreate(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error creating CodeArts deploy application: %s", err)
 	}
 
-	id, err := jmespath.Search("result.id", createRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating DeployApplication: ID is not found in API response")
+	appId := utils.PathSearch("result.id", createRespBody, "").(string)
+	if appId == "" {
+		return diag.Errorf("unable to find the deploy application ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(appId)
 
 	return resourceDeployApplicationRead(ctx, d, meta)
 }

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_group.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_deploy_group.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -192,12 +191,12 @@ func resourceDeployGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error creating CodeArts deploy group: %s", err)
 	}
 
-	id, err := jmespath.Search("id", createRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating CodeArts deploy group: ID is not found in API response")
+	groupId := utils.PathSearch("id", createRespBody, "").(string)
+	if groupId == "" {
+		return diag.Errorf("unable to find the CodeArts deploy group ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(groupId)
 
 	return resourceDeployGroupRead(ctx, d, meta)
 }
@@ -268,8 +267,8 @@ func resourceDeployGroupRead(_ context.Context, d *schema.ResourceData, meta int
 }
 
 func flattenDeployGroupCreatedBy(resp interface{}) []interface{} {
-	curJson, err := jmespath.Search("created_by", resp)
-	if err != nil {
+	curJson := utils.PathSearch("created_by", resp, nil)
+	if curJson == nil {
 		log.Printf("[ERROR] error flatten created_by, cause this field is not found in API response")
 		return nil
 	}
@@ -283,8 +282,8 @@ func flattenDeployGroupCreatedBy(resp interface{}) []interface{} {
 }
 
 func flattenDeployGroupPermission(resp interface{}) []interface{} {
-	curJson, err := jmespath.Search("permission", resp)
-	if err != nil {
+	curJson := utils.PathSearch("permission", resp, nil)
+	if curJson == nil {
 		log.Printf("[ERROR] error flatten permission, cause this field is not found in API response")
 		return nil
 	}

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -175,11 +174,11 @@ func createInspectorWebsite(client *golangsdk.ServiceClient, d *schema.ResourceD
 		return err
 	}
 
-	id, err := jmespath.Search("domain_id", createRespBody)
-	if err != nil || id == nil {
-		return fmt.Errorf("ID is not found in API response")
+	domainId := utils.PathSearch("domain_id", createRespBody, "").(string)
+	if domainId == "" {
+		return fmt.Errorf("unable to find the CodeArts website domain ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(domainId)
 
 	return nil
 }

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website_scan.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_inspector_website_scan.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -229,11 +228,11 @@ func resourceInspectorWebsiteScanCreate(ctx context.Context, d *schema.ResourceD
 		return diag.Errorf("error creating CodeArts inspector website scan: %s", err)
 	}
 
-	id, err := jmespath.Search("task_id", createRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating CodeArts inspector website scan: ID is not found in API response")
+	taskId := utils.PathSearch("task_id", createRespBody, "").(string)
+	if taskId == "" {
+		return diag.Errorf("unable find the CodeArts inspector website scan ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(taskId)
 
 	return resourceInspectorWebsiteScanRead(ctx, d, meta)
 }

--- a/huaweicloud/services/codearts/resource_huaweicloud_codearts_project.go
+++ b/huaweicloud/services/codearts/resource_huaweicloud_codearts_project.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -136,11 +135,11 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("project_id", createProjectRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Project: ID is not found in API response")
+	projectId := utils.PathSearch("project_id", createProjectRespBody, "").(string)
+	if projectId == "" {
+		return diag.Errorf("unable to find the CodeArts project ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(projectId)
 
 	return resourceProjectRead(ctx, d, meta)
 }

--- a/huaweicloud/services/cph/data_source_huaweicloud_cph_server_flavors.go
+++ b/huaweicloud/services/cph/data_source_huaweicloud_cph_server_flavors.go
@@ -8,7 +8,6 @@ package cph
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -16,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -218,9 +216,8 @@ func flattenListServerModelsFlavors(resp interface{}) []interface{} {
 
 func flattenFlavorsExtendSpec(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("extend_spec", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing extend_spec from response= %#v", resp)
+	curJson := utils.PathSearch("extend_spec", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -155,11 +154,11 @@ func resourceMicroserviceEngineConfigurationCreate(ctx context.Context, d *schem
 		return diag.FromErr(err)
 	}
 
-	configId, err := jmespath.Search("id", respBody)
-	if err != nil || configId == nil {
-		return diag.Errorf("failed to find the configuration ID from the API response: %s", err)
+	configId := utils.PathSearch("id", respBody, "").(string)
+	if configId == "" {
+		return diag.Errorf("enable to find the CSE microservice configuration ID from the API response")
 	}
-	d.SetId(configId.(string))
+	d.SetId(configId)
 
 	return resourceMicroserviceEngineConfigurationRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_business_metric.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_business_metric.go
@@ -247,11 +247,11 @@ func resourceBusinessMetricCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("data.value.id", createRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating DataArts Architecture business metric: ID is not found in API response")
+	metricId := utils.PathSearch("data.value.id", createRespBody, "").(string)
+	if metricId == "" {
+		return diag.Errorf("unable to find the DataArts Architecture business metric ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(metricId)
 
 	return resourceBusinessMetricRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_code_table.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_code_table.go
@@ -170,12 +170,12 @@ func resourceArchitectureCodeTableCreate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("data.value.id", createCodeTableRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating DataArts Architecture code table: %s is not found in API response", "id")
+	tableId := utils.PathSearch("data.value.id", createCodeTableRespBody, "").(string)
+	if tableId == "" {
+		return diag.Errorf("unable to find the DataArts Architecture code table ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(tableId)
 
 	return resourceArchitectureCodeTableRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_data_standard.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_data_standard.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -246,11 +245,11 @@ func resourceDataStandardCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("data.value.id", createDataStandardRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DataArts Architecture data standard: ID is not found in API response")
+	standardId := utils.PathSearch("data.value.id", createDataStandardRespBody, "").(string)
+	if standardId == "" {
+		return diag.Errorf("unable to find the DataArts Architecture data standard ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(standardId)
 
 	return resourceDataStandardRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_model.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_model.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -135,12 +134,11 @@ func resourceArchitectureModelCreate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	model := utils.PathSearch("data.value", createModelBody, nil)
-	id, err := jmespath.Search("id", model)
-	if err != nil {
-		return diag.Errorf("error creating DataArts Studio architecture model: %s is not found in API response", "id")
+	modelId := utils.PathSearch("data.value.id", createModelBody, "").(string)
+	if modelId == "" {
+		return diag.Errorf("unable to find the DataArts Studio architecture model ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(modelId)
 
 	return resourceArchitectureModelRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_reviewer.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_reviewer.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -99,11 +98,11 @@ func resourceArchitectureReviewerCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	userName, err := jmespath.Search("data.value.user_name", createReviewerBody)
-	if err != nil {
-		return diag.Errorf("error creating DataArts Studio architecture Reviewer: user_name is not found in API response")
+	userName := utils.PathSearch("data.value.user_name", createReviewerBody, "").(string)
+	if userName == "" {
+		return diag.Errorf("unable to find the user name of the DataArts Studio architecture reviewer from the API response")
 	}
-	d.SetId(userName.(string))
+	d.SetId(userName)
 
 	return resourceArchitectureReviewerRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_subject.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_subject.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -134,12 +133,12 @@ func resourceArchitectureSubjectCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("data.value.id", createSubjectRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating DataArts Architecture subject: %s is not found in API response", "id")
+	subjectId := utils.PathSearch("data.value.id", createSubjectRespBody, "").(string)
+	if subjectId == "" {
+		return diag.Errorf("unable to find the DataArts Architecture subject ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(subjectId)
 
 	return resourceArchitectureSubjectRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_table_model.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_architecture_table_model.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -672,12 +671,12 @@ func resourceTableModelCreate(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	tableModel := utils.PathSearch("data.value", createTableModelRespBody, nil)
-	id, err := jmespath.Search("id", tableModel)
-	if err != nil {
-		return diag.Errorf("error creating DataArts Architecture table model: %s is not found in API response", "id")
+
+	modelId := utils.PathSearch("data.value.id", createTableModelRespBody, "").(string)
+	if modelId == "" {
+		return diag.Errorf("unable to find the DataArts Architecture table model ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(modelId)
 
 	return resourceTableModelRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_api.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -841,11 +840,11 @@ func resourceDataServiceApiCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	apiId, err := jmespath.Search("id", respBody)
-	if err != nil || apiId == "" {
-		return diag.Errorf("the API ID does not found in the API response")
+	apiId := utils.PathSearch("id", respBody, "").(string)
+	if apiId == "" {
+		return diag.Errorf("unable to find the DataArts DataService API ID from the API response")
 	}
-	d.SetId(apiId.(string))
+	d.SetId(apiId)
 
 	return resourceDataServiceApiRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_app.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_app.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -131,11 +130,11 @@ func resourceDataServiceAppCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createAppRespBody)
-	if err != nil {
-		return diag.Errorf("error creating app: ID is not found in API response")
+	appId := utils.PathSearch("id", createAppRespBody, "").(string)
+	if appId == "" {
+		return diag.Errorf("unable to find the DataArts DataService APP ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(appId)
 
 	return resourceDataServiceAppRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_catalog.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_dataservice_catalog.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -156,11 +155,11 @@ func resourceDatatServiceCatalogCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	catalogId, err := jmespath.Search("catalog_id", createAppRespBody)
-	if err != nil {
-		return diag.Errorf("catalog ID does not found in API response")
+	catalogId := utils.PathSearch("catalog_id", createAppRespBody, "").(string)
+	if catalogId == "" {
+		return diag.Errorf("unable to find the DataArts DataService catalog ID from the API response")
 	}
-	d.SetId(catalogId.(string))
+	d.SetId(catalogId)
 
 	return resourceDatatServiceCatalogRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_factory_job.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -991,9 +990,8 @@ func flattenGetJobResponseBodyNode(resp interface{}) []interface{} {
 
 func flattenNodeLocation(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("location", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing location from response= %#v", resp)
+	curJson := utils.PathSearch("location", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -1040,9 +1038,8 @@ func flattenNodeProperties(resp interface{}) []interface{} {
 
 func flattenNodeEventTrigger(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("eventTrigger", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing eventTrigger from response= %#v", resp)
+	curJson := utils.PathSearch("eventTrigger", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -1060,9 +1057,8 @@ func flattenNodeEventTrigger(resp interface{}) []interface{} {
 
 func flattenNodeCronTrigger(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("cron_trigger", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing cron_trigger from response= %#v", resp)
+	curJson := utils.PathSearch("cron_trigger", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -1083,9 +1079,8 @@ func flattenNodeCronTrigger(resp interface{}) []interface{} {
 
 func flattenCronTriggerDependJobs(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("dependJobs", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing dependJobs from response= %#v", resp)
+	curJson := utils.PathSearch("dependJobs", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -1101,9 +1096,8 @@ func flattenCronTriggerDependJobs(resp interface{}) []interface{} {
 
 func flattenGetJobResponseBodySchedule(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("schedule", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing schedule from response= %#v", resp)
+	curJson := utils.PathSearch("schedule", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -1119,9 +1113,8 @@ func flattenGetJobResponseBodySchedule(resp interface{}) []interface{} {
 
 func flattenScheduleCron(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("cron", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing cron from response= %#v", resp)
+	curJson := utils.PathSearch("cron", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -1140,9 +1133,8 @@ func flattenScheduleCron(resp interface{}) []interface{} {
 
 func flattenCronDependJobs(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("dependJobs", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing dependJobs from response= %#v", resp)
+	curJson := utils.PathSearch("dependJobs", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -1158,9 +1150,8 @@ func flattenCronDependJobs(resp interface{}) []interface{} {
 
 func flattenScheduleEvent(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("event", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing event from response= %#v", resp)
+	curJson := utils.PathSearch("event", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -1195,9 +1186,8 @@ func flattenGetJobResponseBodyParam(resp interface{}) []interface{} {
 
 func flattenGetJobResponseBodyBasicConfig(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("basicConfig", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing basicConfig from response= %#v", resp)
+	curJson := utils.PathSearch("basicConfig", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_recognition_rule.go
@@ -167,12 +167,12 @@ func resourceSecurityRuleCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("uuid", createRuleRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating DataArts Security data recognition rule: ID is not found in API response")
+	ruleId := utils.PathSearch("uuid", createRuleRespBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find the recognition rule ID of the DataArts Security from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(ruleId)
 
 	return resourceSecurityRuleRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_secrecy_level.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_data_secrecy_level.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -111,12 +110,12 @@ func resourceSecurityDataSecrecyLevelCreate(ctx context.Context, d *schema.Resou
 		return diag.Errorf("error retrieving DataArts Security data secrecy level: %s", err)
 	}
 
-	id, err := jmespath.Search("secrecy_level_id", respBody)
-	if err != nil {
-		return diag.Errorf("error creating DataArts Security data secrecy level: ID is not found in API response")
+	levelId := utils.PathSearch("secrecy_level_id", respBody, "").(string)
+	if levelId == "" {
+		return diag.Errorf("unable to find the secrecy level ID of the DataArts Security from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(levelId)
 	return resourceSecurityDataSecrecyLevelRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set.go
@@ -136,12 +136,12 @@ func resourceSecurityPermissionSetCreate(ctx context.Context, d *schema.Resource
 		return diag.Errorf("error retrieving DataArts Security permission set: %s", err)
 	}
 
-	id, err := jmespath.Search("id", createPermissionSetRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DataArts Security permission set: ID is not found in API response")
+	setId := utils.PathSearch("id", createPermissionSetRespBody, "").(string)
+	if setId == "" {
+		return diag.Errorf("unable to find the DataArts Security permission set ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(setId)
 	return resourceSecurityPermissionSetRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_member.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_member.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -106,9 +105,9 @@ func resourceSecurityPermissionSetMemberCreate(ctx context.Context, d *schema.Re
 		return diag.Errorf("error retrieving DataArts Security permission set member: %s", err)
 	}
 
-	memberId, err := jmespath.Search("member_id", respBody)
-	if err != nil {
-		return diag.Errorf("error creating DataArts Security permission set member: ID is not found in API response")
+	memberId := utils.PathSearch("member_id", respBody, "").(string)
+	if memberId == "" {
+		return diag.Errorf("unable to find the member ID of the DataArts Security permission set from the API response")
 	}
 
 	d.SetId(fmt.Sprintf("%s/%s/%s", workspaceId, permissionSetId, memberId))

--- a/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
+++ b/huaweicloud/services/dataarts/resource_huaweicloud_dataarts_security_permission_set_privilege.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -155,12 +154,12 @@ func resourceSecurityPermissionSetPrivilegeCreate(ctx context.Context, d *schema
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", respBody)
-	if err != nil {
-		return diag.Errorf("error creating DataArts Security permission set privilege: ID is not found in API response")
+	privilegeId := utils.PathSearch("id", respBody, "").(string)
+	if privilegeId == "" {
+		return diag.Errorf("unable to find the privilege ID of the DataArts Security permission set from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(privilegeId)
 	return resourceSecurityPermissionSetPrivilegeRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/dc/resource_huaweicloud_dc_hosted_connect.go
+++ b/huaweicloud/services/dc/resource_huaweicloud_dc_hosted_connect.go
@@ -7,7 +7,6 @@ package dc
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -135,11 +133,11 @@ func resourceHostedConnectCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("hosted_connect.id", createHostedConnectRespBody)
-	if err != nil {
-		return diag.Errorf("error creating hosted connect: ID is not found in API response")
+	connectId := utils.PathSearch("hosted_connect.id", createHostedConnectRespBody, "").(string)
+	if connectId == "" {
+		return diag.Errorf("unable to find the hosted connect ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(connectId)
 
 	err = hostedConnectWaitingForStateCompleted(ctx, createHostedConnectClient, d.Id(), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -193,12 +191,7 @@ func hostedConnectWaitingForStateCompleted(ctx context.Context, client *golangsd
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`hosted_connect.status`, createHostedConnectWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `status`)
-			}
-
-			status := fmt.Sprintf("%v", statusRaw)
+			status := utils.PathSearch(`hosted_connect.status`, createHostedConnectWaitingRespBody, "").(string)
 
 			targetStatus := []string{
 				"BUILD",
@@ -408,12 +401,7 @@ func deleteHostedConnectWaitingForStateCompleted(ctx context.Context, client *go
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`hosted_connect.status`, deleteHostedConnectWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `status`)
-			}
-
-			status := fmt.Sprintf("%v", statusRaw)
+			status := utils.PathSearch(`hosted_connect.status`, deleteHostedConnectWaitingRespBody, "").(string)
 
 			pendingStatus := []string{
 				"PENDING_DELETE",

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_custom_template.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_custom_template.go
@@ -193,11 +193,11 @@ func resourceCustomTemplateCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createCustomTemplateRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DCS custom template: ID is not found in API response")
+	templateId := utils.PathSearch("id", createCustomTemplateRespBody, "").(string)
+	if templateId == "" {
+		return diag.Errorf("unable to find the DCS custom template ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(templateId)
 
 	return resourceCustomTemplateRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dcs/resource_huaweicloud_dcs_hotkey_analysis.go
+++ b/huaweicloud/services/dcs/resource_huaweicloud_dcs_hotkey_analysis.go
@@ -175,16 +175,16 @@ func resourceHotKeyAnalysisCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", hotkeyAnalysisRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DCS hot key analysis: ID is not found in API response")
+	analysisId := utils.PathSearch("id", hotkeyAnalysisRespBody, "").(string)
+	if analysisId == "" {
+		return diag.Errorf("unable to find the analysis ID of the DCS hot key form the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(analysisId)
 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"waiting", "running"},
 		Target:       []string{"success"},
-		Refresh:      hotKeyAnalysisStatusRefreshFunc(instanceId, id.(string), createHotKeyAnalysisClient),
+		Refresh:      hotKeyAnalysisStatusRefreshFunc(instanceId, analysisId, createHotKeyAnalysisClient),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
@@ -192,7 +192,7 @@ func resourceHotKeyAnalysisCreate(ctx context.Context, d *schema.ResourceData, m
 
 	_, err = stateConf.WaitForStateContext(ctx)
 	if err != nil {
-		return diag.Errorf("error waiting for the hot key analysis(%s) to complete: %s", id.(string), err)
+		return diag.Errorf("error waiting for the hot key analysis(%s) to complete: %s", analysisId, err)
 	}
 
 	return resourceHotKeyAnalysisRead(ctx, d, meta)

--- a/huaweicloud/services/ddm/resource_huaweicloud_ddm_schema.go
+++ b/huaweicloud/services/ddm/resource_huaweicloud_ddm_schema.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -232,13 +231,9 @@ func resourceDdmSchemaCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	schemas, err := jmespath.Search("databases", createSchemaRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DdmSchema: Schema is not found in API response %s", err)
-	}
-	schemaName, err := jmespath.Search("name", schemas.([]interface{})[0])
-	if err != nil {
-		return diag.Errorf("error creating DdmSchema: Schema name is not found in API response %s", err)
+	schemaName := utils.PathSearch("databases[0].name", createSchemaRespBody, "").(string)
+	if schemaName == "" {
+		return diag.Errorf("unable to find the DDM schema name from the API response %s", err)
 	}
 
 	err = waitForInstanceRunning(ctx, d, createSchemaClient, instanceID, schema.TimeoutCreate)
@@ -246,7 +241,7 @@ func resourceDdmSchemaCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	d.SetId(instanceID + "/" + schemaName.(string))
+	d.SetId(instanceID + "/" + schemaName)
 
 	return resourceDdmSchemaRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dew/data_source_huaweicloud_csms_events.go
+++ b/huaweicloud/services/dew/data_source_huaweicloud_csms_events.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk/pagination"
 
@@ -210,13 +208,9 @@ func filterListEventsBody(all []interface{}, d *schema.ResourceData) []interface
 
 func flattenNotification(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("notification", resp)
-	if err != nil {
-		log.Printf("[ERROR] Error parsing notification from response= %#v", resp)
+	curJson := utils.PathSearch("notification", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
-	}
-	if curJson == nil {
-		return nil
 	}
 
 	rst = []interface{}{

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_dedicated_keystore.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_dedicated_keystore.go
@@ -94,11 +94,11 @@ func resourceKmsDedicatedKeystoreCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("keystore.keystore_id", createRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating KMS dedicated keystore: ID is not found in API response")
+	keystoreId := utils.PathSearch("keystore.keystore_id", createRespBody, "").(string)
+	if keystoreId == "" {
+		return diag.Errorf("unable to find the KMS dedicated keystore ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(keystoreId)
 
 	return resourceKmsDedicatedKeystoreRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dew/resource_huaweicloud_kms_grant.go
+++ b/huaweicloud/services/dew/resource_huaweicloud_kms_grant.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -129,11 +128,11 @@ func resourceKmsGrantCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("grant_id", createGrantRespBody)
-	if err != nil {
-		return diag.Errorf("error creating KMS grant: ID is not found in API response")
+	grantId := utils.PathSearch("grant_id", createGrantRespBody, "").(string)
+	if grantId == "" {
+		return diag.Errorf("unable to find the KMS grant ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(grantId)
 
 	return resourceKmsGrantRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_connection.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_datasource_connection.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -186,11 +185,11 @@ func resourceDatasourceConnectionCreate(ctx context.Context, d *schema.ResourceD
 			utils.PathSearch("message", createDatasourceConnectionRespBody, "Message Not Found"))
 	}
 
-	id, err := jmespath.Search("connection_id", createDatasourceConnectionRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DatasourceConnection: ID is not found in API response")
+	connectionId := utils.PathSearch("connection_id", createDatasourceConnectionRespBody, "").(string)
+	if connectionId == "" {
+		return diag.Errorf("unable to find the connection ID of the DLI Data Source from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(connectionId)
 
 	// add routes
 	if v, ok := d.GetOk("routes"); ok {

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_flink_template.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_flink_template.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -117,11 +116,11 @@ func resourceFlinkTemplateCreate(ctx context.Context, d *schema.ResourceData, me
 			utils.PathSearch("message", createFlinkTemplateRespBody, "Message Not Found"))
 	}
 
-	id, err := jmespath.Search("template.template_id", createFlinkTemplateRespBody)
-	if err != nil {
-		return diag.Errorf("error creating FlinkTemplate: ID is not found in API response")
+	templateId := utils.PathSearch("template.template_id", createFlinkTemplateRespBody, float64(0)).(float64)
+	if templateId == 0 {
+		return diag.Errorf("unable to find the Flink template ID from the API response")
 	}
-	d.SetId(fmt.Sprint(id))
+	d.SetId(fmt.Sprint(templateId))
 
 	return resourceFlinkTemplateRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dli/resource_huaweicloud_dli_sql_template.go
+++ b/huaweicloud/services/dli/resource_huaweicloud_dli_sql_template.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -112,11 +111,11 @@ func resourceSQLTemplateCreate(ctx context.Context, d *schema.ResourceData, meta
 			utils.PathSearch("message", createSQLTemplateRespBody, "Message Not Found"))
 	}
 
-	id, err := jmespath.Search("sql_id", createSQLTemplateRespBody)
-	if err != nil {
-		return diag.Errorf("error creating SQLTemplate: ID is not found in API response")
+	templateId := utils.PathSearch("sql_id", createSQLTemplateRespBody, "").(string)
+	if templateId == "" {
+		return diag.Errorf("unable to find the SQL template ID the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(templateId)
 
 	return resourceSQLTemplateRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_custom_line.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -124,11 +123,11 @@ func createDNSCustomLine(customLineClient *golangsdk.ServiceClient, d *schema.Re
 		return err
 	}
 
-	id, err := jmespath.Search("line_id", createDNSCustomLineRespBody)
-	if err != nil {
-		return fmt.Errorf("error creating DNS custom line: ID is not found in API response")
+	lineId := utils.PathSearch("line_id", createDNSCustomLineRespBody, "").(string)
+	if lineId == "" {
+		return fmt.Errorf("unable to find the DNS custom line ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(lineId)
 	return nil
 }
 

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_line_group.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_line_group.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -125,11 +124,11 @@ func createDNSLineGroup(lineGroupClient *golangsdk.ServiceClient, d *schema.Reso
 		return err
 	}
 
-	id, err := jmespath.Search("line_id", createDNSLineGroupRespBody)
-	if err != nil {
-		return fmt.Errorf("error creating DNS line group: ID is not found in API response")
+	lineId := utils.PathSearch("line_id", createDNSLineGroupRespBody, "").(string)
+	if lineId == "" {
+		return fmt.Errorf("unable to find the related line ID of the DNS line group from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(lineId)
 	return nil
 }
 

--- a/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
+++ b/huaweicloud/services/dns/resource_huaweicloud_dns_recordset.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -199,11 +198,11 @@ func createDNSRecordset(recordsetClient *golangsdk.ServiceClient, d *schema.Reso
 		return err
 	}
 
-	id, err := jmespath.Search("id", createDNSRecordsetRespBody)
-	if err != nil {
-		return fmt.Errorf("error creating DNS recordset: ID is not found in API response")
+	recordSetID := utils.PathSearch("id", createDNSRecordsetRespBody, "").(string)
+	if recordSetID == "" {
+		return fmt.Errorf("unable to find the DNS recordset ID from the API response")
 	}
-	d.SetId(fmt.Sprintf("%s/%s", zoneID, id))
+	d.SetId(fmt.Sprintf("%s/%s", zoneID, recordSetID))
 	return nil
 }
 

--- a/huaweicloud/services/dws/data_source_huaweicloud_dws_flavors.go
+++ b/huaweicloud/services/dws/data_source_huaweicloud_dws_flavors.go
@@ -8,7 +8,6 @@ package dws
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -16,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -205,7 +203,7 @@ func flattenListNodeTypesFlavors(resp interface{}) []interface{} {
 		rst = append(rst, map[string]interface{}{
 			"flavor_id":            utils.PathSearch("spec_name", v, nil),
 			"datastore_type":       utils.PathSearch("datastore_type", v, nil),
-			"datastore_version":    flattenFlavorsDatastoreVersion(v),
+			"datastore_version":    utils.PathSearch("datastores[0].version", v, nil),
 			"vcpus":                utils.PathSearch("vcpus", v, nil),
 			"memory":               utils.PathSearch("ram", v, nil),
 			"volumetype":           utils.PathSearch("detail[?type=='LOCAL_DISK' || type=='SSD' ].type|[0]", v, nil),
@@ -217,21 +215,10 @@ func flattenListNodeTypesFlavors(resp interface{}) []interface{} {
 	return rst
 }
 
-func flattenFlavorsDatastoreVersion(resp interface{}) string {
-	version, err := jmespath.Search("datastores[0].version", resp)
-	if err != nil {
-		log.Printf("[WARN] error parsing version from response: %s", err)
-		return ""
-	}
-
-	return version.(string)
-}
-
 func flattenFlavorsElasticVolumeSpecs(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("elastic_volume_specs[0]", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing elastic_volume_specs[0] from response= %#v", resp)
+	curJson := utils.PathSearch("elastic_volume_specs[0]", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_alarm_subscription.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_alarm_subscription.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/pagination"
@@ -119,11 +118,11 @@ func resourceDwsAlarmSubsCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createDwsAlarmSubsRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DWS alarm subscription: ID is not found in API response")
+	subscriptionId := utils.PathSearch("id", createDwsAlarmSubsRespBody, "").(string)
+	if subscriptionId == "" {
+		return diag.Errorf("unable to find the DWS alarm subscription ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(subscriptionId)
 
 	return resourceDwsAlarmSubsRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_disaster_recovery_task.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_disaster_recovery_task.go
@@ -178,11 +178,11 @@ func resourceDwsDisasterRecoveryTaskCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("disaster_recovery.id", respBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating DWS disaster recovery: ID is not found in API response")
+	recoveryId := utils.PathSearch("disaster_recovery.id", respBody, "").(string)
+	if recoveryId == "" {
+		return diag.Errorf("unable to find the DWS disaster recovery ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(recoveryId)
 	// When the disaster recovery successfully created, the status is unstart.
 	err = waitingForActionDisasterRecvery(ctx, d, client, "unstart", d.Timeout(schema.TimeoutCreate))
 	if err != nil {

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_event_subscription.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_event_subscription.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/pagination"
@@ -137,11 +136,11 @@ func resourceDwsEventSubsCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createDwsEventSubsRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DWS event subscription: ID is not found in API response")
+	subscriptionId := utils.PathSearch("id", createDwsEventSubsRespBody, "").(string)
+	if subscriptionId == "" {
+		return diag.Errorf("unable to find the DWS event subscription ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(subscriptionId)
 
 	return resourceDwsEventSubsRead(ctx, d, meta)
 }

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_ext_data_source.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_ext_data_source.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -164,11 +163,11 @@ func resourceDwsExtDataSourceCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createDwsExtDataSourceRespBody)
-	if err != nil {
-		return diag.Errorf("error creating DWS external data source: ID is not found in API response")
+	dataSourceId := utils.PathSearch("id", createDwsExtDataSourceRespBody, "").(string)
+	if dataSourceId == "" {
+		return diag.Errorf("unable to find the DWS external data source ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(dataSourceId)
 
 	jobId := utils.PathSearch("job_id", createDwsExtDataSourceRespBody, nil)
 	if jobId == nil {
@@ -451,12 +450,7 @@ func extDataSourceWaitingForStateCompleted(ctx context.Context, d *schema.Resour
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`status`, extDataSourceWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `status`)
-			}
-
-			status := fmt.Sprintf("%v", statusRaw)
+			status := utils.PathSearch(`status`, extDataSourceWaitingRespBody, "").(string)
 
 			targetStatus := []string{
 				"SUCCESS",

--- a/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
+++ b/huaweicloud/services/dws/resource_huaweicloud_dws_logical_cluster.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -205,11 +204,11 @@ func resourceLogicalClusterCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error waiting for DWS logical cluster (%s) creation to complete: %s", clusterName, err)
 	}
 
-	id, err := jmespath.Search("logical_cluster_id", clusterRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating DWS logical cluster: ID is not found in API response")
+	logicalClusterId := utils.PathSearch("logical_cluster_id", clusterRespBody, "").(string)
+	if logicalClusterId == "" {
+		return diag.Errorf("unable to find the DWS logical cluster ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(logicalClusterId)
 
 	return resourceLogicalClusterRead(ctx, d, meta)
 }

--- a/huaweicloud/services/ecs/resource_huaweicloud_compute_auto_launch_group.go
+++ b/huaweicloud/services/ecs/resource_huaweicloud_compute_auto_launch_group.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -208,11 +207,11 @@ func resourceAutoLaunchGroupCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("auto_launch_group_id", createAutoLaunchGroupRespBody)
-	if err != nil {
-		return diag.Errorf("error creating auto launch group: %s is not found in API response", "id")
+	groupId := utils.PathSearch("auto_launch_group_id", createAutoLaunchGroupRespBody, "").(string)
+	if groupId == "" {
+		return diag.Errorf("unable to find the auto launch group ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(groupId)
 
 	return resourceAutoLaunchGroupRead(ctx, d, meta)
 }

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_connection.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_connection.go
@@ -7,13 +7,11 @@ package eg
 
 import (
 	"context"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -180,11 +178,11 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createConnectionRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Connection: ID is not found in API response")
+	connectionId := utils.PathSearch("id", createConnectionRespBody, "").(string)
+	if connectionId == "" {
+		return diag.Errorf("unable to find the connection ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(connectionId)
 
 	return resourceConnectionRead(ctx, d, meta)
 }
@@ -285,9 +283,8 @@ func resourceConnectionRead(_ context.Context, d *schema.ResourceData, meta inte
 
 func flattenGetConnectionResponseBodyKafkaDetail(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("kafka_detail", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing kafka_detail from response= %#v", resp)
+	curJson := utils.PathSearch("kafka_detail", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_endpoint.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_endpoint.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/pagination"
@@ -129,11 +128,11 @@ func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createEndpointRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Endpoint: ID is not found in API response")
+	endpointId := utils.PathSearch("id", createEndpointRespBody, "").(string)
+	if endpointId == "" {
+		return diag.Errorf("unable to find the EG endpoint ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(endpointId)
 
 	return resourceEndpointRead(ctx, d, meta)
 }

--- a/huaweicloud/services/eg/resource_huaweicloud_eg_event_stream.go
+++ b/huaweicloud/services/eg/resource_huaweicloud_eg_event_stream.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -400,11 +399,11 @@ func resourceEventStreamCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("eventStreamingID", respBody)
-	if err != nil {
-		return diag.Errorf("unable to find the resource ID in API response")
+	streamId := utils.PathSearch("eventStreamingID", respBody, "").(string)
+	if streamId == "" {
+		return diag.Errorf("unable to find the stream ID from API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(streamId)
 
 	if action, ok := d.GetOk("action"); ok && action.(string) == "START" {
 		err := doActionForEventStream(client, d.Id(), action.(string))

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_active_standby_pools.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_active_standby_pools.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk/pagination"
 
@@ -422,13 +421,11 @@ func flattenActiveStandbyPoolMember(resp interface{}) []interface{} {
 
 func flattenActiveStandbyPoolMonitor(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("healthmonitor", resp)
-	if err != nil {
-		return rst
-	}
-	if curJson == nil {
+	curJson := utils.PathSearch("healthmonitor", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return nil
 	}
+
 	rst = []interface{}{
 		map[string]interface{}{
 			"name":             utils.PathSearch("name", curJson, nil),

--- a/huaweicloud/services/elb/data_source_huaweicloud_elb_pools.go
+++ b/huaweicloud/services/elb/data_source_huaweicloud_elb_pools.go
@@ -9,14 +9,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk/pagination"
 
@@ -424,12 +422,8 @@ func flattenPoolMembers(resp interface{}) []interface{} {
 
 func flattenPoolPersistence(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("session_persistence", resp)
-	if err != nil {
-		log.Printf("[ERROR] Error parsing persistence from response= %#v", resp)
-		return rst
-	}
-	if curJson == nil {
+	curJson := utils.PathSearch("session_persistence", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return nil
 	}
 

--- a/huaweicloud/services/elb/resource_huaweicloud_elb_security_policy.go
+++ b/huaweicloud/services/elb/resource_huaweicloud_elb_security_policy.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -131,11 +130,11 @@ func resourceSecurityPoliciesV3Create(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("security_policy.id", createSecurityPolicyRespBody)
-	if err != nil {
-		return diag.Errorf("error creating SecurityPolicies: ID is not found in API response")
+	policyId := utils.PathSearch("security_policy.id", createSecurityPolicyRespBody, "").(string)
+	if policyId == "" {
+		return diag.Errorf("unable to find the security policy ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(policyId)
 
 	return resourceSecurityPoliciesV3Read(ctx, d, meta)
 }

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_account.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_account.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -142,12 +141,11 @@ func resourceGaussDBAccountCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	jobId, err := jmespath.Search("job_id", createGaussDBAccountRespBody)
-	if err != nil {
-		return diag.Errorf("error creating GaussDB MySQL account: job_id is not found in API response")
+	jobId := utils.PathSearch("job_id", createGaussDBAccountRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID of the GaussDB MySQL account from the API response")
 	}
-	err = waitForJobComplete(ctx, createGaussDBAccountClient, d.Timeout(schema.TimeoutCreate), instanceID,
-		jobId.(string))
+	err = waitForJobComplete(ctx, createGaussDBAccountClient, d.Timeout(schema.TimeoutCreate), instanceID, jobId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -325,12 +323,12 @@ func updateGaussDBAccountDescription(ctx context.Context, d *schema.ResourceData
 		return err
 	}
 
-	jobId, err := jmespath.Search("job_id", updateGaussDBAccountRespBody)
-	if err != nil {
-		return fmt.Errorf("error updating GaussDB account description: job_id is not found in API response")
+	jobId := utils.PathSearch("job_id", updateGaussDBAccountRespBody, "").(string)
+	if jobId == "" {
+		return fmt.Errorf("unable to find the job ID of the GaussDB MySQL account from the API response while updating the description")
 	}
 
-	return waitForJobComplete(ctx, client, d.Timeout(schema.TimeoutUpdate), instanceID, jobId.(string))
+	return waitForJobComplete(ctx, client, d.Timeout(schema.TimeoutUpdate), instanceID, jobId)
 }
 
 func updateGaussDBAccountPassword(ctx context.Context, d *schema.ResourceData, client *golangsdk.ServiceClient,
@@ -374,12 +372,12 @@ func updateGaussDBAccountPassword(ctx context.Context, d *schema.ResourceData, c
 		return err
 	}
 
-	jobId, err := jmespath.Search("job_id", updateGaussDBAccountRespBody)
-	if err != nil {
-		return fmt.Errorf("error updating GaussDB account password: job_id is not found in API response")
+	jobId := utils.PathSearch("job_id", updateGaussDBAccountRespBody, "").(string)
+	if jobId == "" {
+		return fmt.Errorf("unable to find the job ID of the GaussDB MySQL account from the API response while updating the password")
 	}
 
-	return waitForJobComplete(ctx, client, d.Timeout(schema.TimeoutUpdate), instanceID, jobId.(string))
+	return waitForJobComplete(ctx, client, d.Timeout(schema.TimeoutUpdate), instanceID, jobId)
 }
 
 func buildUpdateGaussDBAccountDescriptionBodyParams(d *schema.ResourceData) map[string]interface{} {
@@ -457,12 +455,12 @@ func resourceGaussDBAccountDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	jobId, err := jmespath.Search("job_id", deleteGaussDBAccountRespBody)
-	if err != nil {
-		return diag.Errorf("error deleting GaussDB MySQL account: job_id is not found in API response")
+	jobId := utils.PathSearch("job_id", deleteGaussDBAccountRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID of the GaussDB MySQL account from the API response")
 	}
 
-	err = waitForJobComplete(ctx, deleteGaussDBAccountClient, d.Timeout(schema.TimeoutDelete), instanceID, jobId.(string))
+	err = waitForJobComplete(ctx, deleteGaussDBAccountClient, d.Timeout(schema.TimeoutDelete), instanceID, jobId)
 
 	return nil
 }

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_database.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_database.go
@@ -132,13 +132,12 @@ func resourceGaussDBDatabaseCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	jobId, err := jmespath.Search("job_id", createGaussDBDatabaseRespBody)
-	if err != nil {
-		return diag.Errorf("error creating GaussDB MySQL database: job_id is not found in API response")
+	jobId := utils.PathSearch("job_id", createGaussDBDatabaseRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID of the GaussDB MySQL database from the API response")
 	}
 
-	err = waitForJobComplete(ctx, createGaussDBDatabaseClient, d.Timeout(schema.TimeoutCreate),
-		instanceID, jobId.(string))
+	err = waitForJobComplete(ctx, createGaussDBDatabaseClient, d.Timeout(schema.TimeoutCreate), instanceID, jobId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -312,13 +311,12 @@ func resourceGaussDBDatabaseUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	jobId, err := jmespath.Search("job_id", updateGaussDBDatabaseRespBody)
-	if err != nil {
-		return diag.Errorf("error updating GaussDB MySQL database: job_id is not found in API response")
+	jobId := utils.PathSearch("job_id", updateGaussDBDatabaseRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID of the GaussDB MySQL database from the API response")
 	}
 
-	err = waitForJobComplete(ctx, updateGaussDBDatabaseClient, d.Timeout(schema.TimeoutUpdate),
-		instanceID, jobId.(string))
+	err = waitForJobComplete(ctx, updateGaussDBDatabaseClient, d.Timeout(schema.TimeoutUpdate), instanceID, jobId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -387,13 +385,12 @@ func resourceGaussDBDatabaseDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	jobId, err := jmespath.Search("job_id", deleteGaussDBDatabaseRespBody)
-	if err != nil {
-		return diag.Errorf("error deleting GaussDB MySQL database: jobId is not found in API response")
+	jobId := utils.PathSearch("job_id", deleteGaussDBDatabaseRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID of the GaussDB MySQL database from the API response")
 	}
 
-	err = waitForJobComplete(ctx, deleteGaussDBDatabaseClient, d.Timeout(schema.TimeoutDelete),
-		instanceID, jobId.(string))
+	err = waitForJobComplete(ctx, deleteGaussDBDatabaseClient, d.Timeout(schema.TimeoutDelete), instanceID, jobId)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/huaweicloud/services/ges/resource_huaweicloud_ges_graph.go
+++ b/huaweicloud/services/ges/resource_huaweicloud_ges_graph.go
@@ -8,7 +8,6 @@ package ges
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -338,15 +336,15 @@ func resourceGesGraphCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createGraphRespBody)
-	if err != nil {
-		return diag.Errorf("error creating GesGraph: ID is not found in API response")
+	graphId := utils.PathSearch("graph_id", createGraphRespBody, "").(string)
+	if graphId == "" {
+		return diag.Errorf("unable to find the GES graph ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(graphId)
 
 	err = graphWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error waiting for the Create of GesGraph (%s) to complete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the Create of GesGraph (%s) to complete: %s", graphId, err)
 	}
 	return resourceGesGraphRead(ctx, d, meta)
 }
@@ -477,10 +475,7 @@ func graphWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, 
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`graph.status`, createGraphWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `graph.status`)
-			}
+			statusRaw := utils.PathSearch(`graph.status`, createGraphWaitingRespBody, nil)
 
 			status := fmt.Sprintf("%v", statusRaw)
 
@@ -581,9 +576,8 @@ func resourceGesGraphRead(_ context.Context, d *schema.ResourceData, meta interf
 
 func flattenGetGraphRespBodyPublicIp(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("graph.public_ip", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing graph.public_ip from response= %#v", resp)
+	curJson := utils.PathSearch("graph.public_ip", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -598,9 +592,8 @@ func flattenGetGraphRespBodyPublicIp(resp interface{}) []interface{} {
 
 func flattenGetGraphRespBodyvertexIdType(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("graph.vertex_id_type", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing graph.vertex_id_type from response= %#v", resp)
+	curJson := utils.PathSearch("graph.vertex_id_type", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -805,10 +798,7 @@ func deleteGraphWaitingForStateCompleted(ctx context.Context, d *schema.Resource
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`graph.status`, deleteGraphWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `graph.status`)
-			}
+			statusRaw := utils.PathSearch(`graph.status`, deleteGraphWaitingRespBody, nil)
 
 			status := fmt.Sprintf("%v", statusRaw)
 

--- a/huaweicloud/services/ges/resource_huaweicloud_ges_metadata.go
+++ b/huaweicloud/services/ges/resource_huaweicloud_ges_metadata.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -180,11 +179,11 @@ func resourceGesMetadataCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createMetadataRespBody)
-	if err != nil {
-		return diag.Errorf("error creating GES metadata: ID is not found in API response")
+	metadataId := utils.PathSearch("id", createMetadataRespBody, "").(string)
+	if metadataId == "" {
+		return diag.Errorf("unable to find the GES metadata ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(metadataId)
 
 	return resourceGesMetadataRead(ctx, d, meta)
 }
@@ -358,9 +357,8 @@ func flattenGetMetadatasRespBodyEncryption(resp interface{}) []interface{} {
 
 func flattenGetMetadataRespBodyMetadata(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("gesMetadata", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing gesMetadata from response= %#v", resp)
+	curJson := utils.PathSearch("gesMetadata", resp, nil)
+	if curJson == nil {
 		return rst
 	}
 

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_group.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_group.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -108,11 +107,11 @@ func resourceIdentityCenterGroupCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("group_id", createIdentityCenterGroupRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Identity Center Group: ID is not found in API response")
+	groupId := utils.PathSearch("group_id", createIdentityCenterGroupRespBody, "").(string)
+	if groupId == "" {
+		return diag.Errorf("unable to find the Identity Center group ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(groupId)
 
 	return resourceIdentityCenterGroupRead(ctx, d, meta)
 }

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_group_membership.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_group_membership.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -97,11 +96,11 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("membership_id", createGroupMembershipRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Identity Center Group Membership: ID is not found in API response")
+	membershipId := utils.PathSearch("membership_id", createGroupMembershipRespBody, "").(string)
+	if membershipId == "" {
+		return diag.Errorf("unable to find the membership ID of the Identity Center group from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(membershipId)
 
 	return resourceGroupMembershipRead(ctx, d, meta)
 }

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_permission_set.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_permission_set.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -110,12 +109,12 @@ func resourcePermissionSetCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("permission_set.permission_set_id", createPermissionSetRespBody)
-	if err != nil {
-		return diag.Errorf("error creating permission set: ID is not found in API response")
+	permissionSetId := utils.PathSearch("permission_set.permission_set_id", createPermissionSetRespBody, "").(string)
+	if permissionSetId == "" {
+		return diag.Errorf("unable to find the Identity Center permission set ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(permissionSetId)
 	return resourcePermissionSetRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_user.go
+++ b/huaweicloud/services/identitycenter/resource_huaweicloud_identitycenter_user.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -120,11 +119,11 @@ func resourceIdentityCenterUserCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("user_id", createIdentityCenterUserRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Identity Center User: ID is not found in API response")
+	userId := utils.PathSearch("user_id", createIdentityCenterUserRespBody, "").(string)
+	if userId == "" {
+		return diag.Errorf("unable to find the Identity Center user ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(userId)
 
 	return resourceIdentityCenterUserRead(ctx, d, meta)
 }

--- a/huaweicloud/services/ims/resource_huaweicloud_images_image_share.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_images_image_share.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -157,12 +156,12 @@ func dealImageMembers(ctx context.Context, d *schema.ResourceData, cfg *config.C
 		return err
 	}
 
-	jobId, err := jmespath.Search("job_id", imageMemberRespBody)
-	if err != nil {
-		return fmt.Errorf("error %s IMS image share: job_id is not found in API response", operateMethod)
+	jobId := utils.PathSearch("job_id", imageMemberRespBody, "").(string)
+	if jobId == "" {
+		return fmt.Errorf("unable to find the job ID of the IMS image share from the API response")
 	}
 
-	return waitForImageShareOrAcceptJobSuccess(ctx, d, imageMemberClient, jobId.(string), timeout)
+	return waitForImageShareOrAcceptJobSuccess(ctx, d, imageMemberClient, jobId, timeout)
 }
 
 func buildImageMemberBodyParams(imageId string, projectIds []interface{}) map[string]interface{} {

--- a/huaweicloud/services/ims/resource_huaweicloud_images_image_share_accepter.go
+++ b/huaweicloud/services/ims/resource_huaweicloud_images_image_share_accepter.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -158,12 +157,12 @@ func resourceImsImageShareAccepterDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	jobId, err := jmespath.Search("job_id", deleteImageShareAccepterRespBody)
-	if err != nil {
-		return diag.Errorf("error deleting IMS image share accepter: job_id is not found in API response")
+	jobId := utils.PathSearch("job_id", deleteImageShareAccepterRespBody, "").(string)
+	if jobId == "" {
+		return diag.Errorf("unable to find the job ID of IMS image share accepter from the API response")
 	}
 
-	err = waitForImageShareOrAcceptJobSuccess(ctx, d, deleteImageShareAccepterClient, jobId.(string), schema.TimeoutDelete)
+	err = waitForImageShareOrAcceptJobSuccess(ctx, d, deleteImageShareAccepterClient, jobId, schema.TimeoutDelete)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_aom_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_aom_access.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -147,11 +146,11 @@ func resourceAOMAccessCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("[0]|rule_id", createRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating AOM to LTS log mapping rule: ID is not found in API response")
+	ruleId := utils.PathSearch("[0]|rule_id", createRespBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find the rule ID of the AOM to LTS log mapping from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(ruleId)
 
 	return resourceAOMAccessRead(ctx, d, meta)
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_cce_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_cce_access.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -271,11 +270,11 @@ func resourceCceAccessConfigCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("access_config_id", createCceAccessConfigRespBody)
-	if err != nil {
-		return diag.Errorf("error creating CCE access config: ID is not found in API response")
+	configId := utils.PathSearch("access_config_id", createCceAccessConfigRespBody, "").(string)
+	if configId == "" {
+		return diag.Errorf("unable to find the config ID of the CCE access from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(configId)
 
 	return resourceCceAccessConfigRead(ctx, d, meta)
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_cross_account_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_cross_account_access.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -152,11 +151,11 @@ func resourceCrossAccountAccessCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("[0].access_config_id", createRespBody)
-	if err != nil {
-		return diag.Errorf("error creating LTS cross account access: ID is not found in API response")
+	accessId := utils.PathSearch("[0].access_config_id", createRespBody, "").(string)
+	if accessId == "" {
+		return diag.Errorf("unable to find the access ID of the LTS cross account from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(accessId)
 
 	// deal tags
 	if tags, ok := d.GetOk("tags"); ok {

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_group.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_group.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -90,12 +89,12 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("log_group_id", respBody)
-	if err != nil {
-		return diag.Errorf("error creating log group: ID is not found in API response")
+	logGroupId := utils.PathSearch("log_group_id", respBody, "").(string)
+	if logGroupId == "" {
+		return diag.Errorf("unable to find the LTS log group ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(logGroupId)
 
 	if _, ok := d.GetOk("tags"); ok {
 		groupId := d.Id()

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_host_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_host_access.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -222,11 +221,11 @@ func resourceHostAccessConfigCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("access_config_id", createHostAccessConfigRespBody)
-	if err != nil {
-		return diag.Errorf("error creating host access config: ID is not found in API response")
+	accessId := utils.PathSearch("access_config_id", createHostAccessConfigRespBody, "").(string)
+	if accessId == "" {
+		return diag.Errorf("unable to find the LTS host access ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(accessId)
 
 	return resourceHostAccessConfigRead(ctx, d, meta)
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_host_group.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_host_group.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -117,11 +116,11 @@ func resourceHostGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("host_group_id", createHostGroupRespBody)
-	if err != nil {
-		return diag.Errorf("error creating HostGroup: ID is not found in API response")
+	groupId := utils.PathSearch("host_group_id", createHostGroupRespBody, "").(string)
+	if groupId == "" {
+		return diag.Errorf("unable to find the LTS host group ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(groupId)
 
 	return resourceHostGroupRead(ctx, d, meta)
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_keywords_alarm_rule.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_keywords_alarm_rule.go
@@ -8,13 +8,11 @@ package lts
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -336,11 +334,11 @@ func resourceKeywordsAlarmRuleCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("keywords_alarm_rule_id", createKeywordsAlarmRuleRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Keywords alarm rule: ID is not found in API response")
+	ruleId := utils.PathSearch("keywords_alarm_rule_id", createKeywordsAlarmRuleRespBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find the LTS keywords alarm rule ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(ruleId)
 
 	if d.Get("status").(string) == "STOPPING" {
 		// updateKeywordsAlarmRuleStatus: Update the LTS KeywordsAlarmRule status.
@@ -569,9 +567,8 @@ func flattenGetKeywordsAlarmRuleResponseBodyKeywordsRequests(resp interface{}) [
 
 func flattenGetKeywordsAlarmRuleResponseBodyFrequency(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("frequency", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing frequency from response= %#v", resp)
+	curJson := utils.PathSearch("frequency", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_search_criteria.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_search_criteria.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -105,11 +104,11 @@ func resourceSearchCriteriaCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createSearchCriteriaRespBody)
-	if err != nil {
-		return diag.Errorf("error creating LTS search criteria : ID is not found in API response")
+	criteriaId := utils.PathSearch("id", createSearchCriteriaRespBody, "").(string)
+	if criteriaId == "" {
+		return diag.Errorf("unable to find the LTS search criteria ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(criteriaId)
 
 	return resourceSearchCriteriaRead(ctx, d, meta)
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_stream.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_stream.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -107,12 +106,12 @@ func resourceStreamCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("log_stream_id", respBody)
-	if err != nil {
-		return diag.Errorf("error creating flow log: ID is not found in API response")
+	streamId := utils.PathSearch("log_stream_id", respBody, "").(string)
+	if streamId == "" {
+		return diag.Errorf("unable to find the LTS stream ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(streamId)
 
 	if _, ok := d.GetOk("tags"); ok {
 		streamId := d.Id()

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_structing_template.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_structing_template.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -140,11 +139,11 @@ func resourceStructConfigCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.Errorf("error creating LTS structuring configuration (failed to query detail API): %s", err)
 	}
 
-	id, err := jmespath.Search("id", detailRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating LTS structuring configuration: ID is not found in detail API response")
+	templateId := utils.PathSearch("id", detailRespBody, "").(string)
+	if templateId == "" {
+		return diag.Errorf("unable to find the LTS structuring configuration ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(templateId)
 
 	return resourceStructConfigRead(ctx, d, meta)
 }

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_transfer.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_transfer.go
@@ -8,13 +8,11 @@ package lts
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -310,11 +308,11 @@ func resourceLtsTransferCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("log_transfer_id", createTransferRespBody)
-	if err != nil {
-		return diag.Errorf("error creating LTS transfer: ID is not found in API response")
+	transferId := utils.PathSearch("log_transfer_id", createTransferRespBody, "").(string)
+	if transferId == "" {
+		return diag.Errorf("unable to find the LTS transfer ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(transferId)
 
 	return resourceLtsTransferRead(ctx, d, meta)
 }
@@ -488,9 +486,8 @@ func flattenGetTransferResponseBodyLogStreams(resp interface{}) []interface{} {
 
 func flattenGetTransferResponseBodyLogTransferInfo(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("log_transfer_info", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing log_transfer_info from response= %#v", resp)
+	curJson := utils.PathSearch("log_transfer_info", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -509,9 +506,8 @@ func flattenGetTransferResponseBodyLogTransferInfo(resp interface{}) []interface
 
 func flattenLogTransferInfoLogAgency(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("log_agency_transfer", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing log_agency_transfer from response= %#v", resp)
+	curJson := utils.PathSearch("log_agency_transfer", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -528,9 +524,8 @@ func flattenLogTransferInfoLogAgency(resp interface{}) []interface{} {
 
 func flattenLogTransferInfoLogTransferDetail(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("log_transfer_detail", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing log_transfer_detail from response= %#v", resp)
+	curJson := utils.PathSearch("log_transfer_detail", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
+++ b/huaweicloud/services/lts/resource_huaweicloud_lts_waf_access.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -82,20 +81,15 @@ func resourceWAFAccessCreate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("error creating LTS access WAF logs configuration (failed to query detail): %s", err)
 	}
 
-	id, err := jmespath.Search("id", detailRespBody)
-	if err != nil || id == nil {
-		return diag.Errorf("error creating LTS access WAF logs configuration: ID is not found in detail API response")
+	configId := utils.PathSearch("id", detailRespBody, "").(string)
+	if configId == "" {
+		return diag.Errorf("unable to find the configuration ID of the LTS access WAF logs from the API response")
 	}
 
-	idString, isString := id.(string)
-	if !isString {
-		return diag.Errorf("error creating LTS access WAF logs configuration: ID is not string in detail API response")
-	}
-
-	if err := modifyWAFAccessConfiguration(client, d, cfg, idString); err != nil {
+	if err := modifyWAFAccessConfiguration(client, d, cfg, configId); err != nil {
 		return diag.Errorf("error creating LTS access WAF logs configuration: %s", err)
 	}
-	d.SetId(idString)
+	d.SetId(configId)
 
 	return resourceWAFAccessRead(ctx, d, meta)
 }

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_models.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_models.go
@@ -9,14 +9,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk/pagination"
 
@@ -303,9 +301,8 @@ func flattenListModelsModels(resp interface{}) []interface{} {
 
 func flattenModelsSpecification(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("specification", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing specification from response= %#v", resp)
+	curJson := utils.PathSearch("specification", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_notebook_flavors.go
+++ b/huaweicloud/services/modelarts/data_source_huaweicloud_modelarts_notebook_flavors.go
@@ -8,14 +8,12 @@ package modelarts
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -245,9 +243,8 @@ func flattenListNotebookFlavorsFlavors(resp interface{}) []interface{} {
 
 func flattenFlavorsBilling(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("billing", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing billing from response= %#v", resp)
+	curJson := utils.PathSearch("billing", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 
@@ -262,9 +259,8 @@ func flattenFlavorsBilling(resp interface{}) []interface{} {
 
 func flattenFlavorsGpu(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("gpu", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing gpu from response= %#v", resp)
+	curJson := utils.PathSearch("gpu", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_workspace.go
+++ b/huaweicloud/services/modelarts/resource_huaweicloud_modelarts_workspace.go
@@ -146,11 +146,11 @@ func resourceModelartsWorkspaceCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createWorkspaceRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Modelarts workspace: ID is not found in API response")
+	workspaceId := utils.PathSearch("id", createWorkspaceRespBody, "").(string)
+	if workspaceId == "" {
+		return diag.Errorf("unable to find the ModelArts workspace ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(workspaceId)
 	return resourceModelartsWorkspaceRead(ctx, d, meta)
 }
 
@@ -410,12 +410,7 @@ func deleteWorkspaceWaitingForStateCompleted(ctx context.Context, d *schema.Reso
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`status`, deleteWorkspaceWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `status`)
-			}
-
-			status := fmt.Sprintf("%v", statusRaw)
+			status := utils.PathSearch(`status`, deleteWorkspaceWaitingRespBody, "").(string)
 
 			pendingStatus := []string{
 				"DELETING",

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -120,11 +119,11 @@ func resourceAccountInviteCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("handshake.id", createAccountInviteRespBody)
-	if err != nil {
-		return diag.Errorf("error creating AccountInvite: ID is not found in API response")
+	handshakeId := utils.PathSearch("handshake.id", createAccountInviteRespBody, "").(string)
+	if handshakeId == "" {
+		return diag.Errorf("unable to find the Organizations account invite ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(handshakeId)
 
 	return resourceAccountInviteRead(ctx, d, meta)
 }

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_accepter.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_accepter.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -125,11 +124,11 @@ func resourceAccountInviteAccepterCreate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("handshake.id", createAccountInviteAccepterRespBody)
-	if err != nil {
-		return diag.Errorf("error creating AccountInviteAccepter: ID is not found in API response")
+	handshakeId := utils.PathSearch("handshake.id", createAccountInviteAccepterRespBody, "").(string)
+	if handshakeId == "" {
+		return diag.Errorf("unable to find the handshake ID of the Organizations account invite accepter from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(handshakeId)
 
 	return resourceAccountInviteAccepterRead(ctx, d, meta)
 }

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_decliner.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_account_invite_decliner.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -61,11 +60,11 @@ func resourceAccountInviteDeclinerCreate(_ context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("handshake.id", createRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Organizations account invite decliner: ID is not found in API response")
+	handshakeId := utils.PathSearch("handshake.id", createRespBody, "").(string)
+	if handshakeId == "" {
+		return diag.Errorf("unable to find the handshake ID of the Organizations account invite accepter from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(handshakeId)
 
 	return nil
 }

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_organizational_unit.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_organizational_unit.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -101,12 +100,12 @@ func resourceOrganizationalUnitCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("organizational_unit.id", createOrganizationalUnitRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Organizations organizational unit: ID is not found in API response")
+	unitId := utils.PathSearch("organizational_unit.id", createOrganizationalUnitRespBody, "").(string)
+	if unitId == "" {
+		return diag.Errorf("unable to find the organizational unit ID from the API response")
 	}
 
-	d.SetId(id.(string))
+	d.SetId(unitId)
 
 	return resourceOrganizationalUnitRead(ctx, d, meta)
 }

--- a/huaweicloud/services/organizations/resource_huaweicloud_organizations_policy.go
+++ b/huaweicloud/services/organizations/resource_huaweicloud_organizations_policy.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -106,11 +105,11 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("policy.policy_summary.id", createPolicyRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Organizations policy: ID is not found in API response")
+	policyId := utils.PathSearch("policy.policy_summary.id", createPolicyRespBody, "").(string)
+	if policyId == "" {
+		return diag.Errorf("unable to find the Organizations policy ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(policyId)
 
 	return resourcePolicyRead(ctx, d, meta)
 }

--- a/huaweicloud/services/ram/resource_huaweicloud_ram_resource_share.go
+++ b/huaweicloud/services/ram/resource_huaweicloud_ram_resource_share.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -160,11 +159,11 @@ func resourceRAMShareCreate(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("resource_share.id", createRAMShareRespBody)
-	if err != nil {
-		return diag.Errorf("error creating RAM share: ID is not found in API response")
+	shareId := utils.PathSearch("resource_share.id", createRAMShareRespBody, "").(string)
+	if shareId == "" {
+		return diag.Errorf("unable to find the RAM share ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(shareId)
 	return resourceRAMShareRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/ram/resource_huaweicloud_ram_resource_share_accepter.go
+++ b/huaweicloud/services/ram/resource_huaweicloud_ram_resource_share_accepter.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -70,12 +69,12 @@ func resourceShareAccepterCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	invitationId, err := jmespath.Search("resource_share_invitation.resource_share_invitation_id", createResourceShareAccepterRespBody)
-	if err != nil {
-		return diag.Errorf("error creating RAM resource share accepter: resource share invitation ID is not found in API response")
+	invitationId := utils.PathSearch("resource_share_invitation.resource_share_invitation_id", createResourceShareAccepterRespBody, "").(string)
+	if invitationId == "" {
+		return diag.Errorf("unable to find the resource share invitation ID of the RAM share accepter from the API response")
 	}
 
-	d.SetId(invitationId.(string))
+	d.SetId(invitationId)
 	return resourceShareAccepterRead(ctx, d, meta)
 }
 

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_backups.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_backups.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -17,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk/pagination"
 
@@ -258,9 +256,8 @@ func flattenListBackupsBodyBackup(resp interface{}) []interface{} {
 
 func flattenBackupDatastore(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("datastore", resp)
-	if err != nil {
-		log.Printf("[ERROR] error parsing datastore from response= %#v", resp)
+	curJson := utils.PathSearch("datastore", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
 	}
 

--- a/huaweicloud/services/rds/data_source_huaweicloud_rds_pg_accounts.go
+++ b/huaweicloud/services/rds/data_source_huaweicloud_rds_pg_accounts.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk/pagination"
 
@@ -204,12 +203,9 @@ func filterPgAccounts(d *schema.ResourceData, resp interface{}) []interface{} {
 
 func flattenAttributes(resp interface{}) []interface{} {
 	var rst []interface{}
-	curJson, err := jmespath.Search("attributes", resp)
-	if err != nil {
+	curJson := utils.PathSearch("attributes", resp, make(map[string]interface{})).(map[string]interface{})
+	if len(curJson) < 1 {
 		return rst
-	}
-	if curJson == nil {
-		return nil
 	}
 
 	rst = []interface{}{

--- a/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
+++ b/huaweicloud/services/rds/resource_huaweicloud_rds_backup.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -164,11 +163,11 @@ func resourceBackupCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("backup.id", createBackupRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Backup: ID is not found in API response")
+	backupId := utils.PathSearch("backup.id", createBackupRespBody, "").(string)
+	if backupId == "" {
+		return diag.Errorf("unable to find the RDS backup ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(backupId)
 
 	err = createBackupWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -256,16 +255,16 @@ func createBackupWaitingForStateCompleted(ctx context.Context, d *schema.Resourc
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status, err := jmespath.Search(`backups[0].status`, createBackupWaitingRespBody)
+			status := utils.PathSearch(`backups[0].status`, createBackupWaitingRespBody, "").(string)
 			if err != nil {
 				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `backups[0].status`)
 			}
 
-			if utils.StrSliceContains(strings.Split(`FAILED`, ","), status.(string)) {
-				return createBackupWaitingRespBody, status.(string), nil
+			if utils.StrSliceContains(strings.Split(`FAILED`, ","), status) {
+				return createBackupWaitingRespBody, status, nil
 			}
 
-			if utils.StrSliceContains(strings.Split(`COMPLETED`, ","), status.(string)) {
+			if utils.StrSliceContains(strings.Split(`COMPLETED`, ","), status) {
 				return createBackupWaitingRespBody, "COMPLETED", nil
 			}
 
@@ -467,11 +466,7 @@ func deleteBackupWaitingForStateCompleted(ctx context.Context, d *schema.Resourc
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			statusRaw, err := jmespath.Search(`total_count`, deleteBackupWaitingRespBody)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error parse %s from response body", `total_count`)
-			}
-
+			statusRaw := utils.PathSearch(`total_count`, deleteBackupWaitingRespBody, nil)
 			status := fmt.Sprintf("%v", statusRaw)
 			if utils.StrSliceContains(strings.Split(`1`, ","), status) {
 				return deleteBackupWaitingRespBody, "PENDING", nil

--- a/huaweicloud/services/rgc/resource_huaweicloud_rgc_account.go
+++ b/huaweicloud/services/rgc/resource_huaweicloud_rgc_account.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -148,15 +147,15 @@ func resourceAccountCreate(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	operationID, err := jmespath.Search("operation_id", createAccountRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Account: operation_id is not found in API response")
+	operationID := utils.PathSearch("operation_id", createAccountRespBody, "").(string)
+	if operationID == "" {
+		return diag.Errorf("unable to find the account operation ID from the API response")
 	}
 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"IN_PROGRESS"},
 		Target:       []string{"SUCCEEDED"},
-		Refresh:      accountStateRefreshFunc(createAccountClient, operationID.(string)),
+		Refresh:      accountStateRefreshFunc(createAccountClient, operationID),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,
@@ -378,15 +377,15 @@ func resourceAccountDelete(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	operationID, err := jmespath.Search("operation_id", unEnrollAccountRespBody)
-	if err != nil {
-		return diag.Errorf("error creating Account: operation_id is not found in API response")
+	operationID := utils.PathSearch("operation_id", unEnrollAccountRespBody, "").(string)
+	if operationID == "" {
+		return diag.Errorf("unable to find the account operation ID from the API response")
 	}
 
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"IN_PROGRESS"},
 		Target:       []string{"SUCCEEDED"},
-		Refresh:      accountStateRefreshFunc(unEnrollAccountClient, operationID.(string)),
+		Refresh:      accountStateRefreshFunc(unEnrollAccountClient, operationID),
 		Timeout:      d.Timeout(schema.TimeoutDelete),
 		Delay:        10 * time.Second,
 		PollInterval: 10 * time.Second,

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_application.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_application.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -123,11 +122,11 @@ func resourceV3ApplicationCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	appId, err := jmespath.Search("id", respBody)
-	if err != nil || appId == nil {
-		return diag.Errorf("failed to find the application ID from the API response: %s", err)
+	appId := utils.PathSearch("id", respBody, "").(string)
+	if appId == "" {
+		return diag.Errorf("failed to find the application ID from the API response")
 	}
-	d.SetId(appId.(string))
+	d.SetId(appId)
 
 	return resourceV3ApplicationRead(ctx, d, meta)
 }

--- a/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment.go
+++ b/huaweicloud/services/servicestage/resource_huaweicloud_servicestagev3_environment.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -138,11 +137,11 @@ func resourceV3EnvironmentCreate(ctx context.Context, d *schema.ResourceData, me
 		return diag.FromErr(err)
 	}
 
-	envId, err := jmespath.Search("id", respBody)
-	if err != nil || envId == nil {
-		return diag.Errorf("failed to find the environment ID from the API response: %s", err)
+	envId := utils.PathSearch("id", respBody, "").(string)
+	if envId == "" {
+		return diag.Errorf("unable to find the environment ID from the API response")
 	}
-	d.SetId(envId.(string))
+	d.SetId(envId)
 
 	return resourceV3EnvironmentRead(ctx, d, meta)
 }

--- a/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo_du_task.go
+++ b/huaweicloud/services/sfsturbo/resource_huaweicloud_sfs_turbo_du_task.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -164,12 +163,12 @@ func resourceDuTaskCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.FromErr(err)
 	}
 
-	taskId, err := jmespath.Search("task_id", createDuTaskRespBody)
-	if err != nil || taskId == nil {
-		return diag.Errorf("error creating DU task: ID is not found in API response")
+	taskId := utils.PathSearch("task_id", createDuTaskRespBody, "").(string)
+	if taskId == "" {
+		return diag.Errorf("unable to find the DU task ID from the API response")
 	}
 
-	d.SetId(taskId.(string))
+	d.SetId(taskId)
 
 	return resourceDuTaskRead(ctx, d, meta)
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_address_group.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_address_group.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -144,11 +143,11 @@ func resourceAddressGroupCreate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createWAFAddressGroupRespBody)
-	if err != nil {
-		return diag.Errorf("error creating address group: ID is not found in API response")
+	groupId := utils.PathSearch("id", createWAFAddressGroupRespBody, "").(string)
+	if groupId == "" {
+		return diag.Errorf("unable to find the address group ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(groupId)
 
 	return resourceAddressGroupRead(ctx, d, meta)
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_anti_crawler.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_anti_crawler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -156,11 +155,11 @@ func createAntiCrawlerRule(client *golangsdk.ServiceClient, httpPath string, d *
 		return err
 	}
 
-	id, err := jmespath.Search("id", createRespBody)
-	if err != nil {
-		return fmt.Errorf("error creating WAF anti crawler rule: ID is not found in API response")
+	ruleId := utils.PathSearch("id", createRespBody, "").(string)
+	if ruleId == "" {
+		return fmt.Errorf("unable to find the WAF anti crawler rule ID from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(ruleId)
 	return nil
 }
 

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_cc_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_cc_protection.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -222,11 +221,11 @@ func resourceRuleCCProtectionCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createRuleCCProtectionRespBody)
-	if err != nil {
-		return diag.Errorf("error creating RuleCCProtection: ID is not found in API response")
+	protectionId := utils.PathSearch("id", createRuleCCProtectionRespBody, "").(string)
+	if protectionId == "" {
+		return diag.Errorf("unable to find the CC protection ID of the WAF rule from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(protectionId)
 
 	if d.Get("status").(int) == 0 {
 		if err := updateRuleStatus(createClient, d, cfg, "cc"); err != nil {

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_geolocation_access_control.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_geolocation_access_control.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -119,11 +118,11 @@ func resourceRuleGeolocationCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createRespBody)
-	if err != nil {
-		return diag.Errorf("error creating WAF geolocation access control rule: ID is not found in API response")
+	ruleId := utils.PathSearch("id", createRespBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find the control rule ID of the WAF geolocation access from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(ruleId)
 
 	return resourceRuleGeolocationRead(ctx, d, meta)
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_information_leakage_prevention.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_information_leakage_prevention.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -123,12 +122,11 @@ func resourceRuleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createRespBody)
-	if err != nil {
-		return diag.Errorf("error creating WAF information leakage prevention rule: ID is not found in" +
-			" API response")
+	ruleId := utils.PathSearch("id", createRespBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find the prevention rule ID of the WAF information leakage from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(ruleId)
 
 	return resourceRuleRead(ctx, d, meta)
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_known_attack_source.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_known_attack_source.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -108,11 +107,11 @@ func resourceRuleKnownAttackCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createRespBody)
-	if err != nil {
-		return diag.Errorf("error creating WAF known attack source rule: ID is not found in API response")
+	ruleId := utils.PathSearch("id", createRespBody, "").(string)
+	if ruleId == "" {
+		return diag.Errorf("unable to find the rule ID of the WAF known attack source from the API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(ruleId)
 
 	return resourceRuleKnownAttackRead(ctx, d, meta)
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_rule_precise_protection.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_rule_precise_protection.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jmespath/go-jmespath"
 
 	"github.com/chnsz/golangsdk"
 
@@ -189,11 +188,11 @@ func resourceRulePreciseProtectionCreate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 
-	id, err := jmespath.Search("id", createRespBody)
-	if err != nil {
+	protectionId := utils.PathSearch("id", createRespBody, "").(string)
+	if protectionId == "" {
 		return diag.Errorf("error creating RulePreciseProtection: ID is not found in API response")
 	}
-	d.SetId(id.(string))
+	d.SetId(protectionId)
 
 	if d.Get("status").(int) == 0 {
 		if err := updateRuleStatus(preciseProtectionClient, d, cfg, "custom"); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Replace all `jmespath.Search()` functions usage with the `PathSearch` function under the utils package, except the error parsing functions.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. replace all jmespath.Search() functions with the utils.PathSearch function.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o as -f TestAccASBandWidthPolicy_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/as" -v -coverprofile="./huaweicloud/services/acceptance/as_coverage.cov" -coverpkg="./huaweicloud/services/as" -run TestAccASBandWidthPolicy_basic -timeout 360m -parallel 10
=== RUN   TestAccASBandWidthPolicy_basic
=== PAUSE TestAccASBandWidthPolicy_basic
=== CONT  TestAccASBandWidthPolicy_basic
--- PASS: TestAccASBandWidthPolicy_basic (62.44s)
PASS
coverage: 7.8% of statements in ./huaweicloud/services/as
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        62.507s coverage: 7.8% of statements in ./huaweicloud/services/as
```
```
../coverage.sh -o codearts -f TestAccDeployGroup_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/codearts" -v -coverprofile="./huaweicloud/services/acceptance/codearts_coverage.cov" -coverpkg="./huaweicloud/services/codearts" -run TestAccDeployGroup_basic -timeout 360m -parallel 10
=== RUN   TestAccDeployGroup_basic
=== PAUSE TestAccDeployGroup_basic
=== CONT  TestAccDeployGroup_basic
--- PASS: TestAccDeployGroup_basic (36.95s)
PASS
coverage: 19.9% of statements in ./huaweicloud/services/codearts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  36.994s coverage: 19.9% of statements in ./huaweicloud/services/codearts
```
```
../coverage.sh -o codearts -f TestAccDeployHost
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/codearts" -v -coverprofile="./huaweicloud/services/acceptance/codearts_coverage.cov" -coverpkg="./huaweicloud/services/codearts" -run TestAccDeployHost -timeout 360m -parallel 10
=== RUN   TestAccDeployHost_withProxyMode
=== PAUSE TestAccDeployHost_withProxyMode
=== RUN   TestAccDeployHost_withoutProxyMode
=== PAUSE TestAccDeployHost_withoutProxyMode
=== RUN   TestAccDeployHost_errorCheck
=== PAUSE TestAccDeployHost_errorCheck
=== CONT  TestAccDeployHost_withProxyMode
=== CONT  TestAccDeployHost_errorCheck
=== CONT  TestAccDeployHost_withoutProxyMode
--- PASS: TestAccDeployHost_errorCheck (211.91s)
--- PASS: TestAccDeployHost_withoutProxyMode (323.16s)
--- PASS: TestAccDeployHost_withProxyMode (379.66s)
PASS
coverage: 29.7% of statements in ./huaweicloud/services/codearts
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/codearts  379.711s        coverage: 29.7% of statements in ./huaweicloud/services/codearts
```
```
../coverage.sh -o cph -f TestAccDatasourceServerFlavors_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cph" -v -coverprofile="./huaweicloud/services/acceptance/cph_coverage.cov" -coverpkg="./huaweicloud/services/cph" -run TestAccDatasourceServerFlavors_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceServerFlavors_basic
=== PAUSE TestAccDatasourceServerFlavors_basic
=== CONT  TestAccDatasourceServerFlavors_basic
--- PASS: TestAccDatasourceServerFlavors_basic (10.51s)
PASS
coverage: 17.0% of statements in ./huaweicloud/services/cph
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       10.562s coverage: 17.0% of statements in ./huaweicloud/services/cph
```
```
../coverage.sh -o cph -f TestAccCphServer_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cph" -v -coverprofile="./huaweicloud/services/acceptance/cph_coverage.cov" -coverpkg="./huaweicloud/services/cph" -run TestAccCphServer_basic -timeout 360m -parallel 10
=== RUN   TestAccCphServer_basic
=== PAUSE TestAccCphServer_basic
=== CONT  TestAccCphServer_basic
--- PASS: TestAccCphServer_basic (2043.83s)
PASS
coverage: 57.9% of statements in ./huaweicloud/services/cph
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       2043.874s       coverage: 57.9% of statements in ./huaweicloud/services/cph
```
Alread pass the ReadContext phase
```
../coverage.sh -o dataarts -f TestAccFactoryJob_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dataarts" -v -coverprofile="./huaweicloud/services/acceptance/dataarts_coverage.cov" -coverpkg="./huaweicloud/services/dataarts" -run TestAccFactoryJob_basic -timeout 360m -parallel 10
=== RUN   TestAccFactoryJob_basic
=== PAUSE TestAccFactoryJob_basic
=== CONT  TestAccFactoryJob_basic
    testing_new.go:84: Error running post-test destroy, there may be dangling resources: failed to destroy the huaweicloud_dataarts_factory_job resource: tf_test_hxbcm still exists
--- FAIL: TestAccFactoryJob_basic (24.55s)
FAIL
coverage: 7.4% of statements in ./huaweicloud/services/dataarts
FAIL    github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dataarts  24.620s
FAIL
```
```
../coverage.sh -o ddm -f TestAccDdmInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ddm" -v -coverprofile="./huaweicloud/services/acceptance/ddm_coverage.cov" -coverpkg="./huaweicloud/services/ddm" -run TestAccDdmInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccDdmInstance_basic
=== PAUSE TestAccDdmInstance_basic
=== CONT  TestAccDdmInstance_basic
--- PASS: TestAccDdmInstance_basic (1602.96s)
PASS
coverage: 40.5% of statements in ./huaweicloud/services/ddm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ddm       1603.005s       coverage: 40.5% of statements in ./huaweicloud/services/ddm
```
```
../coverage.sh -o ddm -f TestAccDatasourceDdmInstances_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ddm" -v -coverprofile="./huaweicloud/services/acceptance/ddm_coverage.cov" -coverpkg="./huaweicloud/services/ddm" -run TestAccDatasourceDdmInstances_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceDdmInstances_basic
=== PAUSE TestAccDatasourceDdmInstances_basic
=== CONT  TestAccDatasourceDdmInstances_basic
--- PASS: TestAccDatasourceDdmInstances_basic (491.49s)
PASS
coverage: 30.5% of statements in ./huaweicloud/services/ddm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ddm       491.538s        coverage: 30.5% of statements in ./huaweicloud/services/ddm
```
```
../coverage.sh -o ddm -f TestAccDdmSchema_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ddm" -v -coverprofile="./huaweicloud/services/acceptance/ddm_coverage.cov" -coverpkg="./huaweicloud/services/ddm" -run TestAccDdmSchema_basic -timeout 360m -parallel 10
=== RUN   TestAccDdmSchema_basic
=== PAUSE TestAccDdmSchema_basic
=== CONT  TestAccDdmSchema_basic
--- PASS: TestAccDdmSchema_basic (751.71s)
PASS
coverage: 33.6% of statements in ./huaweicloud/services/ddm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ddm       751.759s        coverage: 33.6% of statements in ./huaweicloud/services/ddm
```
```
../coverage.sh -o ddm -f TestAccDdmSchema_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ddm" -v -coverprofile="./huaweicloud/services/acceptance/ddm_coverage.cov" -coverpkg="./huaweicloud/services/ddm" -run TestAccDdmSchema_basic -timeout 360m -parallel 10
=== RUN   TestAccDdmSchema_basic
=== PAUSE TestAccDdmSchema_basic
=== CONT  TestAccDdmSchema_basic
--- PASS: TestAccDdmSchema_basic (751.71s)
PASS
coverage: 33.6% of statements in ./huaweicloud/services/ddm
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ddm       751.759s        coverage: 33.6% of statements in ./huaweicloud/services/ddm
```
```
../coverage.sh -o dew -f TestAccDatasourceCsmsEvents_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDatasourceCsmsEvents_basic -timeout 360m -parallel 10
=== RUN   TestAccDatasourceCsmsEvents_basic
=== PAUSE TestAccDatasourceCsmsEvents_basic
=== CONT  TestAccDatasourceCsmsEvents_basic
--- PASS: TestAccDatasourceCsmsEvents_basic (59.56s)
PASS
coverage: 8.5% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       59.611s coverage: 8.5% of statements in ./huaweicloud/services/dew
```
```
../coverage.sh -o dew -f TestAccDataEncryptDecrypt_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dew" -v -coverprofile="./huaweicloud/services/acceptance/dew_coverage.cov" -coverpkg="./huaweicloud/services/dew" -run TestAccDataEncryptDecrypt_basic -timeout 360m -parallel 10
=== RUN   TestAccDataEncryptDecrypt_basic
=== PAUSE TestAccDataEncryptDecrypt_basic
=== CONT  TestAccDataEncryptDecrypt_basic
--- PASS: TestAccDataEncryptDecrypt_basic (57.07s)
PASS
coverage: 9.9% of statements in ./huaweicloud/services/dew
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dew       57.124s coverage: 9.9% of statements in ./huaweicloud/services/dew
```
```
../coverage.sh -o dli -f TestAccFlinkTemplate_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dli" -v -coverprofile="./huaweicloud/services/acceptance/dli_coverage.cov" -coverpkg="./huaweicloud/services/dli" -run TestAccFlinkTemplate_basic -timeout 360m -parallel 10
=== RUN   TestAccFlinkTemplate_basic
=== PAUSE TestAccFlinkTemplate_basic
=== CONT  TestAccFlinkTemplate_basic
--- PASS: TestAccFlinkTemplate_basic (28.50s)
PASS
coverage: 4.4% of statements in ./huaweicloud/services/dli
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dli       28.563s coverage: 4.4% of statements in ./huaweicloud/services/dli
```
```
../coverage.sh -o dws -f TestAccResourceCluster_basicV2_mutilAZs
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccResourceCluster_basicV2_mutilAZs -timeout 360m -parallel 10
=== RUN   TestAccResourceCluster_basicV2_mutilAZs
=== PAUSE TestAccResourceCluster_basicV2_mutilAZs
=== CONT  TestAccResourceCluster_basicV2_mutilAZs
--- PASS: TestAccResourceCluster_basicV2_mutilAZs (1623.27s)
PASS
coverage: 8.1% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       1623.321s       coverage: 8.1% of statements in ./huaweicloud/services/dws
```
```
../coverage.sh -o dsc -f TestAccAssetObs_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dsc" -v -coverprofile="./huaweicloud/services/acceptance/dsc_coverage.cov" -coverpkg="./huaweicloud/services/dsc" -run TestAccAssetObs_basic -timeout 360m -parallel 10
=== RUN   TestAccAssetObs_basic
=== PAUSE TestAccAssetObs_basic
=== CONT  TestAccAssetObs_basic
--- PASS: TestAccAssetObs_basic (42.05s)
PASS
coverage: 27.3% of statements in ./huaweicloud/services/dsc
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dsc       42.102s coverage: 27.3% of statements in ./huaweicloud/services/dsc
```
```
../coverage.sh -o ecs -f TestAccComputeInterfaceAttach_Basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/ecs" -v -coverprofile="./huaweicloud/services/acceptance/ecs_coverage.cov" -coverpkg="./huaweicloud/services/ecs" -run TestAccComputeInterfaceAttach_Basic -timeout 360m -parallel 10
=== RUN   TestAccComputeInterfaceAttach_Basic
=== PAUSE TestAccComputeInterfaceAttach_Basic
=== CONT  TestAccComputeInterfaceAttach_Basic
--- PASS: TestAccComputeInterfaceAttach_Basic (365.26s)
PASS
coverage: 27.9% of statements in ./huaweicloud/services/ecs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ecs       365.303s        coverage: 27.9% of statements in ./huaweicloud/services/ecs
```
```
../coverage.sh -o css -f TestAccScanTask_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/css" -v -coverprofile="./huaweicloud/services/acceptance/css_coverage.cov" -coverpkg="./huaweicloud/services/css" -run TestAccScanTask_basic -timeout 360m -parallel 10
=== RUN   TestAccScanTask_basic
=== PAUSE TestAccScanTask_basic
=== CONT  TestAccScanTask_basic
--- PASS: TestAccScanTask_basic (1012.81s)
PASS
coverage: 10.0% of statements in ./huaweicloud/services/css
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       1012.859s       coverage: 10.0% of statements in ./huaweicloud/services/css
```
```
../coverage.sh -o css -f TestAccManualLogBackup_elastic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/css" -v -coverprofile="./huaweicloud/services/acceptance/css_coverage.cov" -coverpkg="./huaweicloud/services/css" -run TestAccManualLogBackup_elastic -timeout 360m -parallel 10
=== RUN   TestAccManualLogBackup_elastic
=== PAUSE TestAccManualLogBackup_elastic
=== CONT  TestAccManualLogBackup_elastic
--- PASS: TestAccManualLogBackup_elastic (960.59s)
PASS
coverage: 10.9% of statements in ./huaweicloud/services/css
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/css       960.641s        coverage: 10.9% of statements in ./huaweicloud/services/css
```
```
../coverage.sh -o dws -f TestAccDwsFlavorsDataSource_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/dws" -v -coverprofile="./huaweicloud/services/acceptance/dws_coverage.cov" -coverpkg="./huaweicloud/services/dws" -run TestAccDwsFlavorsDataSource_basic -timeout 360m -parallel 10
=== RUN   TestAccDwsFlavorsDataSource_basic
=== PAUSE TestAccDwsFlavorsDataSource_basic
=== CONT  TestAccDwsFlavorsDataSource_basic
--- PASS: TestAccDwsFlavorsDataSource_basic (34.30s)
PASS
coverage: 3.8% of statements in ./huaweicloud/services/dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws34.375s coverage: 3.8% of statements in ./huaweicloud/services/dws
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
