### PR TITLE
feat(iotda): the space resource supports new API

### DIFF
--- a/docs/resources/iotda_space.md
+++ b/docs/resources/iotda_space.md
@@ -2,7 +2,8 @@
 subcategory: "IoT Device Access (IoTDA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_iotda_space"
-description: ""
+description: -|
+  Manages an IoTDA resource space within HuaweiCloud.
 ---
 
 # huaweicloud_iotda_space
@@ -12,6 +13,8 @@ Manages an IoTDA resource space within HuaweiCloud.
 A resource space is the basic unit of service management and provides independent device management and platform
 configuration capabilities at the service layer. Resources (such as products and devices) must be created on
 a resource space.
+
+-> The **basic** edition instance does not support updating the resource.
 
 -> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify
   the IoTDA service endpoint in `provider` block.
@@ -31,8 +34,10 @@ a resource space.
 ## Example Usage
 
 ```hcl
-resource "huaweicloud_iotda_space" "space" {
-  name = "first_space"
+variable "name" {}
+
+resource "huaweicloud_iotda_space" "test" {
+  name = var.name
 }
 ```
 
@@ -43,9 +48,8 @@ The following arguments are supported:
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the IoTDA resource space resource.
 If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
 
-* `name` - (Required, String, ForceNew) Specifies the space name. The name contains a maximum of `64` characters.
+* `name` - (Required, String) Specifies the space name. The name contains a maximum of `64` characters.
 Only letters, digits, hyphens (-), underscore (_) and the following special characters are allowed: `?'#().,&%@!`.
-Changing this parameter will create a new resource.
 
 ## Attribute Reference
 
@@ -58,8 +62,8 @@ a default resource space (undeletable) to your account.
 
 ## Import
 
-Spaces can be imported using the `id`, e.g.
+The resource can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_iotda_space.test 10022532f4f94f26b01daa1e424853e1
+$ terraform import huaweicloud_iotda_space.test <id>
 ```

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_space_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_space_test.go
@@ -60,6 +60,7 @@ func TestAccSpace_derived(t *testing.T) {
 	var obj model.ShowApplicationRequest
 
 	name := acceptance.RandomAccResourceName()
+	updatename := acceptance.RandomAccResourceName()
 	rName := "huaweicloud_iotda_space.test"
 
 	rc := acceptance.InitResourceCheck(
@@ -82,6 +83,13 @@ func TestAccSpace_derived(t *testing.T) {
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name),
 					resource.TestCheckResourceAttr(rName, "is_default", "false"),
+				),
+			},
+			{
+				Config: testSpace_basic(updatename),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updatename),
 				),
 			},
 			{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The space resource supports new API (update API).

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
The space resource supports update space name.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccSpace_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccSpace_derived -timeout 360m -parallel 4
=== RUN   TestAccSpace_derived
--- PASS: TestAccSpace_derived (31.94s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     32.002s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
