### PR TITLE
refactor(cse): supports auth params to make sure resources are available

### DIFF
--- a/docs/resources/cse_microservice.md
+++ b/docs/resources/cse_microservice.md
@@ -9,43 +9,60 @@ description: ""
 
 Manages a dedicated microservice resource within HuaweiCloud.
 
--> When deleting a microservice, all instances under it will also be deleted together.
+-> 1. Before creating a configuration, make sure the engine has enabled the rules shown in the appendix
+   [table](#microservice_default_engine_access_rules).
+   <br/> 2. When deleting a microservice, all instances under it will also be deleted together.
 
 ## Example Usage
 
 ### Create a microservice in an engine with RBAC authentication disabled
 
 ```hcl
-variable "engine_conn_addr" {}
+variable "microservice_engine_id" {} // Enable the EIP access
 variable "service_name" {}
 variable "app_name" {}
 
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  fileter_engines = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == var.microservice_engine_id]
+}
+
 resource "huaweicloud_cse_microservice" "test" {
-  connect_address = var.engine_conn_addr
-  name            = var.service_name
-  version         = "1.0.0"
-  environment     = "development"
-  app_name        = var.app_name
+  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
+  connect_address = local.fileter_engines[0].service_registry_addresses[0].public
+
+  name        = var.service_name
+  version     = "1.0.0"
+  environment = "development"
+  app_name    = var.app_name
 }
 ```
 
 ### Create a microservice in an engine with RBAC authentication enabled
 
 ```hcl
-variable "engine_conn_addr" {}
+variable "microservice_engine_id" {} // Enable the EIP access
+variable "microservice_engine_admin_password" {}
 variable "service_name" {}
 variable "app_name" {}
-variable "admin_pass" {}
+
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  fileter_engines = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == var.microservice_engine_id]
+}
 
 resource "huaweicloud_cse_microservice" "test" {
-  connect_address = var.engine_conn_addr
-  name            = var.service_name
-  version         = "1.0.0"
-  environment     = "development"
-  app_name        = var.app_name
+  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
+  connect_address = local.fileter_engines[0].service_registry_addresses[0].public
+  admin_user      = "root"
+  admin_pass      = var.microservice_engine_admin_password
 
-  admin_user = "root"
-  admin_pass = var.admin_pass
+  name        = var.service_name
+  version     = "1.0.0"
+  environment = "development"
+  app_name    = var.app_name
 }
 ```
 
@@ -53,10 +70,31 @@ resource "huaweicloud_cse_microservice" "test" {
 
 The following arguments are supported:
 
-* `connect_address` - (Required, String, ForceNew) Specifies the connection address of service registry center for the
-  specified dedicated CSE engine. Changing this will create a new microservice.
+* `auth_address` - (Required, String, ForceNew) Specifies the address that used to request the access token.  
+  Usually is the connection address of service center.  
+  Changing this will create a new resource.
 
--> We are only support IPv4 addresses yet.
+* `connect_address` - (Required, String, ForceNew) Specifies the address that used to access engine and manages
+  microservice.  
+  Usually is the connection address of service center.  
+  Changing this will create a new resource.
+
+-> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
+
+* `admin_user` - (Optional, String, ForceNew) Specifies the account name for **RBAC** login.
+  Changing this will create a new resource.
+
+* `admin_pass` - (Optional, String, ForceNew) Specifies the account password for **RBAC** login.
+  The password format must meet the following conditions:
+  + Must be `8` to `32` characters long.
+  + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
+    (-~!@#%^*_=+?$&()|<>{}[]).
+  + Cannot be the account name or account name spelled backwards.
+  + The password can only start with a letter.
+
+  Changing this will create a new resource.
+
+-> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
 
 * `name` - (Required, String, ForceNew) Specifies the name of the dedicated microservice.
   The name can contain `1` to `128` characters, only letters, digits, underscore (_), hyphens (-) and dots (.) are
@@ -80,18 +118,6 @@ The following arguments are supported:
   The description can contain a maximum of `256` characters.
   Changing this will create a new microservice.
 
-* `admin_user` - (Optional, String, ForceNew) Specifies the account name. The initial account name is **root**.
-  Required if the `auth_type` of engine is **RBAC**. Changing this will create a new microservice.
-
-* `admin_pass` - (Optional, String, ForceNew) Specifies the account password.
-  Required if the `auth_type` of engine is **RBAC**. Changing this will create a new microservice.
-  The password format must meet the following conditions:
-  + Must be `8` to `32` characters long.
-  + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
-    (-~!@#%^*_=+?$&()|<>{}[]).
-  + Cannot be the account name or account name spelled backwards.
-  + The password can only start with a letter.
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -102,16 +128,43 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Microservices can be imported using related `connect_address` and their `id`, separated by a slash (/), e.g.
+Microservices can be imported using related `auth_address`, `connect_address` and their `id`, separated by the
+slashes (/), e.g.
 
 ```bash
-$ terraform import huaweicloud_cse_microservice.test https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d
+$ terraform import huaweicloud_cse_microservice.test <auth_address>/<connect_address>/<id>
 ```
 
-If you enabled the **RBAC** authorization, you also need to provide the account name and password, e.g.
+If you enabled the **RBAC** authorization, you also need to provide the account name (`admin_user`) and password
+(`admin_pass`) of the microservice engine. All fields separated by the slashes (/), e.g.
 
 ```bash
-$ terraform import huaweicloud_cse_microservice.test 'https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d/root/Test!123'
+$ terraform import huaweicloud_cse_microservice.test <auth_address>/<connect_address>/<id>/<admin_user>/<admin_pass>
 ```
 
-The single quotes can help you solve the problem of special characters reporting errors on bash.
+The single quotes (') or backslashes (\\) can help you solve the problem of special characters reporting errors on bash.
+
+```bash
+$ terraform import huaweicloud_cse_microservice.test https://124.70.26.32:30100/https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d/root/Test\!123
+```
+
+```bash
+$ terraform import huaweicloud_cse_microservice.test 'https://124.70.26.32:30100/https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d/root/Test!123'
+```
+
+## Appendix
+
+<a name="microservice_default_engine_access_rules"></a>
+Security group rules required to access the engine:
+(Remote is not the minimum range and can be adjusted according to business needs)
+
+| Direction | Priority | Action | Protocol | Ports         | Ethertype | Remote                |
+| --------- | -------- | ------ | -------- | ------------- | --------- | --------------------- |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | All      | All           | Ipv6      | cse-engine-default-sg |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv4      | 0.0.0.0/0             |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv4      | 0.0.0.0/0             |
+| Ingress   | 1        | Allow  | All      | All           | Ipv4      | cse-engine-default-sg |
+| Egress    | 100      | Allow  | All      | All           | Ipv6      | ::/0                  |
+| Egress    | 100      | Allow  | All      | All           | Ipv4      | 0.0.0.0/0             |

--- a/docs/resources/cse_microservice_engine_configuration.md
+++ b/docs/resources/cse_microservice_engine_configuration.md
@@ -11,7 +11,7 @@ description: |-
 Manages a key/value pair under a dedicated microservice engine (2.0+) resource within HuaweiCloud.
 
 -> Before creating a configuration, make sure the engine has enabled the rules shown in the appendix
-   [table](#default_engine_access_rules).
+   [table](#configuration_default_engine_access_rules).
 
 ## Example Usage
 
@@ -55,6 +55,8 @@ The following arguments are supported:
   configuration.  
   Changing this will create a new resource.
 
+-> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
+
 * `admin_user` - (Optional, String, ForceNew) Specifies the account name for **RBAC** login.
   Changing this will create a new resource.
 
@@ -68,7 +70,7 @@ The following arguments are supported:
 
   Changing this will create a new resource.
 
-  -> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
+-> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
 
 * `key` - (Required, String, ForceNew) Specifies the configuration key (item name).  
   The valid length is limited from `1` to `2,048` characters, only letters, digits, hyphens (-), underscores (_),
@@ -120,10 +122,22 @@ If the related engine is disable the `RBAC`, configurations (key/value pairs) ca
 $ terraform import huaweicloud_cse_microservice_engine_configuration.test <auth_address>/<connect_address>/<key>
 ```
 
-If the related engine is enable the `RBAC`, inputs `admin_user` and `admin_pass` are necessary, e.g.
+If you enabled the **RBAC** authorization in the microservice engine, it's necessary to provide the account
+name (`admin_user`) and password (`admin_pass`) of the microservice engine.
+All fields separated by the slashes (/), e.g.
 
 ```bash
 $ terraform import huaweicloud_cse_microservice_engine_configuration.test <auth_address>/<connect_address>/<key>/<admin_user>/<admin_pass>
+```
+
+The single quotes (') or backslashes (\\) can help you solve the problem of special characters reporting errors on bash.
+
+```bash
+$ terraform import huaweicloud_cse_microservice_engine_configuration.test https://124.70.26.32:30100/https://124.70.26.32:30110/demo/root/Test\!123
+```
+
+```bash
+$ terraform import huaweicloud_cse_microservice_engine_configuration.test 'https://124.70.26.32:30100/https://124.70.26.32:30110/demo/root/Test!123'
 ```
 
 Note that the imported state may not be identical to your resource definition, due to security reason.
@@ -145,7 +159,7 @@ resource "huaweicloud_cse_microservice_engine_configuration" "test" {
 
 ## Appendix
 
-<a name="default_engine_access_rules"></a>
+<a name="configuration_default_engine_access_rules"></a>
 Security group rules required to access the engine:
 (Remote is not the minimum range and can be adjusted according to business needs)
 

--- a/docs/resources/cse_microservice_engine_configuration.md
+++ b/docs/resources/cse_microservice_engine_configuration.md
@@ -15,6 +15,36 @@ Manages a key/value pair under a dedicated microservice engine (2.0+) resource w
 
 ## Example Usage
 
+### Create an engine configuration and the engine RBAC authentication is disabled
+
+```hcl
+variable "microservice_engine_id" {} // Enable the EIP access
+
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  fileter_engines = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == var.microservice_engine_id]
+}
+
+resource "huaweicloud_cse_microservice_engine_configuration" "test" {
+  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
+  connect_address = local.fileter_engines[0].config_center_addresses[0].public
+
+  key        = "demo"
+  value_type = "json"
+  value      = jsonencode({
+    "foo": "bar"
+  })
+  status     = "enabled"
+
+  tags = {
+    owner = "terraform"
+  }
+}
+```
+
+### Create an engine configuration and the engine RBAC authentication is enabled
+
 ```hcl
 variable "microservice_engine_id" {} // Enable the EIP access
 variable "microservice_engine_admin_password" {}

--- a/docs/resources/cse_microservice_instance.md
+++ b/docs/resources/cse_microservice_instance.md
@@ -9,18 +9,29 @@ description: ""
 
 Manages a dedicated microservice instance resource within HuaweiCloud.
 
+-> Before creating a configuration, make sure the engine has enabled the rules shown in the appendix
+   [table](#microservice_instance_default_engine_access_rules).
+
 ## Example Usage
 
 ### Create a microservice instance under a microservice with RBAC authentication of engine disabled
 
 ```hcl
-variable "engine_conn_addr" {}
+variable "microservice_engine_id" {} // Enable the EIP access
 variable "microservice_id" {}
 variable "region_name" {}
 variable "az_name" {}
 
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  fileter_engines = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == var.microservice_engine_id]
+}
+
 resource "huaweicloud_cse_microservice_instance" "test" {
-  connect_address = var.engine_conn_addr
+  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
+  connect_address = local.fileter_engines[0].service_registry_addresses[0].public
+
   microservice_id = var.microservice_id
   host_name       = "localhost"
   endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
@@ -49,14 +60,24 @@ resource "huaweicloud_cse_microservice_instance" "test" {
 ### Create a microservice instance under a microservice with RBAC authentication of engine enabled
 
 ```hcl
-variable "engine_conn_addr" {}
+variable "microservice_engine_id" {} // Enable the EIP access
+variable "microservice_engine_admin_password" {}
 variable "microservice_id" {}
 variable "region_name" {}
 variable "az_name" {}
-variable "admin_pass" {}
+
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  fileter_engines = [for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == var.microservice_engine_id]
+}
 
 resource "huaweicloud_cse_microservice_instance" "test" {
-  connect_address = var.engine_conn_addr
+  auth_address    = local.fileter_engines[0].service_registry_addresses[0].public
+  connect_address = local.fileter_engines[0].service_registry_addresses[0].public
+  admin_user      = "root"
+  admin_pass      = var.microservice_engine_admin_password
+
   microservice_id = var.microservice_id
   host_name       = "localhost"
   endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
@@ -79,9 +100,6 @@ resource "huaweicloud_cse_microservice_instance" "test" {
     region            = var.region_name
     availability_zone = var.az_name
   }
-
-  admin_user = "root"
-  admin_pass = var.admin_pass
 }
 ```
 
@@ -89,10 +107,31 @@ resource "huaweicloud_cse_microservice_instance" "test" {
 
 The following arguments are supported:
 
-* `connect_address` - (Required, String, ForceNew) Specifies the connection address of service registry center for the
-  specified dedicated CSE engine. Changing this will create a new microservice instance.
+* `auth_address` - (Required, String, ForceNew) Specifies the address that used to request the access token.  
+  Usually is the connection address of service center.  
+  Changing this will create a new resource.
 
--> We are only support IPv4 addresses yet.
+* `connect_address` - (Required, String, ForceNew) Specifies the address that used to access engine and manages
+  microservice instance.  
+  Usually is the connection address of service center.  
+  Changing this will create a new resource.
+
+-> We are only support IPv4 addresses yet (for `auth_address` and `connect_address`).
+
+* `admin_user` - (Optional, String, ForceNew) Specifies the account name for **RBAC** login.
+  Changing this will create a new resource.
+
+* `admin_pass` - (Optional, String, ForceNew) Specifies the account password for **RBAC** login.
+  The password format must meet the following conditions:
+  + Must be `8` to `32` characters long.
+  + A password must contain at least one digit, one uppercase letter, one lowercase letter, and one special character
+    (-~!@#%^*_=+?$&()|<>{}[]).
+  + Cannot be the account name or account name spelled backwards.
+  + The password can only start with a letter.
+
+  Changing this will create a new resource.
+
+-> Both `admin_user` and `admin_pass` are required if **RBAC** is enabled for the microservice engine.
 
 * `microservice_id` - (Required, String, ForceNew) Specifies the ID of the dedicated microservice to which the instance
   belongs. Changing this will create a new microservice instance.
@@ -168,17 +207,44 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Microservices can be imported using related `connect_address`, `microservice_id` and their `id`, separated by a
-slash (/), e.g.
+Microservice instances can be imported using related `auth_address`, `connect_address`, `microservice_id` and their `id`,
+separated by the slashes (/), e.g.
 
 ```bash
-$ terraform import huaweicloud_cse_microservice_instance.test https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d/336e7428dd9411eca913fa163e7364b7
+$ terraform import huaweicloud_cse_microservice_instance.test <auth_address>/<connect_address>/<microservice_id>/<id>
 ```
 
-If you enabled the **RBAC** authorization, you also need to provide the account name and password, e.g.
+If you enabled the **RBAC** authorization in the microservice engine, it's necessary to provide the account
+name (`admin_user`) and password (`admin_pass`) of the microservice engine.
+All fields separated by the slashes (/), e.g.
 
 ```bash
-$ terraform import huaweicloud_cse_microservice_instance.test 'https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d/336e7428dd9411eca913fa163e7364b7/root/Test!123'
+$ terraform import huaweicloud_cse_microservice_instance.test <auth_address>/<connect_address>/<microservice_id>/<id>/<admin_user>/<admin_pass>
 ```
 
-The single quotes can help you solve the problem of special characters reporting errors on bash.
+The single quotes (') or backslashes (\\) can help you solve the problem of special characters reporting errors on bash.
+
+```bash
+$ terraform import huaweicloud_cse_microservice_instance.test https://124.70.26.32:30100/https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d/336e7428dd9411eca913fa163e7364b7/root/Test\!123
+```
+
+```bash
+$ terraform import huaweicloud_cse_microservice_instance.test 'https://124.70.26.32:30100/https://124.70.26.32:30100/f14960ba495e03f59f85aacaaafbdef3fbff3f0d/336e7428dd9411eca913fa163e7364b7/root/Test!123'
+```
+
+## Appendix
+
+<a name="microservice_instance_default_engine_access_rules"></a>
+Security group rules required to access the engine:
+(Remote is not the minimum range and can be adjusted according to business needs)
+
+| Direction | Priority | Action | Protocol | Ports         | Ethertype | Remote                |
+| --------- | -------- | ------ | -------- | ------------- | --------- | --------------------- |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv6      | ::/0                  |
+| Ingress   | 1        | Allow  | All      | All           | Ipv6      | cse-engine-default-sg |
+| Ingress   | 1        | Allow  | ICMP     | All           | Ipv4      | 0.0.0.0/0             |
+| Ingress   | 1        | Allow  | TCP      | 30100-30130   | Ipv4      | 0.0.0.0/0             |
+| Ingress   | 1        | Allow  | All      | All           | Ipv4      | cse-engine-default-sg |
+| Egress    | 100      | Allow  | All      | All           | Ipv6      | ::/0                  |
+| Egress    | 100      | Allow  | All      | All           | Ipv4      | 0.0.0.0/0             |

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_configuration_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_engine_configuration_test.go
@@ -24,6 +24,7 @@ func getMicroserviceEngineConfigurationFunc(_ *config.Config, state *terraform.R
 	return cse.QueryMicroserviceEngineConfiguration(client, token, state.Primary.ID)
 }
 
+// Beforce testing, please bind the EIP and open the access rules according to the resource ducoment appendix.
 func TestAccMicroserviceEngineConfiguration_basic(t *testing.T) {
 	var (
 		configuration interface{}

--- a/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
+++ b/huaweicloud/services/acceptance/cse/resource_huaweicloud_cse_microservice_instance_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func getMicroserviceInstanceFunc(_ *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	token, err := cse.GetAuthorizationToken(state.Primary.Attributes["connect_address"],
+	token, err := cse.GetAuthorizationToken(getAuthAddress(state.Primary.Attributes),
 		state.Primary.Attributes["admin_user"], state.Primary.Attributes["admin_pass"])
 	if err != nil {
 		return nil, err
@@ -26,86 +26,135 @@ func getMicroserviceInstanceFunc(_ *config.Config, state *terraform.ResourceStat
 	return instances.Get(client, state.Primary.Attributes["microservice_id"], state.Primary.ID, token)
 }
 
+// Beforce testing, please bind the EIP and open the access rules according to the resource ducoment appendix.
 func TestAccMicroserviceInstance_basic(t *testing.T) {
 	var (
-		instance     instances.Instance
-		randName     = acceptance.RandomAccResourceNameWithDash()
-		resourceName = "huaweicloud_cse_microservice_instance.test"
-	)
+		instance instances.Instance
+		randName = acceptance.RandomAccResourceName()
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getMicroserviceInstanceFunc,
+		withAuthAddress   = "huaweicloud_cse_microservice_instance.with_auth_address"
+		rcWithAuthAddress = acceptance.InitResourceCheck(withAuthAddress, &instance, getMicroserviceInstanceFunc)
+
+		withoutAuthAddress   = "huaweicloud_cse_microservice_instance.without_auth_address"
+		rcWithoutAuthAddress = acceptance.InitResourceCheck(withoutAuthAddress, &instance, getMicroserviceInstanceFunc)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineID(t)
+			acceptance.TestAccPreCheckCSEMicroserviceEngineAdminPassword(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			rcWithAuthAddress.CheckResourceDestroy(),
+			rcWithoutAuthAddress.CheckResourceDestroy(),
+		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMicroserviceInstance_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttrPair(resourceName, "connect_address",
-						"huaweicloud_cse_microservice_engine.test", "service_registry_addresses.0.public"),
-					resource.TestCheckResourceAttrPair(resourceName, "microservice_id",
+					// With auth_address parameter.
+					rcWithAuthAddress.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(withAuthAddress, "microservice_id",
 						"huaweicloud_cse_microservice.test", "id"),
-					resource.TestCheckResourceAttr(resourceName, "host_name", "localhost"),
-					resource.TestCheckResourceAttr(resourceName, "endpoints.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "endpoints.0", "grpc://127.0.1.132:9980"),
-					resource.TestCheckResourceAttr(resourceName, "endpoints.1", "rest://127.0.0.111:8081"),
-					resource.TestCheckResourceAttr(resourceName, "version", "1.0.1"),
-					resource.TestCheckResourceAttr(resourceName, "properties.nodeIP", "127.0.0.1"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.mode", "push"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.interval", "30"),
-					resource.TestCheckResourceAttr(resourceName, "health_check.0.max_retries", "3"),
-					resource.TestCheckResourceAttr(resourceName, "data_center.0.name", "dc1"),
-					resource.TestCheckResourceAttr(resourceName, "data_center.0.region", acceptance.HW_REGION_NAME),
-					resource.TestCheckResourceAttrPair(resourceName, "data_center.0.availability_zone",
+					resource.TestCheckResourceAttr(withAuthAddress, "host_name", "localhost_with_auth_address"),
+					resource.TestCheckResourceAttr(withAuthAddress, "endpoints.#", "2"),
+					resource.TestCheckResourceAttr(withAuthAddress, "endpoints.0", "grpc://127.0.1.132:9980"),
+					resource.TestCheckResourceAttr(withAuthAddress, "endpoints.1", "rest://127.0.0.111:8081"),
+					resource.TestCheckResourceAttr(withAuthAddress, "version", "1.0.1"),
+					resource.TestCheckResourceAttr(withAuthAddress, "properties.nodeIP", "127.0.0.1"),
+					resource.TestCheckResourceAttr(withAuthAddress, "health_check.0.mode", "push"),
+					resource.TestCheckResourceAttr(withAuthAddress, "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr(withAuthAddress, "health_check.0.max_retries", "3"),
+					resource.TestCheckResourceAttr(withAuthAddress, "data_center.0.name", "dc1"),
+					resource.TestCheckResourceAttr(withAuthAddress, "data_center.0.region", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttrPair(withAuthAddress, "data_center.0.availability_zone",
 						"data.huaweicloud_availability_zones.test", "names.0"),
-					resource.TestCheckResourceAttr(resourceName, "status", "UP"),
+					resource.TestCheckResourceAttr(withAuthAddress, "status", "UP"),
+					// Without auth_address parameter.
+					rcWithoutAuthAddress.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(withAuthAddress, "microservice_id",
+						"huaweicloud_cse_microservice.test", "id"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "host_name", "localhost_without_auth_address"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "endpoints.#", "2"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "endpoints.0", "grpc://127.0.1.132:9980"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "endpoints.1", "rest://127.0.0.111:8081"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "version", "1.0.1"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "properties.nodeIP", "127.0.0.1"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "health_check.0.mode", "push"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "health_check.0.max_retries", "3"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "data_center.0.name", "dc1"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "data_center.0.region", acceptance.HW_REGION_NAME),
+					resource.TestCheckResourceAttrPair(withoutAuthAddress, "data_center.0.availability_zone",
+						"data.huaweicloud_availability_zones.test", "names.0"),
+					resource.TestCheckResourceAttr(withoutAuthAddress, "status", "UP"),
 				),
 			},
 			{
-				ResourceName:      resourceName,
+				ResourceName:      withAuthAddress,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: testAccMicroserviceInstanceImportStateIdFunc(),
+				ImportStateIdFunc: testAccMicroserviceInstanceImportStateIdFunc(withAuthAddress),
+			},
+			{
+				ResourceName:      withoutAuthAddress,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccMicroserviceInstanceImportStateIdFunc(withoutAuthAddress),
+				ImportStateVerifyIgnore: []string{
+					"auth_address",
+				},
 			},
 		},
 	})
 }
 
-func testAccMicroserviceInstanceImportStateIdFunc() resource.ImportStateIdFunc {
+func testAccMicroserviceInstanceImportStateIdFunc(resName string) resource.ImportStateIdFunc {
 	return func(s *terraform.State) (string, error) {
-		var connAddr, username, password, microserviceId, instanceId string
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type == "huaweicloud_cse_microservice_instance" {
-				connAddr = rs.Primary.Attributes["connect_address"]
-				microserviceId = rs.Primary.Attributes["microservice_id"]
-				username = rs.Primary.Attributes["admin_user"]
-				password = rs.Primary.Attributes["admin_pass"]
-				instanceId = rs.Primary.ID
-			}
+		var authAddr, connAddr, addrPart, microserviceId, username, password, instanceId string
+		rs, ok := s.RootModule().Resources[resName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found", resName)
 		}
-		if connAddr != "" && microserviceId != "" && instanceId != "" {
+
+		authAddr = rs.Primary.Attributes["auth_address"]
+		connAddr = rs.Primary.Attributes["connect_address"]
+		microserviceId = rs.Primary.Attributes["microservice_id"]
+		username = rs.Primary.Attributes["admin_user"]
+		password = rs.Primary.Attributes["admin_pass"]
+		instanceId = rs.Primary.ID
+
+		addrPart = connAddr
+		if authAddr != "" {
+			addrPart = fmt.Sprintf("%s/%s", authAddr, addrPart)
+		}
+		if addrPart != "" && microserviceId != "" && instanceId != "" {
 			if username != "" && password != "" {
-				return fmt.Sprintf("%s/%s/%s/%s/%s", connAddr, microserviceId, instanceId, username, password), nil
+				return fmt.Sprintf("%s/%s/%s/%s/%s", addrPart, microserviceId, instanceId, username, password), nil
 			}
-			return fmt.Sprintf("%s/%s/%s", connAddr, microserviceId, instanceId), nil
+			return fmt.Sprintf("%s/%s/%s", addrPart, microserviceId, instanceId), nil
 		}
-		return "", fmt.Errorf("resource not found: %s/%s", connAddr, instanceId)
+		return "", fmt.Errorf("missing some attributes: %s/%s/%s", addrPart, microserviceId, instanceId)
 	}
 }
 
-func testAccMicroserviceInstance_basic(rName string) string {
+func testAccMicroserviceInstance_base(name string) string {
 	return fmt.Sprintf(`
-%[1]s
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_cse_microservice_engines" "test" {}
+
+locals {
+  id_filter_result = [
+    for o in data.huaweicloud_cse_microservice_engines.test.engines : o if o.id == "%[1]s"
+  ]
+}
 
 resource "huaweicloud_cse_microservice" "test" {
-  connect_address = huaweicloud_cse_microservice_engine.test.service_registry_addresses.0.public
+  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
+  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
 
   name        = "%[2]s"
   app_name    = "%[2]s"
@@ -114,14 +163,29 @@ resource "huaweicloud_cse_microservice" "test" {
   level       = "BACK"
 
   admin_user = "root"
-  admin_pass = huaweicloud_cse_microservice_engine.test.admin_pass
+  admin_pass = "%[3]s"
+
+  lifecycle {
+    ignore_changes = [
+      admin_pass,
+    ]
+  }
+}
+`, acceptance.HW_CSE_MICROSERVICE_ENGINE_ID,
+		name,
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD)
 }
 
-resource "huaweicloud_cse_microservice_instance" "test" {
-  connect_address = huaweicloud_cse_microservice_engine.test.service_registry_addresses.0.public
+func testAccMicroserviceInstance_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cse_microservice_instance" "with_auth_address" {
+  auth_address    = local.id_filter_result[0].service_registry_addresses[0].public
+  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
 
   microservice_id = huaweicloud_cse_microservice.test.id
-  host_name       = "localhost"
+  host_name       = "localhost_with_auth_address"
   endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
   version         = "1.0.1"
 
@@ -137,12 +201,54 @@ resource "huaweicloud_cse_microservice_instance" "test" {
 
   data_center {
     name              = "dc1"
-    region            = "%[3]s"
+    region            = "%[2]s"
     availability_zone = data.huaweicloud_availability_zones.test.names[0]
   }
 
   admin_user = "root"
-  admin_pass = huaweicloud_cse_microservice_engine.test.admin_pass
+  admin_pass = "%[3]s"
+
+  lifecycle {
+    ignore_changes = [
+      admin_pass,
+    ]
+  }
 }
-`, testAccMicroserviceEngine_config(rName), rName, acceptance.HW_REGION_NAME)
+
+resource "huaweicloud_cse_microservice_instance" "without_auth_address" {
+  connect_address = local.id_filter_result[0].service_registry_addresses[0].public
+
+  microservice_id = huaweicloud_cse_microservice.test.id
+  host_name       = "localhost_without_auth_address"
+  endpoints       = ["grpc://127.0.1.132:9980", "rest://127.0.0.111:8081"]
+  version         = "1.0.1"
+
+  properties = {
+    "nodeIP" = "127.0.0.1"
+  }
+
+  health_check {
+    mode        = "push"
+    interval    = 30
+    max_retries = 3
+  }
+
+  data_center {
+    name              = "dc1"
+    region            = "%[2]s"
+    availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  }
+
+  admin_user = "root"
+  admin_pass = "%[3]s"
+
+  lifecycle {
+    ignore_changes = [
+      admin_pass,
+    ]
+  }
+}
+`, testAccMicroserviceInstance_base(name),
+		acceptance.HW_REGION_NAME,
+		acceptance.HW_CSE_MICROSERVICE_ENGINE_ADMIN_PASSWORD)
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice.go
@@ -12,9 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cse/dedicated/v4/services"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 var microserviceNotFoundCodes = []string{
@@ -35,11 +37,39 @@ func ResourceMicroservice() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"connect_address": {
+			// Authentication and request parameters.
+			"auth_address": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The address that used to request the access token.`,
+					utils.SchemaDescInput{
+						Required: true,
+					}),
 			},
+			"connect_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The address that used to send requests and manage configuration.`,
+			},
+			"admin_user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The user name that used to pass the RBAC control.",
+			},
+			"admin_pass": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ForceNew:     true,
+				RequiredWith: []string{"admin_user"},
+				Description:  "The user password that used to pass the RBAC control.",
+			},
+			// Resource parameters.
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -76,24 +106,21 @@ func ResourceMicroservice() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"admin_user": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"admin_pass": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ForceNew:     true,
-				RequiredWith: []string{"admin_user"},
-			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
 	}
