### PR TITLE
feat(RAM): resource support new field allow_external_principals

### DIFF
--- a/docs/resources/ram_resource_share.md
+++ b/docs/resources/ram_resource_share.md
@@ -63,6 +63,12 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the resource share.
 
+* `allow_external_principals` - (Optional, Bool) Specifies whether resources can be shared with any accounts outside
+  the organization. Defaults to **true**.
+
+  -> Configuring `allow_external_principals` to **false** may cause failure when the resource share contains one or more
+  accounts outside the organization.
+
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the resource share.
 
 ## Attribute Reference


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Resource support new field allow_external_principals.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- There is currently no way to test the scenario where `allow_external_principals` is false, so the test case has not been modified.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/ram' TESTARGS='-run TestAccRAMShare_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccRAMShare_basic -timeout 360m -parallel 4
=== RUN   TestAccRAMShare_basic
=== PAUSE TestAccRAMShare_basic
=== CONT  TestAccRAMShare_basic
--- PASS: TestAccRAMShare_basic (23.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       23.582s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
