### PR TITLE
feat(GaussDBforMySQL): add gaussdb mysql diagnosis instances data source

### DIFF
--- a/docs/data-sources/gaussdb_mysql_diagnosis_instances.md
+++ b/docs/data-sources/gaussdb_mysql_diagnosis_instances.md
@@ -1,0 +1,47 @@
+---
+subcategory: "GaussDB(for MySQL)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_mysql_diagnosis_instances"
+description: |-
+  Use this data source to get the abnormal instance information by a specific metric.
+---
+
+# huaweicloud_gaussdb_mysql_diagnosis_instances
+
+Use this data source to get the abnormal instance information by a specific metric.
+
+## Example Usage
+
+```hcl
+variable "metric_name" {}
+
+data "huaweicloud_gaussdb_mysql_diagnosis_instances" "test" {
+  metric_name = var.metric_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the resource.
+  If omitted, the provider-level region will be used.
+
+* `metric_name` - (Required, String) Specifies the metric name.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instance_infos` - Indicates the information about the abnormal instances.
+
+  The [instance_infos](#instance_infos_struct) structure is documented below.
+
+<a name="instance_infos_struct"></a>
+The `instance_infos` block supports:
+
+* `instance_id` - Indicates the instance ID.
+
+* `master_node_id` - Indicates the primary node ID.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -782,6 +782,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_slow_logs":               gaussdb.DataSourceGaussDBMysqlSlowLogs(),
 			"huaweicloud_gaussdb_mysql_error_logs":              gaussdb.DataSourceGaussDBMysqlErrorLogs(),
 			"huaweicloud_gaussdb_mysql_diagnosis_statistics":    gaussdb.DataSourceGaussdbMysqlDiagnosisStatistics(),
+			"huaweicloud_gaussdb_mysql_diagnosis_instances":     gaussdb.DataSourceGaussDBMysqlDiagnosisInstances(),
 
 			"huaweicloud_gaussdb_influx_instances": gaussdb.DataSourceGaussDBInfluxInstances(),
 

--- a/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_mysql_diagnosis_instances_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/data_source_huaweicloud_gaussdb_mysql_diagnosis_instances_test.go
@@ -1,0 +1,40 @@
+package gaussdb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceGaussDBMysqlDiagnosisInstances_basic(t *testing.T) {
+	dataSource := "data.huaweicloud_gaussdb_mysql_diagnosis_instances.test"
+	dc := acceptance.InitDataSourceCheck(dataSource)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceGaussdbMysqlDiagnosisInstances_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSource, "instance_infos.#"),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceGaussdbMysqlDiagnosisInstances_basic() string {
+	return `
+data "huaweicloud_gaussdb_mysql_diagnosis_statistics" "test" {}
+
+data "huaweicloud_gaussdb_mysql_diagnosis_instances" "test" {
+  metric_name = data.huaweicloud_gaussdb_mysql_diagnosis_statistics.test.diagnosis_info[0].metric_name
+}
+`
+}

--- a/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_diagnosis_instances.go
+++ b/huaweicloud/services/gaussdb/data_source_huaweicloud_gaussdb_mysql_diagnosis_instances.go
@@ -1,0 +1,129 @@
+package gaussdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/pagination"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API GaussDBforMySQL GET /v3/{project_id}/instances/diagnosis-instance-infos
+func DataSourceGaussDBMysqlDiagnosisInstances() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceGaussDBMysqlDiagnosisInstancesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"metric_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Specifies the metric name.`,
+			},
+			"instance_infos": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `Indicates the information about the abnormal instances.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the instance ID.`,
+						},
+						"master_node_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Indicates the primary node ID.`,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGaussDBMysqlDiagnosisInstancesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/instances/diagnosis-instance-infos?offset=0&limit=100"
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	listPath := client.Endpoint + httpUrl
+	listPath = strings.ReplaceAll(listPath, "{project_id}", client.ProjectID)
+	listPath += buildQueryParams(d)
+
+	listResp, err := pagination.ListAllItems(
+		client,
+		"offset",
+		listPath,
+		&pagination.QueryOpts{MarkerField: ""})
+
+	if err != nil {
+		return diag.Errorf("error retrieving GaussDB MySQL diagnosis instances: %s", err)
+	}
+
+	listRespJson, err := json.Marshal(listResp)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	var listRespBody interface{}
+	err = json.Unmarshal(listRespJson, &listRespBody)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceId, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+	d.SetId(dataSourceId)
+
+	mErr := multierror.Append(
+		d.Set("region", region),
+		d.Set("instance_infos", flattenListDiagnosisInstancesBody(listRespBody)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func buildQueryParams(d *schema.ResourceData) string {
+	return fmt.Sprintf("&metric_name=%s", d.Get("metric_name").(string))
+}
+
+func flattenListDiagnosisInstancesBody(resp interface{}) []interface{} {
+	diagnosisInstancesJson := utils.PathSearch("instance_infos", resp, make([]interface{}, 0))
+	diagnosisInstancesArray := diagnosisInstancesJson.([]interface{})
+	if len(diagnosisInstancesArray) < 1 {
+		return nil
+	}
+	rst := make([]interface{}, 0, len(diagnosisInstancesArray))
+
+	for _, v := range diagnosisInstancesArray {
+		rst = append(rst, map[string]interface{}{
+			"instance_id":    utils.PathSearch("instance_id", v, nil),
+			"master_node_id": utils.PathSearch("master_node_id", v, nil),
+		})
+	}
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb mysql diagnosis instances data source
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb mysql diagnosis instances data source
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccDataSourceGaussDBMysqlDiagnosisInstances_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccDataSourceGaussDBMysqlDiagnosisInstances_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceGaussDBMysqlDiagnosisInstances_basic
=== PAUSE TestAccDataSourceGaussDBMysqlDiagnosisInstances_basic
=== CONT  TestAccDataSourceGaussDBMysqlDiagnosisInstances_basic
--- PASS: TestAccDataSourceGaussDBMysqlDiagnosisInstances_basic (21.31s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   21.354s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
