### PR TITLE
fix(GaussDBforMySQL): fix gaussdb mysql instance restart resource wait method for delay

### DIFF
--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_restart_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_restart_test.go
@@ -64,6 +64,12 @@ func TestAccGaussDBMysqlInstanceRestart_basic(t *testing.T) {
 					rc.CheckResourceExists(),
 				),
 			},
+			{
+				Config: testAccGaussDBMysqlInstanceRestart_instance_delay(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
 		},
 	})
 }
@@ -86,6 +92,12 @@ func TestAccGaussDBMysqlInstanceRestart_node(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGaussDBMysqlInstanceRestart_node(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+				),
+			},
+			{
+				Config: testAccGaussDBMysqlInstanceRestart_node_delay(rName),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 				),
@@ -137,5 +149,26 @@ func testAccGaussDBMysqlInstanceRestart_node(rName string) string {
 resource "huaweicloud_gaussdb_mysql_instance_restart" "test" {
   instance_id = huaweicloud_gaussdb_mysql_instance.test.id
   node_id     = huaweicloud_gaussdb_mysql_instance.test.nodes[0].id
+}`, testAccGaussDBMysqlInstanceRestart_base(rName))
+}
+
+func testAccGaussDBMysqlInstanceRestart_instance_delay(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_gaussdb_mysql_instance_restart" "test" {
+  instance_id = huaweicloud_gaussdb_mysql_instance.test.id
+  delay       = true
+}`, testAccGaussDBMysqlInstanceRestart_base(rName))
+}
+
+func testAccGaussDBMysqlInstanceRestart_node_delay(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_gaussdb_mysql_instance_restart" "test" {
+  instance_id = huaweicloud_gaussdb_mysql_instance.test.id
+  node_id     = huaweicloud_gaussdb_mysql_instance.test.nodes[0].id
+  delay       = true
 }`, testAccGaussDBMysqlInstanceRestart_base(rName))
 }

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_restart.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_restart.go
@@ -126,9 +126,12 @@ func restartInstance(ctx context.Context, d *schema.ResourceData, client *golang
 
 	d.SetId(instanceId)
 
-	err = checkGaussDBMySQLJobFinish(ctx, client, jobId.(string), d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return fmt.Errorf("error waiting for restarting instance(%s) job to complete: %s", instanceId, err)
+	// if delay is true, then the task is scheduled task, it is not needed to wait
+	if !d.Get("delay").(bool) {
+		err = checkGaussDBMySQLJobFinish(ctx, client, jobId.(string), d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return fmt.Errorf("error waiting for restarting instance(%s) job to complete: %s", instanceId, err)
+		}
 	}
 
 	return nil
@@ -182,10 +185,13 @@ func restartNode(ctx context.Context, d *schema.ResourceData, client *golangsdk.
 
 	d.SetId(nodeId)
 
-	err = checkGaussDBMySQLJobFinish(ctx, client, jobId.(string), d.Timeout(schema.TimeoutCreate))
-	if err != nil {
-		return fmt.Errorf("error waiting for restarting instance(%s) node(%s) job to complete: %s", instanceId,
-			nodeId, err)
+	// if delay is true, then the task is scheduled task, it is not needed to wait
+	if !d.Get("delay").(bool) {
+		err = checkGaussDBMySQLJobFinish(ctx, client, jobId.(string), d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return fmt.Errorf("error waiting for restarting instance(%s) node(%s) job to complete: %s", instanceId,
+				nodeId, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  fix gaussdb mysql instance restart resource wait method for delay
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  fix gaussdb mysql instance restart resource wait method for delay
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBMysqlInstanceRestart_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBMysqlInstanceRestart_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBMysqlInstanceRestart_basic
=== PAUSE TestAccGaussDBMysqlInstanceRestart_basic
=== RUN   TestAccGaussDBMysqlInstanceRestart_node
=== PAUSE TestAccGaussDBMysqlInstanceRestart_node
=== CONT  TestAccGaussDBMysqlInstanceRestart_basic
=== CONT  TestAccGaussDBMysqlInstanceRestart_node
--- PASS: TestAccGaussDBMysqlInstanceRestart_node (1431.45s)
--- PASS: TestAccGaussDBMysqlInstanceRestart_basic (1594.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1594.436s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
