### PR TITLE
test(dds): fix test for unsupported version

### DIFF
--- a/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_instances_test.go
+++ b/huaweicloud/services/acceptance/dds/data_source_huaweicloud_dds_instances_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccDatasourceDdsInstance_basic(t *testing.T) {
@@ -31,68 +30,14 @@ func TestAccDatasourceDdsInstance_basic(t *testing.T) {
 	})
 }
 
-func testAccDatasourceDdsInstance_base(rName string, port int) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_availability_zones" "test" {}
-
-resource "huaweicloud_dds_instance" "test" {
-  name              = "%s"
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  vpc_id            = huaweicloud_vpc.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-  password          = "Terraform@123"
-  mode              = "Sharding"
-  port              = %d
-
-  datastore {
-    type           = "DDS-Community"
-    version        = "3.4"
-    storage_engine = "wiredTiger"
-  }
-
-  flavor {
-    type      = "mongos"
-    num       = 2
-    spec_code = "dds.mongodb.s6.large.2.mongos"
-  }
-
-  flavor {
-    type      = "shard"
-    num       = 2
-    storage   = "ULTRAHIGH"
-    size      = 20
-    spec_code = "dds.mongodb.s6.large.2.shard"
-  }
-
-  flavor {
-    type      = "config"
-    num       = 1
-    storage   = "ULTRAHIGH"
-    size      = 20
-    spec_code = "dds.mongodb.s6.large.2.config"
-  }
-
-  backup_strategy {
-    start_time = "08:00-09:00"
-    keep_days  = "8"
-  }
-
-  tags = {
-    foo   = "bar"
-    owner = "terraform"
-  }
-}`, common.TestBaseNetwork(rName), rName, port)
-}
-
 func testAccDatasourceDdsInstance_basic(name string, port int) string {
 	return fmt.Sprintf(`
 %s
 
 data "huaweicloud_dds_instances" "test" {
-  name = huaweicloud_dds_instance.test.name
+  depends_on = [huaweicloud_dds_instance.instance]
+
+  name = huaweicloud_dds_instance.instance.name
 }
-`, testAccDatasourceDdsInstance_base(name, port))
+`, testAccDDSInstanceV3Config_basic(name, port))
 }

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_role_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_role_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func getDatabaseRoleFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -91,64 +90,19 @@ func testAccDatabaseRoleImportStateIdFunc() resource.ImportStateIdFunc {
 	}
 }
 
-func testAccDatabaseRole_base(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_availability_zones" "test" {}
-
-resource "huaweicloud_dds_instance" "test" {
-  availability_zone = data.huaweicloud_availability_zones.test.names[0]
-  vpc_id            = huaweicloud_vpc.test.id
-  subnet_id         = huaweicloud_vpc_subnet.test.id
-  security_group_id = huaweicloud_networking_secgroup.test.id
-
-  name     = "%s"
-  mode     = "Sharding"
-  password = "Test@12345678"
-
-  datastore {
-    type           = "DDS-Community"
-    version        = "3.4"
-    storage_engine = "wiredTiger"
-  }
-
-  flavor {
-    type      = "mongos"
-    num       = 2
-    spec_code = "dds.mongodb.s6.xlarge.2.mongos"
-  }
-  flavor {
-    type      = "shard"
-    num       = 2
-    storage   = "ULTRAHIGH"
-    size      = 20
-    spec_code = "dds.mongodb.s6.xlarge.2.shard"
-  }
-  flavor {
-    type      = "config"
-    num       = 1
-    storage   = "ULTRAHIGH"
-    size      = 20
-    spec_code = "dds.mongodb.s6.xlarge.2.config"
-  }
-}
-`, common.TestBaseNetwork(rName), rName)
-}
-
 func testAccDatabaseRole_basic(rName string) string {
 	return fmt.Sprintf(`
 %[1]s
 
 resource "huaweicloud_dds_database_role" "base" {
-  instance_id = huaweicloud_dds_instance.test.id
+  instance_id = huaweicloud_dds_instance.instance.id
 
   name    = "%[2]s-base"
   db_name = "admin"
 }
 
 resource "huaweicloud_dds_database_role" "test" {
-  instance_id = huaweicloud_dds_instance.test.id
+  instance_id = huaweicloud_dds_instance.instance.id
 
   name    = "%[2]s"
   db_name = "admin"
@@ -158,5 +112,5 @@ resource "huaweicloud_dds_database_role" "test" {
     db_name = "admin"
   }
 }
-`, testAccDatabaseRole_base(rName), rName)
+`, testAccDDSInstanceV3Config_basic(rName, 8800), rName)
 }

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_user_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_database_user_test.go
@@ -105,14 +105,14 @@ func testAccDatabaseUser_basic(rName string) string {
 %[1]s
 
 resource "huaweicloud_dds_database_role" "test" {
-  instance_id = huaweicloud_dds_instance.test.id
+  instance_id = huaweicloud_dds_instance.instance.id
 
   name    = "%[2]s"
   db_name = "admin"
 }
 
 resource "huaweicloud_dds_database_user" "test" {
-  instance_id = huaweicloud_dds_instance.test.id
+  instance_id = huaweicloud_dds_instance.instance.id
 
   name     = "%[2]s"
   password = "HuaweiTest@12345678"
@@ -123,7 +123,7 @@ resource "huaweicloud_dds_database_user" "test" {
     db_name = "admin"
   }
 }
-`, testAccDatabaseRole_base(rName), rName)
+`, testAccDDSInstanceV3Config_basic(rName, 8800), rName)
 }
 
 func testAccDatabaseUser_update(rName string) string {
@@ -131,14 +131,14 @@ func testAccDatabaseUser_update(rName string) string {
 %[1]s
 
 resource "huaweicloud_dds_database_role" "test" {
-  instance_id = huaweicloud_dds_instance.test.id
+  instance_id = huaweicloud_dds_instance.instance.id
 
   name    = "%[2]s"
   db_name = "admin"
 }
 
 resource "huaweicloud_dds_database_user" "test" {
-  instance_id = huaweicloud_dds_instance.test.id
+  instance_id = huaweicloud_dds_instance.instance.id
 
   name     = "%[2]s"
   password = "HuaweiTest@123"
@@ -149,5 +149,5 @@ resource "huaweicloud_dds_database_user" "test" {
     db_name = "admin"
   }
 }
-`, testAccDatabaseRole_base(rName), rName)
+`, testAccDDSInstanceV3Config_basic(rName, 8800), rName)
 }

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_internal_ip_modify_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_internal_ip_modify_test.go
@@ -86,7 +86,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_restart_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_restart_test.go
@@ -6,32 +6,19 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
-	"github.com/chnsz/golangsdk/openstack/dds/v3/instances"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
 func TestAccDDSV3InstanceRestart_basic(t *testing.T) {
-	var instance instances.InstanceResponse
 	rName := acceptance.RandomAccResourceName()
-	resourceName := "huaweicloud_dds_instance_restart.test"
-
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&instance,
-		getDdsResourceFunc,
-	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
 		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
+		CheckDestroy:      nil,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDDSInstanceV3Config_restart(rName),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-				),
 			},
 		},
 	})

