### PR TITLE
feat(iotda): the product resource supports new fields

### DIFF
--- a/docs/resources/iotda_product.md
+++ b/docs/resources/iotda_product.md
@@ -2,12 +2,13 @@
 subcategory: "IoT Device Access (IoTDA)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_iotda_product"
-description: ""
+description: |-
+  Manages a product resource within HuaweiCloud.
 ---
 
 # huaweicloud_iotda_product
 
-Manages an IoTDA product within HuaweiCloud.
+Manages a product resource within HuaweiCloud.
 
 -> When accessing an IoTDA **standard** or **enterprise** edition instance, you need to specify the IoTDA service
 endpoint in `provider` block.
@@ -159,6 +160,15 @@ The default value is equal to service ID.
 characters. Only letters, Chinese characters, digits, hyphens (-), underscores (_) and the following special
 characters are allowed: `?'#().,&%@!`.
 
+* `option` - (Optional, String) Specifies whether the device service is mandatory.
+  Currently, this field is not a functional field and is used only for identification.
+  The valid values are as follows:
+  + **Master**: The master service.
+  + **Mandatory**: The mandatory service.
+  + **Optional**:  The optional service.
+
+  Defaults to **Optional**.
+
 * `properties` - (Optional, List) Specifies the list of properties for the service.
 The [properties](#IoTDA_service_properties) structure is documented below.
 
@@ -175,8 +185,12 @@ allowed: `?'#().,&%@!`.
 * `type` - (Required, String) Specifies the type of the parameter.
 The valid values are **int**, **decimal**, **string**, **DateTime**, **jsonObject** and **string list**.
 
+* `required` - (Optional, Bool) Specifies the device property is mandatory or not.
+  The default value is **false**.
+
 * `method` - (Required, String) Specifies the access mode of the device property.
-  Options: **RW**, **W**, **R**.
+  The value can be **RWE**, **RW**, **RE**, **WE**, **R** (the property value can be read),
+  **W** (the property value can be written) or **E** (the property value can be subscribed to).
 
 * `description` - (Optional, String) Specifies the description of the parameter. The description contains a maximum of
 `128` characters. Only letters, Chinese characters, digits, hyphens (-), underscores (_) and the following special
@@ -198,6 +212,13 @@ The unit contains a maximum of 16 characters.
 **jsonObject** or **string list**. Value range: `0` ~ `2,147,483,647`. Defaults to `0`.
 
 * `enum_list` - (Optional, List) Specifies the list of enumerated values of the device property.
+
+* `default_value` - (Optional, String) Specifies the default value of the device property.
+  This parameter allowed value is a JSON string. e.g. **{\"foo\":\"bar\"}**
+  If this parameter is set value, the value will be written to the desired data of the device shadow when
+  the product is used to create a device. When the device goes online, the value will be delivered to the device.
+
+  -> If you want to set this parameter, the `method` must set **RWE**, **RW**, **WE** or **W**.
 
 <a name="IoTDA_service_commands"></a>
 The `commands` block supports:
@@ -221,6 +242,9 @@ allowed: `?'#().,&%@!`.
 
 * `type` - (Required, String) Specifies the type of the parameter.
 The valid values are **int**, **decimal**, **string**, **DateTime**, **jsonObject** and **string list**.
+
+* `required` - (Optional, Bool) Specifies the parameter is mandatory or not.
+  The default value is **false**.
 
 * `description` - (Optional, String) Specifies the description of the parameter. The description contains a maximum of
 `128` characters. Only letters, Chinese characters, digits, hyphens (-), underscores (_) and the following special
@@ -247,12 +271,12 @@ The unit contains a maximum of 16 characters.
 
 In addition to all arguments above, the following attributes are exported:
 
-* `id` - The resource ID in UUID format.
+* `id` - The resource ID.
 
 ## Import
 
-Products can be imported using the `id`, e.g.
+The product resource can be imported using the `id`, e.g.
 
 ```bash
-$ terraform import huaweicloud_iotda_product.test 10022532f4f94f26b01daa1e424853e1
+$ terraform import huaweicloud_iotda_product.test <id>
 ```

--- a/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_product_test.go
+++ b/huaweicloud/services/acceptance/iotda/resource_huaweicloud_iotda_product_test.go
@@ -52,13 +52,16 @@ func TestAccProduct_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "industry", "demo_industry"),
 					resource.TestCheckResourceAttr(rName, "services.0.id", "service_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.type", "serv_type"),
+					resource.TestCheckResourceAttr(rName, "services.0.option", "Master"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.#", "4"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.name", "p_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.required", "false"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.description", "desc"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.min", "3"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.max", "666"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.method", "RW"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.default_value", "{\"foo\":\"bar\"}"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.name", "p_2"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.type", "string"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.max_length", "20"),
@@ -70,27 +73,32 @@ func TestAccProduct_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.name", "cmd_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.name", "cmd_p_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.required", "false"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.description", "desc"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.min", "3"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.max", "33"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.name", "cmd_r_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.required", "false"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.min", "1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.max", "22"),
 				),
 			},
 			{
-				Config: testProduct_update(name + "_update"),
+				Config: testProduct_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "services.0.option", "Optional"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.#", "3"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.name", "p_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.required", "true"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.description", "desc_update"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.min", "4"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.max", "5"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.method", "RW"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.default_value", "{\"tf\":\"test\"}"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.name", "p_3"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.type", "string"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.max_length", "20"),
@@ -102,11 +110,13 @@ func TestAccProduct_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.name", "cmd_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.name", "cmd_p_2"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.required", "true"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.description", "desc"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.min", "5"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.max", "33"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.name", "cmd_r_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.required", "true"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.min", "2"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.max", "33"),
 				),
