### PR TITLE
feat(error/convert): supports new function to convert undefined errors

### DIFF
--- a/huaweicloud/common/errors.go
+++ b/huaweicloud/common/errors.go
@@ -12,6 +12,10 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
+var definedStatusNumbers = []interface{}{
+	400, 401, 402, 403, 404, 405, 408, 429, 500, 503,
+}
+
 // ConvertExpected400ErrInto404Err is a method used to parsing 400 error and try to convert it to 404 error according
 // to the right error code.
 // Arguments:
@@ -198,4 +202,124 @@ func ConvertExpected500ErrInto404Err(err error, errCodeKey string, specErrCodes 
 	}
 	log.Printf("[WARN] Unable to recognize expected error code (%v), want %v", errCode, specErrCodes)
 	return err
+}
+
+// ConvertUndefinedErrInto404Err is a method used to parsing errors which related structures undefined in the golangsdk
+// package (so a general method for parsing such errors is needed) and try to convert it to 404 error according to the
+// right error number and code (omitted means all passed).
+// Unsupported status codes (may not enter the convert logic and returned directly):
+//   - 400, 401, 402, 403, 404, 405, 408, 429, 500, 503
+//
+// Arguments:
+//   - err: The error response obtained through HTTP/HTTPS request.
+//   - errStatusNum: The status number of the error, e.g. 409, 415 (The common status numbers are defined in the
+//     golangsdk package, e.g. 400, 403, 500)
+//   - errCodeKey: The key name of the error code in the error response body, e.g. 'error_code', 'err_code'.
+//   - specErrCodes: One or more error codes that you wish to match against the current error, e.g. 'CSS.0004'.
+//
+// Notes: If you missing specErrCodes input, this function will convert all errors which matched your specifies status
+// into 404 errors.
+//
+// How to use it:
+//   - utils.ConvertUndefinedErrInto404Err(err, 415, "error_code")
+//   - utils.ConvertUndefinedErrInto404Err(err, 415, "error_code", "CSS.0004")
+//   - utils.ConvertUndefinedErrInto404Err(err, 415, "error_code", []string{"CSS.0004", "CSS.0005"}...)
+//   - utils.ConvertUndefinedErrInto404Err(err, 415, "")
+//
+// The corresponding processing of this method are as follows:
+//   - The status code has a corresponding structure definition in golangsdk: the error is recorded in the log and the
+//     original error is returned directly.
+//   - The status code (key) not found: return error (404 error: if the errCodeKey is omitted).
+//   - The input of the expected error code(s) is omitted: return 404 error.
+//   - The expected error code(s) matched: return 404 error.
+//   - Other situations: return original error.
+func ConvertUndefinedErrInto404Err(err error, errStatusNum int, errCodeKey string, specErrCodes ...string) error {
+	if utils.SliceContains(definedStatusNumbers, errStatusNum) {
+		log.Printf("[INFO] The error with status code %d already has a corresponding structure definition in the "+
+			"golangsdk package, please use the corresponding conversion method to process", errStatusNum)
+		return err
+	}
+	errCode, optErr := getExpectedErrCode(err, errStatusNum, errCodeKey)
+	if optErr != nil {
+		return optErr
+	}
+
+	if len(specErrCodes) < 1 {
+		log.Printf("[INFO] Identified error parsed it as 404 error (without the error code control)")
+		return golangsdk.ErrDefault404{}
+	}
+	if utils.StrSliceContains(specErrCodes, fmt.Sprint(errCode)) {
+		log.Printf("[INFO] Identified error with code '%v' and parsed it as 404 error", errCode)
+		return golangsdk.ErrDefault404{}
+	}
+	log.Printf("[WARN] Unable to recognize expected error code (%v), want %v", errCode, specErrCodes)
+	return err
+}
+
+// getExpectedErrCode is a method used to identify whether the status code of the target error meets expectations, and
+// attempts to obtain the error code corresponding to the target error according to the error code key of the target
+// error.
+//
+// Arguments:
+//   - err: The error response obtained through HTTP/HTTPS request.
+//   - errStatusNum: The status number of the error, e.g. 409, 415 (The common status numbers are defined in the
+//     golangsdk package, e.g. 400, 403, 500)
+//   - errCodeKey: The key name of the error code in the error response body, e.g. 'error_code', 'err_code'.
+//
+// How to use it:
+//   - getExpectedErrCode(err, 409, "error_code")
+//   - getExpectedErrCode(err, 409, "")
+//
+// The corresponding processing of this method are as follows:
+//   - The status code has a corresponding structure definition in golangsdk: the error is recorded in the log and the
+//     original error is returned directly, and the error code is returned as null.
+//   - The status code does not match: the error is recorded in the log and the original error is returned directly,
+//     and the error code is returned as null.
+//   - The status code matches and the error code key is null: a 404 error is returned directly, skipping the error code
+//     check.
+//   - The status code matches but the error cannot be parsed normally: a 400 error is returned, and the content is
+//     error parsing failure.
+//   - The status code matches but the error code is not found: a 400 error is returned, and the content is that the
+//     error code does not match.
+//   - The status code matches and the target error code is found: the corresponding error code is returned.
+func getExpectedErrCode(err error, errStatusNum int, errCodeKey string) (string, error) {
+	var apiError interface{}
+	parsedErr, ok := err.(golangsdk.ErrUnexpectedResponseCode)
+	if !ok {
+		log.Printf("[WARN] Failed to recognize error type, want 'golangsdk.ErrUnexpectedResponseCode', but got '%s'",
+			reflect.TypeOf(err).String())
+		return "", err
+	} else if parsedErr.Actual != errStatusNum {
+		log.Printf("[WARN] Unable to recognize expected error status number, want '%d', but got '%d'",
+			errStatusNum, parsedErr.Actual)
+		return "", err
+	}
+
+	if errCodeKey == "" {
+		return "", golangsdk.ErrDefault404{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte("The string input of errCodeKey is not detected, so the error is directly " +
+					"converted to a 404 error and returned"),
+			},
+		}
+	}
+	jsonErr := json.Unmarshal(parsedErr.Body, &apiError)
+	if jsonErr != nil {
+		return "", golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("error parsing the request error: %s", jsonErr)),
+			},
+		}
+	}
+	errCode := utils.PathSearch(errCodeKey, apiError, "").(string)
+	if errCode == "" {
+		// 4xx means the client parsing was failed.
+		return errCode, golangsdk.ErrDefault400{
+			ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+				Body: []byte(fmt.Sprintf("Unable to find the error code from the error body using given status "+
+					"number (%d) and the error code key (%s), the error is: '%v'", errStatusNum, errCodeKey, err)),
+			},
+		}
+	}
+	return errCode, nil
 }

