### PR TITLE
feat(GaussDBforMySQL): add gaussdb mysql scheduled task cancel resource

### DIFF
--- a/docs/resources/gaussdb_mysql_scheduled_task_cancel.md
+++ b/docs/resources/gaussdb_mysql_scheduled_task_cancel.md
@@ -1,0 +1,60 @@
+---
+subcategory: "GaussDB(for MySQL)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_mysql_scheduled_task_cancel"
+description: |-
+  Manages a GaussDB MySQL scheduled task cancel resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_mysql_scheduled_task_cancel
+
+Manages a GaussDB MySQL scheduled task cancel resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource for operating the API.
+Deleting this resource will not clear the corresponding request record,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+resource "huaweicloud_gaussdb_mysql_scheduled_task_cancel" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `job_id` - (Required, String, ForceNew) Specifies the task ID. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is `job_id`.
+
+* `instance_id` - Indicates the instance ID.
+
+* `instance_name` - Indicates the instance name.
+
+* `instance_status` - Indicates the instance status.
+
+* `project_id` - Indicates the project ID of a tenant in a region.
+
+* `job_name` - Indicates the task name.
+
+* `create_time` - Indicates the task creation time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `start_time` - Indicates the task start time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `end_time` - Indicates the task end time in the **yyyy-mm-ddThh:mm:ssZ** format.
+
+* `job_status` - Indicates the task execution status.
+
+* `datastore_type` - Indicates the database type.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1588,6 +1588,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_eip_associate":              gaussdb.ResourceGaussMysqlEipAssociate(),
 			"huaweicloud_gaussdb_mysql_recycling_policy":           gaussdb.ResourceGaussDBRecyclingPolicy(),
 			"huaweicloud_gaussdb_mysql_quota":                      gaussdb.ResourceGaussDBMysqlQuota(),
