### PR TITLE
feat(RAM): support new datasource to query resource share associations

### DIFF
--- a/docs/data-sources/ram_resource_share_associations.md
+++ b/docs/data-sources/ram_resource_share_associations.md
@@ -1,0 +1,72 @@
+---
+subcategory: "Resource Access Manager (RAM)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_ram_resource_share_associations"
+description: |-
+  Use this data source to get the list of principals and resources associated with the RAM shared resources.
+---
+
+# huaweicloud_ram_resource_share_associations
+
+Use this data source to get the list of principals and resources associated with the RAM shared resources.
+
+## Example Usage
+
+```hcl
+variable "association_type" {}
+
+data "huaweicloud_ram_resource_share_associations" "test" {
+  association_type = var.association_type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `association_type` - (Required, String) Specifies the association type. Valid values are **principal** and **resource**.
+
+* `principal` - (Optional, String) Specifies the principal associated with the resource share.
+
+* `resource_urn` - (Optional, String) Specifies the URN of the resource associated with the resource share.
+
+* `resource_share_ids` - (Optional, List) Specifies the list of resource share IDs.
+
+* `resource_ids` - (Optional, List) Specifies the list of resource IDs.
+
+* `status` - (Optional, String) Specifies the status of the association.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `associations` - The list of association details.
+
+  The [associations](#associations_struct) structure is documented below.
+
+<a name="associations_struct"></a>
+The `associations` block supports:
+
+* `associated_entity` - The associated entity. It can be the resource URN, account ID, URN of the root OU, or URN of
+  another OU.
+
+* `created_at` - The time when the association was created.
+
+* `status` - The status of the association.
+
+* `status_message` - The description of the status to the association.
+
+* `association_type` - The entity type in the association.
+
+* `updated_at` - The time when the association was last updated.
+
+* `external` - Whether the principle is in the same organization as the resource owner.
+
+* `resource_share_id` - ID of the resource share.
+
+* `resource_share_name` - Name of the resource share.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -895,10 +895,11 @@ func Provider() *schema.Provider {
 			"huaweicloud_obs_buckets":       obs.DataSourceObsBuckets(),
 			"huaweicloud_obs_bucket_object": obs.DataSourceObsBucketObject(),
 
-			"huaweicloud_ram_resource_permissions":       ram.DataSourceRAMPermissions(),
-			"huaweicloud_ram_resource_share_invitations": ram.DataSourceResourceShareInvitations(),
-			"huaweicloud_ram_shared_resources":           ram.DataSourceRAMSharedResources(),
-			"huaweicloud_ram_shared_principals":          ram.DataSourceRAMSharedPrincipals(),
+			"huaweicloud_ram_resource_permissions":        ram.DataSourceRAMPermissions(),
+			"huaweicloud_ram_resource_share_invitations":  ram.DataSourceResourceShareInvitations(),
+			"huaweicloud_ram_shared_resources":            ram.DataSourceRAMSharedResources(),
+			"huaweicloud_ram_shared_principals":           ram.DataSourceRAMSharedPrincipals(),
+			"huaweicloud_ram_resource_share_associations": ram.DataSourceShareAssociations(),
 
 			"huaweicloud_rds_flavors":                         rds.DataSourceRdsFlavor(),
 			"huaweicloud_rds_engine_versions":                 rds.DataSourceRdsEngineVersionsV3(),

--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -999,6 +999,14 @@ func TestAccPreCheckRAM(t *testing.T) {
 }
 
 // lintignore:AT003
+func TestAccPreCheckRAMResourceShare(t *testing.T) {
+	if HW_RAM_SHARE_ACCOUNT_ID == "" || HW_RAM_SHARE_RESOURCE_URN == "" {
+		t.Skip("HW_RAM_SHARE_ACCOUNT_ID and HW_RAM_SHARE_RESOURCE_URN " +
+			"must be set for create ram resource tests.")
+	}
+}
+
+// lintignore:AT003
 func TestAccPreCheckRAMEnableFlag(t *testing.T) {
 	if HW_RAM_ENABLE_FLAG == "" {
 		t.Skip("Skip the RAM acceptance tests.")

--- a/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_resource_share_associations_test.go
+++ b/huaweicloud/services/acceptance/ram/data_source_huaweicloud_ram_resource_share_associations_test.go
@@ -1,0 +1,194 @@
+package ram
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceAssociations_basic(t *testing.T) {
+	var (
+		rName = acceptance.RandomAccResourceName()
+
+		dataSourcePrincipal = "data.huaweicloud_ram_resource_share_associations.test_principal"
+		dcTestPrincipal     = acceptance.InitDataSourceCheck(dataSourcePrincipal)
+
+		dataSourceResource = "data.huaweicloud_ram_resource_share_associations.test_resource"
+		dcTestResource     = acceptance.InitDataSourceCheck(dataSourceResource)
+
+		byPrincipal   = "data.huaweicloud_ram_resource_share_associations.filter_by_principal"
+		dcByPrincipal = acceptance.InitDataSourceCheck(byPrincipal)
+
+		byResourceShareIds   = "data.huaweicloud_ram_resource_share_associations.filter_by_resource_share_ids"
+		dcByResourceShareIds = acceptance.InitDataSourceCheck(byResourceShareIds)
+
+		byResourceUrn   = "data.huaweicloud_ram_resource_share_associations.filter_by_resource_urn"
+		dcByResourceUrn = acceptance.InitDataSourceCheck(byResourceUrn)
+
+		byStatus   = "data.huaweicloud_ram_resource_share_associations.filter_by_status"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckRAMResourceShare(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAssociations_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dcTestPrincipal.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourcePrincipal, "associations.#"),
+					resource.TestCheckResourceAttrSet(dataSourcePrincipal, "associations.0.associated_entity"),
+					resource.TestCheckResourceAttrSet(dataSourcePrincipal, "associations.0.association_type"),
+					resource.TestCheckResourceAttrSet(dataSourcePrincipal, "associations.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourcePrincipal, "associations.0.external"),
+					resource.TestCheckResourceAttrSet(dataSourcePrincipal, "associations.0.resource_share_id"),
+					resource.TestCheckResourceAttrSet(dataSourcePrincipal, "associations.0.resource_share_name"),
+					resource.TestCheckResourceAttrSet(dataSourcePrincipal, "associations.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourcePrincipal, "associations.0.updated_at"),
+
+					dcTestResource.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceResource, "associations.#"),
+					resource.TestCheckResourceAttrSet(dataSourceResource, "associations.0.associated_entity"),
+					resource.TestCheckResourceAttrSet(dataSourceResource, "associations.0.association_type"),
+					resource.TestCheckResourceAttrSet(dataSourceResource, "associations.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceResource, "associations.0.external"),
+					resource.TestCheckResourceAttrSet(dataSourceResource, "associations.0.resource_share_id"),
+					resource.TestCheckResourceAttrSet(dataSourceResource, "associations.0.resource_share_name"),
+					resource.TestCheckResourceAttrSet(dataSourceResource, "associations.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceResource, "associations.0.updated_at"),
+
+					dcByPrincipal.CheckResourceExists(),
+					resource.TestCheckOutput("is_principal_filter_useful", "true"),
+
+					dcByResourceShareIds.CheckResourceExists(),
+					resource.TestCheckOutput("is_resource_share_ids_filter_useful", "true"),
+
+					dcByResourceUrn.CheckResourceExists(),
+					resource.TestCheckOutput("is_resource_urn_filter_useful", "true"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAssociations_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+# Filter by principal association type. Field association_type is required.
+data "huaweicloud_ram_resource_share_associations" "test_principal" {
+  depends_on = [huaweicloud_ram_resource_share.test]
+
+  association_type = "principal"
+}
+
+# Filter by resource association type. Field association_type is required.
+data "huaweicloud_ram_resource_share_associations" "test_resource" {
+  depends_on = [huaweicloud_ram_resource_share.test]
+
+  association_type = "resource"
+}
+
+# Filter by principal
+locals {
+  principal = data.huaweicloud_ram_resource_share_associations.test_principal.associations[0].associated_entity
+}
+
+data "huaweicloud_ram_resource_share_associations" "filter_by_principal" {
+  depends_on = [huaweicloud_ram_resource_share.test]
+
+  association_type = "principal"
+  principal        = local.principal
+}
+
+locals {
+  principal_filter_result = [
+    for v in data.huaweicloud_ram_resource_share_associations.filter_by_principal.associations[*].associated_entity :
+    v == local.principal
+  ]
+}
+
+output "is_principal_filter_useful" {
+  value = length(local.principal_filter_result) > 0 && alltrue(local.principal_filter_result)
+}
+
+# Filter by resource_share_ids
+locals {
+  resource_share_ids = split(",",
+  data.huaweicloud_ram_resource_share_associations.test_principal.associations[0].resource_share_id)
+}
+
+data "huaweicloud_ram_resource_share_associations" "filter_by_resource_share_ids" {
+  depends_on = [huaweicloud_ram_resource_share.test]
+
+  association_type   = "principal"
+  resource_share_ids = local.resource_share_ids
+}
+
+locals {
+  resource_share_ids_filter_result = [
+    for v in data.huaweicloud_ram_resource_share_associations.filter_by_resource_share_ids.associations[*].
+    resource_share_id : contains(local.resource_share_ids, v)
+  ]
+}
+
+output "is_resource_share_ids_filter_useful" {
+  value = length(local.resource_share_ids_filter_result) > 0 && alltrue(local.resource_share_ids_filter_result)
+}
+
+# Filter by resource_urn
+locals {
+  resource_urn = data.huaweicloud_ram_resource_share_associations.test_resource.associations[0].associated_entity
+}
+
+data "huaweicloud_ram_resource_share_associations" "filter_by_resource_urn" {
+  depends_on = [huaweicloud_ram_resource_share.test]
+
+  association_type = "resource"
+  resource_urn     = local.resource_urn
+}
+
+locals {
+  resource_urn_filter_result = [
+    for v in data.huaweicloud_ram_resource_share_associations.filter_by_resource_urn.associations[*].associated_entity :
+    v == local.resource_urn
+  ]
+}
+
+output "is_resource_urn_filter_useful" {
+  value = length(local.resource_urn_filter_result) > 0 && alltrue(local.resource_urn_filter_result)
+}
+
+# Filter by status
+locals {
+  status = data.huaweicloud_ram_resource_share_associations.test_resource.associations[0].status
+}
+
+data "huaweicloud_ram_resource_share_associations" "filter_by_status" {
+  depends_on = [huaweicloud_ram_resource_share.test]
+
+  association_type = "resource"
+  status           = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_ram_resource_share_associations.filter_by_status.associations[*].status : v == local.status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = length(local.status_filter_result) > 0 && alltrue(local.status_filter_result)
+}
+`, testRAMShare_basic(name))
+}

