### PR TITLE
feat(iotda): add new data source to get the list of upgrade packages

### DIFF
--- a/docs/data-sources/iotda_upgrade_packages.md
+++ b/docs/data-sources/iotda_upgrade_packages.md
@@ -1,0 +1,86 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_upgrade_packages"
+description: |-
+  Use this data source to get a list of the upgrade packages.
+---
+
+# huaweicloud_iotda_upgrade_packages
+
+Use this data source to get a list of the upgrade packages.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "type" {}
+
+data "huaweicloud_iotda_upgrade_packages" "test" {
+  type = var.type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Required, String) Specifies the type of the upgrade package.
+  The valid values are as follows:
+  + **softwarePackage**
+  + **firmwarePackage**
+
+* `space_id` - (Optional, String) Specifies the resource space ID to which the upgrade packages belong.
+
+* `product_id` - (Optional, String) Specifies the product ID associated with the upgrade package.
+
+* `version` - (Optional, String) Specifies the version number of the upgrade package.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `packages` - The list of the upgrade packages.
+
+  The [packages](#packages_struct) structure is documented below.
+
+<a name="packages_struct"></a>
+The `packages` block supports:
+
+* `id` - The ID of the upgrade package.
+
+* `space_id` - The resource space ID to which the upgrade package belongs.
+
+* `product_id` - The product ID associated with the upgrade package.
+
+* `type` - The type of the upgrade package.
+
+* `description` - The description of the upgrade package.
+
+* `version` - The version number of the upgrade package.
+
+* `support_source_versions` - The list of source versions that support the upgrade of this version package.
+
+* `custom_info` - The custom information pushed to the device.
+
+* `created_at` - The time when the software and firmware packages are uploaded to the IoT platform.
+  The format is **yyyyMMdd'T'HHmmss'Z**. e.g. **20190528T153000Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -823,15 +823,16 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_running_tasks": dew.DataSourceDewKpsRunningTasks(),
 			"huaweicloud_kps_keypairs":      dew.DataSourceKeypairs(),
 
-			"huaweicloud_iotda_device_certificates":  iotda.DataSourceDeviceCertificates(),
 			"huaweicloud_iotda_amqps":                iotda.DataSourceAMQPQueues(),
+			"huaweicloud_iotda_batchtasks":           iotda.DataSourceBatchTasks(),
 			"huaweicloud_iotda_dataforwarding_rules": iotda.DataSourceDataForwardingRules(),
+			"huaweicloud_iotda_devices":              iotda.DataSourceDevices(),
+			"huaweicloud_iotda_device_certificates":  iotda.DataSourceDeviceCertificates(),
 			"huaweicloud_iotda_device_groups":        iotda.DataSourceDeviceGroups(),
 			"huaweicloud_iotda_device_linkage_rules": iotda.DataSourceDeviceLinkageRules(),
-			"huaweicloud_iotda_spaces":               iotda.DataSourceSpaces(),
 			"huaweicloud_iotda_products":             iotda.DataSourceProducts(),
-			"huaweicloud_iotda_devices":              iotda.DataSourceDevices(),
-			"huaweicloud_iotda_batchtasks":           iotda.DataSourceBatchTasks(),
+			"huaweicloud_iotda_spaces":               iotda.DataSourceSpaces(),
+			"huaweicloud_iotda_upgrade_packages":     iotda.DataSourceUpgradePackages(),
 
 			"huaweicloud_koogallery_assets": koogallery.DataSourceKooGalleryAssets(),
 

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_upgrade_packages_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_upgrade_packages_test.go
@@ -1,0 +1,140 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceUpgradePackages_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_upgrade_packages.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceUpgradePackages_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.space_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.product_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.support_source_versions.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.custom_info"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.created_at"),
+
+					resource.TestCheckOutput("space_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("product_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("version_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceUpgradePackages_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_upgrade_packages.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		name           = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceUpgradePackages_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.space_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.product_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.support_source_versions.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.custom_info"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "packages.0.created_at"),
+
+					resource.TestCheckOutput("space_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("product_id_filter_is_useful", "true"),
+					resource.TestCheckOutput("version_filter_is_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceUpgradePackages_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_iotda_upgrade_packages" "test" {
+  type = huaweicloud_iotda_upgrade_package.test.type
+}
+
+locals {
+  space_id = data.huaweicloud_iotda_upgrade_packages.test.packages[0].space_id
+}
+
+data "huaweicloud_iotda_upgrade_packages" "space_id_filter" {
+  type     = huaweicloud_iotda_upgrade_package.test.type
+  space_id = local.space_id
+}
+
+output "space_id_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_upgrade_packages.space_id_filter.packages) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_upgrade_packages.space_id_filter.packages[*].space_id : v == local.space_id]
+  )
+}
+
+locals {
+  product_id = data.huaweicloud_iotda_upgrade_packages.test.packages[0].product_id
+}
+
+data "huaweicloud_iotda_upgrade_packages" "product_id_filter" {
+  type       = huaweicloud_iotda_upgrade_package.test.type
+  product_id = local.product_id
+}
+
+output "product_id_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_upgrade_packages.product_id_filter.packages) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_upgrade_packages.product_id_filter.packages[*].product_id : v == local.product_id]
+  )
+}
+
+locals {
+  version = data.huaweicloud_iotda_upgrade_packages.test.packages[0].version
+}
+
+data "huaweicloud_iotda_upgrade_packages" "version_filter" {
+  type    = huaweicloud_iotda_upgrade_package.test.type
+  version = local.version
+}
+
+output "version_filter_is_useful" {
+  value = length(data.huaweicloud_iotda_upgrade_packages.version_filter.packages) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_upgrade_packages.version_filter.packages[*].version : v == local.version]
+  )
+}
+`, testUpgradePackage_basic(name))
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_upgrade_packages.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_upgrade_packages.go
@@ -1,0 +1,185 @@
+package iotda
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/ota-upgrades/packages
+func DataSourceUpgradePackages() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIotdaUpgradePackagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the type of the upgrade package.`,
+			},
+			"space_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the resource space ID to which the upgrade packages belong.`,
+			},
+			"product_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the product ID associated with the upgrade package.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the version number of the upgrade package.`,
+			},
+			"packages": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of the upgrade packages.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The ID of the upgrade package.`,
+						},
+						"space_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The resource space ID to which the upgrade package belongs.`,
+						},
+						"product_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The product ID associated with the upgrade package.`,
+						},
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The type of the upgrade package.`,
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the upgrade package.`,
+						},
+						"version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The version number of the upgrade package.`,
+						},
+						"support_source_versions": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: `The list of source versions that support the upgrade of this version package.`,
+						},
+						"custom_info": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The custom information pushed to the device.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the software and firmware packages are uploaded to the IoT platform.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIotdaUpgradePackagesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+	isDerived := WithDerivedAuth(cfg, region)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		upgradePackages []model.OtaPackageInfo
+		limit           = int32(50)
+		offset          int32
+	)
+
+	for {
+		listOpts := model.ListOtaPackageInfoRequest{
+			AppId:       utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+			PackageType: d.Get("type").(string),
+			ProductId:   utils.StringIgnoreEmpty(d.Get("product_id").(string)),
+			Version:     utils.StringIgnoreEmpty(d.Get("version").(string)),
+			Limit:       utils.Int32(limit),
+			Offset:      &offset,
+		}
+
+		listResp, listErr := client.ListOtaPackageInfo(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error retrieving upgrade packages: %s", listErr)
+		}
+
+		if listResp == nil || listResp.Packages == nil {
+			break
+		}
+
+		if len(*listResp.Packages) == 0 {
+			break
+		}
+
+		upgradePackages = append(upgradePackages, *listResp.Packages...)
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(uuId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("packages", flattenPackages(upgradePackages)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenPackages(packages []model.OtaPackageInfo) []interface{} {
+	if len(packages) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(packages))
+	for _, v := range packages {
+		rst = append(rst, map[string]interface{}{
+			"id":                      v.PackageId,
+			"space_id":                v.AppId,
+			"product_id":              v.ProductId,
+			"type":                    v.PackageType,
+			"version":                 v.Version,
+			"description":             v.Description,
+			"support_source_versions": v.SupportSourceVersions,
+			"custom_info":             v.CustomInfo,
+			"created_at":              v.CreateTime,
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add new data source to get the list of upgrade packages.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.support a new datasource to get the list of upgrade packages.
2.support related document and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceUpgradePackages_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceUpgradePackages_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceUpgradePackages_basic
=== PAUSE TestAccDataSourceUpgradePackages_basic
=== CONT  TestAccDataSourceUpgradePackages_basic
--- PASS: TestAccDataSourceUpgradePackages_basic (102.93s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     102.991s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceUpgradePackages_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceUpgradePackages_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceUpgradePackages_derived
=== PAUSE TestAccDataSourceUpgradePackages_derived
=== CONT  TestAccDataSourceUpgradePackages_derived
--- PASS: TestAccDataSourceUpgradePackages_derived (95.89s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     95.968s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
