### PR TITLE
chore(waf): maintain waf dedicated domain resource (datasource) and fix some problems

### DIFF
--- a/docs/data-sources/waf_dedicated_domains.md
+++ b/docs/data-sources/waf_dedicated_domains.md
@@ -2,7 +2,8 @@
 subcategory: "Web Application Firewall (WAF)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_waf_dedicated_domains"
-description: ""
+description: |
+  Use this data source to get a list of WAF dedicated domains.
 ---
 
 # huaweicloud_waf_dedicated_domains
@@ -12,10 +13,10 @@ Use this data source to get a list of WAF dedicated domains.
 ## Example Usage
 
 ```hcl
-variable domain {}
+variable "domain" {}
 variable "enterprise_project_id" {}
 
-data "huaweicloud_waf_dedicated_domains" "domains" {
+data "huaweicloud_waf_dedicated_domains" "test" {
   domain                = var.domain
   enterprise_project_id = var.enterprise_project_id
 }
@@ -25,16 +26,21 @@ data "huaweicloud_waf_dedicated_domains" "domains" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) The region in which to query the WAF dedicated domains.
+* `region` - (Optional, String) Specifies the region in which to query the WAF dedicated domains.
   If omitted, the provider-level region will be used.
 
-* `domain` - (Optional, String) The protected domain name or IP address (port allowed).
+* `domain` - (Optional, String) Specifies the protected domain name or IP address (port allowed).
 
-* `policy_name` - (Optional, String) The policy name associated with the domain.
+* `policy_name` - (Optional, String) Specifies the policy name associated with the domain.
 
-* `protect_status` - (Optional, Int) The protection status of domain.
+* `protect_status` - (Optional, String) Specifies the protection status of domain. Valid values are:
+  + `0`: The WAF protection is suspended. WAF only forwards requests for the domain name but does not detect attacks.
+  + `1`: The WAF protection is enabled. WAF detects attacks based on the policy you configure.
 
-* `enterprise_project_id` - (Optional, String) The enterprise project ID.
+  If omitted, all domains in different protection status will be queried.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID.
+  For enterprise users, if omitted, default enterprise project will be used.
 
 ## Attribute Reference
 
@@ -62,7 +68,7 @@ The `domains` block supports:
 
 * `policy_id` - The policy ID associated with the domain.
 
-* `protect_status` - The protection status of domain,  `0`: suspended, `1`: enabled. Default value is `0`.
+* `protect_status` - The protection status of domain, `0`: suspended, `1`: enabled.
 
 * `access_status` - Whether a domain name is connected to WAF. Valid values are:
   + `0` - The domain name is not connected to WAF,

--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -2,7 +2,8 @@
 subcategory: "Web Application Firewall (WAF)"
 layout: "huaweicloud"
 page_title: "HuaweiCloud: huaweicloud_waf_dedicated_domain"
-description: ""
+description: |
+  Manages a dedicated mode domain resource within HuaweiCloud.
 ---
 
 # huaweicloud_waf_dedicated_domain
@@ -10,7 +11,7 @@ description: ""
 Manages a dedicated mode domain resource within HuaweiCloud.
 
 -> **NOTE:** All WAF resources depend on WAF instances, and the WAF instances need to be purchased before they can be
-used. The dedicated mode domain name resource can be used in Dedicated Mode and ELB Mode.
+used. The dedicated mode domain name resource can be used in Dedicated Mode.
 
 ## Example Usage
 
@@ -19,7 +20,7 @@ variable "certificated_id" {}
 variable "vpc_id" {}
 variable "enterprise_project_id" {}
 
-resource "huaweicloud_waf_dedicated_domain" "domain_1" {
+resource "huaweicloud_waf_dedicated_domain" "test" {
   domain                = "www.example.com"
   certificate_id        = var.certificated_id
   enterprise_project_id = var.enterprise_project_id
@@ -80,55 +81,56 @@ EOF
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the dedicated mode domain resource. If omitted,
-  the provider-level region will be used. Changing this setting will push a new domain.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the dedicated mode domain resource.
+  If omitted, the provider-level region will be used. Changing this setting will push a new domain.
 
 * `domain` - (Required, String, ForceNew) Specifies the protected domain name or IP address (port allowed). For example,
   `www.example.com` or `*.example.com` or `www.example.com:89`. Changing this creates a new domain.
 
-* `server` - (Required, List, ForceNew) The server configuration list of the domain. A maximum of 80 can be configured.
-  The object structure is documented below.
+* `server` - (Required, List, ForceNew) Specifies the server configuration list of the domain.
+  A maximum of `80` can be configured. The [server](#DedicatedDomain_server) structure is documented below.
 
 * `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID of WAF dedicated domain.
