### PR TITLE
feat(GaussDBforMySQL): add gaussdb mysql instant task delete resource

### DIFF
--- a/docs/resources/gaussdb_mysql_instant_task_delete.md
+++ b/docs/resources/gaussdb_mysql_instant_task_delete.md
@@ -1,0 +1,40 @@
+---
+subcategory: "GaussDB(for MySQL)"
+layout: "huaweicloud"
+page_title: "HuaweiCloud: huaweicloud_gaussdb_mysql_instant_task_delete"
+description: |-
+  Manages a GaussDB MySQL instant task delete resource within HuaweiCloud.
+---
+
+# huaweicloud_gaussdb_mysql_instant_task_delete
+
+Manages a GaussDB MySQL instant task delete resource within HuaweiCloud.
+
+-> This resource is only a one-time action resource for operating the API.
+Deleting this resource will not clear the corresponding request record,
+but will only remove the resource information from the tfstate file.
+
+## Example Usage
+
+```hcl
+variable "job_id" {}
+
+resource "huaweicloud_gaussdb_mysql_instant_task_delete" "test" {
+  job_id = var.job_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `job_id` - (Required, String, ForceNew) Specifies the task ID. Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID. The value is `job_id`.

--- a/huaweicloud/provider.go
+++ b/huaweicloud/provider.go
@@ -1634,6 +1634,7 @@ func Provider() *schema.Provider {
 			"huaweicloud_gaussdb_mysql_quota":                      gaussdb.ResourceGaussDBMysqlQuota(),
 			"huaweicloud_gaussdb_mysql_scheduled_task_cancel":      gaussdb.ResourceGaussDBScheduledTaskCancel(),
 			"huaweicloud_gaussdb_mysql_scheduled_task_delete":      gaussdb.ResourceGaussDBScheduledTaskDelete(),
+			"huaweicloud_gaussdb_mysql_instant_task_delete":        gaussdb.ResourceGaussDBInstantTaskDelete(),
 
 			"huaweicloud_gaussdb_opengauss_instance": gaussdb.ResourceOpenGaussInstance(),
 			"huaweicloud_gaussdb_opengauss_database": gaussdb.ResourceOpenGaussDatabase(),

--- a/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instant_task_delete_test.go
+++ b/huaweicloud/services/acceptance/gaussdb/resource_huaweicloud_gaussdb_mysql_instant_task_delete_test.go
@@ -1,0 +1,34 @@
+package gaussdb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGaussDBMysqlInstantTaskDelete_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acceptance.TestAccPreCheck(t)
+			acceptance.TestAccPreCheckGaussDBMysqlJobId(t)
+		},
+		ProviderFactories: acceptance.TestAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBMysqlInstantTaskDelete_basic(),
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+func testAccGaussDBMysqlInstantTaskDelete_basic() string {
+	return fmt.Sprintf(`
+resource "huaweicloud_gaussdb_mysql_instant_task_delete" "test" {
+  job_id = "%[1]s"
+}`, acceptance.HW_GAUSSDB_MYSQL_JOB_ID)
+}

--- a/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instant_task_delete.go
+++ b/huaweicloud/services/gaussdb/resource_huaweicloud_gaussdb_mysql_instant_task_delete.go
@@ -1,0 +1,83 @@
+package gaussdb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+// @API GaussDBforMySQL DELETE /v3/{project_id}/jobs/{job_id}
+func ResourceGaussDBInstantTaskDelete() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceGaussDBMysqlInstantTaskDeleteCreate,
+		ReadContext:   resourceGaussDBMysqlInstantTaskDeleteRead,
+		DeleteContext: resourceGaussDBMysqlInstantTaskDeleteDelete,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"job_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceGaussDBMysqlInstantTaskDeleteCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	cfg := meta.(*config.Config)
+	region := cfg.GetRegion(d)
+
+	var (
+		httpUrl = "v3/{project_id}/jobs/{job_id}"
+		product = "gaussdb"
+	)
+	client, err := cfg.NewServiceClient(product, region)
+	if err != nil {
+		return diag.Errorf("error creating GaussDB client: %s", err)
+	}
+
+	jobId := d.Get("job_id").(string)
+	createPath := client.Endpoint + httpUrl
+	createPath = strings.ReplaceAll(createPath, "{project_id}", client.ProjectID)
+	createPath = strings.ReplaceAll(createPath, "{job_id}", jobId)
+
+	createOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	_, err = client.Request("DELETE", createPath, &createOpt)
+	if err != nil {
+		return diag.Errorf("error deleting GaussDB MySQL instant task(%s): %s", jobId, err)
+	}
+
+	d.SetId(jobId)
+
+	return nil
+}
+
+func resourceGaussDBMysqlInstantTaskDeleteRead(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceGaussDBMysqlInstantTaskDeleteDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	errorMsg := "Deleting GaussDB MySQL instant task delete resource is not supported. The GaussDB MySQL instant " +
+		"task delete resource is only removed from the state."
+	return diag.Diagnostics{
+		diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  errorMsg,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
  add gaussdb mysql instant task delete resource
**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
  add gaussdb mysql instant task delete resource
```

## PR Checklist

<!-- Before submitting resources, please check the following items and provide the corresponding verification results. -->

* [ ] Tests added/passed.

```
make testacc TEST=./huaweicloud/services/acceptance/gaussdb/ TESTARGS='-run TestAccGaussDBMysqlInstantTaskDelete_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/gaussdb/ -v -run TestAccGaussDBMysqlInstantTaskDelete_basic -timeout 360m -parallel 4
=== RUN   TestAccGaussDBMysqlInstantTaskDelete_basic
=== PAUSE TestAccGaussDBMysqlInstantTaskDelete_basic
=== CONT  TestAccGaussDBMysqlInstantTaskDelete_basic
--- PASS: TestAccGaussDBMysqlInstantTaskDelete_basic (12.19s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/gaussdb   12.237s
```

* [ ] Documentation updated.
* [ ] Schema updated.
* [ ] CheckDeleted.

  - **a. During query operation (Read Context)**
    aa. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    ab. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
  - **b. During delete/disassociate/unbind operation (Delete Context)**
    ba. Resource not found
    \>>>>>> Paste the screenshot here <<<<<<

    <!-- If the resource depends the parent resource(s), please provide the related check result(s) of the CheckDeleted validation.
    bb. Related resources (parent resources) not found
    \>>>>>> Paste the screenshot here <<<<<<
    -->
