### PR TITLE
chore(as): enhance the as datasource test cases

### DIFF
--- a/huaweicloud/services/acceptance/acceptance.go
+++ b/huaweicloud/services/acceptance/acceptance.go
@@ -371,11 +371,12 @@ var (
 	HW_CERT_BATCH_PUSH_ID     = os.Getenv("HW_CERT_BATCH_PUSH_ID")
 	HW_CERT_BATCH_PUSH_WAF_ID = os.Getenv("HW_CERT_BATCH_PUSH_WAF_ID")
 
-	HW_AS_SCALING_GROUP_ID     = os.Getenv("HW_AS_SCALING_GROUP_ID")
-	HW_AS_SCALING_POLICY_ID    = os.Getenv("HW_AS_SCALING_POLICY_ID")
-	HW_AS_LIFECYCLE_ACTION_KEY = os.Getenv("HW_AS_LIFECYCLE_ACTION_KEY")
-	HW_AS_INSTANCE_ID          = os.Getenv("HW_AS_INSTANCE_ID")
-	HW_AS_LIFECYCLE_HOOK_NAME  = os.Getenv("HW_AS_LIFECYCLE_HOOK_NAME")
+	HW_AS_SCALING_GROUP_ID         = os.Getenv("HW_AS_SCALING_GROUP_ID")
+	HW_AS_SCALING_CONFIGURATION_ID = os.Getenv("HW_AS_SCALING_CONFIGURATION_ID")
+	HW_AS_SCALING_POLICY_ID        = os.Getenv("HW_AS_SCALING_POLICY_ID")
+	HW_AS_LIFECYCLE_ACTION_KEY     = os.Getenv("HW_AS_LIFECYCLE_ACTION_KEY")
+	HW_AS_INSTANCE_ID              = os.Getenv("HW_AS_INSTANCE_ID")
+	HW_AS_LIFECYCLE_HOOK_NAME      = os.Getenv("HW_AS_LIFECYCLE_HOOK_NAME")
 
 	// Common
 	HW_DATAARTS_WORKSPACE_ID                               = os.Getenv("HW_DATAARTS_WORKSPACE_ID")
@@ -1978,6 +1979,13 @@ func TestAccPreCheckCSSUpgradeAgency(t *testing.T) {
 func TestAccPreCheckASScalingGroupID(t *testing.T) {
 	if HW_AS_SCALING_GROUP_ID == "" {
 		t.Skip("HW_AS_SCALING_GROUP_ID must be set for the acceptance test")
+	}
+}
+
+// lintignore:AT003
+func TestAccPreCheckASScalingConfigurationID(t *testing.T) {
+	if HW_AS_SCALING_CONFIGURATION_ID == "" {
+		t.Skip("HW_AS_SCALING_CONFIGURATION_ID must be set for the acceptance test")
 	}
 }
 

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_activity_logs_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_activity_logs_test.go
@@ -13,11 +13,24 @@ func TestAccActivityLogsDataSource_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.huaweicloud_as_activity_logs.test"
 		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byStatus   = "data.huaweicloud_as_activity_logs.status_filter"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byStartTime   = "data.huaweicloud_as_activity_logs.start_time_filter"
+		dcByStartTime = acceptance.InitDataSourceCheck(byStartTime)
+
+		byEndTime   = "data.huaweicloud_as_activity_logs.end_time_filter"
+		dcByEndTime = acceptance.InitDataSourceCheck(byEndTime)
+
+		byStartEndTime   = "data.huaweicloud_as_activity_logs.start_end_time_filter"
+		dcByStartEndTime = acceptance.InitDataSourceCheck(byStartEndTime)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Please prepare the scaling group ID with scaling activity logs in advance.
 			acceptance.TestAccPreCheckASScalingGroupID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -26,9 +39,29 @@ func TestAccActivityLogsDataSource_basic(t *testing.T) {
 				Config: testAccActivityLogsDataSource_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "scaling_group_id", acceptance.HW_AS_SCALING_GROUP_ID),
 					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.0.added_instances"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.0.changes_instance_number"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.0.current_instance_number"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.0.desire_instance_number"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.0.end_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.0.start_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "activity_logs.0.status"),
+
+					dcByStatus.CheckResourceExists(),
 					resource.TestCheckOutput("is_status_filter_useful", "true"),
+
+					dcByStartTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_start_time_filter_useful", "true"),
+
+					dcByEndTime.CheckResourceExists(),
+					resource.TestCheckOutput("is_end_time_filter_useful", "true"),
+
+					dcByStartEndTime.CheckResourceExists(),
+					resource.TestCheckOutput("start_time_filter_result1_useful", "true"),
+					resource.TestCheckOutput("end_time_filter_result1_useful", "true"),
 				),
 			},
 		},
@@ -41,17 +74,99 @@ data "huaweicloud_as_activity_logs" "test" {
   scaling_group_id = "%[1]s"
 }
 
+# Filter by status
 locals {
   status = data.huaweicloud_as_activity_logs.test.activity_logs[0].status
 }