--- a/huaweicloud/common/errors_test.go
+++ b/huaweicloud/common/errors_test.go
@@ -200,3 +200,72 @@ func TestErrorFunc_ConvertExpected500ErrInto404Err(t *testing.T) {
 		t.Fatalf("error converting 500 error to 404 error via a non-exist error code")
 	}
 }
+
+func TestErrorFunc_ConvertUndefinedErrInto404Err(t *testing.T) {
+	input403Err := golangsdk.ErrDefault403{
+		ErrUnexpectedResponseCode: golangsdk.ErrUnexpectedResponseCode{
+			Body: []byte("{\"error_code\": \"TESTERR.0002\", \"error_msg\": \"Authentication Failed\"}"),
+		},
+	}
+	input409Err := golangsdk.ErrUnexpectedResponseCode{
+		Actual: 409,
+		Body:   []byte("{\"error_code\": \"TESTERR.0001\", \"error_msg\": \"Conflict, please try again later\"}"),
+	}
+	input415Err := golangsdk.ErrUnexpectedResponseCode{
+		Actual: 415,
+		Body:   []byte("{\"error_code\": \"TESTERR.0002\", \"error_msg\": \"Operation completed\"}"),
+	}
+
+	// Step1: Check whether the function can normally identify the expected error code under follow input and convert
+	// the 409 error into a 404 error.
+	parseResult1 := common.ConvertUndefinedErrInto404Err(input409Err, 409, "error_code", "TESTERR.0001")
+	if _, ok := parseResult1.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 409 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult1).String())
+	}
+	// Step2: Check whether the function can normally recognize unexpected 409 error (strcture is undefined) under
+	// follow input and terminate subsequent processing, and directly return error.
+	parseResult2 := common.ConvertUndefinedErrInto404Err(input415Err, 409, "error_code", "TESTERR.0001")
+	if !reflect.DeepEqual(parseResult2, input415Err) {
+		t.Fatalf("The expected 415 error was not recognized and was incorrectly converted")
+	}
+	// Step3: Check whether the function can normally recognize unexpected 403 error (strcture is defined) under
+	// follow input and terminate subsequent processing, and directly return error.
+	parseResult3 := common.ConvertUndefinedErrInto404Err(input403Err, 409, "error_code", "TESTERR.0001")
+	if _, ok := parseResult3.(golangsdk.ErrDefault403); !ok {
+		t.Fatalf("The expected 403 error was not recognized and was incorrectly converted")
+	}
+	// Step4: Check whether the function can normally recognize unexpected error code key under follow input and
+	// terminate subsequent processing, and return 400 error.
+	parseResult4 := common.ConvertUndefinedErrInto404Err(input409Err, 409, "err_code", "TESTERR.0001")
+	if _, ok := parseResult4.(golangsdk.ErrDefault400); !ok {
+		t.Fatalf("The expected error key 'err_code' was not recognized and the error was incorrectly converted")
+	}
+	// Step5: Check whether the function can normally recognize expected error code key (but the error code is
+	// unexcepted) under follow input and terminate subsequent processing, and directly return original error.
+	parseResult5 := common.ConvertUndefinedErrInto404Err(input409Err, 409, "error_code", "TESTERR.0002")
+	if !reflect.DeepEqual(parseResult5, input409Err) {
+		t.Fatalf("Illegal recognition of unexpected error code key and convert the error to other type")
+	}
+	// Step6: Check whether the function can normally identify the expected error code (during a expected code list)
+	// under follow input and convert the 409 error into a 404 error.
+	parseResult6 := common.ConvertUndefinedErrInto404Err(input409Err, 409, "error_code",
+		[]string{"TESTERR.0001", "TESTERR.0002"}...)
+	if _, ok := parseResult6.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("Unable to convert 409 error to 404 error, the result type of the convert function is: %s",
+			reflect.TypeOf(parseResult6).String())
+	}
+	// Step7: Check whether the function can normally recognize expected error code under (during a unmatched code
+	// list) follow input and terminate subsequent processing, and directly return error.
+	parseResult7 := common.ConvertUndefinedErrInto404Err(input409Err, 409, "error_code",
+		[]string{"TESTERR.0002", "TESTERR.0003"}...)
+	if !reflect.DeepEqual(parseResult7, input409Err) {
+		t.Fatalf("error converting 409 error to 404 error via a non-exist error code")
+	}
+	// Step8: Check whether the function can normally recognize unexpected error status number follow input and
+	// terminate subsequent processing, skipping the error code check and directly return 404 error.
+	parseResult8 := common.ConvertUndefinedErrInto404Err(input409Err, 409, "")
+	if _, ok := parseResult8.(golangsdk.ErrDefault404); !ok {
+		t.Fatalf("error converting 409 error to 404 error with the omitted error code key")
+	}
+}

