### PR TITLE
fix(fgs/async): max async retry attempts supports zero value

### DIFF
--- a/docs/resources/fgs_async_invoke_configuration.md
+++ b/docs/resources/fgs_async_invoke_configuration.md
@@ -52,10 +52,12 @@ The following arguments are supported:
 * `function_urn` - (Required, String, ForceNew) Specifies the function URN to which the asynchronous invocation belongs.
   Changing this will create a new resource.
 
-* `max_async_event_age_in_seconds` - (Required, Int) Specifies the maximum validity period of a message.
+* `max_async_event_age_in_seconds` - (Required, Int) Specifies the maximum validity period of a message.  
+  The valid value is range from `1` to `86,400`.
 
 * `max_async_retry_attempts` - (Required, Int) Specifies the maximum number of retry attempts to be made if
-  asynchronous invocation fails.
+  asynchronous invocation fails.  
+  The valid value is range from `0` to `3`.
 
 * `on_success` - (Optional, List) Specifies the target to be invoked when a function is successfully executed.  
   The [object](#functiongraph_destination_config) structure is documented below.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241008082604-c2c6f5def2b1
+	github.com/chnsz/golangsdk v0.0.0-20241015094204-516de119e710
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241008082604-c2c6f5def2b1 h1:w0bpE1x2mCdRl9kRk5rnaDzGSBU37jHmyO7eANW9RoI=
-github.com/chnsz/golangsdk v0.0.0-20241008082604-c2c6f5def2b1/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241015094204-516de119e710 h1:nFDrxlhY9OOrU7SozBcuNscZbIzmRtekl04/MQs/+x4=
+github.com/chnsz/golangsdk v0.0.0-20241015094204-516de119e710/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_invoke_configuration_test.go
+++ b/huaweicloud/services/acceptance/fgs/resource_huaweicloud_fgs_async_invoke_configuration_test.go
@@ -67,7 +67,7 @@ func TestAccAsyncInvokeConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(rName, "function_urn",
 						"huaweicloud_fgs_function.test", "urn"),
 					resource.TestCheckResourceAttr(rName, "max_async_event_age_in_seconds", "4000"),
-					resource.TestCheckResourceAttr(rName, "max_async_retry_attempts", "3"),
+					resource.TestCheckResourceAttr(rName, "max_async_retry_attempts", "0"),
 					resource.TestCheckResourceAttr(rName, "on_success.0.destination", "DIS"),
 					resource.TestCheckResourceAttrSet(rName, "on_success.0.param"),
 					resource.TestCheckResourceAttr(rName, "on_failure.0.destination", "FunctionGraph"),
@@ -170,7 +170,7 @@ resource "huaweicloud_fgs_function" "test" {
 resource "huaweicloud_fgs_async_invoke_configuration" "test" {
   function_urn                   = huaweicloud_fgs_function.test.urn
   max_async_event_age_in_seconds = 4000
-  max_async_retry_attempts       = 3
+  max_async_retry_attempts       = 0
 
   on_success {
     destination = "DIS"

--- a/huaweicloud/services/fgs/resource_huaweicloud_fgs_async_invoke_configuration.go
+++ b/huaweicloud/services/fgs/resource_huaweicloud_fgs_async_invoke_configuration.go
@@ -111,7 +111,7 @@ func modifyAsyncInvokeConfiguration(client *golangsdk.ServiceClient, d *schema.R
 		functionUrn = d.Get("function_urn").(string)
 		opts        = function.AsyncInvokeConfigOpts{
 			MaxAsyncEventAgeInSeconds: d.Get("max_async_event_age_in_seconds").(int),
-			MaxAsyncRetryAttempts:     d.Get("max_async_retry_attempts").(int),
+			MaxAsyncRetryAttempts:     utils.Int(d.Get("max_async_retry_attempts").(int)),
 			EnableAsyncStatusLog:      utils.Bool(d.Get("enable_async_status_log").(bool)),
 		}
 		destinationConfig = function.DestinationConfig{}

--- a/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/fgs/v2/function/requests.go
@@ -391,7 +391,7 @@ type AsyncInvokeConfigOpts struct {
 	// The maximum validity period of a message.
 	MaxAsyncEventAgeInSeconds int `json:"max_async_event_age_in_seconds,omitempty"`
 	// The maximum number of retry attempts to be made if asynchronous invocation fails.
-	MaxAsyncRetryAttempts int `json:"max_async_retry_attempts,omitempty"`
+	MaxAsyncRetryAttempts *int `json:"max_async_retry_attempts,omitempty"`
 	// Asynchronous invocation target.
 	DestinationConfig DestinationConfig `json:"destination_config,omitempty"`
 	// Whether to enable asynchronous invocation status persistence.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241008082604-c2c6f5def2b1
+# github.com/chnsz/golangsdk v0.0.0-20241015094204-516de119e710
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth
@@ -77,7 +77,6 @@ github.com/chnsz/golangsdk/openstack/cci/v1/persistentvolumeclaims
 github.com/chnsz/golangsdk/openstack/cdm/v1/clusters
 github.com/chnsz/golangsdk/openstack/cdm/v1/job
 github.com/chnsz/golangsdk/openstack/cdm/v1/link
-github.com/chnsz/golangsdk/openstack/cdn/v1/domains
 github.com/chnsz/golangsdk/openstack/cloudeyeservice/v1/alarmrule
 github.com/chnsz/golangsdk/openstack/cloudeyeservice/v2/alarmrule
 github.com/chnsz/golangsdk/openstack/cloudtable/v2/clusters


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameter 'max_async_retry_attempts' supports zero value.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. the max async retry attempts supports zero value.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
../coverage.sh -o fgs -f TestAccAsyncInvokeConfig_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/fgs" -v -coverprofile="./huaweicloud/services/acceptance/fgs_coverage.cov" -coverpkg="./huaweicloud/services/fgs" -run TestAccAsyncInvokeConfig_basic -timeout 360m -parallel 10
=== RUN   TestAccAsyncInvokeConfig_basic
=== PAUSE TestAccAsyncInvokeConfig_basic
=== CONT  TestAccAsyncInvokeConfig_basic
--- PASS: TestAccAsyncInvokeConfig_basic (184.45s)
PASS
coverage: 15.1% of statements in ./huaweicloud/services/fgs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/fgs       184.501s        coverage: 15.1% of statements in ./huaweicloud/services/fgs
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
