### PR TITLE
feat(vpcep): the VPC endpoint service resource supports new fields

### DIFF
--- a/docs/resources/vpcep_service.md
+++ b/docs/resources/vpcep_service.md
@@ -2,12 +2,13 @@
 subcategory: "VPC Endpoint (VPCEP)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_vpcep_service"
-description: ""
+description: -|
+  Manages a VPC endpoint service resource within HuaweiCloud.
 ---
 
 # huaweicloud_vpcep_service
 
-Provides a resource to manage a VPC endpoint service resource.
+Manages a VPC endpoint service resource within HuaweiCloud.
 
 ## Example Usage
 
@@ -81,6 +82,20 @@ The following arguments are supported:
   <br/>2.**Proxy Protocol**: The client information is placed into the `tcp payload` field and sent to the server.
 
   -> This parameter is available only when the server can parse the `tcp option` and `tcp payload` fields.
+
+* `ip_version` - (Optional, String, ForceNew) Specifies the IP version of the VPC endpoint service.
+  The valid values are as follows:
+  + **ipv4** (Default value)
+  + **ipv6**
+
+  -> 1.Only professional VPC endpoint service supports this parameter.
+    <br>2.Currently, professional VPC endpoint service are available in the **cn-east-4**, **me-east-1**,
+    **cn-east-5**, and **af-north-1** regions.
+
+* `snat_network_id` - (Optional, String, ForceNew) Specifies the network ID of any subnet within the VPC used to create
+  the VPC endpoint service.
+
+  -> This parameter is valid only when the `ip_version` is set to **ipv6**.
 
 * `enable_policy` - (Optional, Bool, ForceNew) Specifies whether the VPC endpoint policy is enabled. Defaults to **false**.
   Changing this creates a new VPC endpoint service resource.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/GehirnInc/crypt v0.0.0-20200316065508-bb7000b8a962
