### PR TITLE
feat(aom): add param for service discovery rule

### DIFF
--- a/docs/resources/aom_service_discovery_rule.md
+++ b/docs/resources/aom_service_discovery_rule.md
@@ -95,6 +95,8 @@ The following arguments are supported:
   + `args` - (Required, List) Specifies the command. This is a list of strings.
   + `value` - (Required, List) Specifies the log path. This is a list of strings.
 
+* `description` - (Optional, String) Specifies the rule description.
+
 <a name="name_rules_object"></a>
 The `name_rules` block supports:
 
@@ -121,9 +123,11 @@ The `service_name_rule` block and `application_name_rule` block support:
 
 * `name_type` - (Required, String) Specifies the value type. The value can be **cmdLineHash**, **cmdLine**, **env**
 and **str**.
+
 * `args` - (Required, List) Specifies the input value.
-* `value` - (Optional, List) Specifies the application name, which is mandatory only when the value of
-`name_type` is **cmdLineHash**.
+
+* `value` - (Optional, List) Specifies the application name, which is mandatory only when the value of `name_type` is
+  **cmdLineHash**.
 
 ## Attribute Reference
 
@@ -132,6 +136,8 @@ In addition to all arguments above, the following attributes are exported:
 * `id` - Indicates the resource ID of the service discovery rule. The value is the rule name.
 
 * `rule_id` - The rule ID in uuid format.
+
+* `created_at` - The rule create time.
 
 ## Timeouts
 

--- a/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_service_discovery_rule_test.go
+++ b/huaweicloud/services/acceptance/aom/resource_huaweicloud_aom_service_discovery_rule_test.go
@@ -69,6 +69,7 @@ func TestAccAOMServiceDiscoveryRule_basic(t *testing.T) {
 						resourceName, "name_rules.0.service_name_rule.0.args.0", "python"),
 					resource.TestCheckResourceAttr(
 						resourceName, "name_rules.0.application_name_rule.0.args.0", "python"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test"),
 				),
 			},
 			{
@@ -108,6 +109,7 @@ resource "huaweicloud_aom_service_discovery_rule" "test" {
   is_default_rule        = true
   log_file_suffix        = ["log"]
   service_type           = "Python"
+  description            = "test"
 
   discovery_rules {
     check_content = ["python"]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 add param for service discovery rule

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/aom' TESTARGS='-run TestAccAOMServiceDiscoveryRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/aom -v -run TestAccAOMServiceDiscoveryRule_basic -timeout 360m -parallel 4
=== RUN   TestAccAOMServiceDiscoveryRule_basic
=== PAUSE TestAccAOMServiceDiscoveryRule_basic
=== CONT  TestAccAOMServiceDiscoveryRule_basic
--- PASS: TestAccAOMServiceDiscoveryRule_basic (148.39s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/aom       148.475s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
