### PR TITLE
feat(vpc): support ip_extra_set in address group

### DIFF
--- a/docs/resources/vpc_address_group.md
+++ b/docs/resources/vpc_address_group.md
@@ -37,6 +37,29 @@ resource "huaweicloud_vpc_address_group" "ipv6" {
 }
 ```
 
+### Address Group with ip_extra_set
+
+```hcl
+resource "huaweicloud_vpc_address_group" "ipv6" {
+  name       = "group-ipv4"
+  ip_version = 4
+
+  ip_extra_set {
+    ip      = "192.168.3.2"
+    remarks = "terraform test 1"
+  }
+
+  ip_extra_set {
+    ip      = "192.168.5.0/24"
+    remarks = "terraform test 2"
+  }
+
+  ip_extra_set {
+    ip = "192.168.3.20-192.168.3.100"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -48,8 +71,13 @@ The following arguments are supported:
   The value is a string of `1` to `64` characters that can contain letters, digits, underscores (_), hyphens (-) and
   periods (.).
 
-* `addresses` - (Required, List) Specifies an array of one or more IP addresses. The address can be a single IP
-  address, IP address range or IP address CIDR. The maximum length is 20.
+* `addresses` - (Optional, List) Specifies an array of one or more IP addresses. The address can be a single IP
+  address, IP address range or IP address CIDR. The maximum length is 20. Only one of `addresses` and `ip_extra_set`
+  can be specified.
+
+* `ip_extra_set` - (Optional, List) Specifies the IP addresses and their remarks in an IP address group.
+  The [ip_extra_set](#address_groups_ip_extra_set_struct) structure is documented below.
+  Only one of `addresses` and `ip_extra_set` can be specified.
 
 * `ip_version` - (Optional, Int, ForceNew) Specifies the IP version, either `4` (default) or `6`.
   Changing this creates a new address group.
@@ -66,6 +94,14 @@ The following arguments are supported:
 * `force_destroy` - (Optional, Bool) Specifies whether to forcibly destroy the address group if it is associated with
   a security group rule, the address group and the associated security group rule will be deleted together.
   The default value is **false**.
+
+<a name="address_groups_ip_extra_set_struct"></a>
+The `ip_extra_set` block supports:
+
+* `ip` - (Required, String) Specifies the IP address, IP address range, or CIDR block.
+
+* `remarks` - (Optional, String) Specifies the supplementary information about the IP address,
+  IP address range, or CIDR block.
   
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud' TESTARGS='-run=TestAccSomethingV0_basic'
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcAddressGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcAddressGroup -timeout 360m -parallel 4
=== RUN   TestAccVpcAddressGroup_basic
=== PAUSE TestAccVpcAddressGroup_basic
=== RUN   TestAccVpcAddressGroup_ipExtraSet
=== PAUSE TestAccVpcAddressGroup_ipExtraSet
=== RUN   TestAccVpcAddressGroup_ipv6
=== PAUSE TestAccVpcAddressGroup_ipv6
=== RUN   TestAccVpcAddressGroup_eps
=== PAUSE TestAccVpcAddressGroup_eps
=== CONT  TestAccVpcAddressGroup_basic
=== CONT  TestAccVpcAddressGroup_ipv6
=== CONT  TestAccVpcAddressGroup_eps
=== CONT  TestAccVpcAddressGroup_ipExtraSet
--- PASS: TestAccVpcAddressGroup_eps (26.99s)
--- PASS: TestAccVpcAddressGroup_ipv6 (43.36s)
--- PASS: TestAccVpcAddressGroup_ipExtraSet (43.56s)
--- PASS: TestAccVpcAddressGroup_basic (43.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       43.676s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