--- a/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
+++ b/huaweicloud/services/acceptance/dds/resource_huaweicloud_dds_instance_v3_test.go
@@ -460,7 +460,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -514,7 +514,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -569,7 +569,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -623,7 +623,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -677,7 +677,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -732,7 +732,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -787,7 +787,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -847,7 +847,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -901,7 +901,7 @@ resource "huaweicloud_dds_instance" "instance" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -1190,7 +1190,7 @@ resource "huaweicloud_dds_instance" "test" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 
@@ -1242,7 +1242,7 @@ resource "huaweicloud_dds_instance" "test" {
 
   datastore {
     type           = "DDS-Community"
-    version        = "3.4"
+    version        = "4.0"
     storage_engine = "wiredTiger"
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Verion 3.4 for DDS is unsupported.

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3Instance_"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3Instance_ -timeout 360m -parallel 4
=== RUN   TestAccDDSV3Instance_basic
=== PAUSE TestAccDDSV3Instance_basic
=== RUN   TestAccDDSV3Instance_withEpsId
=== PAUSE TestAccDDSV3Instance_withEpsId
=== RUN   TestAccDDSV3Instance_prePaid
=== PAUSE TestAccDDSV3Instance_prePaid
=== RUN   TestAccDDSV3Instance_withConfigurationSharding
=== PAUSE TestAccDDSV3Instance_withConfigurationSharding
=== RUN   TestAccDDSV3Instance_withConfigurationReplicaSet
=== PAUSE TestAccDDSV3Instance_withConfigurationReplicaSet
=== RUN   TestAccDDSV3Instance_withSecondLevelMonitoring
=== PAUSE TestAccDDSV3Instance_withSecondLevelMonitoring
=== RUN   TestAccDDSV3Instance_updateAZ
=== PAUSE TestAccDDSV3Instance_updateAZ
=== CONT  TestAccDDSV3Instance_basic
=== CONT  TestAccDDSV3Instance_withConfigurationReplicaSet
=== CONT  TestAccDDSV3Instance_withConfigurationSharding
=== CONT  TestAccDDSV3Instance_prePaid
--- PASS: TestAccDDSV3Instance_withConfigurationSharding (1876.98s)
=== CONT  TestAccDDSV3Instance_withEpsId
--- PASS: TestAccDDSV3Instance_prePaid (1906.16s)
=== CONT  TestAccDDSV3Instance_updateAZ
--- PASS: TestAccDDSV3Instance_withEpsId (845.04s)
=== CONT  TestAccDDSV3Instance_withSecondLevelMonitoring
    acceptance.go:2268: HW_DDS_SECOND_LEVEL_MONITORING_ENABLED must be set for the acceptance test
--- SKIP: TestAccDDSV3Instance_withSecondLevelMonitoring (0.15s)
--- PASS: TestAccDDSV3Instance_withConfigurationReplicaSet (3147.47s)
--- PASS: TestAccDDSV3Instance_basic (3150.46s)
--- PASS: TestAccDDSV3Instance_updateAZ (2337.14s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       4243.373s

make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDatabaseUser_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDatabaseUser_basic -timeout 360m -parallel 4
=== RUN   TestAccDatabaseUser_basic
=== PAUSE TestAccDatabaseUser_basic
=== CONT  TestAccDatabaseUser_basic
--- PASS: TestAccDatabaseUser_basic (892.68s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       892.736s

make testacc TEST="./huaweicloud/services/acceptance/dds" TESTARGS="-run TestAccDDSV3InstanceRestart_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dds -v -run TestAccDDSV3InstanceRestart_basic -timeout 360m -parallel 4
=== RUN   TestAccDDSV3InstanceRestart_basic
=== PAUSE TestAccDDSV3InstanceRestart_basic
=== CONT  TestAccDDSV3InstanceRestart_basic
--- PASS: TestAccDDSV3InstanceRestart_basic (934.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dds       935.034s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
