### PR TITLE
chore(vpn): update user_group_id field to be computed

### DIFF
--- a/docs/resources/vpn_user.md
+++ b/docs/resources/vpn_user.md
@@ -5,6 +5,7 @@ page_title: "HuaweiCloud: huaweicloud_vpn_user"
 description: |-
   Manages a VPN user resource within HuaweiCloud.
 ---
+
 # huaweicloud_vpn_user
 
 Manages a VPN user resource within HuaweiCloud.
@@ -39,19 +40,19 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the user.
 
-* `user_group_id` - (Optional, String) Specifies the user group ID.
-
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
 
+* `user_group_id` - The user group ID.
+
+* `user_group_name` - The user group name.
+
 * `created_at` - The creation time.
 
 * `updated_at` - The update time.
-
-* `user_group_name` - The user group name.
 
 ## Import
 

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -44,7 +44,6 @@ var (
 	HW_VPC_ID                 = os.Getenv("HW_VPC_ID")
 	HW_VPN_P2C_GATEWAY_ID     = os.Getenv("HW_VPN_P2C_GATEWAY_ID")
 	HW_VPN_P2C_SERVER         = os.Getenv("HW_VPN_P2C_SERVER")
-	HW_VPN_P2C_USER_GROUP     = os.Getenv("HW_VPN_P2C_USER_GROUP")
 	HW_NETWORK_ID             = os.Getenv("HW_NETWORK_ID")
 	HW_SUBNET_ID              = os.Getenv("HW_SUBNET_ID")
 	HW_SECURITY_GROUP_ID      = os.Getenv("HW_SECURITY_GROUP_ID")
@@ -2350,13 +2349,6 @@ func TestAccPreCheckVPNP2cGatewayId(t *testing.T) {
 func TestAccPreCheckVPNP2cServer(t *testing.T) {
 	if HW_VPN_P2C_SERVER == "" {
 		t.Skip("HW_VPN_P2C_SERVER must be set for the acceptance test")
-	}
-}
-
-// lintignore:AT003
-func TestAccPreCheckVPNP2cUserGroup(t *testing.T) {
-	if HW_VPN_P2C_USER_GROUP == "" {
-		t.Skip("HW_VPN_P2C_USER_GROUP must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_user_test.go
+++ b/huaweicloud/services/acceptance/vpn/resource_huaweicloud_vpn_user_test.go
@@ -57,7 +57,6 @@ func TestAccUser_basic(t *testing.T) {
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPreCheckVPNP2cServer(t)
-			acceptance.TestAccPreCheckVPNP2cUserGroup(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),
@@ -81,7 +80,6 @@ func TestAccUser_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "password", "Gaia1234"),
 					resource.TestCheckResourceAttr(rName, "description", ""),
-					resource.TestCheckResourceAttrSet(rName, "user_group_id"),
 				),
 			},
 			{
@@ -115,7 +113,6 @@ resource "huaweicloud_vpn_user" "test" {
   name          = "%[2]s"
   password      = "Gaia1234"
   description   = ""
-  user_group_id = "%[3]s"
 }
-`, acceptance.HW_VPN_P2C_SERVER, name, acceptance.HW_VPN_P2C_USER_GROUP)
+`, acceptance.HW_VPN_P2C_SERVER, name)
 }

--- a/huaweicloud/services/vpn/resource_huaweicloud_vpn_user.go
+++ b/huaweicloud/services/vpn/resource_huaweicloud_vpn_user.go
@@ -65,9 +65,14 @@ func ResourceUser() *schema.Resource {
 				Description: `The description of the user.`,
 			},
 			"user_group_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `The user group ID.`,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The user group ID.`,
+					utils.SchemaDescInput{
+						Computed: true,
+					}),
 			},
 			"user_group_name": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Deprecated user_group_id field. The functionality of associating VPN user group and VPN users is implemented by the user group resource.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. update user_group_id field to be computed
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
 make testacc TEST="./huaweicloud/services/acceptance/vpn" TESTARGS="-run TestAccUser_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpn -v -run TestAccUser_basic -timeout 360m -parallel 4
=== RUN   TestAccUser_basic
=== PAUSE TestAccUser_basic
=== CONT  TestAccUser_basic
--- PASS: TestAccUser_basic (66.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpn       66.580s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
