### PR TITLE
feat(iotda): the upgrade package resource supports sign field

### DIFF
--- a/docs/resources/iotda_upgrade_package.md
+++ b/docs/resources/iotda_upgrade_package.md
@@ -2,7 +2,8 @@
 subcategory: "IoT Device Access (IoTDA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_iotda_upgrade_package"
-description: ""
+description: -|
+  Manages an IoTDA OTA upgrade package within HuaweiCloud.
 ---
 
 # huaweicloud_iotda_upgrade_package
@@ -113,6 +114,13 @@ The `obs_location` block supports:
   including the folder path. The maximum size of OBS objects is **1GB**, and only supports files in **.bin**, **.dav**,
   **.tar**, **.gz**, **.zip**, **.gzip**, **.apk**, **.ta.gz**, **.tar.xz**, **.pack**, **.exe**, **.bat** and **.img**
   formats. The valid length is limited from `1` to `1024`.
+  Changing this parameter will create a new resource.
+
+* `sign` - (Optional, String, ForceNew) Specifies the signature value of the upgrade package calculated by SHA256 algorithm.
+  After added the upgrade package and created the upgrade task, when the IoT platform issues an upgrade notification to the
+  device, it will send the signature to the device.
+  The valid length is `64`, only letters `a(A)` to `f(F)` and digits are allowed.
+
   Changing this parameter will create a new resource.
 
 ## Attribute Reference

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_upgrade_package_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_upgrade_package_test.go
@@ -65,6 +65,8 @@ func TestAccUpgradePackage_basic(t *testing.T) {
 						"huaweicloud_obs_bucket_object.test", "bucket"),
 					resource.TestCheckResourceAttrPair(resourceName, "file_location.0.obs_location.0.object_key",
 						"huaweicloud_obs_bucket_object.test", "key"),
+					resource.TestCheckResourceAttr(resourceName, "file_location.0.obs_location.0.sign",
+						"0d6afb7e939f0936f40afdc759b5a354ea5427ec250a47e7b904ab1ea800a01d"),
 					resource.TestCheckResourceAttr(resourceName, "support_source_versions.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description test"),
 					resource.TestCheckResourceAttr(resourceName, "custom_info", "custom_info test"),
@@ -113,6 +115,8 @@ func TestAccUpgradePackage_derived(t *testing.T) {
 						"huaweicloud_obs_bucket_object.test", "bucket"),
 					resource.TestCheckResourceAttrPair(resourceName, "file_location.0.obs_location.0.object_key",
 						"huaweicloud_obs_bucket_object.test", "key"),
+					resource.TestCheckResourceAttr(resourceName, "file_location.0.obs_location.0.sign",
+						"0d6afb7e939f0936f40afdc759b5a354ea5427ec250a47e7b904ab1ea800a01d"),
 					resource.TestCheckResourceAttr(resourceName, "support_source_versions.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "description", "description test"),
 					resource.TestCheckResourceAttr(resourceName, "custom_info", "custom_info test"),
@@ -162,6 +166,7 @@ resource "huaweicloud_iotda_upgrade_package" "test" {
       region      = "%[3]s"
       bucket_name = huaweicloud_obs_bucket_object.test.bucket
       object_key  = huaweicloud_obs_bucket_object.test.key
+      sign        = "0d6afb7e939f0936f40afdc759b5a354ea5427ec250a47e7b904ab1ea800a01d"
     }
   }
 

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_upgrade_package.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_upgrade_package.go
@@ -83,6 +83,12 @@ func ResourceUpgradePackage() *schema.Resource {
 										Required: true,
 										ForceNew: true,
 									},
+									"sign": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
 								},
 							},
 						},
@@ -119,6 +125,7 @@ func buildObsLocationParam(raw interface{}) *model.ObsLocation {
 		RegionName: obsLocationMap["region"].(string),
 		BucketName: obsLocationMap["bucket_name"].(string),
 		ObjectKey:  obsLocationMap["object_key"].(string),
+		Sign:       utils.StringIgnoreEmpty(obsLocationMap["sign"].(string)),
 	}
 
 	return &obsLocationParam
@@ -236,6 +243,7 @@ func flattenObsLocation(resp *model.ObsLocation) []interface{} {
 			"region":      resp.RegionName,
 			"bucket_name": resp.BucketName,
 			"object_key":  resp.ObjectKey,
+			"sign":        resp.Sign,
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The upgrade package resource supports sign field.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccUpgradePackage_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccUpgradePackage_basic -timeout 360m -parallel 4
=== RUN   TestAccUpgradePackage_basic
--- PASS: TestAccUpgradePackage_basic (58.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     58.942s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccUpgradePackage_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccUpgradePackage_derived -timeout 360m -parallel 4
=== RUN   TestAccUpgradePackage_derived
--- PASS: TestAccUpgradePackage_derived (57.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     57.453s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