--- a/huaweicloud/services/ram/data_source_huaweicloud_ram_resource_share_associations.go
+++ b/huaweicloud/services/ram/data_source_huaweicloud_ram_resource_share_associations.go
@@ -1,0 +1,213 @@
+package ram
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API RAM POST /v1/resource-share-associations/search
+func DataSourceShareAssociations() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceShareAssociationsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `Specifies the region in which to query the resource. If omitted, the provider-level region will be used.`,
+			},
+			"association_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the association type.`,
+			},
+			"principal": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the principal associated with the resource share.`,
+			},
+			"resource_urn": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the URN of the resource associated with the resource share.`,
+			},
+			"resource_share_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the list of resource share IDs.`,
+			},
+			// This filter field was not tested due to lack of test environment.
+			"resource_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `Specifies the list of resource IDs.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the status of the association.`,
+			},
+			"associations": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The list of association details.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"associated_entity": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The associated entity.`,
+						},
+						"created_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the association was created.`,
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The status of the association.`,
+						},
+						"status_message": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The description of the status to the association.`,
+						},
+						"association_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The entity type in the association.`,
+						},
+						"updated_at": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The time when the association was last updated.`,
+						},
+						"external": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: `Whether the principle is in the same organization as the resource owner.`,
+						},
+						"resource_share_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `ID of the resource share.`,
+						},
+						"resource_share_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Name of the resource share.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildShareAssociationsBodyParams The default limit value for paging query is `200`, so the limit value is not
+// configured here.
+func buildShareAssociationsBodyParams(d *schema.ResourceData, nextMarker string) map[string]interface{} {
+	requestParams := map[string]interface{}{
+		"association_type":   d.Get("association_type"),
+		"principal":          utils.ValueIgnoreEmpty(d.Get("principal")),
+		"resource_urn":       utils.ValueIgnoreEmpty(d.Get("resource_urn")),
+		"resource_share_ids": utils.ValueIgnoreEmpty(d.Get("resource_share_ids")),
+		"resource_ids":       utils.ValueIgnoreEmpty(d.Get("resource_ids")),
+		"association_status": utils.ValueIgnoreEmpty(d.Get("status")),
+	}
+
+	if nextMarker != "" {
+		requestParams["marker"] = nextMarker
+	}
+	return requestParams
+}
+
+func dataSourceShareAssociationsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg               = meta.(*config.Config)
+		region            = cfg.GetRegion(d)
+		mErr              *multierror.Error
+		nextMarker        string
+		httpUrl           = "v1/resource-share-associations/search"
+		product           = "ram"
+		totalAssociations []interface{}
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating RAM client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	for {
+		requestOpt.JSONBody = utils.RemoveNil(buildShareAssociationsBodyParams(d, nextMarker))
+		resp, err := client.Request("POST", requestPath, &requestOpt)
+		if err != nil {
+			return diag.Errorf("error retrieving RAM resource share associations: %s", err)
+		}
+
+		respBody, err := utils.FlattenResponse(resp)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		associations := utils.PathSearch("resource_share_associations", respBody, make([]interface{}, 0)).([]interface{})
+		if len(associations) > 0 {
+			totalAssociations = append(totalAssociations, associations...)
+		}
+
+		nextMarker = utils.PathSearch("page_info.next_marker", respBody, "").(string)
+		if nextMarker == "" {
+			break
+		}
+	}
+
+	generateUUID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(generateUUID)
+
+	mErr = multierror.Append(
+		mErr,
+		d.Set("region", region),
+		d.Set("associations", flattenResourceShareAssociations(totalAssociations)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenResourceShareAssociations(totalAssociations []interface{}) []interface{} {
+	rst := make([]interface{}, 0, len(totalAssociations))
+	for _, v := range totalAssociations {
+		rst = append(rst, map[string]interface{}{
+			"associated_entity":   utils.PathSearch("associated_entity", v, nil),
+			"created_at":          utils.PathSearch("created_at", v, nil),
+			"status":              utils.PathSearch("status", v, nil),
+			"status_message":      utils.PathSearch("status_message", v, nil),
+			"association_type":    utils.PathSearch("association_type", v, nil),
+			"updated_at":          utils.PathSearch("updated_at", v, nil),
+			"external":            utils.PathSearch("external", v, nil),
+			"resource_share_id":   utils.PathSearch("resource_share_id", v, nil),
+			"resource_share_name": utils.PathSearch("resource_share_name", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support new datasource to query resource share associations.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/ram' TESTARGS='-run TestAccDataSourceAssociations_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ram -v -run TestAccDataSourceAssociations_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAssociations_basic
=== PAUSE TestAccDataSourceAssociations_basic
=== CONT  TestAccDataSourceAssociations_basic
--- PASS: TestAccDataSourceAssociations_basic (8.96s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ram       9.004s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
