### PR TITLE
feat(iotda/batchtasks): support batch tasks datasource

### DIFF
--- a/docs/data-sources/iotda_batchtasks.md
+++ b/docs/data-sources/iotda_batchtasks.md
@@ -1,0 +1,133 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_batchtasks"
+description: |-
+  Use this data source to get the list of IoTDA batch tasks within HuaweiCloud.
+---
+
+# huaweicloud_iotda_batchtasks
+
+Use this data source to get the list of IoTDA batch tasks within HuaweiCloud.
+
+-> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
+  endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  **9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com**, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "type" {}
+
+data "huaweicloud_iotda_batchtasks" "test" {
+  type = var.type
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the batch tasks.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Required, String) Specifies the type of the batch task.
+  The valid values are as follows:
+  + **createDevices**: Batch create devices task.
+  + **updateDevices**: Batch update devices task.
+  + **deleteDevices**: Batch deletion of devices task.
+  + **freezeDevices**: Batch freeze devices task.
+  + **unfreezeDevices**: Batch unfreeze devices task.
+
+* `space_id` - (Optional, String) Specifies the space ID.
+  If omitted, query all batch tasks under the current instance.
+
+* `status` - (Optional, String) Specifies the status of the batch task.
+  The valid values are as follows:
+  + **Initializing**
+  + **Waitting**
+  + **Processing**
+  + **Success**
+  + **Fail**
+  + **PartialSuccess**
+  + **Stopped**
+  + **Stopping**
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `batchtasks` - All batch tasks that match the filter parameters.
+  The [batchtasks](#iotda_batchtasks) structure is documented below.
+
+<a name="iotda_batchtasks"></a>
+The `batchtasks` block supports:
+
+* `id` - The batch task ID.
+
+* `name` - The batch task name.
+
+* `type` - The batch task type.
+
+* `targets` - The target device ID array for executing the batch task.
+
+* `targets_filter` - The batch task target filtering parameters. Json format, which contains key value pairs and (K, V)
+  format to identify the parameters required for filtering targets. Currently, the supported K format includes
+  group_ids, and the task will select devices that meet the conditions of the group as targets.
+
+* `task_policy` - The task execution strategy.
+  The [task_policy](#iotda_task_policy) structure is documented below.
+
+* `status` - The status of the batch task.
+
+* `status_desc` - The batch task status description, including main task failure error information.
+
+* `task_progress` - The subtask execution statistics results.
+  The [task_progress](#iotda_task_progress) structure is documented below.
+
+* `created_at` - The creation time of the batch task. The format is **yyyyMMdd'T'HHmmss'Z**. e.g. **20190528T153000Z**.
+
+<a name="iotda_task_policy"></a>
+The `task_policy` block supports:
+
+* `schedule_time` - The batch task specifies execution time.
+  The format is **yyyyMMdd'T'HHmmss'Z**. e.g. **20190528T153000Z**.
+  The valid value is within `7` days. If it is empty, it means task will be executed immediately.
+
+* `retry_count` - The automatic retry times for subtasks of batch tasks.
+  The valid value is range form `1` to `5`.
+
+* `retry_interval` - The time interval for automatic retry after a subtask of a batch task fails. Unit in minutes,
+  the valid value is range form `0` to `1,440`, the `0` means no retry.
+
+<a name="iotda_task_progress"></a>
+The `task_progress` block supports:
+
+* `total` - The total number of subtasks.
+
+* `processing` - The number of subtasks currently being executed.
+
+* `success` - The number of successfully executed subtasks.
+
+* `fail` - The number of subtasks that failed to execute.
+
+* `waitting` - The number of subtasks waiting to be executed.
+
+* `fail_wait_retry` - The number of subtasks waiting for retry due to failure.
+
+* `stopped` - The number of stopped subtasks.
+
+* `removed` - The number of subtasks removed.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -828,6 +828,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_iotda_spaces":               iotda.DataSourceSpaces(),
 			"huaweicloud_iotda_products":             iotda.DataSourceProducts(),
 			"huaweicloud_iotda_devices":              iotda.DataSourceDevices(),
+			"huaweicloud_iotda_batchtasks":           iotda.DataSourceBatchTasks(),
 
 			"huaweicloud_koogallery_assets": koogallery.DataSourceKooGalleryAssets(),
 

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_batchtasks_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_batchtasks_test.go
@@ -1,0 +1,115 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceBatchTasks_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_batchtasks.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceBatchTasks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.task_progress.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.created_at"),
+
+					resource.TestCheckOutput("is_space_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceBatchTasks_derived(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_batchtasks.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceBatchTasks_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.task_progress.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "batchtasks.0.created_at"),
+
+					resource.TestCheckOutput("is_space_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceBatchTasks_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_iotda_batchtasks" "test" {
+  type = huaweicloud_iotda_batchtask.test_freeze.type
+}
+
+# Filter using space ID.
+data "huaweicloud_iotda_batchtasks" "space_id_filter" {
+  depends_on = [huaweicloud_iotda_batchtask.test_freeze]
+
+  type     = data.huaweicloud_iotda_batchtasks.test.batchtasks[0].type
+  space_id = huaweicloud_iotda_space.test.id
+}
+
+output "is_space_id_filter_useful" {
+  value = length(data.huaweicloud_iotda_batchtasks.space_id_filter.batchtasks) > 0
+}
+
+# Filter using status.
+locals {
+  status = data.huaweicloud_iotda_batchtasks.test.batchtasks[0].status
+}
+
+data "huaweicloud_iotda_batchtasks" "status_filter" {
+  type   = data.huaweicloud_iotda_batchtasks.test.batchtasks[0].type
+  status = local.status
+}
+
+output "is_status_filter_useful" {
+  value = length(data.huaweicloud_iotda_batchtasks.status_filter.batchtasks) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_batchtasks.status_filter.batchtasks[*].status : v == local.status]
+  )
+}
+`, testBatchTask_basic(name, name))
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_batchtasks.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_batchtasks.go
@@ -1,0 +1,260 @@
+package iotda
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/batchtasks
+func DataSourceBatchTasks() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceBatchTasksRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"batchtasks": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"targets": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"targets_filter": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"task_policy": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"schedule_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"retry_count": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"retry_interval": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status_desc": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"task_progress": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"total": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"processing": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"success": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"fail": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"waitting": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"fail_wait_retry": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"stopped": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"removed": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceBatchTasksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allTasks []model.Task
+		limit    = int32(50)
+		offset   int32
+	)
+
+	for {
+		listOpts := model.ListBatchTasksRequest{
+			AppId:    utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+			TaskType: d.Get("type").(string),
+			Status:   utils.StringIgnoreEmpty(d.Get("status").(string)),
+			Limit:    utils.Int32(limit),
+			Offset:   &offset,
+		}
+
+		listResp, listErr := client.ListBatchTasks(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error querying IoTDA batch tasks: %s", listErr)
+		}
+
+		if listResp == nil || listResp.Batchtasks == nil {
+			break
+		}
+
+		if len(*listResp.Batchtasks) == 0 {
+			break
+		}
+
+		allTasks = append(allTasks, *listResp.Batchtasks...)
+		offset += limit
+	}
+
+	uuId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuId)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("batchtasks", flattenBatchTasks(allTasks)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenBatchTasks(tasks []model.Task) []interface{} {
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(tasks))
+	for _, v := range tasks {
+		rst = append(rst, map[string]interface{}{
+			"id":             v.TaskId,
+			"name":           v.TaskName,
+			"type":           v.TaskType,
+			"targets":        v.Targets,
+			"targets_filter": v.TargetsFilter,
+			"task_policy":    flattenDataSourceTaskPolicy(v.TaskPolicy),
+			"status":         v.Status,
+			"status_desc":    v.StatusDesc,
+			"task_progress":  flattenDataSourceTaskProgress(v.TaskProgress),
+			"created_at":     v.CreateTime,
+		})
+	}
+
+	return rst
+}
+
+func flattenDataSourceTaskPolicy(taskPolicy *model.TaskPolicy) []interface{} {
+	if taskPolicy == nil {
+		return nil
+	}
+
+	rst := map[string]interface{}{
+		"schedule_time":  taskPolicy.ScheduleTime,
+		"retry_count":    taskPolicy.RetryCount,
+		"retry_interval": taskPolicy.RetryInterval,
+	}
+
+	return []interface{}{rst}
+}
+
+func flattenDataSourceTaskProgress(taskProgress *model.TaskProgress) []interface{} {
+	if taskProgress == nil {
+		return nil
+	}
+
+	rst := map[string]interface{}{
+		"total":           taskProgress.Total,
+		"processing":      taskProgress.Processing,
+		"success":         taskProgress.Success,
+		"fail":            taskProgress.Fail,
+		"waitting":        taskProgress.Waitting,
+		"fail_wait_retry": taskProgress.FailWaitRetry,
+		"stopped":         taskProgress.Stopped,
+		"removed":         taskProgress.Removed,
+	}
+
+	return []interface{}{rst}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support batch tasks datasource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

Support batch tasks datasource

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### Basic
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceBatchTasks_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceBatchTasks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceBatchTasks_basic
=== PAUSE TestAccDataSourceBatchTasks_basic
=== CONT  TestAccDataSourceBatchTasks_basic
--- PASS: TestAccDataSourceBatchTasks_basic (32.38s)
PASS

```

### Derived
```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceBatchTasks_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceBatchTasks_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceBatchTasks_derived
=== PAUSE TestAccDataSourceBatchTasks_derived
=== CONT  TestAccDataSourceBatchTasks_derived
--- PASS: TestAccDataSourceBatchTasks_derived (42.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     42.064s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
