### PR TITLE
chore(nat): unify aotumatically code style and fix some error in test cases

### DIFF
--- a/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_gateways_test.go
+++ b/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_gateways_test.go
@@ -255,7 +255,9 @@ data "huaweicloud_nat_private_gateways" "filter_by_tags" {
 
 locals {
   tags_filter_result = [
-    for v in data.huaweicloud_nat_private_gateways.filter_by_tags.gateways[*].tags : v == local.tags
+    for tagMap in data.huaweicloud_nat_private_gateways.filter_by_tags.gateways[*].tags : alltrue([
+      for k, v in local.tags : tagMap[k] == v
+    ])
   ]
 }
 

--- a/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_transit_ips_test.go
+++ b/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_private_transit_ips_test.go
@@ -197,7 +197,9 @@ data "huaweicloud_nat_private_transit_ips" "filter_by_tags" {
 
 locals {
   tags_filter_result = [
-    for v in data.huaweicloud_nat_private_transit_ips.filter_by_tags.transit_ips[*].tags : v == local.tags
+    for tagMap in data.huaweicloud_nat_private_transit_ips.filter_by_tags.transit_ips[*].tags : alltrue([
+      for k, v in local.tags : tagMap[k] == v
+    ])
   ]
 }
 

--- a/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_snat_rules_test.go
+++ b/huaweicloud/services/acceptance/nat/data_source_huaweicloud_nat_snat_rules_test.go
@@ -26,9 +26,6 @@ func TestAccDatasourceSnatRules_basic(t *testing.T) {
 		bySourceType   = "data.huaweicloud_nat_snat_rules.filter_by_source_type"
 		dcBySourceType = acceptance.InitDataSourceCheck(bySourceType)
 
-		bySubnetId   = "data.huaweicloud_nat_snat_rules.filter_by_subnet_id"
-		dcBySubnetId = acceptance.InitDataSourceCheck(bySubnetId)
-
 		byEipId   = "data.huaweicloud_nat_snat_rules.filter_by_floating_ip_id"
 		dcByEipId = acceptance.InitDataSourceCheck(byEipId)
 	)
@@ -49,9 +46,6 @@ func TestAccDatasourceSnatRules_basic(t *testing.T) {
 
 					dcBySourceType.CheckResourceExists(),
 					resource.TestCheckOutput("source_type_filter_is_useful", "true"),
-
-					dcBySubnetId.CheckResourceExists(),
-					resource.TestCheckOutput("subnet_id_filter_is_useful", "true"),
 
 					dcByEipId.CheckResourceExists(),
 					resource.TestCheckOutput("floating_ip_id_filter_is_useful", "true"),
@@ -110,6 +104,10 @@ locals {
 }
 
 data "huaweicloud_nat_snat_rules" "filter_by_rule_id" {
+  depends_on = [
+    huaweicloud_nat_snat_rule.test
+  ]
+
   rule_id = local.rule_id
 }
 
@@ -128,6 +126,10 @@ locals {
 }
 
 data "huaweicloud_nat_snat_rules" "filter_by_gateway_id" {
+  depends_on = [
+    huaweicloud_nat_snat_rule.test
+  ]
+
   gateway_id = local.gateway_id
 }
 
@@ -146,6 +148,10 @@ locals {
 }
 
 data "huaweicloud_nat_snat_rules" "filter_by_source_type" {
+  depends_on = [
+    huaweicloud_nat_snat_rule.test
+  ]
+
   source_type = local.source_type
 }
 
@@ -160,28 +166,14 @@ output "source_type_filter_is_useful" {
 }
 
 locals {
-  subnet_id = data.huaweicloud_nat_snat_rules.test.rules[0].subnet_id
-}
-
-data "huaweicloud_nat_snat_rules" "filter_by_subnet_id" {
-  subnet_id = local.subnet_id
-}
-
-locals {
-  subnet_id_filter_result = [
-    for v in data.huaweicloud_nat_snat_rules.filter_by_subnet_id.rules[*].subnet_id : v == local.subnet_id
-  ]
-}
-
-output "subnet_id_filter_is_useful" {
-  value = alltrue(local.subnet_id_filter_result) && length(local.subnet_id_filter_result) > 0
-}
-
-locals {
   floating_ip_id = data.huaweicloud_nat_snat_rules.test.rules[0].floating_ip_id
 }
 
 data "huaweicloud_nat_snat_rules" "filter_by_floating_ip_id" {
+  depends_on = [
+    huaweicloud_nat_snat_rule.test
+  ]
+
   floating_ip_id = local.floating_ip_id
 }
 
@@ -205,9 +197,6 @@ func TestAccDatasourceSnatRules_direct(t *testing.T) {
 		dataSourceName = "data.huaweicloud_nat_snat_rules.test"
 		dc             = acceptance.InitDataSourceCheck(dataSourceName)
 
-		byCidr   = "data.huaweicloud_nat_snat_rules.filter_by_cidr"
-		dcByCidr = acceptance.InitDataSourceCheck(byCidr)
-
 		bySourceType   = "data.huaweicloud_nat_snat_rules.filter_by_source_type"
 		dcBySourceType = acceptance.InitDataSourceCheck(bySourceType)
 
@@ -226,8 +215,6 @@ func TestAccDatasourceSnatRules_direct(t *testing.T) {
 				Config: testAccDatasourceSnatRules_direct(baseConfig),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
-					dcByCidr.CheckResourceExists(),
-					resource.TestCheckOutput("cidr_filter_is_useful", "true"),
 
 					dcBySourceType.CheckResourceExists(),
 					resource.TestCheckOutput("source_type_filter_is_useful", "true"),
@@ -289,29 +276,14 @@ data "huaweicloud_nat_snat_rules" "test" {
 }
 
 locals {
-  cidr = data.huaweicloud_nat_snat_rules.test.rules[0].cidr
-}
-
-data "huaweicloud_nat_snat_rules" "filter_by_cidr" {
-  cidr = local.cidr
-}
-
-locals {
-  cidr_filter_result = [
-    for v in data.huaweicloud_nat_snat_rules.filter_by_cidr.rules[*].cidr : 
-    v == local.cidr
-  ]
-}
-
-output "cidr_filter_is_useful" {
-  value = alltrue(local.cidr_filter_result) && length(local.cidr_filter_result) > 0
-}
-
-locals {
   source_type = data.huaweicloud_nat_snat_rules.test.rules[0].source_type
 }
 
 data "huaweicloud_nat_snat_rules" "filter_by_source_type" {
+  depends_on = [
+    huaweicloud_nat_snat_rule.direct
+  ]
+
   source_type = local.source_type
 }
 
@@ -331,6 +303,10 @@ locals {
 }
 
 data "huaweicloud_nat_snat_rules" "filter_by_status" {
+  depends_on = [
+    huaweicloud_nat_snat_rule.direct
+  ]
+
   status = local.status
 }
 
@@ -350,6 +326,10 @@ locals {
 }
 
 data "huaweicloud_nat_snat_rules" "filter_by_floating_ip_address" {
+  depends_on = [
+    huaweicloud_nat_snat_rule.direct
+  ]
+
   floating_ip_address = local.floating_ip_address
 }
 

--- a/huaweicloud/services/nat/data_source_huaweicloud_nat_dnat_rules.go
+++ b/huaweicloud/services/nat/data_source_huaweicloud_nat_dnat_rules.go
@@ -186,57 +186,53 @@ func dnatRuleSchema() *schema.Resource {
 }
 
 func dataSourceDnatRulesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	cfg := meta.(*config.Config)
-	region := cfg.GetRegion(d)
-
-	// listDnatRules: Query the DNAT rule list
 	var (
-		listDnatRulesHttpUrl = "v2/{project_id}/dnat_rules"
-		listDnatRulesProduct = "nat"
+		cfg     = meta.(*config.Config)
+		region  = cfg.GetRegion(d)
+		httpUrl = "v2/{project_id}/dnat_rules"
+		product = "nat"
 	)
-	listDnatRulesClient, err := cfg.NewServiceClient(listDnatRulesProduct, region)
+	client, err := cfg.NewServiceClient(product, region)
 	if err != nil {
 		return diag.Errorf("error creating NAT client: %s", err)
 	}
 
-	listDnatRulesPath := listDnatRulesClient.Endpoint + listDnatRulesHttpUrl
-	listDnatRulesPath = strings.ReplaceAll(listDnatRulesPath, "{project_id}", listDnatRulesClient.ProjectID)
+	requestPath := client.Endpoint + httpUrl
+	requestPath = strings.ReplaceAll(requestPath, "{project_id}", client.ProjectID)
+	requestPath += buildListDnatRuleQueryParams(d)
 
-	listDnatRulesQueryParams := buildListDnatRuleQueryParams(d)
-	listDnatRulesPath += listDnatRulesQueryParams
-
-	listDnatRulesResp, err := pagination.ListAllItems(
-		listDnatRulesClient,
+	resp, err := pagination.ListAllItems(
+		client,
 		"marker",
-		listDnatRulesPath,
+		requestPath,
 		&pagination.QueryOpts{MarkerField: ""})
 
 	if err != nil {
 		return diag.Errorf("error retrieving DNAT rules %s", err)
 	}
 
-	listDnatRulesRespJson, err := json.Marshal(listDnatRulesResp)
+	respJson, err := json.Marshal(resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	var listDnatRulesRespBody interface{}
-	err = json.Unmarshal(listDnatRulesRespJson, &listDnatRulesRespBody)
+	var respBody interface{}
+	err = json.Unmarshal(respJson, &respBody)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	uuid, err := uuid.GenerateUUID()
+	generateUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return diag.Errorf("unable to generate ID: %s", err)
 	}
-	d.SetId(uuid)
+	d.SetId(generateUUID)
 
 	var mErr *multierror.Error
 	mErr = multierror.Append(
 		mErr,
 		d.Set("region", region),
-		d.Set("rules", filterListDnatRuleResponseBody(flattenListDnatRulesResponseBody(listDnatRulesRespBody), d)),
+		d.Set("rules", filterListDnatRuleResponseBody(flattenListDnatRulesResponseBody(respBody), d)),
 	)
 
 	return diag.FromErr(mErr.ErrorOrNil())
@@ -274,15 +270,18 @@ func flattenListDnatRulesResponseBody(resp interface{}) []interface{} {
 }
 
 func filterListDnatRuleResponseBody(all []interface{}, d *schema.ResourceData) []interface{} {
-	rst := make([]interface{}, 0, len(all))
+	var (
+		globalEipID      = d.Get("global_eip_id").(string)
+		globalEipAddress = d.Get("global_eip_address").(string)
+		rst              = make([]interface{}, 0, len(all))
+	)
+
 	for _, v := range all {
-		if param, ok := d.GetOk("global_eip_id"); ok &&
-			fmt.Sprint(param) != utils.PathSearch("global_eip_id", v, nil) {
+		if globalEipID != "" && globalEipID != utils.PathSearch("global_eip_id", v, nil) {
 			continue
 		}
 
-		if param, ok := d.GetOk("global_eip_address"); ok &&
-			fmt.Sprint(param) != utils.PathSearch("global_eip_address", v, nil) {
+		if globalEipAddress != "" && globalEipAddress != utils.PathSearch("global_eip_address", v, nil) {
 			continue
 		}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Unify aotumatically code style and fix some error in test cases.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/nat' TESTARGS='-run TestAccData'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/nat -v -run TestAccData -timeout 360m -parallel 4
=== RUN   TestAccDatasourceDnatRules_basic
=== PAUSE TestAccDatasourceDnatRules_basic
=== RUN   TestAccDataPublicGateway_basic
=== PAUSE TestAccDataPublicGateway_basic
=== RUN   TestAccDatasourcePublicGateways_basic
=== PAUSE TestAccDatasourcePublicGateways_basic
=== RUN   TestAccDatasourcePrivateDnatRules_basic
=== PAUSE TestAccDatasourcePrivateDnatRules_basic
=== RUN   TestAccDatasourcePrivateGateways_basic
=== PAUSE TestAccDatasourcePrivateGateways_basic
=== RUN   TestAccDatasourcePrivateSnatRules_basic
=== PAUSE TestAccDatasourcePrivateSnatRules_basic
=== RUN   TestAccDatasourcePrivateTransitIps_basic
=== PAUSE TestAccDatasourcePrivateTransitIps_basic
=== RUN   TestAccDatasourceSnatRules_basic
=== PAUSE TestAccDatasourceSnatRules_basic
=== RUN   TestAccDatasourceSnatRules_direct
=== PAUSE TestAccDatasourceSnatRules_direct
=== CONT  TestAccDatasourceDnatRules_basic
=== CONT  TestAccDatasourcePrivateSnatRules_basic
=== CONT  TestAccDatasourcePrivateDnatRules_basic
=== CONT  TestAccDatasourcePrivateGateways_basic
--- PASS: TestAccDatasourcePrivateSnatRules_basic (73.97s)
=== CONT  TestAccDatasourcePublicGateways_basic
--- PASS: TestAccDatasourcePrivateGateways_basic (74.47s)
=== CONT  TestAccDatasourcePrivateTransitIps_basic
--- PASS: TestAccDatasourcePrivateTransitIps_basic (93.52s)
=== CONT  TestAccDatasourceSnatRules_direct
--- PASS: TestAccDatasourcePublicGateways_basic (101.25s)
=== CONT  TestAccDataPublicGateway_basic
--- PASS: TestAccDatasourcePrivateDnatRules_basic (209.62s)
=== CONT  TestAccDatasourceSnatRules_basic
--- PASS: TestAccDatasourceDnatRules_basic (215.55s)
--- PASS: TestAccDataPublicGateway_basic (77.17s)
--- PASS: TestAccDatasourceSnatRules_direct (86.45s)
--- PASS: TestAccDatasourceSnatRules_basic (84.17s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/nat       293.833s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
