### PR TITLE
feat(cph): add resource cph server restart

### DIFF
--- a/docs/resources/cph_server_restart.md
+++ b/docs/resources/cph_server_restart.md
@@ -1,0 +1,45 @@
+---
+subcategory: "Cloud Phone (CPH)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_cph_server_restart"
+description: |-
+  Manages a CPH server restart resource within HuaweiCloud.
+---
+
+# huaweicloud_cph_server_restart
+
+Manages a CPH server restart resource within HuaweiCloud.
+
+-> The current resource is a one-time resource, and destroying this resource is only removed from the state.
+
+## Example Usage
+
+```hcl
+variable "server_id" {}
+
+resource "huaweicloud_cph_server_restart" "test" {
+  server_id = var.server_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `server_id` - (Optional, String, NonUpdatable) Specifies the ID of CPH server.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1379,9 +1379,10 @@ func Provider() *schema.Provider {
 			"huaweicloud_coc_script":         coc.ResourceScript(),
 			"huaweicloud_coc_script_execute": coc.ResourceScriptExecute(),
 
-			"huaweicloud_cph_server":      cph.ResourceCphServer(),
-			"huaweicloud_cph_adb_command": cph.ResourceAdbCommand(),
-			"huaweicloud_cph_phone_stop":  cph.ResourcePhoneStop(),
+			"huaweicloud_cph_server":         cph.ResourceCphServer(),
+			"huaweicloud_cph_adb_command":    cph.ResourceAdbCommand(),
+			"huaweicloud_cph_phone_stop":     cph.ResourcePhoneStop(),
+			"huaweicloud_cph_server_restart": cph.ResourceServerRestart(),
 
 			"huaweicloud_cse_microservice":                      cse.ResourceMicroservice(),
 			"huaweicloud_cse_microservice_engine":               cse.ResourceMicroserviceEngine(),

--- a/huaweicloud/services/acceptance/cph/resource_huaweicloud_cph_server_restart_test.go
+++ b/huaweicloud/services/acceptance/cph/resource_huaweicloud_cph_server_restart_test.go
@@ -1,0 +1,37 @@
+package cph
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccCphServerRestart_basic(t *testing.T) {
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testCphServerRestart_basic(name),
+			},
+		},
+	})
+}
+
+func testCphServerRestart_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_cph_server_restart" "test" {
+  server_id = huaweicloud_cph_server.test.id
+}
+`, testCphServer_basic(name))
+}

--- a/huaweicloud/services/cph/resource_huaweicloud_cph_server_restart.go
+++ b/huaweicloud/services/cph/resource_huaweicloud_cph_server_restart.go
@@ -1,0 +1,176 @@
+package cph
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+var serverRestartNonUpdatableParams = []string{"server_id"}
+
+// @API CPH POST /v1/{project_id}/cloud-phone/servers/batch-restart
+// @API CPH GET /v1/{project_id}/cloud-phone/servers/{server_id}
+func ResourceServerRestart() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceServerRestartCreate,
+		UpdateContext: resourceServerRestartUpdate,
+		ReadContext:   resourceServerRestartRead,
+		DeleteContext: resourceServerRestartDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		CustomizeDiff: config.FlexibleForceNew(serverRestartNonUpdatableParams),
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"server_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Specifies the ID of CPH server.`,
+			},
+			"enable_force_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"true", "false"}, false),
+				Description:  utils.SchemaDesc("", utils.SchemaDescInput{Internal: true}),
+			},
+		},
+	}
+}
+
+func resourceServerRestartCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	client, err := cfg.NewServiceClient("cph", region)
+	if err != nil {
+		return diag.Errorf("error creating CPH client: %s", err)
+	}
+
+	// createServerRestart: create CPH server restart
+	createServerRestartHttpUrl := "v1/{project_id}/cloud-phone/servers/batch-restart"
+	createServerRestartPath := client.Endpoint + createServerRestartHttpUrl
+	createServerRestartPath = strings.ReplaceAll(createServerRestartPath, "{project_id}", client.ProjectID)
+
+	createServerRestartOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"server_ids": []string{d.Get("server_id").(string)},
+		},
+	}
+
+	createServerRestartResp, err := client.Request("POST", createServerRestartPath, &createServerRestartOpt)
+	if err != nil {
+		return diag.Errorf("error restarting CPH server: %s", err)
+	}
+
+	createServerRestartRespBody, err := utils.FlattenResponse(createServerRestartResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := utils.PathSearch("jobs|[0].server_id", createServerRestartRespBody, "").(string)
+	if id == "" {
+		return diag.Errorf("Unable to find the server ID from the API response")
+	}
+	d.SetId(id)
+
+	errorCode := utils.PathSearch("jobs|[0].error_code", createServerRestartRespBody, "").(string)
+	if errorCode != "" {
+		errorMsg := utils.PathSearch("jobs|[0].error_msg", createServerRestartRespBody, "").(string)
+		return diag.Errorf("failed to stop CPH server (server_id: %s), error_code: %s, error_msg: %s", id, errorCode, errorMsg)
+	}
+
+	err = checkServerStatus(ctx, client, d.Id(), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceServerRestartRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceServerRestartUpdate(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceServerRestartDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting CPH server restart resource is not supported. The resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}
+
+func checkServerStatus(ctx context.Context, client *golangsdk.ServiceClient, id string, timeout time.Duration) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"PENDING"},
+		Target:       []string{"COMPLETED"},
+		Refresh:      serverStateRefreshFunc(client, id),
+		Timeout:      timeout,
+		PollInterval: 10 * timeout,
+		Delay:        10 * time.Second,
+	}
+	_, err := stateConf.WaitForStateContext(ctx)
+	if err != nil {
+		return fmt.Errorf("error waiting for CPH server restart to be completed: %s", err)
+	}
+	return nil
+}
+
+func serverStateRefreshFunc(client *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		getServerRespBody, err := getServerDetail(client, id)
+		if err != nil {
+			return nil, "ERROR", err
+		}
+
+		// Status is 5, indicates the server is running normally.
+		serverStatus := utils.PathSearch("status", getServerRespBody, float64(0)).(float64)
+		if int(serverStatus) == 5 {
+			return getServerRespBody, "COMPLETED", nil
+		}
+		return getServerRespBody, "PENDING", nil
+	}
+}
+
+func getServerDetail(client *golangsdk.ServiceClient, id string) (interface{}, error) {
+	getServerHttpUrl := "v1/{project_id}/cloud-phone/servers/{server_id}"
+	getServerPath := client.Endpoint + getServerHttpUrl
+	getServerPath = strings.ReplaceAll(getServerPath, "{project_id}", client.ProjectID)
+	getServerPath = strings.ReplaceAll(getServerPath, "{server_id}", id)
+
+	getServerOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getServerResp, err := client.Request("GET", getServerPath, &getServerOpt)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.FlattenResponse(getServerResp)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
add resource cph server restart

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:

```
add resource cph server restart
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/cph" TESTARGS="-run TestAccCphServerRestart_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/cph -v -run TestAccCphServerRestart_basic -timeout 360m -parallel 4
=== RUN   TestAccCphServerRestart_basic
=== PAUSE TestAccCphServerRestart_basic
=== CONT  TestAccCphServerRestart_basic
--- PASS: TestAccCphServerRestart_basic (2316.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/cph       2316.492s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
