### PR TITLE
feat(GaussDBforMySQL): gaussdb mysql instance support slow log show original switch

### DIFF
--- a/docs/resources/gaussdb_mysql_instance.md
+++ b/docs/resources/gaussdb_mysql_instance.md
@@ -82,6 +82,8 @@ The following arguments are supported:
 
   Defaults to **true**.
 
+* `slow_log_show_original_switch` - (Optional, Bool) Specifies the slow log show original switch of the instance.
+
 * `description` - (Optional, String) Specifies the description of the instance.
 
 * `private_write_ip` - (Optional, String) Specifies the private IP address of the DB instance.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241024112204-a96c8484ffa3
+	github.com/chnsz/golangsdk v0.0.0-20241026031406-eeb6712069c7
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241024112204-a96c8484ffa3 h1:afaYCtfr7XhRkJQd2UupmTst+/ProhdVdp6tE616mdg=
-github.com/chnsz/golangsdk v0.0.0-20241024112204-a96c8484ffa3/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241026031406-eeb6712069c7 h1:pjlmJMw0DC5orJnnPxHooMQpMCuKxRFn0ZpiC1EdrBI=
+github.com/chnsz/golangsdk v0.0.0-20241026031406-eeb6712069c7/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instance_test.go
@@ -57,6 +57,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "11:00"),
 					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_period", "1"),
+					resource.TestCheckResourceAttr(resourceName, "slow_log_show_original_switch", "true"),
 					resource.TestCheckResourceAttr(resourceName, "description", "test_description"),
 					resource.TestCheckResourceAttr(resourceName, "encryption_status", "ON"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
@@ -111,6 +112,7 @@ func TestAccGaussDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "14:00"),
 					resource.TestCheckResourceAttr(resourceName, "maintain_end", "18:00"),
 					resource.TestCheckResourceAttr(resourceName, "seconds_level_monitoring_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "slow_log_show_original_switch", "false"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "encryption_status", "OFF"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo_update", "bar"),
@@ -325,6 +327,8 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   seconds_level_monitoring_enabled = true
   seconds_level_monitoring_period  = 1
 
+  slow_log_show_original_switch = true
+
   encryption_status = "ON"
   encryption_type   = "kms"
   kms_key_id        = huaweicloud_kms_key.test.id
@@ -391,6 +395,8 @@ resource "huaweicloud_gaussdb_mysql_instance" "test" {
   description              = ""
 
   seconds_level_monitoring_enabled = false
+
+  slow_log_show_original_switch = false
 
   encryption_status = "OFF"
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/requests.go
@@ -759,3 +759,43 @@ func GetVersion(client *golangsdk.ServiceClient, instanceId string) (r GetVersio
 
 	return
 }
+
+type UpdateSlowLogShowOriginalSwitchOpts struct {
+	OpenSlowLogSwitch bool `json:"open_slow_log_switch"`
+}
+
+type UpdateSlowLogShowOriginalSwitchBuilder interface {
+	ToSlowLogShowOriginalSwitchUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateSlowLogShowOriginalSwitchOpts) ToSlowLogShowOriginalSwitchUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func UpdateSlowLogShowOriginalSwitch(client *golangsdk.ServiceClient, instanceId string,
+	opts UpdateSlowLogShowOriginalSwitchBuilder) (r UpdateSlowLogShowOriginalSwitchResult) {
+	b, err := opts.ToSlowLogShowOriginalSwitchUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(updateURL(client, instanceId, "slowlog/modify"), b, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return
+}
+
+func GetSlowLogShowOriginalSwitch(client *golangsdk.ServiceClient, instanceId string) (r GetSlowLogShowOriginalSwitchResult) {
+	url := slowLogShowOriginalSwitchURL(client, instanceId)
+
+	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/results.go
@@ -311,3 +311,31 @@ func (r GetVersionResult) Extract() (*Version, error) {
 	err := r.ExtractInto(&version)
 	return &version, err
 }
+
+type UpdateSlowLogShowOriginalSwitchResponse struct {
+	Response string `json:"response"`
+}
+
+type UpdateSlowLogShowOriginalSwitchResult struct {
+	commonResult
+}
+
+func (r UpdateSlowLogShowOriginalSwitchResult) ExtractUpdateSlowLogShowOriginalSwitchResponse() (*UpdateSlowLogShowOriginalSwitchResponse, error) {
+	res := new(UpdateSlowLogShowOriginalSwitchResponse)
+	err := r.ExtractInto(res)
+	return res, err
+}
+
+type SlowLogShowOriginalSwitch struct {
+	OpenSlowLogSwitch string `json:"open_slow_log_switch"`
+}
+
+type GetSlowLogShowOriginalSwitchResult struct {
+	commonResult
+}
+
+func (r GetSlowLogShowOriginalSwitchResult) Extract() (*SlowLogShowOriginalSwitch, error) {
+	var slowLogShowOriginalSwitch SlowLogShowOriginalSwitch
+	err := r.ExtractInto(&slowLogShowOriginalSwitch)
+	return &slowLogShowOriginalSwitch, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/taurusdb/v3/instances/urls.go
@@ -38,6 +38,10 @@ func versionURL(c *golangsdk.ServiceClient, instanceID string) string {
 	return c.ServiceURL("instances", instanceID, "database-version")
 }
 
+func slowLogShowOriginalSwitchURL(c *golangsdk.ServiceClient, instanceID string) string {
+	return c.ServiceURL("instances", instanceID, "slowlog/query")
+}
+
 func jobURL(sc *golangsdk.ServiceClient) string {
 	return sc.ServiceURL("jobs")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241024112204-a96c8484ffa3
+# github.com/chnsz/golangsdk v0.0.0-20241026031406-eeb6712069c7
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  gaussdb mysql instance support slow log show original switch
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  gaussdb mysql instance support slow log show original switch
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBInstance_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBInstance_ -timeout 360m -parallel 4
=== RUN   TestAccGaussDBInstance_basic
=== PAUSE TestAccGaussDBInstance_basic
=== RUN   TestAccGaussDBInstance_prePaid
=== PAUSE TestAccGaussDBInstance_prePaid
=== RUN   TestAccGaussDBInstance_updateWithEpsId
=== PAUSE TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_basic
=== CONT  TestAccGaussDBInstance_updateWithEpsId
=== CONT  TestAccGaussDBInstance_prePaid
=== CONT  TestAccGaussDBInstance_updateWithEpsId
    acceptance.go:675: The environment variables does not support Migrate Enterprise Project ID for acc tests
--- SKIP: TestAccGaussDBInstance_updateWithEpsId (0.00s)
--- PASS: TestAccGaussDBInstance_prePaid (1561.28s)
--- PASS: TestAccGaussDBInstance_basic (2967.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   2967.663s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