+  For enterprise users, if omitted, default enterprise project will be used.
   Changing this parameter will create a new resource.
 
 * `certificate_id` - (Optional, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol`
-  is set to HTTPS.
+  is set to **HTTPS**.
 
 * `policy_id` - (Optional, String) Specifies the policy ID associated with the domain. If not specified, a new policy
   will be created automatically.
 
-* `proxy` - (Optional, Bool) Specifies whether a proxy is configured. Default value is `false`.
+* `proxy` - (Optional, Bool) Specifies whether a proxy is configured. Defaults to **false**.
 
   -> **NOTE:** WAF forwards only HTTP/S traffic. So WAF cannot serve your non-HTTP/S traffic, such as UDP, SMTP, FTP,
   and basically all other non-HTTP/S traffic. If a proxy such as public network ELB (or Nginx) has been used, set
   proxy `true` to ensure that the WAF security policy takes effect for the real source IP address.
 
 * `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name.
-  Defaults to `true`.
+  Defaults to **true**.
 
-* `protect_status` - (Optional, Int) The protection status of domain, `0`: suspended, `1`: enabled.
-  Default value is `0`.
+* `protect_status` - (Optional, Int) Specifies the protection status of domain, `0`: suspended, `1`: enabled.
+  Defaults to `0`.
 
-* `tls` - (Optional, String) Specifies the minimum required TLS version. The options include `TLS v1.0`, `TLS v1.1`,
-  `TLS v1.2`.
+* `tls` - (Optional, String) Specifies the minimum required TLS version. The valid values are: **TLS v1.0**,
+  **TLS v1.1** and **TLS v1.2**.
 
-* `cipher` - (Optional, String) Specifies the cipher suite of domain. The options include `cipher_1`, `cipher_2`,
-  `cipher_3`, `cipher_4`, `cipher_default`.
+* `cipher` - (Optional, String) Specifies the cipher suite of domain. The valid values are: **cipher_1**, **cipher_2**,
+  **cipher_3**, **cipher_4** and **cipher_default**.
 
 * `pci_3ds` - (Optional, Bool) Specifies the status of the PCI 3DS compliance certification check. The options
-  include `true` and `false`. This parameter must be used together with tls and cipher.
+  include **true** and **false**. This parameter must be used together with `tls` and `cipher`.
 
-  -> **NOTE:** Tls must be set to TLS v1.2, and cipher must be set to cipher_2. The PCI 3DS compliance certification
+  -> **NOTE:** Tls must be set to **TLS v1.2**, and cipher must be set to **cipher_2**. The PCI 3DS compliance certification
   check cannot be disabled after being enabled.
 
 * `pci_dss` - (Optional, Bool) Specifies the status of the PCI DSS compliance certification check. The options
-  include `true` and `false`. This parameter must be used together with tls and cipher.
+  include **true** and **false**. This parameter must be used together with `tls` and `cipher`.
 
-  -> **NOTE:** Tls must be set to TLS v1.2, and cipher must be set to cipher_2.
+  -> **NOTE:** Tls must be set to **TLS v1.2**, and cipher must be set to **cipher_2**.
 
 * `website_name` - (Optional, String) Specifies the website name. This website name must start with a letter and only
-  letters, digits, underscores (_), hyphens (-), colons (:) and periods (.) are allowed. The value contains 1 to 128
+  letters, digits, underscores (_), hyphens (-), colons (:) and periods (.) are allowed. The value contains `1` to `128`
   characters. The website name must be unique within this account.
 
 * `custom_page` - (Optional, List) Specifies the custom page. Only supports one custom alarm page.
@@ -177,30 +179,31 @@ The following arguments are supported:
   Only supports one traffic identifier.
   The [traffic_mark](#DedicatedDomain_traffic_mark) structure is documented below.
 
+<a name="DedicatedDomain_server"></a>
 The `server` block supports:
 
-* `client_protocol` - (Required, String, ForceNew) Protocol type of the client. The options include `HTTP` and `HTTPS`.
-  Changing this creates a new service.
+* `client_protocol` - (Required, String, ForceNew) Specifies the protocol type of the client. The options include `HTTP`
+  and `HTTPS`. Changing this creates a new service.
 
-* `server_protocol` - (Required, String, ForceNew) Protocol used by WAF to forward client requests to the server. The
-  options include `HTTP` and `HTTPS`. Changing this creates a new service.
+* `server_protocol` - (Required, String, ForceNew) Specifies the protocol used by WAF to forward client requests to the
+  server. The valid values are **HTTP** and **HTTPS**. Changing this creates a new service.
 
-* `vpc_id` - (Required, String, ForceNew) The id of the vpc used by the server. Changing this creates a service.
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC used by the server. Changing this creates a service.
 
-* `type` - (Required, String, ForceNew) Server network type, IPv4 or IPv6. Valid values are: `ipv4` and `ipv6`. Changing
-  this creates a new service.
+* `type` - (Required, String, ForceNew) Specifies the server network type, IPv4 or IPv6.
+  Valid values are **ipv4** and **ipv6**. Changing this creates a new service.
 
-* `address` - (Required, String, ForceNew) IP address or domain name of the web server that the client accesses. For
-  example, `192.168.1.1` or `www.example.com`. Changing this creates a new service.
+* `address` - (Required, String, ForceNew) Specifies the IP address or domain name of the web server accessed by the
+  client. For example, `192.168.1.1` or `www.example.com`. Changing this creates a new service.
 
-* `port` - (Required, Int, ForceNew) Port number used by the web server. The value ranges from 0 to 65535. Changing this
-  creates a new service.
+* `port` - (Required, Int, ForceNew) Specifies the port number used by the web server. The value ranges from `0` to
+  `65535`. Changing this creates a new service.
 
 <a name="DedicatedDomain_custom_page"></a>
 The `custom_page` block supports:
 
 * `http_return_code` - (Required, String) Specifies the HTTP return code.
-  The value can be a positive integer in the range of 200-599 except 408, 444 and 499.
+  The value can be a positive integer in the range of `200`-`599` except `408`, `444` and `499`.
 
 * `block_page_type` - (Required, String) Specifies the content type of the custom alarm page.
   The value can be **text/html**, **text/xml** or **application/json**.
@@ -212,11 +215,11 @@ The `custom_page` block supports:
 <a name="DedicatedDomain_connection_protection"></a>
 The `connection_protection` block supports:
 
-* `error_threshold` - (Optional, Int) Specifies the 502/504 error threshold for every 30 seconds. Valid value ranges
+* `error_threshold` - (Optional, Int) Specifies the `502`/`504` error threshold for every 30 seconds. Valid value ranges
   from `0` to `2,147,483,647`.
 
-* `error_percentage` - (Optional, Float) Specifies the 502/504 error percentage. A breakdown protection is triggered
-  when the 502/504 error threshold and percentage threshold have been reached. Valid value ranges from `0` to `99`.
+* `error_percentage` - (Optional, Float) Specifies the `502`/`504` error percentage. A breakdown protection is triggered
+  when the `502`/`504` error threshold and percentage threshold have been reached. Valid value ranges from `0` to `99`.
 
 * `initial_downtime` - (Optional, Int) Specifies the breakdown duration (s) when the breakdown is triggered for the first
   time. Valid value ranges from `0` to `2,147,483,647`.

--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -182,8 +182,8 @@ The following arguments are supported:
 <a name="DedicatedDomain_server"></a>
 The `server` block supports:
 
-* `client_protocol` - (Required, String, ForceNew) Specifies the protocol type of the client. The options include `HTTP`
-  and `HTTPS`. Changing this creates a new service.
+* `client_protocol` - (Required, String, ForceNew) Specifies the protocol type of the client. The options include **HTTP**
+  and **HTTPS**. Changing this creates a new service.
 
 * `server_protocol` - (Required, String, ForceNew) Specifies the protocol used by WAF to forward client requests to the
   server. The valid values are **HTTP** and **HTTPS**. Changing this creates a new service.
@@ -197,7 +197,7 @@ The `server` block supports:
   client. For example, `192.168.1.1` or `www.example.com`. Changing this creates a new service.
 
 * `port` - (Required, Int, ForceNew) Specifies the port number used by the web server. The value ranges from `0` to
-  `65535`. Changing this creates a new service.
+  `65,535`. Changing this creates a new service.
 
 <a name="DedicatedDomain_custom_page"></a>
 The `custom_page` block supports:

--- a/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_domains_test.go
+++ b/huaweicloud/services/acceptance/waf/data_source_huaweicloud_waf_dedicated_domains_test.go
@@ -9,20 +9,35 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
 )
 
+// Before running the test case, please ensure that there is at least one WAF dedicated instance in the current region.
 func TestAccDatasourceWAFDedicatedDomains_basic(t *testing.T) {
-	name := acceptance.RandomAccResourceName()
-	rName := "data.huaweicloud_waf_dedicated_domains.test"
-	dc := acceptance.InitDataSourceCheck(rName)
+	var (
+		name            = acceptance.RandomAccResourceName()
+		certificateBody = generateCertificateBody()
+
+		rName = "data.huaweicloud_waf_dedicated_domains.test"
+		dc    = acceptance.InitDataSourceCheck(rName)
+
+		byDomain   = "data.huaweicloud_waf_dedicated_domains.domain_filter"
+		dcByDomain = acceptance.InitDataSourceCheck(byDomain)
+
+		byProtectStatus   = "data.huaweicloud_waf_dedicated_domains.protect_status_filter"
+		dcByProtectStatus = acceptance.InitDataSourceCheck(byProtectStatus)
+
+		byAllParameters   = "data.huaweicloud_waf_dedicated_domains.all_parameters_filter"
+		dcByAllParameters = acceptance.InitDataSourceCheck(byAllParameters)
+	)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acceptance.TestAccPreCheck(t)
 			acceptance.TestAccPrecheckWafInstance(t)
+			acceptance.TestAccPreCheckEpsID(t)
 		},
 		ProviderFactories: acceptance.TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatasourceDedicatedDomains_basic(name),
+				Config: testAccDatasourceDedicatedDomains_basic(name, certificateBody),
 				Check: resource.ComposeTestCheckFunc(
 					dc.CheckResourceExists(),
 					resource.TestCheckResourceAttrSet(rName, "domains.0.domain"),
@@ -38,65 +53,87 @@ func TestAccDatasourceWAFDedicatedDomains_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(rName, "domains.0.access_status"),
 					resource.TestCheckResourceAttrSet(rName, "domains.0.website_name"),
 
+					dcByDomain.CheckResourceExists(),
 					resource.TestCheckOutput("domain_filter_is_useful", "true"),
 
+					dcByProtectStatus.CheckResourceExists(),
 					resource.TestCheckOutput("protect_status_filter_is_useful", "true"),
 
-					resource.TestCheckOutput("enterprise_project_id_filter_is_useful", "true"),
+					dcByAllParameters.CheckResourceExists(),
+					resource.TestCheckOutput("all_parameters_filter_is_useful", "true"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDatasourceDedicatedDomains_basic(name string) string {
+func testAccDatasourceDedicatedDomains_basic(name, certificateBody string) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 data "huaweicloud_waf_dedicated_domains" "test" {
-  depends_on = [huaweicloud_waf_dedicated_domain.domain_1]
+  enterprise_project_id = "%[2]s"
+
+  depends_on = [huaweicloud_waf_dedicated_domain.test]
+}
+
+# Filter by domain
+locals {
+  domain = data.huaweicloud_waf_dedicated_domains.test.domains.0.domain
 }
 
 data "huaweicloud_waf_dedicated_domains" "domain_filter" {
-  domain = data.huaweicloud_waf_dedicated_domains.test.domains.0.domain
+  domain                = local.domain
+  enterprise_project_id = "%[2]s"
 }
 
 locals {
-  domain = data.huaweicloud_waf_dedicated_domains.test.domains.0.domain
+  domain_filter_result = [
+    for v in data.huaweicloud_waf_dedicated_domains.domain_filter.domains[*].domain : v == local.domain
+  ]
 }
 
 output "domain_filter_is_useful" {
-  value = length(data.huaweicloud_waf_dedicated_domains.domain_filter.domains) > 0 && alltrue(
-    [for v in data.huaweicloud_waf_dedicated_domains.domain_filter.domains[*].domain : v == local.domain]
-  )  
+  value = length(local.domain_filter_result) > 0 && alltrue(local.domain_filter_result)  
+}
+
+# Filter by protect_status
+locals {
+  protect_status = tostring(data.huaweicloud_waf_dedicated_domains.test.domains.0.protect_status)
 }
 
 data "huaweicloud_waf_dedicated_domains" "protect_status_filter" {
-  protect_status = data.huaweicloud_waf_dedicated_domains.test.domains.0.protect_status
+  protect_status        = local.protect_status
+  enterprise_project_id = "%[2]s"
 }
   
 locals {
-  protect_status = data.huaweicloud_waf_dedicated_domains.test.domains.0.protect_status
+  protect_status_filter_result = [
+    for v in data.huaweicloud_waf_dedicated_domains.protect_status_filter.domains[*].protect_status :
+    tostring(v) == local.protect_status
+  ]
 }
-  
+
 output "protect_status_filter_is_useful" {
-  value = length(data.huaweicloud_waf_dedicated_domains.protect_status_filter.domains) > 0 && alltrue(
-    [for v in data.huaweicloud_waf_dedicated_domains.protect_status_filter.domains[*].protect_status : v == local.protect_status]
-  )  
+  value = length(local.protect_status_filter_result) > 0 && alltrue(local.protect_status_filter_result)  
 }
 
-data "huaweicloud_waf_dedicated_domains" "enterprise_project_id_filter" {
-  enterprise_project_id = data.huaweicloud_waf_dedicated_domains.test.domains.0.enterprise_project_id
+# Filter by all parameters
+data "huaweicloud_waf_dedicated_domains" "all_parameters_filter" {
+  domain                = local.domain
+  protect_status        = local.protect_status
+  enterprise_project_id = "%[2]s"
 }
-	
+
 locals {
-  enterprise_project_id = data.huaweicloud_waf_dedicated_domains.test.domains.0.enterprise_project_id
+  all_parameters_filter_result = [
+    for v in data.huaweicloud_waf_dedicated_domains.all_parameters_filter.domains[*] :
+    tostring(v.protect_status) == local.protect_status && v.domain == local.domain
+  ]
 }
 
-output "enterprise_project_id_filter_is_useful" {
-  value = length(data.huaweicloud_waf_dedicated_domains.enterprise_project_id_filter.domains) > 0 && alltrue(
-    [for v in data.huaweicloud_waf_dedicated_domains.enterprise_project_id_filter.domains[*].enterprise_project_id : v == local.enterprise_project_id]
-  )  
+output "all_parameters_filter_is_useful" {
+  value = length(local.all_parameters_filter_result) > 0 && alltrue(local.all_parameters_filter_result)  
 }
-`, testAccWafDedicatedDomainV1_basic(name))
+`, testAccWafDedicatedDomain_basic(name, certificateBody), acceptance.HW_ENTERPRISE_PROJECT_ID_TEST)
 }

--- a/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
+++ b/huaweicloud/services/waf/resource_huaweicloud_waf_dedicated_domain.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
@@ -96,9 +95,6 @@ func ResourceWafDedicatedDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"TLS v1.0", "TLS v1.1", "TLS v1.2",
-				}, false),
 			},
 			"cipher": {
 				Type:     schema.TypeString,
@@ -209,16 +205,14 @@ func dedicatedDomainServerSchema() *schema.Resource {
 	sc := schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"client_protocol": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"HTTP", "HTTPS"}, false),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			"server_protocol": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"HTTP", "HTTPS"}, false),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			"address": {
 				Type:     schema.TypeString,
@@ -231,10 +225,9 @@ func dedicatedDomainServerSchema() *schema.Resource {
 				ForceNew: true,
 			},
 			"type": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"ipv4", "ipv6"}, false),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			"vpc_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- chore(waf): maintain waf dedicated domain resource and fix some problems.
- chore(waf): maintain waf dedicated domain datasource and fix some problems.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [X] Tests added/passed.

```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccWafDedicateDomain_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccWafDedicateDomain_basic -timeout 360m -parallel 4
=== RUN   TestAccWafDedicateDomain_basic
=== PAUSE TestAccWafDedicateDomain_basic
=== CONT  TestAccWafDedicateDomain_basic
--- PASS: TestAccWafDedicateDomain_basic (48.57s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       48.612s
```
```
make testacc TEST='./huaweicloud/services/acceptance/waf' TESTARGS='-run TestAccDatasourceWAFDedicatedDomains_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/waf -v -run TestAccDatasourceWAFDedicatedDomains_basic -timeout 360m -parallel 4
=== RUN   TestAccDatasourceWAFDedicatedDomains_basic
=== PAUSE TestAccDatasourceWAFDedicatedDomains_basic
=== CONT  TestAccDatasourceWAFDedicatedDomains_basic
--- PASS: TestAccDatasourceWAFDedicatedDomains_basic (13.46s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/waf       13.510s
```

* [X] Documentation updated.
* [X] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
