### PR TITLE
feat(iotda): support device proxy resource

### DIFF
--- a/docs/resources/iotda_device_proxy.md
+++ b/docs/resources/iotda_device_proxy.md
@@ -1,0 +1,89 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_product"
+description: -|
+  Manages an IoTDA device proxy resource within HuaweiCloud.
+---
+
+# huaweicloud_iotda_product
+
+Manages an IoTDA device proxy resource within HuaweiCloud.
+
+-> Currently, device proxy resources are only supported on IoTDA **standard** or **enterprise** edition instance.
+  When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify
+  the IoTDA service endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  *9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com*, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "space_id" {}
+variable "name" {}
+variable "devices" {}
+variable "start_time" {}
+variable "end_time" {}
+
+resource "huaweicloud_iotda_device_proxy" "test" {
+  space_id = var.space_id
+  name     = var.name
+  devices  = var.devices
+
+  effective_time_range {
+    start_time = var.start_time
+    end_time   = var.end_time
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `space_id` - (Required, String, ForceNew) Specifies the resource space ID to which the device proxy belongs.
+
+* `name` - (Required, String) Specifies the device proxy name. The valid length is limited from `1` to `64`.
+
+* `devices` - (Required, List) Specifies the list of proxy device IDs. The number of IDs in the list is limited from
+  `2` to `10`. All devices in the list share gateway permissions, which means that any sub device under any gateway in
+  the list can go online through any gateway in the group and report data.
+
+* `effective_time_range` - (Required, List) Specifies the validity period of the device proxy rule.
+  The [effective_time_range](#IoTDA_effective_time_range) structure is documented below.
+
+<a name="IoTDA_effective_time_range"></a>
+The `effective_time_range` block supports:
+
+* `start_time` - (Optional, String) Specifies the effective time of the device proxy, using UTC time zone,
+  the format is **yyyyMMdd'T'HHMmmss-Z**. e.g. **20250528T153000Z**.
+
+* `end_time` - (Optional, String) Specifies the device proxy expiration time, must be greater than `start_time`,
+  using UTC time zone, the format is **yyyyMMdd'T'HHMmmss-Z**. e.g. **20250528T153000Z**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Import
+
+The device proxy can be imported using the `id`, e.g.
+
+```bash
+$ terraform import huaweicloud_iotda_device_proxy.test <id>
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1674,6 +1674,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_device_linkage_rule": iotda.ResourceDeviceLinkageRule(),
 			"huaweicloud_iotda_upgrade_package":     iotda.ResourceUpgradePackage(),
 			"huaweicloud_iotda_batchtask":           iotda.ResourceBatchTask(),
+			"huaweicloud_iotda_device_proxy":        iotda.ResourceDeviceProxy(),
 
 			"huaweicloud_kms_data_encrypt_decrypt": dew.ResourceKmsDataEncryptDecrypt(),
 			"huaweicloud_kms_key":                  dew.ResourceKmsKey(),

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_proxy_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_proxy_test.go
@@ -1,0 +1,135 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDeviceProxyResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.HcIoTdaV5Client(acceptance.HW_REGION_NAME, WithDerivedAuth())
+	if err != nil {
+		return nil, fmt.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	return client.ShowDeviceProxy(&model.ShowDeviceProxyRequest{ProxyId: state.Primary.ID})
+}
+
+func TestAccDeviceProxy_basic(t *testing.T) {
+	var (
+		obj   model.ShowDeviceProxyResponse
+		name  = acceptance.RandomAccResourceName()
+		rName = "huaweicloud_iotda_device_proxy.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceProxyResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// This resource only supports standard and enterprise version IoTDA instances.
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeviceProxy_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "devices.#", "2"),
+					resource.TestCheckResourceAttr(rName, "effective_time_range.0.start_time", "20881010T121212Z"),
+					resource.TestCheckResourceAttr(rName, "effective_time_range.0.end_time", "20881015T121212Z"),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+				),
+			},
+			{
+				Config: testDeviceProxy_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "devices.#", "3"),
+					resource.TestCheckResourceAttr(rName, "effective_time_range.0.start_time", "20991010T121212Z"),
+					resource.TestCheckResourceAttr(rName, "effective_time_range.0.end_time", "20991015T121212Z"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testDeviceProxy_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_device" "test" {
+  count = 3
+
+  node_id    = format("%[2]s_%%d", count.index)
+  name       = format("%[2]s_%%d", count.index)
+  space_id   = huaweicloud_iotda_space.test.id
+  product_id = huaweicloud_iotda_product.test.id
+}
+
+resource "huaweicloud_iotda_device_proxy" "test" {
+  depends_on = [
+    huaweicloud_iotda_device.test
+  ]
+
+  space_id = huaweicloud_iotda_space.test.id
+  name     = "%[2]s"
+  devices  = slice(huaweicloud_iotda_device.test[*].id, 0, 2)
+
+  effective_time_range {
+    start_time = "20881010T121212Z"
+    end_time   = "20881015T121212Z"
+  }
+}
+`, testProduct_basic(name), name)
+}
+
+func testDeviceProxy_update(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_device" "test" {
+  count = 3
+
+  node_id    = format("%[2]s_%%d", count.index)
+  name       = format("%[2]s_%%d", count.index)
+  space_id   = huaweicloud_iotda_space.test.id
+  product_id = huaweicloud_iotda_product.test.id
+}
+
+resource "huaweicloud_iotda_device_proxy" "test" {
+  depends_on = [
+    huaweicloud_iotda_device.test
+  ]
+
+  space_id = huaweicloud_iotda_space.test.id
+  name     = "%[2]s_update"
+  devices  = slice(huaweicloud_iotda_device.test[*].id, 0, 3)
+
+  effective_time_range {
+    start_time = "20991010T121212Z"
+    end_time   = "20991015T121212Z"
+  }
+}
+`, testProduct_basic(name), name)
+}

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_proxy.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_device_proxy.go
@@ -1,0 +1,227 @@
+package iotda
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA POST /v5/iot/{project_id}/device-proxies
+// @API IoTDA GET /v5/iot/{project_id}/device-proxies/{proxy_id}
+// @API IoTDA PUT /v5/iot/{project_id}/device-proxies/{proxy_id}
+// @API IoTDA DELETE /v5/iot/{project_id}/device-proxies/{proxy_id}
+func ResourceDeviceProxy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDeviceProxyCreate,
+		ReadContext:   resourceDeviceProxyRead,
+		UpdateContext: resourceDeviceProxyUpdate,
+		DeleteContext: resourceDeviceProxyDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"devices": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"effective_time_range": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"start_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"end_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildEffectiveTimeRangeBodyParams(d *schema.ResourceData) *model.EffectiveTimeRange {
+	effectiveTimeRangeMap, ok := d.Get("effective_time_range").([]interface{})[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	return &model.EffectiveTimeRange{
+		StartTime: utils.String(effectiveTimeRangeMap["start_time"].(string)),
+		EndTime:   utils.String(effectiveTimeRangeMap["end_time"].(string)),
+	}
+}
+
+func buildDeviceProxyCreateParams(d *schema.ResourceData) *model.CreateDeviceProxyRequest {
+	createOptsBody := model.AddDeviceProxy{
+		ProxyName:          d.Get("name").(string),
+		ProxyDevices:       utils.ExpandToStringList(d.Get("devices").(*schema.Set).List()),
+		EffectiveTimeRange: buildEffectiveTimeRangeBodyParams(d),
+		AppId:              d.Get("space_id").(string),
+	}
+
+	return &model.CreateDeviceProxyRequest{
+		Body: &createOptsBody,
+	}
+}
+
+func resourceDeviceProxyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	createOpts := buildDeviceProxyCreateParams(d)
+	resp, err := client.CreateDeviceProxy(createOpts)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA device proxy: %s", err)
+	}
+
+	if resp == nil || resp.ProxyId == nil {
+		return diag.Errorf("error creating IoTDA device proxy: ID is not found in API response")
+	}
+
+	d.SetId(*resp.ProxyId)
+
+	return resourceDeviceProxyRead(ctx, d, meta)
+}
+
+func buildDeviceProxyQueryParams(d *schema.ResourceData) *model.ShowDeviceProxyRequest {
+	return &model.ShowDeviceProxyRequest{
+		ProxyId: d.Id(),
+	}
+}
+
+func resourceDeviceProxyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	response, err := client.ShowDeviceProxy(buildDeviceProxyQueryParams(d))
+	// When the resource does not exist, query API will return `404` error code.
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error retrieving IoTDA device proxy")
+	}
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("space_id", response.AppId),
+		d.Set("name", response.ProxyName),
+		d.Set("devices", response.ProxyDevices),
+		d.Set("effective_time_range", flattenEffectiveTimeRange(response.EffectiveTimeRange)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenEffectiveTimeRange(effectiveTimeRangeResp *model.EffectiveTimeRangeResponseDto) []map[string]interface{} {
+	if effectiveTimeRangeResp == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{{
+		"start_time": effectiveTimeRangeResp.StartTime,
+		"end_time":   effectiveTimeRangeResp.EndTime,
+	}}
+}
+
+func buildDeviceProxyUpdateParams(d *schema.ResourceData) *model.UpdateDeviceProxyRequest {
+	updateRequest := model.UpdateDeviceProxyRequest{
+		ProxyId: d.Id(),
+		Body: &model.UpdateDeviceProxy{
+			ProxyName:          utils.String(d.Get("name").(string)),
+			ProxyDevices:       utils.ExpandToStringListPointer(d.Get("devices").(*schema.Set).List()),
+			EffectiveTimeRange: buildEffectiveTimeRangeBodyParams(d),
+		},
+	}
+
+	return &updateRequest
+}
+
+func resourceDeviceProxyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	updateOpts := buildDeviceProxyUpdateParams(d)
+	_, err = client.UpdateDeviceProxy(updateOpts)
+	if err != nil {
+		return diag.Errorf("error updating IoTDA device proxy: %s", err)
+	}
+
+	return resourceDeviceProxyRead(ctx, d, meta)
+}
+
+func buildDeviceProxyDeleteParams(d *schema.ResourceData) *model.DeleteDeviceProxyRequest {
+	return &model.DeleteDeviceProxyRequest{
+		ProxyId: d.Id(),
+	}
+}
+
+func resourceDeviceProxyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	_, err = client.DeleteDeviceProxy(buildDeviceProxyDeleteParams(d))
+	// When the resource does not exist, delete API will return `404` error code.
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "error deleting IoTDA device proxy")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support device proxy resource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support device proxy resource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceProxy_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceProxy_basic -timeout 360m -parallel 4
=== RUN   TestAccDeviceProxy_basic
--- PASS: TestAccDeviceProxy_basic (21.32s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     21.384s

```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
![image](https://github.com/user-attachments/assets/23b3d7a9-fda9-477f-b2fd-b21a642c75a9)

  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
![image](https://github.com/user-attachments/assets/daba2376-283a-4a2f-a91e-83013a030cb6)

