### PR TITLE
chore(waf): modify some issues with the waf certificate resource and datasource

### DIFF
--- a/docs/data-sources/waf_certificate.md
+++ b/docs/data-sources/waf_certificate.md
@@ -2,12 +2,15 @@
 subcategory: "Web Application Firewall (WAF)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_waf_certificate"
-description: ""
+description: |
+  Use this data source to get the certificate of WAF within HuaweiCloud.
 ---
 
 # huaweicloud_waf_certificate
 
-Get the certificate in the WAF, including the one pushed from SCM.
+Use this data source to get the certificate of WAF within HuaweiCloud.
+
+-> When multiple pieces of data are queried, the datasource will process the first piece of data and put it back.
 
 ## Example Usage
 
@@ -24,19 +27,20 @@ data "huaweicloud_waf_certificate" "certificate_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) The region in which to obtain the WAF. If omitted, the provider-level region will be
-  used.
+* `region` - (Optional, String) Specifies the region in which to obtain the WAF. If omitted, the provider-level region
+  will be used.
 
-* `name` - (Required, String) The name of certificate. The value is case sensitive and supports fuzzy matching.
+* `name` - (Optional, String) Specifies the name of certificate. The value is case-sensitive and supports fuzzy matching.
 
-  -> **NOTE:** The certificate name is not unique. Only returns the last created one when matched multiple certificates.
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of WAF certificate.
+  For enterprise users, if omitted, default enterprise project will be used.
 
-* `expire_status` - (Optional, Int) The expire status of certificate. Defaults is `0`. The value can be:
-  + `0`: not expire
-  + `1`: has expired
-  + `2`: wil expired soon
+* `expiration_status` - (Optional, String) Specifies the certificate expiration status. The options are as follows:
+  + `0`: Not expired;
+  + `1`: Expired;
+  + `2`: Expired soon (The certificate will expire in one month.)
 
-* `enterprise_project_id` - (Optional, String) The enterprise project ID of WAF certificate.
+  -> If this field is not configured, all certificates that meet the expired status will be found.
 
 ## Attribute Reference
 
@@ -44,4 +48,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The certificate ID in UUID format.
 
-* `expiration` - Indicates the time when the certificate expires.
+* `created_at` - Indicates the time when the certificate uploaded, in RFC3339 format.
+
+* `expired_at` - Indicates the time when the certificate expires, in RFC3339 format.

--- a/docs/resources/waf_certificate.md
+++ b/docs/resources/waf_certificate.md
@@ -2,7 +2,8 @@
 subcategory: "Web Application Firewall (WAF)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_waf_certificate"
-description: ""
+description: |
+  Manages a WAF certificate resource within HuaweiCloud.
 ---
 
 # huaweicloud_waf_certificate
@@ -10,15 +11,15 @@ description: ""
 Manages a WAF certificate resource within HuaweiCloud.
 
 -> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
-used. The certificate resource can be used in Cloud Mode, Dedicated Mode and ELB Mode.
+used. The certificate resource can be used in Cloud Mode, Dedicated Mode.
 
 ## Example Usage
 
 ```hcl
 variable enterprise_project_id {}
 
-resource "huaweicloud_waf_certificate" "certificate_1" {
-  name                  = "cert_1"
+resource "huaweicloud_waf_certificate" "test" {
+  name                  = "test-name"
   enterprise_project_id = var.enterprise_project_id
   certificate = <<EOT
 -----BEGIN CERTIFICATE-----
@@ -44,7 +45,7 @@ EOT
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the WAF certificate resource. If omitted, the
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the WAF certificate. If omitted, the
   provider-level region will be used. Changing this setting will push a new certificate.
 
 * `name` - (Required, String) Specifies the certificate name. The maximum length is `256` characters. Only digits,
@@ -59,6 +60,7 @@ The following arguments are supported:
 replaced with `\n`.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF certificate.
+  For enterprise users, if omitted, default enterprise project will be used.
   Changing this parameter will create a new resource.
 
 ## Attribute Reference
@@ -67,7 +69,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The certificate ID in UUID format.
 
-* `expiration` - Indicates the time when the certificate expires.
+* `created_at` - Indicates the time when the certificate uploaded, in RFC3339 format.
+
+* `expired_at` - Indicates the time when the certificate expires, in RFC3339 format.
 
 ## Import
 
@@ -89,7 +93,7 @@ Note that the imported state is not identical to your resource definition, due t
 attributes include `certificate`, and `private_key`. You can ignore changes as below.
 
 ```hcl
