### PR TITLE
WIP: fix(dws/queues): fix some errors when cluster is unavailable

### DIFF
--- a/docs/data-sources/dws_workload_queues.md
+++ b/docs/data-sources/dws_workload_queues.md
@@ -67,3 +67,9 @@ The `configuration` block supports:
 * `resource_value` - The resource attribute value.
 
 * `value_unit` - The resource attribute unit.
+
+## Timeouts
+
+This data source provides the following timeouts configuration options:
+
+* `read` - Default is 10 minutes.

--- a/docs/resources/dws_workload_queue.md
+++ b/docs/resources/dws_workload_queue.md
@@ -121,6 +121,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID, same as `name`.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
 ## Import
 
 The workload queue can be imported using `cluster_id` and `name`, separated by a slash, e.g.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->
**What this PR does / why we need it**:

When the cluster is being restarted or other operations are causing the cluster to be unavailable, the status code is `400`.
1. Query the list of the queues.
![image](https://github.com/user-attachments/assets/64baba86-5d07-43ff-8324-fe36b004b555)
2. Create queue.
![image](https://github.com/user-attachments/assets/663f6d6a-b0ff-455c-b2bf-e15a6af9a6f1)

3. Delete queue.
![image](https://github.com/user-attachments/assets/5f868b75-8dff-442c-9593-b126175db885)


**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
fix some errors when cluster is unavailable.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/acc-test.sh
>>> Start to test
=== RUN   TestAccDataSourceWorkloadQueues_basic
=== PAUSE TestAccDataSourceWorkloadQueues_basic
=== RUN   TestAccDataSourceWorkloadQueues_logicalCluster
=== PAUSE TestAccDataSourceWorkloadQueues_logicalCluster
=== CONT  TestAccDataSourceWorkloadQueues_basic
=== CONT  TestAccDataSourceWorkloadQueues_logicalCluster
--- PASS: TestAccDataSourceWorkloadQueues_logicalCluster (75.33s)
--- PASS: TestAccDataSourceWorkloadQueues_basic (100.77s)
PASS
coverage: 6.1% of statements in ../../dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       100.879s


 ./scripts/acc-test.sh
>>> Start to test
=== RUN   TestAccResourceWorkloadQueue_basic
=== PAUSE TestAccResourceWorkloadQueue_basic
=== RUN   TestAccResourceWorkloadQueue_logicalClusterName
=== PAUSE TestAccResourceWorkloadQueue_logicalClusterName
=== CONT  TestAccResourceWorkloadQueue_basic
=== CONT  TestAccResourceWorkloadQueue_logicalClusterName
--- PASS: TestAccResourceWorkloadQueue_basic (53.24s)
--- PASS: TestAccResourceWorkloadQueue_logicalClusterName (54.33s)
PASS
coverage: 4.6% of statements in ../../dws
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dws       54.479s
```

* [x] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
