### PR TITLE
feat(iotda/device_group): device group resource support new parameters

### DIFF
--- a/docs/resources/iotda_device_group.md
+++ b/docs/resources/iotda_device_group.md
@@ -57,6 +57,25 @@ underscores (_) and the following special characters are allowed: `?'#().,&%@!`.
 * `parent_group_id` - (Optional, String, ForceNew) Specifies the parent group id.
 Changing this parameter will create a new resource.
 
+* `type` - (Optional, String, ForceNew) Specifies the device group type.
+  The valid values are as follows:
+  + **STATIC**: Static device group.
+  + **DYNAMIC**: Dynamic device group.
+
+  Defaults to **STATIC**.
+
+-> When the `type` parameter is set to **DYNAMIC**:
+  <br/>1. The `dynamic_group_rule` parameter is required.
+  <br/>2. The `parent_group_id` parameter cannot be set, because dynamic group do not support parent-child nesting.
+  <br/>3. The `device_ids` does not need to be set and cannot be updated, only as an attribute. Because devices in
+  dynamic group can only be managed automatically based on dynamic group rule.
+  <br/>4. Only the standard and enterprise versions of IoTDA instances support dynamic device groups.
+
+* `dynamic_group_rule` - (Optional, String, ForceNew) Specifies the dynamic device group rule, just fill in the content
+  of the **where** clause, the remaining clauses do not need to be filled in.
+  e.g. **device_name = 'xxx' or device_name = 'xxx'**.
+  More grammar rules, please see [API docs](https://support.huaweicloud.com/intl/en-us/api-iothub/SearchDevices.html).
+
 * `device_ids` - (Optional, List) Specifies the list of device IDs bound to the group.
 
 ## Attribute Reference

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_device_group_test.go
@@ -125,6 +125,60 @@ func TestAccDeviceGroup_derived(t *testing.T) {
 	})
 }
 
+func TestAccDeviceGroup_withDynamicGroup(t *testing.T) {
+	var (
+		obj        model.ShowDeviceGroupResponse
+		name       = acceptance.RandomAccResourceName()
+		updateName = acceptance.RandomAccResourceName()
+		rName      = "huaweicloud_iotda_device_group.test"
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getDeviceGroupResourceFunc,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Only the standard and enterprise versions of IoTDA instances support dynamic device groups.
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDeviceGroup_dynamicGroup(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "description test"),
+					resource.TestCheckResourceAttr(rName, "type", "DYNAMIC"),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "device_ids.#", "2"),
+				),
+			},
+			{
+				Config: testDeviceGroup_dynamicGroup_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "description update"),
+					resource.TestCheckResourceAttr(rName, "type", "DYNAMIC"),
+					resource.TestCheckResourceAttrPair(rName, "space_id", "huaweicloud_iotda_space.test", "id"),
+					resource.TestCheckResourceAttr(rName, "device_ids.#", "2"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"space_id"},
+			},
+		},
+	})
+}
+
 func testDeviceGroup_basic(name, deviceName string) string {
 	baseConfig := testDevice_basic(deviceName, deviceName)
 	return fmt.Sprintf(`
@@ -151,4 +205,36 @@ resource "huaweicloud_iotda_device_group" "test" {
   device_ids  = [huaweicloud_iotda_device.test2.id]
 }
 `, baseConfig, name, name)
+}
+
+func testDeviceGroup_dynamicGroup(name string) string {
+	baseConfig := testDevice_basic(name, name)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_device_group" "test" {
+  name               = "%[2]s"
+  space_id           = huaweicloud_iotda_space.test.id
+  description        = "description test"
+  type               = "DYNAMIC"
+  dynamic_group_rule = "device_id = '${huaweicloud_iotda_device.test.id}' or device_id = '${huaweicloud_iotda_device.test2.id}'"
+}
+`, baseConfig, name)
+}
+
+func testDeviceGroup_dynamicGroup_update(name string) string {
+	baseConfig := testDevice_basic(name, name)
+
+	return fmt.Sprintf(`
+%[1]s
+
+resource "huaweicloud_iotda_device_group" "test" {
+  name               = "%[2]s"
+  space_id           = huaweicloud_iotda_space.test.id
+  description        = "description update"
+  type               = "DYNAMIC"
+  dynamic_group_rule = "device_id = '${huaweicloud_iotda_device.test.id}' or device_id = '${huaweicloud_iotda_device.test2.id}'"
+}
+`, baseConfig, name)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. Device group resource support `type` and `dynamic_group_rule` parameters.
2. Add parameter usage restrictions in the document.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

### Newly added tests
```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceGroup_withDynamicGroup"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceGroup_withDynamicGroup -timeout 360m -parallel 4
=== RUN   TestAccDeviceGroup_withDynamicGroup
--- PASS: TestAccDeviceGroup_withDynamicGroup (26.34s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     26.398s

```

### Original tests
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceGroup_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceGroup_basic -timeout 360m -parallel 4
=== RUN   TestAccDeviceGroup_basic
--- PASS: TestAccDeviceGroup_basic (24.85s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     24.898s



$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDeviceGroup_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDeviceGroup_derived -timeout 360m -parallel 4
=== RUN   TestAccDeviceGroup_derived
--- PASS: TestAccDeviceGroup_derived (23.67s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     23.717s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
