### PR TITLE
chore(ga): increase code robustness and improve test cases

### DIFF
--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_accelerators_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_accelerators_test.go
@@ -36,6 +36,17 @@ func TestAccDatasourceAccelerators_basic(t *testing.T) {
 				Config: testAccDataSourceAccelerators_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.0.description"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.0.enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.0.ip_sets.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.0.tags.%"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "accelerators.0.updated_at"),
+
 					dcByName.CheckResourceExists(),
 					resource.TestCheckOutput("name_filter_is_useful", "true"),
 
@@ -81,6 +92,7 @@ data "huaweicloud_ga_accelerators" "test" {
   ]  
 }
 
+# Filter by name
 locals {
   name = data.huaweicloud_ga_accelerators.test.accelerators[0].name
 }
@@ -99,6 +111,7 @@ output "name_filter_is_useful" {
   value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
 }
 
+# Filter by accelerator_id
 locals {
   accelerator_id = data.huaweicloud_ga_accelerators.test.accelerators[0].id
 }
@@ -117,6 +130,7 @@ output "accelerator_id_filter_is_useful" {
   value = alltrue(local.accelerator_id_filter_result) && length(local.accelerator_id_filter_result) > 0
 }
 
+# Filter by status
 locals {
   status = data.huaweicloud_ga_accelerators.test.accelerators[0].status
 }
@@ -135,6 +149,7 @@ output "status_filter_is_useful" {
   value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
 }
 
+# Filter by enterprise_project_id
 locals {
   enterprise_project_id = data.huaweicloud_ga_accelerators.test.accelerators[0].enterprise_project_id
 }

--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_address_groups_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_address_groups_test.go
@@ -23,9 +23,6 @@ func TestAccDatasourceAddressGroups_basic(t *testing.T) {
 
 		byStatus   = "data.huaweicloud_ga_address_groups.filter_by_status"
 		dcByStatus = acceptance.InitDataSourceCheck(byStatus)
-
-		byListenerId   = "data.huaweicloud_ga_address_groups.filter_by_listener_id"
-		dcByListenerId = acceptance.InitDataSourceCheck(byListenerId)
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -43,6 +40,10 @@ func TestAccDatasourceAddressGroups_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "address_groups.0.ip_addresses.0.cidr"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "address_groups.0.associated_listeners.0.id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "address_groups.0.associated_listeners.0.type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "address_groups.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "address_groups.0.status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "address_groups.0.updated_at"),
+
 					dcByAddressGroupId.CheckResourceExists(),
 					resource.TestCheckOutput("address_group_id_filter_is_useful", "true"),
 
@@ -51,9 +52,6 @@ func TestAccDatasourceAddressGroups_basic(t *testing.T) {
 
 					dcByStatus.CheckResourceExists(),
 					resource.TestCheckOutput("status_filter_is_useful", "true"),
-
-					dcByListenerId.CheckResourceExists(),
-					resource.TestCheckOutput("listener_id_filter_is_useful", "true"),
 				),
 			},
 		},