+}
+
+func getAuthAddress(d *schema.ResourceData) string {
+	if v, ok := d.GetOk("auth_address"); ok {
+		return v.(string)
+	}
+	// Using the connect address as the auth address if its empty.
+	// The behavior of the connect address is required.
+	return d.Get("connect_address").(string)
 }
 
 func buildMicroserviceCreateOpts(d *schema.ResourceData) services.CreateOpts {
@@ -111,7 +138,7 @@ func buildMicroserviceCreateOpts(d *schema.ResourceData) services.CreateOpts {
 }
 
 func resourceMicroserviceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(d.Get("connect_address").(string), d.Get("admin_user").(string),
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
 	if err != nil {
 		return diag.FromErr(err)
@@ -130,10 +157,13 @@ func resourceMicroserviceCreate(ctx context.Context, d *schema.ResourceData, met
 }
 
 func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(d.Get("connect_address").(string), d.Get("admin_user").(string),
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
 	if err != nil {
-		return diag.FromErr(err)
+		// When the engine does not exist, obtaining a token will cause a request connection exception.
+		// To ensure that the resource is available on RFS platform, this situation is specially handled as a 404 error.
+		log.Printf("[ERROR] %s", err)
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
 	}
 
 	client := common.NewCustomClient(true, d.Get("connect_address").(string), "v4", "default")
@@ -158,7 +188,7 @@ func resourceMicroserviceRead(_ context.Context, d *schema.ResourceData, _ inter
 }
 
 func resourceMicroserviceDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(d.Get("connect_address").(string), d.Get("admin_user").(string),
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
 	if err != nil {
 		return diag.FromErr(err)
@@ -181,34 +211,57 @@ func resourceMicroserviceDelete(_ context.Context, d *schema.ResourceData, _ int
 
 func resourceMicroserviceImportState(_ context.Context, d *schema.ResourceData,
 	_ interface{}) ([]*schema.ResourceData, error) {
-	re := regexp.MustCompile(`^(https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5})/(.*)$`)
-	if !re.MatchString(d.Id()) {
-		return nil, fmt.Errorf("The imported microservice ID specifies an invalid format, must start with the " +
-			"connection address of the service registry center for the dedicated CSE engine.")
+	var (
+		authAddr, connectAddr, importedIdWithoutAddrs, microserviceId, adminUser, adminPwd string
+		mErr                                                                               *multierror.Error
+
+		importedId   = d.Id()
+		addressRegex = `https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}`
+		re           = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)?/?(%[1]s)/(.*)$`, addressRegex))
+		formatErr    = fmt.Errorf("the imported microservice ID specifies an invalid format, want "+
+			"'<auth_address>/<connect_address>/<id>' or '<auth_address>/<connect_address>/<id>/<admin_user>/<admin_pass>', but got '%s'",
+			importedId)
+	)
+
+	if !re.MatchString(importedId) {
+		return nil, formatErr
 	}
-
-	var mErr *multierror.Error
-	formatErr := fmt.Errorf("The imported microservice ID specifies an invalid format, must be " +
-		"<cnnect_address>/<microservice_id> or <cnnect_address>/<microservice_id>/<admin_user>/<admin_pass>.")
-
-	resp := re.FindAllStringSubmatch(d.Id(), -1)
-	if len(resp) >= 1 && len(resp[0]) == 3 {
-		mErr = multierror.Append(mErr, d.Set("connect_address", resp[0][1]))
-		parts := strings.SplitN(resp[0][2], "/", 3)
-		switch len(parts) {
-		case 1:
-			d.SetId(parts[0])
-		case 3:
-			d.SetId(parts[0])
-			mErr = multierror.Append(mErr,
-				d.Set("admin_user", parts[1]),
-				d.Set("admin_pass", parts[2]),
-			)
-		default:
-			return nil, formatErr
+	resp := re.FindAllStringSubmatch(importedId, -1)
+	// If the imported ID matches the address regular expression, the length of the response result must be greater than 1.
+	switch len(resp[0]) {
+	case 4:
+		authAddr = resp[0][1]
+		connectAddr = resp[0][2]
+		importedIdWithoutAddrs = resp[0][3]
+		if authAddr == "" {
+			authAddr = connectAddr // Using the connect address as the auth address if the auth address input is omitted.
 		}
-		return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+	default:
+		return nil, formatErr
 	}
 
-	return nil, formatErr
+	mErr = multierror.Append(mErr,
+		d.Set("auth_address", authAddr),
+		d.Set("connect_address", connectAddr),
+	)
+
+	parts := strings.Split(importedIdWithoutAddrs, "/")
+	switch len(parts) {
+	case 1:
+		microserviceId = parts[0]
+	case 3:
+		microserviceId = parts[0]
+		adminUser = parts[1]
+		adminPwd = parts[2]
+
+		mErr = multierror.Append(mErr,
+			d.Set("admin_user", adminUser),
+			d.Set("admin_pass", adminPwd),
+		)
+	default:
+		return nil, formatErr
+	}
+
+	d.SetId(microserviceId)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_engine_configuration.go
@@ -326,22 +326,26 @@ func resourceMicroserviceEngineConfigurationImportState(_ context.Context, d *sc
 		err                                                        error
 		mErr                                                       *multierror.Error
 
+		importedId   = d.Id()
 		addressRegex = `https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}`
 		re           = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)?/?(%[1]s)/(.*)$`, addressRegex))
-		formatErr    = fmt.Errorf("the imported microservice ID specifies an invalid format, must be " +
-			"<auth_address>/<connect_address>/<key> or <auth_address>/<connect_address>/<key>/<admin_user>/<admin_pass>")
+		formatErr    = fmt.Errorf("the imported microservice ID specifies an invalid format, want "+
+			"'<auth_address>/<connect_address>/<key>' or '<auth_address>/<connect_address>/<key>/<admin_user>/<admin_pass>', but got '%s'",
+			importedId)
 	)
 	if !re.MatchString(d.Id()) {
-		return nil, fmt.Errorf("the imported microservice ID specifies an invalid format, must start with the " +
-			"connection address of the service registry center for the dedicated CSE engine")
+		return nil, formatErr
 	}
 
 	resp := re.FindAllStringSubmatch(d.Id(), -1)
-	if len(resp) >= 1 && len(resp[0]) == 4 {
+	// If the imported ID matches the address regular expression, the length of the response result must be greater than 1.
+	if len(resp[0]) == 4 {
 		authAddr = resp[0][1]
 		connectAddr = resp[0][2]
-		mErr = multierror.Append(mErr, d.Set("auth_address", resp[0][1]))
-		mErr = multierror.Append(mErr, d.Set("connect_address", resp[0][2]))
+		mErr = multierror.Append(mErr,
+			d.Set("auth_address", resp[0][1]),
+			d.Set("connect_address", resp[0][2]),
+		)
 
 		parts := strings.Split(resp[0][3], "/")
 		switch len(parts) {

--- a/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
+++ b/huaweicloud/services/cse/resource_huaweicloud_cse_microservice_instance.go
@@ -39,11 +39,39 @@ func ResourceMicroserviceInstance() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"connect_address": {
+			// Authentication and request parameters.
+			"auth_address": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The address that used to request the access token.`,
+					utils.SchemaDescInput{
+						Required: true,
+					}),
 			},
+			"connect_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The address that used to send requests and manage configuration.`,
+			},
+			"admin_user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The user name that used to pass the RBAC control.",
+			},
+			"admin_pass": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ForceNew:     true,
+				RequiredWith: []string{"admin_user"},
+				Description:  "The user password that used to pass the RBAC control.",
+			},
+			// Resource parameters.
 			"microservice_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -131,18 +159,6 @@ func ResourceMicroserviceInstance() *schema.Resource {
 					},
 				},
 			},
-			"admin_user": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"admin_pass": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Sensitive:    true,
-				ForceNew:     true,
-				RequiredWith: []string{"admin_user"},
-			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -208,7 +224,7 @@ func buildInstanceCreateOpts(d *schema.ResourceData) instances.CreateOpts {
 }
 
 func resourceMicroserviceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(d.Get("connect_address").(string), d.Get("admin_user").(string),
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
 	if err != nil {
 		return diag.FromErr(err)
@@ -258,7 +274,7 @@ func flattenDataCenter(dataCenter instances.DataCenter) (result []map[string]int
 }
 
 func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(d.Get("connect_address").(string), d.Get("admin_user").(string),
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
 	if err != nil {
 		return diag.FromErr(err)
@@ -286,7 +302,7 @@ func resourceMicroserviceInstanceRead(_ context.Context, d *schema.ResourceData,
 }
 
 func resourceMicroserviceInstanceDelete(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	token, err := GetAuthorizationToken(d.Get("connect_address").(string), d.Get("admin_user").(string),
+	token, err := GetAuthorizationToken(getAuthAddress(d), d.Get("admin_user").(string),
 		d.Get("admin_pass").(string))
 	if err != nil {
 		return diag.FromErr(err)
@@ -304,37 +320,61 @@ func resourceMicroserviceInstanceDelete(_ context.Context, d *schema.ResourceDat
 
 func resourceMicroserviceInstanceImportState(_ context.Context, d *schema.ResourceData,
 	_ interface{}) ([]*schema.ResourceData, error) {
-	re := regexp.MustCompile(`^(https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5})/(.*)$`)
-	if !re.MatchString(d.Id()) {
-		return nil, fmt.Errorf("The imported microservice ID specifies an invalid format, must start with the " +
-			"connection address of the service registry center for the dedicated CSE engine.")
+	var (
+		authAddr, connectAddr, importedIdWithoutAddrs, microserviceId, instanceId, adminUser, adminPwd string
+		mErr                                                                                           *multierror.Error
+
+		importedId   = d.Id()
+		addressRegex = `https://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}`
+		re           = regexp.MustCompile(fmt.Sprintf(`^(%[1]s)?/?(%[1]s)/(.*)$`, addressRegex))
+		formatErr    = fmt.Errorf("the imported microservice ID specifies an invalid format, want "+
+			"'<auth_address>/<connect_address>/<microservice_id>/<id>' or "+
+			"'<auth_address>/<connect_address>/<microservice_id>/<id>/<admin_user>/<admin_pass>', but got '%s'",
+			importedId)
+	)
+
+	if !re.MatchString(importedId) {
+		return nil, formatErr
 	}
-
-	var mErr *multierror.Error
-	formatErr := fmt.Errorf("The imported microservice ID specifies an invalid format, must be " +
-		"<cnnect_address>/<microservice_id>/<instance_id> or " +
-		"<cnnect_address>/<microservice_id>/<instance_id>/<admin_user>/<admin_pass>.")
-
-	resp := re.FindAllStringSubmatch(d.Id(), -1)
-	if len(resp) >= 1 && len(resp[0]) == 3 {
-		mErr = multierror.Append(mErr, d.Set("connect_address", resp[0][1]))
-		parts := strings.SplitN(resp[0][2], "/", 4)
-		switch len(parts) {
-		case 2:
-			d.SetId(parts[1])
-			mErr = multierror.Append(mErr, d.Set("microservice_id", parts[0]))
-		case 4:
-			d.SetId(parts[1])
-			mErr = multierror.Append(mErr,
-				d.Set("microservice_id", parts[0]),
-				d.Set("admin_user", parts[2]),
-				d.Set("admin_pass", parts[3]),
-			)
-		default:
-			return nil, formatErr
+	resp := re.FindAllStringSubmatch(importedId, -1)
+	// If the imported ID matches the address regular expression, the length of the response result must be greater than 1.
+	switch len(resp[0]) {
+	case 4:
+		authAddr = resp[0][1]
+		connectAddr = resp[0][2]
+		importedIdWithoutAddrs = resp[0][3]
+		if authAddr == "" {
+			authAddr = connectAddr // Using the connect address as the auth address if the auth address input is omitted.
 		}
-		return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+	default:
+		return nil, formatErr
 	}
 
-	return nil, formatErr
+	mErr = multierror.Append(mErr,
+		d.Set("auth_address", authAddr),
+		d.Set("connect_address", connectAddr),
+	)
+
+	parts := strings.Split(importedIdWithoutAddrs, "/")
+	switch len(parts) {
+	case 2:
+		microserviceId = parts[0]
+		instanceId = parts[1]
+	case 4:
+		microserviceId = parts[0]
+		instanceId = parts[1]
+		adminUser = parts[2]
+		adminPwd = parts[3]
+
+		mErr = multierror.Append(mErr,
+			d.Set("admin_user", adminUser),
+			d.Set("admin_pass", adminPwd),
+		)
+	default:
+		return nil, formatErr
+	}
+
+	mErr = multierror.Append(mErr, d.Set("microservice_id", microserviceId))
+	d.SetId(instanceId)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supports auth params to make sure resources are available.
For the configuration resource, the auth address and connect address are different.
For the microservice and microservice instance, the auth address and connect address usually are same, but we cannot guarantee that this is the case in all scenarios.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports auth params to make sure resources are available.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o cse -f TestAccMicroserviceInstance_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroserviceInstance_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroserviceInstance_basic
=== PAUSE TestAccMicroserviceInstance_basic
=== CONT  TestAccMicroserviceInstance_basic
--- PASS: TestAccMicroserviceInstance_basic (43.52s)
PASS
coverage: 34.8% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       43.568s coverage: 34.8% of statements in ./huaweicloud/services/cse
```

```
../coverage.sh -o cse -f TestAccMicroservice_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/cse" -v -coverprofile="./huaweicloud/services/acceptance/cse_coverage.cov" -coverpkg="./huaweicloud/services/cse" -run TestAccMicroservice_basic -timeout 360m -parallel 10
=== RUN   TestAccMicroservice_basic
=== PAUSE TestAccMicroservice_basic
=== CONT  TestAccMicroservice_basic
--- PASS: TestAccMicroservice_basic (28.39s)
PASS
coverage: 23.5% of statements in ./huaweicloud/services/cse
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cse       28.435s coverage: 23.5% of statements in ./huaweicloud/services/cse
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