--- a/huaweicloud/services/css/common.go
+++ b/huaweicloud/services/css/common.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/jmespath/go-jmespath"
-
 	"github.com/chnsz/golangsdk"
 
 	"github.com/huaweicloud/huaweicloud-sdk-go-v3/core/sdkerr"
@@ -31,24 +29,6 @@ func ConvertExpectedHwSdkErrInto404Err(err error, httpStatusCode int, expectCode
 				return err
 			}
 			return golangsdk.ErrDefault404{}
-		}
-	}
-
-	return err
-}
-
-func ConvertExpectOtherErrInto404Err(err error, expectStatusCode int, errCodeKey, expectErrCode string) error {
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == expectStatusCode {
-		var response interface{}
-		if jsonErr := json.Unmarshal(errCode.Body, &response); jsonErr == nil {
-			errorCode, parseErr := jmespath.Search(errCodeKey, response)
-			if parseErr != nil {
-				log.Printf("[WARN] failed to parse %s from response body: %s", errCodeKey, parseErr)
-			}
-
-			if errorCode == expectErrCode {
-				return golangsdk.ErrDefault404{}
-			}
 		}
 	}
 

--- a/huaweicloud/services/css/resource_huaweicloud_css_log_setting.go
+++ b/huaweicloud/services/css/resource_huaweicloud_css_log_setting.go
@@ -232,7 +232,7 @@ func resourceLogSettingDelete(_ context.Context, d *schema.ResourceData, meta in
 		err = common.ConvertExpected403ErrInto404Err(err, "errCode", "CSS.0015")
 		// "CSS.0004": Invalid operation. Status code is 415.
 		// {"errCode":"CSS.0004","externalMessage":"CSS.0004 : Invalid operation. (Illegal operation)"}
-		err = ConvertExpectOtherErrInto404Err(err, 415, "errCode", "CSS.0004")
+		err = common.ConvertUndefinedErrInto404Err(err, 415, "errCode", "CSS.0004")
 		return common.CheckDeletedDiag(d, err, "error closing CSS cluster log function")
 	}
 

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_proxy.go
@@ -1447,22 +1447,7 @@ func parseMysqlProxyError(err error) error {
 			return golangsdk.ErrDefault404(errCode)
 		}
 	}
