### PR TITLE
refactor(vpc): remove max items limit in address group

### DIFF
--- a/docs/resources/vpc_address_group.md
+++ b/docs/resources/vpc_address_group.md
@@ -72,8 +72,7 @@ The following arguments are supported:
   periods (.).
 
 * `addresses` - (Optional, List) Specifies an array of one or more IP addresses. The address can be a single IP
-  address, IP address range or IP address CIDR. The maximum length is 20. Only one of `addresses` and `ip_extra_set`
-  can be specified.
+  address, IP address range or IP address CIDR. Only one of `addresses` and `ip_extra_set` can be specified.
 
 * `ip_extra_set` - (Optional, List) Specifies the IP addresses and their remarks in an IP address group.
   The [ip_extra_set](#address_groups_ip_extra_set_struct) structure is documented below.

--- a/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
+++ b/huaweicloud/services/vpc/resource_huaweicloud_vpc_address_group.go
@@ -54,7 +54,6 @@ func ResourceVpcAddressGroup() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				MaxItems: 20,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"ip_version": {
@@ -69,7 +68,6 @@ func ResourceVpcAddressGroup() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				MaxItems: 20,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip": {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/vpc' TESTARGS='-run TestAccVpcAddressGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/vpc -v -run TestAccVpcAddressGroup -timeout 360m -parallel 4
=== RUN   TestAccVpcAddressGroup_basic
=== PAUSE TestAccVpcAddressGroup_basic
=== RUN   TestAccVpcAddressGroup_ipExtraSet
=== PAUSE TestAccVpcAddressGroup_ipExtraSet
=== RUN   TestAccVpcAddressGroup_ipv6
=== PAUSE TestAccVpcAddressGroup_ipv6
=== RUN   TestAccVpcAddressGroup_eps
=== PAUSE TestAccVpcAddressGroup_eps
=== CONT  TestAccVpcAddressGroup_basic
=== CONT  TestAccVpcAddressGroup_ipExtraSet
=== CONT  TestAccVpcAddressGroup_ipv6
=== CONT  TestAccVpcAddressGroup_eps
--- PASS: TestAccVpcAddressGroup_eps (27.35s)
--- PASS: TestAccVpcAddressGroup_ipExtraSet (44.17s)
--- PASS: TestAccVpcAddressGroup_basic (44.21s)
--- PASS: TestAccVpcAddressGroup_ipv6 (44.24s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/vpc       44.290s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
