### PR TITLE
feat(ELB): elb loadbalancer support update enterprise project id

### DIFF
--- a/docs/resources/elb_loadbalancer.md
+++ b/docs/resources/elb_loadbalancer.md
@@ -222,8 +222,7 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the load balancer.
 
-* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the load balancer. Changing this
-  creates a new load balancer.
+* `enterprise_project_id` - (Optional, String) The enterprise project id of the load balancer.
 
 * `charging_mode` - (Optional, String) Specifies the charging mode of the ELB load balancer.
   Valid values are **prePaid** and **postPaid**, defaults to **postPaid**.

--- a/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_loadbalancer_test.go
+++ b/huaweicloud/services/acceptance/elb/resource_huaweicloud_elb_loadbalancer_test.go
@@ -147,7 +147,15 @@ func TestAccElbV3LoadBalancer_withEpsId(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccElbV3LoadBalancerConfig_withEpsId(rName),
+				Config: testAccElbV3LoadBalancerConfig_withEpsId(rName, "0"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", "0"),
+				),
+			},
+			{
+				Config: testAccElbV3LoadBalancerConfig_withEpsId(rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
@@ -607,7 +615,7 @@ resource "huaweicloud_elb_loadbalancer" "test" {
 `, common.TestVpc(rName), rName, deletionProtection)
 }
 
-func testAccElbV3LoadBalancerConfig_withEpsId(rName string) string {
+func testAccElbV3LoadBalancerConfig_withEpsId(rName, enterpriseProjectId string) string {
 	return fmt.Sprintf(`
 data "huaweicloud_vpc_subnet" "test" {
   name = "subnet-default"
@@ -616,9 +624,9 @@ data "huaweicloud_vpc_subnet" "test" {
 data "huaweicloud_availability_zones" "test" {}
 
 resource "huaweicloud_elb_loadbalancer" "test" {
-  name                  = "%s"
+  name                  = "%[1]s"
   ipv4_subnet_id        = data.huaweicloud_vpc_subnet.test.ipv4_subnet_id
-  enterprise_project_id = "%s"
+  enterprise_project_id = "%[2]s"
 
   availability_zone = [
     data.huaweicloud_availability_zones.test.names[0]
@@ -629,7 +637,7 @@ resource "huaweicloud_elb_loadbalancer" "test" {
     owner = "terraform"
   }
 }
-`, rName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
+`, rName, enterpriseProjectId)
 }
 
 func testAccElbV3LoadBalancerConfig_withEIP(rName string) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  elb loadbalancer support update enterprise project id
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  elb loadbalancer support update enterprise project id
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/elb/ TESTARGS='-run TestAccElbV3LoadBalancer_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/elb/ -v -run TestAccElbV3LoadBalancer_ -timeout 360m -parallel 4
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== RUN   TestAccElbV3LoadBalancer_with_deletion_protection
=== PAUSE TestAccElbV3LoadBalancer_with_deletion_protection
=== RUN   TestAccElbV3LoadBalancer_withEpsId
=== PAUSE TestAccElbV3LoadBalancer_withEpsId
=== RUN   TestAccElbV3LoadBalancer_withEIP
=== PAUSE TestAccElbV3LoadBalancer_withEIP
=== RUN   TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== PAUSE TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
=== RUN   TestAccElbV3LoadBalancer_prePaid
=== PAUSE TestAccElbV3LoadBalancer_prePaid
=== RUN   TestAccElbV3LoadBalancer_availabilityZone
=== PAUSE TestAccElbV3LoadBalancer_availabilityZone
=== RUN   TestAccElbV3LoadBalancer_updateChargingMode
=== PAUSE TestAccElbV3LoadBalancer_updateChargingMode
=== RUN   TestAccElbV3LoadBalancer_withIpv6
=== PAUSE TestAccElbV3LoadBalancer_withIpv6
=== RUN   TestAccElbV3LoadBalancer_gateway
=== PAUSE TestAccElbV3LoadBalancer_gateway
=== CONT  TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_prePaid
=== CONT  TestAccElbV3LoadBalancer_withIpv6
=== CONT  TestAccElbV3LoadBalancer_withEIP
--- PASS: TestAccElbV3LoadBalancer_withEIP (50.21s)
=== CONT  TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id
--- PASS: TestAccElbV3LoadBalancer_withIpv6 (95.24s)
=== CONT  TestAccElbV3LoadBalancer_withEpsId
--- PASS: TestAccElbV3LoadBalancer_withEIP_Bandwidth_Id (63.32s)
=== CONT  TestAccElbV3LoadBalancer_with_deletion_protection
--- PASS: TestAccElbV3LoadBalancer_withEpsId (84.34s)
=== CONT  TestAccElbV3LoadBalancer_updateChargingMode
--- PASS: TestAccElbV3LoadBalancer_basic (192.38s)
=== CONT  TestAccElbV3LoadBalancer_availabilityZone
--- PASS: TestAccElbV3LoadBalancer_with_deletion_protection (151.28s)
=== CONT  TestAccElbV3LoadBalancer_gateway
    acceptance.go:2205: HW_ELB_GATEWAY_TYPE must be set for the acceptance test
--- SKIP: TestAccElbV3LoadBalancer_gateway (0.10s)
--- PASS: TestAccElbV3LoadBalancer_prePaid (311.25s)
--- PASS: TestAccElbV3LoadBalancer_availabilityZone (159.26s)
--- PASS: TestAccElbV3LoadBalancer_updateChargingMode (243.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/elb       423.085s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
