### PR TITLE
feat(GaussDBforMySQL): add gaussdb mysql scheduled task delete resource

### DIFF
--- a/docs/resources/gaussdb_mysql_scheduled_task_delete.md
+++ b/docs/resources/gaussdb_mysql_scheduled_task_delete.md
@@ -1,0 +1,44 @@
+---
+subcategory: "GaussDB(for MySQL)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_mysql_scheduled_task_delete"
+description: |-
+  Manages a GaussDB MySQL scheduled task delete resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_mysql_scheduled_task_delete
+
+Manages a GaussDB MySQL scheduled task delete resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource for operating the API.
+Deleting this resource will not clear the corresponding request record,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "job_id" {}
+
+resource "huaweicloud_gaussdb_mysql_scheduled_task_delete" "test" {
+  instance_id = var.instance_id
+  job_id      = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the instance ID. Changing this parameter will create a new resource.
+
+* `job_id` - (Required, String, ForceNew) Specifies the task ID. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is `job_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1591,6 +1591,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_recycling_policy":           gaussdb.ResourceGaussDBRecyclingPolicy(),
 			"huaweicloud_gaussdb_mysql_quota":                      gaussdb.ResourceGaussDBMysqlQuota(),
 			"huaweicloud_gaussdb_mysql_scheduled_task_cancel":      gaussdb.ResourceGaussDBScheduledTaskCancel(),
+			"huaweicloud_gaussdb_mysql_scheduled_task_delete":      gaussdb.ResourceGaussDBScheduledTaskDelete(),
 
 			"huaweicloud_gaussdb_opengauss_instance": gaussdb.ResourceOpenGaussInstance(),
 			"huaweicloud_gaussdb_opengauss_database": gaussdb.ResourceOpenGaussDatabase(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -165,6 +165,7 @@ var (
 	HW_GAUSSDB_MYSQL_INSTANCE_CONFIGURATION_ID = os.Getenv("HW_GAUSSDB_MYSQL_INSTANCE_CONFIGURATION_ID")
 	HW_GAUSSDB_MYSQL_BACKUP_BEGIN_TIME         = os.Getenv("HW_GAUSSDB_MYSQL_BACKUP_BEGIN_TIME")
 	HW_GAUSSDB_MYSQL_BACKUP_END_TIME           = os.Getenv("HW_GAUSSDB_MYSQL_BACKUP_END_TIME")
+	HW_GAUSSDB_MYSQL_JOB_ID                    = os.Getenv("HW_GAUSSDB_MYSQL_JOB_ID")
 
 	HW_VOD_WATERMARK_FILE   = os.Getenv("HW_VOD_WATERMARK_FILE")
 	HW_VOD_MEDIA_ASSET_FILE = os.Getenv("HW_VOD_MEDIA_ASSET_FILE")
@@ -1210,6 +1211,13 @@ func TestAccPreCheckGaussDBMysqlBackupBeginTime(t *testing.T) {
 func TestAccPreCheckGaussDBMysqlBackupEndTime(t *testing.T) {
 	if HW_GAUSSDB_MYSQL_BACKUP_END_TIME == "" {
 		t.Skip("HW_GAUSSDB_MYSQL_BACKUP_END_TIME must be set for GaussDB MySQL acceptance tests.")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckGaussDBMysqlJobId(t *testing.T) {
+	if HW_GAUSSDB_MYSQL_JOB_ID == "" {
+		t.Skip("HW_GAUSSDB_MYSQL_JOB_ID must be set for GaussDB MySQL acceptance tests.")
 	}
 }
 

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_scheduled_task_delete_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_scheduled_task_delete_test.go
@@ -1,0 +1,36 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGaussDBMysqlInstanceScheduledTaskDelete_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBMysqlInstanceId(t)
+			acceptance.TestAccPreCheckGaussDBMysqlJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBMysqlInstanceScheduledTaskDelete_basic(),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func testAccGaussDBMysqlInstanceScheduledTaskDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_mysql_scheduled_task_delete" "test" {
+  instance_id = "%[1]s"
+  job_id      = "%[2]s"
+}`, acceptance.HW_GAUSSDB_MYSQL_INSTANCE_ID, acceptance.HW_GAUSSDB_MYSQL_JOB_ID)
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_scheduled_task_delete.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_scheduled_task_delete.go
@@ -1,0 +1,98 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforMySQL DELETE /v3/{project_id}/instance/{instance_id}/scheduled-jobs
+func ResourceGaussDBScheduledTaskDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGaussDBMysqlScheduledTaskDeleteCreate,
+		ReadContext:   resourceGaussDBMysqlScheduledTaskDeleteRead,
+		DeleteContext: resourceGaussDBMysqlScheduledTaskDeleteDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGaussDBMysqlScheduledTaskDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instance/{instance_id}/scheduled-jobs"
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	instanceId := d.Get("instance_id").(string)
+	jobId := d.Get("job_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{instance_id}", instanceId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	createOpt.JSONBody = utils.RemoveNil(buildCreateGaussDBMySQLScheduledTaskDeleteBodyParams(jobId))
+
+	_, err = client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error deleting GaussDB MySQL(%s) scheduled task(%s): %s", instanceId, jobId, err)
+	}
+
+	d.SetId(jobId)
+
+	return nil
+}
+
+func buildCreateGaussDBMySQLScheduledTaskDeleteBodyParams(jobId string) map[string]interface{} {
+	bodyParams := map[string]interface{}{
+		"job_id": jobId,
+	}
+	return bodyParams
+}
+
+func resourceGaussDBMysqlScheduledTaskDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGaussDBMysqlScheduledTaskDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GaussDB MySQL scheduled task delete resource is not supported. The GaussDB MySQL scheduled " +
+		"task delete resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb mysql scheduled task delete resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb mysql scheduled task delete resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBMysqlInstanceScheduledTaskDelete_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBMysqlInstanceScheduledTaskDelete_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBMysqlInstanceScheduledTaskDelete_basic
=== PAUSE TestAccGaussDBMysqlInstanceScheduledTaskDelete_basic
=== CONT  TestAccGaussDBMysqlInstanceScheduledTaskDelete_basic
--- PASS: TestAccGaussDBMysqlInstanceScheduledTaskDelete_basic (11.61s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   11.659s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