-	if errCode, ok := err.(golangsdk.ErrUnexpectedResponseCode); ok && errCode.Actual == 409 {
-		var apiError interface{}
-		if jsonErr := json.Unmarshal(errCode.Body, &apiError); jsonErr != nil {
-			return err
-		}
-
-		errorCode, errorCodeErr := jmespath.Search("error_code", apiError)
-		if errorCodeErr != nil {
-			return err
-		}
-
-		if errorCode == "DBS.200932" {
-			return golangsdk.ErrDefault404{}
-		}
-	}
-	return err
+	return common.ConvertUndefinedErrInto404Err(err, 409, "error_code", "DBS.200932")
 }
 
 func resourceGaussDBMySQLProxyImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData,

--- a/huaweicloud/utils/utils.go
+++ b/huaweicloud/utils/utils.go
@@ -172,6 +172,17 @@ func NormalizeJsonString(jsonString interface{}) (string, error) {
 	return string(bytes[:]), nil
 }
 
+// SliceContains checks if a target object is present in a slice (the type of the elemetes which same as the target
+// object).
+func SliceContains(slice []interface{}, target interface{}) bool {
+	for _, v := range slice {
+		if reflect.DeepEqual(v, target) {
+			return true
+		}
+	}
+	return false
+}
+
 // StrSliceContains checks if a given string is contained in a slice
 // When anybody asks why Go needs generics, here you go.
 func StrSliceContains(haystack []string, needle string) bool {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We have not any unified public function to convert the errors (except status codes: 400, 401, 402, 403, 404, 405, 408, 429, 500, 503).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. supports new function to convert undefined errors.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
go test -v -run TestErrorFunc_ConvertUndefinedErrInto404Err
=== RUN   TestErrorFunc_ConvertUndefinedErrInto404Err
2024/10/17 20:18:06 [INFO] Identified error with code 'TESTERR.0001' and parsed it as 404 error
2024/10/17 20:18:06 [WARN] Unable to recognize expected error status number, want '409', but got '415'
2024/10/17 20:18:06 [WARN] Failed to recognize error type, want 'golangsdk.ErrUnexpectedResponseCode', but got 'golangsdk.ErrDefault403'
2024/10/17 20:18:06 [WARN] Unable to recognize expected error code (TESTERR.0001), want [TESTERR.0002]
2024/10/17 20:18:06 [INFO] Identified error with code 'TESTERR.0001' and parsed it as 404 error
2024/10/17 20:18:06 [WARN] Unable to recognize expected error code (TESTERR.0001), want [TESTERR.0002 TESTERR.0003]
--- PASS: TestErrorFunc_ConvertUndefinedErrInto404Err (0.00s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common        0.020s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    CSS log setting
    ![1729165613298](https://github.com/user-attachments/assets/cf1745c7-a13d-41fc-a048-e66cb99eaa07)

    EIP associate
    ![image](https://github.com/user-attachments/assets/6e33724a-54c1-4292-bd87-b0b2e31c11ae)

    GaussDB MySQL proxy
    ![image](https://github.com/user-attachments/assets/b497b3e2-e464-4e43-bc7e-6df4ed8e708b)

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
