### PR TITLE
feat(workspace/app): add resource for publishing application

### DIFF
--- a/docs/resources/workspace_app_publishment.md
+++ b/docs/resources/workspace_app_publishment.md
@@ -1,0 +1,126 @@
+---
+subcategory: "Workspace"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_workspace_app_publishment"
+description: |-
+  Manages a Workspace APP pulishing resource within HuaweiCloud.
+---
+
+# huaweicloud_workspace_app_publishment
+
+Manages a Workspace APP pulishing resource within HuaweiCloud.
+
+-> 1. Before using this resource, ensure that the `type` parameter of the `huaweicloud_workspace_app_group` resource
+   must be **COMMON_APP** and `server_group_id` parameter must be set.
+   <br>2. Deleting this resource will unpublish the APP.
+
+## Example Usage
+
+```hcl
+variable "app_group_id" {}
+variable "app_name" {}
+variable "execute_path" {}
+
+resource "huaweicloud_workspace_app_publishment" "test" {
+  app_group_id = var.app_group_id
+  name         = var.app_name
+  type         = 3
+  execute_path = var.execute_path
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+  Changing this creates a new resource.
+
+* `app_group_id` - (Required, String, ForceNew) Specifies the APP group ID to which the application belongs.
+  Changing this creates a new resource.
+
+* `name` - (Required, String) Specifies the name of the application.  
+  The name valid length is limited from `1` to `64` and cannot be all spaces.
+  The name must be unique.
+
+* `type` - (Required, Int, ForceNew) Specifies the type of the application.
+  Changing this creates a new resource.  
+  The valid values are as follows:
+  + **2**: Private image APP.
+  + **3**: Custom APP.
+
+* `execute_path` - (Required, String) Specifies the location where the application file is installed.
+  e.g. `C:\Program Files\Internet Explorer\iexplore.exe`.
+
+* `sandbox_enable` - (Optional, Bool) Specifies whether to run in sandbox mode, defaults to `false`.  
+  If you want to set `true`, please ensure that the application sandbox software has been installed on the associated server
+  group instance. Otherwise, the application cannot be started.
+  
+* `version` - (Optional, String) Specifies the version of the application.  
+  If the `sandbox_enable` is set to `true`, this parameter value is the version of the sandboxed application.
+
+* `publisher` - (Optional, String, ForceNew) Specifies the publisher of the application.
+  Changing this creates a new resource.  
+  If the `sandbox_enable` is set to `true`, this parameter value is the publisher of the sandboxed application.
+
+* `work_path` - (Optional, String) Specifies the publisher of the application, e.g. `C:\Program Files\Internet Explorer`.
+
+* `command_param` - (Optional, String) Specifies the command line parameter used to start the application.  
+  If the `sandbox_enable` is set to `true`, the path of the APP to be started must be enclosed in
+  double quotation marks (""), e.g. `/box:DefaultBox "C:\Program Files\Internet Explorer\iexplore.exe"`.
+
+* `description` - (Optional, String) Specifies the description of the application.
+
+* `icon_index` - (Optional, Int, ForceNew) Specifies the icon index of the application.
+  Changing this creates a new resource.
+
+* `icon_path` - (Optional, String, ForceNew) Specifies the path where the application icon is located.
+  Changing this creates a new resource.
+
+* `status` - (Optional, String) Specifies the current status of the application, defaults to **NORMAL**.
+  The valid values are as follows:
+  + **NORMAL**
+  + **FORBIDDEN**
+
+* `source_image_ids` - (Optional, List, ForceNew) Specifies the list of image IDs corresponding to the server instance
+  to which the application belongs.  
+  The maximum length is `20`.
+  This parameter is required and available only when the `type` is `2`.  
+
+  Changing this creates a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `published_at` - The release time of the application, in RFC3339 format.
+
+## Import
+
+The resource can be imported using `app_group_id` and `name`, separated by a slash (/), e.g.
+
+```bash
+$ terraform import huaweicloud_workspace_app_publishment.test <app_group_id>/<name>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response, security or some other reason.
+The missing attributes include: `source_image_ids`.
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the instance, or the resource definition should be updated to
+align with the instance. Also you can ignore changes as below.
+
+```hcl
+resource "huaweicloud_workspace_app_publishment" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      source_image_ids,
+    ]
+  }
+}
+```

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2009,6 +2009,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_waf_reference_table":                     waf.ResourceWafReferenceTableV1(),
 
 			"huaweicloud_workspace_app_group":         workspace.ResourceWorkspaceAppGroup(),