@@ -124,6 +134,7 @@ func TestAccProduct_derived(t *testing.T) {
 	var obj model.ShowProductResponse
 
 	name := acceptance.RandomAccResourceName()
+
 	rName := "huaweicloud_iotda_product.test"
 
 	rc := acceptance.InitResourceCheck(
@@ -153,13 +164,16 @@ func TestAccProduct_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "industry", "demo_industry"),
 					resource.TestCheckResourceAttr(rName, "services.0.id", "service_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.type", "serv_type"),
+					resource.TestCheckResourceAttr(rName, "services.0.option", "Master"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.#", "4"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.name", "p_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.required", "false"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.description", "desc"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.min", "3"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.max", "666"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.method", "RW"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.default_value", "{\"foo\":\"bar\"}"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.name", "p_2"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.type", "string"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.max_length", "20"),
@@ -171,27 +185,32 @@ func TestAccProduct_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.name", "cmd_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.name", "cmd_p_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.required", "false"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.description", "desc"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.min", "3"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.max", "33"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.name", "cmd_r_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.required", "false"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.min", "1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.max", "22"),
 				),
 			},
 			{
-				Config: testProduct_update(name + "_update"),
+				Config: testProduct_update(name),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
 					resource.TestCheckResourceAttr(rName, "name", name+"_update"),
+					resource.TestCheckResourceAttr(rName, "services.0.option", "Optional"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.#", "3"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.name", "p_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.required", "true"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.description", "desc_update"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.min", "4"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.max", "5"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.0.method", "RW"),
+					resource.TestCheckResourceAttr(rName, "services.0.properties.0.default_value", "{\"tf\":\"test\"}"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.name", "p_3"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.type", "string"),
 					resource.TestCheckResourceAttr(rName, "services.0.properties.1.max_length", "20"),
@@ -203,11 +222,13 @@ func TestAccProduct_derived(t *testing.T) {
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.name", "cmd_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.name", "cmd_p_2"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.required", "true"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.description", "desc"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.min", "5"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.paras.0.max", "33"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.name", "cmd_r_1"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.type", "int"),
+					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.required", "true"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.min", "2"),
 					resource.TestCheckResourceAttr(rName, "services.0.commands.0.responses.0.max", "33"),
 				),
@@ -225,12 +246,8 @@ func testProduct_basic(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_iotda_space" "test" {
-  name = "%[2]s"
-}
-
 resource "huaweicloud_iotda_product" "test" {
-  name              = "%[3]s"
+  name              = "%[2]s"
   device_type       = "test"
   protocol          = "MQTT"
   space_id          = huaweicloud_iotda_space.test.id
@@ -239,16 +256,19 @@ resource "huaweicloud_iotda_product" "test" {
   industry          = "demo_industry"
 
   services {
-    id   = "service_1"
-    type = "serv_type"
+    id     = "service_1"
+    type   = "serv_type"
+    option = "Master"
 
     properties {
-      name        = "p_1"
-      type        = "int"
-      min         = "3"
-      max         = "666"
-      description = "desc"
-      method      = "RW"
+      name          = "p_1"
+      type          = "int"
+      required      = false
+      min           = "3"
+      max           = "666"
+      description   = "desc"
+      method        = "RW"
+      default_value = "{\"foo\":\"bar\"}"
     }
 
     properties {
@@ -280,33 +300,31 @@ resource "huaweicloud_iotda_product" "test" {
       paras {
         name        = "cmd_p_1"
         type        = "int"
+        required    = false
         description = "desc"
         min         = "3"
         max         = 33
       }
 
       responses {
-        name = "cmd_r_1"
-        type = "int"
-        min  = "1"
-        max  = "22"
+        name     = "cmd_r_1"
+        type     = "int"
+        required = false
+        min      = "1"
+        max      = "22"
       }
     }
   }
 }
-`, buildIoTDAEndpoint(), name, name)
+`, testSpace_basic(name), name)
 }
 
 func testProduct_update(name string) string {
 	return fmt.Sprintf(`
 %[1]s
 
-resource "huaweicloud_iotda_space" "test" {
-  name = "%[2]s"
-}
-
 resource "huaweicloud_iotda_product" "test" {
-  name              = "%[3]s"
+  name              = "%[2]s_update"
   device_type       = "test"
   protocol          = "MQTT"
   space_id          = huaweicloud_iotda_space.test.id
@@ -315,16 +333,19 @@ resource "huaweicloud_iotda_product" "test" {
   industry          = "demo_industry"
 
   services {
-    id   = "service_1"
-    type = "serv_type"
+    id     = "service_1"
+    type   = "serv_type"
+    option = "Optional"
 
     properties {
-      name        = "p_1"
-      type        = "int"
-      min         = "4"
-      max         = "5"
-      description = "desc_update"
-      method      = "RW"
+      name          = "p_1"
+      type          = "int"
+      required      = true
+      min           = "4"
+      max           = "5"
+      description   = "desc_update"
+      method        = "RW"
+      default_value = "{\"tf\":\"test\"}"
     }
 
     properties {
@@ -348,19 +369,21 @@ resource "huaweicloud_iotda_product" "test" {
       paras {
         name        = "cmd_p_2"
         type        = "int"
+        required    = true
         description = "desc"
         min         = "5"
         max         = 33
       }
 
       responses {
-        name = "cmd_r_1"
-        type = "int"
-        min  = "2"
-        max  = "33"
+        name     = "cmd_r_1"
+        type     = "int"
+        required = true
+        min      = "2"
+        max      = "33"
       }
     }
   }
 }
-`, buildIoTDAEndpoint(), name, name)
+`, testSpace_basic(name), name)
 }

--- a/huaweicloud/services/iotda/resource_huaweicloud_iotda_product.go
+++ b/huaweicloud/services/iotda/resource_huaweicloud_iotda_product.go
@@ -37,30 +37,25 @@ func ResourceProduct() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
 			"protocol": {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{"MQTT", "CoAP", "HTTP", "HTTPS", "Modbus", "ONVIF",
 					"OPC-UA", "OPC-DA", "Other"}, false),
 			},
-
 			"data_type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"json", "binary"}, false),
 			},
-
 			"device_type": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
 			"services": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -71,19 +66,21 @@ func ResourceProduct() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-
 						"type": { // keep same with console
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
 						},
-
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
 						},
-
+						"option": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 						"properties": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -91,7 +88,6 @@ func ResourceProduct() *schema.Resource {
 							MaxItems: 500,
 							Elem:     propertySchema("services.properties"),
 						},
-
 						"commands": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -103,7 +99,6 @@ func ResourceProduct() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 									},
-
 									"paras": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -111,7 +106,6 @@ func ResourceProduct() *schema.Resource {
 										MaxItems: 500,
 										Elem:     propertySchema("services.commands.paras"),
 									},
-
 									"responses": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -125,31 +119,26 @@ func ResourceProduct() *schema.Resource {
 					},
 				},
 			},
-
 			"manufacturer_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"industry": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
 			"space_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
-
 			"product_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -168,39 +157,38 @@ func propertySchema(category string) *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
 			"type": { // keep same with console
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringInSlice([]string{"int", "decimal", "string", "DateTime",
 					"jsonObject", "string list"}, false),
 			},
-
+			"required": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"enum_list": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
 			"min": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "0",
 			},
-
 			"max": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "65535",
 			},
-
 			"max_length": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
-
 			"step": {
 				Type:     schema.TypeFloat,
 				Optional: true,
@@ -212,6 +200,11 @@ func propertySchema(category string) *schema.Resource {
 				Computed: true,
 			},
 			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"default_value": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -366,6 +359,7 @@ func buildServices(raw []interface{}) *[]model.ServiceCapability {
 			ServiceId:   service["id"].(string),
 			ServiceType: service["type"].(string),
 			Description: utils.StringIgnoreEmpty(service["description"].(string)),
+			Option:      utils.StringIgnoreEmpty(service["option"].(string)),
 			Properties:  buildServiceProperties(service["properties"]),
 			Commands:    buildServiceCommands(service["commands"]),
 		}
@@ -405,6 +399,7 @@ func buildServiceCommandParas(raw interface{}) *[]model.ServiceCommandPara {
 		rst[i] = model.ServiceCommandPara{
 			ParaName:    s["name"].(string),
 			DataType:    s["type"].(string),
+			Required:    utils.Bool(s["required"].(bool)),
 			EnumList:    utils.ExpandToStringListPointer(s["enum_list"].([]interface{})),
 			Min:         utils.String(s["min"].(string)),
 			Max:         utils.String(s["max"].(string)),
@@ -423,9 +418,11 @@ func buildServiceProperties(propertiesRaw interface{}) *[]model.ServiceProperty 
 	rst := make([]model.ServiceProperty, len(properties))
 	for i, v := range properties {
 		s := v.(map[string]interface{})
+		defaultValue := utils.StringToJson(s["default_value"].(string))
 		rst[i] = model.ServiceProperty{
 			PropertyName: s["name"].(string),
 			DataType:     s["type"].(string),
+			Required:     utils.Bool(s["required"].(bool)),
 			EnumList:     utils.ExpandToStringListPointer(s["enum_list"].([]interface{})),
 			Min:          utils.String(s["min"].(string)),
 			Max:          utils.String(s["max"].(string)),
@@ -434,6 +431,9 @@ func buildServiceProperties(propertiesRaw interface{}) *[]model.ServiceProperty 
 			Unit:         utils.StringIgnoreEmpty(s["unit"].(string)),
 			Description:  utils.StringIgnoreEmpty(s["description"].(string)),
 			Method:       s["method"].(string),
+		}
+		if defaultValue != nil {
+			rst[i].DefaultValue = &defaultValue
 		}
 	}
 
@@ -448,6 +448,7 @@ func flattenServices(s *[]model.ServiceCapability) []interface{} {
 				"id":          v.ServiceId,
 				"type":        v.ServiceType,
 				"description": v.Description,
+				"option":      v.Option,
 				"properties":  flattenServiceProperties(v.Properties),
 				"commands":    flattenServiceCommands(v.Commands),
 			}
@@ -463,17 +464,20 @@ func flattenServiceProperties(s *[]model.ServiceProperty) []interface{} {
 	if s != nil {
 		rst := make([]interface{}, len(*s))
 		for i, v := range *s {
+			defaultValue := utils.JsonToString(v.DefaultValue)
 			rst[i] = map[string]interface{}{
-				"name":        v.PropertyName,
-				"type":        v.DataType,
-				"enum_list":   v.EnumList,
-				"min":         v.Min,
-				"max":         v.Max,
-				"max_length":  v.MaxLength,
-				"step":        v.Step,
-				"unit":        v.Unit,
-				"description": v.Description,
-				"method":      v.Method,
+				"name":          v.PropertyName,
+				"type":          v.DataType,
+				"required":      v.Required,
+				"enum_list":     v.EnumList,
+				"min":           v.Min,
+				"max":           v.Max,
+				"max_length":    v.MaxLength,
+				"step":          v.Step,
+				"unit":          v.Unit,
+				"description":   v.Description,
+				"method":        v.Method,
+				"default_value": defaultValue,
 			}
 		}
 
@@ -518,6 +522,7 @@ func flattenServiceCommandParas(s *[]model.ServiceCommandPara) []interface{} {
 			rst[i] = map[string]interface{}{
 				"name":        v.ParaName,
 				"type":        v.DataType,
+				"required":    v.Required,
 				"enum_list":   v.EnumList,
 				"min":         v.Min,
 				"max":         v.Max,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The product resource supports new fields.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
1.the product resource supports new fields contain:
  services.properties.required;services.commands.paras.required;services.commands.responses.required.
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccProduct_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccProduct_basic -timeout 360m -parallel 4
=== RUN   TestAccProduct_basic
--- PASS: TestAccProduct_basic (46.07s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     46.121s
```
```
$ make testacc TEST="./huaweicloud/services/acceptance/iotda" TESTARGS="-run TestAccProduct_derived"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/iotda -v -run TestAccProduct_derived -timeout 360m -parallel 4
=== RUN   TestAccProduct_derived
--- PASS: TestAccProduct_derived (47.41s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/iotda     47.480s
```

* [x] Documentation updated.
* [x] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