+
 data "huaweicloud_as_activity_logs" "status_filter" {
   scaling_group_id = "%[1]s"
   status           = local.status
 }
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_as_activity_logs.status_filter.activity_logs[*].status : v == local.status
+  ]
+}
+
 output "is_status_filter_useful" {
-  value = length(data.huaweicloud_as_activity_logs.status_filter.activity_logs) > 0 && alltrue(
-    [for v in data.huaweicloud_as_activity_logs.status_filter.activity_logs[*].status : v == local.status]
-  )  
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+
+# Filter by time
+locals {
+  start_time = data.huaweicloud_as_activity_logs.test.activity_logs[0].start_time
+  end_time   = data.huaweicloud_as_activity_logs.test.activity_logs[0].end_time
+
+  # The attribute date field format is "yyyy-MM-dd hh:mm:ss", and the parameter date field format is "yyyy-MM-ddThh:mm:ssZ".
+  # The start and end times require format conversion. 
+  start_time_utc = format("%%sZ", replace(local.start_time, " ", "T"))
+  end_time_utc = format("%%sZ", replace(local.end_time, " ", "T"))
+
+  start_time_utc_before24h = timeadd(local.start_time_utc, "-24h")
+  end_time_utc_after24h = timeadd(local.end_time_utc, "24h")
+}
+
+# Filter by start_time
+data "huaweicloud_as_activity_logs" "start_time_filter" {
+  scaling_group_id = "%[1]s"
+  start_time       = local.start_time_utc_before24h
+}
+
+locals {
+  start_time_filter_result = [
+    for v in data.huaweicloud_as_activity_logs.start_time_filter.activity_logs[*].start_time :
+    timecmp(local.start_time_utc_before24h, format("%%sZ", replace(v, " ", "T"))) == -1
+  ]
+}
+
+output "is_start_time_filter_useful" {
+  value = alltrue(local.start_time_filter_result) && length(local.start_time_filter_result) > 0
+}
+
+# Filter by end_time
+data "huaweicloud_as_activity_logs" "end_time_filter" {
+  scaling_group_id = "%[1]s"
+  end_time         = local.end_time_utc_after24h
+}
+
+locals {
+  end_time_filter_result = [
+    for v in data.huaweicloud_as_activity_logs.end_time_filter.activity_logs[*].end_time :
+    timecmp(local.end_time_utc_after24h, format("%%sZ", replace(v, " ", "T"))) == 1
+  ]
+}
+
+output "is_end_time_filter_useful" {
+  value = alltrue(local.end_time_filter_result) && length(local.end_time_filter_result) > 0
+}
+
+# Filter by start_time and end_time
+data "huaweicloud_as_activity_logs" "start_end_time_filter" {
+  scaling_group_id = "%[1]s"
+  start_time       = local.start_time_utc_before24h
+  end_time         = local.end_time_utc_after24h
+}
+
+locals {
+  start_time_filter_result1 = [
+    for v in data.huaweicloud_as_activity_logs.start_end_time_filter.activity_logs[*].start_time :
+    timecmp(local.start_time_utc_before24h, format("%%sZ", replace(v, " ", "T"))) == -1
+  ]
+
+  end_time_filter_result1 = [
+    for v in data.huaweicloud_as_activity_logs.start_end_time_filter.activity_logs[*].end_time :
+    timecmp(local.end_time_utc_after24h, format("%%sZ", replace(v, " ", "T"))) == 1
+  ]
+}
+
+output "start_time_filter_result1_useful" {
+  value = alltrue(local.start_time_filter_result1) && length(local.start_time_filter_result1) > 0
+}
+
+output "end_time_filter_result1_useful" {
+  value = alltrue(local.end_time_filter_result1) && length(local.end_time_filter_result1) > 0
 }
 `, acceptance.HW_AS_SCALING_GROUP_ID)
 }

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_configurations_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_configurations_test.go
@@ -1,7 +1,6 @@
 package as
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -10,36 +9,90 @@ import (
 )
 
 func TestAccDataSourceASConfiguration_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_as_configurations.configurations"
-	name := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	var (
+		dataSourceName = "data.huaweicloud_as_configurations.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byName   = "data.huaweicloud_as_configurations.name_filter"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byImageID   = "data.huaweicloud_as_configurations.image_id_filter"
+		dcByImageID = acceptance.InitDataSourceCheck(byImageID)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Please configure the scaling group configuration in advance.
+			acceptance.TestAccPreCheckASScalingConfigurationID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceASConfiguration_conf(name),
+				Config: testAccDataSourceASConfiguration_conf,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "configurations.0.scaling_configuration_name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.instance_config.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.instance_config.0.charging_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.instance_config.0.disk.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.instance_config.0.flavor"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.instance_config.0.flavor_priority_policy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.instance_config.0.image"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.instance_config.0.key_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.scaling_configuration_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "configurations.0.status"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+
+					dcByImageID.CheckResourceExists(),
+					resource.TestCheckOutput("is_image_id_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceASConfiguration_conf(name string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_as_configurations" "configurations" {
-  name     = huaweicloud_as_configuration.acc_as_config.scaling_configuration_name
-  image_id = huaweicloud_as_configuration.acc_as_config.instance_config.0.image
-
-  depends_on = [huaweicloud_as_configuration.acc_as_config]
+const testAccDataSourceASConfiguration_conf = `
+data "huaweicloud_as_configurations" "test" {
 }
-`, testAccASConfiguration_basic(name))
+
+# Filter by name
+locals {
+  name = data.huaweicloud_as_configurations.test.configurations[0].scaling_configuration_name
 }
+
+data "huaweicloud_as_configurations" "name_filter" {
+  name = local.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_as_configurations.name_filter.configurations[*].scaling_configuration_name : v == local.name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
+}
+
+# Filter by image_id
+locals {
+  image_id = data.huaweicloud_as_configurations.test.configurations[0].instance_config[0].image
+}
+
+data "huaweicloud_as_configurations" "image_id_filter" {
+  image_id = local.image_id
+}
+
+locals {
+  image_id_filter_result = [
+    for v in data.huaweicloud_as_configurations.image_id_filter.configurations[*].instance_config[0].image : v == local.image_id
+  ]
+}
+
+output "is_image_id_filter_useful" {
+  value = alltrue(local.image_id_filter_result) && length(local.image_id_filter_result) > 0
+}
+`

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_group_quotas_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_group_quotas_test.go
@@ -12,18 +12,19 @@ import (
 func TestAccDataSourceAsGroupQuotas_basic(t *testing.T) {
 	var (
 		dataSource = "data.huaweicloud_as_group_quotas.test"
-		rName      = acceptance.RandomAccResourceName()
 		dc         = acceptance.InitDataSourceCheck(dataSource)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Please prepare AS group ID in advance.
+			acceptance.TestAccPreCheckASScalingGroupID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceDataSourceAsGroupQuotas_basic(rName),
+				Config: testDataSourceDataSourceAsGroupQuotas_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSource, "quotas.#"),
@@ -39,12 +40,10 @@ func TestAccDataSourceAsGroupQuotas_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceDataSourceAsGroupQuotas_basic(name string) string {
+func testDataSourceDataSourceAsGroupQuotas_basic() string {
 	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_as_group_quotas" "test" {
-  scaling_group_id = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id = "%s"
 }
-`, testACCASGroup_base(name))
+`, acceptance.HW_AS_SCALING_GROUP_ID)
 }

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_groups_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_groups_test.go
@@ -1,7 +1,6 @@
 package as
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -10,35 +9,158 @@ import (
 )
 
 func TestAccDataSourceASGroup_basic(t *testing.T) {
-	dataSourceName := "data.huaweicloud_as_groups.groups"
-	name := acceptance.RandomAccResourceName()
-	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	var (
+		dataSourceName = "data.huaweicloud_as_groups.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byName   = "data.huaweicloud_as_groups.name_filter"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byScalingConfigurationID   = "data.huaweicloud_as_groups.scaling_configuration_id_filter"
+		dcByScalingConfigurationID = acceptance.InitDataSourceCheck(byScalingConfigurationID)
+
+		byStatus   = "data.huaweicloud_as_groups.status_filter"
+		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
+
+		byEnterpriseProjectID   = "data.huaweicloud_as_groups.enterprise_project_id_filter"
+		dcByEnterpriseProjectID = acceptance.InitDataSourceCheck(byEnterpriseProjectID)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Please prepare AS group in advance and configure the group ID into the environment variable.
+			acceptance.TestAccPreCheckASScalingGroupID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceASGroup_conf(name),
+				Config: testAccDataSourceASGroup_conf,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(dataSourceName, "groups.0.scaling_group_name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.availability_zones.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.cool_down_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.current_instance_number"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.delete_publicip"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.delete_volume"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.desire_instance_number"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.health_periodic_audit_grace_period"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.health_periodic_audit_method"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.health_periodic_audit_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.instance_terminate_policy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.instances.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.is_scaling"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.max_instance_number"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.min_instance_number"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.multi_az_scaling_policy"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.networks.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.networks.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.networks.0.ipv6_enable"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.networks.0.source_dest_check"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.scaling_configuration_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.scaling_configuration_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.scaling_group_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.scaling_group_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "groups.0.vpc_id"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+
+					dcByScalingConfigurationID.CheckResourceExists(),
+					resource.TestCheckOutput("is_scaling_configuration_id_filter_useful", "true"),
+
+					dcByStatus.CheckResourceExists(),
+					resource.TestCheckOutput("is_status_filter_useful", "true"),
+
+					dcByEnterpriseProjectID.CheckResourceExists(),
+					resource.TestCheckOutput("is_enterprise_project_id_filter_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceASGroup_conf(name string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_as_groups" "groups" {
-  name = huaweicloud_as_group.acc_as_group.scaling_group_name
-
-  depends_on = [huaweicloud_as_group.acc_as_group]
+const testAccDataSourceASGroup_conf = `
+data "huaweicloud_as_groups" "test" {
 }
-`, testASGroup_basic(name))
+
+# Filter by name
+locals {
+  name = data.huaweicloud_as_groups.test.groups[0].scaling_group_name
 }
+
+data "huaweicloud_as_groups" "name_filter" {
+  name = local.name
+}
+
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_as_groups.name_filter.groups[*].scaling_group_name : v == local.name
+  ]
+}
+
+output "is_name_filter_useful" {
+  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
+}
+
+# Filter by scaling_configuration_id
+locals {
+  scaling_configuration_id = data.huaweicloud_as_groups.test.groups[0].scaling_configuration_id
+}
+
+data "huaweicloud_as_groups" "scaling_configuration_id_filter" {
+  scaling_configuration_id = local.scaling_configuration_id
+}
+
+locals {
+  scaling_configuration_id_filter_result = [
+    for v in data.huaweicloud_as_groups.scaling_configuration_id_filter.groups[*].scaling_configuration_id : v == local.scaling_configuration_id
+  ]
+}
+
+output "is_scaling_configuration_id_filter_useful" {
+  value = alltrue(local.scaling_configuration_id_filter_result) && length(local.scaling_configuration_id_filter_result) > 0
+}
+
+# Filter by status
+locals {
+  status = data.huaweicloud_as_groups.test.groups[0].status
+}
+
+data "huaweicloud_as_groups" "status_filter" {
+  status = local.status
+}
+
+locals {
+  status_filter_result = [
+    for v in data.huaweicloud_as_groups.status_filter.groups[*].status : v == local.status
+  ]
+}
+
+output "is_status_filter_useful" {
+  value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
+}
+
+# Filter by enterprise_project_id
+locals {
+  enterprise_project_id = data.huaweicloud_as_groups.test.groups[0].enterprise_project_id
+}
+
+data "huaweicloud_as_groups" "enterprise_project_id_filter" {
+  enterprise_project_id = local.enterprise_project_id
+}
+
+locals {
+  enterprise_project_id_filter_result = [
+    for v in data.huaweicloud_as_groups.enterprise_project_id_filter.groups[*].enterprise_project_id : v == local.enterprise_project_id
+  ]
+}
+
+output "is_enterprise_project_id_filter_useful" {
+  value = alltrue(local.enterprise_project_id_filter_result) && length(local.enterprise_project_id_filter_result) > 0
+}
+`

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_hook_instances_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_hook_instances_test.go
@@ -28,6 +28,8 @@ func TestAccDataSourceHookInstances_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Please prepare the AS group in the hooked state in advance and configure the AS group ID into the
+			// environment variable.
 			acceptance.TestAccPreCheckASScalingGroupID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_instances_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_instances_test.go
@@ -12,16 +12,29 @@ import (
 func TestAccDatasourceASInstances_basic(t *testing.T) {
 	var (
 		rName = "data.huaweicloud_as_instances.test"
-		name  = acceptance.RandomAccResourceName()
 		dc    = acceptance.InitDataSourceCheck(rName)
+
+		byLifeCycleState   = "data.huaweicloud_as_instances.life_cycle_state_filter"
+		dcByLifeCycleState = acceptance.InitDataSourceCheck(byLifeCycleState)
+
+		byHealthStatus   = "data.huaweicloud_as_instances.health_status_filter"
+		dcByHealthStatus = acceptance.InitDataSourceCheck(byHealthStatus)
+
+		byProtectFromScalingDown   = "data.huaweicloud_as_instances.protect_from_scaling_down_filter"
+		dcByProtectFromScalingDown = acceptance.InitDataSourceCheck(byProtectFromScalingDown)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Please prepare the AS group containing the instance in advance and configure the AS group ID into the
+			// environment variable.
+			acceptance.TestAccPreCheckASScalingGroupID(t)
+		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceASInstances_basic(name),
+				Config: testAccDatasourceASInstances_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(rName, "instances.0.instance_id"),
@@ -33,10 +46,13 @@ func TestAccDatasourceASInstances_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "instances.0.created_at"),
 					resource.TestCheckResourceAttrSet(rName, "instances.0.protect_from_scaling_down"),
 
+					dcByLifeCycleState.CheckResourceExists(),
 					resource.TestCheckOutput("life_cycle_state_filter_is_useful", "true"),
 
+					dcByHealthStatus.CheckResourceExists(),
 					resource.TestCheckOutput("health_status_filter_is_useful", "true"),
 
+					dcByProtectFromScalingDown.CheckResourceExists(),
 					resource.TestCheckOutput("protect_from_scaling_down_filter_is_useful", "true"),
 				),
 			},
@@ -44,12 +60,10 @@ func TestAccDatasourceASInstances_basic(t *testing.T) {
 	})
 }
 
-func testAccDatasourceASInstances_basic(name string) string {
+func testAccDatasourceASInstances_basic() string {
 	return fmt.Sprintf(`
-%[1]s
-
 data "huaweicloud_as_instances" "test" {
-  scaling_group_id = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id = "%[1]s"
 }
 
 # Test with life_cycle_state
@@ -58,14 +72,18 @@ locals {
 }
 
 data "huaweicloud_as_instances" "life_cycle_state_filter" {
-  scaling_group_id = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id = "%[1]s"
   life_cycle_state = local.life_cycle_state
 }
 
+locals {
+  life_cycle_state_filter_result = [
+    for v in data.huaweicloud_as_instances.life_cycle_state_filter.instances[*].life_cycle_state : v == local.life_cycle_state
+  ]
+}
+
 output "life_cycle_state_filter_is_useful" {
-  value = length(data.huaweicloud_as_instances.life_cycle_state_filter.instances) > 0 && alltrue(
-    [for v in data.huaweicloud_as_instances.life_cycle_state_filter.instances[*].life_cycle_state : v == local.life_cycle_state]
-  )  
+  value = length(local.life_cycle_state_filter_result) > 0 && alltrue(local.life_cycle_state_filter_result)  
 }
 
 # Test with health_status
@@ -74,14 +92,18 @@ locals {
 }
 
 data "huaweicloud_as_instances" "health_status_filter" {
-  scaling_group_id = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id = "%[1]s"
   health_status    = local.health_status
 }
 
+locals {
+  health_status_filter_result = [
+    for v in data.huaweicloud_as_instances.health_status_filter.instances[*].health_status : v == local.health_status
+  ]
+}
+
 output "health_status_filter_is_useful" {
-  value = length(data.huaweicloud_as_instances.health_status_filter.instances) > 0 && alltrue(
-    [for v in data.huaweicloud_as_instances.health_status_filter.instances[*].health_status : v == local.health_status]
-  )  
+  value = length(local.health_status_filter_result) > 0 && alltrue(local.health_status_filter_result)  
 }
 
 # Test with protect_from_scaling_down
@@ -90,15 +112,19 @@ locals {
 }
 
 data "huaweicloud_as_instances" "protect_from_scaling_down_filter" {
-  scaling_group_id          = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id          = "%[1]s"
   protect_from_scaling_down = local.protect_from_scaling_down
 }
 
-output "protect_from_scaling_down_filter_is_useful" {
-  value = length(data.huaweicloud_as_instances.protect_from_scaling_down_filter.instances) > 0 && alltrue(
-    [for v in data.huaweicloud_as_instances.protect_from_scaling_down_filter.instances[*].protect_from_scaling_down :
-    v == local.protect_from_scaling_down]
-  )  
+locals {
+  protect_from_scaling_down_filter_result = [
+    for v in data.huaweicloud_as_instances.protect_from_scaling_down_filter.instances[*].protect_from_scaling_down :
+    v == local.protect_from_scaling_down
+  ]
 }
-`, testASGroup_forceDelete(name))
+
+output "protect_from_scaling_down_filter_is_useful" {
+  value = length(local.protect_from_scaling_down_filter_result) > 0 && alltrue(local.protect_from_scaling_down_filter_result)  
+}
+`, acceptance.HW_AS_SCALING_GROUP_ID)
 }

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_lifecycle_hooks_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_lifecycle_hooks_test.go
@@ -13,11 +13,22 @@ func TestAccDataSourceLifecycleHooks_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.huaweicloud_as_lifecycle_hooks.test"
 		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+
+		byName   = "data.huaweicloud_as_lifecycle_hooks.filter_by_name"
+		dcByName = acceptance.InitDataSourceCheck(byName)
+
+		byType   = "data.huaweicloud_as_lifecycle_hooks.filter_by_type"
+		dcByType = acceptance.InitDataSourceCheck(byType)
+
+		byDefaultResult   = "data.huaweicloud_as_lifecycle_hooks.filter_by_default_result"
+		dcByDefaultResult = acceptance.InitDataSourceCheck(byDefaultResult)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Please prepare the AS group containing the lifecycle hooks in advance and configure the AS group ID into
+			// the environment variable.
 			acceptance.TestAccPreCheckASScalingGroupID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
@@ -26,10 +37,23 @@ func TestAccDataSourceLifecycleHooks_basic(t *testing.T) {
 				Config: testAccLifecycleHooks_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					resource.TestCheckResourceAttrSet(dataSourceName, "scaling_group_id"),
-					resource.TestCheckOutput("name_filter_is_useful", "true"),
-					resource.TestCheckOutput("type_filter_is_useful", "true"),
-					resource.TestCheckOutput("default_result_filter_is_useful", "true"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "lifecycle_hooks.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "lifecycle_hooks.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "lifecycle_hooks.0.default_result"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "lifecycle_hooks.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "lifecycle_hooks.0.notification_topic_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "lifecycle_hooks.0.notification_topic_urn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "lifecycle_hooks.0.timeout"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "lifecycle_hooks.0.type"),
+
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+
+					dcByType.CheckResourceExists(),
+					resource.TestCheckOutput("is_type_filter_useful", "true"),
+
+					dcByDefaultResult.CheckResourceExists(),
+					resource.TestCheckOutput("is_default_result_filter_useful", "true"),
 				),
 			},
 		},
@@ -37,90 +61,69 @@ func TestAccDataSourceLifecycleHooks_basic(t *testing.T) {
 }
 
 func testAccLifecycleHooks_basic() string {
-	rName := acceptance.RandomAccResourceName()
 	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_as_lifecycle_hook" "test1" {
-  name                   = "%[2]s1"
-  type                   = "ADD"
-  default_result         = "ABANDON"
-  scaling_group_id       = huaweicloud_as_group.acc_as_group.id
-  notification_topic_urn = huaweicloud_smn_topic.test.topic_urn
-  notification_message   = "This is a test message"
-}
-
-resource "huaweicloud_as_lifecycle_hook" "test2" {
-  name                   = "%[2]s2"
-  type                   = "REMOVE"
-  default_result         = "CONTINUE"
-  scaling_group_id       = huaweicloud_as_group.acc_as_group.id
-  notification_topic_urn = huaweicloud_smn_topic.test.topic_urn
-  notification_message   = "This is a test message"
-}
-
-resource "huaweicloud_as_lifecycle_hook" "test3" {
-  name                   = "%[2]s3"
-  type                   = "ADD"
-  default_result         = "CONTINUE"
-  scaling_group_id       = huaweicloud_as_group.acc_as_group.id
-  notification_topic_urn = huaweicloud_smn_topic.test.topic_urn
-  notification_message   = "This is a test message"
-}
-
 data "huaweicloud_as_lifecycle_hooks" "test" {
-  depends_on = [
-	huaweicloud_as_lifecycle_hook.test1,
-	huaweicloud_as_lifecycle_hook.test2,
-	huaweicloud_as_lifecycle_hook.test3,
-  ]
-
-  scaling_group_id = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id = "%[1]s"
 }
 
+# Filter by name
 locals {
   name = data.huaweicloud_as_lifecycle_hooks.test.lifecycle_hooks[0].name
 }
 
 data "huaweicloud_as_lifecycle_hooks" "filter_by_name" {
-  scaling_group_id = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id = "%[1]s"
   name             = local.name
 }
 
-output "name_filter_is_useful" {
-  value = length(data.huaweicloud_as_lifecycle_hooks.filter_by_name.lifecycle_hooks) > 0 && alltrue( 
-    [for v in data.huaweicloud_as_lifecycle_hooks.filter_by_name.lifecycle_hooks[*].name : v == local.name]
-  )  
+locals {
+  name_filter_result = [
+    for v in data.huaweicloud_as_lifecycle_hooks.filter_by_name.lifecycle_hooks[*].name : v == local.name
+  ]
 }
 
+output "is_name_filter_useful" {
+  value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
+}
+
+# Filter by type
 locals {
   type = data.huaweicloud_as_lifecycle_hooks.test.lifecycle_hooks[0].type
 }
 
 data "huaweicloud_as_lifecycle_hooks" "filter_by_type" {
-  scaling_group_id = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id = "%[1]s"
   type             = local.type
 }
 
-output "type_filter_is_useful" {
-  value = length(data.huaweicloud_as_lifecycle_hooks.filter_by_type.lifecycle_hooks) > 0 && alltrue( 
-    [for v in data.huaweicloud_as_lifecycle_hooks.filter_by_type.lifecycle_hooks[*].type : v == local.type]
-  )  
+locals {
+  type_filter_result = [
+    for v in data.huaweicloud_as_lifecycle_hooks.filter_by_type.lifecycle_hooks[*].type : v == local.type
+  ]
 }
 
+output "is_type_filter_useful" {
+  value = alltrue(local.type_filter_result) && length(local.type_filter_result) > 0
+}
+
+# Filter by default_result
 locals {
   default_result = data.huaweicloud_as_lifecycle_hooks.test.lifecycle_hooks[0].default_result
 }
 
 data "huaweicloud_as_lifecycle_hooks" "filter_by_default_result" {
-  scaling_group_id = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id = "%[1]s"
   default_result   = local.default_result
 }
 
-output "default_result_filter_is_useful" {
-  value = length(data.huaweicloud_as_lifecycle_hooks.filter_by_default_result.lifecycle_hooks) > 0 && alltrue(
-    [for v in data.huaweicloud_as_lifecycle_hooks.filter_by_default_result.lifecycle_hooks[*].default_result : v == local.default_result]
-  )  
+locals {
+  default_result_filter_result = [
+    for v in data.huaweicloud_as_lifecycle_hooks.filter_by_default_result.lifecycle_hooks[*].default_result : v == local.default_result
+  ]
 }
-`, testASLifecycleHook_base(rName), rName)
+
+output "is_default_result_filter_useful" {
+  value = alltrue(local.default_result_filter_result) && length(local.default_result_filter_result) > 0
+}
+`, acceptance.HW_AS_SCALING_GROUP_ID)
 }

--- a/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_policies_test.go
+++ b/huaweicloud/services/acceptance/as/data_source_huaweicloud_as_policies_test.go
@@ -7,24 +7,34 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccPoliciesDataSource_basic(t *testing.T) {
 	var (
 		dataSourceName = "data.huaweicloud_as_policies.test"
 		dc             = acceptance.InitDataSourceCheck(dataSourceName)
-		baseConfig     = testACCPolicy_base()
+
+		byScalingPolicyID   = "data.huaweicloud_as_policies.scaling_policy_id_filter"
+		dcByScalingPolicyID = acceptance.InitDataSourceCheck(byScalingPolicyID)
+
+		byScalingPolicyName   = "data.huaweicloud_as_policies.scaling_policy_name_filter"
+		dcByScalingPolicyName = acceptance.InitDataSourceCheck(byScalingPolicyName)
+
+		byScalingPolicyType   = "data.huaweicloud_as_policies.scaling_policy_type_filter"
+		dcByScalingPolicyType = acceptance.InitDataSourceCheck(byScalingPolicyType)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
+			// Please prepare the AS group containing the policies in advance and configure the AS group ID into
+			// the environment variable.
+			acceptance.TestAccPreCheckASScalingGroupID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPoliciesDataSource_basic(baseConfig),
+				Config: testAccPoliciesDataSource_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.scaling_group_id"),
@@ -32,13 +42,19 @@ func TestAccPoliciesDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.name"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.status"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.type"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.alarm_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.action.0.operation"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.action.0.instance_number"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.cool_down_time"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "policies.0.scheduled_policy.#"),
+
+					dcByScalingPolicyID.CheckResourceExists(),
 					resource.TestCheckOutput("is_scaling_policy_id_filter_useful", "true"),
+
+					dcByScalingPolicyName.CheckResourceExists(),
 					resource.TestCheckOutput("is_scaling_policy_name_filter_useful", "true"),
+
+					dcByScalingPolicyType.CheckResourceExists(),
 					resource.TestCheckOutput("is_scaling_policy_type_filter_useful", "true"),
 				),
 			},
@@ -46,104 +62,10 @@ func TestAccPoliciesDataSource_basic(t *testing.T) {
 	})
 }
 