+			"huaweicloud_workspace_app_publishment":   workspace.ResourceAppPublishment(),
 			"huaweicloud_workspace_user_group":        workspace.ResourceUserGroup(),
 			"huaweicloud_workspace_access_policy":     workspace.ResourceAccessPolicy(),
 			"huaweicloud_workspace_desktop_name_rule": workspace.ResourceDesktopNameRule(),

--- a/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_publishment_test.go
+++ b/huaweicloud/services/acceptance/workspace/resource_huaweicloud_workspace_app_publishment_test.go
@@ -1,0 +1,148 @@
+package workspace
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/workspace"
+)
+
+func getApplicationFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NewServiceClient("appstream", acceptance.HW_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+	return workspace.GetApplicationByName(client, state.Primary.Attributes["app_group_id"], state.Primary.Attributes["name"])
+}
+
+func TestAccAppPublishment_basic(t *testing.T) {
+	var (
+		application  interface{}
+		resourceName = "huaweicloud_workspace_app_publishment.test"
+		name         = acceptance.RandomAccResourceName()
+		updateName   = acceptance.RandomAccResourceName()
+	)
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&application,
+		getApplicationFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckWorkspaceAppServerGroupId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppPublishment_basic_step1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "app_group_id", "huaweicloud_workspace_app_group.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "3"),
+					resource.TestCheckResourceAttr(resourceName, "execute_path", "C:\\Program Files\\Sandboxie\\Start.exe"),
+					resource.TestCheckResourceAttr(resourceName, "sandbox_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "version", "19.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "publisher", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "work_path", "C:\\Program Files\\Sandboxie"),
+					resource.TestCheckResourceAttr(resourceName, "command_param", "/box:DefaultBox \"7567\""),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created APP by script"),
+					resource.TestCheckResourceAttr(resourceName, "icon_path", "C:\\Program Files\\Sandboxie\\Start.exe"),
+					resource.TestCheckResourceAttr(resourceName, "icon_index", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "FORBIDDEN"),
+					resource.TestMatchResourceAttr(resourceName, "published_at",
+						regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}?(Z|([+-]\d{2}:\d{2}))$`))),
+			},
+			{
+				Config: testAccAppPublishment_basic_step2(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "type", "3"),
+					resource.TestCheckResourceAttr(resourceName, "execute_path", "C:\\Program Files\\7-Zip\\7zFM.exe"),
+					resource.TestCheckResourceAttr(resourceName, "sandbox_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "version", ""),
+					resource.TestCheckResourceAttr(resourceName, "publisher", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "work_path", ""),
+					resource.TestCheckResourceAttr(resourceName, "command_param", ""),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "icon_path", "C:\\Program Files\\Sandboxie\\Start.exe"),
+					resource.TestCheckResourceAttr(resourceName, "icon_index", "0"),
+					resource.TestCheckResourceAttr(resourceName, "status", "NORMAL"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAppPublishmentImportState(resourceName),
+			},
+		},
+	})
+}
+
+func testAccAppPublishment_basic_step1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_publishment" "test" {
+  app_group_id   = huaweicloud_workspace_app_group.test.id
+  name           = "%[2]s"
+  type           = 3
+  execute_path   = "C:\\Program Files\\Sandboxie\\Start.exe"
+  sandbox_enable = true
+  version        = "19.0.0.0"
+  publisher      = "terraform"
+  work_path      = "C:\\Program Files\\Sandboxie"
+  command_param  = "/box:DefaultBox \"7567\""
+  description    = "Created APP by script"
+  icon_path      = "C:\\Program Files\\Sandboxie\\Start.exe"
+  icon_index     = 0
+  status         = "FORBIDDEN"
+}
+`, testResourceWorkspaceAppGroup_basic_step1(name), name)
+}
+
+func testAccAppPublishment_basic_step2(updateName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_workspace_app_publishment" "test" {
+  app_group_id   = huaweicloud_workspace_app_group.test.id
+  name           = "%[2]s"
+  type           = 3
+  execute_path   = "C:\\Program Files\\7-Zip\\7zFM.exe"
+  sandbox_enable = false
+  publisher      = "terraform"
+  icon_path      = "C:\\Program Files\\Sandboxie\\Start.exe"
+  icon_index     = 0
+  status         = "NORMAL"
+}
+`, testResourceWorkspaceAppGroup_basic_step1(updateName), updateName)
+}
+
+func testAppPublishmentImportState(rName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[rName]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", rName, rs)
+		}
+		appGroupId := rs.Primary.Attributes["app_group_id"]
+		appName := rs.Primary.Attributes["name"]
+		if appGroupId == "" || appName == "" {
+			return "", fmt.Errorf("invalid format specified for import ID, want '<app_group_id>/<name>', but got '%s/%s'",
+				appGroupId, appName)
+		}
+
+		return fmt.Sprintf("%s/%s", appGroupId, appName), nil
+	}
+}

--- a/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_publishment.go
+++ b/huaweicloud/services/workspace/resource_huaweicloud_workspace_app_publishment.go
@@ -1,0 +1,368 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API WORKSPACEAPP POST /v1/{project_id}/app-groups/{app_group_id}/apps
+// @API WORKSPACEAPP GET /v1/{project_id}/app-groups/{app_group_id}/apps
+// @API WORKSPACEAPP PATCH /v1/{project_id}/app-groups/{app_group_id}/apps/{app_id}
+// @API WORKSPACEAPP POST /v1/{project_id}/app-groups/{app_group_id}/apps/batch-unpublish
+func ResourceAppPublishment() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppPublishmentCreate,
+		ReadContext:   resourceAppPublishmentRead,
+		UpdateContext: resourceAppPublishmentUpdate,
+		DeleteContext: resourceAppPublishmentDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceAppPublishmentImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"app_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The APP group ID to which the application belongs.`,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The name of the application.`,
+			},
+			"type": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The type of the application.`,
+			},
+			"execute_path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The location where the application file is installed.`,
+			},
+			"sandbox_enable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Whether to run in sandbox mode.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The version of the application.`,
+			},
+			"publisher": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The publisher of the application.`,
+			},
+			"work_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The publisher of the application.`,
+			},
+			"command_param": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The command line parameter used to start the application.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The description of the application.`,
+			},
+			"icon_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The path where the application icon is located.`,
+			},
+			"icon_index": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The icon index of the application.`,
+			},
+			"source_image_ids": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `The list of image IDs corresponding to the server instance to which the application belongs.`,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: `The current status of the application.`,
+			},
+			"published_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The release time of the application, in RFC3339 format.`,
+			},
+		},
+	}
+}
+
+func resourceAppPublishmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	httpUrl := "v1/{project_id}/app-groups/{app_group_id}/apps"
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	appGroupId := d.Get("app_group_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{app_group_id}", appGroupId)
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(buildCreateAppBodyParams(d)),
+	}
+	requestResp, err := client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error publishing application: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	applicationId := utils.PathSearch("items|[0].id", respBody, "").(string)
+	d.SetId(applicationId)
+
+	if d.HasChange("status") {
+		updateStateOpt := map[string]interface{}{
+			"state": d.Get("status"),
+		}
+		if err = updateApplication(client, appGroupId, applicationId, updateStateOpt); err != nil {
+			return diag.Errorf("error updating status of the application (%s): %s", d.Get("name").(string), err)
+		}
+	}
+
+	return resourceAppPublishmentRead(ctx, d, meta)
+}
+
+func buildCreateAppBodyParams(d *schema.ResourceData) map[string]interface{} {
+	rest := make([]map[string]interface{}, 0)
+	params := map[string]interface{}{
+		"name":             d.Get("name"),
+		"source_type":      d.Get("type"),
+		"execute_path":     d.Get("execute_path"),
+		"sandbox_enable":   utils.ValueIgnoreEmpty(d.Get("sandbox_enable")),
+		"version":          utils.ValueIgnoreEmpty(d.Get("version")),
+		"publisher":        utils.ValueIgnoreEmpty(d.Get("publisher")),
+		"work_path":        utils.ValueIgnoreEmpty(d.Get("work_path")),
+		"command_param":    utils.ValueIgnoreEmpty(d.Get("command_param")),
+		"description":      utils.ValueIgnoreEmpty(d.Get("description")),
+		"icon_path":        utils.ValueIgnoreEmpty(d.Get("icon_path")),
+		"icon_index":       utils.ValueIgnoreEmpty(d.Get("icon_index")),
+		"source_image_ids": utils.ExpandToStringList(d.Get("source_image_ids").([]interface{})),
+	}
+
+	rest = append(rest, params)
+	return map[string]interface{}{
+		"items": rest,
+	}
+}
+
+func resourceAppPublishmentRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg    = meta.(*config.Config)
+		region = cfg.GetRegion(d)
+	)
+
+	client, err := cfg.NewServiceClient("appstream", region)
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	application, err := GetApplicationByName(client, d.Get("app_group_id").(string), d.Get("name").(string))
+	if err != nil {
+		return common.CheckDeletedDiag(d, err, "Workspace application")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("app_group_id", utils.PathSearch("app_group_id", application, nil)),
+		d.Set("name", utils.PathSearch("name", application, nil)),
+		d.Set("type", utils.PathSearch("source_type", application, nil)),
+		d.Set("execute_path", utils.PathSearch("execute_path", application, nil)),
+		d.Set("sandbox_enable", utils.PathSearch("sandbox_enable", application, false)),
+		d.Set("version", utils.PathSearch("version", application, nil)),
+		d.Set("publisher", utils.PathSearch("publisher", application, nil)),
+		d.Set("work_path", utils.PathSearch("work_path", application, nil)),
+		d.Set("command_param", utils.PathSearch("command_param", application, nil)),
+		d.Set("description", utils.PathSearch("description", application, nil)),
+		d.Set("icon_path", utils.PathSearch("icon_path", application, nil)),
+		d.Set("icon_index", utils.PathSearch("icon_index", application, nil)),
+		d.Set("status", utils.PathSearch("state", application, nil)),
+		d.Set("published_at", utils.FormatTimeStampRFC3339(
+			utils.ConvertTimeStrToNanoTimestamp(utils.PathSearch("publish_at", application, "").(string))/1000, false)),
+	)
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func GetApplicationByName(client *golangsdk.ServiceClient, appGroupId, appName string) (interface{}, error) {
+	httpUrl := "v1/{project_id}/app-groups/{app_group_id}/apps?name={app_name}"
+	getPath := client.Endpoint + httpUrl
+	getPath = strings.ReplaceAll(getPath, "{project_id}", client.ProjectID)
+	getPath = strings.ReplaceAll(getPath, "{app_group_id}", appGroupId)
+	// Fuzzy matching for name parameter.
+	getPath = strings.ReplaceAll(getPath, "{app_name}", appName)
+	getOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+	requestResp, err := client.Request("GET", getPath, &getOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving published application: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(requestResp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parsing application from API response: %s", err)
+	}
+
+	express := fmt.Sprintf("items[?name=='%s']|[0]", appName)
+	application := utils.PathSearch(express, respBody, nil)
+	// When the application or application group does not exist, the status code is `200`.
+	if application == nil {
+		return nil, golangsdk.ErrDefault404{}
+	}
+	return application, nil
+}
+
+func resourceAppPublishmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	if d.HasChanges("name", "sandbox_enable", "version", "execute_path", "work_path", "command_param", "description", "status") {
+		appName := d.Get("name")
+		updateOpt := map[string]interface{}{
+			"name":           appName,
+			"execute_path":   utils.ValueIgnoreEmpty(d.Get("execute_path")),
+			"sandbox_enable": d.Get("sandbox_enable"),
+			"version":        d.Get("version"),
+			"work_path":      d.Get("work_path"),
+			"command_param":  d.Get("command_param"),
+			"description":    d.Get("description"),
+			"state":          utils.ValueIgnoreEmpty(d.Get("status")),
+		}
+
+		appGroupId := d.Get("app_group_id").(string)
+		if err := updateApplication(client, appGroupId, d.Id(), updateOpt); err != nil {
+			return diag.Errorf("error updating application (%s): %s", appName.(string), err)
+		}
+	}
+
+	return resourceAppPublishmentRead(ctx, d, meta)
+}
+
+func updateApplication(client *golangsdk.ServiceClient, appGroupId, appId string, params map[string]interface{}) error {
+	httpUrl := "v1/{project_id}/app-groups/{app_group_id}/apps/{app_id}"
+	updatePath := client.Endpoint + httpUrl
+	updatePath = strings.ReplaceAll(updatePath, "{project_id}", client.ProjectID)
+	updatePath = strings.ReplaceAll(updatePath, "{app_group_id}", appGroupId)
+	updatePath = strings.ReplaceAll(updatePath, "{app_id}", appId)
+	updateOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody:         utils.RemoveNil(params),
+	}
+
+	_, err := client.Request("PATCH", updatePath, &updateOpt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAppPublishmentDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	httpUrl := "v1/{project_id}/app-groups/{app_group_id}/apps/batch-unpublish"
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{app_group_id}", d.Get("app_group_id").(string))
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		JSONBody: map[string]interface{}{
+			"ids": []string{d.Id()},
+		},
+	}
+	// In any case, the interface response status code is `200`.
+	appName := d.Get("name").(string)
+	_, err = client.Request("POST", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error deleting application (%s): %s", appName, err)
+	}
+
+	return nil
+}
+
+func resourceAppPublishmentImportState(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	importedId := d.Id()
+	parts := strings.Split(importedId, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format specified for import ID, want '<app_group_id>/<name>', but got '%s'",
+			importedId)
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("app_group_id", parts[0]),
+		d.Set("name", parts[1]),
+	)
+
+	cfg := meta.(*config.Config)
+	client, err := cfg.NewServiceClient("appstream", cfg.GetRegion(d))
+	if err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error creating Workspace APP client: %s", err)
+	}
+
+	application, err := GetApplicationByName(client, parts[0], parts[1])
+	if err != nil {
+		return []*schema.ResourceData{d}, fmt.Errorf("error getting published application from API response: %s", err)
+	}
+
+	applicationId := utils.PathSearch("id", application, "").(string)
+	if applicationId == "" {
+		return []*schema.ResourceData{d}, fmt.Errorf("unable to find application ID from API response")
+	}
+
+	d.SetId(applicationId)
+	return []*schema.ResourceData{d}, mErr.ErrorOrNil()
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new resource used to manage application publishment.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1. add new resource.
2. add corresponding to docunment and acceptance test.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
./scripts/coverage.sh -o workspace -f TestAccAppPublishment_basic
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/workspace" -v -coverprofile="./huaweicloud/services/acceptance/workspace/workspace_coverage.cov" -coverpkg="./huaweicloud/services/workspace" -run TestAccAppPublishment_basic -timeout 360m -parallel 10
=== RUN   TestAccAppPublishment_basic
=== PAUSE TestAccAppPublishment_basic
=== CONT  TestAccAppPublishment_basic
--- PASS: TestAccAppPublishment_basic (51.34s)
PASS
coverage: 12.5% of statements in ./huaweicloud/services/workspace
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/workspace 51.406s coverage: 12.5% of statements in ./huaweicloud/services/workspace
```

* [x] Documentation updated.
* [x] Schema updated.
* [x] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    ![image](https://github.com/user-attachments/assets/fe109648-c466-4a65-bba4-cf72637e9081)
  
    ab. Related resources (parent resources) not found
  ![image](https://github.com/user-attachments/assets/abe2e413-e76f-4eca-b0b0-b09a560648b2)

  