@@ -173,25 +171,6 @@ locals {
 
 output "status_filter_is_useful" {
   value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
-}
-
-locals {
-  listener_id = data.huaweicloud_ga_address_groups.test.address_groups[0].associated_listeners[0].id
-}
-
-data "huaweicloud_ga_address_groups" "filter_by_listener_id" {
-  listener_id = local.listener_id
-}
-
-locals {
-  listener_id_filter_result = [
-    for v in data.huaweicloud_ga_address_groups.filter_by_listener_id.address_groups[*].associated_listeners[0].id : 
-    v == local.listener_id
-  ]
-}
-
-output "listener_id_filter_is_useful" {
-  value = alltrue(local.listener_id_filter_result) && length(local.listener_id_filter_result) > 0
 }
 `, testAccDataSourceAddressGroups_base(name))
 }

--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_availability_zones_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_availability_zones_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceGaAvailabilityZones_basic(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceAvailabilityZones_basic(),
+				Config: testDataSourceAvailabilityZones_basic,
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(dataSourceName, "regions.#"),
@@ -40,8 +40,7 @@ func TestAccDataSourceGaAvailabilityZones_basic(t *testing.T) {
 	})
 }
 
-func testDataSourceAvailabilityZones_basic() string {
-	return (`
+const testDataSourceAvailabilityZones_basic = `
 data "huaweicloud_ga_availability_zones" "test" {}
 
 locals {
@@ -61,5 +60,4 @@ locals {
 output "area_filter_is_useful" {
   value = alltrue(local.area_filter_result) && length(local.area_filter_result) > 0
 }
-`)
-}
+`

--- a/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_endpoint_groups_test.go
+++ b/huaweicloud/services/acceptance/ga/data_source_huaweicloud_ga_endpoint_groups_test.go
@@ -43,6 +43,9 @@ func TestAccDatasourceEndpointGroups_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.traffic_dial_percentage"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.region_id"),
 					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.listener_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.created_at"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "endpoint_groups.0.status"),
+
 					dcByEndpointGroupId.CheckResourceExists(),
 					resource.TestCheckOutput("endpoint_group_id_filter_is_useful", "true"),
 
@@ -115,6 +118,7 @@ data "huaweicloud_ga_endpoint_groups" "test" {
   ]
 }
 
+# Filter by endpoint_group_id
 locals {
   endpoint_group_id = data.huaweicloud_ga_endpoint_groups.test.endpoint_groups[0].id
 }
@@ -134,6 +138,7 @@ output "endpoint_group_id_filter_is_useful" {
   value = alltrue(local.endpoint_group_id_filter_result) && length(local.endpoint_group_id_filter_result) > 0
 }
 
+# Filter by name
 locals {
   name = data.huaweicloud_ga_endpoint_groups.test.endpoint_groups[0].name
 }
@@ -152,6 +157,7 @@ output "name_filter_is_useful" {
   value = alltrue(local.name_filter_result) && length(local.name_filter_result) > 0
 }
 
+# Filter by status
 locals {
   status = data.huaweicloud_ga_endpoint_groups.test.endpoint_groups[0].status
 }
@@ -170,6 +176,7 @@ output "status_filter_is_useful" {
   value = alltrue(local.status_filter_result) && length(local.status_filter_result) > 0
 }
 
+# Filter by listener_id
 locals {
   listener_id = data.huaweicloud_ga_endpoint_groups.test.endpoint_groups[0].listener_id
 }

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_accelerator_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_accelerator_test.go
@@ -16,38 +16,34 @@ import (
 )
 
 func getAcceleratorResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	// getAccelerator: Query the GA accelerator detail
 	var (
-		getAcceleratorHttpUrl = "v1/accelerators/{id}"
-		getAcceleratorProduct = "ga"
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/accelerators/{id}"
+		product = "ga"
 	)
-	getAcceleratorClient, err := conf.NewServiceClient(getAcceleratorProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Accelerator Client: %s", err)
+		return nil, fmt.Errorf("error creating GA client: %s", err)
 	}
 
-	getAcceleratorPath := getAcceleratorClient.Endpoint + getAcceleratorHttpUrl
-	getAcceleratorPath = strings.ReplaceAll(getAcceleratorPath, "{id}", state.Primary.ID)
-
-	getAcceleratorOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{id}", state.Primary.ID)
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getAcceleratorResp, err := getAcceleratorClient.Request("GET", getAcceleratorPath, &getAcceleratorOpt)
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving Accelerator: %s", err)
+		return nil, fmt.Errorf("error retrieving GA accelerator: %s", err)
 	}
-	return utils.FlattenResponse(getAcceleratorResp)
+	return utils.FlattenResponse(resp)
 }
 
 func TestAccAccelerator_basic(t *testing.T) {
-	var obj interface{}
-
-	name := acceptance.RandomAccResourceNameWithDash()
-	rName := "huaweicloud_ga_accelerator.test"
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceNameWithDash()
+		rName = "huaweicloud_ga_accelerator.test"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		rName,

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_address_group_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_address_group_test.go
@@ -16,34 +16,28 @@ import (
 )
 
 func getIpAddressGroupResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-
-	// getIpAddressGroup: Query the GA IP address group detail
 	var (
-		getIpAddressGroupHttpUrl = "v1/ip-groups/{ip_group_id}"
-		getIpAddressGroupProduct = "ga"
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/ip-groups/{ip_group_id}"
+		product = "ga"
 	)
 
-	getIpAddressGroupClient, err := cfg.NewServiceClient(getIpAddressGroupProduct, region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating IP address group client: %s", err)
+		return nil, fmt.Errorf("error creating GA client: %s", err)
 	}
 
-	getIpAddressGroupPath := getIpAddressGroupClient.Endpoint + getIpAddressGroupHttpUrl
-	getIpAddressGroupPath = strings.ReplaceAll(getIpAddressGroupPath, "{ip_group_id}", state.Primary.ID)
-
-	getIpAddressGroupOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{ip_group_id}", state.Primary.ID)
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 
-	getIpAddressGroupResp, err := getIpAddressGroupClient.Request("GET", getIpAddressGroupPath, &getIpAddressGroupOpt)
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving IP address group: %s", err)
+		return nil, fmt.Errorf("error retrieving GA IP address group: %s", err)
 	}
-	return utils.FlattenResponse(getIpAddressGroupResp)
+	return utils.FlattenResponse(resp)
 }
 
 func TestAccIpAddressGroup_basic(t *testing.T) {

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_group_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_group_test.go
@@ -16,38 +16,34 @@ import (
 )
 
 func getEndpointGroupResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	// getEndpointGroup: Query the GA Endpoint Group detail
 	var (
-		getEndpointGroupHttpUrl = "v1/endpoint-groups/{id}"
-		getEndpointGroupProduct = "ga"
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/endpoint-groups/{id}"
+		product = "ga"
 	)
-	getEndpointGroupClient, err := conf.NewServiceClient(getEndpointGroupProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating EndpointGroup Client: %s", err)
+		return nil, fmt.Errorf("error creating GA client: %s", err)
 	}
 
-	getEndpointGroupPath := getEndpointGroupClient.Endpoint + getEndpointGroupHttpUrl
-	getEndpointGroupPath = strings.ReplaceAll(getEndpointGroupPath, "{id}", state.Primary.ID)
-
-	getEndpointGroupOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{id}", state.Primary.ID)
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getEndpointGroupResp, err := getEndpointGroupClient.Request("GET", getEndpointGroupPath, &getEndpointGroupOpt)
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving EndpointGroup: %s", err)
+		return nil, fmt.Errorf("error retrieving GA endpoint group: %s", err)
 	}
-	return utils.FlattenResponse(getEndpointGroupResp)
+	return utils.FlattenResponse(resp)
 }
 
 func TestAccEndpointGroup_basic(t *testing.T) {
-	var obj interface{}
-
-	name := acceptance.RandomAccResourceNameWithDash()
-	rName := "huaweicloud_ga_endpoint_group.test"
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceNameWithDash()
+		rName = "huaweicloud_ga_endpoint_group.test"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		rName,

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_endpoint_test.go
@@ -16,39 +16,36 @@ import (
 )
 
 func getEndpointResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	// getEndpoint: Query the GA Endpoint detail
 	var (
-		getEndpointHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{id}"
-		getEndpointProduct = "ga"
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{id}"
+		product = "ga"
 	)
-	getEndpointClient, err := conf.NewServiceClient(getEndpointProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Endpoint Client: %s", err)
+		return nil, fmt.Errorf("error creating GA client: %s", err)
 	}
 
-	getEndpointPath := getEndpointClient.Endpoint + getEndpointHttpUrl
-	getEndpointPath = strings.ReplaceAll(getEndpointPath, "{endpoint_group_id}", state.Primary.Attributes["endpoint_group_id"])
-	getEndpointPath = strings.ReplaceAll(getEndpointPath, "{id}", state.Primary.ID)
-
-	getEndpointOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_group_id}", state.Primary.Attributes["endpoint_group_id"])
+	requestPath = strings.ReplaceAll(requestPath, "{id}", state.Primary.ID)
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getEndpointResp, err := getEndpointClient.Request("GET", getEndpointPath, &getEndpointOpt)
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving Endpoint: %s", err)
+		return nil, fmt.Errorf("error retrieving GA endpoint: %s", err)
 	}
-	return utils.FlattenResponse(getEndpointResp)
+	return utils.FlattenResponse(resp)
 }
 
 func TestAccEndpoint_basic(t *testing.T) {
-	var obj interface{}
-
-	name := acceptance.RandomAccResourceNameWithDash()
-	rName := "huaweicloud_ga_endpoint.test"
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceNameWithDash()
+		rName = "huaweicloud_ga_endpoint.test"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		rName,

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_health_check_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_health_check_test.go
@@ -16,38 +16,35 @@ import (
 )
 
 func getHealthCheckResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	// getHealthCheck: Query the GA Health Check detail
 	var (
-		getHealthCheckHttpUrl = "v1/health-checks/{id}"
-		getHealthCheckProduct = "ga"
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/health-checks/{id}"
+		product = "ga"
 	)
-	getHealthCheckClient, err := conf.NewServiceClient(getHealthCheckProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating HealthCheck Client: %s", err)
+		return nil, fmt.Errorf("error creating GA client: %s", err)
 	}
 
-	getHealthCheckPath := getHealthCheckClient.Endpoint + getHealthCheckHttpUrl
-	getHealthCheckPath = strings.ReplaceAll(getHealthCheckPath, "{id}", state.Primary.ID)
-
-	getHealthCheckOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{id}", state.Primary.ID)
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getHealthCheckResp, err := getHealthCheckClient.Request("GET", getHealthCheckPath, &getHealthCheckOpt)
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving HealthCheck: %s", err)
+		return nil, fmt.Errorf("error retrieving GA health check: %s", err)
 	}
-	return utils.FlattenResponse(getHealthCheckResp)
+	return utils.FlattenResponse(resp)
 }
 
 func TestAccHealthCheck_basic(t *testing.T) {
-	var obj interface{}
-
-	name := acceptance.RandomAccResourceNameWithDash()
-	rName := "huaweicloud_ga_health_check.test"
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceNameWithDash()
+		rName = "huaweicloud_ga_health_check.test"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		rName,

--- a/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_listener_test.go
+++ b/huaweicloud/services/acceptance/ga/resource_huaweicloud_ga_listener_test.go
@@ -16,38 +16,35 @@ import (
 )
 
 func getListenerResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
-	region := acceptance.HW_REGION_NAME
-	// getListener: Query the GA Listener detail
 	var (
-		getListenerHttpUrl = "v1/listeners/{id}"
-		getListenerProduct = "ga"
+		region  = acceptance.HW_REGION_NAME
+		httpUrl = "v1/listeners/{id}"
+		product = "ga"
 	)
-	getListenerClient, err := conf.NewServiceClient(getListenerProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Listener Client: %s", err)
+		return nil, fmt.Errorf("error creating GA client: %s", err)
 	}
 
-	getListenerPath := getListenerClient.Endpoint + getListenerHttpUrl
-	getListenerPath = strings.ReplaceAll(getListenerPath, "{id}", state.Primary.ID)
-
-	getListenerOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{id}", state.Primary.ID)
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getListenerResp, err := getListenerClient.Request("GET", getListenerPath, &getListenerOpt)
+
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving Listener: %s", err)
+		return nil, fmt.Errorf("error retrieving GA listener: %s", err)
 	}
-	return utils.FlattenResponse(getListenerResp)
+	return utils.FlattenResponse(resp)
 }
 
 func TestAccListener_basic(t *testing.T) {
-	var obj interface{}
-
-	name := acceptance.RandomAccResourceNameWithDash()
-	rName := "huaweicloud_ga_listener.test"
+	var (
+		obj   interface{}
+		name  = acceptance.RandomAccResourceNameWithDash()
+		rName = "huaweicloud_ga_listener.test"
+	)
 
 	rc := acceptance.InitResourceCheck(
 		rName,

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_endpoints.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_endpoints.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/chnsz/golangsdk/pagination"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -127,56 +126,51 @@ func endpointsSchema() *schema.Resource {
 }
 
 func dataSourceEndpointsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// listEndpoints: Query the list of endpoints
 	var (
-		listEndpointsHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints"
-		listEndpointsProduct = "ga"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints"
+		product = "ga"
 	)
-	listEndpointsClient, err := cfg.NewServiceClient(listEndpointsProduct, region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	listEndpointsPath := listEndpointsClient.Endpoint + listEndpointsHttpUrl
-	listEndpointsPath = strings.ReplaceAll(listEndpointsPath, "{endpoint_group_id}", d.Get("endpoint_group_id").(string))
-
-	listEndpointsqueryParams := buildListEndpointsQueryParams(d)
-	listEndpointsPath += listEndpointsqueryParams
-
-	listEndpointsResp, err := pagination.ListAllItems(
-		listEndpointsClient,
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_group_id}", d.Get("endpoint_group_id").(string))
+	requestPath += buildListEndpointsQueryParams(d)
+	resp, err := pagination.ListAllItems(
+		client,
 		"marker",
-		listEndpointsPath,
+		requestPath,
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving endpoints")
+		return diag.Errorf("error retrieving GA endpoints: %s", err)
 	}
 
-	listEndpointsRespJson, err := json.Marshal(listEndpointsResp)
+	respJson, err := json.Marshal(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	var listEndpointsRespBody interface{}
-	err = json.Unmarshal(listEndpointsRespJson, &listEndpointsRespBody)
+	var respBody interface{}
+	err = json.Unmarshal(respJson, &respBody)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	uuid, err := uuid.GenerateUUID()
+	generateUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(generateUUID)
 
 	var mErr *multierror.Error
 	mErr = multierror.Append(
 		mErr,
-		d.Set("endpoints", filterListEndpointsResponseBody(flattenListEndpointsResponseBody(listEndpointsRespBody), d)),
+		d.Set("endpoints", filterListEndpointsResponseBody(flattenListEndpointsResponseBody(respBody), d)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -208,25 +202,28 @@ func flattenListEndpointsResponseBody(resp interface{}) []interface{} {
 }
 
 func filterListEndpointsResponseBody(all []interface{}, d *schema.ResourceData) []interface{} {
-	rst := make([]interface{}, 0, len(all))
+	var (
+		resourceID   = d.Get("resource_id").(string)
+		resourceType = d.Get("resource_type").(string)
+		healthState  = d.Get("health_state").(string)
+		ipAddress    = d.Get("ip_address").(string)
+		rst          = make([]interface{}, 0, len(all))
+	)
+
 	for _, v := range all {
-		if param, ok := d.GetOk("resource_id"); ok &&
-			fmt.Sprint(param) != utils.PathSearch("resource_id", v, nil) {
+		if resourceID != "" && resourceID != utils.PathSearch("resource_id", v, "").(string) {
 			continue
 		}
 
-		if param, ok := d.GetOk("resource_type"); ok &&
-			fmt.Sprint(param) != utils.PathSearch("resource_type", v, nil) {
+		if resourceType != "" && resourceType != utils.PathSearch("resource_type", v, "").(string) {
 			continue
 		}
 
-		if param, ok := d.GetOk("health_state"); ok &&
-			fmt.Sprint(param) != utils.PathSearch("health_state", v, nil) {
+		if healthState != "" && healthState != utils.PathSearch("health_state", v, "").(string) {
 			continue
 		}
 
-		if param, ok := d.GetOk("ip_address"); ok &&
-			fmt.Sprint(param) != utils.PathSearch("ip_address", v, nil) {
+		if ipAddress != "" && ipAddress != utils.PathSearch("ip_address", v, "").(string) {
 			continue
 		}
 

--- a/huaweicloud/services/ga/data_source_huaweicloud_ga_health_checks.go
+++ b/huaweicloud/services/ga/data_source_huaweicloud_ga_health_checks.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/chnsz/golangsdk/pagination"
 
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -121,70 +120,68 @@ func healthChecksSchema() *schema.Resource {
 }
 
 func dataSourceHealthChecksRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// listHealthChecks: Query the list of health checks
 	var (
-		listHealthChecksHttpUrl = "v1/health-checks"
-		listHealthChecksProduct = "ga"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/health-checks"
+		product = "ga"
+		mErr    *multierror.Error
 	)
-	listHealthChecksClient, err := cfg.NewServiceClient(listHealthChecksProduct, region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	listHealthChecksPath := listHealthChecksClient.Endpoint + listHealthChecksHttpUrl
-
-	listHealthChecksqueryParams := buildListHealthChecksQueryParams(d)
-	listHealthChecksPath += listHealthChecksqueryParams
-
-	listHealthChecksResp, err := pagination.ListAllItems(
-		listHealthChecksClient,
+	requestPath := client.Endpoint + httpUrl
+	requestPath += buildListHealthChecksQueryParams(d)
+	resp, err := pagination.ListAllItems(
+		client,
 		"marker",
-		listHealthChecksPath,
+		requestPath,
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving health checks")
+		return diag.Errorf("error retrieving GA health checks: %s", err)
 	}
 
-	listHealthChecksRespJson, err := json.Marshal(listHealthChecksResp)
+	respJson, err := json.Marshal(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	var listHealthChecksRespBody interface{}
-	err = json.Unmarshal(listHealthChecksRespJson, &listHealthChecksRespBody)
+	var respBody interface{}
+	err = json.Unmarshal(respJson, &respBody)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	uuid, err := uuid.GenerateUUID()
+	generateUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(generateUUID)
 
-	var mErr *multierror.Error
 	mErr = multierror.Append(
 		mErr,
-		d.Set("health_checks", filterListHealthChecksResponseBody(flattenListHealthChecksResponseBody(listHealthChecksRespBody), d)),
+		d.Set("health_checks", filterListHealthChecksResponseBody(flattenListHealthChecksResponseBody(respBody), d)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
 }
 
 func filterListHealthChecksResponseBody(all []interface{}, d *schema.ResourceData) []interface{} {
-	rst := make([]interface{}, 0, len(all))
+	var (
+		protocol = d.Get("protocol").(string)
+		enabled  = d.Get("enabled").(string)
+		rst      = make([]interface{}, 0, len(all))
+	)
+
 	for _, v := range all {
-		if param, ok := d.GetOk("protocol"); ok &&
-			fmt.Sprint(param) != utils.PathSearch("protocol", v, nil) {
+		if protocol != "" && protocol != utils.PathSearch("protocol", v, "").(string) {
 			continue
 		}
 
-		if param, ok := d.GetOk("enabled"); ok &&
-			fmt.Sprint(param) != fmt.Sprint(utils.PathSearch("enabled", v, nil)) {
+		if enabled != "" && enabled != fmt.Sprint(utils.PathSearch("enabled", v, nil)) {
 			continue
 		}
 

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_accelerator.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_accelerator.go
@@ -7,6 +7,7 @@ package ga
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -186,47 +187,42 @@ func AcceleratorFrozenInfoSchema() *schema.Resource {
 }
 
 func resourceAcceleratorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	// createAccelerator: Create a GA Accelerator.
 	var (
-		createAcceleratorHttpUrl = "v1/accelerators"
-		createAcceleratorProduct = "ga"
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		httpUrl = "v1/accelerators"
+		product = "ga"
 	)
-	createAcceleratorClient, err := conf.NewServiceClient(createAcceleratorProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating Accelerator Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	createAcceleratorPath := createAcceleratorClient.Endpoint + createAcceleratorHttpUrl
-
-	createAcceleratorOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
-	}
-	createAcceleratorOpt.JSONBody = utils.RemoveNil(buildCreateAcceleratorBodyParams(d, conf))
-	createAcceleratorResp, err := createAcceleratorClient.Request("POST", createAcceleratorPath, &createAcceleratorOpt)
-	if err != nil {
-		return diag.Errorf("error creating Accelerator: %s", err)
+		JSONBody:         utils.RemoveNil(buildCreateAcceleratorBodyParams(d, conf)),
 	}
 
-	createAcceleratorRespBody, err := utils.FlattenResponse(createAcceleratorResp)
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating GA accelerator: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	acceleratorId := utils.PathSearch("accelerator.id", createAcceleratorRespBody, "").(string)
+	acceleratorId := utils.PathSearch("accelerator.id", respBody, "").(string)
 	if acceleratorId == "" {
-		return diag.Errorf("unable to find the accelerator ID from the API response")
+		return diag.Errorf("error creating GA accelerator: unable to find the accelerator ID from the API response")
 	}
 	d.SetId(acceleratorId)
 
 	err = createAcceleratorWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error waiting for the Create of Accelerator (%s) to complete: %s", acceleratorId, err)
+		return diag.Errorf("error waiting for the accelerator (%s) creation to complete: %s", acceleratorId, err)
 	}
 	return resourceAcceleratorRead(ctx, d, meta)
 }
@@ -266,115 +262,99 @@ func buildCreateAcceleratorIpSetsChildBody(d *schema.ResourceData) []map[string]
 }
 
 func createAcceleratorWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/accelerators/{accelerator_id}"
+		product          = "ga"
+		targetStatus     = []string{"ACTIVE"}
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{accelerator_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// createAcceleratorWaiting: missing operation notes
-			var (
-				createAcceleratorWaitingHttpUrl = "v1/accelerators/{accelerator_id}"
-				createAcceleratorWaitingProduct = "ga"
-			)
-			createAcceleratorWaitingClient, err := config.NewServiceClient(createAcceleratorWaitingProduct, region)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating Accelerator Client: %s", err)
-			}
-
-			createAcceleratorWaitingPath := createAcceleratorWaitingClient.Endpoint + createAcceleratorWaitingHttpUrl
-			createAcceleratorWaitingPath = strings.ReplaceAll(createAcceleratorWaitingPath, "{accelerator_id}", d.Id())
-
-			createAcceleratorWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			createAcceleratorWaitingResp, err := createAcceleratorWaitingClient.Request("GET",
-				createAcceleratorWaitingPath, &createAcceleratorWaitingOpt)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			createAcceleratorWaitingRespBody, err := utils.FlattenResponse(createAcceleratorWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`accelerator.status`, createAcceleratorWaitingRespBody, "").(string)
 
-			targetStatus := []string{
-				"ACTIVE",
-			}
+			status := utils.PathSearch(`accelerator.status`, respBody, "").(string)
 			if utils.StrSliceContains(targetStatus, status) {
-				return createAcceleratorWaitingRespBody, "COMPLETED", nil
+				return respBody, "COMPLETED", nil
 			}
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return createAcceleratorWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return createAcceleratorWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }
 
 func resourceAcceleratorRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	var mErr *multierror.Error
-
-	// getAccelerator: Query the GA accelerator detail
 	var (
-		getAcceleratorHttpUrl = "v1/accelerators/{accelerator_id}"
-		getAcceleratorProduct = "ga"
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/accelerators/{accelerator_id}"
+		product = "ga"
 	)
-	getAcceleratorClient, err := conf.NewServiceClient(getAcceleratorProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating Accelerator Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	getAcceleratorPath := getAcceleratorClient.Endpoint + getAcceleratorHttpUrl
-	getAcceleratorPath = strings.ReplaceAll(getAcceleratorPath, "{accelerator_id}", d.Id())
-
-	getAcceleratorOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{accelerator_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getAcceleratorResp, err := getAcceleratorClient.Request("GET", getAcceleratorPath, &getAcceleratorOpt)
 
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving Accelerator")
+		return diag.Errorf("error retrieving GA accelerator: %s", err)
 	}
 
-	getAcceleratorRespBody, err := utils.FlattenResponse(getAcceleratorResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	mErr = multierror.Append(
 		mErr,
-		d.Set("name", utils.PathSearch("accelerator.name", getAcceleratorRespBody, nil)),
-		d.Set("description", utils.PathSearch("accelerator.description", getAcceleratorRespBody, nil)),
-		d.Set("ip_sets", flattenGetAcceleratorResponseBodyAccelerateIp(getAcceleratorRespBody)),
-		d.Set("enterprise_project_id", utils.PathSearch("accelerator.enterprise_project_id", getAcceleratorRespBody, nil)),
-		d.Set("tags", flattenGetAcceleratorResponseBodyResourceTag(getAcceleratorRespBody)),
-		d.Set("status", utils.PathSearch("accelerator.status", getAcceleratorRespBody, nil)),
-		d.Set("flavor_id", utils.PathSearch("accelerator.flavor_id", getAcceleratorRespBody, nil)),
-		d.Set("frozen_info", flattenGetAcceleratorResponseBodyFrozenInfo(getAcceleratorRespBody)),
-		d.Set("created_at", utils.PathSearch("accelerator.created_at", getAcceleratorRespBody, nil)),
-		d.Set("updated_at", utils.PathSearch("accelerator.updated_at", getAcceleratorRespBody, nil)),
+		d.Set("name", utils.PathSearch("accelerator.name", respBody, nil)),
+		d.Set("description", utils.PathSearch("accelerator.description", respBody, nil)),
+		d.Set("ip_sets", flattenGetAcceleratorResponseBodyAccelerateIp(respBody)),
+		d.Set("enterprise_project_id", utils.PathSearch("accelerator.enterprise_project_id", respBody, nil)),
+		d.Set("tags", flattenGetAcceleratorResponseBodyResourceTag(respBody)),
+		d.Set("status", utils.PathSearch("accelerator.status", respBody, nil)),
+		d.Set("flavor_id", utils.PathSearch("accelerator.flavor_id", respBody, nil)),
+		d.Set("frozen_info", flattenGetAcceleratorResponseBodyFrozenInfo(respBody)),
+		d.Set("created_at", utils.PathSearch("accelerator.created_at", respBody, nil)),
+		d.Set("updated_at", utils.PathSearch("accelerator.updated_at", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -423,52 +403,37 @@ func flattenGetAcceleratorResponseBodyFrozenInfo(resp interface{}) []interface{}
 }
 
 func resourceAcceleratorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
+	var (
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		product = "ga"
+	)
 
-	updateAcceleratorhasChanges := []string{
-		"name",
-		"description",
+	client, err := conf.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	if d.HasChanges(updateAcceleratorhasChanges...) {
-		// updateAccelerator: Update the configuration of GA accelerator
-		var (
-			updateAcceleratorHttpUrl = "v1/accelerators/{accelerator_id}"
-			updateAcceleratorProduct = "ga"
-		)
-		updateAcceleratorClient, err := conf.NewServiceClient(updateAcceleratorProduct, region)
-		if err != nil {
-			return diag.Errorf("error creating Accelerator Client: %s", err)
-		}
-
-		updateAcceleratorPath := updateAcceleratorClient.Endpoint + updateAcceleratorHttpUrl
-		updateAcceleratorPath = strings.ReplaceAll(updateAcceleratorPath, "{accelerator_id}", d.Id())
-
-		updateAcceleratorOpt := golangsdk.RequestOpts{
+	if d.HasChanges("name", "description") {
+		requestPath := client.Endpoint + "v1/accelerators/{accelerator_id}"
+		requestPath = strings.ReplaceAll(requestPath, "{accelerator_id}", d.Id())
+		requestOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
+			JSONBody:         utils.RemoveNil(buildUpdateAcceleratorBodyParams(d)),
 		}
-		updateAcceleratorOpt.JSONBody = utils.RemoveNil(buildUpdateAcceleratorBodyParams(d))
-		_, err = updateAcceleratorClient.Request("PUT", updateAcceleratorPath, &updateAcceleratorOpt)
+
+		_, err = client.Request("PUT", requestPath, &requestOpt)
 		if err != nil {
-			return diag.Errorf("error updating Accelerator: %s", err)
+			return diag.Errorf("error updating GA accelerator: %s", err)
 		}
+
 		err = updateAcceleratorWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.Errorf("error waiting for the Update of Accelerator (%s) to complete: %s", d.Id(), err)
+			return diag.Errorf("error waiting for the GA accelerator (%s) update to complete: %s", d.Id(), err)
 		}
 	}
 
-	// update tags
 	if d.HasChange("tags") {
-		client, err := conf.NewServiceClient("ga", region)
-		if err != nil {
-			return diag.Errorf("error creating GA Client: %s", err)
-		}
-
 		oldRaw, newRaw := d.GetChange("tags")
 		oldMap := oldRaw.(map[string]interface{})
 		newMap := newRaw.(map[string]interface{})
@@ -508,7 +473,7 @@ func createTags(createTagsClient *golangsdk.ServiceClient, resourceType, resourc
 
 	_, err := createTagsClient.Request("POST", createTagsPath, &createTagsOpt)
 	if err != nil {
-		return fmt.Errorf("error creating tags: %s", err)
+		return fmt.Errorf("error creating GA (%s) tags: %s", resourceType, err)
 	}
 	return nil
 }
@@ -530,7 +495,7 @@ func deleteTags(deleteTagsClient *golangsdk.ServiceClient, resourceType, resourc
 
 	_, err := deleteTagsClient.Request("DELETE", deleteTagsPath, &deleteTagsOpt)
 	if err != nil {
-		return fmt.Errorf("error deleting tags: %s", err)
+		return fmt.Errorf("error deleting GA (%s) tags: %s", resourceType, err)
 	}
 	return nil
 }
@@ -551,158 +516,138 @@ func buildUpdateAcceleratorAcceleratorChildBody(d *schema.ResourceData) map[stri
 }
 
 func updateAcceleratorWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/accelerators/{accelerator_id}"
+		product          = "ga"
+		targetStatus     = []string{"ACTIVE"}
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{accelerator_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// updateAcceleratorWaiting: missing operation notes
-			var (
-				updateAcceleratorWaitingHttpUrl = "v1/accelerators/{accelerator_id}"
-				updateAcceleratorWaitingProduct = "ga"
-			)
-			updateAcceleratorWaitingClient, err := config.NewServiceClient(updateAcceleratorWaitingProduct, region)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating Accelerator Client: %s", err)
-			}
-
-			updateAcceleratorWaitingPath := updateAcceleratorWaitingClient.Endpoint + updateAcceleratorWaitingHttpUrl
-			updateAcceleratorWaitingPath = strings.ReplaceAll(updateAcceleratorWaitingPath, "{accelerator_id}", d.Id())
-
-			updateAcceleratorWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			updateAcceleratorWaitingResp, err := updateAcceleratorWaitingClient.Request("GET",
-				updateAcceleratorWaitingPath, &updateAcceleratorWaitingOpt)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			updateAcceleratorWaitingRespBody, err := utils.FlattenResponse(updateAcceleratorWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`accelerator.status`, updateAcceleratorWaitingRespBody, "").(string)
 
-			targetStatus := []string{
-				"ACTIVE",
-			}
+			status := utils.PathSearch(`accelerator.status`, respBody, "").(string)
 			if utils.StrSliceContains(targetStatus, status) {
-				return updateAcceleratorWaitingRespBody, "COMPLETED", nil
+				return respBody, "COMPLETED", nil
 			}
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return updateAcceleratorWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return updateAcceleratorWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }
 
 func resourceAcceleratorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	// deleteAccelerator: Delete an existing GA Accelerator
 	var (
-		deleteAcceleratorHttpUrl = "v1/accelerators/{accelerator_id}"
-		deleteAcceleratorProduct = "ga"
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		httpUrl = "v1/accelerators/{accelerator_id}"
+		product = "ga"
 	)
-	deleteAcceleratorClient, err := conf.NewServiceClient(deleteAcceleratorProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating Accelerator Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	deleteAcceleratorPath := deleteAcceleratorClient.Endpoint + deleteAcceleratorHttpUrl
-	deleteAcceleratorPath = strings.ReplaceAll(deleteAcceleratorPath, "{accelerator_id}", d.Id())
-
-	deleteAcceleratorOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{accelerator_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
-	_, err = deleteAcceleratorClient.Request("DELETE", deleteAcceleratorPath, &deleteAcceleratorOpt)
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error deleting Accelerator: %s", err)
+		return diag.Errorf("error deleting GA accelerator: %s", err)
 	}
 
 	err = deleteAcceleratorWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.Errorf("error waiting for the Delete of Accelerator (%s) to complete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the GA accelerator (%s) delete to complete: %s", d.Id(), err)
 	}
 	return nil
 }
 
 func deleteAcceleratorWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/accelerators/{accelerator_id}"
+		product          = "ga"
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{accelerator_id}", d.Id())
+	deleteOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// deleteAcceleratorWaiting: missing operation notes
-			var (
-				deleteAcceleratorWaitingHttpUrl = "v1/accelerators/{accelerator_id}"
-				deleteAcceleratorWaitingProduct = "ga"
-			)
-			deleteAcceleratorWaitingClient, err := config.NewServiceClient(deleteAcceleratorWaitingProduct, region)
+			resp, err := client.Request("GET", requestPath, &deleteOpt)
 			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating Accelerator Client: %s", err)
-			}
-
-			deleteAcceleratorWaitingPath := deleteAcceleratorWaitingClient.Endpoint + deleteAcceleratorWaitingHttpUrl
-			deleteAcceleratorWaitingPath = strings.ReplaceAll(deleteAcceleratorWaitingPath, "{accelerator_id}", d.Id())
-
-			deleteAcceleratorWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			deleteAcceleratorWaitingResp, err := deleteAcceleratorWaitingClient.Request("GET",
-				deleteAcceleratorWaitingPath, &deleteAcceleratorWaitingOpt)
-			if err != nil {
-				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				var errDefault404 golangsdk.ErrDefault404
+				if errors.As(err, &errDefault404) {
+					// When the error code is `404`, the value of respBody is nil, and a non-null value is returned to
+					// avoid continuing the loop check.
 					return "Resource Not Found", "COMPLETED", nil
 				}
-
 				return nil, "ERROR", err
 			}
 
-			deleteAcceleratorWaitingRespBody, err := utils.FlattenResponse(deleteAcceleratorWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`accelerator.status`, deleteAcceleratorWaitingRespBody, "").(string)
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
+			status := utils.PathSearch(`accelerator.status`, respBody, "").(string)
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return deleteAcceleratorWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return deleteAcceleratorWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_address_group.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_address_group.go
@@ -2,6 +2,7 @@ package ga
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -126,58 +127,54 @@ func buildCreateIpAddressGroupBodyParams(d *schema.ResourceData) map[string]inte
 }
 
 func resourceIpAddressGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
-		createIpAddressGroupHttpUrl = "v1/ip-groups"
-		createEndpointProduct       = "ga"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/ip-groups"
+		product = "ga"
 	)
-	createIpAddressGroupClient, err := cfg.NewServiceClient(createEndpointProduct, region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IP address group client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	createIpAddressGroupPath := createIpAddressGroupClient.Endpoint + createIpAddressGroupHttpUrl
-	createIpAddressGroupOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
+		JSONBody:         utils.RemoveNil(buildCreateIpAddressGroupBodyParams(d)),
 	}
 
-	createIpAddressGroupOpt.JSONBody = utils.RemoveNil(buildCreateIpAddressGroupBodyParams(d))
-	createIpAddressGroupResp, err := createIpAddressGroupClient.Request("POST", createIpAddressGroupPath, &createIpAddressGroupOpt)
+	resp, err := client.Request("POST", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error creating IP address group: %s", err)
+		return diag.Errorf("error creating GA IP address group: %s", err)
 	}
 
-	createIpAddressGroupRespBody, err := utils.FlattenResponse(createIpAddressGroupResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	groupId := utils.PathSearch("ip_group.id", createIpAddressGroupRespBody, "").(string)
+	groupId := utils.PathSearch("ip_group.id", respBody, "").(string)
 	if groupId == "" {
-		return diag.Errorf("unable to find the GA IP address group ID from the API response")
+		return diag.Errorf("error creating GA IP address group: ID is not found in API response")
 	}
 
 	d.SetId(groupId)
 
 	err = waitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error waiting for the creation of IP address group (%s) to complete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the GA IP address group (%s) creation to complete: %s", d.Id(), err)
 	}
 
 	//  call addIps to support more than 20 ip addresses
 	if val, ok := d.GetOk("ip_addresses"); ok {
-		err = addIps(ctx, d, meta, createIpAddressGroupClient, val.(*schema.Set).List())
+		err = addIps(ctx, d, meta, client, val.(*schema.Set).List())
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	if val, ok := d.GetOk("listeners"); ok {
-		err = associateListener(ctx, d, meta, createIpAddressGroupClient, val.(*schema.Set).List())
+		err = associateListener(ctx, d, meta, client, val.(*schema.Set).List())
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -187,34 +184,25 @@ func resourceIpAddressGroupCreate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func getIpAddressGroupInfo(d *schema.ResourceData, meta interface{}) (*http.Response, error) {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
-		getIpAddressGroupHttpUrl = "v1/ip-groups/{ip_group_id}"
-		getIpAddressGroupProduct = "ga"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/ip-groups/{ip_group_id}"
+		product = "ga"
 	)
 
-	getIpAddressGroupClient, err := cfg.NewServiceClient(getIpAddressGroupProduct, region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return nil, fmt.Errorf("error creating IP address group client: %s", err)
+		return nil, fmt.Errorf("error creating GA client: %s", err)
 	}
 
-	getIpAddressGroupPath := getIpAddressGroupClient.Endpoint + getIpAddressGroupHttpUrl
-	getIpAddressGroupPath = strings.ReplaceAll(getIpAddressGroupPath, "{ip_group_id}", d.Id())
-	getIpAddressGroupOpts := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{ip_group_id}", d.Id())
+	requestOpts := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
 
-	resp, err := getIpAddressGroupClient.Request("GET", getIpAddressGroupPath, &getIpAddressGroupOpts)
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return client.Request("GET", requestPath, &requestOpts)
 }
 
 func flattenGetIpListResponseBody(rawParams interface{}) []interface{} {
@@ -254,27 +242,27 @@ func flattenGetListenersResponseBody(resp interface{}) []interface{} {
 }
 
 func resourceIpAddressGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	getIpAddressGroupResp, err := getIpAddressGroupInfo(d, meta)
+	resp, err := getIpAddressGroupInfo(d, meta)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "GA IP address group")
+		return common.CheckDeletedDiag(d, err, "error retrieving GA IP address group")
 	}
 
-	getIpAddressGroupRespBody, err := utils.FlattenResponse(getIpAddressGroupResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	mErr := multierror.Append(
 		nil,
-		d.Set("name", utils.PathSearch("ip_group.name", getIpAddressGroupRespBody, nil)),
-		d.Set("description", utils.PathSearch("ip_group.description", getIpAddressGroupRespBody, nil)),
+		d.Set("name", utils.PathSearch("ip_group.name", respBody, nil)),
+		d.Set("description", utils.PathSearch("ip_group.description", respBody, nil)),
 		d.Set("ip_addresses", flattenGetIpListResponseBody(utils.PathSearch("ip_group.ip_list",
-			getIpAddressGroupRespBody, make([]interface{}, 0)))),
-		d.Set("status", utils.PathSearch("ip_group.status", getIpAddressGroupRespBody, nil)),
-		d.Set("created_at", utils.PathSearch("ip_group.created_at", getIpAddressGroupRespBody, nil)),
-		d.Set("updated_at", utils.PathSearch("ip_group.updated_at", getIpAddressGroupRespBody, nil)),
+			respBody, make([]interface{}, 0)))),
+		d.Set("status", utils.PathSearch("ip_group.status", respBody, nil)),
+		d.Set("created_at", utils.PathSearch("ip_group.created_at", respBody, nil)),
+		d.Set("updated_at", utils.PathSearch("ip_group.updated_at", respBody, nil)),
 		d.Set("listeners", flattenGetListenersResponseBody(utils.PathSearch("ip_group.associated_listeners",
-			getIpAddressGroupRespBody, make([]interface{}, 0)))),
+			respBody, make([]interface{}, 0)))),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -291,33 +279,29 @@ func buildUpdateIpAddressGroupBodyParams(d *schema.ResourceData) map[string]inte
 }
 
 func resourceIpAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
-		updateIpAddressGroupHttpUrl = "v1/ip-groups/{ip_group_id}"
-		updateIpAddressGroupProduct = "ga"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/ip-groups/{ip_group_id}"
+		product = "ga"
 	)
 
-	updateIpAddressGroupClient, err := cfg.NewServiceClient(updateIpAddressGroupProduct, region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IP address group client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
 	if d.HasChanges("name", "description") {
-		updateIpAddressGroupPath := updateIpAddressGroupClient.Endpoint + updateIpAddressGroupHttpUrl
-		updateIpAddressGroupPath = strings.ReplaceAll(updateIpAddressGroupPath, "{ip_group_id}", d.Id())
-		updateIpAddressGroupOpt := golangsdk.RequestOpts{
+		requestPath := client.Endpoint + httpUrl
+		requestPath = strings.ReplaceAll(requestPath, "{ip_group_id}", d.Id())
+		requestOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
+			JSONBody:         utils.RemoveNil(buildUpdateIpAddressGroupBodyParams(d)),
 		}
 
-		updateIpAddressGroupOpt.JSONBody = utils.RemoveNil(buildUpdateIpAddressGroupBodyParams(d))
-		_, err = updateIpAddressGroupClient.Request("PUT", updateIpAddressGroupPath, &updateIpAddressGroupOpt)
+		_, err = client.Request("PUT", requestPath, &requestOpt)
 		if err != nil {
-			return diag.Errorf("error updating IP address group: %s", err)
+			return diag.Errorf("error updating GA IP address group: %s", err)
 		}
 	}
 
@@ -327,14 +311,14 @@ func resourceIpAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 		removeIpsRaw := oldIpsRaw.(*schema.Set).Difference(newIpsRaw.(*schema.Set))
 
 		if removeIpsRaw.Len() > 0 {
-			err = removeIps(ctx, d, meta, updateIpAddressGroupClient, removeIpsRaw.List())
+			err = removeIps(ctx, d, meta, client, removeIpsRaw.List())
 			if err != nil {
 				return diag.FromErr(err)
 			}
 		}
 
 		if addIpsRaw.Len() > 0 {
-			err = addIps(ctx, d, meta, updateIpAddressGroupClient, addIpsRaw.List())
+			err = addIps(ctx, d, meta, client, addIpsRaw.List())
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -347,14 +331,14 @@ func resourceIpAddressGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 		disassociateListenerRaw := oldListenerRaw.(*schema.Set).Difference(newListenerRaw.(*schema.Set))
 
 		if disassociateListenerRaw.Len() > 0 {
-			err = disassociateListener(ctx, d, meta, updateIpAddressGroupClient, disassociateListenerRaw.List())
+			err = disassociateListener(ctx, d, meta, client, disassociateListenerRaw.List())
 			if err != nil {
 				return diag.FromErr(err)
 			}
 		}
 
 		if associateListenerRaw.Len() > 0 {
-			err = associateListener(ctx, d, meta, updateIpAddressGroupClient, associateListenerRaw.List())
+			err = associateListener(ctx, d, meta, client, associateListenerRaw.List())
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -475,7 +459,7 @@ func associateListener(ctx context.Context, d *schema.ResourceData, meta interfa
 			}
 			_, err := client.Request("POST", associateListenerPath, &associateListenerOpt)
 			if err != nil {
-				return fmt.Errorf("error associate listener (%s) for IP address group: %s", listenerId, err)
+				return fmt.Errorf("error associating listener (%s) for IP address group: %s", listenerId, err)
 			}
 
 			err = waitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
@@ -507,7 +491,7 @@ func disassociateListener(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 			_, err := client.Request("POST", disassociateListenerPath, &disassociateListenerOpt)
 			if err != nil {
-				return fmt.Errorf("error disassociated listener (%s) from IP address group: %s", listenerId, err)
+				return fmt.Errorf("error disassociating listener (%s) from IP address group: %s", listenerId, err)
 			}
 
 			err = waitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
@@ -521,38 +505,34 @@ func disassociateListener(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceIpAddressGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
 	var (
-		deleteIpAddressGroupHttpUrl = "v1/ip-groups/{ip_group_id}"
-		deleteIpAddressGroupProduct = "ga"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v1/ip-groups/{ip_group_id}"
+		product = "ga"
 	)
 
-	deleteIpAddressGroupClient, err := cfg.NewServiceClient(deleteIpAddressGroupProduct, region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating IP address group client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
 	if val, ok := d.GetOk("listeners"); ok {
-		err = disassociateListener(ctx, d, meta, deleteIpAddressGroupClient, val.(*schema.Set).List())
+		err = disassociateListener(ctx, d, meta, client, val.(*schema.Set).List())
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	deleteIpAddressGroupPath := deleteIpAddressGroupClient.Endpoint + deleteIpAddressGroupHttpUrl
-	deleteIpAddressGroupPath = strings.ReplaceAll(deleteIpAddressGroupPath, "{ip_group_id}", d.Id())
-	deleteIpAddressGroupOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{ip_group_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
 
-	_, err = deleteIpAddressGroupClient.Request("DELETE", deleteIpAddressGroupPath, &deleteIpAddressGroupOpt)
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error deleting IP address group: %s", err)
+		return diag.Errorf("error deleting GA IP address group: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
@@ -565,11 +545,7 @@ func resourceIpAddressGroupDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	_, err = stateConf.WaitForStateContext(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-
-	return nil
+	return diag.FromErr(err)
 }
 
 func waitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
@@ -589,8 +565,10 @@ func waitIpAddressGroupStatusRefreshFunc(d *schema.ResourceData, meta interface{
 	return func() (interface{}, string, error) {
 		resp, err := getIpAddressGroupInfo(d, meta)
 		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault404); ok && isDelete {
-				// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+			var errDefault404 golangsdk.ErrDefault404
+			if errors.As(err, &errDefault404) && isDelete {
+				// When the error code is `404`, the value of respBody is nil, and a non-null value is returned to avoid
+				// continuing the loop check.
 				return "Resource Not Found", "DELETED", nil
 			}
 

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_endpoint.go
@@ -7,6 +7,7 @@ package ga
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -104,48 +105,44 @@ func ResourceEndpoint() *schema.Resource {
 }
 
 func resourceEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	// createEndpoint: Create a GA Endpoint.
 	var (
-		createEndpointHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints"
-		createEndpointProduct = "ga"
+		conf            = meta.(*config.Config)
+		region          = conf.GetRegion(d)
+		httpUrl         = "v1/endpoint-groups/{endpoint_group_id}/endpoints"
+		product         = "ga"
+		endpointGroupID = d.Get("endpoint_group_id").(string)
 	)
-	createEndpointClient, err := conf.NewServiceClient(createEndpointProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating Endpoint Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	createEndpointPath := createEndpointClient.Endpoint + createEndpointHttpUrl
-	createEndpointPath = strings.ReplaceAll(createEndpointPath, "{endpoint_group_id}", fmt.Sprintf("%v", d.Get("endpoint_group_id")))
-
-	createEndpointOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_group_id}", endpointGroupID)
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
-	}
-	createEndpointOpt.JSONBody = utils.RemoveNil(buildCreateEndpointBodyParams(d))
-	createEndpointResp, err := createEndpointClient.Request("POST", createEndpointPath, &createEndpointOpt)
-	if err != nil {
-		return diag.Errorf("error creating Endpoint: %s", err)
+		JSONBody:         utils.RemoveNil(buildCreateEndpointBodyParams(d)),
 	}
 
-	createEndpointRespBody, err := utils.FlattenResponse(createEndpointResp)
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating GA endpoint: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	endpointId := utils.PathSearch("endpoint.id", createEndpointRespBody, "").(string)
+	endpointId := utils.PathSearch("endpoint.id", respBody, "").(string)
 	if endpointId == "" {
-		return diag.Errorf("unable to find the GA endpoint ID from the API response")
+		return diag.Errorf("error creating GA endpoint: ID is not found in API response")
 	}
 	d.SetId(endpointId)
 
 	err = createEndpointWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error waiting for the Create of Endpoint (%s) to complete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the GA endpoint (%s) creation to complete: %s", d.Id(), err)
 	}
 	return resourceEndpointRead(ctx, d, meta)
 }
@@ -163,116 +160,101 @@ func buildCreateEndpointBodyParams(d *schema.ResourceData) map[string]interface{
 }
 
 func createEndpointWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
+		product          = "ga"
+		endpointGroupID  = d.Get("endpoint_group_id").(string)
+		targetStatus     = []string{"ACTIVE"}
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_group_id}", endpointGroupID)
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// createEndpointWaiting: missing operation notes
-			var (
-				createEndpointWaitingHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
-				createEndpointWaitingProduct = "ga"
-			)
-			createEndpointWaitingClient, err := config.NewServiceClient(createEndpointWaitingProduct, region)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating Endpoint Client: %s", err)
-			}
-
-			createEndpointWaitingPath := createEndpointWaitingClient.Endpoint + createEndpointWaitingHttpUrl
-			createEndpointWaitingPath = strings.ReplaceAll(createEndpointWaitingPath,
-				"{endpoint_group_id}", fmt.Sprintf("%v", d.Get("endpoint_group_id")))
-			createEndpointWaitingPath = strings.ReplaceAll(createEndpointWaitingPath, "{endpoint_id}", d.Id())
-
-			createEndpointWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			createEndpointWaitingResp, err := createEndpointWaitingClient.Request("GET", createEndpointWaitingPath, &createEndpointWaitingOpt)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			createEndpointWaitingRespBody, err := utils.FlattenResponse(createEndpointWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`endpoint.status`, createEndpointWaitingRespBody, "").(string)
+			status := utils.PathSearch(`endpoint.status`, respBody, "").(string)
 
-			targetStatus := []string{
-				"ACTIVE",
-			}
 			if utils.StrSliceContains(targetStatus, status) {
-				return createEndpointWaitingRespBody, "COMPLETED", nil
+				return respBody, "COMPLETED", nil
 			}
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return createEndpointWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return createEndpointWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }
 
 func resourceEndpointRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	var mErr *multierror.Error
-
-	// getEndpoint: Query the GA Endpoint detail
 	var (
-		getEndpointHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
-		getEndpointProduct = "ga"
+		conf            = meta.(*config.Config)
+		region          = conf.GetRegion(d)
+		mErr            *multierror.Error
+		httpUrl         = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
+		product         = "ga"
+		endpointGroupID = d.Get("endpoint_group_id").(string)
 	)
-	getEndpointClient, err := conf.NewServiceClient(getEndpointProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating Endpoint Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	getEndpointPath := getEndpointClient.Endpoint + getEndpointHttpUrl
-	getEndpointPath = strings.ReplaceAll(getEndpointPath, "{endpoint_group_id}", fmt.Sprintf("%v", d.Get("endpoint_group_id")))
-	getEndpointPath = strings.ReplaceAll(getEndpointPath, "{endpoint_id}", d.Id())
-
-	getEndpointOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_group_id}", endpointGroupID)
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getEndpointResp, err := getEndpointClient.Request("GET", getEndpointPath, &getEndpointOpt)
-
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving Endpoint")
+		return common.CheckDeletedDiag(d, err, "error retrieving GA endpoint")
 	}
 
-	getEndpointRespBody, err := utils.FlattenResponse(getEndpointResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	mErr = multierror.Append(
 		mErr,
-		d.Set("created_at", utils.PathSearch("endpoint.created_at", getEndpointRespBody, nil)),
-		d.Set("endpoint_group_id", utils.PathSearch("endpoint.endpoint_group_id", getEndpointRespBody, nil)),
-		d.Set("health_state", utils.PathSearch("endpoint.health_state", getEndpointRespBody, nil)),
-		d.Set("ip_address", utils.PathSearch("endpoint.ip_address", getEndpointRespBody, nil)),
-		d.Set("resource_id", utils.PathSearch("endpoint.resource_id", getEndpointRespBody, nil)),
-		d.Set("resource_type", utils.PathSearch("endpoint.resource_type", getEndpointRespBody, nil)),
-		d.Set("status", utils.PathSearch("endpoint.status", getEndpointRespBody, nil)),
-		d.Set("updated_at", utils.PathSearch("endpoint.updated_at", getEndpointRespBody, nil)),
-		d.Set("weight", utils.PathSearch("endpoint.weight", getEndpointRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("endpoint.created_at", respBody, nil)),
+		d.Set("endpoint_group_id", utils.PathSearch("endpoint.endpoint_group_id", respBody, nil)),
+		d.Set("health_state", utils.PathSearch("endpoint.health_state", respBody, nil)),
+		d.Set("ip_address", utils.PathSearch("endpoint.ip_address", respBody, nil)),
+		d.Set("resource_id", utils.PathSearch("endpoint.resource_id", respBody, nil)),
+		d.Set("resource_type", utils.PathSearch("endpoint.resource_type", respBody, nil)),
+		d.Set("status", utils.PathSearch("endpoint.status", respBody, nil)),
+		d.Set("updated_at", utils.PathSearch("endpoint.updated_at", respBody, nil)),
+		d.Set("weight", utils.PathSearch("endpoint.weight", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -282,39 +264,32 @@ func resourceEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 
-	updateEndpointhasChanges := []string{
-		"weight",
-	}
-
-	if d.HasChanges(updateEndpointhasChanges...) {
-		// updateEndpoint: Update the configuration of GA Endpoint
+	if d.HasChange("weight") {
 		var (
-			updateEndpointHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
-			updateEndpointProduct = "ga"
+			httpUrl         = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
+			product         = "ga"
+			endpointGroupID = d.Get("endpoint_group_id").(string)
 		)
-		updateEndpointClient, err := conf.NewServiceClient(updateEndpointProduct, region)
+		client, err := conf.NewServiceClient(product, region)
 		if err != nil {
-			return diag.Errorf("error creating Endpoint Client: %s", err)
+			return diag.Errorf("error creating GA client: %s", err)
 		}
 
-		updateEndpointPath := updateEndpointClient.Endpoint + updateEndpointHttpUrl
-		updateEndpointPath = strings.ReplaceAll(updateEndpointPath, "{endpoint_group_id}", fmt.Sprintf("%v", d.Get("endpoint_group_id")))
-		updateEndpointPath = strings.ReplaceAll(updateEndpointPath, "{endpoint_id}", d.Id())
-
-		updateEndpointOpt := golangsdk.RequestOpts{
+		requestPath := client.Endpoint + httpUrl
+		requestPath = strings.ReplaceAll(requestPath, "{endpoint_group_id}", endpointGroupID)
+		requestPath = strings.ReplaceAll(requestPath, "{endpoint_id}", d.Id())
+		requestOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
+			JSONBody:         utils.RemoveNil(buildUpdateEndpointBodyParams(d)),
 		}
-		updateEndpointOpt.JSONBody = utils.RemoveNil(buildUpdateEndpointBodyParams(d))
-		_, err = updateEndpointClient.Request("PUT", updateEndpointPath, &updateEndpointOpt)
+
+		_, err = client.Request("PUT", requestPath, &requestOpt)
 		if err != nil {
-			return diag.Errorf("error updating Endpoint: %s", err)
+			return diag.Errorf("error updating GA endpoint: %s", err)
 		}
 		err = updateEndpointWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.Errorf("error waiting for the Update of Endpoint (%s) to complete: %s", d.Id(), err)
+			return diag.Errorf("error waiting for the GA endpoint (%s) update to complete: %s", d.Id(), err)
 		}
 	}
 	return resourceEndpointRead(ctx, d, meta)
@@ -330,173 +305,157 @@ func buildUpdateEndpointBodyParams(d *schema.ResourceData) map[string]interface{
 }
 
 func updateEndpointWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
+		product          = "ga"
+		endpointGroupID  = d.Get("endpoint_group_id").(string)
+		targetStatus     = []string{"ACTIVE"}
+		unexpectedStatus = []string{"ERROR"}
+	)
+
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_group_id}", endpointGroupID)
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// updateEndpointWaiting: missing operation notes
-			var (
-				updateEndpointWaitingHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
-				updateEndpointWaitingProduct = "ga"
-			)
-			updateEndpointWaitingClient, err := config.NewServiceClient(updateEndpointWaitingProduct, region)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating Endpoint Client: %s", err)
-			}
-
-			updateEndpointWaitingPath := updateEndpointWaitingClient.Endpoint + updateEndpointWaitingHttpUrl
-			updateEndpointWaitingPath = strings.ReplaceAll(updateEndpointWaitingPath,
-				"{endpoint_group_id}", fmt.Sprintf("%v", d.Get("endpoint_group_id")))
-			updateEndpointWaitingPath = strings.ReplaceAll(updateEndpointWaitingPath, "{endpoint_id}", d.Id())
-
-			updateEndpointWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			updateEndpointWaitingResp, err := updateEndpointWaitingClient.Request("GET", updateEndpointWaitingPath, &updateEndpointWaitingOpt)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			updateEndpointWaitingRespBody, err := utils.FlattenResponse(updateEndpointWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`endpoint.status`, updateEndpointWaitingRespBody, "").(string)
 
-			targetStatus := []string{
-				"ACTIVE",
-			}
+			status := utils.PathSearch(`endpoint.status`, respBody, "").(string)
 			if utils.StrSliceContains(targetStatus, status) {
-				return updateEndpointWaitingRespBody, "COMPLETED", nil
+				return respBody, "COMPLETED", nil
 			}
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return updateEndpointWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return updateEndpointWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }
 
 func resourceEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	// deleteEndpoint: Delete an existing GA Endpoint
 	var (
-		deleteEndpointHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
-		deleteEndpointProduct = "ga"
+		conf            = meta.(*config.Config)
+		region          = conf.GetRegion(d)
+		httpUrl         = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
+		product         = "ga"
+		endpointGroupID = d.Get("endpoint_group_id").(string)
 	)
-	deleteEndpointClient, err := conf.NewServiceClient(deleteEndpointProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating Endpoint Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	deleteEndpointPath := deleteEndpointClient.Endpoint + deleteEndpointHttpUrl
-	deleteEndpointPath = strings.ReplaceAll(deleteEndpointPath, "{endpoint_group_id}", fmt.Sprintf("%v", d.Get("endpoint_group_id")))
-	deleteEndpointPath = strings.ReplaceAll(deleteEndpointPath, "{endpoint_id}", d.Id())
-
-	deleteEndpointOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_group_id}", endpointGroupID)
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
-	_, err = deleteEndpointClient.Request("DELETE", deleteEndpointPath, &deleteEndpointOpt)
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error deleting Endpoint: %s", err)
+		return diag.Errorf("error deleting GA endpoint: %s", err)
 	}
 
 	err = deleteEndpointWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.Errorf("error waiting for the Delete of Endpoint (%s) to complete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the GA endpoint (%s) deletion to complete: %s", d.Id(), err)
 	}
 	return nil
 }
 
 func deleteEndpointWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
+		product          = "ga"
+		endpointGroupID  = d.Get("endpoint_group_id").(string)
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_group_id}", endpointGroupID)
+	requestPath = strings.ReplaceAll(requestPath, "{endpoint_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// deleteEndpointWaiting: missing operation notes
-			var (
-				deleteEndpointWaitingHttpUrl = "v1/endpoint-groups/{endpoint_group_id}/endpoints/{endpoint_id}"
-				deleteEndpointWaitingProduct = "ga"
-			)
-			deleteEndpointWaitingClient, err := config.NewServiceClient(deleteEndpointWaitingProduct, region)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating Endpoint Client: %s", err)
-			}
-
-			deleteEndpointWaitingPath := deleteEndpointWaitingClient.Endpoint + deleteEndpointWaitingHttpUrl
-			deleteEndpointWaitingPath = strings.ReplaceAll(deleteEndpointWaitingPath,
-				"{endpoint_group_id}", fmt.Sprintf("%v", d.Get("endpoint_group_id")))
-			deleteEndpointWaitingPath = strings.ReplaceAll(deleteEndpointWaitingPath, "{endpoint_id}", d.Id())
-
-			deleteEndpointWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			deleteEndpointWaitingResp, err := deleteEndpointWaitingClient.Request("GET", deleteEndpointWaitingPath, &deleteEndpointWaitingOpt)
-			if err != nil {
-				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				var errDefault404 golangsdk.ErrDefault404
+				if errors.As(err, &errDefault404) {
+					// When the error code is `404`, the value of respBody is nil, and a non-null value is returned to
+					// avoid continuing the loop check.
 					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err
 			}
 
-			deleteEndpointWaitingRespBody, err := utils.FlattenResponse(deleteEndpointWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`endpoint.status`, deleteEndpointWaitingRespBody, "").(string)
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
+			status := utils.PathSearch(`endpoint.status`, respBody, "").(string)
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return deleteEndpointWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return deleteEndpointWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }
 
 func resourceEndpointImportState(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid format specified for import id, must be <endpoint_group_id>/<id>")
+		return nil, fmt.Errorf("invalid format specified for import ID, must be <endpoint_group_id>/<id>")
 	}
 
-	d.Set("endpoint_group_id", parts[0])
 	d.SetId(parts[1])
 
-	return []*schema.ResourceData{d}, nil
+	return []*schema.ResourceData{d}, d.Set("endpoint_group_id", parts[0])
 }

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_health_check.go
@@ -7,6 +7,7 @@ package ga
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -110,47 +111,42 @@ func ResourceHealthCheck() *schema.Resource {
 }
 
 func resourceHealthCheckCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	// createHealthCheck: Create a GA Health Check.
 	var (
-		createHealthCheckHttpUrl = "v1/health-checks"
-		createHealthCheckProduct = "ga"
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		httpUrl = "v1/health-checks"
+		product = "ga"
 	)
-	createHealthCheckClient, err := conf.NewServiceClient(createHealthCheckProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating HealthCheck Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	createHealthCheckPath := createHealthCheckClient.Endpoint + createHealthCheckHttpUrl
-
-	createHealthCheckOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
-	}
-	createHealthCheckOpt.JSONBody = utils.RemoveNil(buildCreateHealthCheckBodyParams(d))
-	createHealthCheckResp, err := createHealthCheckClient.Request("POST", createHealthCheckPath, &createHealthCheckOpt)
-	if err != nil {
-		return diag.Errorf("error creating HealthCheck: %s", err)
+		JSONBody:         utils.RemoveNil(buildCreateHealthCheckBodyParams(d)),
 	}
 
-	createHealthCheckRespBody, err := utils.FlattenResponse(createHealthCheckResp)
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating GA health check: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	healthCheckId := utils.PathSearch("health_check.id", createHealthCheckRespBody, "").(string)
+	healthCheckId := utils.PathSearch("health_check.id", respBody, "").(string)
 	if healthCheckId == "" {
-		return diag.Errorf("unable to find the GA health check ID from the API response")
+		return diag.Errorf("error creating GA health check: ID is not found in API response")
 	}
 	d.SetId(healthCheckId)
 
 	err = createHealthCheckWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error waiting for the Create of HealthCheck (%s) to complete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the GA health check (%s) creation to complete: %s", d.Id(), err)
 	}
 	return resourceHealthCheckRead(ctx, d, meta)
 }
@@ -171,99 +167,83 @@ func buildCreateHealthCheckBodyParams(d *schema.ResourceData) map[string]interfa
 }
 
 func createHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/health-checks/{health_check_id}"
+		product          = "ga"
+		targetStatus     = []string{"ACTIVE"}
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{health_check_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// createHealthCheckWaiting: missing operation notes
-			var (
-				createHealthCheckWaitingHttpUrl = "v1/health-checks/{health_check_id}"
-				createHealthCheckWaitingProduct = "ga"
-			)
-			createHealthCheckWaitingClient, err := config.NewServiceClient(createHealthCheckWaitingProduct, region)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating HealthCheck Client: %s", err)
-			}
-
-			createHealthCheckWaitingPath := createHealthCheckWaitingClient.Endpoint + createHealthCheckWaitingHttpUrl
-			createHealthCheckWaitingPath = strings.ReplaceAll(createHealthCheckWaitingPath, "{health_check_id}", d.Id())
-
-			createHealthCheckWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			createHealthCheckWaitingResp, err := createHealthCheckWaitingClient.Request("GET",
-				createHealthCheckWaitingPath, &createHealthCheckWaitingOpt)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			createHealthCheckWaitingRespBody, err := utils.FlattenResponse(createHealthCheckWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`health_check.status`, createHealthCheckWaitingRespBody, "").(string)
 
-			targetStatus := []string{
-				"ACTIVE",
-			}
+			status := utils.PathSearch(`health_check.status`, respBody, "").(string)
 			if utils.StrSliceContains(targetStatus, status) {
-				return createHealthCheckWaitingRespBody, "COMPLETED", nil
+				return respBody, "COMPLETED", nil
 			}
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return createHealthCheckWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return createHealthCheckWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }
 
 func resourceHealthCheckRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	var mErr *multierror.Error
-
-	// getHealthCheck: Query the GA Health Check detail
 	var (
-		getHealthCheckHttpUrl = "v1/health-checks/{health_check_id}"
-		getHealthCheckProduct = "ga"
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/health-checks/{health_check_id}"
+		product = "ga"
 	)
-	getHealthCheckClient, err := conf.NewServiceClient(getHealthCheckProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating HealthCheck Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	getHealthCheckPath := getHealthCheckClient.Endpoint + getHealthCheckHttpUrl
-	getHealthCheckPath = strings.ReplaceAll(getHealthCheckPath, "{health_check_id}", d.Id())
-
-	getHealthCheckOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{health_check_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getHealthCheckResp, err := getHealthCheckClient.Request("GET", getHealthCheckPath, &getHealthCheckOpt)
 
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving HealthCheck")
+		return common.CheckDeletedDiag(d, err, "error retrieving GA health check")
 	}
 
-	getHealthCheckRespBody, err := utils.FlattenResponse(getHealthCheckResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -271,16 +251,16 @@ func resourceHealthCheckRead(_ context.Context, d *schema.ResourceData, meta int
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
-		d.Set("created_at", utils.PathSearch("health_check.created_at", getHealthCheckRespBody, nil)),
-		d.Set("enabled", utils.PathSearch("health_check.enabled", getHealthCheckRespBody, nil)),
-		d.Set("endpoint_group_id", utils.PathSearch("health_check.endpoint_group_id", getHealthCheckRespBody, nil)),
-		d.Set("interval", utils.PathSearch("health_check.interval", getHealthCheckRespBody, nil)),
-		d.Set("max_retries", utils.PathSearch("health_check.max_retries", getHealthCheckRespBody, nil)),
-		d.Set("port", utils.PathSearch("health_check.port", getHealthCheckRespBody, nil)),
-		d.Set("protocol", utils.PathSearch("health_check.protocol", getHealthCheckRespBody, nil)),
-		d.Set("status", utils.PathSearch("health_check.status", getHealthCheckRespBody, nil)),
-		d.Set("timeout", utils.PathSearch("health_check.timeout", getHealthCheckRespBody, nil)),
-		d.Set("updated_at", utils.PathSearch("health_check.updated_at", getHealthCheckRespBody, nil)),
+		d.Set("created_at", utils.PathSearch("health_check.created_at", respBody, nil)),
+		d.Set("enabled", utils.PathSearch("health_check.enabled", respBody, nil)),
+		d.Set("endpoint_group_id", utils.PathSearch("health_check.endpoint_group_id", respBody, nil)),
+		d.Set("interval", utils.PathSearch("health_check.interval", respBody, nil)),
+		d.Set("max_retries", utils.PathSearch("health_check.max_retries", respBody, nil)),
+		d.Set("port", utils.PathSearch("health_check.port", respBody, nil)),
+		d.Set("protocol", utils.PathSearch("health_check.protocol", respBody, nil)),
+		d.Set("status", utils.PathSearch("health_check.status", respBody, nil)),
+		d.Set("timeout", utils.PathSearch("health_check.timeout", respBody, nil)),
+		d.Set("updated_at", utils.PathSearch("health_check.updated_at", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -290,7 +270,7 @@ func resourceHealthCheckUpdate(ctx context.Context, d *schema.ResourceData, meta
 	conf := meta.(*config.Config)
 	region := conf.GetRegion(d)
 
-	updateHealthCheckhasChanges := []string{
+	updateHealthCheckHasChanges := []string{
 		"enabled",
 		"interval",
 		"max_retries",
@@ -299,34 +279,31 @@ func resourceHealthCheckUpdate(ctx context.Context, d *schema.ResourceData, meta
 		"timeout",
 	}
 
-	if d.HasChanges(updateHealthCheckhasChanges...) {
-		// updateHealthCheck: Update the configuration of GA Health Check
+	if d.HasChanges(updateHealthCheckHasChanges...) {
 		var (
-			updateHealthCheckHttpUrl = "v1/health-checks/{health_check_id}"
-			updateHealthCheckProduct = "ga"
+			httpUrl = "v1/health-checks/{health_check_id}"
+			product = "ga"
 		)
-		updateHealthCheckClient, err := conf.NewServiceClient(updateHealthCheckProduct, region)
+		client, err := conf.NewServiceClient(product, region)
 		if err != nil {
-			return diag.Errorf("error creating HealthCheck Client: %s", err)
+			return diag.Errorf("error creating GA client: %s", err)
 		}
 
-		updateHealthCheckPath := updateHealthCheckClient.Endpoint + updateHealthCheckHttpUrl
-		updateHealthCheckPath = strings.ReplaceAll(updateHealthCheckPath, "{health_check_id}", d.Id())
-
-		updateHealthCheckOpt := golangsdk.RequestOpts{
+		requestPath := client.Endpoint + httpUrl
+		requestPath = strings.ReplaceAll(requestPath, "{health_check_id}", d.Id())
+		requestOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
+			JSONBody:         utils.RemoveNil(buildUpdateHealthCheckBodyParams(d)),
 		}
-		updateHealthCheckOpt.JSONBody = utils.RemoveNil(buildUpdateHealthCheckBodyParams(d))
-		_, err = updateHealthCheckClient.Request("PUT", updateHealthCheckPath, &updateHealthCheckOpt)
+
+		_, err = client.Request("PUT", requestPath, &requestOpt)
 		if err != nil {
-			return diag.Errorf("error updating HealthCheck: %s", err)
+			return diag.Errorf("error updating GA health check: %s", err)
 		}
+
 		err = updateHealthCheckWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.Errorf("error waiting for the Update of HealthCheck (%s) to complete: %s", d.Id(), err)
+			return diag.Errorf("error waiting for the GA health check (%s) update to complete: %s", d.Id(), err)
 		}
 	}
 	return resourceHealthCheckRead(ctx, d, meta)
@@ -347,158 +324,139 @@ func buildUpdateHealthCheckBodyParams(d *schema.ResourceData) map[string]interfa
 }
 
 func updateHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/health-checks/{health_check_id}"
+		product          = "ga"
+		targetStatus     = []string{"ACTIVE"}
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{health_check_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// updateHealthCheckWaiting: missing operation notes
-			var (
-				updateHealthCheckWaitingHttpUrl = "v1/health-checks/{health_check_id}"
-				updateHealthCheckWaitingProduct = "ga"
-			)
-			updateHealthCheckWaitingClient, err := config.NewServiceClient(updateHealthCheckWaitingProduct, region)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating HealthCheck Client: %s", err)
-			}
-
-			updateHealthCheckWaitingPath := updateHealthCheckWaitingClient.Endpoint + updateHealthCheckWaitingHttpUrl
-			updateHealthCheckWaitingPath = strings.ReplaceAll(updateHealthCheckWaitingPath, "{health_check_id}", d.Id())
-
-			updateHealthCheckWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			updateHealthCheckWaitingResp, err := updateHealthCheckWaitingClient.Request("GET",
-				updateHealthCheckWaitingPath, &updateHealthCheckWaitingOpt)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			updateHealthCheckWaitingRespBody, err := utils.FlattenResponse(updateHealthCheckWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`health_check.status`, updateHealthCheckWaitingRespBody, "").(string)
 
-			targetStatus := []string{
-				"ACTIVE",
-			}
+			status := utils.PathSearch(`health_check.status`, respBody, "").(string)
 			if utils.StrSliceContains(targetStatus, status) {
-				return updateHealthCheckWaitingRespBody, "COMPLETED", nil
+				return respBody, "COMPLETED", nil
 			}
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return updateHealthCheckWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return updateHealthCheckWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }
 
 func resourceHealthCheckDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	// deleteHealthCheck: Delete an existing GA Health Check
 	var (
-		deleteHealthCheckHttpUrl = "v1/health-checks/{health_check_id}"
-		deleteHealthCheckProduct = "ga"
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		httpUrl = "v1/health-checks/{health_check_id}"
+		product = "ga"
 	)
-	deleteHealthCheckClient, err := conf.NewServiceClient(deleteHealthCheckProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating HealthCheck Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	deleteHealthCheckPath := deleteHealthCheckClient.Endpoint + deleteHealthCheckHttpUrl
-	deleteHealthCheckPath = strings.ReplaceAll(deleteHealthCheckPath, "{health_check_id}", d.Id())
-
-	deleteHealthCheckOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{health_check_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
-	_, err = deleteHealthCheckClient.Request("DELETE", deleteHealthCheckPath, &deleteHealthCheckOpt)
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error deleting HealthCheck: %s", err)
+		return diag.Errorf("error deleting GA health check: %s", err)
 	}
 
 	err = deleteHealthCheckWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.Errorf("error waiting for the Delete of HealthCheck (%s) to complete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the GA health check (%s) delete to complete: %s", d.Id(), err)
 	}
 	return nil
 }
 
 func deleteHealthCheckWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/health-checks/{health_check_id}"
+		product          = "ga"
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{health_check_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// deleteHealthCheckWaiting: missing operation notes
-			var (
-				deleteHealthCheckWaitingHttpUrl = "v1/health-checks/{health_check_id}"
-				deleteHealthCheckWaitingProduct = "ga"
-			)
-			deleteHealthCheckWaitingClient, err := config.NewServiceClient(deleteHealthCheckWaitingProduct, region)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating HealthCheck Client: %s", err)
-			}
-
-			deleteHealthCheckWaitingPath := deleteHealthCheckWaitingClient.Endpoint + deleteHealthCheckWaitingHttpUrl
-			deleteHealthCheckWaitingPath = strings.ReplaceAll(deleteHealthCheckWaitingPath, "{health_check_id}", d.Id())
-
-			deleteHealthCheckWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			deleteHealthCheckWaitingResp, err := deleteHealthCheckWaitingClient.Request("GET",
-				deleteHealthCheckWaitingPath, &deleteHealthCheckWaitingOpt)
-			if err != nil {
-				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				var errDefault404 golangsdk.ErrDefault404
+				if errors.As(err, &errDefault404) {
+					// When the error code is `404`, the value of respBody is nil, and a non-null value is returned to
+					// avoid continuing the loop check.
 					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err
 			}
 
-			deleteHealthCheckWaitingRespBody, err := utils.FlattenResponse(deleteHealthCheckWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`health_check.status`, deleteHealthCheckWaitingRespBody, "").(string)
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
+			status := utils.PathSearch(`health_check.status`, respBody, "").(string)
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return deleteHealthCheckWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return deleteHealthCheckWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }

--- a/huaweicloud/services/ga/resource_huaweicloud_ga_listener.go
+++ b/huaweicloud/services/ga/resource_huaweicloud_ga_listener.go
@@ -7,6 +7,7 @@ package ga
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -140,47 +141,42 @@ func ListenerPortRangeSchema() *schema.Resource {
 }
 
 func resourceListenerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	// createListener: Create a GA Listener.
 	var (
-		createListenerHttpUrl = "v1/listeners"
-		createListenerProduct = "ga"
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		httpUrl = "v1/listeners"
+		product = "ga"
 	)
-	createListenerClient, err := conf.NewServiceClient(createListenerProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating Listener Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	createListenerPath := createListenerClient.Endpoint + createListenerHttpUrl
-
-	createListenerOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			201,
-		},
-	}
-	createListenerOpt.JSONBody = utils.RemoveNil(buildCreateListenerBodyParams(d))
-	createListenerResp, err := createListenerClient.Request("POST", createListenerPath, &createListenerOpt)
-	if err != nil {
-		return diag.Errorf("error creating Listener: %s", err)
+		JSONBody:         utils.RemoveNil(buildCreateListenerBodyParams(d)),
 	}
 
-	createListenerRespBody, err := utils.FlattenResponse(createListenerResp)
+	resp, err := client.Request("POST", requestPath, &requestOpt)
+	if err != nil {
+		return diag.Errorf("error creating GA listener: %s", err)
+	}
+
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	listenerId := utils.PathSearch("listener.id", createListenerRespBody, "").(string)
+	listenerId := utils.PathSearch("listener.id", respBody, "").(string)
 	if listenerId == "" {
-		return diag.Errorf("unable to find the GA listener ID from the API response")
+		return diag.Errorf("error creating GA listener: ID is not found in API response")
 	}
 	d.SetId(listenerId)
 
 	err = createListenerWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
-		return diag.Errorf("error waiting for the Create of Listener (%s) to complete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the GA listener (%s) creation to complete: %s", d.Id(), err)
 	}
 	return resourceListenerRead(ctx, d, meta)
 }
@@ -220,114 +216,99 @@ func buildCreateListenerRequestBodyPortRange(rawParams interface{}) []map[string
 }
 
 func createListenerWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/listeners/{listener_id}"
+		product          = "ga"
+		targetStatus     = []string{"ACTIVE"}
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{listener_id}", d.Id())
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// createListenerWaiting: missing operation notes
-			var (
-				createListenerWaitingHttpUrl = "v1/listeners/{listener_id}"
-				createListenerWaitingProduct = "ga"
-			)
-			createListenerWaitingClient, err := config.NewServiceClient(createListenerWaitingProduct, region)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating Listener Client: %s", err)
-			}
-
-			createListenerWaitingPath := createListenerWaitingClient.Endpoint + createListenerWaitingHttpUrl
-			createListenerWaitingPath = strings.ReplaceAll(createListenerWaitingPath, "{listener_id}", d.Id())
-
-			createListenerWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			createListenerWaitingResp, err := createListenerWaitingClient.Request("GET", createListenerWaitingPath, &createListenerWaitingOpt)
+			resp, err := client.Request("GET", requestPath, &createOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			createListenerWaitingRespBody, err := utils.FlattenResponse(createListenerWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`listener.status`, createListenerWaitingRespBody, "").(string)
 
-			targetStatus := []string{
-				"ACTIVE",
-			}
+			status := utils.PathSearch(`listener.status`, respBody, "").(string)
 			if utils.StrSliceContains(targetStatus, status) {
-				return createListenerWaitingRespBody, "COMPLETED", nil
+				return respBody, "COMPLETED", nil
 			}
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return createListenerWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return createListenerWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }
 
 func resourceListenerRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	var mErr *multierror.Error
-
-	// getListener: Query the GA Listener detail
 	var (
-		getListenerHttpUrl = "v1/listeners/{listener_id}"
-		getListenerProduct = "ga"
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		mErr    *multierror.Error
+		httpUrl = "v1/listeners/{listener_id}"
+		product = "ga"
 	)
-	getListenerClient, err := conf.NewServiceClient(getListenerProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating Listener Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	getListenerPath := getListenerClient.Endpoint + getListenerHttpUrl
-	getListenerPath = strings.ReplaceAll(getListenerPath, "{listener_id}", d.Id())
-
-	getListenerOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{listener_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			200,
-		},
 	}
-	getListenerResp, err := getListenerClient.Request("GET", getListenerPath, &getListenerOpt)
 
+	resp, err := client.Request("GET", requestPath, &requestOpt)
 	if err != nil {
-		return common.CheckDeletedDiag(d, err, "error retrieving Listener")
+		return common.CheckDeletedDiag(d, err, "error retrieving GA listener")
 	}
 
-	getListenerRespBody, err := utils.FlattenResponse(getListenerResp)
+	respBody, err := utils.FlattenResponse(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	mErr = multierror.Append(
 		mErr,
-		d.Set("accelerator_id", utils.PathSearch("listener.accelerator_id", getListenerRespBody, nil)),
-		d.Set("client_affinity", utils.PathSearch("listener.client_affinity", getListenerRespBody, nil)),
-		d.Set("created_at", utils.PathSearch("listener.created_at", getListenerRespBody, nil)),
-		d.Set("description", utils.PathSearch("listener.description", getListenerRespBody, nil)),
-		d.Set("name", utils.PathSearch("listener.name", getListenerRespBody, nil)),
-		d.Set("port_ranges", flattenGetListenerResponseBodyPortRange(getListenerRespBody)),
-		d.Set("protocol", utils.PathSearch("listener.protocol", getListenerRespBody, nil)),
-		d.Set("status", utils.PathSearch("listener.status", getListenerRespBody, nil)),
-		d.Set("tags", flattenGetListenerResponseBodyResourceTag(getListenerRespBody)),
-		d.Set("updated_at", utils.PathSearch("listener.updated_at", getListenerRespBody, nil)),
+		d.Set("accelerator_id", utils.PathSearch("listener.accelerator_id", respBody, nil)),
+		d.Set("client_affinity", utils.PathSearch("listener.client_affinity", respBody, nil)),
+		d.Set("created_at", utils.PathSearch("listener.created_at", respBody, nil)),
+		d.Set("description", utils.PathSearch("listener.description", respBody, nil)),
+		d.Set("name", utils.PathSearch("listener.name", respBody, nil)),
+		d.Set("port_ranges", flattenGetListenerResponseBodyPortRange(respBody)),
+		d.Set("protocol", utils.PathSearch("listener.protocol", respBody, nil)),
+		d.Set("status", utils.PathSearch("listener.status", respBody, nil)),
+		d.Set("tags", flattenGetListenerResponseBodyResourceTag(respBody)),
+		d.Set("updated_at", utils.PathSearch("listener.updated_at", respBody, nil)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -358,54 +339,44 @@ func flattenGetListenerResponseBodyResourceTag(resp interface{}) map[string]inte
 }
 
 func resourceListenerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
+	var (
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		product = "ga"
+	)
+	client, err := conf.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GA client: %s", err)
+	}
 
-	updateListenerhasChanges := []string{
+	updateListenerHasChanges := []string{
 		"client_affinity",
 		"description",
 		"name",
 		"port_ranges",
 	}
 
-	if d.HasChanges(updateListenerhasChanges...) {
-		// updateListener: Update the configuration of GA Listener
-		var (
-			updateListenerHttpUrl = "v1/listeners/{listener_id}"
-			updateListenerProduct = "ga"
-		)
-		updateListenerClient, err := conf.NewServiceClient(updateListenerProduct, region)
-		if err != nil {
-			return diag.Errorf("error creating Listener Client: %s", err)
-		}
-
-		updateListenerPath := updateListenerClient.Endpoint + updateListenerHttpUrl
-		updateListenerPath = strings.ReplaceAll(updateListenerPath, "{listener_id}", d.Id())
-
-		updateListenerOpt := golangsdk.RequestOpts{
+	if d.HasChanges(updateListenerHasChanges...) {
+		requestPath := client.Endpoint + "v1/listeners/{listener_id}"
+		requestPath = strings.ReplaceAll(requestPath, "{listener_id}", d.Id())
+		requestOpt := golangsdk.RequestOpts{
 			KeepResponseBody: true,
-			OkCodes: []int{
-				200,
-			},
+			JSONBody:         utils.RemoveNil(buildUpdateListenerBodyParams(d)),
 		}
-		updateListenerOpt.JSONBody = utils.RemoveNil(buildUpdateListenerBodyParams(d))
-		_, err = updateListenerClient.Request("PUT", updateListenerPath, &updateListenerOpt)
+
+		_, err = client.Request("PUT", requestPath, &requestOpt)
 		if err != nil {
-			return diag.Errorf("error updating Listener: %s", err)
+			return diag.Errorf("error updating GA listener: %s", err)
 		}
+
 		err = updateListenerWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return diag.Errorf("error waiting for the Update of Listener (%s) to complete: %s", d.Id(), err)
+			return diag.Errorf("error waiting for the GA listener (%s) update to complete: %s", d.Id(), err)
 		}
 	}
 
 	// update tags
 	if d.HasChange("tags") {
-		client, err := conf.NewServiceClient("ga", region)
-		if err != nil {
-			return diag.Errorf("error creating GA Client: %s", err)
-		}
-
 		oldRaw, newRaw := d.GetChange("tags")
 		oldMap := oldRaw.(map[string]interface{})
 		newMap := newRaw.(map[string]interface{})
@@ -460,156 +431,139 @@ func buildUpdateListenerRequestBodyPortRange(rawParams interface{}) []map[string
 }
 
 func updateListenerWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/listeners/{listener_id}"
+		product          = "ga"
+		targetStatus     = []string{"ACTIVE"}
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{listener_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// updateListenerWaiting: missing operation notes
-			var (
-				updateListenerWaitingHttpUrl = "v1/listeners/{listener_id}"
-				updateListenerWaitingProduct = "ga"
-			)
-			updateListenerWaitingClient, err := config.NewServiceClient(updateListenerWaitingProduct, region)
-			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating Listener Client: %s", err)
-			}
-
-			updateListenerWaitingPath := updateListenerWaitingClient.Endpoint + updateListenerWaitingHttpUrl
-			updateListenerWaitingPath = strings.ReplaceAll(updateListenerWaitingPath, "{listener_id}", d.Id())
-
-			updateListenerWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			updateListenerWaitingResp, err := updateListenerWaitingClient.Request("GET", updateListenerWaitingPath, &updateListenerWaitingOpt)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
 				return nil, "ERROR", err
 			}
 
-			updateListenerWaitingRespBody, err := utils.FlattenResponse(updateListenerWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`listener.status`, updateListenerWaitingRespBody, "").(string)
 
-			targetStatus := []string{
-				"ACTIVE",
-			}
+			status := utils.PathSearch(`listener.status`, respBody, "").(string)
 			if utils.StrSliceContains(targetStatus, status) {
-				return updateListenerWaitingRespBody, "COMPLETED", nil
+				return respBody, "COMPLETED", nil
 			}
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return updateListenerWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return updateListenerWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }
 
 func resourceListenerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	conf := meta.(*config.Config)
-	region := conf.GetRegion(d)
-
-	// deleteListener: Delete an existing GA Listener
 	var (
-		deleteListenerHttpUrl = "v1/listeners/{listener_id}"
-		deleteListenerProduct = "ga"
+		conf    = meta.(*config.Config)
+		region  = conf.GetRegion(d)
+		httpUrl = "v1/listeners/{listener_id}"
+		product = "ga"
 	)
-	deleteListenerClient, err := conf.NewServiceClient(deleteListenerProduct, region)
+	client, err := conf.NewServiceClient(product, region)
 	if err != nil {
-		return diag.Errorf("error creating Listener Client: %s", err)
+		return diag.Errorf("error creating GA client: %s", err)
 	}
 
-	deleteListenerPath := deleteListenerClient.Endpoint + deleteListenerHttpUrl
-	deleteListenerPath = strings.ReplaceAll(deleteListenerPath, "{listener_id}", d.Id())
-
-	deleteListenerOpt := golangsdk.RequestOpts{
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{listener_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
 		KeepResponseBody: true,
-		OkCodes: []int{
-			204,
-		},
 	}
-	_, err = deleteListenerClient.Request("DELETE", deleteListenerPath, &deleteListenerOpt)
+
+	_, err = client.Request("DELETE", requestPath, &requestOpt)
 	if err != nil {
-		return diag.Errorf("error deleting Listener: %s", err)
+		return diag.Errorf("error deleting GA listener: %s", err)
 	}
 
 	err = deleteListenerWaitingForStateCompleted(ctx, d, meta, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
-		return diag.Errorf("error waiting for the Delete of Listener (%s) to complete: %s", d.Id(), err)
+		return diag.Errorf("error waiting for the GA listener (%s) delete to complete: %s", d.Id(), err)
 	}
 	return nil
 }
 
 func deleteListenerWaitingForStateCompleted(ctx context.Context, d *schema.ResourceData, meta interface{}, t time.Duration) error {
+	var (
+		cfg              = meta.(*config.Config)
+		region           = cfg.GetRegion(d)
+		httpUrl          = "v1/listeners/{listener_id}"
+		product          = "ga"
+		unexpectedStatus = []string{"ERROR"}
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return fmt.Errorf("error creating GA client: %s", err)
+	}
+
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{listener_id}", d.Id())
+	requestOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending: []string{"PENDING"},
 		Target:  []string{"COMPLETED"},
 		Refresh: func() (interface{}, string, error) {
-			config := meta.(*config.Config)
-			region := config.GetRegion(d)
-			// deleteListenerWaiting: missing operation notes
-			var (
-				deleteListenerWaitingHttpUrl = "v1/listeners/{listener_id}"
-				deleteListenerWaitingProduct = "ga"
-			)
-			deleteListenerWaitingClient, err := config.NewServiceClient(deleteListenerWaitingProduct, region)
+			resp, err := client.Request("GET", requestPath, &requestOpt)
 			if err != nil {
-				return nil, "ERROR", fmt.Errorf("error creating Listener Client: %s", err)
-			}
-
-			deleteListenerWaitingPath := deleteListenerWaitingClient.Endpoint + deleteListenerWaitingHttpUrl
-			deleteListenerWaitingPath = strings.ReplaceAll(deleteListenerWaitingPath, "{listener_id}", d.Id())
-
-			deleteListenerWaitingOpt := golangsdk.RequestOpts{
-				KeepResponseBody: true,
-				OkCodes: []int{
-					200,
-				},
-			}
-			deleteListenerWaitingResp, err := deleteListenerWaitingClient.Request("GET", deleteListenerWaitingPath, &deleteListenerWaitingOpt)
-			if err != nil {
-				if _, ok := err.(golangsdk.ErrDefault404); ok {
-					// When the error code is 404, the value of respBody is nil, and a non-null value is returned to avoid continuing the loop check.
+				var errDefault404 golangsdk.ErrDefault404
+				if errors.As(err, &errDefault404) {
+					// When the error code is `404`, the value of respBody is nil, and a non-null value is returned to
+					// avoid continuing the loop check.
 					return "Resource Not Found", "COMPLETED", nil
 				}
 
 				return nil, "ERROR", err
 			}
 
-			deleteListenerWaitingRespBody, err := utils.FlattenResponse(deleteListenerWaitingResp)
+			respBody, err := utils.FlattenResponse(resp)
 			if err != nil {
 				return nil, "ERROR", err
 			}
-			status := utils.PathSearch(`listener.status`, deleteListenerWaitingRespBody, "").(string)
 
-			unexpectedStatus := []string{
-				"ERROR",
-			}
+			status := utils.PathSearch(`listener.status`, respBody, "").(string)
 			if utils.StrSliceContains(unexpectedStatus, status) {
-				return deleteListenerWaitingRespBody, status, nil
+				return respBody, status, nil
 			}
 
-			return deleteListenerWaitingRespBody, "PENDING", nil
+			return respBody, "PENDING", nil
 		},
 		Timeout:      t,
 		Delay:        10 * time.Second,
 		PollInterval: 5 * time.Second,
 	}
-	_, err := stateConf.WaitForStateContext(ctx)
+	_, err = stateConf.WaitForStateContext(ctx)
 	return err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- 1、Modify the lint problem and improve the readability of the code.
- 2、Optimize GA test cases.
- 3、Make test cases to execute successfully.
  - Add logic to make the wait state available after editing the label.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/ga' TESTARGS='-run TestAcc.*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/ga -v -run TestAcc.* -timeout 360m -parallel 4
=== RUN   TestAccDatasourceAccelerators_basic
=== PAUSE TestAccDatasourceAccelerators_basic
=== RUN   TestAccDatasourceAddressGroups_basic
=== PAUSE TestAccDatasourceAddressGroups_basic
=== RUN   TestAccDataSourceGaAvailabilityZones_basic
=== PAUSE TestAccDataSourceGaAvailabilityZones_basic
=== RUN   TestAccDatasourceEndpointGroups_basic
=== PAUSE TestAccDatasourceEndpointGroups_basic
=== RUN   TestAccDatasourceEndpoints_basic
=== PAUSE TestAccDatasourceEndpoints_basic
=== RUN   TestAccDatasourceHealthChecks_basic
=== PAUSE TestAccDatasourceHealthChecks_basic
=== RUN   TestAccDatasourceListeners_basic
=== PAUSE TestAccDatasourceListeners_basic
=== RUN   TestAccAccelerator_basic
=== PAUSE TestAccAccelerator_basic
=== RUN   TestAccIpAddressGroup_basic
=== PAUSE TestAccIpAddressGroup_basic
=== RUN   TestAccIpAddressGroup_associateListener
=== PAUSE TestAccIpAddressGroup_associateListener
=== RUN   TestAccEndpointGroup_basic
=== PAUSE TestAccEndpointGroup_basic
=== RUN   TestAccEndpoint_basic
=== PAUSE TestAccEndpoint_basic
=== RUN   TestAccHealthCheck_basic
=== PAUSE TestAccHealthCheck_basic
=== RUN   TestAccListener_basic
=== PAUSE TestAccListener_basic
=== CONT  TestAccDatasourceAccelerators_basic
=== CONT  TestAccAccelerator_basic
=== CONT  TestAccDatasourceEndpoints_basic
=== CONT  TestAccDatasourceListeners_basic
--- PASS: TestAccDatasourceAccelerators_basic (45.06s)
=== CONT  TestAccDataSourceGaAvailabilityZones_basic
--- PASS: TestAccDataSourceGaAvailabilityZones_basic (7.11s)
=== CONT  TestAccDatasourceEndpointGroups_basic
--- PASS: TestAccDatasourceListeners_basic (72.79s)
=== CONT  TestAccDatasourceAddressGroups_basic
--- PASS: TestAccAccelerator_basic (79.42s)
=== CONT  TestAccEndpoint_basic
--- PASS: TestAccDatasourceEndpoints_basic (135.84s)
=== CONT  TestAccListener_basic
--- PASS: TestAccDatasourceEndpointGroups_basic (102.89s)
=== CONT  TestAccHealthCheck_basic
--- PASS: TestAccDatasourceAddressGroups_basic (123.61s)
=== CONT  TestAccIpAddressGroup_associateListener
--- PASS: TestAccListener_basic (96.12s)
=== CONT  TestAccEndpointGroup_basic
--- PASS: TestAccEndpoint_basic (157.72s)
=== CONT  TestAccDatasourceHealthChecks_basic
--- PASS: TestAccHealthCheck_basic (143.74s)
=== CONT  TestAccIpAddressGroup_basic
--- PASS: TestAccIpAddressGroup_associateListener (153.36s)
--- PASS: TestAccEndpointGroup_basic (124.67s)
--- PASS: TestAccDatasourceHealthChecks_basic (128.88s)
--- PASS: TestAccIpAddressGroup_basic (80.47s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/ga        379.309s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