+			"huaweicloud_gaussdb_mysql_scheduled_task_cancel":      gaussdb.ResourceGaussDBScheduledTaskCancel(),
 
 			"huaweicloud_gaussdb_opengauss_instance": gaussdb.ResourceOpenGaussInstance(),
 			"huaweicloud_gaussdb_opengauss_database": gaussdb.ResourceOpenGaussDatabase(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_scheduled_task_cancel_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_scheduled_task_cancel_test.go
@@ -1,0 +1,84 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
+)
+
+func TestAccGaussDBMysqlInstanceScheduledTaskCancel_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_gaussdb_mysql_scheduled_task_cancel.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBMysqlInstanceScheduledTaskCancel_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "job_status", "Canceled"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_status"),
+					resource.TestCheckResourceAttrSet(resourceName, "project_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "job_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "create_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "start_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "end_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "datastore_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGaussDBMysqlInstanceScheduledTaskCancel_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_gaussdb_mysql_flavors" "test" {
+  engine                 = "gaussdb-mysql"
+  version                = "8.0"
+  availability_zone_mode = "multi"
+}
+
+resource "huaweicloud_gaussdb_mysql_instance" "test" {
+  name                     = "%[2]s"
+  password                 = "Test@12345678"
+  flavor                   = data.huaweicloud_gaussdb_mysql_flavors.test.flavors[0].name
+  vpc_id                   = huaweicloud_vpc.test.id
+  subnet_id                = huaweicloud_vpc_subnet.test.id
+  security_group_id        = huaweicloud_networking_secgroup.test.id
+  enterprise_project_id    = "0"
+  master_availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  availability_zone_mode   = "multi"
+  read_replicas            = 2
+}
+
+resource "huaweicloud_gaussdb_mysql_instance_restart" "test" {
+  instance_id = huaweicloud_gaussdb_mysql_instance.test.id
+  delay       = true
+}
+
+data "huaweicloud_gaussdb_mysql_scheduled_tasks" "test" {
+  depends_on = [huaweicloud_gaussdb_mysql_instance_restart.test]
+}
+`, common.TestBaseNetwork(rName), rName)
+}
+
+func testAccGaussDBMysqlInstanceScheduledTaskCancel_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_gaussdb_mysql_scheduled_task_cancel" "test" {
+  job_id = data.huaweicloud_gaussdb_mysql_scheduled_tasks.test.tasks[0].job_id
+}`, testAccGaussDBMysqlInstanceScheduledTaskCancel_base(rName))
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_scheduled_tasks.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_scheduled_tasks.go
@@ -158,7 +158,7 @@ func dataSourceGaussDBMysqlScheduledTasksRead(_ context.Context, d *schema.Resou
 }
 
 func buildGaussDBMysqlScheduledTasksQueryParams(d *schema.ResourceData, page int) string {
-	res := fmt.Sprintf("?limit=6&offset=%v", page)
+	res := fmt.Sprintf("?limit=100&offset=%v", page)
 	if v, ok := d.GetOk("status"); ok {
 		res = fmt.Sprintf("%s&status=%s", res, v)
 	}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_scheduled_task_cancel.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_scheduled_task_cancel.go
@@ -1,0 +1,187 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforMySQL DELETE /v3/{project_id}/scheduled-jobs
+// @API GaussDBforMySQL POST /v3/{project_id}/instances/{instance_id}/nodes/{node_id}/restart
+// @API GaussDBforMySQL GET /v3/{project_id}/jobs
+func ResourceGaussDBScheduledTaskCancel() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGaussDBMysqlScheduledTaskCancelCreate,
+		ReadContext:   resourceGaussDBMysqlScheduledTaskCancelRead,
+		DeleteContext: resourceGaussDBMysqlScheduledTaskCancelDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"job_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"job_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"datastore_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGaussDBMysqlScheduledTaskCancelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/scheduled-jobs"
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	jobId := d.Get("job_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateGaussDBMySQLScheduledTaskCancelBodyParams(jobId))
+
+	_, err = client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error canceling GaussDB MySQL scheduled task(%s): %s", jobId, err)
+	}
+
+	d.SetId(jobId)
+
+	return resourceGaussDBMysqlScheduledTaskCancelRead(ctx, d, meta)
+}
+
+func buildCreateGaussDBMySQLScheduledTaskCancelBodyParams(jobId string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"job_ids": []string{jobId},
+	}
+	return bodyParams
+}
+
+func resourceGaussDBMysqlScheduledTaskCancelRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var mErr *multierror.Error
+
+	var (
+		httpUrl = "v3/{project_id}/scheduled-jobs?job_id={job_id}"
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{job_id}", d.Id())
+
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	getResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving GaussDB MySQL scheduled task")
+	}
+
+	getRespBody, err := utils.FlattenResponse(getResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	scheduledTask := utils.PathSearch("schedules[0]", getRespBody, nil)
+	if scheduledTask == nil {
+		return common.CheckDeletedDiag(d, golangsdk.ErrDefault404{}, "")
+	}
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("instance_id", utils.PathSearch("instance_id", scheduledTask, nil)),
+		d.Set("instance_name", utils.PathSearch("instance_name", scheduledTask, nil)),
+		d.Set("instance_status", utils.PathSearch("instance_status", scheduledTask, nil)),
+		d.Set("project_id", utils.PathSearch("project_id", scheduledTask, nil)),
+		d.Set("job_name", utils.PathSearch("job_name", scheduledTask, nil)),
+		d.Set("create_time", utils.PathSearch("create_time", scheduledTask, nil)),
+		d.Set("start_time", utils.PathSearch("start_time", scheduledTask, nil)),
+		d.Set("end_time", utils.PathSearch("end_time", scheduledTask, nil)),
+		d.Set("job_status", utils.PathSearch("job_status", scheduledTask, nil)),
+		d.Set("datastore_type", utils.PathSearch("datastore_type", scheduledTask, nil)),
+		d.Set("job_status", utils.PathSearch("job_status", scheduledTask, nil)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func resourceGaussDBMysqlScheduledTaskCancelDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GaussDB MySQL scheduled task cancel resource is not supported. The GaussDB MySQL scheduled " +
+		"task cancel resource is only removed from the state, the GaussDB MySQL scheduled task remains in the cloud."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb mysql scheduled task cancel resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb mysql scheduled task cancel resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBMysqlInstanceScheduledTaskCancel_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBMysqlInstanceScheduledTaskCancel_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBMysqlInstanceScheduledTaskCancel_basic
=== PAUSE TestAccGaussDBMysqlInstanceScheduledTaskCancel_basic
=== CONT  TestAccGaussDBMysqlInstanceScheduledTaskCancel_basic
--- PASS: TestAccGaussDBMysqlInstanceScheduledTaskCancel_basic (1380.10s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   1380.139s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