-resource "huaweicloud_waf_certificate" "certificate_2" {
+resource "huaweicloud_waf_certificate" "test" {
     ...
   lifecycle {
     ignore_changes = [

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -2008,7 +2008,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpn_client_ca_certificate":   vpn.ResourceClientCACertificate(),
 
 			"huaweicloud_waf_address_group":                       waf.ResourceWafAddressGroup(),
-			"huaweicloud_waf_certificate":                         waf.ResourceWafCertificateV1(),
+			"huaweicloud_waf_certificate":                         waf.ResourceWafCertificate(),
 			"huaweicloud_waf_cloud_instance":                      waf.ResourceCloudInstance(),
 			"huaweicloud_waf_domain":                              waf.ResourceWafDomain(),
 			"huaweicloud_waf_policy":                              waf.ResourceWafPolicyV1(),

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1075,7 +1075,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_vpn_user_groups":                    vpn.DataSourceVpnUserGroups(),
 
 			"huaweicloud_waf_address_groups":                       waf.DataSourceWafAddressGroups(),
-			"huaweicloud_waf_certificate":                          waf.DataSourceWafCertificateV1(),
+			"huaweicloud_waf_certificate":                          waf.DataSourceWafCertificate(),
 			"huaweicloud_waf_dedicated_domains":                    waf.DataSourceWafDedicatedDomains(),
 			"huaweicloud_waf_dedicated_instances":                  waf.DataSourceWafDedicatedInstancesV1(),
 			"huaweicloud_waf_domains":                              waf.DataSourceWafDomains(),

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_certificate_test.go
@@ -5,39 +5,18 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
-func TestAccDataSourceWafCertificateV1_basic(t *testing.T) {
-	name := acceptance.RandomAccResourceName()
-	dataSourceName := "data.huaweicloud_waf_certificate.cert_1"
+// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+func TestAccDataSourceWafCertificate_basic(t *testing.T) {
+	var (
+		name = acceptance.RandomAccResourceName()
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPrecheckWafInstance(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccWafCertificateListV1_conf(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafCertDataSourceID(dataSourceName),
-					resource.TestCheckResourceAttr(dataSourceName, "name", name),
-					resource.TestCheckResourceAttr(dataSourceName, "expire_status", "1"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccDataSourceWafCertificateV1_withEpsID(t *testing.T) {
-	name := acceptance.RandomAccResourceName()
-	dataSourceName := "data.huaweicloud_waf_certificate.cert_1"
+		datasourceName = "data.huaweicloud_waf_certificate.test"
+		dc             = acceptance.InitDataSourceCheck(datasourceName)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
@@ -48,59 +27,29 @@ func TestAccDataSourceWafCertificateV1_withEpsID(t *testing.T) {
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafCertificateListV1_conf_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Config: testAccDatasourceWafCertificate_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckWafCertDataSourceID(dataSourceName),
-					resource.TestCheckResourceAttr(dataSourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-					resource.TestCheckResourceAttr(dataSourceName, "name", name),
-					resource.TestCheckResourceAttr(dataSourceName, "expire_status", "1"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "expiration"),
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(datasourceName, "name"),
+					resource.TestCheckResourceAttrSet(datasourceName, "enterprise_project_id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "created_at"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckWafCertDataSourceID(r string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[r]
-		if !ok {
-			return fmtp.Errorf("Can't find waf data source: %s ", r)
-		}
-		if rs.Primary.ID == "" {
-			return fmtp.Errorf("The Waf Certificate data source ID not set ")
-		}
-		return nil
-	}
-}
-
-func testAccWafCertificateListV1_conf(name string) string {
+func testAccDatasourceWafCertificate_basic(name string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
-data "huaweicloud_waf_certificate" "cert_1" {
-  name          = huaweicloud_waf_certificate.certificate_1.name
-  expire_status = 1
+data "huaweicloud_waf_certificate" "test" {
+  name                  = huaweicloud_waf_certificate.test.name
+  enterprise_project_id = "%[2]s"
 
   depends_on = [
-    huaweicloud_waf_certificate.certificate_1
+    huaweicloud_waf_certificate.test
   ]
 }
-`, testAccWafCertificateV1_conf(name))
-}
-
-func testAccWafCertificateListV1_conf_withEpsID(name, epsID string) string {
-	return fmt.Sprintf(`
-%s
-
-data "huaweicloud_waf_certificate" "cert_1" {
-  name                  = huaweicloud_waf_certificate.certificate_1.name
-  enterprise_project_id = "%s"
-  expire_status         = 1
-
-  depends_on = [
-    huaweicloud_waf_certificate.certificate_1
-  ]
-}
-`, testAccWafCertificateV1_conf_withEpsID(name, epsID), epsID)
+`, testAccWafCertificate_basic(name, generateCertificateBody()), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
+++ b/huaweicloud/services/acceptance/waf/resource_huaweicloud_waf_certificate_test.go
@@ -2,6 +2,7 @@ package waf
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func getResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
@@ -21,54 +23,16 @@ func getResourceFunc(conf *config.Config, state *terraform.ResourceState) (inter
 	return certificates.GetWithEpsID(client, state.Primary.ID, state.Primary.Attributes["enterprise_project_id"]).Extract()
 }
 
-func TestAccWafCertificateV1_basic(t *testing.T) {
-	var certificate certificates.Certificate
-	resourceName := "huaweicloud_waf_certificate.certificate_1"
-	name := acceptance.RandomAccResourceName()
+// Before running the test case, please ensure that there is at least one WAF instance in the current region.
+func TestAccWafCertificate_basic(t *testing.T) {
+	var (
+		certificate           certificates.Certificate
+		certificateBody       = generateCertificateBody()
+		certificateBodyUpdate = generateCertificateBody()
 
-	rc := acceptance.InitResourceCheck(
-		resourceName,
-		&certificate,
-		getResourceFunc,
+		resourceName = "huaweicloud_waf_certificate.test"
+		name         = acceptance.RandomAccResourceName()
 	)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acceptance.TestAccPreCheck(t)
-			acceptance.TestAccPrecheckWafInstance(t)
-		},
-		ProviderFactories: acceptance.TestAccProviderFactories,
-		CheckDestroy:      rc.CheckResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccWafCertificateV1_conf(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-				),
-			},
-			{
-				Config: testAccWafCertificateV1_conf_update(name),
-				Check: resource.ComposeTestCheckFunc(
-					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"certificate", "private_key"},
-			},
-		},
-	})
-}
-
-func TestAccWafCertificateV1_withEpsID(t *testing.T) {
-	var certificate certificates.Certificate
-	resourceName := "huaweicloud_waf_certificate.certificate_1"
-	name := acceptance.RandomAccResourceName()
-	updateName := name + "_update"
 
 	rc := acceptance.InitResourceCheck(
 		resourceName,
@@ -86,19 +50,21 @@ func TestAccWafCertificateV1_withEpsID(t *testing.T) {
 		CheckDestroy:      rc.CheckResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWafCertificateV1_conf_withEpsID(name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Config: testAccWafCertificate_basic(name, certificateBody),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "expired_at"),
 				),
 			},
 			{
-				Config: testAccWafCertificateV1_conf_withEpsID(updateName, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
+				Config: testAccWafCertificate_basic_update(name, certificateBodyUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					rc.CheckResourceExists(),
-					resource.TestCheckResourceAttr(resourceName, "enterprise_project_id", acceptance.HW_ENTERPRISE_PROJECT_ID_TEST),
-					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_update", name)),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "expired_at"),
 				),
 			},
 			{
@@ -112,6 +78,124 @@ func TestAccWafCertificateV1_withEpsID(t *testing.T) {
 	})
 }
 
+// generateCertificateBody Using to generate the certificate body for testing and add random strings to avoid API errors
+// caused by duplicate certificates.
+func generateCertificateBody() string {
+	template := `
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
+MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
+JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
+QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
+DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
+n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
+TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
++BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
+A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
+XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
+RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
+ZoURg5WiRskhtHEvBsLF
+-----END CERTIFICATE-----
+`
+	return strings.ReplaceAll(template, "6mr7qu1dAlcVMLS", utils.RandomString(15))
+}
+
+func testAccWafCertificate_basic(name, certificateBody string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_certificate" "test" {
+  name                  = "%[1]s"
+  enterprise_project_id = "%[2]s"
+
+  certificate = <<EOT
+%[3]s
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, certificateBody)
+}
+
+func testAccWafCertificate_basic_update(name, certificateBody string) string {
+	return fmt.Sprintf(`
+resource "huaweicloud_waf_certificate" "test" {
+  name                  = "%[1]s_update"
+  enterprise_project_id = "%[2]s"
+
+  certificate = <<EOT
+%[3]s
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNo
+-----END PRIVATE KEY-----
+EOT
+}
+`, name, acceptance.HW_ENTERPRISE_PROJECT_ID_TEST, certificateBody)
+}
+
+// This test case has dependencies, so keep it for now and delete it later.
 func testAccWafCertificateV1_conf(name string) string {
 	return fmt.Sprintf(`
 %s
@@ -181,75 +265,7 @@ EOT
 `, testAccWafDedicatedInstanceV1_conf(name), name)
 }
 
-func testAccWafCertificateV1_conf_update(name string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "huaweicloud_waf_certificate" "certificate_1" {
-  name = "%s_update"
-
-  certificate = <<EOT
------BEGIN CERTIFICATE-----
-MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
-BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
-GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
-MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
-HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
-AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
-z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
-ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
-Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
-JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
-QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
-DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
-n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
-TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
-+BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
-A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
-XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
-RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
-ZoURg5WiRskhtHEvBsLA
------END CERTIFICATE-----
-EOT
-
-  private_key = <<EOT
------BEGIN PRIVATE KEY-----
-MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
-vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
-8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
-73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
-9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
-5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
-aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
-Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
-mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
-pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
-xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
-MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
-cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
-KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
-4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
-rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
-YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
-MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
-yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
-purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
-M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
-6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
-FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
-f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
-x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
-X7ioLbTeWGBqFM+C80PkdBNo
------END PRIVATE KEY-----
-EOT
-
-  depends_on = [
-    huaweicloud_waf_dedicated_instance.instance_1
-  ]
-}
-`, testAccWafDedicatedInstanceV1_conf(name), name)
-}
-
+// This test case has dependencies, so keep it for now and delete it later.
 func testAccWafCertificateV1_conf_withEpsID(name, epsID string) string {
 	return fmt.Sprintf(`
 %s


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- modify waf certificate datasource and fix some problems.
  - fix some problems in datasource code.
  - support new filter fields in datasource.
  - discard two invalid fields.
  - refactor datasource code to automatically generate styles.
  - supplementary datasource documentation description.
  - improve test case execution efficiency.
- modify waf certificate resource and fix some problems.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [x] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDataSourceWafCertificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDataSourceWafCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccDataSourceWafCertificate_basic
=== PAUSE TestAccDataSourceWafCertificate_basic
=== CONT  TestAccDataSourceWafCertificate_basic
--- PASS: TestAccDataSourceWafCertificate_basic (13.15s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       13.191s
```
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafCertificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafCertificate_basic -timeout 360m -parallel 4
=== RUN   TestAccWafCertificate_basic
=== PAUSE TestAccWafCertificate_basic
=== CONT  TestAccWafCertificate_basic
--- PASS: TestAccWafCertificate_basic (18.88s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       18.928s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