-	github.com/chnsz/golangsdk v0.0.0-20241026031406-eeb6712069c7
+	github.com/chnsz/golangsdk v0.0.0-20241028021804-ed476dc428f2
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/chnsz/golangsdk v0.0.0-20241026031406-eeb6712069c7 h1:pjlmJMw0DC5orJnnPxHooMQpMCuKxRFn0ZpiC1EdrBI=
-github.com/chnsz/golangsdk v0.0.0-20241026031406-eeb6712069c7/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
+github.com/chnsz/golangsdk v0.0.0-20241028021804-ed476dc428f2 h1:aCj1mILjj+zE65oHzboFlKJh2HsvHWuxkEuS/a4XdL0=
+github.com/chnsz/golangsdk v0.0.0-20241028021804-ed476dc428f2/go.mod h1:Erm4hDWxXgAdbkG3+hhJFgRzEL1TvvcroWzw2Gax4uI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
+++ b/huaweicloud/services/acceptance/vpcep/resource_huaweicloud_vpcep_service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/common"
 )
 
 func TestAccVPCEPService_Basic(t *testing.T) {
@@ -246,3 +247,124 @@ data "huaweicloud_networking_secgroup" "test" {
   name = "default"
 }
 `
+
+// Currently, the professional VPC endpoint service only four regions support
+// Such as cn-east-4
+func TestAccVPCEPService_ipVersion(t *testing.T) {
+	var service services.Service
+
+	name := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "huaweicloud_vpcep_service.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&service,
+		getVpcepServiceResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEPService_ipVersion(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "approval", "false"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test desc"),
+					resource.TestCheckResourceAttr(resourceName, "server_type", "VM"),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "interface"),
+					resource.TestCheckResourceAttr(resourceName, "tcp_proxy", "close"),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "ipv6"),
+					resource.TestCheckResourceAttrPair(resourceName, "snat_network_id", "huaweicloud_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.service_port", "8088"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.terminal_port", "80"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccVPCEPService_ipVersion_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "huaweicloud_availability_zones" "test" {}
+
+data "huaweicloud_compute_flavors" "test" {
+  availability_zone = data.huaweicloud_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core_count    = 2
+  memory_size       = 4
+}
+
+data "huaweicloud_images_image" "test" {
+  name        = "Ubuntu 20.04 server 64bit"
+  most_recent = true
+}
+
+resource "huaweicloud_vpc" "test" {
+  name = "%[2]s-vpc"
+  cidr = "192.168.0.0/24"
+}
+
+resource "huaweicloud_vpc_subnet" "test" {
+  vpc_id      = huaweicloud_vpc.test.id
+  name        = "%[2]s-subnet"
+  cidr        = "192.168.0.0/24"
+  gateway_ip  = "192.168.0.1"
+  ipv6_enable = true
+}
+
+resource "huaweicloud_compute_instance" "test" {
+  name               = "%[2]s"
+  image_id           = data.huaweicloud_images_image.test.id
+  flavor_id          = data.huaweicloud_compute_flavors.test.ids[0]
+  security_group_ids = [huaweicloud_networking_secgroup.test.id]
+  availability_zone  = data.huaweicloud_availability_zones.test.names[0]
+
+  network {
+    uuid        = huaweicloud_vpc_subnet.test.id
+    ipv6_enable = true
+  }
+}
+`, common.TestSecGroup(name), name)
+}
+
+func testAccVPCEPService_ipVersion(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "huaweicloud_vpcep_service" "test" {
+  name                     = "%[2]s"
+  server_type              = "VM"
+  vpc_id                   = huaweicloud_vpc.test.id
+  port_id                  = huaweicloud_compute_instance.test.network[0].port
+  approval                 = false
+  tcp_proxy                = "close"
+  ip_version               = "ipv6"
+  snat_network_id          = huaweicloud_vpc_subnet.test.id
+  description              = "test desc"
+  permissions              = ["*"]
+  organization_permissions = ["organizations:orgPath::*"]
+
+  port_mapping {
+    service_port  = 8088
+    terminal_port = 80
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, testAccVPCEPService_ipVersion_base(name), name)
+}

--- a/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
+++ b/huaweicloud/services/vpcep/resource_huaweicloud_vpcep_service.go
@@ -136,6 +136,41 @@ func ResourceVPCEndpointService() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"ip_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"snat_network_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			// This field is not tested due to insufficient testing conditions.
+			"ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: utils.SchemaDesc(
+					`The IPv4 address or domain name of the server in the interface type VLAN scenario.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
+			// This field is not tested due to insufficient testing conditions.
+			"pool_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Description: utils.SchemaDesc(
+					`The dedicated cluster ID associated with the VPC endpoint service.`,
+					utils.SchemaDescInput{
+						Internal: true,
+					}),
+			},
 			"tags": common.TagsSchema(),
 			"service_name": {
 				Type:     schema.TypeString,
@@ -264,16 +299,20 @@ func resourceVPCEndpointServiceCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	createOpts := services.CreateOpts{
-		VpcID:       d.Get("vpc_id").(string),
-		PortID:      d.Get("port_id").(string),
-		ServerType:  d.Get("server_type").(string),
-		ServiceName: d.Get("name").(string),
-		ServiceType: d.Get("service_type").(string),
-		Description: d.Get("description").(string),
-		TCPProxy:    d.Get("tcp_proxy").(string),
-		Approval:    utils.Bool(d.Get("approval").(bool)),
-		Ports:       buildPortMappingOpts(d),
-		Tags:        utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
+		VpcID:         d.Get("vpc_id").(string),
+		PortID:        d.Get("port_id").(string),
+		ServerType:    d.Get("server_type").(string),
+		ServiceName:   d.Get("name").(string),
+		ServiceType:   d.Get("service_type").(string),
+		Description:   d.Get("description").(string),
+		TCPProxy:      d.Get("tcp_proxy").(string),
+		IpVersion:     d.Get("ip_version").(string),
+		SnatNetworkId: d.Get("snat_network_id").(string),
+		IpAddress:     d.Get("ip_address").(string),
+		PoolId:        d.Get("pool_id").(string),
+		Approval:      utils.Bool(d.Get("approval").(bool)),
+		Ports:         buildPortMappingOpts(d),
+		Tags:          utils.ExpandResourceTags(d.Get("tags").(map[string]interface{})),
 	}
 
 	// The European station does not support this parameter, so set it separately.
@@ -338,6 +377,10 @@ func resourceVPCEndpointServiceRead(_ context.Context, d *schema.ResourceData, m
 		d.Set("port_mapping", flattenVPCEndpointServicePorts(n)),
 		d.Set("tags", utils.TagsToMap(n.Tags)),
 		d.Set("enable_policy", n.EnablePolicy),
+		d.Set("ip_version", n.IpVersion),
+		d.Set("snat_network_id", n.SnatNetworkId),
+		d.Set("ip_address", n.IpAddress),
+		d.Set("pool_id", n.PoolId),
 	)
 
 	nameList := strings.Split(n.ServiceName, ".")
@@ -367,7 +410,7 @@ func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error creating VPC endpoint client: %s", err)
 	}
 
-	if d.HasChanges("name", "approval", "port_id", "port_mapping", "description", "tcp_proxy") {
+	if d.HasChanges("name", "approval", "port_id", "port_mapping", "description", "tcp_proxy", "ip_address") {
 		updateOpts := services.UpdateOpts{
 			ServiceName: d.Get("name").(string),
 			Description: utils.String(d.Get("description").(string)),
@@ -384,6 +427,9 @@ func resourceVPCEndpointServiceUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 		if d.HasChange("tcp_proxy") {
 			updateOpts.TCPProxy = d.Get("tcp_proxy").(string)
+		}
+		if d.HasChange("ip_address") {
+			updateOpts.IpAddress = d.Get("ip_address").(string)
 		}
 
 		_, err = services.Update(vpcepClient, d.Id(), updateOpts).Extract()

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/requests.go
@@ -43,6 +43,12 @@ type CreateOpts struct {
 	IpVersion string `json:"ip_version,omitempty"`
 	// Specifies whether the VPC endpoint policy is enabled.
 	EnablePolicy *bool `json:"enable_policy,omitempty"`
+	// Specifies the network ID of any subnet within the VPC used to create the VPC endpoint service
+	SnatNetworkId string `json:"snat_network_id,omitempty"`
+	// Specifies the IPv4 address or domain name of the server in the interface type VLAN scenario
+	IpAddress string `json:"ip,omitempty"`
+	// Specifies the dedicated cluster ID associated with the VPC endpoint service
+	PoolId string `json:"pool_id,omitempty"`
 }
 
 // PortOpts contains the port mappings opened to the VPC endpoint service.
@@ -101,6 +107,8 @@ type UpdateOpts struct {
 	Description *string `json:"description,omitempty"`
 	// Specifies whether the client IP address and port number or marker_id information is transmitted to the server.
 	TCPProxy string `json:"tcp_proxy,omitempty"`
+	// Specifies the IPv4 address or domain name of the server in the interface type VLAN scenario
+	IpAddress string `json:"ip,omitempty"`
 }
 
 // ToServiceUpdateMap builds an update body based on UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/vpcep/v1/services/results.go
@@ -52,6 +52,12 @@ type Service struct {
 	PublicBorderGroup string `json:"public_border_group"`
 	// the number of VPC endpoints that are in the Creating or Accepted status.
 	ConnectionCount int `json:"connection_count"`
+	// the network ID of any subnet within the VPC used to create the VPC endpoint service
+	SnatNetworkId string `json:"snat_network_id"`
+	// the IPv4 address or domain name of the server in the interface type VLAN scenario
+	IpAddress string `json:"ip"`
+	// the dedicated cluster ID associated with the VPC endpoint service
+	PoolId string `json:"pool_id"`
 }
 
 // PortMapping contains the port mappings opened to the VPC endpoint service

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg/v13 v13.0.0
 ## explicit; go 1.16
 github.com/apparentlymart/go-textseg/v13/textseg
-# github.com/chnsz/golangsdk v0.0.0-20241026031406-eeb6712069c7
+# github.com/chnsz/golangsdk v0.0.0-20241028021804-ed476dc428f2
 ## explicit; go 1.14
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/auth


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The VPC endpoint service resource supports new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccVPCEPService_Basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEPService_Basic -timeout 360m -parallel 4
=== RUN   TestAccVPCEPService_Basic
=== PAUSE TestAccVPCEPService_Basic
=== CONT  TestAccVPCEPService_Basic
--- PASS: TestAccVPCEPService_Basic (294.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     294.951s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/vpcep" TESTARGS="-run TestAccVPCEPService_ipVersion"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpcep -v -run TestAccVPCEPService_ipVersion -timeout 360m -parallel 4
=== RUN   TestAccVPCEPService_ipVersion
=== PAUSE TestAccVPCEPService_ipVersion
=== CONT  TestAccVPCEPService_ipVersion
--- PASS: TestAccVPCEPService_ipVersion (257.44s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpcep     257.486s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
