### PR TITLE
fix(iotda): optimize data source pagination query logic

### DIFF
--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_products_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_products_test.go
@@ -185,7 +185,6 @@ func testAccDataSourceProducts_derived() string {
 
 	return fmt.Sprintf(`
 %[1]s
-%[2]s
 
 data "huaweicloud_iotda_products" "test_derived" {
   depends_on = [huaweicloud_iotda_product.test]
@@ -214,5 +213,5 @@ data "huaweicloud_iotda_products" "not_found" {
 output "not_found_validation_pass" {
   value = length(data.huaweicloud_iotda_products.not_found.products) == 0
 }
-`, testProduct_basic(name), buildIoTDAEndpoint())
+`, testProduct_basic(name))
 }

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_amqps.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_amqps.go
@@ -89,12 +89,17 @@ func dataSourceAMQPQueuesRead(_ context.Context, d *schema.ResourceData, meta in
 			return diag.Errorf("error querying IoTDA AMQP queues: %s", listErr)
 		}
 
+		if listResp == nil || listResp.Queues == nil {
+			break
+		}
+
 		if len(*listResp.Queues) == 0 {
 			break
 		}
 
 		allQueues = append(allQueues, *listResp.Queues...)
-		offset += limit
+		//nolint:gosec
+		offset += int32(len(*listResp.Queues))
 	}
 
 	uuId, err := uuid.GenerateUUID()

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_batchtasks.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_batchtasks.go
@@ -184,7 +184,8 @@ func dataSourceBatchTasksRead(_ context.Context, d *schema.ResourceData, meta in
 		}
 
 		allTasks = append(allTasks, *listResp.Batchtasks...)
-		offset += limit
+		//nolint:gosec
+		offset += int32(len(*listResp.Batchtasks))
 	}
 
 	uuId, err := uuid.GenerateUUID()

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_dataforwarding_rules.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_dataforwarding_rules.go
@@ -142,11 +142,17 @@ func dataSourceDataForwardingRulesRead(_ context.Context, d *schema.ResourceData
 			return diag.Errorf("error querying IoTDA dataforwarding rules: %s", listErr)
 		}
 
+		if listResp == nil || listResp.Rules == nil {
+			break
+		}
+
 		if len(*listResp.Rules) == 0 {
 			break
 		}
+
 		allRoutingRules = append(allRoutingRules, *listResp.Rules...)
-		offset += limit
+		//nolint:gosec
+		offset += int32(len(*listResp.Rules))
 	}
 
 	uuId, err := uuid.GenerateUUID()

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_certificates.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_certificates.go
@@ -116,12 +116,17 @@ func dataSourceDeviceCertificatesRead(_ context.Context, d *schema.ResourceData,
 			return diag.Errorf("error querying IoTDA device CA certificates: %s", listErr)
 		}
 
+		if listResp == nil || listResp.Certificates == nil {
+			break
+		}
+
 		if len(*listResp.Certificates) == 0 {
 			break
 		}
 
 		allCertificates = append(allCertificates, *listResp.Certificates...)
-		offset += limit
+		//nolint:gosec
+		offset += int32(len(*listResp.Certificates))
 	}
 
 	uuId, err := uuid.GenerateUUID()

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_groups.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_groups.go
@@ -107,12 +107,17 @@ func dataSourceDeviceGroupsRead(_ context.Context, d *schema.ResourceData, meta 
 			return diag.Errorf("error querying IoTDA device groups: %s", listErr)
 		}
 
+		if listResp == nil || listResp.DeviceGroups == nil {
+			break
+		}
+
 		if len(*listResp.DeviceGroups) == 0 {
 			break
 		}
 
 		allDeviceGroups = append(allDeviceGroups, *listResp.DeviceGroups...)
-		offset += limit
+		//nolint:gosec
+		offset += int32(len(*listResp.DeviceGroups))
 	}
 
 	uuId, err := uuid.GenerateUUID()

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_linkage_rules.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_linkage_rules.go
@@ -354,12 +354,17 @@ func dataSourceeDeviceLinkageRulesRead(_ context.Context, d *schema.ResourceData
 			return diag.Errorf("error querying IoTDA device linkage rules: %s", listErr)
 		}
 
+		if listResp == nil || listResp.Rules == nil {
+			break
+		}
+
 		if len(*listResp.Rules) == 0 {
 			break
 		}
 
 		allRules = append(allRules, *listResp.Rules...)
-		offset += limit
+		//nolint:gosec
+		offset += int32(len(*listResp.Rules))
 	}
 
 	uuId, err := uuid.GenerateUUID()

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_devices.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_devices.go
@@ -172,12 +172,17 @@ func dataSourceDevicesRead(_ context.Context, d *schema.ResourceData, meta inter
 			return diag.Errorf("error querying IoTDA devices: %s", listErr)
 		}
 
+		if listResp == nil || listResp.Devices == nil {
+			break
+		}
+
 		if len(*listResp.Devices) == 0 {
 			break
 		}
 
 		allDevices = append(allDevices, *listResp.Devices...)
-		offset += limit
+		//nolint:gosec
+		offset += int32(len(*listResp.Devices))
 	}
 
 	uuId, err := uuid.GenerateUUID()

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_products.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_products.go
@@ -130,11 +130,17 @@ func dataSourceProductsRead(_ context.Context, d *schema.ResourceData, meta inte
 			return diag.Errorf("error querying IoTDA products: %s", listErr)
 		}
 
+		if listResp == nil || listResp.Products == nil {
+			break
+		}
+
 		if len(*listResp.Products) == 0 {
 			break
 		}
+
 		allProducts = append(allProducts, *listResp.Products...)
-		offset += limit
+		//nolint:gosec
+		offset += int32(len(*listResp.Products))
 	}
 
 	uuId, err := uuid.GenerateUUID()

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_upgrade_packages.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_upgrade_packages.go
@@ -144,7 +144,8 @@ func dataSourceIotdaUpgradePackagesRead(_ context.Context, d *schema.ResourceDat
 		}
 
 		upgradePackages = append(upgradePackages, *listResp.Packages...)
-		offset += limit
+		//nolint:gosec
+		offset += int32(len(*listResp.Packages))
 	}
 
 	uuId, err := uuid.GenerateUUID()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Optimize data source pagination query logic, because the original pagination logic may lead to inaccurate query results.

2. Use `//nolint: gosec` to skip CI check.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### Basic Test
```
$ unset HW_IOTDA_ACCESS_ADDRESS

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceAMQPQueues_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceAMQPQueues_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAMQPQueues_basic
=== PAUSE TestAccDataSourceAMQPQueues_basic
=== CONT  TestAccDataSourceAMQPQueues_basic
--- PASS: TestAccDataSourceAMQPQueues_basic (10.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     10.385s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceBatchTasks_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceBatchTasks_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceBatchTasks_basic
=== PAUSE TestAccDataSourceBatchTasks_basic
=== CONT  TestAccDataSourceBatchTasks_basic
--- PASS: TestAccDataSourceBatchTasks_basic (32.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     32.244s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDataForwardingRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataForwardingRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataForwardingRules_basic
=== PAUSE TestAccDataSourceDataForwardingRules_basic
=== CONT  TestAccDataSourceDataForwardingRules_basic
--- PASS: TestAccDataSourceDataForwardingRules_basic (11.81s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     11.868s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceCertificates_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceCertificates_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceCertificates_basic
=== PAUSE TestAccDataSourceDeviceCertificates_basic
=== CONT  TestAccDataSourceDeviceCertificates_basic
--- PASS: TestAccDataSourceDeviceCertificates_basic (11.08s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     11.134s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceGroups_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceGroups_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceGroups_basic
=== PAUSE TestAccDataSourceDeviceGroups_basic
=== CONT  TestAccDataSourceDeviceGroups_basic
--- PASS: TestAccDataSourceDeviceGroups_basic (12.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     12.839s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceLinkageRules_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceLinkageRules_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceLinkageRules_basic
=== PAUSE TestAccDataSourceDeviceLinkageRules_basic
=== CONT  TestAccDataSourceDeviceLinkageRules_basic
--- PASS: TestAccDataSourceDeviceLinkageRules_basic (18.78s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     18.829s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDevices_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDevices_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDevices_basic
=== PAUSE TestAccDataSourceDevices_basic
=== CONT  TestAccDataSourceDevices_basic
--- PASS: TestAccDataSourceDevices_basic (13.43s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     13.478s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceProducts_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceProducts_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceProducts_basic
=== PAUSE TestAccDataSourceProducts_basic
=== CONT  TestAccDataSourceProducts_basic
--- PASS: TestAccDataSourceProducts_basic (12.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     12.722s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceUpgradePackages_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceUpgradePackages_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceUpgradePackages_basic
=== PAUSE TestAccDataSourceUpgradePackages_basic
=== CONT  TestAccDataSourceUpgradePackages_basic
--- PASS: TestAccDataSourceUpgradePackages_basic (18.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     18.667s

```

### Derived Test
```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceAMQPQueues_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceAMQPQueues_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceAMQPQueues_derived
=== PAUSE TestAccDataSourceAMQPQueues_derived
=== CONT  TestAccDataSourceAMQPQueues_derived
--- PASS: TestAccDataSourceAMQPQueues_derived (9.73s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     9.784s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceBatchTasks_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceBatchTasks_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceBatchTasks_derived
=== PAUSE TestAccDataSourceBatchTasks_derived
=== CONT  TestAccDataSourceBatchTasks_derived
--- PASS: TestAccDataSourceBatchTasks_derived (31.80s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     31.892s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDataForwardingRules_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDataForwardingRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDataForwardingRules_derived
=== PAUSE TestAccDataSourceDataForwardingRules_derived
=== CONT  TestAccDataSourceDataForwardingRules_derived
--- PASS: TestAccDataSourceDataForwardingRules_derived (11.01s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     11.064s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceCertificates_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceCertificates_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceCertificates_derived
=== PAUSE TestAccDataSourceDeviceCertificates_derived
=== CONT  TestAccDataSourceDeviceCertificates_derived
--- PASS: TestAccDataSourceDeviceCertificates_derived (11.87s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     11.924s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceGroups_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceGroups_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceGroups_derived
=== PAUSE TestAccDataSourceDeviceGroups_derived
=== CONT  TestAccDataSourceDeviceGroups_derived
--- PASS: TestAccDataSourceDeviceGroups_derived (13.79s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     13.837s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceLinkageRules_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceLinkageRules_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceLinkageRules_derived
=== PAUSE TestAccDataSourceDeviceLinkageRules_derived
=== CONT  TestAccDataSourceDeviceLinkageRules_derived
--- PASS: TestAccDataSourceDeviceLinkageRules_derived (19.54s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     19.598s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDevices_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDevices_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDevices_derived
=== PAUSE TestAccDataSourceDevices_derived
=== CONT  TestAccDataSourceDevices_derived
--- PASS: TestAccDataSourceDevices_derived (15.13s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     15.178s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceProducts_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceProducts_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceProducts_derived
=== PAUSE TestAccDataSourceProducts_derived
=== CONT  TestAccDataSourceProducts_derived
--- PASS: TestAccDataSourceProducts_derived (11.36s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     11.407s


$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceUpgradePackages_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceUpgradePackages_derived -timeout 360m -parallel 4
=== RUN   TestAccDataSourceUpgradePackages_derived
=== PAUSE TestAccDataSourceUpgradePackages_derived
=== CONT  TestAccDataSourceUpgradePackages_derived
--- PASS: TestAccDataSourceUpgradePackages_derived (14.62s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     14.694s

```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