-func testACCASGroup_base(rName string) string {
+func testAccPoliciesDataSource_basic() string {
 	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_kps_keypair" "test" {
-  name = "%[2]s"
-}
-
-resource "huaweicloud_as_configuration" "test" {
-  scaling_configuration_name = "%[2]s"
-
-  instance_config {
-    image    = data.huaweicloud_images_image.test.id
-    flavor   = data.huaweicloud_compute_flavors.test.ids[0]
-    key_name = huaweicloud_kps_keypair.test.id
-
-    disk {
-      size        = 40
-      volume_type = "SATA"
-      disk_type   = "SYS"
-    }
-  }
-}
-
-resource "huaweicloud_as_group" "acc_as_group" {
-  scaling_group_name       = "%[2]s"
-  scaling_configuration_id = huaweicloud_as_configuration.test.id
-  vpc_id                   = huaweicloud_vpc.test.id
-
-  networks {
-    id = huaweicloud_vpc_subnet.test.id
-  }
-
-  security_groups {
-    id = huaweicloud_networking_secgroup.test.id
-  }
-}
-`, common.TestBaseComputeResources(rName), rName)
-}
-
-func testACCPolicy_base() string {
-	name := acceptance.RandomAccResourceNameWithDash()
-
-	return fmt.Sprintf(`
-%[1]s
-
-resource "huaweicloud_ces_alarmrule" "alarm_rule" {
-  alarm_name = "%[2]s"
-
-  metric {
-    namespace   = "SYS.AS"
-    metric_name = "cpu_util"
-
-    dimensions {
-      name  = "AutoScalingGroup"
-      value = huaweicloud_as_group.acc_as_group.id
-    }
-  }
-
-  condition {
-    period              = 300
-    filter              = "average"
-    comparison_operator = ">="
-    value               = 60
-    unit                = "%%"
-    count               = 1
-    suppress_duration   = 300
-  }
-
-  alarm_actions {
-    type              = "autoscaling"
-    notification_list = []
-  }
-}
-
-resource "huaweicloud_as_policy" "policy_alarm" {
-  scaling_policy_name = "%[2]s"
-  scaling_policy_type = "ALARM"
-  scaling_group_id    = huaweicloud_as_group.acc_as_group.id
-  alarm_id            = huaweicloud_ces_alarmrule.alarm_rule.id
-  cool_down_time      = 600
-
-  scaling_policy_action {
-    operation       = "ADD"
-    instance_number = 1
-  }
-}
-`, testACCASGroup_base(name), name)
-}
-
-func testAccPoliciesDataSource_basic(baseConfig string) string {
-	return fmt.Sprintf(`
-%s
-
 data "huaweicloud_as_policies" "test" {
-  depends_on = [huaweicloud_as_policy.policy_alarm]
-
-  scaling_group_id = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id = "%[1]s"
 }
 
 // Filter using scaling policy ID.
@@ -152,14 +74,18 @@ locals {
 }
 
 data "huaweicloud_as_policies" "scaling_policy_id_filter" {
-  scaling_group_id  = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id  = "%[1]s"
   scaling_policy_id = local.scaling_policy_id
 }
 
+locals {
+  scaling_policy_id_filter_result = [
+    for v in data.huaweicloud_as_policies.scaling_policy_id_filter.policies[*].id : v == local.scaling_policy_id
+  ]
+}
+
 output "is_scaling_policy_id_filter_useful" {
-  value = length(data.huaweicloud_as_policies.scaling_policy_id_filter.policies) > 0 && alltrue(
-    [for v in data.huaweicloud_as_policies.scaling_policy_id_filter.policies[*].id : v == local.scaling_policy_id]
-  )
+  value = alltrue(local.scaling_policy_id_filter_result) && length(local.scaling_policy_id_filter_result) > 0
 }
 
 // Filter using scaling policy name.
@@ -168,14 +94,18 @@ locals {
 }
 
 data "huaweicloud_as_policies" "scaling_policy_name_filter" {
-  scaling_group_id    = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id    = "%[1]s"
   scaling_policy_name = local.scaling_policy_name
 }
 
+locals {
+  scaling_policy_name_filter_result = [
+    for v in data.huaweicloud_as_policies.scaling_policy_name_filter.policies[*].name : v == local.scaling_policy_name
+  ]
+}
+
 output "is_scaling_policy_name_filter_useful" {
-  value = length(data.huaweicloud_as_policies.scaling_policy_name_filter.policies) > 0 && alltrue(
-    [for v in data.huaweicloud_as_policies.scaling_policy_name_filter.policies[*].name : v == local.scaling_policy_name]
-  )
+  value = alltrue(local.scaling_policy_name_filter_result) && length(local.scaling_policy_name_filter_result) > 0
 }
 
 // Filter using scaling policy type.
@@ -184,14 +114,18 @@ locals {
 }
 
 data "huaweicloud_as_policies" "scaling_policy_type_filter" {
-  scaling_group_id    = huaweicloud_as_group.acc_as_group.id
+  scaling_group_id    = "%[1]s"
   scaling_policy_type = local.scaling_policy_type
 }
 
-output "is_scaling_policy_type_filter_useful" {
-  value = length(data.huaweicloud_as_policies.scaling_policy_type_filter.policies) > 0 && alltrue(
-    [for v in data.huaweicloud_as_policies.scaling_policy_type_filter.policies[*].type : v == local.scaling_policy_type]
-  )
+locals {
+  scaling_policy_type_filter_result = [
+    for v in data.huaweicloud_as_policies.scaling_policy_type_filter.policies[*].type : v == local.scaling_policy_type
+  ]
 }
-`, baseConfig)
+
+output "is_scaling_policy_type_filter_useful" {
+  value = alltrue(local.scaling_policy_type_filter_result) && length(local.scaling_policy_type_filter_result) > 0
+}
+`, acceptance.HW_AS_SCALING_GROUP_ID)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Enhance the as datasource test cases.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

- commit1: Enhance the datasource as activity logs test case.
- commit2: Enhance the datasource as configurations test case.
- commit3: Enhance the datasource as group quotas test case.
- commit4: Enhance the datasource as groups test case.
- commit5: Add comment to as hook instances datasource test case.
- commit6: Enhance the datasource as instances test case.
- commit7: Enhance the datasource as lifecycle hooks test case.
- commit8: Enhance the datasource as notifications test case.
- commit9: Enhance the datasource as planned tasks test case.
- commit10: Enhance the datasource as policies test case.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccActivityLogsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccActivityLogsDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccActivityLogsDataSource_basic
=== PAUSE TestAccActivityLogsDataSource_basic
=== CONT  TestAccActivityLogsDataSource_basic
--- PASS: TestAccActivityLogsDataSource_basic (8.83s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        8.878s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourceASConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceASConfiguration_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceASConfiguration_basic
=== PAUSE TestAccDataSourceASConfiguration_basic
=== CONT  TestAccDataSourceASConfiguration_basic
--- PASS: TestAccDataSourceASConfiguration_basic (7.49s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        7.553s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourceAsGroupQuotas_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceAsGroupQuotas_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAsGroupQuotas_basic
=== PAUSE TestAccDataSourceAsGroupQuotas_basic
=== CONT  TestAccDataSourceAsGroupQuotas_basic
--- PASS: TestAccDataSourceAsGroupQuotas_basic (6.40s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        6.445s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourceASGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceASGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceASGroup_basic
=== PAUSE TestAccDataSourceASGroup_basic
=== CONT  TestAccDataSourceASGroup_basic
--- PASS: TestAccDataSourceASGroup_basic (9.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        9.707s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourceHookInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceHookInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceHookInstances_basic
=== PAUSE TestAccDataSourceHookInstances_basic
=== CONT  TestAccDataSourceHookInstances_basic
--- PASS: TestAccDataSourceHookInstances_basic (8.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        8.198s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDatasourceASInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDatasourceASInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceASInstances_basic
=== PAUSE TestAccDatasourceASInstances_basic
=== CONT  TestAccDatasourceASInstances_basic
--- PASS: TestAccDatasourceASInstances_basic (9.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        9.277s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourceLifecycleHooks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceLifecycleHooks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceLifecycleHooks_basic
=== PAUSE TestAccDataSourceLifecycleHooks_basic
=== CONT  TestAccDataSourceLifecycleHooks_basic
--- PASS: TestAccDataSourceLifecycleHooks_basic (7.97s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        8.017s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourceAsNotifications_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourceAsNotifications_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAsNotifications_basic
=== PAUSE TestAccDataSourceAsNotifications_basic
=== CONT  TestAccDataSourceAsNotifications_basic
--- PASS: TestAccDataSourceAsNotifications_basic (7.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        7.237s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccDataSourcePlannedTasks_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccDataSourcePlannedTasks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourcePlannedTasks_basic
=== PAUSE TestAccDataSourcePlannedTasks_basic
=== CONT  TestAccDataSourcePlannedTasks_basic
--- PASS: TestAccDataSourcePlannedTasks_basic (7.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        7.124s
```
```
make testacc TEST='./huaweicloud/services/acceptance/as' TESTARGS='-run TestAccPoliciesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/as -v -run TestAccPoliciesDataSource_basic -timeout 360m -parallel 4
=== RUN   TestAccPoliciesDataSource_basic
=== PAUSE TestAccPoliciesDataSource_basic
=== CONT  TestAccPoliciesDataSource_basic
--- PASS: TestAccPoliciesDataSource_basic (7.66s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/as        7.701s
```


* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
