### PR TITLE
feat(iotda/device_proxies): support device proxies datasource

### DIFF
--- a/docs/data-sources/iotda_device_proxies.md
+++ b/docs/data-sources/iotda_device_proxies.md
@@ -1,0 +1,79 @@
+---
+subcategory: "IoT Device Access (IoTDA)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_iotda_device_proxies"
+description: |-
+  Use this data source to get the list of IoTDA device proxies within HuaweiCloud.
+---
+
+# huaweicloud_iotda_device_proxies
+
+Use this data source to get the list of IoTDA device proxies within HuaweiCloud.
+
+-> Currently, device proxy resources are only supported on IoTDA **standard** or **enterprise** edition instance.
+  When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify
+  the IoTDA service endpoint in `provider` block.
+  You can login to the IoTDA console, choose the instance **Overview** and click **Access Details**
+  to view the HTTPS application access address. An example of the access address might be
+  *9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com*, then you need to configure the
+  `provider` block as follows:
+
+  ```hcl
+  provider "huaweicloud" {
+    endpoints = {
+      iotda = "https://9bc34xxxxx.st1.iotda-app.ap-southeast-1.myhuaweicloud.com"
+    }
+  }
+  ```
+
+## Example Usage
+
+```hcl
+variable "name" {}
+
+data "huaweicloud_iotda_device_proxies" "test" {
+  name = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the device proxies.
+  If omitted, the provider-level region will be used.
+
+* `space_id` - (Optional, String) Specifies the space ID to which the device proxies belong.
+  If omitted, query all device proxies under the current instance.
+
+* `name` - (Optional, String) Specifies the name of the device proxy.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `proxies` - All device proxies that match the filter parameters.
+  The [proxies](#iotda_proxies) structure is documented below.
+
+<a name="iotda_proxies"></a>
+The `proxies` block supports:
+
+* `id` - The device proxy ID.
+
+* `name` - The device proxy name.
+
+* `space_id` - The space ID to which the device proxy belongs.
+
+* `effective_time_range` - The validity period of the device proxy rule.
+  The [effective_time_range](#IoTDA_effective_time_range) structure is documented below.
+
+<a name="IoTDA_effective_time_range"></a>
+The `effective_time_range` block supports:
+
+* `start_time` - The effective time of the device proxy, using UTC time zone,
+  the format is **yyyyMMdd'T'HHMmmss-Z**. e.g. **20250528T153000Z**.
+
+* `end_time` - The device proxy expiration time, using UTC time zone,
+  the format is **yyyyMMdd'T'HHMmmss-Z**. e.g. **20250528T153000Z**.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -836,6 +836,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_kps_running_tasks": dew.DataSourceDewKpsRunningTasks(),
 			"huaweicloud_kps_keypairs":      dew.DataSourceKeypairs(),
 
+			"huaweicloud_iotda_device_proxies":        iotda.DataSourceDeviceProxies(),
 			"huaweicloud_iotda_device_binding_groups": iotda.DataSourceDeviceBindingGroups(),
 			"huaweicloud_iotda_amqps":                 iotda.DataSourceAMQPQueues(),
 			"huaweicloud_iotda_batchtasks":            iotda.DataSourceBatchTasks(),

--- a/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_proxies_test.go
+++ b/huaweicloud/services/acceptance/iotda/data_source_huaweicloud_iotda_device_proxies_test.go
@@ -1,0 +1,98 @@
+package iotda
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceDeviceProxies_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.huaweicloud_iotda_device_proxies.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			// Only standard and enterprise IoTDA instances support this resource.
+			acceptance.TestAccPreCheckHWIOTDAAccessAddress(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceDeviceProxies_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxies.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxies.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxies.0.name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxies.0.space_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxies.0.effective_time_range.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxies.0.effective_time_range.0.start_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "proxies.0.effective_time_range.0.end_time"),
+
+					resource.TestCheckOutput("is_space_id_filter_useful", "true"),
+					resource.TestCheckOutput("is_name_filter_useful", "true"),
+					resource.TestCheckOutput("not_found_validation_pass", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceDeviceProxies_basic() string {
+	name := acceptance.RandomAccResourceName()
+
+	return fmt.Sprintf(`
+%s
+
+data "huaweicloud_iotda_device_proxies" "test" {
+  depends_on = [
+    huaweicloud_iotda_device_proxy.test,
+  ]
+}
+
+# Filter using space_id.
+locals {
+  space_id = data.huaweicloud_iotda_device_proxies.test.proxies[0].space_id
+}
+
+data "huaweicloud_iotda_device_proxies" "space_id_filter" {
+  space_id = local.space_id
+}
+
+output "is_space_id_filter_useful" {
+  value = length(data.huaweicloud_iotda_device_proxies.space_id_filter.proxies) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_proxies.space_id_filter.proxies[*].space_id : v == local.space_id]
+  )
+}
+
+# Filter using name.
+locals {
+  name = data.huaweicloud_iotda_device_proxies.test.proxies[0].name
+}
+
+data "huaweicloud_iotda_device_proxies" "name_filter" {
+  name = local.name
+}
+
+output "is_name_filter_useful" {
+  value = length(data.huaweicloud_iotda_device_proxies.name_filter.proxies) > 0 && alltrue(
+    [for v in data.huaweicloud_iotda_device_proxies.name_filter.proxies[*].name : v == local.name]
+  )
+}
+
+# Filter using non existent name.
+data "huaweicloud_iotda_device_proxies" "not_found" {
+  name = "resource_not_found"
+}
+
+output "not_found_validation_pass" {
+  value = length(data.huaweicloud_iotda_device_proxies.not_found.proxies) == 0
+}
+`, testDeviceProxy_basic(name))
+}

--- a/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_proxies.go
+++ b/huaweicloud/services/iotda/data_source_huaweicloud_iotda_device_proxies.go
@@ -1,0 +1,151 @@
+package iotda
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/iotda/v5/model"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+// @API IoTDA GET /v5/iot/{project_id}/device-proxies
+func DataSourceDeviceProxies() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDeviceProxiesRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"space_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"proxies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"space_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"effective_time_range": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"start_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"end_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceDeviceProxiesRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var (
+		cfg       = meta.(*config.Config)
+		region    = cfg.GetRegion(d)
+		isDerived = WithDerivedAuth(cfg, region)
+	)
+
+	client, err := cfg.HcIoTdaV5Client(region, isDerived)
+	if err != nil {
+		return diag.Errorf("error creating IoTDA v5 client: %s", err)
+	}
+
+	var (
+		allProxies []model.QueryDeviceProxySimplify
+		limit      = int32(50)
+		offset     int32
+	)
+
+	for {
+		listOpts := model.ListDeviceProxiesRequest{
+			AppId:     utils.StringIgnoreEmpty(d.Get("space_id").(string)),
+			ProxyName: utils.StringIgnoreEmpty(d.Get("name").(string)),
+			Limit:     utils.Int32(limit),
+			Offset:    &offset,
+		}
+
+		listResp, listErr := client.ListDeviceProxies(&listOpts)
+		if listErr != nil {
+			return diag.Errorf("error querying IoTDA device proxies: %s", listErr)
+		}
+
+		if listResp == nil || listResp.DeviceProxies == nil {
+			break
+		}
+
+		if len(*listResp.DeviceProxies) == 0 {
+			break
+		}
+
+		allProxies = append(allProxies, *listResp.DeviceProxies...)
+		//nolint:gosec
+		offset += int32(len(*listResp.DeviceProxies))
+	}
+
+	uuID, err := uuid.GenerateUUID()
+	if err != nil {
+		return diag.Errorf("unable to generate ID: %s", err)
+	}
+
+	d.SetId(uuID)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("proxies", flattenDeviceProxies(allProxies)),
+	)
+
+	return diag.FromErr(mErr.ErrorOrNil())
+}
+
+func flattenDeviceProxies(proxies []model.QueryDeviceProxySimplify) []interface{} {
+	if len(proxies) == 0 {
+		return nil
+	}
+
+	rst := make([]interface{}, 0, len(proxies))
+	for _, v := range proxies {
+		rst = append(rst, map[string]interface{}{
+			"id":                   v.ProxyId,
+			"name":                 v.ProxyName,
+			"space_id":             v.AppId,
+			"effective_time_range": flattenEffectiveTimeRange(v.EffectiveTimeRange),
+		})
+	}
+
+	return rst
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support device proxies datasource

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ export HW_IOTDA_ACCESS_ADDRESS=xxxxxxxxxxxxx

$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccDataSourceDeviceProxies_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccDataSourceDeviceProxies_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceDeviceProxies_basic
=== PAUSE TestAccDataSourceDeviceProxies_basic
=== CONT  TestAccDataSourceDeviceProxies_basic
--- PASS: TestAccDataSourceDeviceProxies_basic (14.64s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     14.693s

```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
